### PR TITLE
Context tostring fixes

### DIFF
--- a/Source/OpenTK/Graphics/GraphicsContextBase.cs
+++ b/Source/OpenTK/Graphics/GraphicsContextBase.cs
@@ -141,8 +141,8 @@ namespace OpenTK.Graphics
 
         public override string ToString()
         {
-            return string.Format("[{0}: IsCurrent={1}, IsDisposed={2}, VSync={3}, SwapInterval={4}, GraphicsMode={5}, ErrorChecking={6}, Implementation={7}, Context={8}]",
-                GetType().Name, IsCurrent, IsDisposed, VSync, SwapInterval, GraphicsMode, ErrorChecking, Implementation, Context);
+            return string.Format("[{0}: IsCurrent={1}, IsDisposed={2}, VSync={3}, SwapInterval={4}, GraphicsMode={5}, Context={6}]",
+                GetType().Name, IsCurrent, IsDisposed, VSync, SwapInterval, GraphicsMode, Context);
         }
 
         public override int GetHashCode()

--- a/Source/OpenTK/Platform/Egl/EglContext.cs
+++ b/Source/OpenTK/Platform/Egl/EglContext.cs
@@ -117,7 +117,7 @@ namespace OpenTK.Platform.Egl
         {
             if (!Egl.SwapBuffers(WindowInfo.Display, WindowInfo.Surface))
             {
-                throw new GraphicsContextException(string.Format("Failed to swap buffers for context {0} current. Error: {1}", this, Egl.GetError()));
+                throw new GraphicsContextException(string.Format("Failed to swap buffers for context {0} current. Error: {1}", Handle, Egl.GetError()));
             }
         }
 
@@ -133,7 +133,7 @@ namespace OpenTK.Platform.Egl
                     WindowInfo = (EglWindowInfo) window;
                 if (!Egl.MakeCurrent(WindowInfo.Display, WindowInfo.Surface, WindowInfo.Surface, HandleAsEGLContext))
                 {
-                    throw new GraphicsContextException(string.Format("Failed to make context {0} current. Error: {1}", this, Egl.GetError()));
+                    throw new GraphicsContextException(string.Format("Failed to make context {0} current. Error: {1}", Handle, Egl.GetError()));
                 }
             }
             else


### PR DESCRIPTION
ErrorChecking is throwing exception in GraphicsResourceBase and implementation returns this.
As a result most GraphicsContextBase.ToString() were crashing or infinite recursing.

It was actually happening in EglContext (now switched to Handle instead of this when creating exception message, so that it doesn't matter even without the ToString() improvements)