### PR TITLE
Invert Y axis on all GamePad

### DIFF
--- a/Source/OpenTK/Input/GamePadState.cs
+++ b/Source/OpenTK/Input/GamePadState.cs
@@ -171,7 +171,7 @@ namespace OpenTK.Input
 
             if ((axis & GamePadAxes.LeftY) != 0)
             {
-                left_stick_y = value;
+                left_stick_y = (short)(-value);
             }
 
             if ((axis & GamePadAxes.RightX) != 0)
@@ -181,7 +181,7 @@ namespace OpenTK.Input
 
             if ((axis & GamePadAxes.RightY) != 0)
             {
-                right_stick_y = value;
+                right_stick_y = (short)(-value);
             }
 
             if ((axis & GamePadAxes.LeftTrigger) != 0)


### PR DESCRIPTION
Hello,

OpenTK Input API is said to be modeled after XNA / XInput, but comparatively OpenTK has inverted Y axis on all ```GamePadState```, no matter the controller brand. This implicitly impacts MonoGame.

This PR inverts all Y's on ```GamePadState``` to be conformed to XNA / XInput.

Ping @Frassle :)

(more gamepad fixes coming)

EDIT: #335 