### PR TITLE
Improved Validation of Joystick Input Devices

### DIFF
--- a/Source/OpenTK/Platform/Windows/WinRawJoystick.cs
+++ b/Source/OpenTK/Platform/Windows/WinRawJoystick.cs
@@ -476,149 +476,132 @@ namespace OpenTK.Platform.Windows
             try
             {
                 Debug.Indent();
-
-                // Attempt to retrieve the device capabilities
                 HidProtocolCaps caps;
-                if (!GetPreparsedData(stick.Handle, ref PreparsedData))
-                    return false;
-                if (!GetDeviceCaps(stick, PreparsedData, out caps))
-                    return false;
 
-                // Filter out touch devices and others with a suspicously high amount of axes and buttons
-                if (stick.AxisCaps.Count >= JoystickState.MaxAxes ||
-                    stick.ButtonCaps.Count >= JoystickState.MaxButtons)
+                if (GetPreparsedData(stick.Handle, ref PreparsedData) &&
+                    GetDeviceCaps(stick, PreparsedData, out caps))
                 {
-                    Debug.Print("Device {0} has {1} and {2} buttons. This might be a touch device - skipping.",
-                        stick.Handle, stick.AxisCaps.Count, stick.ButtonCaps.Count);
-                    return false;
-                }
-
-                // Keep track of whether we find anything useful
-                bool anyAxesOrButtons = false;
-
-                // Determine device axes
-                for (int i = 0; i < stick.AxisCaps.Count; i++)
-                {
-                    Debug.Print("Analyzing value collection {0} {1} {2}",
-                        i,
-                        stick.AxisCaps[i].IsRange ? "range" : "",
-                        stick.AxisCaps[i].IsAlias ? "alias" : "");
-
-                    if (stick.AxisCaps[i].IsRange || stick.AxisCaps[i].IsAlias)
+                    if (stick.AxisCaps.Count >= JoystickState.MaxAxes ||
+                        stick.ButtonCaps.Count >= JoystickState.MaxButtons)
                     {
-                        Debug.Print("Skipping value collection {0}", i);
-                        continue;
+                        Debug.Print("Device {0} has {1} and {2} buttons. This might be a touch device - skipping.",
+                            stick.Handle, stick.AxisCaps.Count, stick.ButtonCaps.Count);
+                        return false;
                     }
 
-                    HIDPage page = stick.AxisCaps[i].UsagePage;
-                    short collection = stick.AxisCaps[i].LinkCollection;
-                    switch (page)
+                    for (int i = 0; i < stick.AxisCaps.Count; i++)
                     {
-                        case HIDPage.GenericDesktop:
-                            HIDUsageGD gd_usage = (HIDUsageGD)stick.AxisCaps[i].NotRange.Usage;
-                            switch (gd_usage)
-                            {
-                                case HIDUsageGD.X:
-                                case HIDUsageGD.Y:
-                                case HIDUsageGD.Z:
-                                case HIDUsageGD.Rx:
-                                case HIDUsageGD.Ry:
-                                case HIDUsageGD.Rz:
-                                case HIDUsageGD.Slider:
-                                case HIDUsageGD.Dial:
-                                case HIDUsageGD.Wheel:
-                                    Debug.Print("Found axis {0} ({1} / {2})",
-                                        JoystickAxis.Axis0 + stick.GetCapabilities().AxisCount,
-                                        page, (HIDUsageGD)stick.AxisCaps[i].NotRange.Usage);
-                                    stick.SetAxis(collection, page, stick.AxisCaps[i].NotRange.Usage, 0);
-                                    anyAxesOrButtons = true;
-                                    break;
+                        Debug.Print("Analyzing value collection {0} {1} {2}",
+                            i,
+                            stick.AxisCaps[i].IsRange ? "range" : "",
+                            stick.AxisCaps[i].IsAlias ? "alias" : "");
 
-                                case HIDUsageGD.Hatswitch:
-                                    Debug.Print("Found hat {0} ({1} / {2})",
-                                        JoystickHat.Hat0 + stick.GetCapabilities().HatCount,
-                                        page, (HIDUsageGD)stick.AxisCaps[i].NotRange.Usage);
-                                    stick.SetHat(collection, page, stick.AxisCaps[i].NotRange.Usage, HatPosition.Centered);
-                                    anyAxesOrButtons = true;
-                                    break;
+                        if (stick.AxisCaps[i].IsRange || stick.AxisCaps[i].IsAlias)
+                        {
+                            Debug.Print("Skipping value collection {0}", i);
+                            continue;
+                        }
 
-                                default:
-                                    Debug.Print("Unknown usage {0} for page {1}",
-                                        gd_usage, page);
-                                    break;
-                            }
-                            break;
+                        HIDPage page = stick.AxisCaps[i].UsagePage;
+                        short collection = stick.AxisCaps[i].LinkCollection;
+                        switch (page)
+                        {
+                            case HIDPage.GenericDesktop:
+                                HIDUsageGD gd_usage = (HIDUsageGD)stick.AxisCaps[i].NotRange.Usage;
+                                switch (gd_usage)
+                                {
+                                    case HIDUsageGD.X:
+                                    case HIDUsageGD.Y:
+                                    case HIDUsageGD.Z:
+                                    case HIDUsageGD.Rx:
+                                    case HIDUsageGD.Ry:
+                                    case HIDUsageGD.Rz:
+                                    case HIDUsageGD.Slider:
+                                    case HIDUsageGD.Dial:
+                                    case HIDUsageGD.Wheel:
+                                        Debug.Print("Found axis {0} ({1} / {2})",
+                                            JoystickAxis.Axis0 + stick.GetCapabilities().AxisCount,
+                                            page, (HIDUsageGD)stick.AxisCaps[i].NotRange.Usage);
+                                        stick.SetAxis(collection, page, stick.AxisCaps[i].NotRange.Usage, 0);
+                                        break;
 
-                        case HIDPage.Simulation:
-                            switch ((HIDUsageSim)stick.AxisCaps[i].NotRange.Usage)
-                            {
-                                case HIDUsageSim.Rudder:
-                                case HIDUsageSim.Throttle:
-                                    Debug.Print("Found simulation axis {0} ({1} / {2})",
-                                        JoystickAxis.Axis0 + stick.GetCapabilities().AxisCount,
-                                        page, (HIDUsageSim)stick.AxisCaps[i].NotRange.Usage);
-                                    stick.SetAxis(collection, page, stick.AxisCaps[i].NotRange.Usage, 0);
-                                    anyAxesOrButtons = true;
-                                    break;
-                            }
-                            break;
+                                    case HIDUsageGD.Hatswitch:
+                                        Debug.Print("Found hat {0} ({1} / {2})",
+                                            JoystickHat.Hat0 + stick.GetCapabilities().HatCount,
+                                            page, (HIDUsageGD)stick.AxisCaps[i].NotRange.Usage);
+                                        stick.SetHat(collection, page, stick.AxisCaps[i].NotRange.Usage, HatPosition.Centered);
+                                        break;
 
-                        default:
-                            Debug.Print("Unknown page {0}", page);
-                            break;
-                    }
-                }
+                                    default:
+                                        Debug.Print("Unknown usage {0} for page {1}",
+                                            gd_usage, page);
+                                        break;
+                                }
+                                break;
 
-                // Determine device buttons
-                for (int i = 0; i < stick.ButtonCaps.Count; i++)
-                {
-                    Debug.Print("Analyzing button collection {0} {1} {2}",
-                        i,
-                        stick.ButtonCaps[i].IsRange ? "range" : "",
-                        stick.ButtonCaps[i].IsAlias ? "alias" : "");
+                            case HIDPage.Simulation:
+                                switch ((HIDUsageSim)stick.AxisCaps[i].NotRange.Usage)
+                                {
+                                    case HIDUsageSim.Rudder:
+                                    case HIDUsageSim.Throttle:
+                                        Debug.Print("Found simulation axis {0} ({1} / {2})",
+                                            JoystickAxis.Axis0 + stick.GetCapabilities().AxisCount,
+                                            page, (HIDUsageSim)stick.AxisCaps[i].NotRange.Usage);
+                                        stick.SetAxis(collection, page, stick.AxisCaps[i].NotRange.Usage, 0);
+                                        break;
+                                }
+                                break;
 
-                    if (stick.ButtonCaps[i].IsAlias)
-                    {
-                        Debug.Print("Skipping button collection {0}", i);
-                        continue;
+                            default:
+                                Debug.Print("Unknown page {0}", page);
+                                break;
+                        }
                     }
 
-                    bool is_range = stick.ButtonCaps[i].IsRange;
-                    HIDPage page = stick.ButtonCaps[i].UsagePage;
-                    short collection = stick.ButtonCaps[i].LinkCollection;
-                    switch (page)
+                    for (int i = 0; i < stick.ButtonCaps.Count; i++)
                     {
-                        case HIDPage.Button:
-                            if (is_range)
-                            {
-                                for (short usage = stick.ButtonCaps[i].Range.UsageMin; usage <= stick.ButtonCaps[i].Range.UsageMax; usage++)
+                        Debug.Print("Analyzing button collection {0} {1} {2}",
+                            i,
+                            stick.ButtonCaps[i].IsRange ? "range" : "",
+                            stick.ButtonCaps[i].IsAlias ? "alias" : "");
+
+                        if (stick.ButtonCaps[i].IsAlias)
+                        {
+                            Debug.Print("Skipping button collection {0}", i);
+                            continue;
+                        }
+
+                        bool is_range = stick.ButtonCaps[i].IsRange;
+                        HIDPage page = stick.ButtonCaps[i].UsagePage;
+                        short collection = stick.ButtonCaps[i].LinkCollection;
+                        switch (page)
+                        {
+                            case HIDPage.Button:
+                                if (is_range)
+                                {
+                                    for (short usage = stick.ButtonCaps[i].Range.UsageMin; usage <= stick.ButtonCaps[i].Range.UsageMax; usage++)
+                                    {
+                                        Debug.Print("Found button {0} ({1} / {2})",
+                                            JoystickButton.Button0 + stick.GetCapabilities().ButtonCount,
+                                            page, usage);
+                                        stick.SetButton(collection, page, usage, false);
+                                    }
+                                }
+                                else
                                 {
                                     Debug.Print("Found button {0} ({1} / {2})",
                                         JoystickButton.Button0 + stick.GetCapabilities().ButtonCount,
-                                        page, usage);
-                                    stick.SetButton(collection, page, usage, false);
-                                    anyAxesOrButtons = true;
+                                        page, stick.ButtonCaps[i].NotRange.Usage);
+                                    stick.SetButton(collection, page, stick.ButtonCaps[i].NotRange.Usage, false);
                                 }
-                            }
-                            else
-                            {
-                                Debug.Print("Found button {0} ({1} / {2})",
-                                    JoystickButton.Button0 + stick.GetCapabilities().ButtonCount,
-                                    page, stick.ButtonCaps[i].NotRange.Usage);
-                                stick.SetButton(collection, page, stick.ButtonCaps[i].NotRange.Usage, false);
-                                anyAxesOrButtons = true;
-                            }
-                            break;
+                                break;
 
-                        default:
-                            Debug.Print("Unknown page {0} for button.", page);
-                            break;
+                            default:
+                                Debug.Print("Unknown page {0} for button.", page);
+                                break;
+                        }
                     }
                 }
