### PR TITLE
Removed redundant printout for "OnMouseMove called without moving the mouse"

### DIFF
--- a/src/OpenTK/Platform/NativeWindowBase.cs
+++ b/src/OpenTK/Platform/NativeWindowBase.cs
@@ -269,7 +269,6 @@ namespace OpenTK.Platform
 
             if (e.XDelta == 0 && e.YDelta == 0)
             {
-                Debug.WriteLine("OnMouseMove called without moving the mouse");
                 return;
             }
 


### PR DESCRIPTION
This fixes #416.
The problem with this printout (as explained in the issue) is that on
Windows (at least for specific devices/OS) GetMouseMovePointsEx can
return duplicate points, so it’s either adding a check in the Windows
layer or remove the printout. Adding a check in the Windows layer looks
redundant though, as this is already checked in NativeWindowBase, so
removing the printout looks preferable.