### PR TITLE
Fix documentation for NativeWindow.Width

### DIFF
--- a/Source/OpenTK/NativeWindow.cs
+++ b/Source/OpenTK/NativeWindow.cs
@@ -493,7 +493,7 @@ namespace OpenTK
         #region WindowBorder
 
         /// <summary>
-        /// Gets or states the border of the NativeWindow.
+        /// Gets or sets the border of the NativeWindow.
         /// </summary>
         public WindowBorder WindowBorder
         {

--- a/Source/OpenTK/NativeWindow.cs
+++ b/Source/OpenTK/NativeWindow.cs
@@ -471,7 +471,7 @@ namespace OpenTK
         #region Width
 
         /// <summary>
-        /// Gets or sets the height of the OpenGL surface in window coordinates.
+        /// Gets or sets the width of the OpenGL surface in window coordinates.
         /// The coordinates are specified in device-dependent pixels.
         /// </summary>
         public int Width

--- a/Source/OpenTK/NativeWindow.cs
+++ b/Source/OpenTK/NativeWindow.cs
@@ -528,7 +528,7 @@ namespace OpenTK
         #region WindowState
 
         /// <summary>
-        /// Gets or states the state of the NativeWindow.
+        /// Gets or sets the state of the NativeWindow.
         /// </summary>
         public virtual WindowState WindowState
         {


### PR DESCRIPTION
I noticed this while working with the current master version, it's just a slight documentation error.