### PR TITLE
Fix: Insert key not working on Linux, due to typo in X11KeyMap.cs

### DIFF
--- a/Source/OpenTK/Platform/X11/X11KeyMap.cs
+++ b/Source/OpenTK/Platform/X11/X11KeyMap.cs
@@ -509,7 +509,7 @@ namespace OpenTK.Platform.X11
                 case XKey.Scroll_Lock:
                     return Key.Pause;
                 case XKey.Insert:
-                    return Key.PrintScreen;
+                    return Key.Insert;
                 case XKey.Print:
                     return Key.PrintScreen;
                 case XKey.Sys_Req:


### PR DESCRIPTION
Re-attempt of pull request https://github.com/opentk/opentk/pull/313

Commit to the right branch this time (I hope....)