### PR TITLE
Colorspace conversion functions.

### DIFF
--- a/Source/OpenTK/Graphics/Color4.cs
+++ b/Source/OpenTK/Graphics/Color4.cs
@@ -1319,6 +1319,114 @@ namespace OpenTK.Graphics
 
         #endregion
 
+        #region HCY
+
+        /// <summary>
+        /// Converts HCY color values to RGB color values.
+        /// </summary>
+        /// <returns>
+        /// Returns the converted color value.
+        /// </returns>
+        /// <param name="hcy">
+        /// Color value to convert in hue, chroma, luminance (HCY).
+        /// The X element is Hue (H), the Y element is Chroma (C), the Z element is luminance (Y), and the W element is Alpha (which is copied to the output's Alpha value).
+        /// Each has a range of 0.0 to 1.0.
+        /// </param>
+        public static Color4 FromHcy(Vector4 hcy)
+        {
+            var hue = hcy.X * 360.0f;
+            var C = hcy.Y;
+            var luminance = hcy.Z;
+
+            var h = hue / 60.0f;
+            var X = C * (1.0f - Math.Abs(h % 2.0f - 1.0f));
+
+            float r, g, b;
+            if (0.0f <= h && h < 1.0f)
+            {
+                r = C;
+                g = X;
+                b = 0.0f;
+            }
+            else if (1.0f <= h && h < 2.0f)
+            {
+                r = X;
+                g = C;
+                b = 0.0f;
+            }
+            else if (2.0f <= h && h < 3.0f)
+            {
+                r = 0.0f;
+                g = C;
+                b = X;
+            }
+            else if (3.0f <= h && h < 4.0f)
+            {
+                r = 0.0f;
+                g = X;
+                b = C;
+            }
+            else if (4.0f <= h && h < 5.0f)
+            {
+                r = X;
+                g = 0.0f;
+                b = C;
+            }
+            else if (5.0f <= h && h < 6.0f)
+            {
+                r = C;
+                g = 0.0f;
+                b = X;
+            }
+            else
+            {
+                r = 0.0f;
+                g = 0.0f;
+                b = 0.0f;
+            }
+
+            var m = luminance - (0.30f * r + 0.59f * g + 0.11f * b);
+            return new Color4(r + m, g + m, b + m, hcy.W);
+        }
+
+        /// <summary>
+        /// Converts RGB color values to HCY color values.
+        /// </summary>
+        /// <returns>
+        /// Returns the converted color value.
+        /// The X element is Hue (H), the Y element is Chroma (C), the Z element is luminance (Y), and the W element is Alpha (a copy of the input's Alpha value).
+        /// Each has a range of 0.0 to 1.0.
+        /// </returns>
+        /// <param name="rgb">Color value to convert.</param>
+        public static Vector4 ToHcy(Color4 rgb)
+        {
+            var M = Math.Max(rgb.R, Math.Max(rgb.G, rgb.B));
+            var m = Math.Min(rgb.R, Math.Min(rgb.G, rgb.B));
+            var C = M - m;
+
+            float h = 0.0f;
+            if (M == rgb.R)
+            {
+                h = ((rgb.G - rgb.B) / C) % 6.0f;
+            }
+            else if (M == rgb.G)
+            {
+                h = ((rgb.B - rgb.R) / C) + 2.0f;
+            }
+            else if (M == rgb.B)
+            {
+                h = ((rgb.R - rgb.G) / C) + 4.0f;
+            }
+
+            var hue = (h * 60.0f) / 360.0f;
+
+            var luminance = 0.30f * rgb.R + 0.59f * rgb.G + 0.11f * rgb.B;
+
+            return new Vector4(hue, C, luminance, rgb.A);
+        }
+
+        #endregion
+
         #endregion
 
         #region IEquatable<Color4> Members


### PR DESCRIPTION
Trying to bring our color support in line with other major graphic packages.

New methods on Color4 to convert between linear RGB and:
sRGB
Hue, Saturation, Lightness (HSL)
Hue, Saturation, Value (HSV)
CIE 1931 XYZ
YCbCr (which pretty much everyone seems to just call YUV, I'm not sure if we should follow suit here or rename the methods from YUV to YCbCr)
Hue, Chroma, Luminosity (HCY) (Y meaning luminance is very common, see YUV) 
