### PR TITLE
Fix axis range

### DIFF
--- a/Source/OpenTK/Input/GamePadState.cs
+++ b/Source/OpenTK/Input/GamePadState.cs
@@ -171,7 +171,7 @@ namespace OpenTK.Input
 
             if ((axis & GamePadAxes.LeftY) != 0)
             {
-                left_stick_y = (short)(-value);
+                left_stick_y = (short)~value;
             }
 
             if ((axis & GamePadAxes.RightX) != 0)
@@ -181,7 +181,7 @@ namespace OpenTK.Input
 
             if ((axis & GamePadAxes.RightY) != 0)
             {
-                right_stick_y = (short)(-value);
+                right_stick_y = (short)~value;
             }
 
             if ((axis & GamePadAxes.LeftTrigger) != 0)


### PR DESCRIPTION
So turns out that axis is using all the numbers in short... tho I would think that it would make more sense to just don't use the smallest number... 
 
Anyway read https://github.com/mono/MonoGame/issues/4539#issuecomment-196951477 for more details.

CC. @amulware @wcdeich4 @mrhelmut @dellis1972 