### PR TITLE
[NUnit] Add NUnit test project for OpenGL.

### DIFF
--- a/NUnit.OpenGL/NUnit.OpenGL.csproj
+++ b/NUnit.OpenGL/NUnit.OpenGL.csproj
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>10.0.0</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{4FF852F7-A00C-4B3D-8092-9A63C1835726}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>NUnit.OpenGL</RootNamespace>
+    <AssemblyName>NUnit.OpenGL</AssemblyName>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>full</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="nunit.framework">
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="System.Drawing" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Test.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <ItemGroup>
+    <ProjectReference Include="..\Source\OpenTK\OpenTK.csproj">
+      <Project>{A37A7E14-0000-0000-0000-000000000000}</Project>
+      <Name>OpenTK</Name>
+    </ProjectReference>
+  </ItemGroup>
+</Project>

--- a/NUnit.OpenGL/Test.cs
+++ b/NUnit.OpenGL/Test.cs
@@ -1,0 +1,65 @@
+using NUnit.Framework;
+using System;
+
+namespace NUnit.OpenGL
+{
+	[TestFixture()]
+	public class GameWindowTests
+	{
+		[Test()]
+		public void OpenClose()
+		{
+			OpenTK.GameWindow gamewindow = new OpenTK.GameWindow();
+			gamewindow.Close();
+		}
+
+		[Test()]
+		public void OpenExit()
+		{
+			OpenTK.GameWindow gamewindow = new OpenTK.GameWindow();
+			gamewindow.Exit();
+		}
+
+		[Test()]
+		public void OpenRunExit()
+		{
+			OpenTK.GameWindow gamewindow = new OpenTK.GameWindow();
+			gamewindow.UpdateFrame += (object sender, OpenTK.FrameEventArgs e) =>
+			{
+				var me = sender as OpenTK.GameWindow;
+				me.Exit();
+			};
+			gamewindow.Run();
+		}
+
+		[Test()]
+		public void ClearColor()
+		{
+			OpenTK.GameWindow gamewindow = new OpenTK.GameWindow();
+			gamewindow.RenderFrame += (object sender, OpenTK.FrameEventArgs e) =>
+			{
+				var me = sender as OpenTK.GameWindow;
+
+				OpenTK.Graphics.OpenGL.GL.ClearColor(System.Drawing.Color.CornflowerBlue);
+				OpenTK.Graphics.OpenGL.GL.Clear(OpenTK.Graphics.OpenGL.ClearBufferMask.ColorBufferBit);
+
+				me.SwapBuffers();
+
+				var pixels = new byte[32 * 32 * 4];
+				OpenTK.Graphics.OpenGL.GL.ReadPixels(0, 0, 32, 32, OpenTK.Graphics.OpenGL.PixelFormat.Rgba, OpenTK.Graphics.OpenGL.PixelType.UnsignedByte, pixels);
+
+				for(int i = 0; i < pixels.Length; i += 4)
+				{
+					Assert.AreEqual(System.Drawing.Color.CornflowerBlue.R, pixels[i + 0]);
+					Assert.AreEqual(System.Drawing.Color.CornflowerBlue.G, pixels[i + 1]);
+					Assert.AreEqual(System.Drawing.Color.CornflowerBlue.B, pixels[i + 2]);
+					Assert.AreEqual(System.Drawing.Color.CornflowerBlue.A, pixels[i + 3]);
+				}
+
+				me.Exit();
+			};
+			gamewindow.Run();
+		}
+	}
+}
+

--- a/OpenTK.sln
+++ b/OpenTK.sln
@@ -79,6 +79,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Test.API.Desktop", "Source\
 		{75DC22B1-113F-4A66-96B9-2FF8208C10E8} = {75DC22B1-113F-4A66-96B9-2FF8208C10E8}
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NUnit.OpenGL", "NUnit.OpenGL\NUnit.OpenGL.csproj", "{4FF852F7-A00C-4B3D-8092-9A63C1835726}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -171,6 +173,14 @@ Global
 		{C4DDD20F-CB4E-43F4-A75C-4A3D668E1F99}.Nsis|Any CPU.Build.0 = Release|Any CPU
 		{C4DDD20F-CB4E-43F4-A75C-4A3D668E1F99}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C4DDD20F-CB4E-43F4-A75C-4A3D668E1F99}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4FF852F7-A00C-4B3D-8092-9A63C1835726}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4FF852F7-A00C-4B3D-8092-9A63C1835726}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4FF852F7-A00C-4B3D-8092-9A63C1835726}.Documentation|Any CPU.ActiveCfg = Release|Any CPU
+		{4FF852F7-A00C-4B3D-8092-9A63C1835726}.Documentation|Any CPU.Build.0 = Release|Any CPU
+		{4FF852F7-A00C-4B3D-8092-9A63C1835726}.Nsis|Any CPU.ActiveCfg = Release|Any CPU
+		{4FF852F7-A00C-4B3D-8092-9A63C1835726}.Nsis|Any CPU.Build.0 = Release|Any CPU
+		{4FF852F7-A00C-4B3D-8092-9A63C1835726}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4FF852F7-A00C-4B3D-8092-9A63C1835726}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Runs a number of tests to check that GameWindows can be created and closed and
that basic OpenGL calls work.

This was raised a few months ago on the forums as part of my Silk work (http://www.opentk.com/node/3692). This is just a very simple test case to start with to check that this test framework will work on the development platforms we care about. I'm currently running it with MonoDevelop 4.0.12 on Ubuntu 14.04 (which works once pull request #194 is merged). I don't have access to any other machines at the moment (out of country) so would appreciate if others could check that it can be run (preferably simply) on Windows (Visual Studio and MonoDevelop), OSX and other Linux distros or without and IDE. I'm not an NUnit guru so advice welcome!

Once we're happy with the project setup and the format in which to write the tests I'll work on adding a variety of other tests to try and cover all the binding rewrite code.

Keep in mind these tests are to make sure that OpenTK code is working, that is our Window/Input/etc handling code and the CIL we generate to call native OpenGL functions. These are not testing that OpenGL works, there are GL conformance tests for that!