### PR TITLE
Proof of concept: Fix CPU waste

### DIFF
--- a/src/OpenTK/GameWindow.cs
+++ b/src/OpenTK/GameWindow.cs
@@ -458,9 +458,12 @@ namespace OpenTK
             double timestamp = watch.Elapsed.TotalSeconds;
             double elapsed = 0;
 
+            bool updatedEver = false;
+
             elapsed = ClampElapsed(timestamp - update_timestamp);
             while (elapsed > 0 && elapsed + update_epsilon >= TargetUpdatePeriod)
             {
+                updatedEver = true;
                 RaiseUpdateFrame(elapsed, ref timestamp);
                 
                 // Calculate difference (positive or negative) between
@@ -492,7 +495,13 @@ namespace OpenTK
             elapsed = ClampElapsed(timestamp - render_timestamp);
             if (elapsed > 0 && elapsed >= TargetRenderPeriod)
             {
+                updatedEver = true;
                 RaiseRenderFrame(elapsed, ref timestamp);
+            }
+
+            if (!updatedEver)
+            {
+                Thread.Sleep(1);
             }
         }
 

--- a/src/OpenTK/GameWindow.cs
+++ b/src/OpenTK/GameWindow.cs
@@ -102,6 +102,8 @@ namespace OpenTK
 
         bool is_running_slowly; // true, when UpdatePeriod cannot reach TargetUpdatePeriod
 
+        bool fix_cpu_waste = false;
+
         FrameEventArgs update_args = new FrameEventArgs();
         FrameEventArgs render_args = new FrameEventArgs();
 
@@ -458,7 +460,7 @@ namespace OpenTK
             double timestamp = watch.Elapsed.TotalSeconds;
             double elapsed = 0;
 
-            bool updatedEver = false;
+            bool updatedEver = !fix_cpu_waste;
 
             elapsed = ClampElapsed(timestamp - update_timestamp);
             while (elapsed > 0 && elapsed + update_epsilon >= TargetUpdatePeriod)
@@ -885,6 +887,27 @@ namespace OpenTK
             {
                 EnsureUndisposed();
                 return update_time;
+            }
+        }
+
+        #endregion
+
+        #region ReduceCPUWaste
+
+        /// <summary>
+        /// Gets or sets a boolean indicating whether CPU usage should be reduced via thread yielding.
+        /// </summary>
+        public bool ReduceCPUWaste
+        {
+            get
+            {
+                EnsureUndisposed();
+                return fix_cpu_waste;
+            }
+            set
+            {
+                EnsureUndisposed();
+                fix_cpu_waste = value;
             }
         }
 


### PR DESCRIPTION
### This PR

This Pull Request is a mere PROOF OF CONCEPT and/or a conversation starter.
As such, it is not necessarily read to be pulled in current state.

I wanted to discuss with the OpenTK team a possibility of fixing a potentially major issue.

Single core CPUs users and for some reason also occasionally Linux users will be happy to have this dealt with.

### Prior to this change

OpenTK GameWindows, for reasons unknown to me, SPINLOCK while trying to calculate frames.

This means it will USE AN ENTIRE CPU CORE INFINITELY while a game is running!

This is fine if a CPU is going to be pegged by the game regardless, (This change could be made optional?), but it is NOT REASONABLE for slower games, and further, NOT NECESSARY for MOST games!
Particularly not on weaker CPUs!

### My proposed solution?

It is fairly simple: DO NOT SPINLOCK.

How? If the system is running faster than necessary to update at the correct speed... Sleep for about 1 millisecond (or more, if system needs more) before continuing.

### How does this effect the issue?

It entirely solves it. No more spinlock, no more CPU pegging, no more anything painful!

### How does this effect unrelated things?

**Vsync disabled:** Don't ask me how or why, but my FPS was higher now for projects in which Vsync is off. Probably needs more testing to be sure.

**Vsync enabled:** FPS gets a TINY BIT shifty (potentially) when this change is done with vsync enabled. FPS drops the smallest fraction but not majorly - my project, which was just above 60 FPS with vsync off (Approx 67 off, static 60/59 on), was shifting around near 60 FPS still, but now occasionally dipping to 58 rather than just 59 (though still hovering at 60 most of the time).

For both of the above, more testing would be needed to confirm results.

### Things that still need work

As I said above, this should probably be made into an optional feature, for projects in which pegging the CPU to get every drop of framerate potential might be important.

Could potentially also change the 1ms sleep to a shorter yield, dependent on testing.
