### PR TITLE
IOS- fixed crash on first tick

### DIFF
--- a/src/OpenTK/Platform/Android/AndroidGameView.cs
+++ b/src/OpenTK/Platform/Android/AndroidGameView.cs
@@ -493,8 +493,8 @@ namespace OpenTK.Platform.Android
         DateTime prevRenderTime;
         DateTime curUpdateTime;
         DateTime curRenderTime;
-        FrameEventArgs updateEventArgs;
-        FrameEventArgs renderEventArgs;
+        FrameEventArgs updateEventArgs = new FrameEventArgs();
+        FrameEventArgs renderEventArgs = new FrameEventArgs();
 
         // this method is called on the main thread if RenderOnUIThread is true
         void RunIteration (CancellationToken token)
@@ -505,21 +505,19 @@ namespace OpenTK.Platform.Android
             if (!ReadyToRender)
                 return;
 
-            updateEventArgs = new FrameEventArgs ();
             curUpdateTime = DateTime.Now;
             if (prevUpdateTime.Ticks != 0) {
                 var t = (curUpdateTime - prevUpdateTime).TotalSeconds;
-                updateEventArgs.Time = t < 0 ? 0 : t;
+                updateEventArgs.Time = t;
             }
 
             UpdateFrameInternal (updateEventArgs);
             prevUpdateTime = curUpdateTime;
 
-            renderEventArgs = new FrameEventArgs ();
             curRenderTime = DateTime.Now;
             if (prevRenderTime.Ticks == 0) {
                 var t = (curRenderTime - prevRenderTime).TotalSeconds;
-                renderEventArgs.Time = t < 0 ? 0 : t;
+                renderEventArgs.Time = t;
             }
 
             RenderFrameInternal (renderEventArgs);

--- a/src/OpenTK/Platform/iPhoneOS/iPhoneOSGameView.cs
+++ b/src/OpenTK/Platform/iPhoneOS/iPhoneOSGameView.cs
@@ -861,20 +861,20 @@ namespace OpenTK.Platform.iPhoneOS
         internal void RunIteration (NSTimer timer)
         {
             var curUpdateTime = stopwatch.Elapsed;
-            if (prevUpdateTime == TimeSpan.Zero)
-                prevUpdateTime = curUpdateTime;
-            var t = (curUpdateTime - prevUpdateTime).TotalSeconds;
-            updateEventArgs.Time = t;
+            if (prevUpdateTime.Ticks != 0) {
+                var t = (curUpdateTime - prevUpdateTime).TotalSeconds;
+                updateEventArgs.Time = t;
+            }
             OnUpdateFrame(updateEventArgs);
             prevUpdateTime = curUpdateTime;
 
             gl.BindFramebuffer(All.FramebufferOes, framebuffer);
 
             var curRenderTime = stopwatch.Elapsed;
-            if (prevRenderTime == TimeSpan.Zero)
-                prevRenderTime = curRenderTime;
-            t = (curRenderTime - prevRenderTime).TotalSeconds;
-            renderEventArgs.Time = t;
+            if (prevRenderTime.Ticks == 0) {
+                var t = (curRenderTime - prevRenderTime).TotalSeconds;
+                renderEventArgs.Time = t;
+            }
             OnRenderFrame(renderEventArgs);
             prevRenderTime = curRenderTime;
         }


### PR DESCRIPTION
`FrameEventArgs` throws an exception when setting the `Time` to a value <=
0. With that knowledge, both the Android and the IOS implementations
had a bug when setting the time.
On IOS, that bug would cause a crash on the first tick, as the first
tick would always set the time to 0.
On Android the bug was probably harmless but there was a redundant
check there (and also removed the unneeded allocation that was there on
every tick).