### PR TITLE
X11: Fix so ClientSize can resize windows with fixed borders

### DIFF
--- a/Source/OpenTK/Platform/NativeWindowBase.cs
+++ b/Source/OpenTK/Platform/NativeWindowBase.cs
@@ -417,8 +417,7 @@ namespace OpenTK.Platform
             }
             set
             {
-                Rectangle old = ClientRectangle;
-                ClientRectangle = new Rectangle(old.X, old.Y, value, old.Height);
+                ClientSize = new Size(value, ClientSize.Height);
             }
         }
 
@@ -430,8 +429,7 @@ namespace OpenTK.Platform
             }
             set
             {
-                Rectangle old = ClientRectangle;
-                Bounds = new Rectangle(old.X, old.Y, old.Width, value);
+                ClientSize = new Size(ClientSize.Width, value);
             }
         }
 

--- a/Source/OpenTK/Platform/X11/X11GLNative.cs
+++ b/Source/OpenTK/Platform/X11/X11GLNative.cs
@@ -1072,11 +1072,25 @@ namespace OpenTK.Platform.X11
             }
             set
             {
+                bool is_size_changed = client_rectangle.Size != value;
+
+                int width = value.Width;
+                int height = value.Height;
+
+                if (WindowBorder != WindowBorder.Resizable)
+                {
+                    SetWindowMinMax(width, height, width, height);
+                }
+
                 using (new XLock(window.Display))
                 {
-                    Functions.XResizeWindow(window.Display, window.Handle,
-                        value.Width, value.Height);
+                    if (is_size_changed)
+                    {
+                        Functions.XResizeWindow(window.Display, window.Handle,
+                            width, height);
+                    }
                 }
+
                 ProcessEvents();
             }
         }


### PR DESCRIPTION
Also fixes issue that NativeWindowBase.Height was setting non-client
height but Width was setting client Width. Both now set client size.

Fixes #259