### PR TITLE
ANGLE: keep the backbuffer's size updated when the window resizes

### DIFF
--- a/src/OpenTK/Platform/Egl/EglContext.cs
+++ b/src/OpenTK/Platform/Egl/EglContext.cs
@@ -171,6 +171,18 @@ namespace OpenTK.Platform.Egl
             }
         }
 
+        public override void Update(IWindowInfo window)
+        {
+            // ANGLE updates the width and height of the back buffer surfaces in the WaitClient function.
+            // So without this calling this function, the surface won't match the size of the window after it 
+            // was resized.
+            // https://bugs.chromium.org/p/angleproject/issues/detail?id=1438
+            if (!Egl.WaitClient())
+            {
+                Debug.Print("[Warning] Egl.WaitClient() failed. Error: {0}", Egl.GetError());
+            }
+        }
+
         #endregion
 
         #region IGraphicsContextInternal Members

--- a/src/OpenTK/Platform/Egl/EglContext.cs
+++ b/src/OpenTK/Platform/Egl/EglContext.cs
@@ -173,6 +173,7 @@ namespace OpenTK.Platform.Egl
 
         public override void Update(IWindowInfo window)
         {
+            MakeCurrent(window);
             // ANGLE updates the width and height of the back buffer surfaces in the WaitClient function.
             // So without this calling this function, the surface won't match the size of the window after it 
             // was resized.


### PR DESCRIPTION
This PR fixes a resizing problem with ANGLE.

The ANGLE example from https://github.com/thefiddler/opentk-wpf works, but when I tried to update the ANGLE dlls with custom built ones, the backbuffer's size lags behind one frame when the window is resized.

This is because ANGLE changed its strategy from capturing the WM_SIZE messages to updating the backbuffer's size in the [eglWaitClient](https://www.khronos.org/registry/EGL/sdk/docs/man/html/eglWaitClient.xhtml) function.

See here for more information: 

- The change that removed the WindowProc handler that updated the back buffer's size on WM_SIZE: https://chromium-review.googlesource.com/c/228916/10/src/libANGLE/Surface.cpp
- The bug and the solution via `Egl.WaitClient`: https://bugs.chromium.org/p/angleproject/issues/detail?id=1438

So this PR adds a call to `Egl.WaitClient` in the `Update` method in `EglContext.cs`.

I'm not sure if `Egl.WaitClient` should be called directly, because it is supported from ES1.2 and up. Is a version check required and should `GetProcAddressed` be used for this?