### PR TITLE
Two small Parser changes

### DIFF
--- a/src/Generator.Converter/GLXmlParser.cs
+++ b/src/Generator.Converter/GLXmlParser.cs
@@ -47,8 +47,6 @@ namespace OpenTK.Convert
         static readonly Regex ExtensionRegex = new Regex(
             @"3DFX|(?!(?<=[1-4])D)[A-Z]{2,}$",
             RegexOptions.Compiled);
-        string EnumPrefix { get { return Prefix.ToUpper() + "_"; } }
-        string FuncPrefix { get { return Prefix; } }
 
         public GLXmlParser()
         {
@@ -446,16 +444,6 @@ namespace OpenTK.Convert
             }
 
             return ret;
-        }
-
-        string TrimName(string name)
-        {
-            if (name.StartsWith(EnumPrefix))
-                return name.Remove(0, EnumPrefix.Length);
-            else if (name.StartsWith(FuncPrefix))
-                return name.Remove(0, FuncPrefix.Length);
-            else
-                return name;
         }
 
         static string Join(string left, string right)

--- a/src/Generator.Converter/Main.cs
+++ b/src/Generator.Converter/Main.cs
@@ -68,15 +68,12 @@ namespace OpenTK.Convert
             {
                 bool showHelp = false;
                 string prefix = "gl";
-                string version = null;
                 string path = null;
                 OptionSet opts = new OptionSet
                 {
                     { "p=", "The {PREFIX} to remove from parsed functions and constants.  " +
                         "Defaults to \"" + prefix + "\".",
                         v => prefix = v },
-                    { "v:", "The {VERSION} of the specification being parsed.",
-                        v => version = v },
                     { "o:", "The {PATH} to the output file.",
                         v => path = v },
                     { "?|h|help", "Show this message and exit.",
@@ -86,7 +83,7 @@ namespace OpenTK.Convert
                 var app = Path.GetFileName(Environment.GetCommandLineArgs()[0]);
                 if (showHelp)
                 {
-                    Console.WriteLine("usage: {0} -p:PREFIX -v:VERSION SPECIFICATIONS", app);
+                    Console.WriteLine("usage: {0} -p:PREFIX SPECIFICATIONS", app);
                     Console.WriteLine();
                     Console.WriteLine("Options:");
                     opts.WriteOptionDescriptions(Console.Out);
@@ -101,7 +98,7 @@ namespace OpenTK.Convert
                     return;
                 }
 
-                Parser parser = new GLXmlParser { Prefix = prefix, Version = version };
+                Parser parser = new GLXmlParser { Prefix = prefix };
 
                 var sigs = headers.Select(h => parser.Parse(h)).ToList();
 

--- a/src/Generator.Converter/Parser.cs
+++ b/src/Generator.Converter/Parser.cs
@@ -33,9 +33,6 @@ namespace OpenTK.Convert
     {
         // Defines a prefix that should be removed from methods and tokens in the XML files, e.g. "gl", "cl", etc.
         public string Prefix { get; set; }
-        
-        // Defines the version of the spec files (optional).
-        public string Version { get; set; }
 
         // Implements the parsing logic for a specific input file.
         public abstract IEnumerable<XElement> Parse(string[] lines);

--- a/src/Generator.Converter/Parser.cs
+++ b/src/Generator.Converter/Parser.cs
@@ -33,6 +33,8 @@ namespace OpenTK.Convert
     {
         // Defines a prefix that should be removed from methods and tokens in the XML files, e.g. "gl", "cl", etc.
         public string Prefix { get; set; }
+        public string EnumPrefix { get { return Prefix.ToUpper() + "_"; } }
+        public string FuncPrefix { get { return Prefix; } }
 
         // Implements the parsing logic for a specific input file.
         public abstract IEnumerable<XElement> Parse(string[] lines);
@@ -78,6 +80,16 @@ namespace OpenTK.Convert
             }
 
             return Parse(contents);
+        }
+
+        public string TrimName(string name)
+        {
+            if (name.StartsWith(EnumPrefix))
+                return name.Remove(0, EnumPrefix.Length);
+            else if (name.StartsWith(FuncPrefix))
+                return name.Remove(0, FuncPrefix.Length);
+            else
+                return name;
         }
     }
 }


### PR DESCRIPTION
First change is to remove the Version property that was never used.

Second change is to move EnumPrefix, FuncPrefix and TrimName from GLXmlParser to Parser. Doesn't seem a particularly useful change by itself but helps with handling Vulkan specifications. They need a new main Parser class but name triming is pretty much the same.