### PR TITLE
Fix AngleWindowInfo compile errors on mobile introduced by #458

### DIFF
--- a/src/OpenTK/Platform/Android/AndroidGameView.cs
+++ b/src/OpenTK/Platform/Android/AndroidGameView.cs
@@ -27,6 +27,7 @@ using Android.Views;
 using Android.Runtime;
 using Android.Graphics;
 using OpenTK.Platform.Egl;
+using SurfaceType = Android.Views.SurfaceType;
 
 namespace OpenTK.Platform.Android
 {

--- a/src/OpenTK/Platform/Egl/EglContext.cs
+++ b/src/OpenTK/Platform/Egl/EglContext.cs
@@ -155,8 +155,10 @@ namespace OpenTK.Platform.Egl
             {
                 if (window is EglWindowInfo)
                     WindowInfo = (EglWindowInfo) window;
+                #if !ANDROID
                 else if (window is IAngleWindowInfoInternal)
                     WindowInfo = ((IAngleWindowInfoInternal) window).EglWindowInfo;
+                #endif
 
                 if (!Egl.MakeCurrent(WindowInfo.Display, WindowInfo.Surface, WindowInfo.Surface, HandleAsEGLContext))
                 {

--- a/src/OpenTK/Platform/Factory.cs
+++ b/src/OpenTK/Platform/Factory.cs
@@ -27,7 +27,6 @@
 
 using System;
 using System.Diagnostics;
-using OpenTK.Platform.Egl;
 
 namespace OpenTK.Platform
 {
@@ -103,7 +102,12 @@ namespace OpenTK.Platform
                 else if (Configuration.RunningOnAndroid) Embedded = new Android.AndroidFactory();
                 #endif
                 else Embedded = new UnsupportedPlatform();
-                Angle = new EglAnglePlatformFactory(Embedded);
+
+                #if ANDROID
+                Angle = new UnsupportedPlatform();
+                #else
+                Angle = new Egl.EglAnglePlatformFactory(Embedded);
+                #endif
             }
             #endif
             else

--- a/src/OpenTK/Platform/Utilities.cs
+++ b/src/OpenTK/Platform/Utilities.cs
@@ -13,7 +13,6 @@ using System.Runtime.InteropServices;
 using System.Reflection;
 using System.Diagnostics;
 using OpenTK.Graphics;
-using OpenTK.Platform.Egl;
 
 #endregion
 
@@ -396,6 +395,7 @@ namespace OpenTK.Platform
 
         #region
 
+        #if !__MOBILE__
         /// <summary>
         /// Creates an IWindowInfo instance for Angle rendering, based on 
         /// supplied platform window (e.g. a window created with 
@@ -403,11 +403,12 @@ namespace OpenTK.Platform
         /// </summary>
         /// <param name="platformWindow"></param>
         /// <returns></returns>
-        public static IAngleWindowInfo CreateAngleWindowInfo(IWindowInfo platformWindow)
+        public static Egl.IAngleWindowInfo CreateAngleWindowInfo(IWindowInfo platformWindow)
         {
-            return new AngleWindowInfo(platformWindow);
+            return new Egl.AngleWindowInfo(platformWindow);
         }
-        
+        #endif
+
         #endregion
 
         #endregion


### PR DESCRIPTION
I'm not sure if the indentation of the ifdef's are correct and in line with the rest of the project, or if there's even a better way to handle this entire thing, but it's at the very least better then having broken builds.

travis or appveyor should have avoided this mistake entirely tho.