### PR TITLE
[X11] Fix CursorVisible

### DIFF
--- a/Source/OpenTK/Platform/X11/X11GLNative.cs
+++ b/Source/OpenTK/Platform/X11/X11GLNative.cs
@@ -1480,7 +1480,7 @@ namespace OpenTK.Platform.X11
             get { return cursor_visible; }
             set
             {
-                if (value)
+                if (value && !cursor_visible)
                 {
                     using (new XLock(window.Display))
                     {
@@ -1495,7 +1495,7 @@ namespace OpenTK.Platform.X11
                         cursor_visible = true;
                     }
                 }
-                else
+                else if(!value && cursor_visible)
                 {
                     using (new XLock(window.Display))
                     {


### PR DESCRIPTION
Change X11 CursorVisible to only execute if a change is actually needed,
that is if we're going from visible to not visible or vice versa.

Fixes #281