### PR TITLE
Use GetMouseMovePointsEx to smooth mouse input.

### DIFF
--- a/Source/OpenTK/Platform/Windows/API.cs
+++ b/Source/OpenTK/Platform/Windows/API.cs
@@ -111,13 +111,6 @@ namespace OpenTK.Platform.Windows
 
     internal static class Functions
     {
-        #region GetLastError
-
-        [DllImport("Kernel32.dll")]
-        internal static extern uint GetLastError();
-
-        #endregion
-
         #region Window functions
 
         #region SetWindowPos
@@ -1679,6 +1672,14 @@ namespace OpenTK.Platform.Windows
             internal static readonly IntPtr MESSAGE_ONLY = new IntPtr(-3);
 
             internal static readonly IntPtr HKEY_LOCAL_MACHINE = new IntPtr(unchecked((int)0x80000002));
+
+            // System Error Codes
+            // http://msdn.microsoft.com/en-us/library/windows/desktop/ms681381(v=vs.85).aspx
+
+            /// <summary>
+            /// The point passed to GetMouseMovePoints is not in the buffer.
+            /// </summary>
+            internal const int ERROR_POINT_NOT_FOUND = 1171;
 
             /// <summary>
             /// Retrieves the points using the display resolution.

--- a/Source/OpenTK/Platform/Windows/WinGLNative.cs
+++ b/Source/OpenTK/Platform/Windows/WinGLNative.cs
@@ -435,17 +435,17 @@ namespace OpenTK.Platform.Windows
                     &movePoint, movePoints, numPoints,
                     Constants.GMMP_USE_DISPLAY_POINTS);
 
-                uint lastError = Functions.GetLastError();
+                int lastError = Marshal.GetLastWin32Error();
 
                 // No points returned or search point not found
-                if (points == 0 || (points == -1 && lastError == 1171))
+                if (points == 0 || (points == -1 && lastError == Constants.ERROR_POINT_NOT_FOUND))
                 {
                     // Just use the mouse move position
                     mouse.Position = point;
                 }
                 else if (points == -1)
                 {
-                    throw new System.ComponentModel.Win32Exception((int)lastError);
+                    throw new System.ComponentModel.Win32Exception(lastError);
                 }
                 else
                 {


### PR DESCRIPTION
Uses GetMouseMovePointsEx to get mouse move history so mouse events aren't dropped even with low framerates.

Fixes #76.
