### PR TITLE
[Win] Avoid NRE in WinFactory.Dispose()

### DIFF
--- a/Source/OpenTK/Platform/Windows/WinFactory.cs
+++ b/Source/OpenTK/Platform/Windows/WinFactory.cs
@@ -163,7 +163,12 @@ namespace OpenTK.Platform.Windows
             {
                 if (manual)
                 {
-                    rawinput_driver.Dispose();
+                    WinRawInput raw = rawinput_driver;
+                    if (raw != null)
+                    {
+                        raw.Dispose();
+                        rawinput_driver = null;
+                    }
                 }
 
                 base.Dispose(manual);


### PR DESCRIPTION
WinFactory.Dispose() could crash with a NRE when the joystick driver has
not been initialized. Fixed by checking for null before disposing the
input driver.
