### PR TITLE
Fix XIEventMask to work on any architecture

### DIFF
--- a/Source/OpenTK/Platform/X11/Structs.cs
+++ b/Source/OpenTK/Platform/X11/Structs.cs
@@ -1811,7 +1811,7 @@ namespace OpenTK.Platform.X11
     {
         public int deviceid; // 0 = XIAllDevices, 1 = XIAllMasterDevices
         int mask_len;
-        unsafe XIEventMasks* mask;
+        unsafe byte* mask;
 
         public XIEventMask(int id, XIEventMasks m)
         {
@@ -1819,8 +1819,9 @@ namespace OpenTK.Platform.X11
             mask_len = sizeof(XIEventMasks);
             unsafe
             {
-                mask = (XIEventMasks*)Marshal.AllocHGlobal(mask_len);
-                *mask = m;
+                mask = (byte*)Marshal.AllocHGlobal(mask_len);
+                for (int i = 0; i < mask_len; i++)
+                    mask[i] = (byte)((uint)m >> i*8);
             }
         }
 


### PR DESCRIPTION
The mask part of an XIEventMask struct is actually not a pointer to an
integer containing the mask, but rather to an array of bytes each
holding 8 bits of the mask, with the first byte holding bit 0-7.
Therefore the old code would only work on little endian arches.

Please see the `XISetMask()` macro in `<X11/extensions/XI2.h>` for reference.