### PR TITLE
Destroy context after OnHandleDestroyed to allow cleanup

### DIFF
--- a/Source/GLControl/GLControl.cs
+++ b/Source/GLControl/GLControl.cs
@@ -226,6 +226,10 @@ namespace OpenTK
         /// <param name="e">Not used.</param>
         protected override void OnHandleDestroyed(EventArgs e)
         {
+            // Ensure that context is still alive when passing to events
+            // => This allows to perform cleanup operations in OnHandleDestroyed handlers
+            base.OnHandleDestroyed(e);
+
             if (context != null)
             {
                 context.Dispose();
@@ -238,7 +242,6 @@ namespace OpenTK
                 implementation = null;
             }
 
-            base.OnHandleDestroyed(e);
         }
 
         /// <summary>


### PR DESCRIPTION
Hi OpenTK-Team,

I would like use the HandleDestroyed event to cleanup dependent resources.
This requires that the context still exists, when the HandleDestroyed event.

Therefore, I changed the ordered of the cleanup process.

Best regards
Michael