### PR TITLE
[Win] GDI handle leak

### DIFF
--- a/Source/OpenTK/Platform/Windows/API.cs
+++ b/Source/OpenTK/Platform/Windows/API.cs
@@ -1732,12 +1732,11 @@ namespace OpenTK.Platform.Windows
 
         #region GDI functions
 
-        #region GetStockObject
-
         [DllImport("gdi32.dll", SetLastError = true)]
         internal static extern IntPtr GetStockObject(int index);
 
-        #endregion
+        [DllImport("gdi32.dll", SetLastError = true)]
+        internal static extern BOOL DeleteObject([In] IntPtr hObject);
 
         #endregion
 

--- a/Source/OpenTK/Platform/Windows/WinGLNative.cs
+++ b/Source/OpenTK/Platform/Windows/WinGLNative.cs
@@ -93,6 +93,7 @@ namespace OpenTK.Platform.Windows
 
         MouseCursor cursor = MouseCursor.Default;
         IntPtr cursor_handle = Functions.LoadCursor(CursorName.Arrow);
+        IntPtr old_cursor_handle = IntPtr.Zero;
         int cursor_visible_count = 0;
 
         static readonly object SyncRoot = new object();
@@ -1130,12 +1131,11 @@ namespace OpenTK.Platform.Windows
                 if (value != cursor)
                 {
                     bool destoryOld = cursor != MouseCursor.Default;
-                    IntPtr oldCursor = IntPtr.Zero;
 
                     if (value == MouseCursor.Default)
                     {
                         cursor_handle = Functions.LoadCursor(CursorName.Arrow);
-                        oldCursor = Functions.SetCursor(cursor_handle);
+                        Functions.SetCursor(cursor_handle);
                         cursor = value;
                     }
                     else
@@ -1173,20 +1173,22 @@ namespace OpenTK.Platform.Windows
                                     // once replaced
                                     cursor = value;
                                     cursor_handle = icon;
-                                    oldCursor = Functions.SetCursor(icon);
+                                    Functions.SetCursor(icon);
                                 }
+                                // GetIconInfo creates bitmaps for the hbmMask and hbmColor members of ICONINFO. 
+                                // The calling application must manage these bitmaps and delete them when they are no longer necessary.
+                                Functions.DeleteObject(iconInfo.hbmColor);
+                                Functions.DeleteObject(iconInfo.hbmMask);
                             }
-                            // GetIconInfo creates bitmaps for the hbmMask and hbmColor members of ICONINFO. 
-                            // The calling application must manage these bitmaps and delete them when they are no longer necessary.
-                            Functions.DeleteObject(iconInfo.hbmColor);
-                            Functions.DeleteObject(iconInfo.hbmMask);
+                            Functions.DestroyIcon(bmpIcon);
                         }
                     }
 
-                    if (destoryOld && oldCursor != IntPtr.Zero)
+                    if (destoryOld && old_cursor_handle != IntPtr.Zero)
                     {
-                        Functions.DestroyIcon(oldCursor);
+                        Functions.DestroyIcon(old_cursor_handle);
                     }
+                    old_cursor_handle = cursor_handle;
                 }
             }
         }

--- a/Source/OpenTK/Platform/Windows/WinGLNative.cs
+++ b/Source/OpenTK/Platform/Windows/WinGLNative.cs
@@ -1176,6 +1176,10 @@ namespace OpenTK.Platform.Windows
                                     oldCursor = Functions.SetCursor(icon);
                                 }
                             }
+                            // GetIconInfo creates bitmaps for the hbmMask and hbmColor members of ICONINFO. 
+                            // The calling application must manage these bitmaps and delete them when they are no longer necessary.
+                            Functions.DeleteObject(iconInfo.hbmColor);
+                            Functions.DeleteObject(iconInfo.hbmMask);
                         }
                     }
 


### PR DESCRIPTION
Changed pull request of https://github.com/opentk/opentk/pull/276 against opentk/develop instead of opentk/master

Reiterating what was said there:
The Cursor property for WinGLNative leaks GDI handles.

It uses the function GetIconInfo (https://msdn.microsoft.com/en-us/library/windows/desktop/ms648070(v=vs.85).aspx) to which creates bitmaps that are not properly deleted after the call to CreateIconIndirect, which copies the bitmaps to the icon it creates. The change I made was to call DeleteObject on the bitmaps after CreateIconIndirect, as they were no longer needed.

Also, the bmpIcon created by Bitmap.GetHicon was not properly destroyed either, and there was one last possible leak if the return value of SetCursor was used to retrieve the last cursor, as it could have been set by another library. (Some UI libraries change the cursor using the .net Cursor)