### PR TITLE
Scaling mouse coordinate to match Retina scaling

### DIFF
--- a/Source/OpenTK/Platform/SDL2/Sdl2Mouse.cs
+++ b/Source/OpenTK/Platform/SDL2/Sdl2Mouse.cs
@@ -83,6 +83,8 @@ namespace OpenTK.Platform.SDL2
             }
         }
 
+        internal static float Scale = 1.0f;
+
         #endregion
 
         #region Public Members
@@ -110,13 +112,19 @@ namespace OpenTK.Platform.SDL2
 
         public MouseState GetState()
         {
-            return state;
+            MouseState scaledState = state;
+            if (Configuration.RunningOnMacOS)
+            {
+                scaledState.X = (int)Math.Round(scaledState.X * Scale);
+                scaledState.Y = (int)Math.Round(scaledState.Y * Scale);
+            }
+            return scaledState;
         }
 
         public MouseState GetState(int index)
         {
             if (index == 0)
-                return state;
+                return GetState();
             else
                 return new MouseState();
         }
@@ -125,6 +133,12 @@ namespace OpenTK.Platform.SDL2
         {
             int x, y;
             var buttons = SDL.GetMouseState(out x, out y);
+
+            if (Configuration.RunningOnMacOS)
+            {
+                x = (int)Math.Round(x * Scale);
+                y = (int)Math.Round(y * Scale);
+            }
 
             var c = new MouseState();
             c.SetIsConnected(true);
@@ -137,7 +151,7 @@ namespace OpenTK.Platform.SDL2
             c[MouseButton.Button1] = (buttons & ButtonFlags.X1) != 0;
             c[MouseButton.Button2] = (buttons & ButtonFlags.X2) != 0;
 
-            return state;
+            return c;
         }
 
         public void SetPosition(double x, double y)

--- a/Source/OpenTK/Platform/SDL2/Sdl2NativeWindow.cs
+++ b/Source/OpenTK/Platform/SDL2/Sdl2NativeWindow.cs
@@ -285,6 +285,7 @@ namespace OpenTK.Platform.SDL2
             window.OnMouseMove(
                 (int)Math.Round(ev.X * scale),
                 (int)Math.Round(ev.Y * scale));
+            Sdl2Mouse.Scale = scale;
         }
 
         static void ProcessMouseWheelEvent(Sdl2NativeWindow window, MouseWheelEvent ev)


### PR DESCRIPTION
On OS X with Retina displays, mouse coordinates should be scaled to match the Retina scaling (when HiDPI is allowed).

This PR only fixes the SDL2 backend.

Windows and Linux correctly use unscaled coordinates.

EDIT: this also fixes a bug in ```GetCursorState()``` which was returning a previous state and not the newly constructed one.