### PR TITLE
Wrong cast for interop when setting mouse position(MacOS)

### DIFF
--- a/src/OpenTK/Platform/MacOS/HIDInput.cs
+++ b/src/OpenTK/Platform/MacOS/HIDInput.cs
@@ -1049,8 +1049,18 @@ namespace OpenTK.Platform.MacOS
             NSPoint p = new NSPoint();
             unsafe
             {
-                p.X.Value = *(IntPtr *)&x;
-                p.Y.Value = *(IntPtr *)&y;
+                if (IntPtr.Size == 8)
+                {
+                    p.X.Value = *(IntPtr *)&x;
+                    p.Y.Value = *(IntPtr *)&y;
+                }
+                else
+                {
+                    float f1 = (float)x; 
+                    float f2 = (float)y;
+                    p.X.Value = *(IntPtr *)&f1;
+                    p.Y.Value = *(IntPtr *)&f2;
+                }
             }
 
             CG.WarpMouseCursorPosition(p);


### PR DESCRIPTION
Casting double to IntPtr(which can be 4 or 8 byte size) on x86 arch crop value and as cropped value isn't valid float it will send wrong data to MacOS libs. 