### PR TITLE
Fix 2 crashes on Android

### DIFF
--- a/src/OpenTK/Platform/Android/AndroidGameView.cs
+++ b/src/OpenTK/Platform/Android/AndroidGameView.cs
@@ -457,7 +457,7 @@ namespace OpenTK.Platform.Android
 
             // if the render thread is paused, let it run so it exits
             pauseSignal.Set ();
-            stopWatch.Stop ();
+            if (stopWatch != null) stopWatch.Stop ();
         }
 
         void PauseThread ()

--- a/src/OpenTK/Platform/Android/AndroidGraphicsContext.cs
+++ b/src/OpenTK/Platform/Android/AndroidGraphicsContext.cs
@@ -57,7 +57,7 @@ namespace OpenTK.Platform.Android {
 
         public bool HasSurface
         {
-            get { return eglWindowInfo.Surface != IntPtr.Zero; }
+            get { return eglWindowInfo != null && eglWindowInfo.Surface != IntPtr.Zero; }
         }
 
         public ISurfaceHolder Holder {


### PR DESCRIPTION
This adds 2 missing null checks to solve 2 crashes I experienced when testing Android.