### PR TITLE
Fix: Xbox controller D-Pad not working under Windows

### DIFF
--- a/src/OpenTK/Platform/Windows/XInputJoystick.cs
+++ b/src/OpenTK/Platform/Windows/XInputJoystick.cs
@@ -130,7 +130,7 @@ namespace OpenTK.Platform.Windows
                 int buttons = TranslateButtons(xcaps.GamePad.Buttons);
                 int axes = TranslateAxes(ref xcaps.GamePad);
 
-                return new JoystickCapabilities(axes, buttons, 0, true);
+                return new JoystickCapabilities(axes, buttons, 1, true);
             }
             return new JoystickCapabilities();
         }


### PR DESCRIPTION
Appears to be a typo, setting the controller to have a single hat makes things work.

(Windows native backend issue only)