### PR TITLE
[Input] Fix keyboard layout issues on Windows

### DIFF
--- a/Source/OpenTK/Input/Key.cs
+++ b/Source/OpenTK/Input/Key.cs
@@ -2,7 +2,7 @@
  //
  // The Open Toolkit Library License
  //
- // Copyright (c) 2006 - 2009 the Open Toolkit library.
+ // Copyright (c) 2006 - 2015 the Open Toolkit library.
  //
  // Permission is hereby granted, free of charge, to any person obtaining a copy
  // of this software and associated documentation files (the "Software"), to deal
@@ -342,39 +342,99 @@ namespace OpenTK.Input
         /// <summary>The number 9 key.</summary>
         Number9,
     
+        // Oem
+        /// <summmary>
+        /// Used for miscellaneous characters; it can vary by keyboard.
+        /// For the US standard keyboard, the ';:' key.
+        /// </summmary>
+        Oem1,
+        /// <summmary>
+        /// Used for miscellaneous characters; it can vary by keyboard.
+        /// For the US standard keyboard, the '/?' key.
+        /// </summmary>
+        Oem2,
+        /// <summmary>
+        /// Used for miscellaneous characters; it can vary by keyboard.
+        /// For the US standard keyboard, the '`~' key.
+        /// </summmary>
+        Oem3,
+        /// <summmary>
+        /// Used for miscellaneous characters; it can vary by keyboard.
+        /// For the US standard keyboard, the '[{' key.
+        /// </summmary>
+        Oem4,
+        /// <summmary>
+        /// Used for miscellaneous characters; it can vary by keyboard.
+        /// For the US standard keyboard, the '\|' key.
+        /// </summmary>
+        Oem5,
+        /// <summmary>
+        /// Used for miscellaneous characters; it can vary by keyboard.
+        /// For the US standard keyboard, the ']}' key.
+        /// </summmary>
+        Oem6,
+        /// <summmary>
+        /// Used for miscellaneous characters; it can vary by keyboard.
+        /// For the US standard keyboard, the 'single-quote/double-quote' key.
+        /// </summmary>
+        Oem7,
+        /// <summmary>
+        /// Used for miscellaneous characters; it can vary by keyboard.
+        /// </summmary>
+        Oem8,
+        /// <summmary>
+        /// Either the angle bracket key or the backslash key on the RT 102-key keyboard.
+        /// </summmary>
+        Oem102,
+
         // Symbols
-        /// <summary>The tilde key.</summary>
-        Tilde,
-        /// <summary>The grave key (equivaent to Tilde).</summary>
-        Grave = Tilde,
+
         /// <summary>The minus key.</summary>
         Minus,
-        //Equal,
         /// <summary>The plus key.</summary>
         Plus,
-        /// <summary>The left bracket key.</summary>
-        BracketLeft,
-        /// <summary>The left bracket key (equivalent to BracketLeft).</summary>
-        LBracket = BracketLeft,
-        /// <summary>The right bracket key.</summary>
-        BracketRight,
-        /// <summary>The right bracket key (equivalent to BracketRight).</summary>
-        RBracket = BracketRight,
-        /// <summary>The semicolon key.</summary>
-        Semicolon,
-        /// <summary>The quote key.</summary>
-        Quote,
         /// <summary>The comma key.</summary>
         Comma,
         /// <summary>The period key.</summary>
         Period,
-        /// <summary>The slash key.</summary>
-        Slash,
-        /// <summary>The backslash key.</summary>
-        BackSlash,
-        /// <summary>The secondary backslash key.</summary>
-        NonUSBackSlash,
+
         /// <summary>Indicates the last available keyboard key.</summary>
-        LastKey
+        LastKey,
+
+        #region Deprecated keys
+        /// <summary>The tilde key (equivaent to Oem3).</summary>
+        [System.Obsolete("Use Oem3 instead.")]
+        Tilde = Oem3,
+        /// <summary>The grave key (equivaent to Oem3).</summary>
+        [System.Obsolete("Use Oem3 instead.")]
+        Grave = Oem3,
+        /// <summary>The left bracket key (equivalent to Oem4).</summary>
+        [System.Obsolete("Use Oem4 instead.")]
+        BracketLeft = Oem4,
+        /// <summary>The left bracket key (equivalent to Oem4).</summary>
+        [System.Obsolete("Use Oem4 instead.")]
+        LBracket = Oem4,
+        /// <summary>The right bracket key (equivalent to Oem6).</summary>
+        [System.Obsolete("Use Oem6 instead.")]
+        BracketRight = Oem6,
+        /// <summary>The right bracket key (equivalent to Oem6).</summary>
+        [System.Obsolete("Use Oem6 instead.")]
+        RBracket = Oem6,
+        /// <summary>The semicolon key (equivalent to Oem1).</summary>
+        [System.Obsolete("Use Oem1 instead.")]
+        Semicolon = Oem1,
+        /// <summary>The quote key (equivalent to Oem7).</summary>
+        [System.Obsolete("Use Oem7 instead.")]
+        Quote = Oem7,
+        /// <summary>The slash key (equivalent Oem2).</summary>
+        [System.Obsolete("Use Oem2 instead.")]
+        Slash = Oem2,
+        /// <summary>The backslash key (equivalent to Oem5).</summary>
+        [System.Obsolete("Use Oem5 instead.")]
+        BackSlash = Oem5,
+        /// <summary>The secondary backslash key (equivalent to Oem102).</summary>
+        [System.Obsolete("Use Oem102 instead.")]
+        NonUSBackSlash = Oem102,
+        #endregion
     }
 }

