### PR TITLE
Clarify OpenTK.dll.config use for #217

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,11 @@ OpenTK is available for Windows, Linux, Mac OS X, *BSD, SteamOS, Android and iOS
 Instructions
 ============
 
-The simplest way to use OpenTK in your project is to install the [NuGet package](http://www.nuget.org/packages/OpenTK/).
+The simplest way to use OpenTK in your project is to install the [NuGet package](http://www.nuget.org/packages/OpenTK/). 
+
+Note what installing NuGet package will add reference to OpenTK.dll, but OpenTK.dll.config 
+will not be copied to the project output directory automatically, so you need to add it to your project 
+and then enable the "Copy to Output Directory" option (as in step 3 below).
 
 Alternatively, download the [OpenTK binaries](http://www.opentk.com) and:
 


### PR DESCRIPTION
This adds note about OpenTK.dll.config use to the NuGet package installation instruction.