### PR TITLE
Fix: Some joysticks return an invalid HID page of 1

### DIFF
--- a/src/OpenTK/Platform/Windows/WinRawJoystick.cs
+++ b/src/OpenTK/Platform/Windows/WinRawJoystick.cs
@@ -83,8 +83,13 @@ namespace OpenTK.Platform.Windows
             {
                 if (page == HIDPage.GenericDesktop || page == HIDPage.Simulation) // set axis only when HIDPage is known by HidHelper.TranslateJoystickAxis() to avoid axis0 to be overwritten by unknown HIDPage
                 {
-                    JoystickAxis axis = GetAxis(collection, page, usage);
-                    State.SetAxis(axis, value);
+					//Certain joysticks (Speedlink Black Widow, PS3 pad connected via USB)
+					//return an invalid HID page of 1, so 
+                    if ((int)usage != 1)
+                    {
+                        JoystickAxis axis = GetAxis(collection, page, usage);
+                        State.SetAxis(axis, value);
+                    }
                 }
             }
 


### PR DESCRIPTION
Just discovered this one.

Some joysticks using the Windows HID driver appear to return a HID page of 1 (0x0001 is the raw short), which then generates a phantom extra axis.
This phantom extra axis overwrites axis 0, and it then displays as being stuck at max.

I don't especially like this fix, in an ideal world it'd be fixed in the GetAxis function, but that would entail re-writing the whole function as it's got no concept of an invalid axis. Something like this instead of the change below:
```C#
JoystickAxis axis = GetAxis(collection, page, usage);
if(axis != JoystickAxis.Invalid)
{
  State.SetAxis(axis, value);
}
```
GetAxis function something like this:
```C#
JoystickAxis GetAxis(short collection, HIDPage page, short usage)
            {
                int key = MakeKey(collection, page, usage);
                if (!axes.ContainsKey(key))
                {
                    JoystickAxis axis = HidHelper.TranslateJoystickAxis(page, usage);
                    if(axis == JoystickAxis.Invalid)
                    {
                        return axis;
                    }
                    axes.Add(key, axis);
                }
                return axes[key];
            }
```
The absolute ideal would probably be to implement the change pattern from my other PR for joystick axes ( https://github.com/opentk/opentk/pull/453 ) , and to just use -1 as the invalid axis identifier.

At the minute though, the proposed change works around the problem with as little extra changes as possible.

Feedback :)