### PR TITLE
Added missing 'ProgramBinaryLength' entry to GetProgramParameterName,…

### DIFF
--- a/Source/OpenTK/Graphics/OpenGL4/GL4Enums.cs
+++ b/Source/OpenTK/Graphics/OpenGL4/GL4Enums.cs
@@ -20698,6 +20698,10 @@ namespace OpenTK.Graphics.OpenGL4
         /// Original was GL_ACTIVE_ATOMIC_COUNTER_BUFFERS = 0x92D9
         /// </summary>
         ActiveAtomicCounterBuffers = ((int)0x92D9)        ,
+        /// <summary>
+        /// Original was GL_PROGRAM_BINARY_LENGTH = 0x8741
+        /// </summary>
+        ProgramBinaryLength = ((int)All.ProgramBinaryLength),
     }
 
     /// <summary>


### PR DESCRIPTION
… so it can be used in GL.GetProgram as per https://www.opengl.org/wiki/Shader_Compilation#Binary_upload