### PR TITLE
Fix wrong obsolete message

### DIFF
--- a/src/OpenTK/Math/Matrix4.cs
+++ b/src/OpenTK/Math/Matrix4.cs
@@ -1157,7 +1157,7 @@ namespace OpenTK
         /// </summary>
         /// <param name="q">the quaternion</param>
         /// <returns>A rotation matrix</returns>
-        [Obsolete("Use CreateRotation instead.")]
+        [Obsolete("Use CreateFromQuaternion instead.")]
         public static Matrix4 Rotate(Quaternion q)
         {
             return CreateFromQuaternion(q);


### PR DESCRIPTION
Fix wrong obsolete message for method "public static Matrix4 Rotate(Quaternion q)"
from CreateRotation to CreateFromQuaternion