### PR TITLE
Normalize indentation style

### DIFF
--- a/src/Generator.Bind/Main.cs
+++ b/src/Generator.Bind/Main.cs
@@ -241,7 +241,7 @@ namespace Bind
 
                 case "gl3":
                 case "gl4":
-					mode = GeneratorMode.GL4;
+                    mode = GeneratorMode.GL4;
                     break;
 
                 case "es10":

--- a/src/Generator.Rewrite/Program.cs
+++ b/src/Generator.Rewrite/Program.cs
@@ -157,7 +157,7 @@ namespace OpenTK.Rewrite
             var entry_points = type.Fields.FirstOrDefault(f => f.Name == "EntryPoints");
             if (entry_points != null)
             {
-                // Build list of entry point signatures (one per entry point) 
+                // Build list of entry point signatures (one per entry point)
                 var entry_signatures = new List<MethodDefinition>();
                 entry_signatures.AddRange(type.Methods
                     .Where(t => t.CustomAttributes.Any(a => a.AttributeType.Name == "SlotAttribute")));
@@ -339,7 +339,7 @@ namespace OpenTK.Rewrite
             DebugVariables vars = null;
             if (il.Body.Method.Name != "GetError")
             {
-                // Pull out the namespace name, method fullname will look 
+                // Pull out the namespace name, method fullname will look
                 // something like "type namespace.class::method(type arg)"
                 var module = il.Body.Method.FullName;
                 module = module.Substring(module.IndexOf(' ') + 1);
@@ -525,10 +525,10 @@ namespace OpenTK.Rewrite
             }
         }
 
