### PR TITLE
[SDL] Do not attempt to use versions < 2.0.0

### DIFF
--- a/Source/OpenTK/Configuration.cs
+++ b/Source/OpenTK/Configuration.cs
@@ -246,8 +246,7 @@ namespace OpenTK
             }
             else
             {
-                Debug.Print("SDL2 is {0}. Version is {1}.{2}.{3}",
-                    supported ? "supported" : "not supported",
+                Debug.Print("SDL2 is supported. Version is {0}.{1}.{2}",
                     version.Major, version.Minor, version.Patch);
             }
 


### PR DESCRIPTION
Versions prior to 2.0.0 are not ABI-compatible with 2.0.x and
attempting to use those will result in random instability. We now
explicitly check the SDL2 version before enabling the SDL2 backend.
