### PR TITLE
Fix broken IOS bindings

### DIFF
--- a/src/OpenTK/OpenTK.iOS.csproj
+++ b/src/OpenTK/OpenTK.iOS.csproj
@@ -244,9 +244,9 @@
   </Target>
   -->
   <Target Name="AfterBuild">
-    <Exec Command="$(OutputPath)..\..\..\..\Generator.Rewrite\bin\Debug\Rewrite.exe $(OutputPath)OpenTK.dll ..\..\OpenTK.snk -debug" Condition="$(OS) == 'Windows_NT' and $(Configuration) == 'Debug'" />
-    <Exec Command="$(OutputPath)..\..\..\..\Generator.Rewrite\bin\Release\Rewrite.exe $(OutputPath)OpenTK.dll ..\..\OpenTK.snk" Condition="$(OS) == 'Windows_NT' and $(Configuration) == 'Release'" />
-    <Exec WorkingDirectory="$(SolutionDir)src/Generator.Rewrite/bin/Debug/" Command="mono ./Rewrite.exe $(SolutionDir)src/OpenTK/bin/Debug/iOS/OpenTK.dll $(SolutionDir)OpenTK.snk -debug" Condition="$(OS) != 'Windows_NT' and $(Configuration) == 'Debug'" />
-    <Exec WorkingDirectory="$(SolutionDir)src/Generator.Rewrite/bin/Release" Command="mono ./Rewrite.exe $(SolutionDir)src/OpenTK/bin/Release/iOS/OpenTK.dll $(SolutionDir)OpenTK.snk" Condition="$(OS) != 'Windows_NT' and $(Configuration) == 'Release'" />
+    <Exec Command="$(OutputPath)..\..\..\..\Generator.Rewrite\bin\Debug\Rewrite.exe $(OutputPath)OpenTK.dll ..\..\OpenTK.snk -dllimport -debug" Condition="$(OS) == 'Windows_NT' and $(Configuration) == 'Debug'" />
+    <Exec Command="$(OutputPath)..\..\..\..\Generator.Rewrite\bin\Release\Rewrite.exe $(OutputPath)OpenTK.dll ..\..\OpenTK.snk -dllimport" Condition="$(OS) == 'Windows_NT' and $(Configuration) == 'Release'" />
+    <Exec WorkingDirectory="$(SolutionDir)src/Generator.Rewrite/bin/Debug/" Command="mono ./Rewrite.exe $(SolutionDir)src/OpenTK/bin/Debug/iOS/OpenTK.dll $(SolutionDir)OpenTK.snk -dllimport -debug" Condition="$(OS) != 'Windows_NT' and $(Configuration) == 'Debug'" />
+    <Exec WorkingDirectory="$(SolutionDir)src/Generator.Rewrite/bin/Release" Command="mono ./Rewrite.exe $(SolutionDir)src/OpenTK/bin/Release/iOS/OpenTK.dll $(SolutionDir)OpenTK.snk -dllimport" Condition="$(OS) != 'Windows_NT' and $(Configuration) == 'Release'" />
   </Target>
 </Project>


### PR DESCRIPTION
The IOS bindings have been broken ever since moving projects to different folders.
More specifically, this commit (https://github.com/opentk/opentk/commit/2ea8334e717a7880202b90b953a5193f137027dd) seem to have accidentally(I think it's accidentally, @varon?) removed the -dllimport option from the after build rewrite for the ios project.

This resulted in code like this (viewed in disassembly):

    [CLSCompliant (false)]
    public unsafe static void GetInteger (GetPName pname, [Out] int* data)
    {
        using (new ErrorHelper (GraphicsContext.CurrentContext)) {
            calli (System.Void(System.Int32,System.Int32*), pname, data, GL.EntryPoints [163]);
        }
    }  

Instead of this:

    [CLSCompliant (false)]
    public unsafe static void GetInteger (GetPName pname, [Out] int* data)
    {
        using (new ErrorHelper (GraphicsContext.CurrentContext)) {
            GL.glGetIntegerv ((int)pname, data);
        }
    }

GL.EntryPoints is null for ios (nobody loads it) crashing the application on any attempt to call any GL method, so it seems that dllimport is required.  