### PR TITLE
[Bind] Add int overloads to buffer size (IntPtr) parameters

### DIFF
--- a/Source/Bind/Utilities.cs
+++ b/Source/Bind/Utilities.cs
@@ -89,6 +89,11 @@ namespace Bind
         /// Function takes a String[] parameter
         /// </summary>
         StringArrayParameter = 1 << 13,
+        /// <summary>
+        /// Functions takes an IntPtr that corresponds to a size_t.
+        /// Add an int32 overload for convenience.
+        /// </summary>
+        SizeParameter = 1 << 14,
     }
 
     #endregion


### PR DESCRIPTION
As a convenience, int overloads are provided for IntPtr size
parameters (corresponding to BufferSize or size_t). In the vast
majority of cases, a 32bit int is sufficient for buffer sizes,
so these overloads avoid the necessity of annoying (IntPtr) casts.

If more than 2^31-1 elements are required, the IntPtr overloads
remain available. (As always, this requires a 64bit runtime
environment.)
