### PR TITLE
Set Linux joystick as connected by default

### DIFF
--- a/Source/OpenTK/Platform/Linux/LinuxJoystick.cs
+++ b/Source/OpenTK/Platform/Linux/LinuxJoystick.cs
@@ -321,6 +321,9 @@ namespace OpenTK.Platform.Linux
 
                             stick.Caps = new JoystickCapabilities(axes, buttons, hats, false);
 
+                            stick.Caps.SetIsConnected(true);
+                            stick.State.SetIsConnected(true);
+
                             // Poll the joystick once, to initialize its state
                             PollJoystick(stick);
                         }
@@ -373,12 +376,6 @@ namespace OpenTK.Platform.Linux
                     length = (long)Libc.read(js.FileDescriptor, (void*)events, (UIntPtr)(sizeof(InputEvent) * EventCount));
                     if (length <= 0)
                         break;
-
-                    // Only mark the joystick as connected when we actually start receiving events.
-                    // Otherwise, the Xbox wireless receiver will register 4 joysticks even if no
-                    // actual joystick is connected to the receiver.
-                    js.Caps.SetIsConnected(true);
-                    js.State.SetIsConnected(true);
 
                     length /= sizeof(InputEvent);
                     for (int i = 0; i < length; i++)


### PR DESCRIPTION
So this:
```
// Only mark the joystick as connected when we actually start receiving events.
// Otherwise, the Xbox wireless receiver will register 4 joysticks even if no
// actual joystick is connected to the receiver.
```
is incorrect.

Let me explain, unlike Windows, on Linux to get wireless Xbox360 controller working you need a driver called xboxdrv. Every time you want to use the controller, you need to start it from terminal or setup a startup script. For each controller you have, you have to launch an instance of xboxdrv (https://github.com/petrockblog/RetroPie-Setup/wiki/Setting-up-the-XBox360-controller). 

Now the problem/misconception comes from ubuntu-xboxdrv (https://github.com/raelgc/ubuntu_xboxdrv). This package is meant for Ubuntu and it just contains a configuration for xboxdrv that has 4 xboxdrv instances set to launch immediately when system starts up.