### PR TITLE
[SDL2] Don't test Stereo Mode when setting STENCIL_SIZE

### DIFF
--- a/Source/OpenTK/Platform/SDL2/Sdl2GraphicsContext.cs
+++ b/Source/OpenTK/Platform/SDL2/Sdl2GraphicsContext.cs
@@ -230,7 +230,7 @@ namespace OpenTK.Platform.SDL2
 
             if (mode.Stencil > 0)
             {
-                SDL.GL.SetAttribute(ContextAttribute.STENCIL_SIZE, mode.Stereo ? 1 : 0);
+                SDL.GL.SetAttribute(ContextAttribute.STENCIL_SIZE, 1);
             }
 
             if (mode.Stereo)


### PR DESCRIPTION
**Fix bug Stencil buffer not enabled on SDL2 platform.**

Remove stereo mode testing when enabling Stencil buffer.

Maybe the error is that the test case is inverted, and stencil buffer shouldn't be enabled if stereo mode is on (but I know nothing about stereo mode).
In doubt, I removed the test to get stenciling working.

