### PR TITLE
Fixes bugs in String marshalling.

### DIFF
--- a/Source/OpenTK/BindingsBase.cs
+++ b/Source/OpenTK/BindingsBase.cs
@@ -202,10 +202,25 @@ namespace OpenTK
                     throw new OutOfMemoryException();
                 }
 
-                for (int i = 0; i < str_array.Length; i++)
+                int i = 0;
+                try
                 {
-                    IntPtr str = MarshalStringToPtr(str_array[i]);
-                    Marshal.WriteIntPtr(ptr, i * IntPtr.Size, str);
+                    for (i = 0; i < str_array.Length; i++)
+                    {
+                        IntPtr str = MarshalStringToPtr(str_array[i]);
+                        Marshal.WriteIntPtr(ptr, i * IntPtr.Size, str);
+                    }
+                }
+                catch (OutOfMemoryException oom)
+                {
+                    for (i = i - 1; i >= 0; --i)
+                    {
+                        Marshal.FreeHGlobal(Marshal.ReadIntPtr(ptr, i * IntPtr.Size));
+                    }
+
+                    Marshal.FreeHGlobal(ptr);
+
+                    throw oom;
                 }
             }
             return ptr;
@@ -220,7 +235,7 @@ namespace OpenTK
         {
             for (int i = 0; i < length; i++)
             {
-                Marshal.FreeHGlobal(Marshal.ReadIntPtr(ptr, length * IntPtr.Size));
+                Marshal.FreeHGlobal(Marshal.ReadIntPtr(ptr, i * IntPtr.Size));
             }
             Marshal.FreeHGlobal(ptr);
         }


### PR DESCRIPTION
Fixes two issues:
1. FreeStringArrayPtr used the wrong variable in the offset to
ReadIntPtr causing an access violation.
2. Better cleanup of memory in MarshalStringArrayToPtr when any alloc
fails.
