### PR TITLE
Replace non-breaking space.

### DIFF
--- a/Source/Bind/Structures/Parameter.cs
+++ b/Source/Bind/Structures/Parameter.cs
@@ -343,7 +343,7 @@ namespace Bind.Structures
 
         #region public bool HasGenericParameters
 
-        public bool HasGenericParameters
+        public bool HasGenericParameters
         {
             get
             {


### PR DESCRIPTION
Replace non-breaking space with a standard space. The non-breaking space causes the build on Ubuntu to fail.
