### PR TITLE
Rewrite program file name confusion: .mdb vs .dll.mdb

### DIFF
--- a/Source/Generator.Rewrite/Program.cs
+++ b/Source/Generator.Rewrite/Program.cs
@@ -65,7 +65,7 @@ namespace OpenTK.Rewrite
             var read_params = new ReaderParameters();
             var write_params = new WriterParameters();
             var pdb = Path.ChangeExtension(file, "pdb");
-            var mdb = Path.ChangeExtension(file, "mdb");
+            var mdb = file + ".mdb";
             ISymbolReaderProvider provider = null;
             if (File.Exists(pdb))
             {


### PR DESCRIPTION
Fixed Generator.Rewrite program mistake because of which it was looking for
 "filename.mdb" file instead of "filename.dll.mdb"

The _.mdb_ files are used to be named as "filename.dll.mdb", while _.pdb_ files are used to have names such as "filename.pdb".

At least, this is which names Mono.Cecil library is searching for:

**PDB:** https://github.com/jbevain/cecil/blob/55da3138f73b99bd776c1cfd5db135f4660631b5/symbols/pdb/Mono.Cecil.Pdb/PdbHelper.cs#L35

**MDB:** https://github.com/jbevain/cecil/blob/55da3138f73b99bd776c1cfd5db135f4660631b5/symbols/mdb/Mono.Cecil.Mdb/MdbReader.cs#L25