### PR TITLE
Fix: Incorrect documentation for MathHelper.NextPowerOfTwo

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ OpenTK 1.1.4c was released on 24 July 2014.
 
 This is a hotfix release that improves stability on Mac OS X. Moreover, it synchronizes the GamePad configuration database with SDL 2.0.4 and fixes an invalid GUID introduced in 1.1.4b.
 
-### 214-07-21
+### 2014-07-21
 
 OpenTK 1.1.4 was released on 21 July 2014.
 

--- a/src/OpenTK/Math/MathHelper.cs
+++ b/src/OpenTK/Math/MathHelper.cs
@@ -78,7 +78,7 @@ namespace OpenTK
         #region NextPowerOfTwo
 
         /// <summary>
-        /// Returns the next power of two that is larger than the specified number.
+        /// Returns the next power of two that is greater than or equal to the specified number.
         /// </summary>
         /// <param name="n">The specified number.</param>
         /// <returns>The next power of two.</returns>
@@ -89,7 +89,7 @@ namespace OpenTK
         }
 
         /// <summary>
-        /// Returns the next power of two that is larger than the specified number.
+        /// Returns the next power of two that is greater than or equal to the specified number.
         /// </summary>
         /// <param name="n">The specified number.</param>
         /// <returns>The next power of two.</returns>
@@ -100,7 +100,7 @@ namespace OpenTK
         }
 
         /// <summary>
-        /// Returns the next power of two that is larger than the specified number.
+        /// Returns the next power of two that is greater than or equal to the specified number.
         /// </summary>
         /// <param name="n">The specified number.</param>
         /// <returns>The next power of two.</returns>
@@ -111,7 +111,7 @@ namespace OpenTK
         }
 
         /// <summary>
-        /// Returns the next power of two that is larger than the specified number.
+        /// Returns the next power of two that is greater than or equal to the specified number.
         /// </summary>
         /// <param name="n">The specified number.</param>
         /// <returns>The next power of two.</returns>


### PR DESCRIPTION
Couple of typos :)
Closes https://github.com/opentk/opentk/issues/477
Closes https://github.com/opentk/opentk/issues/473