### PR TITLE
Removed confusing Vector3 Matrix4 interactions introduced with #331

### DIFF
--- a/Source/OpenTK/Math/Vector3.cs
+++ b/Source/OpenTK/Math/Vector3.cs
@@ -1138,28 +1138,6 @@ namespace OpenTK
                 vec.X * mat.Row0.Z + vec.Y * mat.Row1.Z + vec.Z * mat.Row2.Z);
         }
 
-        /// <summary>Transform a Vector by the given Matrix</summary>
-        /// <param name="vec">The vector to transform</param>
-        /// <param name="mat">The desired transformation</param>
-        /// <returns>The transformed vector</returns>
-        public static Vector3 Transform(Vector3 vec, Matrix4 mat)
-        {
-            Vector3 result;
-            Transform(ref vec, ref mat, out result);
-            return result;
-        }
-
-        /// <summary>Transform a Vector by the given Matrix</summary>
-        /// <param name="vec">The vector to transform</param>
-        /// <param name="mat">The desired transformation</param>
-        /// <param name="result">The transformed vector</param>
-        public static void Transform(ref Vector3 vec, ref Matrix4 mat, out Vector3 result)
-        {
-            Vector4 v4 = new Vector4(vec.X, vec.Y, vec.Z, 1.0f);
-            Vector4.Transform(ref v4, ref mat, out v4);
-            result = v4.Xyz;
-        }
-
         /// <summary>
         /// Transforms a vector by a quaternion rotation.
         /// </summary>
@@ -1212,28 +1190,6 @@ namespace OpenTK
                 mat.Row0.X * vec.X + mat.Row0.Y * vec.Y + mat.Row0.Z * vec.Z,
                 mat.Row1.X * vec.X + mat.Row1.Y * vec.Y + mat.Row1.Z * vec.Z,
                 mat.Row2.X * vec.X + mat.Row2.Y * vec.Y + mat.Row2.Z * vec.Z);
-        }
-
-        /// <summary>Transform a Vector by the given Matrix using right-handed notation</summary>
-        /// <param name="mat">The desired transformation</param>
-        /// <param name="vec">The vector to transform</param>
-        public static Vector3 Transform(Matrix4 mat, Vector3 vec)
-        {
-            Vector3 result;
-            Transform(ref mat, ref vec, out result);
-            return result;
-        }
-
-        /// <summary>Transform a Vector by the given Matrix using right-handed notation</summary>
-        /// <param name="mat">The desired transformation</param>
-        /// <param name="vec">The vector to transform</param>
-        /// <param name="result">The transformed vector</param>
-        public static void Transform(ref Matrix4 mat, ref Vector3 vec, out Vector3 result)
-        {
-            result = new Vector3(
-                mat.Row0.X * vec.X + mat.Row0.Y * vec.Y + mat.Row0.Z * vec.Z + mat.Row0.W,
-                mat.Row1.X * vec.X + mat.Row1.Y * vec.Y + mat.Row1.Z * vec.Z + mat.Row1.W,
-                mat.Row2.X * vec.X + mat.Row2.Y * vec.Y + mat.Row2.Z * vec.Z + mat.Row2.W);
         }
 
         /// <summary>Transform a Vector3 by the given Matrix, and project the resulting Vector4 back to a Vector3</summary>
@@ -1585,38 +1541,12 @@ namespace OpenTK
         }
 
         /// <summary>
-        /// Transform a Vector by the given Matrix.
-        /// </summary>
-        /// <param name="vec">The vector to transform</param>
-        /// <param name="mat">The desired transformation</param>
-        /// <returns>The transformed vector</returns>
-        public static Vector3 operator *(Vector3 vec, Matrix4 mat)
-        {
-            Vector3 result;
-            Vector3.Transform(ref vec, ref mat, out result);
-            return result;
-        }
-
-        /// <summary>
         /// Transform a Vector by the given Matrix using right-handed notation
         /// </summary>
         /// <param name="mat">The desired transformation</param>
         /// <param name="vec">The vector to transform</param>
         /// <returns>The transformed vector</returns>
         public static Vector3 operator *(Matrix3 mat, Vector3 vec)
-        {
-            Vector3 result;
-            Vector3.Transform(ref mat, ref vec, out result);
-            return result;
-        }
-
-        /// <summary>
-        /// Transform a Vector by the given Matrix using right-handed notation
-        /// </summary>
-        /// <param name="mat">The desired transformation</param>
-        /// <param name="vec">The vector to transform</param>
-        /// <returns>The transformed vector</returns>
-        public static Vector3 operator *(Matrix4 mat, Vector3 vec)
         {
             Vector3 result;
             Vector3.Transform(ref mat, ref vec, out result);


### PR DESCRIPTION
As discussed at length in #331, un-named operations between Vector3 and Matrix4 are ambiguous. This removes them.

Left in tact are the **named** interactions.

Looking over the code there are a lot of things that could be improved in terms of simplicity, code duplication, organisation, etc.
I will create a separate pull request for that, since it is a different concern.