### PR TITLE
Added support for Euler angles in Quaternion structs

### DIFF
--- a/Source/OpenTK/Math/Quaternion.cs
+++ b/Source/OpenTK/Math/Quaternion.cs
@@ -67,6 +67,39 @@ namespace OpenTK
             : this(new Vector3(x, y, z), w)
         { }
 
+        /// <summary>
+        /// Construct a new Quaternion from given Euler angles
+        /// </summary>
+        /// <param name="pitch">The pitch (attitude), rotation around X axis</param>
+        /// <param name="yaw">The yaw (heading), rotation around Y axis</param>
+        /// <param name="roll">The roll (bank), rotation around Z axis</param>
+        public Quaternion(float pitch, float yaw, float roll)
+        {
+            yaw *= 0.5f;
+            pitch *= 0.5f;
+            roll *= 0.5f;
+
+            float c1 = (float)Math.Cos(yaw);
+            float c2 = (float)Math.Cos(pitch);
+            float c3 = (float)Math.Cos(roll);
+            float s1 = (float)Math.Sin(yaw);
+            float s2 = (float)Math.Sin(pitch);
+            float s3 = (float)Math.Sin(roll);
+
+            this.w = c1 * c2 * c3 - s1 * s2 * s3;
+            this.xyz.X = s1 * s2 * c3 + c1 * c2 * s3;
+            this.xyz.Y = s1 * c2 * c3 + c1 * s2 * s3;
+            this.xyz.Z = c1 * s2 * c3 - s1 * c2 * s3;
+        }
+
+        /// <summary>
+        /// Construct a new Quaternion from given Euler angles
+        /// </summary>
+        /// <param name="eulerAngles">The euler angles as a Vector3</param>
+        public Quaternion(Vector3 eulerAngles)
+            :this(eulerAngles.X, eulerAngles.Y, eulerAngles.Z)
+        { }
+
         #endregion
 
         #region Public Members
@@ -508,6 +541,52 @@ namespace OpenTK
             result.W = (float)System.Math.Cos(angle);
 
             return Normalize(result);
+        }
+
+        #endregion
+
+        #region FromEulerAngles
+
+        /// <summary>
+        /// Builds a Quaternion from the given euler angles
+        /// </summary>
+        /// <param name="pitch">The pitch (attitude), rotation around X axis</param>
+        /// <param name="yaw">The yaw (heading), rotation around Y axis</param>
+        /// <param name="roll">The roll (bank), rotation around Z axis</param>
+        /// <returns></returns>
+        public static Quaternion FromEulerAngles(float pitch, float yaw, float roll)
+        {
+            return new Quaternion(pitch, yaw, roll);
+        }
+
+        /// <summary>
+        /// Builds a Quaternion from the given euler angles
+        /// </summary>
+        /// <param name="eulerAngles">The euler angles as a vector</param>
+        /// <returns>The equivalent Quaternion</returns>
+        public static Quaternion FromEulerAngles(Vector3 eulerAngles)
+        {
+            return new Quaternion(eulerAngles);
+        }
+
+        /// <summary>
+        /// Builds a Quaternion from the given euler angles
+        /// </summary>
+        /// <param name="eulerAngles">The euler angles a vector</param>
+        /// <param name="result">The equivalent Quaternion</param>
+        public static void FromEulerAngles(ref Vector3 eulerAngles, out Quaternion result)
+        {
+            float c1 = (float)Math.Cos(eulerAngles.Y * 0.5f);
+            float c2 = (float)Math.Cos(eulerAngles.X * 0.5f);
+            float c3 = (float)Math.Cos(eulerAngles.Z * 0.5f);
+            float s1 = (float)Math.Sin(eulerAngles.Y * 0.5f);
+            float s2 = (float)Math.Sin(eulerAngles.X * 0.5f);
+            float s3 = (float)Math.Sin(eulerAngles.Z * 0.5f);
+
+            result.w = c1 * c2 * c3 - s1 * s2 * s3;
+            result.xyz.X = s1 * s2 * c3 + c1 * c2 * s3;
+            result.xyz.Y = s1 * c2 * c3 + c1 * s2 * s3;
+            result.xyz.Z = c1 * s2 * c3 - s1 * c2 * s3;
         }
 
         #endregion

