### PR TITLE
Removed the stubs for System.Diagnostics.Debug from Android & IOS

### DIFF
--- a/src/OpenTK/Minimal.cs
+++ b/src/OpenTK/Minimal.cs
@@ -13,6 +13,8 @@ namespace OpenTK
     // minimal targets (e.g. MonoTouch).
     // Note: the "overriden" classes must not be fully qualified for this to work!
 
+    #if MINIMAL
+
     // System.Diagnostics.Debug
     static class Debug
     {
@@ -38,8 +40,6 @@ namespace OpenTK
         public static void Unindent() { }
         public static void Flush() { }
     }
-
-    #if MINIMAL
 
     // System.Diagnostics.Stopwatch
     sealed class Stopwatch


### PR DESCRIPTION
This looks like it was once a Xamarin limitation, but it’s not anymore.
Note: tested this on Android, but not on IOS (tested compilation on IOS
only).
Fixes #447