### PR TITLE
Add Stable and Devel NuGet packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,8 @@ Source/GLControl/OpenTK.GLControl.xml
 Documentation/Source
 opentk*.exe
 opentk*.zip
-opentk*.nupkg
 Installers/Nuget/lib
+*.nupkg
 
 # OpenTK Resource files that seem like they should be ignored:
 Source/Compatibility/Properties/Resources.resources

--- a/Installers/Nuget/Build.Installer.Nuget.csproj
+++ b/Installers/Nuget/Build.Installer.Nuget.csproj
@@ -59,6 +59,21 @@
     <OutputPath>obj\</OutputPath>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup>
+    <Stable>false</Stable>
+  </PropertyGroup>
+  <Choose>
+    <When Condition=" '$(Stable)'=='True' ">
+      <PropertyGroup>
+        <Name>Desktop</Name>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <Name>Desktop.Devel</Name>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
   <Target Name="Build">
     <!-- Copy built files to the tree format expected by nuget -->
     <CreateItem Include="../../Binaries/OpenTK/Release/OpenTK*">
@@ -70,10 +85,10 @@
       <Output TaskParameter="Lines" ItemName="Version" />
     </ReadLinesFromFile>
     <!-- Execute nuget script -->
-    <Exec Command="nuget.exe	 pack OpenTK.nuspec -Version @(Version)" Condition="$(OS) == 'Windows_NT'" />
-    <Exec Command="nuget.exe   pack OpenTK.GLControl.nuspec -Version @(Version)" Condition="$(OS) == 'Windows_NT'" />
-    <Exec Command="mono nuget.exe pack OpenTK.nuspec  -Version @(Version)" Condition="$(OS) != 'Windows_NT'" />
-    <Exec Command="mono nuget.exe pack OpenTK.GLControl.nuspec  -Version @(Version)" Condition="$(OS) != 'Windows_NT'" />
+    <Exec Command="nuget.exe pack OpenTK.$(Name).nuspec -Version @(Version)" Condition="$(OS) == 'Windows_NT'" />
+    <Exec Command="nuget.exe pack OpenTK.GLControl.nuspec -Version @(Version)" Condition="$(OS) == 'Windows_NT'" />
+    <Exec Command="mono nuget.exe pack OpenTK.$(Name).nuspec -Version @(Version)" Condition="$(OS) != 'Windows_NT'" />
+    <Exec Command="mono nuget.exe pack OpenTK.GLControl.nuspec -Version @(Version)" Condition="$(OS) != 'Windows_NT'" />
     <!-- Copy the nuget archive to the root directory and add a date stamp -->
     <CreateItem Include="OpenTK*.nupkg">
       <Output TaskParameter="Include" ItemName="NugetPackage" />

--- a/Installers/Nuget/OpenTK.Desktop.Devel.nuspec
+++ b/Installers/Nuget/OpenTK.Desktop.Devel.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
-        <id>OpenTK</id>
+        <id>OpenTK.Desktop.Devel</id>
         <version>$version$</version>
         <authors>The Open Toolkit Team</authors>
         <owners>The Open Toolkit Team</owners>
@@ -13,6 +13,8 @@
             The Open Toolkit library (OpenTK) is an advanced, low-level C# wrapper for OpenGL, OpenGL ES and OpenAL.
         </summary>
         <description>
+            WARNING: This is a development release, use at your own risk.
+        
             The Open Toolkit library (OpenTK) is an advanced, low-level C# wrapper for OpenGL, OpenGL ES and OpenAL.
             It is suitable for games, scientific visualizations and projects that require 3d graphics, audio or compute functionality.
 

--- a/Installers/Nuget/OpenTK.Desktop.nuspec
+++ b/Installers/Nuget/OpenTK.Desktop.nuspec
@@ -1,0 +1,48 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+    <metadata>
+        <id>OpenTK.Desktop</id>
+        <version>$version$</version>
+        <authors>The Open Toolkit Team</authors>
+        <owners>The Open Toolkit Team</owners>
+        <licenseUrl>http://www.opentk.com/project/license</licenseUrl>
+        <projectUrl>http://www.opentk.com</projectUrl>
+        <iconUrl>file:///./logo.png</iconUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <summary>
+            The Open Toolkit library (OpenTK) is an advanced, low-level C# wrapper for OpenGL, OpenGL ES and OpenAL.
+        </summary>
+        <description>
+            The Open Toolkit library (OpenTK) is an advanced, low-level C# wrapper for OpenGL, OpenGL ES and OpenAL.
+            It is suitable for games, scientific visualizations and projects that require 3d graphics, audio or compute functionality.
+
+            Features
+            - Create cutting-edge graphics with OpenGL 4.4 and OpenGL ES 3.0
+            - Integrate 3d graphics into your Windows.Forms, WPF or GTK# applications
+            - Write once run everywhere: Windows, Mac OS X, Linux, Android and iOS
+            - Use the .Net/Mono language of your choice: C#, F#, VB.Net, Boo, IronPython, IronRuby
+            - Develop faster with inline documentation and strongly-typed enumerations for all OpenGL and OpenAL functions
+
+            This is the official nuget package from http://www.opentk.com
+            The source code can be found at https://github.com/opentk/opentk
+        </description>
+        <releaseNotes>
+            http://www.opentk.com/news
+        </releaseNotes>
+        <copyright>Copyright 2006-2013 Stefanos Apostolopoulos</copyright>
+        <tags>OpenTK OpenGL OpenGLES OpenAL C# F# VB .Net Mono</tags>
+        <references>
+            <reference file="OpenTK.dll" />
+        </references>
+        <frameworkAssemblies>
+            <frameworkAssembly assemblyName="System" />
+            <frameworkAssembly assemblyName="System.Drawing" />
+            <frameworkAssembly assemblyName="System.Xml" />
+        </frameworkAssemblies>
+	</metadata>
+    <files>
+        <file src="lib/net20/OpenTK.dll" target="lib/net20" />
+        <file src="lib/net20/OpenTK.xml" target="lib/net20" />
+        <file src="lib/net20/OpenTK.dll.config" target="content" />
+    </files>
+</package>


### PR DESCRIPTION
This adds an extra option to https://github.com/opentk/opentk/wiki/Nuget-Build-Script 
```
/p:Stable={True/False}
```
so it can choose between generating stable and devel package. The packages have ids "OpenTK.Desktop" and "OpenTK.Desktop.Devel" (I've claimed both so we can take out sweet time on this).

We should probably do a stable release before revealing OpenTK.Desktop package. Once this is merged I'll make the Devel package public.

On the question of the account used, I added "opentk" nuget and "opentkbase" gmail accounts, I'll give the password info to the rest of the members, just tell me in gitter where do you want the info sent(email / gitter / preferably something 3rd which actually has an encryption and doesn't store messages).

CC. @thefiddler @amulware @wcdeich4