### PR TITLE
[Input] Legacy keyboard respects the KeyRepeat field.

### DIFF
--- a/Source/Examples/OpenTK/Test/GameWindowStates.cs
+++ b/Source/Examples/OpenTK/Test/GameWindowStates.cs
@@ -70,7 +70,7 @@ namespace Examples.Tests
             : base(800, 600, GraphicsMode.Default)
         {
             VSync = VSyncMode.On;
-            Keyboard.KeyRepeat = true;
+            Keyboard.KeyRepeat = false;
             KeyDown += KeyDownHandler;
             KeyUp += KeyUpHandler;
             KeyPress += KeyPressHandler;
@@ -159,22 +159,26 @@ namespace Examples.Tests
                     p = PointToScreen(p);
                     OpenTK.Input.Mouse.SetPosition(p.X, p.Y);
                     break;
+
+				case Key.R:
+					Keyboard.KeyRepeat = !Keyboard.KeyRepeat;
+					break;
             }
 
             if (!keyboard_keys.ContainsKey(e.Key))
             {
                 keyboard_keys.Add(e.Key, 0);
             }
-            keyboard_keys[e.Key] = e.IsRepeat ? 1 : 0;
+			keyboard_keys[e.Key] = keyboard_keys[e.Key] + 1;
             keyboard_modifiers = e.Modifiers;
             keyboard_state = e.Keyboard;
         }
 
         void KeyUpHandler(object sender, KeyboardKeyEventArgs e)
         {
-            keyboard_keys.Remove(e.Key);
-            keyboard_modifiers = e.Modifiers;
-            keyboard_state = e.Keyboard;
+			keyboard_keys.Remove(e.Key);
+			keyboard_modifiers = e.Modifiers;
+			keyboard_state = e.Keyboard;
         }
 
         void KeyboardDeviceDownHandler(object sender, KeyboardKeyEventArgs e)
@@ -183,14 +187,14 @@ namespace Examples.Tests
             {
                 legacy_keyboard_keys.Add(e.Key, 0);
             }
-            legacy_keyboard_keys[e.Key] = e.IsRepeat ? 1 : 0;
+			legacy_keyboard_keys[e.Key] = legacy_keyboard_keys[e.Key] + 1;
             legacy_keyboard_modifiers = e.Modifiers;
             legacy_keyboard_state = e.Keyboard;
         }
 
         void KeyboardDeviceUpHandler(object sender, KeyboardKeyEventArgs e)
         {
-            legacy_keyboard_keys.Remove(e.Key);
+			legacy_keyboard_keys.Remove(e.Key);
             legacy_keyboard_modifiers = e.Modifiers;
             legacy_keyboard_state = e.Keyboard;
         }

--- a/Source/OpenTK/Input/KeyboardDevice.cs
+++ b/Source/OpenTK/Input/KeyboardDevice.cs
@@ -210,7 +210,15 @@ namespace OpenTK.Input
         internal void HandleKeyDown(object sender, KeyboardKeyEventArgs e)
         {
             state = e.Keyboard;
-            KeyDown(this, e);
+            // KeyRepeat IsRepeat KeyDown
+            // False     False    True
+            // False     True     False
+            // True      False    True
+            // True      True     True
+            if (this.KeyRepeat || !e.IsRepeat)
+            {
+                KeyDown(this, e);
+            }
         }
 
         internal void HandleKeyUp(object sender, KeyboardKeyEventArgs e)
@@ -218,36 +226,6 @@ namespace OpenTK.Input
             state = e.Keyboard;
             KeyUp(this, e);
         }
-
-        #if false
-        internal void SetKey(Key key, uint scancode, KeyModifiers mods, bool pressed)
-        {
-            if (state[key] != pressed || KeyRepeat)
-            {
-                // limit scancode to 8bits, otherwise the assignment
-                // below will crash randomly
-                scancode &= 0xff;
-
-                keys[(int)key] = scancodes[scancode] = state;
-
-                if (state && KeyDown != null)
-                {
-
-                    args.Key = key;
-                    args.ScanCode = scancode;
-                    args.Modifiers = mods;
-                    KeyDown(this, args);
-                }
-                else if (!state && KeyUp != null)
-                {
-                    args.Key = key;
-                    args.ScanCode = scancode;
-                    args.Modifiers = mods;
-                    KeyUp(this, args);
-                }
-            }
-        }
-        #endif
 
         #endregion
     }


### PR DESCRIPTION
If the legacy keyboard device receives a key down event with IsRepeat set it
will only raise it's own key down event if it's KeyRepeat field is set to true.

This is as documented, regression casused by refactoring. Fixes issue #201.

Also change the GameWindowState example to show setting of KeyRepeat to true
and false and how that changes the event counts for the legacy and new keyboard
devices.