--- a/Source/OpenTK/Math/Quaterniond.cs
+++ b/Source/OpenTK/Math/Quaterniond.cs
@@ -67,6 +67,39 @@ namespace OpenTK
             : this(new Vector3d(x, y, z), w)
         { }
 
+        /// <summary>
+        /// Construct a new Quaterniond from given Euler angles
+        /// </summary>
+        /// <param name="pitch">The pitch (attitude), rotation around X axis</param>
+        /// <param name="yaw">The yaw (heading), rotation around Y axis</param>
+        /// <param name="roll">The roll (bank), rotation around Z axis</param>
+        public Quaterniond(double pitch, double yaw, double roll)
+        {
+            yaw *= 0.5;
+            pitch *= 0.5;
+            roll *= 0.5;
+
+            double c1 = Math.Cos(yaw);
+            double c2 = Math.Cos(pitch);
+            double c3 = Math.Cos(roll);
+            double s1 = Math.Sin(yaw);
+            double s2 = Math.Sin(pitch);
+            double s3 = Math.Sin(roll);
+
+            this.w = c1 * c2 * c3 - s1 * s2 * s3;
+            this.xyz.X = s1 * s2 * c3 + c1 * c2 * s3;
+            this.xyz.Y = s1 * c2 * c3 + c1 * s2 * s3;
+            this.xyz.Z = c1 * s2 * c3 - s1 * c2 * s3;
+        }
+
+        /// <summary>
+        /// Construct a new Quaterniond from given Euler angles
+        /// </summary>
+        /// <param name="eulerAngles">The euler angles as a Vector3d</param>
+        public Quaterniond(Vector3d eulerAngles)
+            :this(eulerAngles.X, eulerAngles.Y, eulerAngles.Z)
+        { }
+
         #endregion
 
         #region Public Members
@@ -507,6 +540,52 @@ namespace OpenTK
             result.W = (double)System.Math.Cos(angle);
 
             return Normalize(result);
+        }
+
+        #endregion
+
+        #region FromEulerAngles
+
+        /// <summary>
+        /// Builds a Quaterniond from the given euler angles
+        /// </summary>
+        /// <param name="pitch">The pitch (attitude), rotation around X axis</param>
+        /// <param name="yaw">The yaw (heading), rotation around Y axis</param>
+        /// <param name="roll">The roll (bank), rotation around Z axis</param>
+        /// <returns></returns>
+        public static Quaterniond FromEulerAngles(double pitch, double yaw, double roll)
+        {
+            return new Quaterniond(pitch, yaw, roll);
+        }
+
+        /// <summary>
+        /// Builds a Quaterniond from the given euler angles
+        /// </summary>
+        /// <param name="eulerAngles">The euler angles as a vector</param>
+        /// <returns>The equivalent Quaterniond</returns>
+        public static Quaterniond FromEulerAngles(Vector3d eulerAngles)
+        {
+            return new Quaterniond(eulerAngles);
+        }
+
+        /// <summary>
+        /// Builds a Quaterniond from the given euler angles
+        /// </summary>
+        /// <param name="eulerAngles">The euler angles a vector</param>
+        /// <param name="result">The equivalent Quaterniond</param>
+        public static void FromEulerAngles(ref Vector3d eulerAngles, out Quaterniond result)
+        {
+            double c1 = Math.Cos(eulerAngles.Y * 0.5);
+            double c2 = Math.Cos(eulerAngles.X * 0.5);
+            double c3 = Math.Cos(eulerAngles.Z * 0.5);
+            double s1 = Math.Sin(eulerAngles.Y * 0.5);
+            double s2 = Math.Sin(eulerAngles.X * 0.5);
+            double s3 = Math.Sin(eulerAngles.Z * 0.5);
+
+            result.w = c1 * c2 * c3 - s1 * s2 * s3;
+            result.xyz.X = s1 * s2 * c3 + c1 * c2 * s3;
+            result.xyz.Y = s1 * c2 * c3 + c1 * s2 * s3;
+            result.xyz.Z = c1 * s2 * c3 - s1 * c2 * s3;
         }
 
         #endregion


### PR DESCRIPTION
Added support for Euler angles in Quaternion and Quaterniond by adding proper vec3 and pitch-yaw-roll constructors, and also added similar static helper functions. I unit tested them locally and the results match to the calculator found from the bottom of this web page: http://www.euclideanspace.com/maths/geometry/rotations/conversions/eulerToQuaternion/index.htm
