### PR TITLE
Fix a nameof() using wrong variable in GeneratedVariableIdentifier

### DIFF
--- a/src/Generator.Rewrite/GeneratedVariableIdentifier.cs
+++ b/src/Generator.Rewrite/GeneratedVariableIdentifier.cs
@@ -40,7 +40,7 @@ namespace OpenTK.Rewrite
 
             if (definition == null)
             {
-                throw new ArgumentException("The definition argument cannot be null.", nameof(body));
+                throw new ArgumentException("The definition argument cannot be null.", nameof(definition));
             }
 
             if (string.IsNullOrEmpty(name))


### PR DESCRIPTION
Very minor issue though.