### PR TITLE
Fix duplicate scroll input on windows 10

### DIFF
--- a/src/OpenTK/Platform/Windows/WinGLNative.cs
+++ b/src/OpenTK/Platform/Windows/WinGLNative.cs
@@ -97,6 +97,9 @@ namespace OpenTK.Platform.Windows
         IntPtr cursor_handle = Functions.LoadCursor(CursorName.Arrow);
         int cursor_visible_count = 0;
 
+        // tracking for w10 duplicate scroll inputs.
+        IntPtr scrollHandle;
+
         static readonly object SyncRoot = new object();
 
         #endregion
@@ -534,7 +537,12 @@ namespace OpenTK.Platform.Windows
         {
             // This is due to inconsistent behavior of the WParam value on 64bit arch, whese
             // wparam = 0xffffffffff880000 or wparam = 0x00000000ff100000
-            OnMouseWheel(0, ((long)wParam << 32 >> 48) / 120.0f);
+	        if (scrollHandle == IntPtr.Zero) {
+		        scrollHandle = handle;
+	        }
+            if (handle == scrollHandle) {
+		        OnMouseWheel(0, ((long)wParam << 32 >> 48) / 120.0f);
+            }
         }
 
         void HandleMouseHWheel(IntPtr handle, WindowMessage message, IntPtr wParam, IntPtr lParam)


### PR DESCRIPTION
For whatever reason, the scrolling seems to be fired twice.
This should fix #488.

Could really do with some extra testing here, so here's a few mentions. @quadratron @croxxx @daerogami 