### PR TITLE
Added generic RenderbufferStorage.DepthComponent

### DIFF
--- a/Source/OpenTK/Graphics/OpenGL/GLEnums.cs
+++ b/Source/OpenTK/Graphics/OpenGL/GLEnums.cs
@@ -48642,6 +48642,10 @@ namespace OpenTK.Graphics.OpenGL
         /// </summary>
         Rgba16 = ((int)0x805B)        ,
         /// <summary>
+        /// Original was GL_DEPTH_COMPONENT = 0x1902
+        /// </summary>
+        DepthComponent = ((int)0x1902)        ,
+        /// <summary>
         /// Original was GL_DEPTH_COMPONENT16 = 0x81a5
         /// </summary>
         DepthComponent16 = ((int)0x81a5)        ,


### PR DESCRIPTION
Tao had it as `Gl.GL_DEPTH_COMPONENT` and we need it badly https://github.com/Mailaender/OpenRA/commit/1a47db0f7cecf39559592512bc730223799d178d#commitcomment-6235712 as hard-coding those to specific ones caused problems in the past https://github.com/OpenRA/OpenRA/issues/3753.
