### PR TITLE
fix issue #488, input events fired more than once

### DIFF
--- a/src/OpenTK/Platform/Windows/WinGLNative.cs
+++ b/src/OpenTK/Platform/Windows/WinGLNative.cs
@@ -97,9 +97,6 @@ namespace OpenTK.Platform.Windows
         IntPtr cursor_handle = Functions.LoadCursor(CursorName.Arrow);
         int cursor_visible_count = 0;
 
-        // tracking for w10 duplicate scroll inputs.
-        IntPtr scrollHandle;
-
         static readonly object SyncRoot = new object();
 
         #endregion
@@ -537,12 +534,7 @@ namespace OpenTK.Platform.Windows
         {
             // This is due to inconsistent behavior of the WParam value on 64bit arch, whese
             // wparam = 0xffffffffff880000 or wparam = 0x00000000ff100000
-	        if (scrollHandle == IntPtr.Zero) {
-		        scrollHandle = handle;
-	        }
-            if (handle == scrollHandle) {
-		        OnMouseWheel(0, ((long)wParam << 32 >> 48) / 120.0f);
-            }
+            OnMouseWheel(0, ((long)wParam << 32 >> 48) / 120.0f);
         }
 
         void HandleMouseHWheel(IntPtr handle, WindowMessage message, IntPtr wParam, IntPtr lParam)


### PR DESCRIPTION
Make `WinGLNative.WindowProcedure` only listen to window events which are actually for its matching `window.Handle`. This fixes issue #488 