-
-                // If we didn't find any usable axes or buttons, this is probably not a valid game controller
-                if (!anyAxesOrButtons)
-                    return false;
             }
             finally
             {

--- a/Source/OpenTK/Platform/Windows/WinRawJoystick.cs
+++ b/Source/OpenTK/Platform/Windows/WinRawJoystick.cs
@@ -476,132 +476,149 @@ namespace OpenTK.Platform.Windows
             try
             {
                 Debug.Indent();
+
+				// Attempt to retrieve the device capabilities
                 HidProtocolCaps caps;
+				if (!GetPreparsedData(stick.Handle, ref PreparsedData))
+					return false;
+				if (!GetDeviceCaps(stick, PreparsedData, out caps))
+					return false;
 
-                if (GetPreparsedData(stick.Handle, ref PreparsedData) &&
-                    GetDeviceCaps(stick, PreparsedData, out caps))
+				// Filter out touch devices and others with a suspicously high amount of axes and buttons
+                if (stick.AxisCaps.Count >= JoystickState.MaxAxes ||
+                    stick.ButtonCaps.Count >= JoystickState.MaxButtons)
                 {
-                    if (stick.AxisCaps.Count >= JoystickState.MaxAxes ||
-                        stick.ButtonCaps.Count >= JoystickState.MaxButtons)
+                    Debug.Print("Device {0} has {1} and {2} buttons. This might be a touch device - skipping.",
+                        stick.Handle, stick.AxisCaps.Count, stick.ButtonCaps.Count);
+                    return false;
+                }
+
+				// Keep track of whether we find anything useful
+				bool anyAxesOrButtons = false;
+
+				// Determine device axes
+                for (int i = 0; i < stick.AxisCaps.Count; i++)
+                {
+                    Debug.Print("Analyzing value collection {0} {1} {2}",
+                        i,
+                        stick.AxisCaps[i].IsRange ? "range" : "",
+                        stick.AxisCaps[i].IsAlias ? "alias" : "");
+
+                    if (stick.AxisCaps[i].IsRange || stick.AxisCaps[i].IsAlias)
                     {
-                        Debug.Print("Device {0} has {1} and {2} buttons. This might be a touch device - skipping.",
-                            stick.Handle, stick.AxisCaps.Count, stick.ButtonCaps.Count);
-                        return false;
+                        Debug.Print("Skipping value collection {0}", i);
+                        continue;
                     }
 
-                    for (int i = 0; i < stick.AxisCaps.Count; i++)
+                    HIDPage page = stick.AxisCaps[i].UsagePage;
+                    short collection = stick.AxisCaps[i].LinkCollection;
+                    switch (page)
                     {
-                        Debug.Print("Analyzing value collection {0} {1} {2}",
-                            i,
-                            stick.AxisCaps[i].IsRange ? "range" : "",
-                            stick.AxisCaps[i].IsAlias ? "alias" : "");
+                        case HIDPage.GenericDesktop:
+                            HIDUsageGD gd_usage = (HIDUsageGD)stick.AxisCaps[i].NotRange.Usage;
+                            switch (gd_usage)
+                            {
+                                case HIDUsageGD.X:
+                                case HIDUsageGD.Y:
+                                case HIDUsageGD.Z:
+                                case HIDUsageGD.Rx:
+                                case HIDUsageGD.Ry:
+                                case HIDUsageGD.Rz:
+                                case HIDUsageGD.Slider:
+                                case HIDUsageGD.Dial:
+                                case HIDUsageGD.Wheel:
+                                    Debug.Print("Found axis {0} ({1} / {2})",
+                                        JoystickAxis.Axis0 + stick.GetCapabilities().AxisCount,
+                                        page, (HIDUsageGD)stick.AxisCaps[i].NotRange.Usage);
+                                    stick.SetAxis(collection, page, stick.AxisCaps[i].NotRange.Usage, 0);
+									anyAxesOrButtons = true;
+                                    break;
 
-                        if (stick.AxisCaps[i].IsRange || stick.AxisCaps[i].IsAlias)
-                        {
-                            Debug.Print("Skipping value collection {0}", i);
-                            continue;
-                        }
+                                case HIDUsageGD.Hatswitch:
+                                    Debug.Print("Found hat {0} ({1} / {2})",
+                                        JoystickHat.Hat0 + stick.GetCapabilities().HatCount,
+                                        page, (HIDUsageGD)stick.AxisCaps[i].NotRange.Usage);
+                                    stick.SetHat(collection, page, stick.AxisCaps[i].NotRange.Usage, HatPosition.Centered);
+									anyAxesOrButtons = true;
+                                    break;
 
-                        HIDPage page = stick.AxisCaps[i].UsagePage;
-                        short collection = stick.AxisCaps[i].LinkCollection;
-                        switch (page)
-                        {
-                            case HIDPage.GenericDesktop:
-                                HIDUsageGD gd_usage = (HIDUsageGD)stick.AxisCaps[i].NotRange.Usage;
-                                switch (gd_usage)
-                                {
-                                    case HIDUsageGD.X:
-                                    case HIDUsageGD.Y:
-                                    case HIDUsageGD.Z:
-                                    case HIDUsageGD.Rx:
-                                    case HIDUsageGD.Ry:
-                                    case HIDUsageGD.Rz:
-                                    case HIDUsageGD.Slider:
-                                    case HIDUsageGD.Dial:
-                                    case HIDUsageGD.Wheel:
-                                        Debug.Print("Found axis {0} ({1} / {2})",
-                                            JoystickAxis.Axis0 + stick.GetCapabilities().AxisCount,
-                                            page, (HIDUsageGD)stick.AxisCaps[i].NotRange.Usage);
-                                        stick.SetAxis(collection, page, stick.AxisCaps[i].NotRange.Usage, 0);
-                                        break;
+                                default:
+                                    Debug.Print("Unknown usage {0} for page {1}",
+                                        gd_usage, page);
+                                    break;
+                            }
+                            break;
 
-                                    case HIDUsageGD.Hatswitch:
-                                        Debug.Print("Found hat {0} ({1} / {2})",
-                                            JoystickHat.Hat0 + stick.GetCapabilities().HatCount,
-                                            page, (HIDUsageGD)stick.AxisCaps[i].NotRange.Usage);
-                                        stick.SetHat(collection, page, stick.AxisCaps[i].NotRange.Usage, HatPosition.Centered);
-                                        break;
+                        case HIDPage.Simulation:
+                            switch ((HIDUsageSim)stick.AxisCaps[i].NotRange.Usage)
+                            {
+                                case HIDUsageSim.Rudder:
+                                case HIDUsageSim.Throttle:
+                                    Debug.Print("Found simulation axis {0} ({1} / {2})",
+                                        JoystickAxis.Axis0 + stick.GetCapabilities().AxisCount,
+                                        page, (HIDUsageSim)stick.AxisCaps[i].NotRange.Usage);
+                                    stick.SetAxis(collection, page, stick.AxisCaps[i].NotRange.Usage, 0);
+									anyAxesOrButtons = true;
+                                    break;
+                            }
+                            break;
 
-                                    default:
-                                        Debug.Print("Unknown usage {0} for page {1}",
-                                            gd_usage, page);
-                                        break;
-                                }
-                                break;
+                        default:
+                            Debug.Print("Unknown page {0}", page);
+                            break;
+                    }
+                }
 
-                            case HIDPage.Simulation:
-                                switch ((HIDUsageSim)stick.AxisCaps[i].NotRange.Usage)
-                                {
-                                    case HIDUsageSim.Rudder:
-                                    case HIDUsageSim.Throttle:
-                                        Debug.Print("Found simulation axis {0} ({1} / {2})",
-                                            JoystickAxis.Axis0 + stick.GetCapabilities().AxisCount,
-                                            page, (HIDUsageSim)stick.AxisCaps[i].NotRange.Usage);
-                                        stick.SetAxis(collection, page, stick.AxisCaps[i].NotRange.Usage, 0);
-                                        break;
-                                }
-                                break;
+				// Determine device buttons
+                for (int i = 0; i < stick.ButtonCaps.Count; i++)
+                {
+                    Debug.Print("Analyzing button collection {0} {1} {2}",
+                        i,
+                        stick.ButtonCaps[i].IsRange ? "range" : "",
+                        stick.ButtonCaps[i].IsAlias ? "alias" : "");
 
-                            default:
-                                Debug.Print("Unknown page {0}", page);
-                                break;
-                        }
+                    if (stick.ButtonCaps[i].IsAlias)
+                    {
+                        Debug.Print("Skipping button collection {0}", i);
+                        continue;
                     }
 
-                    for (int i = 0; i < stick.ButtonCaps.Count; i++)
+                    bool is_range = stick.ButtonCaps[i].IsRange;
+                    HIDPage page = stick.ButtonCaps[i].UsagePage;
+                    short collection = stick.ButtonCaps[i].LinkCollection;
+                    switch (page)
                     {
-                        Debug.Print("Analyzing button collection {0} {1} {2}",
-                            i,
-                            stick.ButtonCaps[i].IsRange ? "range" : "",
-                            stick.ButtonCaps[i].IsAlias ? "alias" : "");
-
-                        if (stick.ButtonCaps[i].IsAlias)
-                        {
-                            Debug.Print("Skipping button collection {0}", i);
-                            continue;
-                        }
-
-                        bool is_range = stick.ButtonCaps[i].IsRange;
-                        HIDPage page = stick.ButtonCaps[i].UsagePage;
-                        short collection = stick.ButtonCaps[i].LinkCollection;
-                        switch (page)
-                        {
-                            case HIDPage.Button:
-                                if (is_range)
-                                {
-                                    for (short usage = stick.ButtonCaps[i].Range.UsageMin; usage <= stick.ButtonCaps[i].Range.UsageMax; usage++)
-                                    {
-                                        Debug.Print("Found button {0} ({1} / {2})",
-                                            JoystickButton.Button0 + stick.GetCapabilities().ButtonCount,
-                                            page, usage);
-                                        stick.SetButton(collection, page, usage, false);
-                                    }
-                                }
-                                else
+                        case HIDPage.Button:
+                            if (is_range)
+                            {
+                                for (short usage = stick.ButtonCaps[i].Range.UsageMin; usage <= stick.ButtonCaps[i].Range.UsageMax; usage++)
                                 {
                                     Debug.Print("Found button {0} ({1} / {2})",
                                         JoystickButton.Button0 + stick.GetCapabilities().ButtonCount,
-                                        page, stick.ButtonCaps[i].NotRange.Usage);
-                                    stick.SetButton(collection, page, stick.ButtonCaps[i].NotRange.Usage, false);
+                                        page, usage);
+                                    stick.SetButton(collection, page, usage, false);
+									anyAxesOrButtons = true;
                                 }
-                                break;
+                            }
+                            else
+                            {
+                                Debug.Print("Found button {0} ({1} / {2})",
+                                    JoystickButton.Button0 + stick.GetCapabilities().ButtonCount,
+                                    page, stick.ButtonCaps[i].NotRange.Usage);
+                                stick.SetButton(collection, page, stick.ButtonCaps[i].NotRange.Usage, false);
+								anyAxesOrButtons = true;
+                            }
+                            break;
 
-                            default:
-                                Debug.Print("Unknown page {0} for button.", page);
-                                break;
-                        }
+                        default:
+                            Debug.Print("Unknown page {0} for button.", page);
+                            break;
                     }
                 }
+
+				// If we didn't find any usable axes or buttons, this is probably not a valid game controller
+				if (!anyAxesOrButtons)
+					return false;
             }
             finally
             {

--- a/Source/OpenTK/Platform/Windows/WinRawJoystick.cs
+++ b/Source/OpenTK/Platform/Windows/WinRawJoystick.cs
@@ -477,14 +477,14 @@ namespace OpenTK.Platform.Windows
             {
                 Debug.Indent();
 
-				// Attempt to retrieve the device capabilities
+                // Attempt to retrieve the device capabilities
                 HidProtocolCaps caps;
-				if (!GetPreparsedData(stick.Handle, ref PreparsedData))
-					return false;
-				if (!GetDeviceCaps(stick, PreparsedData, out caps))
-					return false;
+                if (!GetPreparsedData(stick.Handle, ref PreparsedData))
+                    return false;
+                if (!GetDeviceCaps(stick, PreparsedData, out caps))
+                    return false;
 
-				// Filter out touch devices and others with a suspicously high amount of axes and buttons
+                // Filter out touch devices and others with a suspicously high amount of axes and buttons
                 if (stick.AxisCaps.Count >= JoystickState.MaxAxes ||
                     stick.ButtonCaps.Count >= JoystickState.MaxButtons)
                 {
@@ -493,10 +493,10 @@ namespace OpenTK.Platform.Windows
                     return false;
                 }
 
-				// Keep track of whether we find anything useful
-				bool anyAxesOrButtons = false;
+                // Keep track of whether we find anything useful
+                bool anyAxesOrButtons = false;
 
-				// Determine device axes
+                // Determine device axes
                 for (int i = 0; i < stick.AxisCaps.Count; i++)
                 {
                     Debug.Print("Analyzing value collection {0} {1} {2}",
@@ -531,7 +531,7 @@ namespace OpenTK.Platform.Windows
                                         JoystickAxis.Axis0 + stick.GetCapabilities().AxisCount,
                                         page, (HIDUsageGD)stick.AxisCaps[i].NotRange.Usage);
                                     stick.SetAxis(collection, page, stick.AxisCaps[i].NotRange.Usage, 0);
-									anyAxesOrButtons = true;
+                                    anyAxesOrButtons = true;
                                     break;
 
                                 case HIDUsageGD.Hatswitch:
@@ -539,7 +539,7 @@ namespace OpenTK.Platform.Windows
                                         JoystickHat.Hat0 + stick.GetCapabilities().HatCount,
                                         page, (HIDUsageGD)stick.AxisCaps[i].NotRange.Usage);
                                     stick.SetHat(collection, page, stick.AxisCaps[i].NotRange.Usage, HatPosition.Centered);
-									anyAxesOrButtons = true;
+                                    anyAxesOrButtons = true;
                                     break;
 
                                 default:
@@ -558,7 +558,7 @@ namespace OpenTK.Platform.Windows
                                         JoystickAxis.Axis0 + stick.GetCapabilities().AxisCount,
                                         page, (HIDUsageSim)stick.AxisCaps[i].NotRange.Usage);
                                     stick.SetAxis(collection, page, stick.AxisCaps[i].NotRange.Usage, 0);
-									anyAxesOrButtons = true;
+                                    anyAxesOrButtons = true;
                                     break;
                             }
                             break;
