### PR TITLE
Fix pointless warning when compiling Box2.cs

### DIFF
--- a/src/OpenTK/Math/Box2.cs
+++ b/src/OpenTK/Math/Box2.cs
@@ -190,9 +190,9 @@ namespace OpenTK
             return obj is Box2 && Equals((Box2) obj);
         }
 
-        ///// <summary>
-        ///// Gets the hash code for this Box2.
-        ///// </summary>
+        /// <summary>
+        /// Gets the hash code for this Box2.
+        /// </summary>
         public override int GetHashCode()
         {
             unchecked


### PR DESCRIPTION
Showed warning "Missing XML comment for publicly visible type or member 'OpenTK.Box2.GetHashCode()' (CS1591) ", because there were five / instead of three / to indicate an XML comment.