### PR TITLE
improved GetHashCode overrides of float/double Math types, closes #355

### DIFF
--- a/Source/OpenTK/Math/Box2.cs
+++ b/Source/OpenTK/Math/Box2.cs
@@ -12,7 +12,7 @@ namespace OpenTK
     /// Defines a 2d box (rectangle).
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
-    public struct Box2
+    public struct Box2 : IEquatable<Box2>
     {
         /// <summary>
         /// The left boundary of the structure.
@@ -190,14 +190,21 @@ namespace OpenTK
             return obj is Box2 && Equals((Box2) obj);
         }
 
-        /// <summary>
-        /// Gets the hash code for this Box2.
-        /// </summary>
-        /// <returns></returns>
+        ///// <summary>
+        ///// Gets the hash code for this Box2.
+        ///// </summary>
         public override int GetHashCode()
         {
-            return Left.GetHashCode() ^ Right.GetHashCode() ^ Top.GetHashCode() ^ Bottom.GetHashCode();
+            unchecked
+            {
+                var hashCode = this.Left.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.Right.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.Top.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.Bottom.GetHashCode();
+                return hashCode;
+            }
         }
+
 
         private static string listSeparator = System.Globalization.CultureInfo.CurrentCulture.TextInfo.ListSeparator;
         /// <summary>

