### PR TITLE
Fix file drop string marshalling

### DIFF
--- a/src/OpenTK/Platform/Windows/API.cs
+++ b/src/OpenTK/Platform/Windows/API.cs
@@ -128,13 +128,13 @@ namespace OpenTK.Platform.Windows
 
     internal static class Functions
     {
-        [DllImport("shell32.dll")]
+        [DllImport("shell32.dll", CharSet = CharSet.Auto)]
         internal static extern bool DragAcceptFiles(
             IntPtr handle,
             [MarshalAs(UnmanagedType.Bool)] bool fAccept
         );
 
-        [DllImport("shell32.dll")]
+        [DllImport("shell32.dll", CharSet = CharSet.Auto)]
         internal static extern uint DragQueryFile(
             HDROP hDrop,
             uint iFile,


### PR DESCRIPTION
Changes file drop string marshalling on the Windows platform to specifically request the Unicode string, rather than leaving it up to the system to decide.

Fixes https://github.com/opentk/opentk/issues/561