### PR TITLE
Change security declartions of OpenTK

### DIFF
--- a/Source/Compatibility/Properties/AssemblyInfo.cs
+++ b/Source/Compatibility/Properties/AssemblyInfo.cs
@@ -13,7 +13,3 @@ using System.Runtime.InteropServices;
 [assembly: Guid("7c495044-4b1a-4bff-aee9-ff9dbf85433f")]
 
 [assembly: System.CLSCompliant(true)]
-[assembly: System.Security.AllowPartiallyTrustedCallers]
-#if NET40
-[assembly: System.Security.SecurityRules(System.Security.SecurityRuleSet.Level1)]
-#endif

--- a/Source/GLControl/Properties/AssemblyInfo.cs
+++ b/Source/GLControl/Properties/AssemblyInfo.cs
@@ -12,7 +12,3 @@ using System.Runtime.InteropServices;
 [assembly: Guid("5414b90b-d7be-4382-b0e1-f07ce154f7f7")]
 
 [assembly: System.CLSCompliant(true)]
-[assembly: System.Security.AllowPartiallyTrustedCallers]
-#if NET40
-[assembly: System.Security.SecurityRules(System.Security.SecurityRuleSet.Level1)]
-#endif

--- a/Source/OpenTK/Properties/AssemblyInfo.cs
+++ b/Source/OpenTK/Properties/AssemblyInfo.cs
@@ -13,7 +13,3 @@ using System.Runtime.InteropServices;
 [assembly: Guid("7652241e-158d-4eb1-85f4-ed40ee356791")]
 
 [assembly: CLSCompliant(true)]
-[assembly: System.Security.AllowPartiallyTrustedCallers]
-#if NET40
-[assembly: System.Security.SecurityRules(System.Security.SecurityRuleSet.Level1)]
-#endif


### PR DESCRIPTION
OpenTK was declared as safe for partially trusted callers but we never security gated native methods causing security requirements to fail with the new .NET 4 security model. The easy fix is to mark OpenTK as requiring default security (full trust).