### PR TITLE
[travis] Remove mono 3.2.8 and 2.10.8 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ mono:
  - latest
  - 3.10.0
  - 3.8.0
- - 3.2.8
- - 2.10.8
 
 script:
   - xbuild /p:Configuration=Release OpenTK.sln


### PR DESCRIPTION
Old versions of mono on travis didn't have nuget support that we now use to
fetch Mono.Cecil.