--- a/Source/OpenTK/Math/Box2d.cs
+++ b/Source/OpenTK/Math/Box2d.cs
@@ -12,8 +12,9 @@ namespace OpenTK
     /// Defines a 2d box (rectangle).
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
-    public struct Box2d
+    public struct Box2d : IEquatable<Box2d>
     {
+
         /// <summary>
         /// The left boundary of the structure.
         /// </summary>
@@ -193,10 +194,16 @@ namespace OpenTK
         /// <summary>
         /// Gets the hash code for this Box2d.
         /// </summary>
-        /// <returns></returns>
         public override int GetHashCode()
         {
-            return Left.GetHashCode() ^ Right.GetHashCode() ^ Top.GetHashCode() ^ Bottom.GetHashCode();
+            unchecked
+            {
+                var hashCode = this.Left.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.Right.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.Top.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.Bottom.GetHashCode();
+                return hashCode;
+            }
         }
 
         private static string listSeparator = System.Globalization.CultureInfo.CurrentCulture.TextInfo.ListSeparator;

--- a/Source/OpenTK/Math/Matrix2.cs
+++ b/Source/OpenTK/Math/Matrix2.cs
@@ -721,7 +721,10 @@ namespace OpenTK
         /// <returns>A System.Int32 containing the unique hashcode for this instance.</returns>
         public override int GetHashCode()
         {
-            return Row0.GetHashCode() ^ Row1.GetHashCode();
+            unchecked
+            {
+                return (this.Row0.GetHashCode() * 397) ^ this.Row1.GetHashCode();
+            }
         }
 
         #endregion

--- a/Source/OpenTK/Math/Matrix2d.cs
+++ b/Source/OpenTK/Math/Matrix2d.cs
@@ -721,7 +721,10 @@ namespace OpenTK
         /// <returns>A System.Int32 containing the unique hashcode for this instance.</returns>
         public override int GetHashCode()
         {
-            return Row0.GetHashCode() ^ Row1.GetHashCode();
+            unchecked
+            {
+                return (this.Row0.GetHashCode() * 397) ^ this.Row1.GetHashCode();
+            }
         }
 
         #endregion

--- a/Source/OpenTK/Math/Matrix2x3.cs
+++ b/Source/OpenTK/Math/Matrix2x3.cs
@@ -679,7 +679,10 @@ namespace OpenTK
         /// <returns>A System.Int32 containing the unique hashcode for this instance.</returns>
         public override int GetHashCode()
         {
-            return Row0.GetHashCode() ^ Row1.GetHashCode();
+            unchecked
+            {
+                return (this.Row0.GetHashCode() * 397) ^ this.Row1.GetHashCode();
+            }
         }
 
         #endregion

--- a/Source/OpenTK/Math/Matrix2x3d.cs
+++ b/Source/OpenTK/Math/Matrix2x3d.cs
@@ -679,7 +679,10 @@ namespace OpenTK
         /// <returns>A System.Int32 containing the unique hashcode for this instance.</returns>
         public override int GetHashCode()
         {
-            return Row0.GetHashCode() ^ Row1.GetHashCode();
+            unchecked
+            {
+                return (this.Row0.GetHashCode() * 397) ^ this.Row1.GetHashCode();
+            }
         }
 
         #endregion

--- a/Source/OpenTK/Math/Matrix2x4.cs
+++ b/Source/OpenTK/Math/Matrix2x4.cs
@@ -716,7 +716,10 @@ namespace OpenTK
         /// <returns>A System.Int32 containing the unique hashcode for this instance.</returns>
         public override int GetHashCode()
         {
-            return Row0.GetHashCode() ^ Row1.GetHashCode();
+            unchecked
+            {
+                return (this.Row0.GetHashCode() * 397) ^ this.Row1.GetHashCode();
+            }
         }
 
         #endregion

--- a/Source/OpenTK/Math/Matrix2x4d.cs
+++ b/Source/OpenTK/Math/Matrix2x4d.cs
@@ -716,7 +716,10 @@ namespace OpenTK
         /// <returns>A System.Int32 containing the unique hashcode for this instance.</returns>
         public override int GetHashCode()
         {
-            return Row0.GetHashCode() ^ Row1.GetHashCode();
+            unchecked
+            {
+                return (this.Row0.GetHashCode() * 397) ^ this.Row1.GetHashCode();
+            }
         }
 
         #endregion

--- a/Source/OpenTK/Math/Matrix3.cs
+++ b/Source/OpenTK/Math/Matrix3.cs
@@ -960,7 +960,13 @@ namespace OpenTK
         /// <returns>A System.Int32 containing the unique hashcode for this instance.</returns>
         public override int GetHashCode()
         {
-            return Row0.GetHashCode() ^ Row1.GetHashCode() ^ Row2.GetHashCode();
+            unchecked
+            {
+                var hashCode = this.Row0.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.Row1.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.Row2.GetHashCode();
+                return hashCode;
+            }
         }
         
         #endregion

--- a/Source/OpenTK/Math/Matrix3d.cs
+++ b/Source/OpenTK/Math/Matrix3d.cs
@@ -951,7 +951,13 @@ namespace OpenTK
         /// <returns>A System.Int32 containing the unique hashcode for this instance.</returns>
         public override int GetHashCode()
         {
-            return Row0.GetHashCode() ^ Row1.GetHashCode() ^ Row2.GetHashCode();
+            unchecked
+            {
+                var hashCode = this.Row0.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.Row1.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.Row2.GetHashCode();
+                return hashCode;
+            }
         }
         
         #endregion

--- a/Source/OpenTK/Math/Matrix3x2.cs
+++ b/Source/OpenTK/Math/Matrix3x2.cs
@@ -690,7 +690,13 @@ namespace OpenTK
         /// <returns>A System.Int32 containing the unique hashcode for this instance.</returns>
         public override int GetHashCode()
         {
-            return Row0.GetHashCode() ^ Row1.GetHashCode() ^ Row2.GetHashCode();
+            unchecked
+            {
+                var hashCode = this.Row0.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.Row1.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.Row2.GetHashCode();
+                return hashCode;
+            }
         }
 
         #endregion

--- a/Source/OpenTK/Math/Matrix3x2d.cs
+++ b/Source/OpenTK/Math/Matrix3x2d.cs
@@ -690,7 +690,13 @@ namespace OpenTK
         /// <returns>A System.Int32 containing the unique hashcode for this instance.</returns>
         public override int GetHashCode()
         {
-            return Row0.GetHashCode() ^ Row1.GetHashCode() ^ Row2.GetHashCode();
+            unchecked
+            {
+                var hashCode = this.Row0.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.Row1.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.Row2.GetHashCode();
+                return hashCode;
+            }
         }
 
         #endregion

--- a/Source/OpenTK/Math/Matrix3x4.cs
+++ b/Source/OpenTK/Math/Matrix3x4.cs
@@ -954,7 +954,13 @@ namespace OpenTK
         /// <returns>A System.Int32 containing the unique hashcode for this instance.</returns>
         public override int GetHashCode()
         {
-            return Row0.GetHashCode() ^ Row1.GetHashCode() ^ Row2.GetHashCode();
+            unchecked
+            {
+                var hashCode = this.Row0.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.Row1.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.Row2.GetHashCode();
+                return hashCode;
+            }
         }
 
         #endregion

--- a/Source/OpenTK/Math/Matrix3x4d.cs
+++ b/Source/OpenTK/Math/Matrix3x4d.cs
@@ -954,7 +954,13 @@ namespace OpenTK
         /// <returns>A System.Int32 containing the unique hashcode for this instance.</returns>
         public override int GetHashCode()
         {
-            return Row0.GetHashCode() ^ Row1.GetHashCode() ^ Row2.GetHashCode();
+            unchecked
+            {
+                var hashCode = this.Row0.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.Row1.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.Row2.GetHashCode();
+                return hashCode;
+            }
         }
 
         #endregion

--- a/Source/OpenTK/Math/Matrix4.cs
+++ b/Source/OpenTK/Math/Matrix4.cs
@@ -1715,7 +1715,14 @@ namespace OpenTK
         /// <returns>A System.Int32 containing the unique hashcode for this instance.</returns>
         public override int GetHashCode()
         {
-            return Row0.GetHashCode() ^ Row1.GetHashCode() ^ Row2.GetHashCode() ^ Row3.GetHashCode();
+            unchecked
+            {
+                var hashCode = this.Row0.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.Row1.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.Row2.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.Row3.GetHashCode();
+                return hashCode;
+            }
         }
 
         #endregion

--- a/Source/OpenTK/Math/Matrix4d.cs
+++ b/Source/OpenTK/Math/Matrix4d.cs
@@ -1665,7 +1665,14 @@ namespace OpenTK
         /// <returns>A System.Int32 containing the unique hashcode for this instance.</returns>
         public override int GetHashCode()
         {
-            return Row0.GetHashCode() ^ Row1.GetHashCode() ^ Row2.GetHashCode() ^ Row3.GetHashCode();
+            unchecked
+            {
+                var hashCode = this.Row0.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.Row1.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.Row2.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.Row3.GetHashCode();
+                return hashCode;
+            }
         }
 
         #endregion

--- a/Source/OpenTK/Math/Matrix4x2.cs
+++ b/Source/OpenTK/Math/Matrix4x2.cs
@@ -739,7 +739,14 @@ namespace OpenTK
         /// <returns>A System.Int32 containing the unique hashcode for this instance.</returns>
         public override int GetHashCode()
         {
-            return Row0.GetHashCode() ^ Row1.GetHashCode() ^ Row2.GetHashCode() ^ Row3.GetHashCode();
+            unchecked
+            {
+                var hashCode = this.Row0.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.Row1.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.Row2.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.Row3.GetHashCode();
+                return hashCode;
+            }
         }
 
         #endregion

--- a/Source/OpenTK/Math/Matrix4x2d.cs
+++ b/Source/OpenTK/Math/Matrix4x2d.cs
@@ -739,7 +739,14 @@ namespace OpenTK
         /// <returns>A System.Int32 containing the unique hashcode for this instance.</returns>
         public override int GetHashCode()
         {
-            return Row0.GetHashCode() ^ Row1.GetHashCode() ^ Row2.GetHashCode() ^ Row3.GetHashCode();
+            unchecked
+            {
+                var hashCode = this.Row0.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.Row1.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.Row2.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.Row3.GetHashCode();
+                return hashCode;
+            }
         }
 
         #endregion

--- a/Source/OpenTK/Math/Matrix4x3.cs
+++ b/Source/OpenTK/Math/Matrix4x3.cs
@@ -962,7 +962,14 @@ namespace OpenTK
         /// <returns>A System.Int32 containing the unique hashcode for this instance.</returns>
         public override int GetHashCode()
         {
-            return Row0.GetHashCode() ^ Row1.GetHashCode() ^ Row2.GetHashCode();
+            unchecked
+            {
+                var hashCode = this.Row0.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.Row1.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.Row2.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.Row3.GetHashCode();
+                return hashCode;
+            }
         }
 
         #endregion

--- a/Source/OpenTK/Math/Matrix4x3d.cs
+++ b/Source/OpenTK/Math/Matrix4x3d.cs
@@ -962,7 +962,14 @@ namespace OpenTK
         /// <returns>A System.Int32 containing the unique hashcode for this instance.</returns>
         public override int GetHashCode()
         {
-            return Row0.GetHashCode() ^ Row1.GetHashCode() ^ Row2.GetHashCode();
+            unchecked
+            {
+                var hashCode = this.Row0.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.Row1.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.Row2.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.Row3.GetHashCode();
+                return hashCode;
+            }
         }
 
         #endregion

--- a/Source/OpenTK/Math/Quaternion.cs
+++ b/Source/OpenTK/Math/Quaternion.cs
@@ -857,7 +857,10 @@ namespace OpenTK
         /// <returns>A hash code formed from the bitwise XOR of this objects members.</returns>
         public override int GetHashCode()
         {
-            return Xyz.GetHashCode() ^ W.GetHashCode();
+            unchecked
+            {
+                return (this.xyz.GetHashCode() * 397) ^ this.w.GetHashCode();
+            }
         }
 
         #endregion

--- a/Source/OpenTK/Math/Quaterniond.cs
+++ b/Source/OpenTK/Math/Quaterniond.cs
@@ -854,9 +854,13 @@ namespace OpenTK
         /// Provides the hash code for this object. 
         /// </summary>
         /// <returns>A hash code formed from the bitwise XOR of this objects members.</returns>
+
         public override int GetHashCode()
         {
-            return Xyz.GetHashCode() ^ W.GetHashCode();
+            unchecked
+            {
+                return (this.xyz.GetHashCode() * 397) ^ this.w.GetHashCode();
+            }
         }
 
         #endregion

--- a/Source/OpenTK/Math/Vector2.cs
+++ b/Source/OpenTK/Math/Vector2.cs
@@ -1137,7 +1137,10 @@ namespace OpenTK
         /// <returns>A System.Int32 containing the unique hashcode for this instance.</returns>
         public override int GetHashCode()
         {
-            return X.GetHashCode() ^ Y.GetHashCode();
+            unchecked
+            {
+                return (this.X.GetHashCode() * 397) ^ this.Y.GetHashCode();
+            }
         }
 
         #endregion

--- a/Source/OpenTK/Math/Vector2d.cs
+++ b/Source/OpenTK/Math/Vector2d.cs
@@ -1015,7 +1015,10 @@ namespace OpenTK
         /// <returns>A System.Int32 containing the unique hashcode for this instance.</returns>
         public override int GetHashCode()
         {
-            return X.GetHashCode() ^ Y.GetHashCode();
+            unchecked
+            {
+                return (this.X.GetHashCode() * 397) ^ this.Y.GetHashCode();
+            }
         }
 
         #endregion

--- a/Source/OpenTK/Math/Vector3.cs
+++ b/Source/OpenTK/Math/Vector3.cs
@@ -1629,7 +1629,13 @@ namespace OpenTK
         /// <returns>A System.Int32 containing the unique hashcode for this instance.</returns>
         public override int GetHashCode()
         {
-            return X.GetHashCode() ^ Y.GetHashCode() ^ Z.GetHashCode();
+            unchecked
+            {
+                var hashCode = this.X.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.Y.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.Z.GetHashCode();
+                return hashCode;
+            }
         }
 
         #endregion

--- a/Source/OpenTK/Math/Vector3d.cs
+++ b/Source/OpenTK/Math/Vector3d.cs
@@ -1466,7 +1466,13 @@ namespace OpenTK
         /// <returns>A System.Int32 containing the unique hashcode for this instance.</returns>
         public override int GetHashCode()
         {
-            return X.GetHashCode() ^ Y.GetHashCode() ^ Z.GetHashCode();
+            unchecked
+            {
+                var hashCode = this.X.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.Y.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.Z.GetHashCode();
+                return hashCode;
+            }
         }
 
         #endregion

--- a/Source/OpenTK/Math/Vector4.cs
+++ b/Source/OpenTK/Math/Vector4.cs
@@ -1657,7 +1657,14 @@ namespace OpenTK
         /// <returns>A System.Int32 containing the unique hashcode for this instance.</returns>
         public override int GetHashCode()
         {
-            return X.GetHashCode() ^ Y.GetHashCode() ^ Z.GetHashCode() ^ W.GetHashCode();
+            unchecked
+            {
+                var hashCode = this.X.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.Y.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.Z.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.W.GetHashCode();
+                return hashCode;
+            }
         }
 
         #endregion

--- a/Source/OpenTK/Math/Vector4d.cs
+++ b/Source/OpenTK/Math/Vector4d.cs
@@ -1613,7 +1613,14 @@ namespace OpenTK
         /// <returns>A System.Int32 containing the unique hashcode for this instance.</returns>
         public override int GetHashCode()
         {
-            return X.GetHashCode() ^ Y.GetHashCode() ^ Z.GetHashCode() ^ W.GetHashCode();
+            unchecked
+            {
+                var hashCode = this.X.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.Y.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.Z.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.W.GetHashCode();
+                return hashCode;
+            }
         }
 
         #endregion


### PR DESCRIPTION
Specifically, all Vector/Matrix/Quaternion/Box types based on float and double (not those based on Half) have been changed to calculate their hash-codes as follows:

```
public override int GetHashCode()
{
    unchecked
    {
        var hashCode = this.component1.GetHashCode();
        hashCode = (hashCode * 397) ^ this.component2.GetHashCode();
        hashCode = (hashCode * 397) ^ this.component3.GetHashCode();
        /* .. */
        return hashCode;
    }
}
```

The previous implementation was symmetrical (simple xor) between components, which for example would cause the vectors (1, 0, 0), (0, 1, 0) and (0, 0, 1) to all have the same hash-code.

This new algorithm is the one used by ReSharper's automatic implementation of `GetHashCode` and does not have this problem.

For more discussion, see #355.

---

Oh, also I made Box2 and Box2d implement the IEquatable interface. That will make using them in generic algorithms and data structures more performant.

---

For the future, we should consider implementing GetHashCode for Half, and the Vector and Matrix types based on it.
Unfortunately, Half.Equals() is quite complicated, and we have to make sure the has-code implementation does not violate the equality.