### PR TITLE
Centering the cursor at (width/2, height/2) when the mouse is hidden

### DIFF
--- a/Source/OpenTK/Platform/X11/X11GLNative.cs
+++ b/Source/OpenTK/Platform/X11/X11GLNative.cs
@@ -898,8 +898,14 @@ namespace OpenTK.Platform.X11
                         // is very very uncommon. Todo: Can this be remedied?
                         int x = e.MotionEvent.x;
                         int y =e.MotionEvent.y;
-                        int middle_x = (Bounds.Left + Bounds.Right) / 2;
-                        int middle_y = (Bounds.Top + Bounds.Bottom) / 2;
+                        // TODO: Have offset as a stored field, only update it when the window moves
+                        // The middle point cannot be the average of the Bounds.left/right/top/bottom,
+                        // because these fields take into account window decoration (borders, etc),
+                        // which we do not want to account for.
+                        Point offset = this.PointToClient(Point.Empty);
+                        int middle_x = Width/2-offset.X;
+                        int middle_y = Height/2-offset.Y;
+
                         Point screen_xy = PointToScreen(new Point(x, y));
                         if (!CursorVisible && MouseWarpActive &&
                             screen_xy.X == middle_x && screen_xy.Y == middle_y)


### PR DESCRIPTION
This change affects the Linux platform on X11. When the cursor is hidden, it should be centered at (width/2, height/2), instead of the average of its bounds (which takes into account the borders of the window). 
This solves part of the issue described in https://github.com/mono/MonoGame/issues/2283.