--- a/Source/OpenTK/Platform/Windows/API.cs
+++ b/Source/OpenTK/Platform/Windows/API.cs
@@ -8,6 +8,10 @@
 // Copyright (c) 2006 Stefanos Apostolopoulos
 // Copyright (c) 2007 Erik Ylvisaker
 //
+// The Open Toolkit Library License
+//
+// Copyright (c) 2015 the Open Toolkit library
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
@@ -683,10 +687,6 @@ namespace OpenTK.Platform.Windows
         [System.Security.SuppressUnmanagedCodeSecurity]
         [DllImport("user32.dll", SetLastError = true)]
         internal static extern UINT MapVirtualKey(UINT uCode, MapVirtualKeyType uMapType);
-
-        [System.Security.SuppressUnmanagedCodeSecurity]
-        [DllImport("user32.dll", SetLastError = true)]
-        internal static extern UINT MapVirtualKey(VirtualKeys vkey, MapVirtualKeyType uMapType);
 
         #endregion
 
@@ -3828,9 +3828,51 @@ namespace OpenTK.Platform.Windows
         
         /*
          * 0 - 9 are the same as ASCII '0' - '9' (0x30 - 0x39)
+         */
+        D0 = 0x30,
+        D1 = 0x31,
+        D2 = 0x32,
+        D3 = 0x33,
+        D4 = 0x34,
+        D5 = 0x35,
+        D6 = 0x36,
+        D7 = 0x37,
+        D8 = 0x38,
+        D9 = 0x39,
+
+        /*
          * 0x40 : unassigned
+         */
+
+        /*
          * A - Z are the same as ASCII 'A' - 'Z' (0x41 - 0x5A)
          */
+        A = 0x41,
+        B = 0x42,
+        C = 0x43,
+        D = 0x44,
+        E = 0x45,
+        F = 0x46,
+        G = 0x47,
+        H = 0x48,
+        I = 0x49,
+        J = 0x4A,
+        K = 0x4B,
+        L = 0x4C,
+        M = 0x4D,
+        N = 0x4E,
+        O = 0x4F,
+        P = 0x50,
+        Q = 0x51,
+        R = 0x52,
+        S = 0x53,
+        T = 0x54,
+        U = 0x55,
+        V = 0x56,
+        W = 0x57,
+        X = 0x58,
+        Y = 0x59,
+        Z = 0x5A,
 
         LWIN         = 0x5B,
         RWIN         = 0x5C,

--- a/Source/OpenTK/Platform/Windows/WinGLNative.cs
+++ b/Source/OpenTK/Platform/Windows/WinGLNative.cs
@@ -2,7 +2,7 @@
 //
 // The Open Toolkit Library License
 //
-// Copyright (c) 2006 - 2009 the Open Toolkit library.
+// Copyright (c) 2006 - 2015 the Open Toolkit library.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -81,15 +81,6 @@ namespace OpenTK.Platform.Windows
         Icon icon;
 
         const ClassStyle DefaultClassStyle = ClassStyle.OwnDC;
-
-        const long ExtendedBit = 1 << 24;           // Used to distinguish left and right control, alt and enter keys.
-
-        public static readonly uint ShiftLeftScanCode = Functions.MapVirtualKey(VirtualKeys.LSHIFT, 0);
-        public static readonly uint ShiftRightScanCode = Functions.MapVirtualKey(VirtualKeys.RSHIFT, 0);
-        public static readonly uint ControlLeftScanCode = Functions.MapVirtualKey(VirtualKeys.LCONTROL, 0);
-        public static readonly uint ControlRightScanCode = Functions.MapVirtualKey(VirtualKeys.RCONTROL, 0);
-        public static readonly uint AltLeftScanCode = Functions.MapVirtualKey(VirtualKeys.LMENU, 0);
-        public static readonly uint AltRightScanCode = Functions.MapVirtualKey(VirtualKeys.RMENU, 0);
 
         MouseCursor cursor = MouseCursor.Default;
         IntPtr cursor_handle = Functions.LoadCursor(CursorName.Arrow);
