### PR TITLE
Fix: KP_ENTER key missing from SDL2 keymap.

### DIFF
--- a/Source/OpenTK/Platform/SDL2/Sdl2KeyMap.cs
+++ b/Source/OpenTK/Platform/SDL2/Sdl2KeyMap.cs
@@ -283,8 +283,8 @@ namespace OpenTK.Platform.SDL2
                     return Key.KeypadDivide;
                 case Code.KP_MULTIPLY:
                     return Key.KeypadMultiply;
-				case Code.KP_ENTER:
-					return Key.KeypadEnter;
+                case Code.KP_ENTER:
+                    return Key.KeypadEnter;
 
                 // Navigation
                 case Code.UP:

--- a/Source/OpenTK/Platform/SDL2/Sdl2KeyMap.cs
+++ b/Source/OpenTK/Platform/SDL2/Sdl2KeyMap.cs
@@ -283,6 +283,8 @@ namespace OpenTK.Platform.SDL2
                     return Key.KeypadDivide;
                 case Code.KP_MULTIPLY:
                     return Key.KeypadMultiply;
+				case Code.KP_ENTER:
+					return Key.KeypadEnter;
 
                 // Navigation
                 case Code.UP:


### PR DESCRIPTION
Keypad enter is missing from the SDL2 keymap, fixed.