### PR TITLE
Fix: Joysticks with an axis range below zero were inverted

### DIFF
--- a/src/OpenTK/Platform/Windows/WinRawJoystick.cs
+++ b/src/OpenTK/Platform/Windows/WinRawJoystick.cs
@@ -83,8 +83,8 @@ namespace OpenTK.Platform.Windows
             {
                 if (page == HIDPage.GenericDesktop || page == HIDPage.Simulation) // set axis only when HIDPage is known by HidHelper.TranslateJoystickAxis() to avoid axis0 to be overwritten by unknown HIDPage
                 {
-					//Certain joysticks (Speedlink Black Widow, PS3 pad connected via USB)
-					//return an invalid HID page of 1, so 
+                    //Certain joysticks (Speedlink Black Widow, PS3 pad connected via USB)
+                    //return an invalid HID page of 1, so 
                     if ((int)usage != 1)
                     {
                         JoystickAxis axis = GetAxis(collection, page, usage);
@@ -405,11 +405,24 @@ namespace OpenTK.Platform.Windows
                 }
                 else
                 {
-                    short scaled_value = (short)HidHelper.ScaleValue(
-                        (int)((long)value + stick.AxisCaps[i].LogicalMin),
-                        stick.AxisCaps[i].LogicalMin, stick.AxisCaps[i].LogicalMax,
-                        Int16.MinValue, Int16.MaxValue);
-                    stick.SetAxis(collection, page, usage, scaled_value);
+                    if (stick.AxisCaps[i].LogicalMin > 0)
+                    {
+                        short scaled_value = (short) HidHelper.ScaleValue(
+                            (int) ((long) value + stick.AxisCaps[i].LogicalMin),
+                            stick.AxisCaps[i].LogicalMin, stick.AxisCaps[i].LogicalMax,
+                            Int16.MinValue, Int16.MaxValue);
+                        stick.SetAxis(collection, page, usage, scaled_value);
+                    }
+                    else
+                    {
+                        //If our stick returns a minimum value below zero, we should not add this to our value
+                        //before attempting to scale it, as this then inverts the value
+                        short scaled_value = (short)HidHelper.ScaleValue(
+                            (int)(long)value,
+                            stick.AxisCaps[i].LogicalMin, stick.AxisCaps[i].LogicalMax,
+                            Int16.MinValue, Int16.MaxValue);
+                        stick.SetAxis(collection, page, usage, scaled_value);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Another issue I've just discovered, which is marginally related to this one:
https://github.com/opentk/opentk/issues/480

Take a joystick with an axis range of -128 to 128.
With our axis centered (Returning a raw value of 0), it returns a translated value of -1
With our axis pushed all the way forwards, it returns a translated value of 1
With our axis pushed all the way backwards, it returns a translated value of 0

To fix this, we need to check if our logical minimum is below zero, and not add it to the value if this is the case.

_Note:_
Windows native backend issue only.