### PR TITLE
Fixed few bugs related to getting mouse coordinates

### DIFF
--- a/Source/OpenTK/Platform/Linux/LinuxNativeWindow.cs
+++ b/Source/OpenTK/Platform/Linux/LinuxNativeWindow.cs
@@ -351,27 +351,14 @@ namespace OpenTK.Platform.Linux
 
         public override Point PointToClient(Point point)
         {
-            var origin = Point.Empty;
-            var display = DisplayDevice.Default;
-            if (display != null)
-            {
-                origin = display.Bounds.Location;
-            }
             var client = Location;
-            return new Point(point.X + client.X - origin.X, point.Y + client.Y - origin.Y);
+            return new Point(point.X - client.X, point.Y - client.Y);
         }
 
         public override Point PointToScreen(Point point)
         {
-            var origin = Point.Empty;
-            var display = DisplayDevice.Default;
-            if (display != null)
-            {
-                origin = display.Bounds.Location;
-            }
             var client = Location;
-            return new Point(point.X + origin.X - client.X, point.Y + origin.Y - client.Y);
-
+            return new Point(point.X + client.X, point.Y + client.Y);
         }
 
         protected override void Dispose(bool disposing)

--- a/Source/OpenTK/Platform/SDL2/Sdl2.cs
+++ b/Source/OpenTK/Platform/SDL2/Sdl2.cs
@@ -249,6 +249,10 @@ namespace OpenTK.Platform.SDL2
         public static extern ButtonFlags GetMouseState(out int hx, out int hy);
 
         [SuppressUnmanagedCodeSecurity]
+        [DllImport(lib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "SDL_GetGlobalMouseState", ExactSpelling = true)]
+        public static extern ButtonFlags GetGlobalMouseState(out int hx, out int hy);
+
+        [SuppressUnmanagedCodeSecurity]
         [DllImport(lib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "SDL_GetNumDisplayModes", ExactSpelling = true)]
         public static extern int GetNumDisplayModes(int displayIndex);
 

--- a/Source/OpenTK/Platform/SDL2/Sdl2Mouse.cs
+++ b/Source/OpenTK/Platform/SDL2/Sdl2Mouse.cs
@@ -124,7 +124,7 @@ namespace OpenTK.Platform.SDL2
         public MouseState GetCursorState()
         {
             int x, y;
-            var buttons = SDL.GetMouseState(out x, out y);
+            var buttons = SDL.GetGlobalMouseState(out x, out y);
 
             var c = new MouseState();
             c.SetIsConnected(true);
@@ -137,7 +137,7 @@ namespace OpenTK.Platform.SDL2
             c[MouseButton.Button1] = (buttons & ButtonFlags.X1) != 0;
             c[MouseButton.Button2] = (buttons & ButtonFlags.X2) != 0;
 
-            return state;
+            return c;
         }
 
         public void SetPosition(double x, double y)
@@ -145,7 +145,7 @@ namespace OpenTK.Platform.SDL2
             SDL.WarpMouseInWindow(IntPtr.Zero, (int)x, (int)y);
         }
 
-        #endregion
+    #endregion
     }
 }
 

--- a/Source/OpenTK/Platform/SDL2/Sdl2NativeWindow.cs
+++ b/Source/OpenTK/Platform/SDL2/Sdl2NativeWindow.cs
@@ -577,26 +577,14 @@ namespace OpenTK.Platform.SDL2
 
         public override Point PointToClient(Point point)
         {
-            var origin = Point.Empty;
-            var display = DisplayDevice.Default;
-            if (display != null)
-            {
-                origin = display.Bounds.Location;
-            }
             var client = Location;
-            return new Point(point.X + client.X - origin.X, point.Y + client.Y - origin.Y);
+            return new Point(point.X - client.X, point.Y - client.Y);
         }
 
         public override Point PointToScreen(Point point)
         {
-            var origin = Point.Empty;
-            var display = DisplayDevice.Default;
-            if (display != null)
-            {
-                origin = display.Bounds.Location;
-            }
             var client = Location;
-            return new Point(point.X + origin.X - client.X, point.Y + origin.Y - client.Y);
+            return new Point(point.X + client.X, point.Y + client.Y);
         }
 
         public override Icon Icon


### PR DESCRIPTION
I was getting client window coordinates instead of screen coordinates from Mouse.GetCursorState method on my linux machine. It lead me to these changes. Plus I think implementations of SdlNativeWindow.PointToClient and PointToScreen were mixed up.