### PR TITLE
Fix interop for wheel events(MacOS)

### DIFF
--- a/src/OpenTK/Platform/MacOS/Cocoa/Cocoa.cs
+++ b/src/OpenTK/Platform/MacOS/Cocoa/Cocoa.cs
@@ -138,13 +138,17 @@ namespace OpenTK.Platform.MacOS
         [DllImport(LibObjC, EntryPoint="objc_msgSend_fpret")]
         extern static float SendFloat_i386(IntPtr receiver, IntPtr selector);
 
+        // On x64 using selector that return CGFloat give you 64 bit == double
         [DllImport(LibObjC, EntryPoint="objc_msgSend")]
-        extern static float SendFloat_normal(IntPtr receiver, IntPtr selector);
+        extern static double SendFloat_x64(IntPtr receiver, IntPtr selector);
+
+        [DllImport(LibObjC, EntryPoint="objc_msgSend")]
+        extern static float SendFloat_ios(IntPtr receiver, IntPtr selector);
 
         public static float SendFloat(IntPtr receiver, IntPtr selector)
         {
             #if IOS
-            return SendFloat_normal(receiver, selector);
+            return SendFloat_ios(receiver, selector);
             #else
             if (IntPtr.Size == 4)
             {
@@ -152,7 +156,7 @@ namespace OpenTK.Platform.MacOS
             }
             else
             {
-                return SendFloat_normal(receiver, selector);
+                return (float)SendFloat_x64(receiver, selector);
             }
             #endif
         }


### PR DESCRIPTION
This solve macOS bug.

Before: on x64 CGFloat - 64 bit, on x86 - 32 bit, so when calling function SendFloat  here https://github.com/opentk/opentk/blob/develop/src/OpenTK/Platform/MacOS/CocoaNativeWindow.cs#L682 on x64 you get cropped value. 
After: when calling function it will call appropriate function for x64 or x86 and cast it to float.

On x64 OnMouseWheel never called(mono 5.2, macOS 10.12). 