@@ -569,7 +569,7 @@ namespace OpenTK.Platform.Windows
                     }
                 }
 
-				// Determine device buttons
+                // Determine device buttons
                 for (int i = 0; i < stick.ButtonCaps.Count; i++)
                 {
                     Debug.Print("Analyzing button collection {0} {1} {2}",
@@ -597,7 +597,7 @@ namespace OpenTK.Platform.Windows
                                         JoystickButton.Button0 + stick.GetCapabilities().ButtonCount,
                                         page, usage);
                                     stick.SetButton(collection, page, usage, false);
-									anyAxesOrButtons = true;
+                                    anyAxesOrButtons = true;
                                 }
                             }
                             else
@@ -606,7 +606,7 @@ namespace OpenTK.Platform.Windows
                                     JoystickButton.Button0 + stick.GetCapabilities().ButtonCount,
                                     page, stick.ButtonCaps[i].NotRange.Usage);
                                 stick.SetButton(collection, page, stick.ButtonCaps[i].NotRange.Usage, false);
-								anyAxesOrButtons = true;
+                                anyAxesOrButtons = true;
                             }
                             break;
 
@@ -616,9 +616,9 @@ namespace OpenTK.Platform.Windows
                     }
                 }
 
-				// If we didn't find any usable axes or buttons, this is probably not a valid game controller
-				if (!anyAxesOrButtons)
-					return false;
+                // If we didn't find any usable axes or buttons, this is probably not a valid game controller
+                if (!anyAxesOrButtons)
+                    return false;
             }
             finally
             {


### PR DESCRIPTION
This pull request fixes [issue 286](https://github.com/opentk/opentk/issues/286) with my testing setup by introducing two additional checks to the `WinRawJoystick.QueryDeviceCaps` method.

*I do not have a sufficient testing setup to perform in-depth regression testing on different hardware though. Please verify this.*