### PR TITLE
Fix OpenTK assembly name error

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -93,7 +93,12 @@ let activeProjects =
 
 // Generate assembly info files with the right version & up-to-date information
 Target "AssemblyInfo" (fun _ ->
-    let getAssemblyInfoAttributes projectName =
+    let getAssemblyInfoAttributes (projectName:string) =
+        let projectName = 
+            if projectName.Contains(".iOS") || projectName.Contains(".Android") then
+                projectName.Split('.').[0]
+            else
+                projectName
         [ Attribute.Title (projectName)
           Attribute.Product project
           Attribute.Description summary

--- a/src/OpenTK/Properties/AssemblyInfo.cs
+++ b/src/OpenTK/Properties/AssemblyInfo.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Reflection;
 
-[assembly: AssemblyTitleAttribute("OpenTK.iOS")]
+[assembly: AssemblyTitleAttribute("OpenTK")]
 [assembly: AssemblyProductAttribute("OpenTK")]
 [assembly: AssemblyDescriptionAttribute("A set of fast, low-level C# bindings for OpenGL, OpenGL ES and OpenAL.")]
 [assembly: AssemblyVersionAttribute("2.0.0")]


### PR DESCRIPTION
This fix works around the name generation for OpenTK. It ensures that assemblies are titled OpenTK, rather than OpenTK.iOS or OpenTK.Android.

With this in place, we should be able to do a NuGet release.