### PR TITLE
Change 3 GameWindow Render/Update loop functions to Protected

### DIFF
--- a/Source/OpenTK/GameWindow.cs
+++ b/Source/OpenTK/GameWindow.cs
@@ -452,7 +452,7 @@ namespace OpenTK
             return MathHelper.Clamp(elapsed, 0.0, 1.0);
         }
 
-        void DispatchUpdateAndRenderFrame(object sender, EventArgs e)
+        protected void DispatchUpdateAndRenderFrame(object sender, EventArgs e)
         {
             int is_running_slowly_retries = 4;
             double timestamp = watch.Elapsed.TotalSeconds;
@@ -496,7 +496,7 @@ namespace OpenTK
             }
         }
 
-        void RaiseUpdateFrame(double elapsed, ref double timestamp)
+		protected void RaiseUpdateFrame( double elapsed, ref double timestamp )
         {
             // Raise UpdateFrame event
             update_args.Time = elapsed;
@@ -512,7 +512,7 @@ namespace OpenTK
         }
 
 
-        void RaiseRenderFrame(double elapsed, ref double timestamp)
+		protected void RaiseRenderFrame( double elapsed, ref double timestamp )
         {
             // Raise RenderFrame event
             render_args.Time = elapsed;


### PR DESCRIPTION
One single easy commit:
- Make OpenTK.GameWindow.DispatchUpdateAndRenderFrame, OpenTK.GameWindow.RaiseUpdateFrame, and OpenTK.GameWindow.RaiseRenderFrame protected instead of internel so that they can be override by developers who want more control over the render/update loop.

Mainly, I wanted this for a project I am working on and since it's so simple, and potentially useful to others, i figured i would create a pull request.
- Monk