@@ -579,14 +570,15 @@ namespace OpenTK.Platform.Windows
             // Win95 does not distinguish left/right key constants (GetAsyncKeyState returns 0).
             // In this case, both keys will be reported as pressed.
 
-            bool extended = (lParam.ToInt64() & ExtendedBit) != 0;
-            short scancode = (short)((lParam.ToInt64() >> 16) & 0xff);
-            //ushort repeat_count = unchecked((ushort)((ulong)lParam.ToInt64() & 0xffffu));
-            VirtualKeys vkey = (VirtualKeys)wParam;
-            bool is_valid;
-            Key key = WinKeyMap.TranslateKey(scancode, vkey, extended, false, out is_valid);
+            // Used to distinguish left and right control, alt and enter keys.
+            bool extended = (lParam.ToInt64() & (1 << 24)) != 0;
 
-            if (is_valid)
+            int scancode = (int)((lParam.ToInt64() >> 16) & 0xFF);
+            VirtualKeys vkey = (VirtualKeys)(wParam.ToInt32());
+
+            Key key = WinKeyMap.TranslateKey(scancode, vkey, extended, false);
+
+            if (key != Key.Unknown)
             {
                 if (pressed)
                 {

--- a/Source/OpenTK/Platform/Windows/WinKeyMap.cs
+++ b/Source/OpenTK/Platform/Windows/WinKeyMap.cs
@@ -2,7 +2,7 @@
 //
 // The Open Toolkit Library License
 //
-// Copyright (c) 2006 - 2010 the Open Toolkit library.
+// Copyright (c) 2006 - 2015 the Open Toolkit library.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -34,187 +34,270 @@ namespace OpenTK.Platform.Windows
 {
     static class WinKeyMap
     {
-        public static Key GetKey(int code)
+        public static Key TranslateKey(VirtualKeys vk)
         {
-            switch (code)
+            switch (vk)
             {
-                // 0 - 15
-                case 0: return Key.Unknown;
-                case 1: return Key.Escape;
-                case 2: return Key.Number1;
-                case 3: return Key.Number2;
-                case 4: return Key.Number3;
-                case 5: return Key.Number4;
-                case 6: return Key.Number5;
-                case 7: return Key.Number6;
-                case 8: return Key.Number7;
-                case 9: return Key.Number8;
-                case 10: return Key.Number9;
-                case 11: return Key.Number0;
-                case 12: return Key.Minus;
-                case 13: return Key.Plus;
-                case 14: return Key.BackSpace;
-                case 15: return Key.Tab;
-
-                // 16-31
-                case 16: return Key.Q;
-                case 17: return Key.W;
-                case 18: return Key.E;
-                case 19: return Key.R;
-                case 20: return Key.T;
-                case 21: return Key.Y;
-                case 22: return Key.U;
-                case 23: return Key.I;
-                case 24: return Key.O;
-                case 25: return Key.P;
-                case 26: return Key.BracketLeft;
-                case 27: return Key.BracketRight;
-                case 28: return Key.Enter;
-                case 29: return Key.ControlLeft;
-                case 30: return Key.A;
-                case 31: return Key.S;
-
-                // 32 - 47
-                case 32: return Key.D;
-                case 33: return Key.F;
-                case 34: return Key.G;
-                case 35: return Key.H;
-                case 36: return Key.J;
-                case 37: return Key.K;
-                case 38: return Key.L;
-                case 39: return Key.Semicolon;
-                case 40: return Key.Quote;
-                case 41: return Key.Grave;
-                case 42: return Key.ShiftLeft;
-                case 43: return Key.BackSlash;
-                case 44: return Key.Z;
-                case 45: return Key.X;
-                case 46: return Key.C;
-                case 47: return Key.V;
-
-                // 48 - 63
-                case 48: return Key.B;
-                case 49: return Key.N;
-                case 50: return Key.M;
-                case 51: return Key.Comma;
-                case 52: return Key.Period;
-                case 53: return Key.Slash;
-                case 54: return Key.ShiftRight;
-                case 55: return Key.PrintScreen;
-                case 56: return Key.AltLeft;
-                case 57: return Key.Space;
-                case 58: return Key.CapsLock;
-                case 59: return Key.F1;
-                case 60: return Key.F2;
-                case 61: return Key.F3;
-                case 62: return Key.F4;
-                case 63: return Key.F5;
-
-                // 64 - 79
-                case 64: return Key.F6;
-                case 65: return Key.F7;
-                case 66: return Key.F8;
-                case 67: return Key.F9;
-                case 68: return Key.F10;
-                case 69: return Key.NumLock;
-                case 70: return Key.ScrollLock;
-                case 71: return Key.Home;
-                case 72: return Key.Up;
-                case 73: return Key.PageUp;
-                case 74: return Key.KeypadMinus;
-                case 75: return Key.Left;
-                case 76: return Key.Keypad5;
-                case 77: return Key.Right;
-                case 78: return Key.KeypadPlus;
-                case 79: return Key.End;
-
-                // 80 - 95
-                case 80: return Key.Down;
-                case 81: return Key.PageDown;
-                case 82: return Key.Insert;
-                case 83: return Key.Delete;
-                case 84: return Key.Unknown;
-                case 85: return Key.Unknown;
-                case 86: return Key.NonUSBackSlash;
-                case 87: return Key.F11;
-                case 88: return Key.F12;
-                case 89: return Key.Pause;
-                case 90: return Key.Unknown;
-                case 91: return Key.WinLeft;
-                case 92: return Key.WinRight;
-                case 93: return Key.Menu;
-                case 94: return Key.Unknown;
-                case 95: return Key.Unknown;
-
-                // 96 - 106
-                case 96: return Key.Unknown;
-                case 97: return Key.Unknown;
-                case 98: return Key.Unknown;
-                case 99: return Key.Unknown;
-                case 100: return Key.F13;
-                case 101: return Key.F14;
-                case 102: return Key.F15;
-                case 103: return Key.F16;
-                case 104: return Key.F17;
-                case 105: return Key.F18;
-                case 106: return Key.F19;
-
-                default: return Key.Unknown;
+                // case VirtualKeys.LBUTTON: //Left mouse button
+                // case VirtualKeys.RBUTTON: //Right mouse button
+                // case VirtualKeys.CANCEL: //Control-break processing
+                // case VirtualKeys.MBUTTON: //Middle mouse button (three-button mouse)
+                // case VirtualKeys.XBUTTON1: //X1 mouse button
+                // case VirtualKeys.XBUTTON2: //X2 mouse button
+                // 0x07 Undefined
+                case VirtualKeys.BACK: return Key.BackSpace; //BACKSPACE key
+                case VirtualKeys.TAB: return Key.Tab; //TAB key
+                // 0x0A-0B Reserved
+                case VirtualKeys.CLEAR: return Key.Clear; //CLEAR key
+                case VirtualKeys.RETURN: return Key.Enter; //ENTER key
+                // 0x0E-0F Undefined
+                case VirtualKeys.SHIFT: return Key.ShiftLeft; //SHIFT key
+                case VirtualKeys.CONTROL: return Key.ControlLeft; //CTRL key
+                case VirtualKeys.MENU: return Key.AltLeft; //ALT key
+                case VirtualKeys.PAUSE: return Key.Pause; //PAUSE key
+                case VirtualKeys.CAPITAL: return Key.CapsLock; //CAPS LOCK key
+                //case VirtualKeys.KANA: //IME Kana mode
+                //case VirtualKeys.HANGUEL: //IME Hanguel mode (maintained for compatibility; use VK_HANGUL)
+                //case VirtualKeys.HANGUL: //IME Hangul mode
+                // 0x16 Undefined
+                // case VirtualKeys.JUNJA: //IME Junja mode
+                // case VirtualKeys.FINAL: //IME final mode
+                // case VirtualKeys.HANJA: //IME Hanja mode
+                // case VirtualKeys.KANJI: //IME Kanji mode
+                // 0x1A Undefined
+                case VirtualKeys.ESCAPE: return Key.Escape; //ESC key
+                //case VirtualKeys.CONVERT: //IME convert
+                //case VirtualKeys.NONCONVERT: //IME nonconvert
+                //case VirtualKeys.ACCEPT: //IME accept
+                //case VirtualKeys.MODECHANGE: //IME mode change request
+                case VirtualKeys.SPACE: return Key.Space; //SPACEBAR
+                case VirtualKeys.PRIOR: return Key.PageUp; //PAGE UP key
+                case VirtualKeys.NEXT: return Key.PageDown; //PAGE DOWN key
+                case VirtualKeys.END: return Key.End; //END key
+                case VirtualKeys.HOME: return Key.Home; //HOME key
+                case VirtualKeys.LEFT: return Key.Left; //LEFT ARROW key
+                case VirtualKeys.UP: return Key.Up; //UP ARROW key
+                case VirtualKeys.RIGHT: return Key.Right; //RIGHT ARROW key
+                case VirtualKeys.DOWN: return Key.Down; //DOWN ARROW key
+                //case VirtualKeys.SELECT: //SELECT key
+                //case VirtualKeys.PRINT: //PRINT key
+                //case VirtualKeys.EXECUTE: return Key; //EXECUTE key
+                case VirtualKeys.SNAPSHOT: return Key.PrintScreen; //PRINT SCREEN key
+                case VirtualKeys.INSERT: return Key.Insert; //INS key
+                case VirtualKeys.DELETE: return Key.Delete; //DEL key
+                //case VirtualKeys.HELP: //HELP key
+                case VirtualKeys.D0: return Key.Number0;
+                case VirtualKeys.D1: return Key.Number1;
+                case VirtualKeys.D2: return Key.Number2;
+                case VirtualKeys.D3: return Key.Number3;
+                case VirtualKeys.D4: return Key.Number4;
+                case VirtualKeys.D5: return Key.Number5;
+                case VirtualKeys.D6: return Key.Number6;
+                case VirtualKeys.D7: return Key.Number7;
+                case VirtualKeys.D8: return Key.Number8;
+                case VirtualKeys.D9: return Key.Number9;
+                // 0x3A-40 Undefined
+                case VirtualKeys.A: return Key.A;
+                case VirtualKeys.B: return Key.B;
+                case VirtualKeys.C: return Key.C;
+                case VirtualKeys.D: return Key.D;
+                case VirtualKeys.E: return Key.E;
+                case VirtualKeys.F: return Key.F;
+                case VirtualKeys.G: return Key.G;
+                case VirtualKeys.H: return Key.H;
+                case VirtualKeys.I: return Key.I;
+                case VirtualKeys.J: return Key.J;
+                case VirtualKeys.K: return Key.K;
+                case VirtualKeys.L: return Key.L;
+                case VirtualKeys.M: return Key.M;
+                case VirtualKeys.N: return Key.N;
+                case VirtualKeys.O: return Key.O;
+                case VirtualKeys.P: return Key.P;
+                case VirtualKeys.Q: return Key.Q;
+                case VirtualKeys.R: return Key.R;
+                case VirtualKeys.S: return Key.S;
+                case VirtualKeys.T: return Key.T;
+                case VirtualKeys.U: return Key.U;
+                case VirtualKeys.V: return Key.V;
+                case VirtualKeys.W: return Key.W;
+                case VirtualKeys.X: return Key.X;
+                case VirtualKeys.Y: return Key.Y;
+                case VirtualKeys.Z: return Key.Z;
+                case VirtualKeys.LWIN: return Key.WinLeft; //Left Windows key (Natural keyboard)
+                case VirtualKeys.RWIN: return Key.WinRight; //Right Windows key (Natural keyboard)
+                case VirtualKeys.APPS: return Key.Menu; //Applications key (Natural keyboard)
+                // 0x5E Reserved
+                case VirtualKeys.SLEEP: return Key.Sleep; //Computer Sleep key
+                case VirtualKeys.NUMPAD0: return Key.Keypad0; //Numeric keypad 0 key
+                case VirtualKeys.NUMPAD1: return Key.Keypad1; //Numeric keypad 1 key
+                case VirtualKeys.NUMPAD2: return Key.Keypad2; //Numeric keypad 2 key
+                case VirtualKeys.NUMPAD3: return Key.Keypad3; //Numeric keypad 3 key
+                case VirtualKeys.NUMPAD4: return Key.Keypad4; //Numeric keypad 4 key
+                case VirtualKeys.NUMPAD5: return Key.Keypad5; //Numeric keypad 5 key
+                case VirtualKeys.NUMPAD6: return Key.Keypad6; //Numeric keypad 6 key
+                case VirtualKeys.NUMPAD7: return Key.Keypad7; //Numeric keypad 7 key
+                case VirtualKeys.NUMPAD8: return Key.Keypad8; //Numeric keypad 8 key
+                case VirtualKeys.NUMPAD9: return Key.Keypad9; //Numeric keypad 9 key
+                case VirtualKeys.MULTIPLY: return Key.KeypadMultiply; //Multiply key
+                case VirtualKeys.ADD: return Key.KeypadAdd; //Add key
+                //case VirtualKeys.SEPARATOR: //Separator key
+                case VirtualKeys.SUBTRACT: return Key.KeypadSubtract; //Subtract key
+                case VirtualKeys.DECIMAL: return Key.KeypadDecimal; //Decimal key
+                case VirtualKeys.DIVIDE: return Key.KeypadDivide; //Divide key
+                case VirtualKeys.F1: return Key.F1; //F1 key
+                case VirtualKeys.F2: return Key.F2; //F2 key
+                case VirtualKeys.F3: return Key.F3; //F3 key
+                case VirtualKeys.F4: return Key.F4; //F4 key
+                case VirtualKeys.F5: return Key.F5; //F5 key
+                case VirtualKeys.F6: return Key.F6; //F6 key
+                case VirtualKeys.F7: return Key.F7; //F7 key
+                case VirtualKeys.F8: return Key.F8; //F8 key
+                case VirtualKeys.F9: return Key.F9; //F9 key
+                case VirtualKeys.F10: return Key.F10; //F10 key
+                case VirtualKeys.F11: return Key.F11; //F11 key
+                case VirtualKeys.F12: return Key.F12; //F12 key
+                case VirtualKeys.F13: return Key.F13; //F13 key
+                case VirtualKeys.F14: return Key.F14; //F14 key
+                case VirtualKeys.F15: return Key.F15; //F15 key
+                case VirtualKeys.F16: return Key.F16; //F16 key
+                case VirtualKeys.F17: return Key.F17; //F17 key
+                case VirtualKeys.F18: return Key.F18; //F18 key
+                case VirtualKeys.F19: return Key.F19; //F19 key
+                case VirtualKeys.F20: return Key.F20; //F20 key
+                case VirtualKeys.F21: return Key.F21; //F21 key
+                case VirtualKeys.F22: return Key.F22; //F22 key
+                case VirtualKeys.F23: return Key.F23; //F23 key
+                case VirtualKeys.F24: return Key.F24; //F24 key
+                // 0x88-8F Unassigned
+                case VirtualKeys.NUMLOCK: return Key.NumLock; //NUM LOCK key
+                case VirtualKeys.SCROLL: return Key.ScrollLock; //SCROLL LOCK key 
+                // 0x92-96 OEM specific
+                // 0x97-9F Unassigned
+                case VirtualKeys.LSHIFT: return Key.ShiftLeft; //Left SHIFT key
+                case VirtualKeys.RSHIFT: return Key.ShiftRight; //Right SHIFT key
+                case VirtualKeys.LCONTROL: return Key.ControlLeft; //Left CONTROL key
+                case VirtualKeys.RCONTROL: return Key.ControlRight; //Right CONTROL key
+                case VirtualKeys.LMENU: return Key.AltLeft; //Left MENU key
+                case VirtualKeys.RMENU: return Key.AltRight; //Right MENU key
+                //case VirtualKeys.BROWSER_BACK: //Browser Back key
+                //case VirtualKeys.BROWSER_FORWARD: //Browser Forward key
+                //case VirtualKeys.BROWSER_REFRESH: //Browser Refresh key
+                //case VirtualKeys.BROWSER_STOP: //Browser Stop key
+                //case VirtualKeys.BROWSER_SEARCH: //Browser Search key
+                //case VirtualKeys.BROWSER_FAVORITES: //Browser Favorites key
+                //case VirtualKeys.BROWSER_HOME: //Browser Start and Home key
+                //case VirtualKeys.VOLUME_MUTE: //Volume Mute key
+                //case VirtualKeys.VOLUME_DOWN: //Volume Down key
+                //case VirtualKeys.VOLUME_UP: //Volume Up key
+                //case VirtualKeys.MEDIA_NEXT_TRACK: //Next Track key
+                //case VirtualKeys.MEDIA_PREV_TRACK: //Previous Track key
+                //case VirtualKeys.MEDIA_STOP: //Stop Media key
+                //case VirtualKeys.MEDIA_PLAY_PAUSE: //Play/Pause Media key
+                //case VirtualKeys.LAUNCH_MAIL: //Start Mail key
+                //case VirtualKeys.LAUNCH_MEDIA_SELECT: //Select Media key
+                //case VirtualKeys.LAUNCH_APP1: //Start Application 1 key
+                //case VirtualKeys.LAUNCH_APP2: //Start Application 2 key
+                // 0xB8-B9 Reserved
+                case VirtualKeys.OEM_1: return Key.Oem1; //Used for miscellaneous characters; it can vary by keyboard. For the US standard keyboard, the ';: ' key
+                case VirtualKeys.OEM_PLUS: return Key.Plus; //For any country/region, the '+' key
+                case VirtualKeys.OEM_COMMA: return Key.Comma; //For any country/region, the ',' key
+                case VirtualKeys.OEM_MINUS: return Key.Minus; //For any country/region, the '// -' key
+                case VirtualKeys.OEM_PERIOD: return Key.Period; //For any country/region, the '.' key
+                case VirtualKeys.OEM_2: return Key.Oem2; //Used for miscellaneous characters; it can vary by keyboard. For the US standard keyboard, the '/?' key
+                case VirtualKeys.OEM_3: return Key.Oem3; //Used for miscellaneous characters; it can vary by keyboard. For the US standard keyboard, the '`~' key
+                // 0xC1-D7 Reserved
+                // 0xD8-DA Unassigned
+                case VirtualKeys.OEM_4: return Key.Oem4; //Used for miscellaneous characters; it can vary by keyboard. For the US standard keyboard, the '[{' key
+                case VirtualKeys.OEM_5: return Key.Oem5; //Used for miscellaneous characters; it can vary by keyboard. For the US standard keyboard, the '\|' key
+                case VirtualKeys.OEM_6: return Key.Oem6; //Used for miscellaneous characters; it can vary by keyboard. For the US standard keyboard, the ']}' key
+                case VirtualKeys.OEM_7: return Key.Oem7; //Used for miscellaneous characters; it can vary by keyboard. For the US standard keyboard, the 'single-quote/double-quote' key
+                case VirtualKeys.OEM_8: return Key.Oem8; //Used for miscellaneous characters; it can vary by keyboard.
+                // 0xE0 Reserved
+                // 0xE1 OEM specific
+                case VirtualKeys.OEM_102: return Key.Oem102; //Either the angle bracket key or the backslash key on the RT 102-key keyboard
+                // 0xE3-E4 OEM specific
+                //case VirtualKeys.PROCESSKEY: //IME PROCESS key
+                // 0xE6 OEM specific
+                //case VirtualKeys.PACKET: //Used to pass Unicode characters as if they were keystrokes. The case VirtualKeys.PACKET: key is the low word of a 32-bit Virtual Key value used for non-keyboard input methods. For more information, see Remark in KEYBDINPUT, SendInput, WM_KEYDOWN, and WM_KEYUP
+                // 0xE8 Unassigned
+                // 0xE9-F5 OEM specific
+                //case VirtualKeys.ATTN: //Attn key
+                //case VirtualKeys.CRSEL: //CrSel key
+                //case VirtualKeys.EXSEL: //ExSel key
+                //case VirtualKeys.EREOF: //Erase EOF key
+                //case VirtualKeys.PLAY: //Play key
+                //case VirtualKeys.ZOOM: //Zoom key
+                //case VirtualKeys.NONAME: //Reserved
+                //case VirtualKeys.PA1: //PA1 key
+                //case VirtualKeys.OEM_CLEAR: //Clear key
             }
+
+            return Key.Unknown;
         }
 
-        public static Key TranslateKey(short scancode, VirtualKeys vkey, bool extended0, bool extended1, out bool is_valid)
+        public static Key TranslateKey(int scancode, VirtualKeys vkey, bool extended0, bool extended1)
         {
-            is_valid = true;
+            // Starting with Windows Vista, the high byte of the uCode value 
+            // can contain either 0xe0 or 0xe1 to specify the extended scan code.
+            scancode |= (int)(extended0 ? 0xE000 : 0);
+            scancode |= (int)(extended1 ? 0xE100 : 0);
 
-            Key key = GetKey(scancode);
+            // Map the scan code to a virtual key, we can't just use vkey passed 
+            // in by windows message here as that isn't decoded taking the 
+            // extended bit into account.
+            VirtualKeys mapped_vkey = (VirtualKeys)Functions.MapVirtualKey(
+                (uint)scancode, MapVirtualKeyType.ScanCodeToVirtualKeyExtended);
 
-            if (!extended0)
+            // Some keys aren't handled by MapVirtualKey, so we translate them
+            // here checking against the extended flags and original virtual
+            // key code them up here
+            if (extended0)
             {
-                switch (key)
+                if(vkey == VirtualKeys.NUMLOCK)
                 {
-                    case Key.Insert: key = Key.Keypad0; break;
-                    case Key.End: key = Key.Keypad1; break;
-                    case Key.Down: key = Key.Keypad2; break;
-                    case Key.PageDown: key = Key.Keypad3; break;
-                    case Key.Left: key = Key.Keypad4; break;
-                    case Key.Right: key = Key.Keypad6; break;
-                    case Key.Home: key = Key.Keypad7; break;
-                    case Key.Up: key = Key.Keypad8; break;
-                    case Key.PageUp: key = Key.Keypad9; break;
-                    case Key.PrintScreen: key = Key.KeypadMultiply; break;
-                    case Key.Delete: key = Key.KeypadDecimal; break;
-                    case Key.NumLock:
-                        if (vkey == VirtualKeys.Last)
-                            is_valid = false;
-                        else if (vkey == VirtualKeys.PAUSE)
-                            key = Key.Pause;
-                        break;
+                    // NumLock has extended bit set and isn't translated at all 
+                    // by MapVirtualKey (it returns zero), but the standard 
+                    // vkey reports numlock correctly.
+                    return Key.NumLock;
+                }
+
+                // The following have left/right keys based on extended bit 
+                // being set but for some reason MapVirtualKey doesn't 
+                // translate them.
+                switch (mapped_vkey)
+                {
+                    case VirtualKeys.RETURN:
+                        // Keypad enter key has extended bit set
+                        return Key.KeypadEnter;
+                    case VirtualKeys.MENU:
+                        // RAlt has extended bit set
+                        return Key.RAlt;
                 }
             }
             else
             {
-                switch (key)
+                switch (mapped_vkey)
                 {
-                    case Key.Slash: key = Key.KeypadDivide; break;
-                    case Key.Enter: key = Key.KeypadEnter; break;
-                    case Key.AltLeft: key = Key.AltRight; break;
-                    case Key.AltRight: key = Key.AltLeft; break;
-                    case Key.ControlLeft: key = Key.ControlRight; break;
-                    case Key.ControlRight: key = Key.ControlLeft; break;
-                    case Key.ShiftLeft: is_valid = false; break;
+                    // MapVirtualKey translates numpad keys to the function keys, we map back to the numpad keys.
+                    case VirtualKeys.INSERT: return Key.Keypad0;
+                    case VirtualKeys.END: return Key.Keypad1;
+                    case VirtualKeys.DOWN: return Key.Keypad2;
+                    case VirtualKeys.NEXT: return Key.Keypad3;
+                    case VirtualKeys.LEFT: return Key.Keypad4;
+                    case VirtualKeys.CLEAR: return Key.Keypad5;
+                    case VirtualKeys.RIGHT: return Key.Keypad6;
+                    case VirtualKeys.HOME: return Key.Keypad7;
+                    case VirtualKeys.UP: return Key.Keypad8;
+                    case VirtualKeys.PRIOR: return Key.Keypad9;
+                    case VirtualKeys.DELETE: return Key.KeypadPeriod;
+
+                    // Pause is mapped to numlock by MapVirtualKey, map it back to pause
+                    case VirtualKeys.NUMLOCK: return Key.Pause;
                 }
             }
 
-            if (extended1)
-            {
-                switch (key)
-                {
-                    case Key.ControlLeft: key = Key.Pause; break;
-                }
-            }
-
-            return key;
+            // Translate windows virtual key into our Key type.
+            return WinKeyMap.TranslateKey(mapped_vkey);
         }
     }
 }

--- a/Source/OpenTK/Platform/Windows/WinRawKeyboard.cs
+++ b/Source/OpenTK/Platform/Windows/WinRawKeyboard.cs
@@ -2,7 +2,7 @@
 //
 // The Open Toolkit Library License
 //
-// Copyright (c) 2006 - 2010 the Open Toolkit library.
+// Copyright (c) 2006 - 2015 the Open Toolkit library.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -169,8 +169,6 @@ namespace OpenTK.Platform.Windows
                 bool extended0 = (int)(rin.Data.Keyboard.Flags & RawInputKeyboardDataFlags.E0) != 0;
                 bool extended1 = (int)(rin.Data.Keyboard.Flags & RawInputKeyboardDataFlags.E1) != 0;
 
-                bool is_valid = true;
-
                 ContextHandle handle = new ContextHandle(rin.Header.Device);
                 KeyboardState keyboard;
                 if (!rawids.ContainsKey(handle))
@@ -188,12 +186,10 @@ namespace OpenTK.Platform.Windows
                 int keyboard_handle = rawids.ContainsKey(handle) ? rawids[handle] : 0;
                 keyboard = keyboards[keyboard_handle];
 
-                Key key = WinKeyMap.TranslateKey(scancode, vkey, extended0, extended1, out is_valid);
-
-                if (is_valid)
+                Key key = WinKeyMap.TranslateKey(scancode, vkey, extended0, extended1);
+                if (key != Key.Unknown)
                 {
                     keyboard.SetKeyState(key, pressed);
-                    processed = true;
                 }
 
                 lock (UpdateLock)


### PR DESCRIPTION
Changes the Windows keyboard handling code to return keycodes based on keyboard layout. So Key.A is triggered when the A key is pressed, not when the first key on the home row is pressed (old behaviour that only looked at scancodes).

Fixes #260 
