### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root=true
+
+[*.{cs,fsx}]
+indent_style=space
+indent_size=4
+
+[*.{sln,spec}]
+indent_style=tab
+indent_size=4
+
+[*.{xml,sh,cmd,yml,csproj}]
+indent_style=space
+indent_size=2


### PR DESCRIPTION
This PR adds an `.editorconfig` file at the root of the repository so that editors that support http://www.editorconfig.org preserve the indenting style for the different file types.