-        static void EmitParameterEpilogues(MethodDefinition wrapper, MethodDefinition native, MethodBody body, ILProcessor il, 
+        static void EmitParameterEpilogues(MethodDefinition wrapper, MethodDefinition native, MethodBody body, ILProcessor il,
             List<GeneratedVariableIdentifier> generatedVariables)
         {
-            foreach (var p in wrapper.Parameters) 
+            foreach (var p in wrapper.Parameters)
             {
                 if (p.ParameterType.Name == "StringBuilder")
                 {
@@ -548,7 +548,7 @@ namespace OpenTK.Rewrite
         }
 
         /// <summary>
-        /// Retrieves a generated variable by searching the given list by the variable's name and associated method body. 
+        /// Retrieves a generated variable by searching the given list by the variable's name and associated method body.
         /// </summary>
         /// <param name="variableIdentifiers"></param>
         /// <param name="name"></param>
@@ -597,14 +597,14 @@ namespace OpenTK.Rewrite
             return stringBuilderPtrVar;
         }
 
-        static void EmitStringBuilderEpilogue(MethodDefinition wrapper, MethodDefinition native, 
+        static void EmitStringBuilderEpilogue(MethodDefinition wrapper, MethodDefinition native,
             ParameterDefinition parameter, MethodBody body, ILProcessor il, GeneratedVariableIdentifier generatedPtrVar)
         {
             if (generatedPtrVar == null)
             {
                 throw new ArgumentNullException(nameof(generatedPtrVar));
             }
-            
+
             var p = parameter.ParameterType;
             if (p.Name == "StringBuilder")
             {
@@ -639,7 +639,7 @@ namespace OpenTK.Rewrite
             }
         }
 
-        static GeneratedVariableIdentifier EmitStringParameter(MethodDefinition wrapper, ParameterDefinition parameter, MethodBody body, 
+        static GeneratedVariableIdentifier EmitStringParameter(MethodDefinition wrapper, ParameterDefinition parameter, MethodBody body,
             ILProcessor il)
         {
             var p = parameter.ParameterType;
@@ -654,7 +654,7 @@ namespace OpenTK.Rewrite
             var variableDefinition = new VariableDefinition(TypeIntPtr);
             body.Variables.Add(variableDefinition);
             int generatedPointerVarIndex = body.Variables.Count - 1;
-            
+
             GeneratedVariableIdentifier stringPtrVar = new GeneratedVariableIdentifier(body, variableDefinition, parameter.Name + "_string_ptr");
 
             // ptr = Marshal.StringToHGlobalAnsi(str);
@@ -666,7 +666,7 @@ namespace OpenTK.Rewrite
             return stringPtrVar;
         }
 
-        static void EmitStringEpilogue(MethodDefinition wrapper, ParameterDefinition parameter, MethodBody body, 
+        static void EmitStringEpilogue(MethodDefinition wrapper, ParameterDefinition parameter, MethodBody body,
             ILProcessor il, GeneratedVariableIdentifier generatedPtrVar)
         {
             var p = parameter.ParameterType;
@@ -692,7 +692,7 @@ namespace OpenTK.Rewrite
             var variableDefinition = new VariableDefinition(TypeIntPtr);
             body.Variables.Add(variableDefinition);
             int generatedPointerVarIndex = body.Variables.Count - 1;
-            
+
             GeneratedVariableIdentifier stringArrayPtrVar = new GeneratedVariableIdentifier(body, variableDefinition, parameter.Name + "_string_array_ptr");
 
             // ptr = MarshalStringArrayToPtr(strings);
@@ -705,14 +705,14 @@ namespace OpenTK.Rewrite
             return stringArrayPtrVar;
         }
 
-        static void EmitStringArrayEpilogue(MethodDefinition wrapper, ParameterDefinition parameter, MethodBody body, 
+        static void EmitStringArrayEpilogue(MethodDefinition wrapper, ParameterDefinition parameter, MethodBody body,
             ILProcessor il, GeneratedVariableIdentifier generatedPtrVar)
         {
             if (generatedPtrVar == null)
             {
                 throw new ArgumentNullException(nameof(generatedPtrVar));
             }
-            
+
             // Note: only works for string vectors (1d arrays).
             // We do not (and will probably never) support 2d or higher string arrays
             var p = parameter.ParameterType;
@@ -769,7 +769,7 @@ namespace OpenTK.Rewrite
                     //   return result;
                     // }
                     body.Variables.Add(new VariableDefinition(wrapper.ReturnType));
-                    
+
                     generatedVariables = EmitParameters(wrapper, native, body, il);
                     il.Emit(OpCodes.Ldloca, body.Variables.Count - 1);
                 }

--- a/src/OpenTK/Compute/CL10/CLHelper.cs
+++ b/src/OpenTK/Compute/CL10/CLHelper.cs
@@ -90,8 +90,8 @@ namespace OpenTK.Compute.CL10
         public static unsafe IntPtr CreateContext(ContextProperties[] properties, uint num_devices, IntPtr[] devices, IntPtr pfn_notify, IntPtr user_data, OpenTK.Compute.CL10.ErrorCode[] errcode_ret)
         {
             IntPtr[] properties_correct = properties != null ? new IntPtr[properties.Length] : null;
-			for (int i = 0; i < properties_correct.Length; i++)
-				properties_correct[i] = new IntPtr((int)properties[i]);
+            for (int i = 0; i < properties_correct.Length; i++)
+                properties_correct[i] = new IntPtr((int)properties[i]);
             return CreateContext(properties_correct, num_devices, devices, pfn_notify, user_data, errcode_ret);
         }
 
@@ -101,23 +101,23 @@ namespace OpenTK.Compute.CL10
             return CreateContext(ref properties_correct, num_devices, ref devices, pfn_notify, user_data, out errcode_ret);
         }
 
-		public static unsafe IntPtr CreateContext<T4>(ContextProperties* properties, uint num_devices, IntPtr* devices, IntPtr pfn_notify, ref T4 user_data, OpenTK.Compute.CL10.ErrorCode* errcode_ret)
-			where T4 : struct
+        public static unsafe IntPtr CreateContext<T4>(ContextProperties* properties, uint num_devices, IntPtr* devices, IntPtr pfn_notify, ref T4 user_data, OpenTK.Compute.CL10.ErrorCode* errcode_ret)
+            where T4 : struct
         {
             return CreateContext((IntPtr*)properties, num_devices, devices, pfn_notify, ref user_data, errcode_ret);
         }
 
         public static unsafe IntPtr CreateContext<T4>(ContextProperties[] properties, uint num_devices, IntPtr[] devices, IntPtr pfn_notify, ref T4 user_data, OpenTK.Compute.CL10.ErrorCode[] errcode_ret)
-			where T4 : struct
+            where T4 : struct
         {
             IntPtr[] properties_correct = properties != null ? new IntPtr[properties.Length] : null;
-			for (int i = 0; i < properties_correct.Length; i++)
-				properties_correct[i] = new IntPtr((int)properties[i]);
+            for (int i = 0; i < properties_correct.Length; i++)
+                properties_correct[i] = new IntPtr((int)properties[i]);
             return CreateContext(properties_correct, num_devices, devices, pfn_notify, ref user_data, errcode_ret);
         }
 
         public static unsafe IntPtr CreateContext<T4>(ref ContextProperties properties, uint num_devices, ref IntPtr devices, IntPtr pfn_notify, ref T4 user_data, out OpenTK.Compute.CL10.ErrorCode errcode_ret)
-			where T4 : struct
+            where T4 : struct
         {
             IntPtr properties_correct = new IntPtr((int)properties);
             return CreateContext(ref properties_correct, num_devices, ref devices, pfn_notify, ref user_data, out errcode_ret);
@@ -130,37 +130,37 @@ namespace OpenTK.Compute.CL10
 
         public static unsafe IntPtr CreateContextFromType(ContextProperties[] properties, DeviceTypeFlags device_type, IntPtr pfn_notify, IntPtr user_data, OpenTK.Compute.CL10.ErrorCode[] errcode_ret)
         {
-			IntPtr[] properties_correct = properties != null ? new IntPtr[properties.Length] : null;
-			for (int i = 0; i < properties_correct.Length; i++)
-				properties_correct[i] = new IntPtr((int)properties[i]);
+            IntPtr[] properties_correct = properties != null ? new IntPtr[properties.Length] : null;
+            for (int i = 0; i < properties_correct.Length; i++)
+                properties_correct[i] = new IntPtr((int)properties[i]);
             return CreateContextFromType(properties_correct, device_type, pfn_notify, user_data, errcode_ret);
         }
 
         public static unsafe IntPtr CreateContextFromType(ref ContextProperties properties, DeviceTypeFlags device_type, IntPtr pfn_notify, IntPtr user_data, out OpenTK.Compute.CL10.ErrorCode errcode_ret)
         {
-			IntPtr properties_correct = new IntPtr((int)properties);
+            IntPtr properties_correct = new IntPtr((int)properties);
             return CreateContextFromType(ref properties_correct, device_type, pfn_notify, user_data, out errcode_ret);
         }
 
-		public static unsafe IntPtr CreateContextFromType<T4>(ContextProperties* properties, DeviceTypeFlags device_type, IntPtr pfn_notify, ref T4 user_data, OpenTK.Compute.CL10.ErrorCode* errcode_ret)
-			where T4 : struct
+        public static unsafe IntPtr CreateContextFromType<T4>(ContextProperties* properties, DeviceTypeFlags device_type, IntPtr pfn_notify, ref T4 user_data, OpenTK.Compute.CL10.ErrorCode* errcode_ret)
+            where T4 : struct
         {
             return CreateContextFromType((IntPtr*)properties, device_type, pfn_notify, ref user_data, errcode_ret);
         }
 
         public static unsafe IntPtr CreateContextFromType<T4>(ContextProperties[] properties, DeviceTypeFlags device_type, IntPtr pfn_notify, ref T4 user_data, OpenTK.Compute.CL10.ErrorCode[] errcode_ret)
-			where T4 : struct
+            where T4 : struct
         {
-			IntPtr[] properties_correct = properties != null ? new IntPtr[properties.Length] : null;
-			for (int i = 0; i < properties_correct.Length; i++)
-				properties_correct[i] = new IntPtr((int)properties[i]);
+            IntPtr[] properties_correct = properties != null ? new IntPtr[properties.Length] : null;
+            for (int i = 0; i < properties_correct.Length; i++)
+                properties_correct[i] = new IntPtr((int)properties[i]);
             return CreateContextFromType(properties_correct, device_type, pfn_notify, ref user_data, errcode_ret);
         }
 
         public static unsafe IntPtr CreateContextFromType<T4>(ref ContextProperties properties, DeviceTypeFlags device_type, IntPtr pfn_notify, ref T4 user_data, out OpenTK.Compute.CL10.ErrorCode errcode_ret)
-			where T4 : struct
+            where T4 : struct
         {
-			IntPtr properties_correct = new IntPtr((int)properties);
+            IntPtr properties_correct = new IntPtr((int)properties);
             return CreateContextFromType(ref properties_correct, device_type, pfn_notify, ref user_data, out errcode_ret);
         }
     }

--- a/src/OpenTK/Graphics/ES20/Helper.cs
+++ b/src/OpenTK/Graphics/ES20/Helper.cs
@@ -175,7 +175,7 @@ namespace OpenTK.Graphics.ES20
         public static string GetActiveAttrib(int program, int index, out int size, out ActiveAttribType type)
         {
             int length;
-			GetProgram(program, GetProgramParameterName.ActiveAttributeMaxLength, out length);
+            GetProgram(program, GetProgramParameterName.ActiveAttributeMaxLength, out length);
             StringBuilder sb = new StringBuilder(length == 0 ? 1 : length * 2);
 
             GetActiveAttrib(program, index, sb.Capacity, out length, out size, out type, sb);
@@ -185,7 +185,7 @@ namespace OpenTK.Graphics.ES20
         public static string GetActiveUniform(int program, int uniformIndex, out int size, out ActiveUniformType type)
         {
             int length;
-			GetProgram(program, GetProgramParameterName.ActiveUniformMaxLength, out length);
+            GetProgram(program, GetProgramParameterName.ActiveUniformMaxLength, out length);
 
             StringBuilder sb = new StringBuilder(length == 0 ? 1 : length);
             GetActiveUniform(program, uniformIndex, sb.Capacity, out length, out size, out type, sb);
@@ -237,7 +237,7 @@ namespace OpenTK.Graphics.ES20
             unsafe
             {
                 int length;
-				GL.GetProgram(program, GetProgramParameterName.InfoLogLength, out length); if (length == 0)
+                GL.GetProgram(program, GetProgramParameterName.InfoLogLength, out length); if (length == 0)
                 {
                     info = String.Empty;
                     return;

--- a/src/OpenTK/Graphics/ES30/Helper.cs
+++ b/src/OpenTK/Graphics/ES30/Helper.cs
@@ -175,17 +175,17 @@ namespace OpenTK.Graphics.ES30
         public static string GetActiveAttrib(int program, int index, out int size, out ActiveAttribType type)
         {
             int length;
-			GetProgram(program, ES30.GetProgramParameterName.ActiveAttributeMaxLength, out length);
+            GetProgram(program, ES30.GetProgramParameterName.ActiveAttributeMaxLength, out length);
             StringBuilder sb = new StringBuilder(length == 0 ? 1 : length * 2);
 
-			GetActiveAttrib(program, index, sb.Capacity, out length, out size, out type, sb);
+            GetActiveAttrib(program, index, sb.Capacity, out length, out size, out type, sb);
             return sb.ToString();
         }
 
         public static string GetActiveUniform(int program, int uniformIndex, out int size, out ActiveUniformType type)
         {
             int length;
-			GetProgram(program, ES30.GetProgramParameterName.ActiveUniformMaxLength, out length);
+            GetProgram(program, ES30.GetProgramParameterName.ActiveUniformMaxLength, out length);
 
             StringBuilder sb = new StringBuilder(length == 0 ? 1 : length);
             GetActiveUniform(program, uniformIndex, sb.Capacity, out length, out size, out type, sb);
@@ -237,7 +237,7 @@ namespace OpenTK.Graphics.ES30
             unsafe
             {
                 int length;
-				GL.GetProgram(program, ES30.GetProgramParameterName.InfoLogLength, out length); if (length == 0)
+                GL.GetProgram(program, ES30.GetProgramParameterName.InfoLogLength, out length); if (length == 0)
                 {
                     info = String.Empty;
                     return;

--- a/src/OpenTK/Graphics/OpenGL/GLHelper.cs
+++ b/src/OpenTK/Graphics/OpenGL/GLHelper.cs
@@ -96,7 +96,7 @@ namespace OpenTK.Graphics.OpenGL
 
         public static void Color3(Color color)
         {
-			GL.Color3(color.R, color.G, color.B);
+            GL.Color3(color.R, color.G, color.B);
         }
 
         public static void Color4(Color color)

--- a/src/OpenTK/Graphics/OpenGL4/Helper.cs
+++ b/src/OpenTK/Graphics/OpenGL4/Helper.cs
@@ -246,7 +246,7 @@ namespace OpenTK.Graphics.OpenGL4
         public static string GetActiveAttrib(int program, int index, out int size, out ActiveAttribType type)
         {
             int length;
-			GetProgram(program, OpenGL4.GetProgramParameterName.ActiveAttributeMaxLength, out length);
+            GetProgram(program, OpenGL4.GetProgramParameterName.ActiveAttributeMaxLength, out length);
             StringBuilder sb = new StringBuilder(length == 0 ? 1 : length * 2);
 
             GetActiveAttrib(program, index, sb.Capacity, out length, out size, out type, sb);
@@ -256,7 +256,7 @@ namespace OpenTK.Graphics.OpenGL4
         public static string GetActiveUniform(int program, int uniformIndex, out int size, out ActiveUniformType type)
         {
             int length;
-			GetProgram(program, OpenGL4.GetProgramParameterName.ActiveUniformMaxLength, out length);
+            GetProgram(program, OpenGL4.GetProgramParameterName.ActiveUniformMaxLength, out length);
 
             StringBuilder sb = new StringBuilder(length == 0 ? 1 : length);
             GetActiveUniform(program, uniformIndex, sb.Capacity, out length, out size, out type, sb);
@@ -308,7 +308,7 @@ namespace OpenTK.Graphics.OpenGL4
             unsafe
             {
                 int length;
-				GL.GetProgram(program, OpenGL4.GetProgramParameterName.InfoLogLength, out length); if (length == 0)
+                GL.GetProgram(program, OpenGL4.GetProgramParameterName.InfoLogLength, out length); if (length == 0)
                 {
                     info = String.Empty;
                     return;

--- a/src/OpenTK/Math/MathHelper.cs
+++ b/src/OpenTK/Math/MathHelper.cs
@@ -293,33 +293,33 @@ namespace OpenTK
             return Math.Max(Math.Min(n, max), min);
         }
 
-		private static unsafe int FloatToInt32Bits(float f) {
-			return *((int*) &f);
-		}
+        private static unsafe int FloatToInt32Bits(float f) {
+            return *((int*) &f);
+        }
 
-		/// <summary>
-		/// Approximates floating point equality with a maximum number of different bits.
-		/// This is typically used in place of an epsilon comparison.
-		/// see: https://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/
-		/// see: https://stackoverflow.com/questions/3874627/floating-point-comparison-functions-for-c-sharp
-		/// </summary>
-		/// <param name="a">the first value to compare</param>
-		/// <param name="b">>the second value to compare</param>
-		/// <param name="maxDeltaBits">the number of floating point bits to check</param>
-		/// <returns></returns>
-		public static bool ApproximatelyEqual(float a, float b, int maxDeltaBits) {
-			// we use longs here, otherwise we run into a two's complement problem, causing this to fail with -2 and 2.0
-			long aInt = FloatToInt32Bits(a);
-			if (aInt < 0)
-				aInt = Int32.MinValue - aInt;
+        /// <summary>
+        /// Approximates floating point equality with a maximum number of different bits.
+        /// This is typically used in place of an epsilon comparison.
+        /// see: https://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/
+        /// see: https://stackoverflow.com/questions/3874627/floating-point-comparison-functions-for-c-sharp
+        /// </summary>
+        /// <param name="a">the first value to compare</param>
+        /// <param name="b">>the second value to compare</param>
+        /// <param name="maxDeltaBits">the number of floating point bits to check</param>
+        /// <returns></returns>
+        public static bool ApproximatelyEqual(float a, float b, int maxDeltaBits) {
+            // we use longs here, otherwise we run into a two's complement problem, causing this to fail with -2 and 2.0
+            long aInt = FloatToInt32Bits(a);
+            if (aInt < 0)
+                aInt = Int32.MinValue - aInt;
 
-			long bInt = FloatToInt32Bits(b);
-			if (bInt < 0)
-				bInt = Int32.MinValue - bInt;
+            long bInt = FloatToInt32Bits(b);
+            if (bInt < 0)
+                bInt = Int32.MinValue - bInt;
 
-			long intDiff = Math.Abs(aInt - bInt);
-			return intDiff <= (1 << maxDeltaBits);
-		}
+            long intDiff = Math.Abs(aInt - bInt);
+            return intDiff <= (1 << maxDeltaBits);
+        }
 
         /// <summary>
         /// Approximates double-precision floating point equality by an epsilon (maximum error) value.
@@ -435,5 +435,5 @@ namespace OpenTK
         }
 
 
-			}
+            }
 }

--- a/src/OpenTK/Platform/Egl/EglWindowInfo.cs
+++ b/src/OpenTK/Platform/Egl/EglWindowInfo.cs
@@ -72,11 +72,11 @@ namespace OpenTK.Platform.Egl
         public void CreateWindowSurface(IntPtr config)
         {
             Surface = Egl.CreateWindowSurface(Display, config, Handle, IntPtr.Zero);
-			if (Surface==IntPtr.Zero)
-			{
+            if (Surface==IntPtr.Zero)
+            {
                 throw new GraphicsContextException(String.Format(
                     "[EGL] Failed to create window surface, error {0}.", Egl.GetError()));
-			}
+            }
         }
 
         //public void CreatePixmapSurface(EGLConfig config)

--- a/src/OpenTK/Platform/MacOS/Carbon/MacOSKeys.cs
+++ b/src/OpenTK/Platform/MacOS/Carbon/MacOSKeys.cs
@@ -29,8 +29,8 @@ using System.Text;
 
 namespace OpenTK.Platform.MacOS
 {
-	//
-	// http://web.archive.org/web/20100501161453/http://www.classicteck.com/rbarticles/mackeyboard.php
+    //
+    // http://web.archive.org/web/20100501161453/http://www.classicteck.com/rbarticles/mackeyboard.php
 
     enum MacOSKeyCode
     {

--- a/src/OpenTK/Platform/MacOS/Cocoa/Selector.cs
+++ b/src/OpenTK/Platform/MacOS/Cocoa/Selector.cs
@@ -40,7 +40,7 @@ namespace OpenTK.Platform.MacOS
         public static readonly IntPtr Release = Selector.Get("release");
         public static readonly IntPtr Autorelease = Selector.Get("autorelease");
 
-		[DllImport ("/usr/lib/libobjc.dylib", EntryPoint="sel_registerName")]
-		public extern static IntPtr Get(string name);
-	}
+        [DllImport ("/usr/lib/libobjc.dylib", EntryPoint="sel_registerName")]
+        public extern static IntPtr Get(string name);
+    }
 }

--- a/src/OpenTK/RewrittenAttribute.cs
+++ b/src/OpenTK/RewrittenAttribute.cs
@@ -27,14 +27,14 @@ using System;
 
 namespace OpenTK
 {
-	[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false, Inherited = false)]
-	class RewrittenAttribute : Attribute
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false, Inherited = false)]
+    class RewrittenAttribute : Attribute
     {
-		internal bool Rewritten;
+        internal bool Rewritten;
 
-		public RewrittenAttribute(bool rewritten)
+        public RewrittenAttribute(bool rewritten)
         {
-			Rewritten = rewritten;
+            Rewritten = rewritten;
         }
     }
 }

--- a/src/OpenTK/SlotAttribute.cs
+++ b/src/OpenTK/SlotAttribute.cs
@@ -27,26 +27,26 @@ using System;
 
 namespace OpenTK
 {
-	/// <summary>
-	/// Defines the slot index for a wrapper function.
-	/// This type supports OpenTK and should not be
-	/// used in user code.
-	/// </summary>
-	[AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
-	public class SlotAttribute : Attribute
+    /// <summary>
+    /// Defines the slot index for a wrapper function.
+    /// This type supports OpenTK and should not be
+    /// used in user code.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
+    public class SlotAttribute : Attribute
     {
-		/// <summary>
-		/// Defines the slot index for a wrapper function.
-		/// </summary>
-		internal int Slot;
+        /// <summary>
+        /// Defines the slot index for a wrapper function.
+        /// </summary>
+        internal int Slot;
 
-		/// <summary>
-		/// Constructs a new instance.
-		/// </summary>
-		/// <param name="index">The slot index for a wrapper function.</param>
-		public SlotAttribute(int index)
+        /// <summary>
+        /// Constructs a new instance.
+        /// </summary>
+        /// <param name="index">The slot index for a wrapper function.</param>
+        public SlotAttribute(int index)
         {
-			Slot = index;
+            Slot = index;
         }
     }
 }


### PR DESCRIPTION
This PR normalizes indentation characters across the codebase, removing tab characters and replacing them with four spaces. 

In the future, this should be an enforced rule by way of ReSharper or StyleCop.