### PR TITLE
Fix a bug in single->half conversion.

### DIFF
--- a/Source/OpenTK/Math/Half.cs
+++ b/Source/OpenTK/Math/Half.cs
@@ -228,7 +228,7 @@ namespace OpenTK
 
                 mantissa = mantissa + 0x00000fff + ((mantissa >> 13) & 1);
 
-                if ((mantissa & 0x00800000) == 1)
+                if ((mantissa & 0x00800000) != 0)
                 {
                     mantissa = 0;        // overflow in significand,
                     exponent += 1;        // adjust exponent


### PR DESCRIPTION
The original C code had if(m & 0x00800000) which is true if the
expresssion does not evaluate to zero. This was inncorretly translated
to the C# code if((m & 0x00800000) == 1) which only evaluates true if
the expression evalaute to 1, which it never does. The correct test is
to test not equal to zero (!= 0).
