### PR TITLE
[Math] Fix NaN issue in CalculateAngle

### DIFF
--- a/Source/OpenTK/Math/Vector3.cs
+++ b/Source/OpenTK/Math/Vector3.cs
@@ -1205,7 +1205,9 @@ namespace OpenTK
         /// <remarks>Note that the returned angle is never bigger than the constant Pi.</remarks>
         public static float CalculateAngle(Vector3 first, Vector3 second)
         {
-            return (float)System.Math.Acos((Vector3.Dot(first, second)) / (first.Length * second.Length));
+            float result;
+            CalculateAngle(ref first, ref second, out result);
+            return result;
         }
 
         /// <summary>Calculates the angle (in radians) between two vectors.</summary>
@@ -1217,7 +1219,7 @@ namespace OpenTK
         {
             float temp;
             Vector3.Dot(ref first, ref second, out temp);
-            result = (float)System.Math.Acos(temp / (first.Length * second.Length));
+            result = (float)System.Math.Acos(MathHelper.Clamp(temp / (first.Length * second.Length), -1.0, 1.0));
         }
 
         #endregion

--- a/Source/OpenTK/Math/Vector3d.cs
+++ b/Source/OpenTK/Math/Vector3d.cs
@@ -1203,7 +1203,9 @@ namespace OpenTK
         /// <remarks>Note that the returned angle is never bigger than the constant Pi.</remarks>
         public static double CalculateAngle(Vector3d first, Vector3d second)
         {
-            return System.Math.Acos((Vector3d.Dot(first, second)) / (first.Length * second.Length));
+            double result;
+            CalculateAngle(ref first, ref second, out result);
+            return result;
         }
 
         /// <summary>Calculates the angle (in radians) between two vectors.</summary>
@@ -1215,7 +1217,7 @@ namespace OpenTK
         {
             double temp;
             Vector3d.Dot(ref first, ref second, out temp);
-            result = System.Math.Acos(temp / (first.Length * second.Length));
+            result = System.Math.Acos(MathHelper.Clamp(temp / (first.Length * second.Length), -1.0, 1.0));
         }
 
         #endregion


### PR DESCRIPTION
Clamp dot product between -1 and 1 so acos always has a valid input.

Fixes #222.