### PR TITLE
[Rewrite] Fixed 2d/3d arrays on .Net

### DIFF
--- a/Source/Generator.Rewrite/Program.cs
+++ b/Source/Generator.Rewrite/Program.cs
@@ -814,9 +814,7 @@ namespace OpenTK.Rewrite
                         {
                             // 2d-3d array, address must be taken as follows:
                             // call instance T& T[0..., 0..., 0...]::Address(int, int, int)
-                            ByReferenceType t_ref = array.IsGenericParameter ?
-                                array.ElementType.MakeByReferenceType() :
-                                array.ElementType.MakeByReferenceType();
+                            ByReferenceType t_ref = array.ElementType.MakeByReferenceType();
                             MethodReference get_address = new MethodReference("Address", t_ref, array);
                             for (int r = 0; r < array.Rank; r++)
                             {


### PR DESCRIPTION
Mono can use ldlen and ldelema on both 1d arrays (vectors) and 2d/3d arrays. However, .Net can only use these instructions on 1d arrays - higher rank arrays must use get_Length and Address explicitly.

Closes issue #116
