### PR TITLE
Fix for multiple HID driver issues

### DIFF
--- a/Source/OpenTK/Input/GamePadConfigurationDatabase.cs
+++ b/Source/OpenTK/Input/GamePadConfigurationDatabase.cs
@@ -76,6 +76,8 @@ namespace OpenTK.Input
 
             // Windows - XInput
             Add("78696e70757400000000000000000000,XInput Controller,a:b0,b:b1,back:b6,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,guide:b10,leftshoulder:b4,leftstick:b8,lefttrigger:a2,leftx:a0,lefty:a1,rightshoulder:b5,rightstick:b9,righttrigger:a5,rightx:a3,righty:a4,start:b7,x:b2,y:b3,");
+            // Windows - XInput (SDL2)
+            Add("78696e70757401000000000000000000,XInput Controller,a:b0,b:b1,back:b6,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,guide:b10,leftshoulder:b4,leftstick:b8,lefttrigger:a2,leftx:a0,lefty:a1,rightshoulder:b5,rightstick:b9,righttrigger:a5,rightx:a3,righty:a4,start:b7,x:b2,y:b3,");
 
             // Windows
             Add("341a3608000000000000504944564944,Afterglow PS3 Controller,a:b1,b:b2,back:b8,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,guide:b12,leftshoulder:b4,leftstick:b10,lefttrigger:b6,leftx:a0,lefty:a1,rightshoulder:b5,rightstick:b11,righttrigger:b7,rightx:a2,righty:a3,start:b9,x:b0,y:b3,");
@@ -88,7 +90,8 @@ namespace OpenTK.Input
             Add("4c056802000000000000504944564944,PS3 Controller,a:b14,b:b13,back:b0,dpdown:b6,dpleft:b7,dpright:b5,dpup:b4,guide:b16,leftshoulder:b10,leftstick:b1,lefttrigger:b8,leftx:a0,lefty:a1,rightshoulder:b11,rightstick:b2,righttrigger:b9,rightx:a2,righty:a3,start:b3,x:b15,y:b12,");
             Add("25090500000000000000504944564944,PS3 DualShock,a:b2,b:b1,back:b9,dpdown:h0.8,dpleft:h0.4,dpright:h0.2,dpup:h0.1,guide:,leftshoulder:b6,leftstick:b10,lefttrigger:b4,leftx:a0,lefty:a1,rightshoulder:b7,rightstick:b11,righttrigger:b5,rightx:a2,righty:a3,start:b8,x:b0,y:b3,");
             Add("4c05c405000000000000504944564944,PS4 Controller,a:b1,b:b2,back:b8,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,guide:b12,leftshoulder:b4,leftstick:b10,lefttrigger:a3,leftx:a0,lefty:a1,rightshoulder:b5,rightstick:b11,righttrigger:a4,rightx:a2,righty:a5,start:b9,x:b0,y:b3,");
-
+            Add("05c4054c000000000000504944564944,PS4 Controller,a:b1,b:b2,back:b8,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,guide:b12,leftshoulder:b4,leftstick:b10,lefttrigger:a4,leftx:a0,lefty:a1,rightshoulder:b5,rightstick:b11,righttrigger:a5,rightx:a2,righty:a3,start:b9,x:b0,y:b3,");
+            
             // Mac OS X
             Add("0500000047532047616d657061640000,GameStop Gamepad,a:b0,b:b1,back:b8,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,guide:,leftshoulder:b4,leftstick:b10,lefttrigger:b6,leftx:a0,lefty:a1,rightshoulder:b5,rightstick:b11,righttrigger:b7,rightx:a2,righty:a3,start:b9,x:b2,y:b3,");
             Add("6d0400000000000016c2000000000000,Logitech F310 Gamepad (DInput),a:b1,b:b2,back:b8,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,leftshoulder:b4,leftstick:b10,lefttrigger:b6,leftx:a0,lefty:a1,rightshoulder:b5,rightstick:b11,righttrigger:b7,rightx:a2,righty:a3,start:b9,x:b0,y:b3,"); // Guide button doesn't seem to be sent in DInput mode.

--- a/Source/OpenTK/Platform/Windows/WinRawJoystick.cs
+++ b/Source/OpenTK/Platform/Windows/WinRawJoystick.cs
@@ -81,8 +81,11 @@ namespace OpenTK.Platform.Windows
 
             public void SetAxis(short collection, HIDPage page, short usage, short value)
             {
-                JoystickAxis axis = GetAxis(collection, page, usage);
-                State.SetAxis(axis, value);
+                if (page == HIDPage.GenericDesktop || page == HIDPage.Simulation) // set axis only when HIDPage is known by HidHelper.TranslateJoystickAxis() to avoid axis0 to be overwritten by unknown HIDPage
+                {
+                    JoystickAxis axis = GetAxis(collection, page, usage);
+                    State.SetAxis(axis, value);
+                }
             }
 
             public void SetButton(short collection, HIDPage page, short usage, bool value)
@@ -351,6 +354,12 @@ namespace OpenTK.Platform.Windows
         {
             if (caps.LogicalMax == 8)
                 return (HatPosition)value;
+            else if (caps.LogicalMax == 7)
+            {
+                value++;
+                value %= 9;
+                return (HatPosition)value;
+            }
             else
                 return HatPosition.Centered;
         }

--- a/Source/OpenTK/Platform/Windows/WinRawJoystick.cs
+++ b/Source/OpenTK/Platform/Windows/WinRawJoystick.cs
@@ -261,7 +261,7 @@ namespace OpenTK.Platform.Windows
 
                     // This is a new device, query its capabilities and add it
                     // to the device list
-                    if (!QueryDeviceCaps(device))
+                    if (!QueryDeviceCaps(device) && !is_xinput)
                     {
                         continue;
                     }
@@ -611,6 +611,8 @@ namespace OpenTK.Platform.Windows
                         }
                     }
                 }
+                else
+                    return false;
             }
             finally
             {


### PR DESCRIPTION
Hello,

This PR fixes multiple problems, most of them documented in #333 and mono/MonoGame#4252 :
- fixes the Windows mapping of PS4 controllers (a GUID was missing and most axis were wrong)
- fixes SDL2 returning different GUID for XInput controllers (I added a dedicated mapping)
- fixes a problem where PS4 Axis0 would get overwritten by unknown HIDPage / HIDUsage combo (because the PS4 controller has multiple other captors and ```HidHelper.TranslateJoystickAxis()``` didn't handled that, Axis0 was overwritten by the LED pulse signal)
- fixes a problem with joystick hats not always having a ```LogicalMax``` of 8 (some can have a max of 7,  with 8 being the center position; PS4 controllers do this)
- fixes keyboard being recognized as multiple HID devices with no capability

Fixes #333 
Fixes #286 
Fixes #332 

Ping @Frassle :)