### PR TITLE
Use MSBuild on modern Mono platforms

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -31,6 +31,18 @@ fi
 
 run .paket/paket.exe restore
 
+# FAKE workaround - msbuild is the new primary build tool on Mono >= 5.0
+MONO_VER=$(mono --version | awk 'NR == 1 { print $5; }')
+if [[ ( $MONO_VER > "5.0.0.0" )  || ( $MONO_VER == "5.0.0.0" ) ]]
+then
+	MSBUILD_PRESENT=$(which msbuild)
+	if [[ -z $MSBUILD_PRESENT ]]; then
+		MSBuild=$(which msbuild)
+	else
+		MSBuild=$(which xbuild)
+	fi
+fi
+
 [ ! -e build.fsx ] && run .paket/paket.exe update
 [ ! -e build.fsx ] && run packages/FAKE/tools/FAKE.exe init.fsx
 run packages/FAKE/tools/FAKE.exe "$@" $FSIARGS build.fsx

--- a/build.sh
+++ b/build.sh
@@ -32,17 +32,23 @@ fi
 run .paket/paket.exe restore
 
 # FAKE workaround - msbuild is the new primary build tool on Mono >= 5.0
-MONO_VER=$(mono --version | awk 'NR == 1 { print $5; }')
-if [[ ( $MONO_VER > "5.0.0.0" )  || ( $MONO_VER == "5.0.0.0" ) ]]
-then
-	MSBUILD_PRESENT=$(which msbuild)
-	if [[ -z $MSBUILD_PRESENT ]]; then
-		MSBuild=$(which msbuild)
-	else
-		MSBuild=$(which xbuild)
-	fi
-fi
+if [[ -z $(command -v mono) ]]; then
+  if [[ -z $(command -v awk) ]]; then
+    echo "awk is required to correctly detect the installed mono version."
+    exit 1
+  fi
 
+  MONO_VER=$(mono --version | awk 'NR == 1 { print $5; }')
+  if [[ ( ${MONO_VER} > "5.0.0.0" )  || ( ${MONO_VER} == "5.0.0.0" ) ]]
+  then
+    MSBUILD_PRESENT=$(command -v msbuild)
+    if [[ -z ${MSBUILD_PRESENT} ]]; then
+      MSBuild=${MSBUILD_PRESENT}
+    else
+      MSBuild=$(command -v xbuild)
+    fi
+  fi
+fi
 [ ! -e build.fsx ] && run .paket/paket.exe update
 [ ! -e build.fsx ] && run packages/FAKE/tools/FAKE.exe init.fsx
 run packages/FAKE/tools/FAKE.exe "$@" $FSIARGS build.fsx


### PR DESCRIPTION
MSBuild replaced xbuild as the primary build tool on modern Mono platforms (>= Mono 5.0). FAKE does not yet detect this itself, however, and uses xbuild by default.

This PR adds a workaround in the build script that checks the installed version of Mono and whether or not msbuild is present, and sets an environment variable which FAKE recognizes. In the case that the Mono installation is >= 5.0 but msbuild is not present, xbuild is used instead.

The issue has been reported to FAKE ([#1570](https://github.com/fsharp/FAKE/issues/1570)), and the workaround can be removed once FAKE has corrected this.