### PR TITLE
[Input] Add IsAnyKey/ButtonDown to Keyboard/MouseState.

### DIFF
--- a/Source/OpenTK/Input/GamePadButtons.cs
+++ b/Source/OpenTK/Input/GamePadButtons.cs
@@ -140,6 +140,19 @@ namespace OpenTK.Input
             get { return GetButton(Buttons.Start); }
         }
 
+        /// <summary>
+        /// Gets a value indicating whether any button is pressed.
+        /// </summary>
+        /// <value><c>true</c> if any button is pressed; otherwise, <c>false</c>.</value>
+        public bool IsAnyButtonPressed
+        {
+            get
+            {
+                // If any bit is set then a button is down.
+                return buttons != 0;
+            }
+        }
+
         /// <param name="left">A <see cref="GamePadButtons"/> instance to test for equality.</param>
         /// <param name="right">A <see cref="GamePadButtons"/> instance to test for equality.</param>
         public static bool operator ==(GamePadButtons left, GamePadButtons right)

--- a/Source/OpenTK/Input/JoystickState.cs
+++ b/Source/OpenTK/Input/JoystickState.cs
@@ -124,6 +124,19 @@ namespace OpenTK.Input
         }
 
         /// <summary>
+        /// Gets a value indicating whether any button is down.
+        /// </summary>
+        /// <value><c>true</c> if any button is down; otherwise, <c>false</c>.</value>
+        public bool IsAnyButtonDown
+        {
+            get
+            {
+                // If any bit is set then a button is down.
+                return buttons != 0;
+            }
+        }
+
+        /// <summary>
         /// Gets a value indicating whether this instance is connected.
         /// </summary>
         /// <value><c>true</c> if this instance is connected; otherwise, <c>false</c>.</value>

--- a/Source/OpenTK/Input/KeyboardState.cs
+++ b/Source/OpenTK/Input/KeyboardState.cs
@@ -39,7 +39,7 @@ namespace OpenTK.Input
         #region Fields
 
         // Allocate enough ints to store all keyboard keys
-        const int IntSize = sizeof(int);
+        const int IntSize = sizeof(int) * 8;
         const int NumInts = ((int)Key.LastKey + IntSize - 1) / IntSize;
         // The following line triggers bogus CS0214 in gmcs 2.0.1, sigh...
         unsafe fixed int Keys[NumInts];
@@ -106,6 +106,33 @@ namespace OpenTK.Input
         public bool IsKeyUp(short code)
         {
             return !IsKeyDown(code);
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether any key is down.
+        /// </summary>
+        /// <value><c>true</c> if any key is down; otherwise, <c>false</c>.</value>
+        public bool IsAnyKeyDown
+        {
+            get
+            {
+                // If any bit is set then a key is down.
+                unsafe
+                {
+                    fixed (int* k = Keys)
+                    {
+                        for(int i = 0; i < NumInts; ++i)
+                        {
+                            if (k[i] != 0)
+                            {
+                                return true;
+                            }
+                        }
+                    }
+                }
+
+                return false;
+            }
         }
 
         /// <summary>
@@ -226,8 +253,8 @@ namespace OpenTK.Input
         {
             ValidateOffset(offset);
 
-            int int_offset = offset / 32;
-            int bit_offset = offset % 32;
+            int int_offset = offset / IntSize;
+            int bit_offset = offset % IntSize;
             unsafe
             {
                 fixed (int* k = Keys) { return (*(k + int_offset) & (1 << bit_offset)) != 0u; }
@@ -238,8 +265,8 @@ namespace OpenTK.Input
         {
             ValidateOffset(offset);
 
-            int int_offset = offset / 32;
-            int bit_offset = offset % 32;
+            int int_offset = offset / IntSize;
+            int bit_offset = offset % IntSize;
             unsafe
             {
                 fixed (int* k = Keys) { *(k + int_offset) |= 1 << bit_offset; }
@@ -250,8 +277,8 @@ namespace OpenTK.Input
         {
             ValidateOffset(offset);
 
-            int int_offset = offset / 32;
-            int bit_offset = offset % 32;
+            int int_offset = offset / IntSize;
+            int bit_offset = offset % IntSize;
             unsafe
             {
                 fixed (int* k = Keys) { *(k + int_offset) &= ~(1 << bit_offset); }

--- a/Source/OpenTK/Input/MouseState.cs
+++ b/Source/OpenTK/Input/MouseState.cs
@@ -174,6 +174,19 @@ namespace OpenTK.Input
         }
 
         /// <summary>
+        /// Gets a value indicating whether any button is down.
+        /// </summary>
+        /// <value><c>true</c> if any button is down; otherwise, <c>false</c>.</value>
+        public bool IsAnyButtonDown
+        {
+            get
+            {
+                // If any bit is set then a button is down.
+                return buttons != 0;
+            }
+        }
+
+        /// <summary>
         /// Gets the absolute wheel position in integer units. This property is intended for XNA compatibility.
         /// To support high-precision mice, it is recommended to use <see cref="WheelPrecise"/> instead.
         /// </summary>


### PR DESCRIPTION
Adds properties to KeyboardState and MouseState to see if any key or button is
down. This should be faster than iterating over all the public IsDown
properties as we can make use of the internal bit fields.

Request from a [twitter conversation](https://twitter.com/Frassle/status/534817689945255937) with @Phrohdoh.