### PR TITLE
Remember DisplayDevice original resolutions

### DIFF
--- a/Source/OpenTK/DisplayDevice.cs
+++ b/Source/OpenTK/DisplayDevice.cs
@@ -48,7 +48,7 @@ namespace OpenTK
         bool primary;
         Rectangle bounds;
         DisplayResolution current_resolution = new DisplayResolution();
-        internal DisplayResolution original_resolution;
+        DisplayResolution original_resolution;
         List<DisplayResolution> available_resolutions = new List<DisplayResolution>();
         IList<DisplayResolution> available_resolutions_readonly;
         
@@ -330,6 +330,23 @@ namespace OpenTK
         public static DisplayDevice GetDisplay(DisplayIndex index)
         {
             return implementation.GetDisplay(index);
+        }
+
+        #endregion
+
+        #endregion
+
+        #region --- Internal Methods ---
+
+        #region internal DisplayResolution OriginalResolution
+
+        /// <summary>
+        /// Gets the original resolution of this instance.
+        /// </summary>
+        internal DisplayResolution OriginalResolution
+        {
+            get { return original_resolution; }
+            set { original_resolution = value; }
         }
 
         #endregion

--- a/Source/OpenTK/Platform/Windows/WinDisplayDevice.cs
+++ b/Source/OpenTK/Platform/Windows/WinDisplayDevice.cs
@@ -97,7 +97,7 @@ namespace OpenTK.Platform.Windows
             lock (display_lock)
             {
                 // Store an array of the current available DisplayDevice objects.
-                // This is needed to preserve the original_resolution.
+                // This is needed to preserve the original resolution.
                 DisplayDevice[] previousDevices = AvailableDevices.ToArray();
 
                 AvailableDevices.Clear();
@@ -163,10 +163,10 @@ namespace OpenTK.Platform.Windows
                         opentk_dev_current_res.Bounds,
                         dev1.DeviceName);
 
-                    // Set the original_resolution if the DisplayDevice was previously available.
+                    // Set the original resolution if the DisplayDevice was previously available.
                     foreach (DisplayDevice existingDevice in previousDevices)
                         if ((string)existingDevice.Id == (string)opentk_dev.Id)
-                            opentk_dev.original_resolution = existingDevice.original_resolution;
+                            opentk_dev.OriginalResolution = existingDevice.OriginalResolution;
 
                     AvailableDevices.Add(opentk_dev);
 


### PR DESCRIPTION
When refreshing the AvailableDevices list, it is important to set the
original resolution on any DisplayDevices that were previously available
to allow the RestoreResolution() method to work correctly.
