### PR TITLE
XInputGetStateEx obtained through ordinal

### DIFF
--- a/src/OpenTK/Platform/Windows/XInputJoystick.cs
+++ b/src/OpenTK/Platform/Windows/XInputJoystick.cs
@@ -371,14 +371,22 @@ namespace OpenTK.Platform.Windows
                 // Load the entry points we are interested in from that dll
                 GetCapabilities = (XInputGetCapabilities)Load("XInputGetCapabilities", typeof(XInputGetCapabilities));
                 GetState =
-                    // undocumented XInputGetStateEx with support for the "Guide" button (requires XINPUT_1_3+)
-                    (XInputGetState)Load("XInputGetStateEx", typeof(XInputGetState)) ??
+                    // undocumented XInputGetStateEx (Ordinal 100) with support for the "Guide" button (requires XINPUT_1_3+)
+                    (XInputGetState)Load(100, typeof(XInputGetState)) ??
                     // documented XInputGetState (no support for the "Guide" button)
                     (XInputGetState)Load("XInputGetState", typeof(XInputGetState));
                 SetState = (XInputSetState)Load("XInputSetState", typeof(XInputSetState));
             }
 
             #region Private Members
+
+            Delegate Load(ushort ordinal, Type type)
+            {
+                IntPtr pfunc = Functions.GetProcAddress(dll, (IntPtr)ordinal);
+                if (pfunc != IntPtr.Zero)
+                    return Marshal.GetDelegateForFunctionPointer(pfunc, type);
+                return null;
+            }
 
             Delegate Load(string name, Type type)
             {


### PR DESCRIPTION
To be able to detect the Guide button on XBOX controllers through the XInput API, one needs to use the undocumented XInputGetStateEx entry point. 

Current version of OpenTK uses GetProcAddress with the entry point's name but XINPUT_1_*.dll's don't export this symbol's name as publicly visible. As a consequence OpenTK is unable to find that entry point and the Guide button is never detected.

This merge changes the code in XInputJoystick.cs to call GetProcAddress with the symbol's ordinal instead of the symbol name.