### PR TITLE
Transform compatible properties to auto-properties

### DIFF
--- a/src/Generator.Bind/Structures/Constant.cs
+++ b/src/Generator.Bind/Structures/Constant.cs
@@ -17,14 +17,8 @@ namespace Bind.Structures
     /// </summary>
     class Constant : IComparable<Constant>
     {
-        string original_name;
-
         // Gets the name prior to translation.
-        public string OriginalName
-        {
-            get { return original_name; }
-            private set { original_name = value; }
-        }
+        public string OriginalName { get; private set; }
 
         string _name;
 
@@ -67,20 +61,11 @@ namespace Bind.Structures
             }
         }
 
-        string _reference;
-
         /// <summary>
         /// Gets or sets a string indicating the OpenGL enum reference by this constant.
         /// Can be null.
         /// </summary>
-        public string Reference
-        {
-            get { return _reference; }
-            set
-            {
-                _reference = value;
-            }
-        }
+        public string Reference { get; set; }
 
         public bool Unchecked
         {

--- a/src/Generator.Bind/Structures/Delegate.cs
+++ b/src/Generator.Bind/Structures/Delegate.cs
@@ -82,13 +82,7 @@ namespace Bind.Structures
             }
         }
 
-        private string _category;
-
-        public string Category
-        {
-            get { return _category; }
-            set { _category = value; }
-        }
+        public string Category { get; set; }
 
         /// <summary>
         /// Gets a value that indicates whether this function needs to be wrapped with a Marshaling function.
@@ -141,18 +135,10 @@ namespace Bind.Structures
             }
         }
 
-        Type _return_type = new Type();
         /// <summary>
         /// Gets or sets the return value of the opengl function.
         /// </summary>
-        public Type ReturnType
-        {
-            get { return _return_type; }
-            set
-            {
-                _return_type = value;
-            }
-        }
+        public Type ReturnType { get; set; } = new Type();
 
         string _name;
         /// <summary>
@@ -170,24 +156,12 @@ namespace Bind.Structures
             }
         }
 
-        ParameterCollection _parameters;
-
-        public ParameterCollection Parameters
-        {
-            get { return _parameters; }
-            set { _parameters = value; }
-        }
-
-        string _version;
+        public ParameterCollection Parameters { get; set; }
 
         /// <summary>
         /// Defines the opengl version that introduced this function.
         /// </summary>
-        public string Version
-        {
-            get { return _version; }
-            set { _version = value; }
-        }
+        public string Version { get; set; }
 
         public string Extension
         {

--- a/src/Generator.Bind/Structures/Function.cs
+++ b/src/Generator.Bind/Structures/Function.cs
@@ -12,8 +12,6 @@ namespace Bind.Structures
 {
     class Function : Delegate, IEquatable<Function>, IComparable<Function>
     {
-        Delegate wrapped_delegate;
-
         public Function(Delegate d)
             : base(d)
         {
@@ -34,11 +32,7 @@ namespace Bind.Structures
             Body.AddRange(f.Body);
         }
 
-        public Delegate WrappedDelegate
-        {
-            get { return wrapped_delegate; }
-            set { wrapped_delegate = value; }
-        }
+        public Delegate WrappedDelegate { get; set; }
 
         public void TurnVoidPointersToIntPtr()
         {
@@ -60,13 +54,7 @@ namespace Bind.Structures
             }
         }
 
-        FunctionBody _body;
-
-        public FunctionBody Body
-        {
-            get { return _body; }
-            set { _body = value; }
-        }
+        public FunctionBody Body { get; set; }
 
         public string TrimmedName { get; set; }
 

--- a/src/Generator.Bind/Structures/Parameter.cs
+++ b/src/Generator.Bind/Structures/Parameter.cs
@@ -134,12 +134,7 @@ namespace Bind.Structures
             }
         }
 
-        bool generic;
-        public bool Generic
-        {
-            get { return generic; }
-            set { generic = value; }
-        }
+        public bool Generic { get; set; }
 
         // Returns true if this parameter differs only on reference compared to another parameter, i.e:
         // returns true for 'int' & 'ref int'
@@ -155,12 +150,7 @@ namespace Bind.Structures
                 other.Reference && !(Reference || Array > 0 || Pointer != 0));
         }
 
-        string computeSize;
-        public string ComputeSize
-        {
-            get { return computeSize; }
-            set { computeSize = value; }
-        }
+        public string ComputeSize { get; set; }
 
         // Returns the FlowDirection that matches the specified string
         // ("out" or "in", otherwise undefined).

--- a/src/Generator.Bind/Structures/Type.cs
+++ b/src/Generator.Bind/Structures/Type.cs
@@ -13,7 +13,6 @@ namespace Bind.Structures
     class Type : IComparable<Type>, IEquatable<Type>
     {
         string current_qualifier = String.Empty;
-        string previous_qualifier = String.Empty;
 
         public Type()
         {
@@ -41,11 +40,7 @@ namespace Bind.Structures
             set { PreviousQualifier = CurrentQualifier; current_qualifier = value; }
         }
 
-        string PreviousQualifier
-        {
-            get { return previous_qualifier; }
-            set { previous_qualifier = value; }
-        }
+        private string PreviousQualifier { get; set; } = String.Empty;
 
         public string QualifiedType
         {
@@ -103,21 +98,9 @@ namespace Bind.Structures
             }
         }
 
-        private string _previous_type;
+        public string PreviousType { get; private set; }
 
-        public string PreviousType
-        {
-            get { return _previous_type; }
-            private set { _previous_type = value; }
-        }
-
-        bool reference;
-
-        public bool Reference
-        {
-            get { return reference; }
-            set { reference = value; }
-        }
+        public bool Reference { get; set; }
 
         int array;
 
@@ -209,13 +192,7 @@ namespace Bind.Structures
             }
         }
 
-        private WrapperTypes _wrapper_type = WrapperTypes.None;
-
-        public WrapperTypes WrapperType
-        {
-            get { return _wrapper_type; }
-            set { _wrapper_type = value; }
-        }
+        public WrapperTypes WrapperType { get; set; } = WrapperTypes.None;
 
         static readonly string[] PointerLevels =
         {

--- a/src/OpenTK.GLControl/CarbonGLControl.cs
+++ b/src/OpenTK.GLControl/CarbonGLControl.cs
@@ -38,14 +38,13 @@ namespace OpenTK
     {
         GraphicsMode mode;
         Control control;
-        IWindowInfo window_info;
 
         internal CarbonGLControl(GraphicsMode mode, Control owner)
         {
             this.mode = mode;
             this.control = owner;
 
-            window_info = Utilities.CreateMacOSCarbonWindowInfo(control.Handle, false, true);
+            WindowInfo = Utilities.CreateMacOSCarbonWindowInfo(control.Handle, false, true);
         }
 
         private int GetXOffset()
@@ -82,12 +81,6 @@ namespace OpenTK
             }
         }
 
-        public IWindowInfo WindowInfo
-        {
-            get
-            {
-                return window_info;
-            }
-        }
+        public IWindowInfo WindowInfo { get; }
     }
 }

--- a/src/OpenTK.GLControl/DummyGLControl.cs
+++ b/src/OpenTK.GLControl/DummyGLControl.cs
@@ -50,12 +50,7 @@ namespace OpenTK
         {
             static int instance_count;
 
-            readonly ContextHandle handle = new ContextHandle(new IntPtr(
-                System.Threading.Interlocked.Increment(ref instance_count)));
-
             IWindowInfo current_window;
-            bool is_disposed;
-            int swap_interval;
 
             public void SwapBuffers()
             {
@@ -71,10 +66,7 @@ namespace OpenTK
                 get { return current_window != null; }
             }
 
-            public bool IsDisposed
-            {
-                get { return is_disposed; }
-            }
+            public bool IsDisposed { get; private set; }
 
             public bool VSync
             {
@@ -88,17 +80,7 @@ namespace OpenTK
                 }
             }
 
-            public int SwapInterval
-            {
-                get
-                {
-                    return swap_interval;
-                }
-                set
-                {
-                    swap_interval = value;
-                }
-            }
+            public int SwapInterval { get; set; }
 
             public void Update(IWindowInfo window)
             {
@@ -126,13 +108,11 @@ namespace OpenTK
 
             public void Dispose()
             {
-                is_disposed = true;
+                IsDisposed = true;
             }
 
-            public ContextHandle Context
-            {
-                get { return handle; }
-            }
+            public ContextHandle Context { get; } = new ContextHandle(new IntPtr(
+                System.Threading.Interlocked.Increment(ref instance_count)));
 
             public IntPtr GetAddress(IntPtr function)
             {

--- a/src/OpenTK.GLControl/Sdl2GLControl.cs
+++ b/src/OpenTK.GLControl/Sdl2GLControl.cs
@@ -35,13 +35,12 @@ namespace OpenTK
 {
     class Sdl2GLControl : IGLControl
     {
-        IWindowInfo window_info;
         GraphicsMode mode;
 
         public Sdl2GLControl(GraphicsMode mode, Control control)
         {
             this.mode = mode;
-            window_info = Utilities.CreateSdl2WindowInfo(control.Handle);
+            WindowInfo = Utilities.CreateSdl2WindowInfo(control.Handle);
             // Fixme: SDL2 will refuse to create an OpenGL context on
             // a window with the SDL_WINDOW_FOREIGN flag (i.e. windows
             // that are passed to SDL2 through SDL_CreateWindowFrom).
@@ -50,7 +49,7 @@ namespace OpenTK
 
         public Graphics.IGraphicsContext CreateContext(int major, int minor, Graphics.GraphicsContextFlags flags)
         {
-            return new GraphicsContext(mode, window_info, major, minor, flags);
+            return new GraphicsContext(mode, WindowInfo, major, minor, flags);
         }
 
         public bool IsIdle
@@ -58,10 +57,7 @@ namespace OpenTK
             get { return NativeMethods.SDL_HasEvents(0, 0xffff); }
         }
 
-        public Platform.IWindowInfo WindowInfo
-        {
-            get { return window_info; }
-        }
+        public Platform.IWindowInfo WindowInfo { get; }
 
         static class NativeMethods
         {

--- a/src/OpenTK.GLControl/WinGLControl.cs
+++ b/src/OpenTK.GLControl/WinGLControl.cs
@@ -78,19 +78,18 @@ namespace OpenTK
         static extern bool PeekMessage(ref MSG msg, IntPtr hWnd, int messageFilterMin, int messageFilterMax, int flags);
 
         MSG msg = new MSG();
-        IWindowInfo window_info;
         GraphicsMode mode;
 
         public WinGLControl(GraphicsMode mode, Control control)
         {
             this.mode = mode;
 
-            window_info = Utilities.CreateWindowsWindowInfo(control.Handle);
+            WindowInfo = Utilities.CreateWindowsWindowInfo(control.Handle);
         }
 
         public IGraphicsContext CreateContext(int major, int minor, GraphicsContextFlags flags)
         {
-            return new GraphicsContext(mode, window_info, major, minor, flags);
+            return new GraphicsContext(mode, WindowInfo, major, minor, flags);
         }
 
         public bool IsIdle
@@ -98,13 +97,6 @@ namespace OpenTK
             get { return !PeekMessage(ref msg, IntPtr.Zero, 0, 0, 0); }
         }
 
-        public IWindowInfo WindowInfo
-        {
-            get
-            {
-                // This method forces the creation of the control. Beware of this side-effect!
-                return window_info;
-            }
-        }
+        public IWindowInfo WindowInfo { get; }
     }
 }

--- a/src/OpenTK.GLControl/X11GLControl.cs
+++ b/src/OpenTK.GLControl/X11GLControl.cs
@@ -53,7 +53,6 @@ namespace OpenTK
         }
 
         GraphicsMode mode;
-        IWindowInfo window_info;
         IntPtr display;
         IntPtr rootWindow;
 
@@ -92,7 +91,7 @@ namespace OpenTK
             rootWindow = (IntPtr)GetStaticFieldValue(xplatui, "RootWindow");
             int screen = (int)GetStaticFieldValue(xplatui, "ScreenNo");
 
-            window_info = Utilities.CreateX11WindowInfo(display, screen, control.Handle, rootWindow, IntPtr.Zero);
+            WindowInfo = Utilities.CreateX11WindowInfo(display, screen, control.Handle, rootWindow, IntPtr.Zero);
         }
 
         public IGraphicsContext CreateContext(int major, int minor, GraphicsContextFlags flags)
@@ -121,13 +120,7 @@ namespace OpenTK
             get { return XPending(display) == 0; }
         }
 
-        public IWindowInfo WindowInfo
-        {
-            get
-            {
-                return window_info;
-            }
-        }
+        public IWindowInfo WindowInfo { get; }
 
         static object GetStaticFieldValue(Type type, string fieldName)
         {

--- a/src/OpenTK.GLWidget/GLWidget.cs
+++ b/src/OpenTK.GLWidget/GLWidget.cs
@@ -24,7 +24,6 @@ namespace OpenTK
 
         private IGraphicsContext _GraphicsContext;
         private IWindowInfo _WindowInfo;
-        private GraphicsContextFlags _GraphicsContextFlags;
         private bool _Initialized = false;
 
         /// <summary>
@@ -76,17 +75,7 @@ namespace OpenTK
         /// <summary>
         /// The set <see cref="GraphicsContextFlags"/> for this widget.
         /// </summary>
-        public GraphicsContextFlags GraphicsContextFlags
-        {
-            get
-            {
-                return _GraphicsContextFlags;
-            }
-            set
-            {
-                _GraphicsContextFlags = value;
-            }
-        }
+        public GraphicsContextFlags GraphicsContextFlags { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="GLWidget"/> class.
@@ -364,7 +353,7 @@ namespace OpenTK
                 _WindowInfo = XWindowInfoInitializer.Initialize(graphicsMode, this.Display.Handle, this.Screen.Number, widgetWindowHandle, this.Screen.RootWindow.Handle);
 
             // GraphicsContext
-            _GraphicsContext = new GraphicsContext(graphicsMode, _WindowInfo, GlVersionMajor, GlVersionMinor, _GraphicsContextFlags);
+            _GraphicsContext = new GraphicsContext(graphicsMode, _WindowInfo, GlVersionMajor, GlVersionMinor, GraphicsContextFlags);
             _GraphicsContext.MakeCurrent(_WindowInfo);
 
             if (GraphicsContext.ShareContexts)

--- a/src/OpenTK/Audio/AudioDeviceEnumerator.cs
+++ b/src/OpenTK/Audio/AudioDeviceEnumerator.cs
@@ -52,32 +52,11 @@ namespace OpenTK.Audio
             }
         }
 
-        private static string default_playback_device;
-        internal static string DefaultPlaybackDevice
-        {
-            get
-            {
-                return default_playback_device;
-            }
-        }
+        internal static string DefaultPlaybackDevice { get; }
 
-        private static string default_recording_device;
-        internal static string DefaultRecordingDevice
-        {
-            get
-            {
-                return default_recording_device;
-            }
-        }
+        internal static string DefaultRecordingDevice { get; }
 
-        private static bool openal_supported = true;
-        internal static bool IsOpenALSupported
-        {
-            get
-            {
-                return openal_supported;
-            }
-        }
+        internal static bool IsOpenALSupported { get; } = true;
 
         internal enum AlcVersion
         {
@@ -85,14 +64,7 @@ namespace OpenTK.Audio
             Alc1_1
         }
 
-        private static AlcVersion version;
-        internal static AlcVersion Version
-        {
-            get
-            {
-                return version;
-            }
-        }
+        internal static AlcVersion Version { get; }
 
         // Loads all available audio devices into the available_*_devices lists.
         static AudioDeviceEnumerator()
@@ -121,21 +93,21 @@ namespace OpenTK.Audio
                 // Get a list of all known playback devices, using best extension available
                 if (Alc.IsExtensionPresent(IntPtr.Zero, "ALC_ENUMERATION_EXT"))
                 {
-                    version = AlcVersion.Alc1_1;
+                    Version = AlcVersion.Alc1_1;
                     if (Alc.IsExtensionPresent(IntPtr.Zero, "ALC_ENUMERATE_ALL_EXT"))
                     {
                         available_playback_devices.AddRange(Alc.GetString(IntPtr.Zero, AlcGetStringList.AllDevicesSpecifier));
-                        default_playback_device = Alc.GetString(IntPtr.Zero, AlcGetString.DefaultAllDevicesSpecifier);
+                        DefaultPlaybackDevice = Alc.GetString(IntPtr.Zero, AlcGetString.DefaultAllDevicesSpecifier);
                     }
                     else
                     {
                         available_playback_devices.AddRange(Alc.GetString(IntPtr.Zero, AlcGetStringList.DeviceSpecifier));
-                        default_playback_device = Alc.GetString(IntPtr.Zero, AlcGetString.DefaultDeviceSpecifier);
+                        DefaultPlaybackDevice = Alc.GetString(IntPtr.Zero, AlcGetString.DefaultDeviceSpecifier);
                     }
                 }
                 else
                 {
-                    version = AlcVersion.Alc1_0;
+                    Version = AlcVersion.Alc1_0;
                     Debug.Print("Device enumeration extension not available. Failed to enumerate playback devices.");
                 }
                 AlcError playback_err = Alc.GetError(dummy_device);
@@ -143,10 +115,10 @@ namespace OpenTK.Audio
                     throw new AudioContextException("Alc Error occured when querying available playback devices. " + playback_err.ToString());
 
                 // Get a list of all known recording devices, at least ALC_ENUMERATION_EXT is needed too
-                if (version == AlcVersion.Alc1_1 && Alc.IsExtensionPresent(IntPtr.Zero, "ALC_EXT_CAPTURE"))
+                if (Version == AlcVersion.Alc1_1 && Alc.IsExtensionPresent(IntPtr.Zero, "ALC_EXT_CAPTURE"))
                 {
                     available_recording_devices.AddRange(Alc.GetString(IntPtr.Zero, AlcGetStringList.CaptureDeviceSpecifier));
-                    default_recording_device = Alc.GetString(IntPtr.Zero, AlcGetString.CaptureDefaultDeviceSpecifier);
+                    DefaultRecordingDevice = Alc.GetString(IntPtr.Zero, AlcGetString.CaptureDefaultDeviceSpecifier);
                 }
                 else
                 {
@@ -161,30 +133,30 @@ namespace OpenTK.Audio
                 foreach (string s in available_playback_devices)
                     Debug.WriteLine(s);
 
-                Debug.WriteLine("Default playback device: " + default_playback_device);
+                Debug.WriteLine("Default playback device: " + DefaultPlaybackDevice);
 
                 Debug.WriteLine("Found recording devices:");
                 foreach (string s in available_recording_devices)
                     Debug.WriteLine(s);
 
-                Debug.WriteLine("Default recording device: " + default_recording_device);
+                Debug.WriteLine("Default recording device: " + DefaultRecordingDevice);
 #endif
             }
             catch (DllNotFoundException e)
             {
                 Trace.WriteLine(e.ToString());
-                openal_supported = false;
+                IsOpenALSupported = false;
             }
             catch (AudioContextException ace)
             {
                 Trace.WriteLine(ace.ToString());
-                openal_supported = false;
+                IsOpenALSupported = false;
             }
             finally
             {
                 Debug.Unindent();
 
-                if (openal_supported)
+                if (IsOpenALSupported)
                 {
                     try
                     {
@@ -197,7 +169,7 @@ namespace OpenTK.Audio
                     }
                     catch
                     {
-                        openal_supported = false;
+                        IsOpenALSupported = false;
                     }
                 }
             }

--- a/src/OpenTK/Audio/OpenAL/AL/EffectsExtension.cs
+++ b/src/OpenTK/Audio/OpenAL/AL/EffectsExtension.cs
@@ -1070,23 +1070,15 @@ namespace OpenTK.Audio.OpenAL
         // typedef void (__cdecl *LPALGETAUXILIARYEFFECTSLOTIV)( ALuint asid, ALenum pname, ALint* values );
         // typedef void (__cdecl *LPALGETAUXILIARYEFFECTSLOTFV)( ALuint asid, ALenum pname, ALfloat* values );
 
-        private bool _valid;
-
         /// <summary>Returns True if the EFX Extension has been found and could be initialized.</summary>
-        public bool IsInitialized
-        {
-            get
-            {
-                return _valid;
-            }
-        }
+        public bool IsInitialized { get; }
 
         /// <summary>
         /// Constructs a new EffectsExtension instance.
         /// </summary>
         public EffectsExtension()
         {
-            _valid = false;
+            IsInitialized = false;
 
             if (AudioContext.CurrentContext == null)
                 throw new InvalidOperationException("AL.LoadAll() needs a current AudioContext.");
@@ -1152,7 +1144,7 @@ namespace OpenTK.Audio.OpenAL
             // Console.WriteLine("Auxiliary Effect Slot functions appear to be ok.");
 
             // didn't return so far, everything went fine.
-            _valid = true;
+            IsInitialized = true;
         }
     }
 }

--- a/src/OpenTK/Audio/OpenAL/AL/XRamExtension.cs
+++ b/src/OpenTK/Audio/OpenAL/AL/XRamExtension.cs
@@ -19,13 +19,8 @@ namespace OpenTK.Audio.OpenAL
     [CLSCompliant(true)]
     public sealed class XRamExtension
     {
-        private bool _valid = false;
-
         /// <summary>Returns True if the X-Ram Extension has been found and could be initialized.</summary>
-        public bool IsInitialized
-        {
-            get { return _valid; }
-        }
+        public bool IsInitialized { get; } = false;
 
         // [CLSCompliant(false)]
         private delegate bool Delegate_SetBufferMode(int n, ref uint buffers, int value);
@@ -48,7 +43,7 @@ namespace OpenTK.Audio.OpenAL
         /// </summary>
         public XRamExtension()
         { // Query if Extension supported and retrieve Tokens/Pointers if it is.
-            _valid = false;
+            IsInitialized = false;
             if (AL.IsExtensionPresent("EAX-RAM") == false)
                 return;
 
@@ -83,7 +78,7 @@ namespace OpenTK.Audio.OpenAL
                 return;
             }
 
-            _valid = true;
+            IsInitialized = true;
         }
 
         /// <summary>Query total amount of X-RAM in bytes.</summary>

--- a/src/OpenTK/BindingsBase.cs
+++ b/src/OpenTK/BindingsBase.cs
@@ -37,8 +37,6 @@ namespace OpenTK
     /// </summary>
     public abstract class BindingsBase
     {
-        bool rebuildExtensionList = true;
-
         /// <summary>
         /// Constructs a new BindingsBase instance.
         /// </summary>
@@ -49,11 +47,7 @@ namespace OpenTK
         /// <summary>
         /// Gets or sets a <see cref="System.Boolean"/> that indicates whether the list of supported extensions may have changed.
         /// </summary>
-        protected bool RebuildExtensionList
-        {
-            get { return rebuildExtensionList; }
-            set { rebuildExtensionList = value; }
-        }
+        protected bool RebuildExtensionList { get; set; } = true;
 
         /// <summary>
         /// Retrieves an unmanaged function pointer to the specified function.

--- a/src/OpenTK/BlittableValueType.cs
+++ b/src/OpenTK/BlittableValueType.cs
@@ -42,7 +42,6 @@ namespace OpenTK
     public static class BlittableValueType<T>
     {
         static readonly Type Type;
-        static readonly int stride;
 
         static BlittableValueType()
         {
@@ -52,7 +51,7 @@ namespace OpenTK
                 // Does this support generic types? On Mono 2.4.3 it does
                 // On .Net it doesn't.
                 // http://msdn.microsoft.com/en-us/library/5s4920fa.aspx
-                stride = Marshal.SizeOf(typeof(T));
+                Stride = Marshal.SizeOf(typeof(T));
             }
         }
 
@@ -62,7 +61,7 @@ namespace OpenTK
         /// <remarks>
         /// This property returns 0 for non-blittable types.
         /// </remarks>
-        public static int Stride { get { return stride; } }
+        public static int Stride { get; }
 
         /// <summary>
         /// Checks whether the current typename T is blittable.

--- a/src/OpenTK/Configuration.cs
+++ b/src/OpenTK/Configuration.cs
@@ -40,21 +40,17 @@ namespace OpenTK
     /// </summary>
     public sealed class Configuration
     {
-        static bool runningOnWindows, runningOnUnix, runningOnX11, runningOnMacOS, runningOnLinux;
-        static bool runningOnMono;
+        static bool runningOnUnix, runningOnMacOS, runningOnLinux;
         volatile static bool initialized;
         readonly static object InitLock = new object();
 
         Configuration() { }
 
         /// <summary>Gets a System.Boolean indicating whether OpenTK is running on a Windows platform.</summary>
-        public static bool RunningOnWindows { get { return runningOnWindows; } }
+        public static bool RunningOnWindows { get; private set; }
 
         /// <summary>Gets a System.Boolean indicating whether OpenTK is running on an X11 platform.</summary>
-        public static bool RunningOnX11
-        {
-            get { return runningOnX11; }
-        }
+        public static bool RunningOnX11 { get; private set; }
 
         /// <summary>
         /// Gets a <see cref="System.Boolean"/> indicating whether OpenTK is running on a Unix platform.
@@ -82,7 +78,7 @@ namespace OpenTK
         /// <summary>
         /// Gets a System.Boolean indicating whether OpenTK is running on the Mono runtime.
         /// </summary>
-        public static bool RunningOnMono { get { return runningOnMono; } }
+        public static bool RunningOnMono { get; private set; }
 
         /// <summary>
         /// Gets a <c>System.Boolean</c> indicating whether
@@ -287,9 +283,9 @@ namespace OpenTK
 #if ANDROID || IPHONE
                     runningOnMono = true;
 #else
-                    runningOnMono = DetectMono();
-                    runningOnWindows = DetectWindows();
-                    if (!runningOnWindows)
+                    RunningOnMono = DetectMono();
+                    RunningOnWindows = DetectWindows();
+                    if (!RunningOnWindows)
                     {
                         DetectUnix(out runningOnUnix, out runningOnLinux, out runningOnMacOS);
                     }
@@ -301,7 +297,7 @@ namespace OpenTK
 
                     if ((runningOnLinux && !RunningOnSdl2) || options.Backend == PlatformBackend.PreferX11)
                     {
-                        runningOnX11 = DetectX11();
+                        RunningOnX11 = DetectX11();
                     }
 
                     initialized = true;

--- a/src/OpenTK/DisplayDevice.cs
+++ b/src/OpenTK/DisplayDevice.cs
@@ -44,7 +44,6 @@ namespace OpenTK
         bool primary;
         Rectangle bounds;
         DisplayResolution current_resolution = new DisplayResolution();
-        DisplayResolution original_resolution;
         List<DisplayResolution> available_resolutions = new List<DisplayResolution>();
         IList<DisplayResolution> available_resolutions_readonly;
 
@@ -191,8 +190,8 @@ namespace OpenTK
 
             if (implementation.TryChangeResolution(this, resolution))
             {
-                if (original_resolution == null)
-                    original_resolution = current_resolution;
+                if (OriginalResolution == null)
+                    OriginalResolution = current_resolution;
                 current_resolution = resolution;
             }
             else throw new Graphics.GraphicsModeException(String.Format("Device {0}: Failed to change resolution to {1}.",
@@ -216,14 +215,14 @@ namespace OpenTK
         /// <exception cref="Graphics.GraphicsModeException">Thrown if the original resolution could not be restored.</exception>
         public void RestoreResolution()
         {
-            if (original_resolution != null)
+            if (OriginalResolution != null)
             {
                 //effect.FadeOut();
 
                 if (implementation.TryRestoreResolution(this))
                 {
-                    current_resolution = original_resolution;
-                    original_resolution = null;
+                    current_resolution = OriginalResolution;
+                    OriginalResolution = null;
                 }
                 else throw new Graphics.GraphicsModeException(String.Format("Device {0}: Failed to restore resolution.", this));
 
@@ -250,11 +249,7 @@ namespace OpenTK
         /// <summary>
         /// Gets the original resolution of this instance.
         /// </summary>
-        internal DisplayResolution OriginalResolution
-        {
-            get { return original_resolution; }
-            set { original_resolution = value; }
-        }
+        internal DisplayResolution OriginalResolution { get; set; }
 
         internal static DisplayDevice FromPoint(int x, int y)
         {

--- a/src/OpenTK/DisplayResolution.cs
+++ b/src/OpenTK/DisplayResolution.cs
@@ -18,8 +18,6 @@ namespace OpenTK
     public class DisplayResolution
     {
         Rectangle bounds;
-        int bits_per_pixel;
-        float refresh_rate;
 
         internal DisplayResolution() { }
 
@@ -33,8 +31,8 @@ namespace OpenTK
             if (refreshRate < 0) throw new ArgumentOutOfRangeException("refreshRate", "Must be greater than, or equal to zero.");
 
             this.bounds = new Rectangle(x, y, width, height);
-            this.bits_per_pixel = bitsPerPixel;
-            this.refresh_rate = refreshRate;
+            this.BitsPerPixel = bitsPerPixel;
+            this.RefreshRate = refreshRate;
         }
 
 #if false
@@ -91,20 +89,12 @@ namespace OpenTK
         }
 
         /// <summary>Gets a System.Int32 that contains number of bits per pixel of this display. Typical values include 8, 16, 24 and 32.</summary>
-        public int BitsPerPixel
-        {
-            get { return bits_per_pixel; }
-            internal set { bits_per_pixel = value; }
-        }
+        public int BitsPerPixel { get; internal set; }
 
         /// <summary>
         /// Gets a System.Single representing the vertical refresh rate of this display.
         /// </summary>
-        public float RefreshRate
-        {
-            get { return refresh_rate; }
-            internal set { refresh_rate = value; }
-        }
+        public float RefreshRate { get; internal set; }
 
         /// <summary>
         /// Returns a System.String representing this DisplayResolution.
@@ -113,7 +103,7 @@ namespace OpenTK
         public override string ToString()
         {
             #pragma warning disable 612,618
-            return String.Format("{0}x{1}@{2}Hz", Bounds, bits_per_pixel, refresh_rate);
+            return String.Format("{0}x{1}@{2}Hz", Bounds, BitsPerPixel, RefreshRate);
             #pragma warning restore 612,618
         }
 
@@ -141,7 +131,7 @@ namespace OpenTK
         public override int GetHashCode()
         {
             #pragma warning disable 612,618
-            return Bounds.GetHashCode() ^ bits_per_pixel ^ refresh_rate.GetHashCode();
+            return Bounds.GetHashCode() ^ BitsPerPixel ^ RefreshRate.GetHashCode();
             #pragma warning restore 612,618
         }
 

--- a/src/OpenTK/Exceptions.cs
+++ b/src/OpenTK/Exceptions.cs
@@ -33,26 +33,18 @@ namespace OpenTK
     /// </summary>
     public class ContextExistsException : ApplicationException
     {
-        string msg;
-
         /// <summary>
         /// Constructs a new ContextExistsException instance.
         /// </summary>
         /// <param name="message">A System.String explaining the cause of this exception.</param>
         public ContextExistsException(string message)
         {
-            msg = message;
+            Message = message;
         }
 
         /// <summary>
         /// Gets a System.String explaining the cause of this exception.
         /// </summary>
-        public override string Message
-        {
-            get
-            {
-                return msg;
-            }
-        }
+        public override string Message { get; }
     }
 }

--- a/src/OpenTK/Graphics/ColorFormat.cs
+++ b/src/OpenTK/Graphics/ColorFormat.cs
@@ -37,8 +37,6 @@ namespace OpenTK.Graphics
     public struct ColorFormat : IComparable<ColorFormat>, IEquatable<ColorFormat>
     {
         byte red, green, blue, alpha;
-        bool isIndexed;
-        int bitsPerPixel;
 
         /// <summary>
         /// Constructs a new ColorFormat with the specified aggregate bits per pixel.
@@ -49,8 +47,8 @@ namespace OpenTK.Graphics
             if (bpp < 0)
                 throw new ArgumentOutOfRangeException("bpp", "Must be greater or equal to zero.");
             red = green = blue = alpha = 0;
-            bitsPerPixel = bpp;
-            isIndexed = false;
+            BitsPerPixel = bpp;
+            IsIndexed = false;
 
             switch (bpp)
             {
@@ -103,10 +101,10 @@ namespace OpenTK.Graphics
             this.green = (byte)green;
             this.blue = (byte)blue;
             this.alpha = (byte)alpha;
-            this.bitsPerPixel = red + green + blue + alpha;
-            this.isIndexed = false;
-            if (this.bitsPerPixel < 15 && this.bitsPerPixel != 0)
-                this.isIndexed = true;
+            this.BitsPerPixel = red + green + blue + alpha;
+            this.IsIndexed = false;
+            if (this.BitsPerPixel < 15 && this.BitsPerPixel != 0)
+                this.IsIndexed = true;
         }
 
         /// <summary>Gets the bits per pixel for the Red channel.</summary>
@@ -118,9 +116,10 @@ namespace OpenTK.Graphics
         /// <summary>Gets the bits per pixel for the Alpha channel.</summary>
         public int Alpha { get { return alpha; } private set { alpha = (byte)value; } }
         /// <summary>Gets a System.Boolean indicating whether this ColorFormat is indexed.</summary>
-        public bool IsIndexed { get { return isIndexed; } private set { isIndexed = value; } }
+        public bool IsIndexed { get; private set; }
+
         /// <summary>Gets the sum of Red, Green, Blue and Alpha bits per pixel.</summary>
-        public int BitsPerPixel { get { return bitsPerPixel; } private set { bitsPerPixel = value; } }
+        public int BitsPerPixel { get; private set; }
 
         /// <summary>
         /// Defines an empty ColorFormat, where all properties are set to zero.

--- a/src/OpenTK/Graphics/GraphicsContext.cs
+++ b/src/OpenTK/Graphics/GraphicsContext.cs
@@ -52,7 +52,7 @@ namespace OpenTK.Graphics
 
         IGraphicsContext implementation;  // The actual render context implementation for the underlying platform.
         bool disposed;
-        bool check_errors = true;
+
         // Cache for the context handle. We need this for RemoveContext()
         // in case the user does not call Dispose(). When this happens,
         // RemoveContext() is called by the finalizer, in which case
@@ -61,8 +61,6 @@ namespace OpenTK.Graphics
         // the handle.)
         ContextHandle handle_cached;
 
-        static bool share_contexts = true;
-        static bool direct_rendering = true;
         readonly static object SyncRoot = new object();
         // Maps OS-specific context handles to GraphicsContext instances.
         readonly static Dictionary<ContextHandle, IGraphicsContext> available_contexts =
@@ -172,7 +170,7 @@ namespace OpenTK.Graphics
                             GetCurrentContext = factory.CreateGetCurrentGraphicsContext();
                         }
 
-                        implementation = factory.CreateGLContext(mode, window, shareContext, direct_rendering, major, minor, flags);
+                        implementation = factory.CreateGLContext(mode, window, shareContext, DirectRendering, major, minor, flags);
                         handle_cached = ((IGraphicsContextInternal)implementation).Context;
                         factory.RegisterResource(this);
                     }
@@ -392,7 +390,7 @@ namespace OpenTK.Graphics
         /// false, new GLContexts will not share resources.</para>
         /// <para>Changing this value will not affect already created GLContexts.</para>
         /// </remarks>
-        public static bool ShareContexts { get { return share_contexts; } set { share_contexts = value; } }
+        public static bool ShareContexts { get; set; } = true;
 
         /// <summary>Gets or sets a System.Boolean, indicating whether GraphicsContexts will perform direct rendering.</summary>
         /// <remarks>
@@ -405,11 +403,7 @@ namespace OpenTK.Graphics
         /// This property is ignored on Operating Systems without support for indirect rendering, like Windows and OS X.
         /// </para>
         /// </remarks>
-        public static bool DirectRendering
-        {
-            get { return direct_rendering; }
-            set { direct_rendering = value; }
-        }
+        public static bool DirectRendering { get; set; } = true;
 
         /// <summary>
         /// Gets or sets a System.Boolean, indicating whether automatic error checking should be performed.
@@ -417,11 +411,7 @@ namespace OpenTK.Graphics
         /// </summary>
         /// <remarks>Automatic error checking will clear the OpenGL error state. Set CheckErrors to false if you use
         /// the OpenGL error state in your code flow (e.g. for checking supported texture formats).</remarks>
-        public bool ErrorChecking
-        {
-            get { return check_errors; }
-            set { check_errors = value; }
-        }
+        public bool ErrorChecking { get; set; } = true;
 
         /// <summary>
         /// Swaps buffers on a context. This presents the rendered scene to the user.

--- a/src/OpenTK/Graphics/GraphicsContextBase.cs
+++ b/src/OpenTK/Graphics/GraphicsContextBase.cs
@@ -36,8 +36,6 @@ namespace OpenTK.Graphics
     // Provides the foundation for all IGraphicsContext implementations.
     abstract class GraphicsContextBase : IGraphicsContext, IGraphicsContextInternal, IEquatable<IGraphicsContextInternal>
     {
-        bool disposed;
-
         protected ContextHandle Handle;
         protected GraphicsMode Mode;
 
@@ -47,11 +45,7 @@ namespace OpenTK.Graphics
 
         public abstract bool IsCurrent { get; }
 
-        public bool IsDisposed
-        {
-            get { return disposed; }
-            protected set { disposed = value; }
-        }
+        public bool IsDisposed { get; protected set; }
 
         public bool VSync
         {

--- a/src/OpenTK/Graphics/GraphicsContextVersion.cs
+++ b/src/OpenTK/Graphics/GraphicsContextVersion.cs
@@ -34,9 +34,6 @@ namespace OpenTK.Graphics
     /// </summary>
     public sealed class GraphicsContextVersion
     {
-        int minor, major;
-        string vendor = String.Empty, renderer = String.Empty;
-
         internal GraphicsContextVersion(int minor, int major, string vendor, string renderer)
         {
             Minor = minor;
@@ -48,21 +45,21 @@ namespace OpenTK.Graphics
         /// <summary>
         /// Gets a System.Int32 indicating the minor version of a GraphicsContext instance.
         /// </summary>
-        public int Minor { get { return minor; } private set { minor = value; } }
+        public int Minor { get; private set; }
 
         /// <summary>
         /// Gets a System.Int32 indicating the major version of a GraphicsContext instance.
         /// </summary>
-        public int Major { get { return major; } private set { major = value; } }
+        public int Major { get; private set; }
 
         /// <summary>
         /// Gets a System.String indicating the vendor of a GraphicsContext instance.
         /// </summary>
-        public string Vendor { get { return vendor; } private set { vendor = value; } }
+        public string Vendor { get; private set; } = String.Empty;
 
         /// <summary>
         /// Gets a System.String indicating the renderer of a GraphicsContext instance.
         /// </summary>
-        public string Renderer { get { return renderer; } private set { renderer = value; } }
+        public string Renderer { get; private set; } = String.Empty;
     }
 }

--- a/src/OpenTK/Graphics/GraphicsMode.cs
+++ b/src/OpenTK/Graphics/GraphicsMode.cs
@@ -14,10 +14,7 @@ namespace OpenTK.Graphics
     /// <summary>Defines the format for graphics operations.</summary>
     public class GraphicsMode : IEquatable<GraphicsMode>
     {
-        ColorFormat color_format, accumulator_format;
-        int depth, stencil, buffers, samples;
-        bool stereo;
-        IntPtr? index = null;  // The id of the pixel format or visual.
+        int samples;
 
         static GraphicsMode defaultMode;
         static readonly object SyncRoot = new object();
@@ -116,64 +113,29 @@ namespace OpenTK.Graphics
         /// <summary>
         /// Gets a nullable <see cref="System.IntPtr"/> value, indicating the platform-specific index for this GraphicsMode.
         /// </summary>
-        public IntPtr? Index
-        {
-            get
-            {
-                return index;
-            }
-            set { index = value; }
-        }
+        public IntPtr? Index { get; set; } = null;
 
         /// <summary>
         /// Gets an OpenTK.Graphics.ColorFormat that describes the color format for this GraphicsFormat.
         /// </summary>
-        public ColorFormat ColorFormat
-        {
-            get
-            {
-                return color_format;
-            }
-            private set { color_format = value; }
-        }
+        public ColorFormat ColorFormat { get; private set; }
 
         /// <summary>
         /// Gets an OpenTK.Graphics.ColorFormat that describes the accumulator format for this GraphicsFormat.
         /// </summary>
-        public ColorFormat AccumulatorFormat
-        {
-            get
-            {
-                return accumulator_format;
-            }
-            private set { accumulator_format = value; }
-        }
+        public ColorFormat AccumulatorFormat { get; private set; }
 
         /// <summary>
         /// Gets a System.Int32 that contains the bits per pixel for the depth buffer
         /// for this GraphicsFormat.
         /// </summary>
-        public int Depth
-        {
-            get
-            {
-                return depth;
-            }
-            private set { depth = value; }
-        }
+        public int Depth { get; private set; }
 
         /// <summary>
         /// Gets a System.Int32 that contains the bits per pixel for the stencil buffer
         /// of this GraphicsFormat.
         /// </summary>
-        public int Stencil
-        {
-            get
-            {
-                return stencil;
-            }
-            private set { stencil = value; }
-        }
+        public int Stencil { get; private set; }
 
         /// <summary>
         /// Gets a System.Int32 that contains the number of FSAA samples per pixel for this GraphicsFormat.
@@ -197,27 +159,13 @@ namespace OpenTK.Graphics
         /// <summary>
         /// Gets a System.Boolean indicating whether this DisplayMode is stereoscopic.
         /// </summary>
-        public bool Stereo
-        {
-            get
-            {
-                return stereo;
-            }
-            private set { stereo = value; }
-        }
+        public bool Stereo { get; private set; }
 
         /// <summary>
         /// Gets a System.Int32 containing the number of buffers associated with this
         /// DisplayMode.
         /// </summary>
-        public int Buffers
-        {
-            get
-            {
-                return buffers;
-            }
-            private set { buffers = value; }
-        }
+        public int Buffers { get; private set; }
 
         /// <summary>Returns an OpenTK.GraphicsFormat compatible with the underlying platform.</summary>
         public static GraphicsMode Default

--- a/src/OpenTK/Input/GamePadCapabilities.cs
+++ b/src/OpenTK/Input/GamePadCapabilities.cs
@@ -37,8 +37,6 @@ namespace OpenTK.Input
         Buttons buttons;
         GamePadAxes axes;
         byte gamepad_type;
-        bool is_connected;
-        bool is_mapped;
 
         internal GamePadCapabilities(GamePadType type, GamePadAxes axes, Buttons buttons, bool is_connected, bool is_mapped)
             : this()
@@ -46,8 +44,8 @@ namespace OpenTK.Input
             gamepad_type = (byte)type;
             this.axes = axes;
             this.buttons = buttons;
-            this.is_connected = is_connected;
-            this.is_mapped = is_mapped;
+            this.IsConnected = is_connected;
+            this.IsMapped = is_mapped;
         }
 
         /// <summary>
@@ -306,19 +304,13 @@ namespace OpenTK.Input
         /// currently connected.
         /// </summary>
         /// <value><c>true</c> if this instance is currently connected; otherwise, <c>false</c>.</value>
-        public bool IsConnected
-        {
-            get { return is_connected; }
-        }
+        public bool IsConnected { get; }
 
         /// <summary>
         /// Gets a <see cref="System.Boolean"/> value describing whether a valid button configuration
         /// exists for this <c>GamePad</c> in the GamePad configuration database.
         /// </summary>
-        public bool IsMapped
-        {
-            get { return is_mapped; }
-        }
+        public bool IsMapped { get; }
 
         /// <param name="left">A <see cref="GamePadCapabilities"/> structure to test for equality.</param>
         /// <param name="right">A <see cref="GamePadCapabilities"/> structure to test for equality.</param>
@@ -358,8 +350,8 @@ namespace OpenTK.Input
         {
             return
                 buttons.GetHashCode() ^
-                is_connected.GetHashCode() ^
-                is_mapped.GetHashCode() ^
+                IsConnected.GetHashCode() ^
+                IsMapped.GetHashCode() ^
                 gamepad_type.GetHashCode();
         }
 
@@ -386,8 +378,8 @@ namespace OpenTK.Input
         {
             return
                 buttons == other.buttons &&
-                is_connected == other.is_connected &&
-                is_mapped == other.is_mapped &&
+                IsConnected == other.IsConnected &&
+                IsMapped == other.IsMapped &&
                 gamepad_type == other.gamepad_type;
         }
     }

--- a/src/OpenTK/Input/GamePadConfiguration.cs
+++ b/src/OpenTK/Input/GamePadConfiguration.cs
@@ -36,22 +36,12 @@ namespace OpenTK.Input
     {
         static readonly char[] ConfigurationSeparator = new char[] { ',' };
 
-        Guid guid;
-        string name;
         readonly List<GamePadConfigurationItem> configuration_items =
             new List<GamePadConfigurationItem>();
 
-        public Guid Guid
-        {
-            get { return guid; }
-            private set { guid = value; }
-        }
+        public Guid Guid { get; private set; }
 
-        public string Name
-        {
-            get { return name; }
-            private set { name = value; }
-        }
+        public string Name { get; private set; }
 
         public GamePadConfiguration(string configuration)
         {

--- a/src/OpenTK/Input/GamePadConfigurationItem.cs
+++ b/src/OpenTK/Input/GamePadConfigurationItem.cs
@@ -31,26 +31,15 @@ namespace OpenTK.Input
 {
     class GamePadConfigurationItem
     {
-        GamePadConfigurationSource source;
-        GamePadConfigurationTarget target;
-
         public GamePadConfigurationItem(GamePadConfigurationSource source, GamePadConfigurationTarget target)
         {
             Source = source;
             Target = target;
         }
 
-        public GamePadConfigurationSource Source
-        {
-            get { return source; }
-            private set { source = value; }
-        }
+        public GamePadConfigurationSource Source { get; private set; }
 
-        public GamePadConfigurationTarget Target
-        {
-            get { return target; }
-            private set { target = value; }
-        }
+        public GamePadConfigurationTarget Target { get; private set; }
     }
 }
 

--- a/src/OpenTK/Input/GamePadConfigurationSource.cs
+++ b/src/OpenTK/Input/GamePadConfigurationSource.cs
@@ -31,7 +31,6 @@ namespace OpenTK.Input
 {
     struct GamePadConfigurationSource
     {
-        ConfigurationType map_type;
         int? map_button;
         JoystickAxis? map_axis;
         JoystickHat? map_hat;
@@ -59,11 +58,7 @@ namespace OpenTK.Input
             map_hat_position = pos;
         }
 
-        public ConfigurationType Type
-        {
-            get { return map_type; }
-            private set { map_type = value; }
-        }
+        public ConfigurationType Type { get; private set; }
 
         public JoystickAxis Axis
         {

--- a/src/OpenTK/Input/GamePadConfigurationTarget.cs
+++ b/src/OpenTK/Input/GamePadConfigurationTarget.cs
@@ -31,7 +31,6 @@ namespace OpenTK.Input
 {
     struct GamePadConfigurationTarget
     {
-        ConfigurationType map_type;
         Nullable<Buttons> map_button;
         Nullable<GamePadAxes> map_axis;
 
@@ -49,11 +48,7 @@ namespace OpenTK.Input
             map_axis = axis;
         }
 
-        public ConfigurationType Type
-        {
-            get { return map_type; }
-            private set { map_type = value; }
-        }
+        public ConfigurationType Type { get; private set; }
 
         public GamePadAxes Axis
         {

--- a/src/OpenTK/Input/GamePadState.cs
+++ b/src/OpenTK/Input/GamePadState.cs
@@ -35,14 +35,12 @@ namespace OpenTK.Input
         const float RangeMultiplier = 1.0f / (short.MaxValue + 1);
 
         Buttons buttons;
-        int packet_number;
         short left_stick_x;
         short left_stick_y;
         short right_stick_x;
         short right_stick_y;
         byte left_trigger;
         byte right_trigger;
-        bool is_connected;
 
         /// <summary>
         /// Gets a <see cref="GamePadThumbSticks"/> structure describing the
@@ -84,20 +82,14 @@ namespace OpenTK.Input
         /// Gets a value indicating whether this <c>GamePad</c> instance is connected.
         /// </summary>
         /// <value><c>true</c> if this instance is connected; otherwise, <c>false</c>.</value>
-        public bool IsConnected
-        {
-            get { return is_connected; }
-        }
+        public bool IsConnected { get; private set; }
 
         /// <summary>
         /// Gets the packet number for this <c>GamePadState</c> instance.
         /// Use the packet number to determine whether the state of a
         /// <c>GamePad</c> device has changed.
         /// </summary>
-        public int PacketNumber
-        {
-            get { return packet_number; }
-        }
+        public int PacketNumber { get; private set; }
 
         /// <summary>
         /// Returns a <see cref="System.String"/> that represents the current <see cref="OpenTK.Input.GamePadState"/>.
@@ -199,7 +191,7 @@ namespace OpenTK.Input
 
         internal void SetConnected(bool connected)
         {
-            is_connected = connected;
+            IsConnected = connected;
         }
 
         internal void SetTriggers(byte left, byte right)
@@ -210,7 +202,7 @@ namespace OpenTK.Input
 
         internal void SetPacketNumber(int number)
         {
-            packet_number = number;
+            PacketNumber = number;
         }
 
         bool IsAxisValid(GamePadAxes axis)

--- a/src/OpenTK/Input/JoystickCapabilities.cs
+++ b/src/OpenTK/Input/JoystickCapabilities.cs
@@ -40,7 +40,6 @@ namespace OpenTK.Input
         byte axis_count;
         byte button_count;
         byte hat_count;
-        bool is_connected;
 
         internal JoystickCapabilities(int axis_count, int button_count, int hat_count, bool is_connected)
         {
@@ -61,12 +60,12 @@ namespace OpenTK.Input
             this.axis_count = (byte)axis_count;
             this.button_count = (byte)button_count;
             this.hat_count = (byte)hat_count;
-            this.is_connected = is_connected;
+            this.IsConnected = is_connected;
         }
 
         internal void SetIsConnected(bool value)
         {
-            is_connected = value;
+            IsConnected = value;
         }
 
         /// <summary>
@@ -97,11 +96,7 @@ namespace OpenTK.Input
         /// Gets a value indicating whether this <see cref="JoystickDevice"/> is connected.
         /// </summary>
         /// <value><c>true</c> if this instance is connected; otherwise, <c>false</c>.</value>
-        public bool IsConnected
-        {
-            get { return is_connected; }
-            private set { is_connected = value; }
-        }
+        public bool IsConnected { get; private set; }
 
         /// <summary>
         /// Returns a <see cref="System.String"/> that represents the current <see cref="OpenTK.Input.JoystickCapabilities"/>.

--- a/src/OpenTK/Input/JoystickDevice.cs
+++ b/src/OpenTK/Input/JoystickDevice.cs
@@ -33,10 +33,6 @@ namespace OpenTK.Input
     /// </summary>
     public abstract class JoystickDevice : IInputDevice
     {
-        int id;
-        string description;
-        JoystickAxisCollection axis_collection;
-        JoystickButtonCollection button_collection;
         JoystickMoveEventArgs move_args = new JoystickMoveEventArgs(0, 0, 0);
         JoystickButtonEventArgs button_args = new JoystickButtonEventArgs(0, false);
 
@@ -49,28 +45,24 @@ namespace OpenTK.Input
                 throw new ArgumentOutOfRangeException("buttons");
 
             Id = id;
-            axis_collection = new JoystickAxisCollection(axes);
-            button_collection = new JoystickButtonCollection(buttons);
+            Axis = new JoystickAxisCollection(axes);
+            Button = new JoystickButtonCollection(buttons);
         }
 
         /// <summary>
         /// Gets a JoystickAxisCollection containing the state of each axis on this instance. Values are normalized in the [-1, 1] range.
         /// </summary>
-        public JoystickAxisCollection Axis { get { return axis_collection; } }
+        public JoystickAxisCollection Axis { get; }
 
         /// <summary>
         /// Gets JoystickButtonCollection containing the state of each button on this instance. True indicates that the button is pressed.
         /// </summary>
-        public JoystickButtonCollection Button { get { return button_collection; } }
+        public JoystickButtonCollection Button { get; }
 
         /// <summary>
         /// Gets a System.String containing a unique description for this instance.
         /// </summary>
-        public string Description
-        {
-            get { return description; }
-            internal set { description = value; }
-        }
+        public string Description { get; internal set; }
 
         /// <summary>
         /// Gets a value indicating the InputDeviceType of this InputDevice.
@@ -98,31 +90,27 @@ namespace OpenTK.Input
         public EventHandler<JoystickButtonEventArgs> ButtonUp =
             delegate(object sender, JoystickButtonEventArgs e) { };
 
-        internal int Id
-        {
-            get { return id; }
-            set { id = value; }
-        }
+        internal int Id { get; set; }
 
         internal void SetAxis(JoystickAxis axis, float @value)
         {
-            if ((int)axis < axis_collection.Count)
+            if ((int)axis < Axis.Count)
             {
                 move_args.Axis = axis;
                 move_args.Delta = move_args.Value - @value;
-                axis_collection[axis] = move_args.Value = @value;
+                Axis[axis] = move_args.Value = @value;
                 Move(this, move_args);
             }
         }
 
         internal void SetButton(int button, bool @value)
         {
-            if (button < button_collection.Count)
+            if (button < Button.Count)
             {
-                if (button_collection[button] != @value)
+                if (Button[button] != @value)
                 {
                     button_args.Button = button;
-                    button_collection[button] = button_args.Pressed = @value;
+                    Button[button] = button_args.Pressed = @value;
                     if (@value)
                         ButtonDown(this, button_args);
                     else
@@ -156,9 +144,6 @@ namespace OpenTK.Input
     /// </summary>
     public class JoystickButtonEventArgs : EventArgs
     {
-        int button;
-        bool pressed;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="JoystickButtonEventArgs"/> class.
         /// </summary>
@@ -166,19 +151,19 @@ namespace OpenTK.Input
         /// <param name="pressed">The current state of the button.</param>
         internal JoystickButtonEventArgs(int button, bool pressed)
         {
-            this.button = button;
-            this.pressed = pressed;
+            this.Button = button;
+            this.Pressed = pressed;
         }
 
         /// <summary>
         /// The index of the joystick button for the event.
         /// </summary>
-        public int Button { get { return this.button; } internal set { this.button = value; } }
+        public int Button { get; internal set; }
 
         /// <summary>
         /// Gets a System.Boolean representing the state of the button for the event.
         /// </summary>
-        public bool Pressed { get { return pressed; } internal set { this.pressed = value; } }
+        public bool Pressed { get; internal set; }
     }
 
     /// <summary>
@@ -187,10 +172,6 @@ namespace OpenTK.Input
     /// </summary>
     public class JoystickMoveEventArgs : JoystickEventArgs
     {
-        JoystickAxis axis;
-        float value;
-        float delta;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="JoystickMoveEventArgs"/> class.
         /// </summary>
@@ -199,25 +180,25 @@ namespace OpenTK.Input
         /// <param name="delta">The relative change in value of the joystick axis.</param>
         public JoystickMoveEventArgs(JoystickAxis axis, float value, float delta)
         {
-            this.axis = axis;
-            this.value = value;
-            this.delta = delta;
+            this.Axis = axis;
+            this.Value = value;
+            this.Delta = delta;
         }
 
         /// <summary>
         /// Gets a System.Int32 representing the index of the axis that was moved.
         /// </summary>
-        public JoystickAxis Axis { get { return axis; } internal set { this.axis = value; } }
+        public JoystickAxis Axis { get; internal set; }
 
         /// <summary>
         /// Gets a System.Single representing the absolute position of the axis.
         /// </summary>
-        public float Value { get { return value; } internal set { this.value = value; } }
+        public float Value { get; internal set; }
 
         /// <summary>
         /// Gets a System.Single representing the relative change in the position of the axis.
         /// </summary>
-        public float Delta { get { return delta; } internal set { this.delta = value; } }
+        public float Delta { get; internal set; }
     }
 
     /// <summary>

--- a/src/OpenTK/Input/JoystickHatState.cs
+++ b/src/OpenTK/Input/JoystickHatState.cs
@@ -34,11 +34,9 @@ namespace OpenTK.Input
     /// </summary>
     public struct JoystickHatState : IEquatable<JoystickHatState>
     {
-        HatPosition position;
-
         internal JoystickHatState(HatPosition pos)
         {
-            position = pos;
+            Position = pos;
         }
 
         /// <summary>
@@ -46,7 +44,7 @@ namespace OpenTK.Input
         /// the position of this hat.
         /// </summary>
         /// <value>The position.</value>
-        public HatPosition Position { get { return position; } }
+        public HatPosition Position { get; }
 
         /// <summary>
         /// Gets a <see cref="System.Boolean"/> indicating

--- a/src/OpenTK/Input/JoystickState.cs
+++ b/src/OpenTK/Input/JoystickState.cs
@@ -44,14 +44,12 @@ namespace OpenTK.Input
 
         const float ConversionFactor = 1.0f / (short.MaxValue + 0.5f);
 
-        int packet_number;
         long buttons;
         unsafe fixed short axes[MaxAxes];
         JoystickHatState hat0;
         JoystickHatState hat1;
         JoystickHatState hat2;
         JoystickHatState hat3;
-        bool is_connected;
 
         /// <summary>
         /// Gets a value between -1.0 and 1.0 representing the current offset of the specified  <see cref="JoystickAxis"/>.
@@ -136,10 +134,7 @@ namespace OpenTK.Input
         /// Gets a value indicating whether this instance is connected.
         /// </summary>
         /// <value><c>true</c> if this instance is connected; otherwise, <c>false</c>.</value>
-        public bool IsConnected
-        {
-            get { return is_connected; }
-        }
+        public bool IsConnected { get; private set; }
 
         /// <summary>
         /// Returns a <see cref="System.String"/> that represents the current <see cref="OpenTK.Input.JoystickState"/>.
@@ -189,10 +184,7 @@ namespace OpenTK.Input
                 Equals((JoystickState)obj);
         }
 
-        internal int PacketNumber
-        {
-            get { return packet_number; }
-        }
+        internal int PacketNumber { get; private set; }
 
         internal short GetAxisRaw(JoystickAxis axis)
         {
@@ -271,12 +263,12 @@ namespace OpenTK.Input
 
         internal void SetIsConnected(bool value)
         {
-            is_connected = value;
+            IsConnected = value;
         }
 
         internal void SetPacketNumber(int number)
         {
-            packet_number = number;
+            PacketNumber = number;
         }
 
         short GetAxisUnsafe(int index)

--- a/src/OpenTK/Input/KeyboardDevice.cs
+++ b/src/OpenTK/Input/KeyboardDevice.cs
@@ -15,10 +15,8 @@ namespace OpenTK.Input
     public sealed class KeyboardDevice : IInputDevice
     {
         //private IKeyboard keyboard;
-        private string description;
-        private int numKeys, numFKeys, numLeds;
+
         private IntPtr devID;
-        private bool repeat;
         private KeyboardState state;
 
         internal KeyboardDevice() { }
@@ -47,29 +45,17 @@ namespace OpenTK.Input
         /// <summary>
         /// Gets an integer representing the number of keys on this KeyboardDevice.
         /// </summary>
-        public int NumberOfKeys
-        {
-            get { return numKeys; }
-            internal set { numKeys = value; }
-        }
+        public int NumberOfKeys { get; internal set; }
 
         /// <summary>
         /// Gets an integer representing the number of function keys (F-keys) on this KeyboardDevice.
         /// </summary>
-        public int NumberOfFunctionKeys
-        {
-            get { return numFKeys; }
-            internal set { numFKeys = value; }
-        }
+        public int NumberOfFunctionKeys { get; internal set; }
 
         /// <summary>
         /// Gets a value indicating the number of led indicators on this KeyboardDevice.
         /// </summary>
-        public int NumberOfLeds
-        {
-            get { return numLeds; }
-            internal set { numLeds = value; }
-        }
+        public int NumberOfLeds { get; internal set; }
 
         /// <summary>
         /// Gets an IntPtr representing a device dependent ID.
@@ -96,11 +82,7 @@ namespace OpenTK.Input
         /// for game input.
         /// </para>
         /// </remarks>
-        public bool KeyRepeat
-        {
-            get { return repeat; }
-            set { repeat = value; }
-        }
+        public bool KeyRepeat { get; set; }
 
         /// <summary>
         /// Occurs when a key is pressed.
@@ -115,11 +97,7 @@ namespace OpenTK.Input
         /// <summary>
         /// Gets a <see cref="System.String"/> which describes this instance.
         /// </summary>
-        public string Description
-        {
-            get { return description; }
-            internal set { description = value; }
-        }
+        public string Description { get; internal set; }
 
         /// <summary>
         /// Gets the <see cref="InputDeviceType"/> for this instance.
@@ -157,7 +135,7 @@ namespace OpenTK.Input
         public override int GetHashCode()
         {
             //return base.GetHashCode();
-            return (int)(numKeys ^ numFKeys ^ numLeds ^ devID.GetHashCode() ^ description.GetHashCode());
+            return (int)(NumberOfKeys ^ NumberOfFunctionKeys ^ NumberOfLeds ^ devID.GetHashCode() ^ Description.GetHashCode());
         }
 
         /// <summary>

--- a/src/OpenTK/Input/KeyboardKeyEventArgs.cs
+++ b/src/OpenTK/Input/KeyboardKeyEventArgs.cs
@@ -41,10 +41,6 @@ namespace OpenTK.Input
     /// </remarks>
     public class KeyboardKeyEventArgs : EventArgs
     {
-        Key key;
-        bool repeat;
-        KeyboardState state;
-
         /// <summary>
         /// Constructs a new KeyboardEventArgs instance.
         /// </summary>
@@ -62,11 +58,7 @@ namespace OpenTK.Input
         /// <summary>
         /// Gets the <see cref="Key"/> that generated this event.
         /// </summary>
-        public Key Key
-        {
-            get { return key; }
-            internal set { key = value; }
-        }
+        public Key Key { get; internal set; }
 
         /// <summary>
         /// Gets the scancode which generated this event.
@@ -83,7 +75,7 @@ namespace OpenTK.Input
         /// <value><c>true</c> if pressed; otherwise, <c>false</c>.</value>
         public bool Alt
         {
-            get { return state[Key.AltLeft] || state[Key.AltRight]; }
+            get { return Keyboard[Key.AltLeft] || Keyboard[Key.AltRight]; }
         }
 
         /// <summary>
@@ -92,7 +84,7 @@ namespace OpenTK.Input
         /// <value><c>true</c> if pressed; otherwise, <c>false</c>.</value>
         public bool Control
         {
-            get { return state[Key.ControlLeft] || state[Key.ControlRight]; }
+            get { return Keyboard[Key.ControlLeft] || Keyboard[Key.ControlRight]; }
         }
 
         /// <summary>
@@ -101,7 +93,7 @@ namespace OpenTK.Input
         /// <value><c>true</c> if pressed; otherwise, <c>false</c>.</value>
         public bool Shift
         {
-            get { return state[Key.ShiftLeft] || state[Key.ShiftRight]; }
+            get { return Keyboard[Key.ShiftLeft] || Keyboard[Key.ShiftRight]; }
         }
 
         /// <summary>
@@ -125,11 +117,7 @@ namespace OpenTK.Input
         /// Gets the current <see cref="OpenTK.Input.KeyboardState"/>.
         /// </summary>
         /// <value>The keyboard.</value>
-        public KeyboardState Keyboard
-        {
-            get { return state; }
-            internal set { state = value; }
-        }
+        public KeyboardState Keyboard { get; internal set; }
 
         /// <summary>
         /// Gets a <see cref="System.Boolean"/> indicating whether
@@ -140,10 +128,6 @@ namespace OpenTK.Input
         /// a key; false, if this was caused by the user pressing a
         /// key for the first time.
         /// </value>
-        public bool IsRepeat
-        {
-            get { return repeat; }
-            internal set { repeat = value; }
-        }
+        public bool IsRepeat { get; internal set; }
     }
 }

--- a/src/OpenTK/Input/KeyboardState.cs
+++ b/src/OpenTK/Input/KeyboardState.cs
@@ -39,7 +39,6 @@ namespace OpenTK.Input
         const int NumInts = ((int)Key.LastKey + IntSize - 1) / IntSize;
         // The following line triggers bogus CS0214 in gmcs 2.0.1, sigh...
         unsafe fixed int Keys[NumInts];
-        bool is_connected;
 
         /// <summary>
         /// Gets a <see cref="System.Boolean"/> indicating whether the specified
@@ -131,11 +130,7 @@ namespace OpenTK.Input
         /// Gets a <see cref="System.Boolean"/> indicating whether this keyboard
         /// is connected.
         /// </summary>
-        public bool IsConnected
-        {
-            get { return is_connected; }
-            internal set { is_connected = value; }
-        }
+        public bool IsConnected { get; internal set; }
 
 #if false
         // Disabled until the correct cross-platform API can be determined.

--- a/src/OpenTK/Input/MouseDevice.cs
+++ b/src/OpenTK/Input/MouseDevice.cs
@@ -40,9 +40,7 @@ namespace OpenTK.Input
     /// </summary>
     public sealed class MouseDevice : IInputDevice
     {
-        string description;
         IntPtr id;
-        int numButtons, numWheels;
 
         MouseState state;
 #if COMPAT_REV1519
@@ -53,11 +51,7 @@ namespace OpenTK.Input
         /// <summary>
         /// Gets a string describing this MouseDevice.
         /// </summary>
-        public string Description
-        {
-            get { return description; }
-            internal set { description = value; }
-        }
+        public string Description { get; internal set; }
 
         /// <summary>
         /// Gets a value indicating the InputDeviceType of this InputDevice.
@@ -104,20 +98,12 @@ namespace OpenTK.Input
         /// <summary>
         /// Gets an integer representing the number of buttons on this MouseDevice.
         /// </summary>
-        public int NumberOfButtons
-        {
-            get { return numButtons; }
-            internal set { numButtons = value; }
-        }
+        public int NumberOfButtons { get; internal set; }
 
         /// <summary>
         /// Gets an integer representing the number of wheels on this MouseDevice.
         /// </summary>
-        public int NumberOfWheels
-        {
-            get { return numWheels; }
-            internal set { numWheels = value; }
-        }
+        public int NumberOfWheels { get; internal set; }
 
         /// <summary>
         /// Gets an IntPtr representing a device dependent ID.
@@ -228,7 +214,7 @@ namespace OpenTK.Input
         /// <returns></returns>
         public override int GetHashCode()
         {
-            return (int)(numButtons ^ numWheels ^ id.GetHashCode() ^ description.GetHashCode());
+            return (int)(NumberOfButtons ^ NumberOfWheels ^ id.GetHashCode() ^ Description.GetHashCode());
         }
 
         /// <summary>

--- a/src/OpenTK/Input/MouseEventArgs.cs
+++ b/src/OpenTK/Input/MouseEventArgs.cs
@@ -147,8 +147,6 @@ namespace OpenTK.Input
     /// </remarks>
     public class MouseMoveEventArgs : MouseEventArgs
     {
-        int x_delta, y_delta;
-
         /// <summary>
         /// Constructs a new <see cref="MouseMoveEventArgs"/> instance.
         /// </summary>
@@ -180,12 +178,12 @@ namespace OpenTK.Input
         /// <summary>
         /// Gets the change in X position produced by this event.
         /// </summary>
-        public int XDelta { get { return x_delta; } internal set { x_delta = value; } }
+        public int XDelta { get; internal set; }
 
         /// <summary>
         /// Gets the change in Y position produced by this event.
         /// </summary>
-        public int YDelta { get { return y_delta; } internal set { y_delta = value; } }
+        public int YDelta { get; internal set; }
     }
 
     /// <summary>
@@ -200,8 +198,6 @@ namespace OpenTK.Input
     /// </remarks>
     public class MouseButtonEventArgs : MouseEventArgs
     {
-        MouseButton button;
-
         /// <summary>
         /// Constructs a new <see cref="MouseButtonEventArgs"/> instance.
         /// </summary>
@@ -217,7 +213,7 @@ namespace OpenTK.Input
         public MouseButtonEventArgs(int x, int y, MouseButton button, bool pressed)
             : base(x, y)
         {
-            this.button = button;
+            this.Button = button;
             this.IsPressed = pressed;
         }
 
@@ -233,7 +229,7 @@ namespace OpenTK.Input
         /// <summary>
         /// Gets the <see cref="MouseButton"/> that triggered this event.
         /// </summary>
-        public MouseButton Button { get { return button; } internal set { button = value; } }
+        public MouseButton Button { get; internal set; }
 
         /// <summary>
         /// Gets a System.Boolean representing the state of the mouse button for the event.
@@ -257,8 +253,6 @@ namespace OpenTK.Input
     /// </remarks>
     public class MouseWheelEventArgs : MouseEventArgs
     {
-        float delta;
-
         /// <summary>
         /// Constructs a new <see cref="MouseWheelEventArgs"/> instance.
         /// </summary>
@@ -275,7 +269,7 @@ namespace OpenTK.Input
             : base(x, y)
         {
             Mouse.SetScrollAbsolute(Mouse.Scroll.X, value);
-            this.delta = delta;
+            this.DeltaPrecise = delta;
         }
 
         /// <summary>
@@ -297,7 +291,7 @@ namespace OpenTK.Input
         /// Gets the change in value of the wheel for this event in integer units.
         /// To support high-precision mice, it is recommended to use <see cref="DeltaPrecise"/> instead.
         /// </summary>
-        public int Delta { get { return (int)Math.Round(delta, MidpointRounding.AwayFromZero); } }
+        public int Delta { get { return (int)Math.Round(DeltaPrecise, MidpointRounding.AwayFromZero); } }
 
         /// <summary>
         /// Gets the precise value of the wheel in floating-point units.
@@ -310,7 +304,7 @@ namespace OpenTK.Input
         /// <summary>
         /// Gets the precise change in value of the wheel for this event in floating-point units.
         /// </summary>
-        public float DeltaPrecise { get { return delta; } internal set { delta = value; } }
+        public float DeltaPrecise { get; internal set; }
     }
 }
 

--- a/src/OpenTK/Input/MouseState.cs
+++ b/src/OpenTK/Input/MouseState.cs
@@ -38,7 +38,6 @@ namespace OpenTK.Input
         Vector2 position;
         MouseScroll scroll;
         ushort buttons;
-        bool is_connected;
 
         /// <summary>
         /// Gets a <see cref="System.Boolean"/> indicating whether the specified
@@ -191,11 +190,7 @@ namespace OpenTK.Input
         /// Gets a value indicating whether this instance is connected.
         /// </summary>
         /// <value><c>true</c> if this instance is connected; otherwise, <c>false</c>.</value>
-        public bool IsConnected
-        {
-            get { return is_connected; }
-            internal set { is_connected = value; }
-        }
+        public bool IsConnected { get; internal set; }
 
         /// <summary>
         /// Checks whether two <see cref="MouseState" /> instances are equal.

--- a/src/OpenTK/KeyPressEventArgs.cs
+++ b/src/OpenTK/KeyPressEventArgs.cs
@@ -33,8 +33,6 @@ namespace OpenTK
     /// </summary>
     public class KeyPressEventArgs : EventArgs
     {
-        char key_char;
-
         /// <summary>
         /// Constructs a new instance.
         /// </summary>
@@ -47,10 +45,6 @@ namespace OpenTK
         /// <summary>
         /// Gets a <see cref="System.Char"/> that defines the ASCII character that was typed.
         /// </summary>
-        public char KeyChar
-        {
-            get { return key_char; }
-            internal set { key_char = value; }
-        }
+        public char KeyChar { get; internal set; }
     }
 }

--- a/src/OpenTK/MouseCursor.cs
+++ b/src/OpenTK/MouseCursor.cs
@@ -34,13 +34,6 @@ namespace OpenTK
     /// </summary>
     public sealed class MouseCursor : WindowIcon
     {
-        static readonly MouseCursor default_cursor = new MouseCursor();
-        static readonly MouseCursor empty_cursor = new MouseCursor(
-            0, 0, 16, 16, new byte[16 * 16 * 4]);
-
-        int x;
-        int y;
-
         MouseCursor()
         {
         }
@@ -71,8 +64,8 @@ namespace OpenTK
             if (hotx < 0 || hotx >= Width || hoty < 0 || hoty >= Height)
                 throw new ArgumentOutOfRangeException();
 
-            x = hotx;
-            y = hoty;
+            X = hotx;
+            Y = hoty;
         }
 
         /// <summary>
@@ -100,34 +93,23 @@ namespace OpenTK
             if (hotx < 0 || hotx >= Width || hoty < 0 || hoty >= Height)
                 throw new ArgumentOutOfRangeException();
 
-            x = hotx;
-            y = hoty;
+            X = hotx;
+            Y = hoty;
         }
 
-        internal int X { get { return x; } }
-        internal int Y { get { return y; } }
+        internal int X { get; }
+        internal int Y { get; }
 
         /// <summary>
         /// Gets the default mouse cursor for this platform.
         /// </summary>
-        public static MouseCursor Default
-        {
-            get
-            {
-                return default_cursor;
-            }
-        }
+        public static MouseCursor Default { get; } = new MouseCursor();
 
         /// <summary>
         /// Gets an empty (invisible) mouse cursor.
         /// </summary>
-        public static MouseCursor Empty
-        {
-            get
-            {
-                return empty_cursor;
-            }
-        }
+        public static MouseCursor Empty { get; } = new MouseCursor(
+            0, 0, 16, 16, new byte[16 * 16 * 4]);
     }
 }
 

--- a/src/OpenTK/NativeWindow.cs
+++ b/src/OpenTK/NativeWindow.cs
@@ -46,7 +46,7 @@ namespace OpenTK
 
         private readonly INativeWindow implementation;
 
-        private bool disposed, events;
+        private bool events;
         private bool cursor_visible = true;
         private bool previous_cursor_visible = true;
 
@@ -619,11 +619,7 @@ namespace OpenTK
         /// Gets or sets a <see cref="System.Boolean"/>, which indicates whether
         /// this instance has been disposed.
         /// </summary>
-        protected bool IsDisposed
-        {
-            get { return disposed; }
-            set { disposed = value; }
-        }
+        protected bool IsDisposed { get; set; }
 
         /// <summary>
         /// Called when the NativeWindow has closed.

--- a/src/OpenTK/Platform/Dummy/DummyGLContext.cs
+++ b/src/OpenTK/Platform/Dummy/DummyGLContext.cs
@@ -22,7 +22,6 @@ namespace OpenTK.Platform.Dummy
     {
         readonly GraphicsContext.GetAddressDelegate Loader;
 
-        int swap_interval;
         static int handle_count;
         Thread current_thread;
 
@@ -77,17 +76,7 @@ namespace OpenTK.Platform.Dummy
             return Loader(str);
         }
 
-        public override int SwapInterval
-        {
-            get
-            {
-                return swap_interval;
-            }
-            set
-            {
-                swap_interval = value;
-            }
-        }
+        public override int SwapInterval { get; set; }
 
         public override void Update(IWindowInfo window)
         { }

--- a/src/OpenTK/Platform/Egl/AngleWindowInfo.cs
+++ b/src/OpenTK/Platform/Egl/AngleWindowInfo.cs
@@ -53,18 +53,14 @@ namespace OpenTK.Platform.Egl
 
     internal class AngleWindowInfo : IAngleWindowInfoInternal
     {
-        private readonly IWindowInfo _platform_window;
         private bool _disposed;
 
         public AngleWindowInfo(IWindowInfo platform_window)
         {
-            _platform_window = platform_window;
+            PlatformWindow = platform_window;
         }
 
-        public IWindowInfo PlatformWindow
-        {
-            get { return _platform_window; }
-        }
+        public IWindowInfo PlatformWindow { get; }
 
         public IWindowInfo WindowInfo
         {
@@ -75,7 +71,7 @@ namespace OpenTK.Platform.Egl
         {
             get
             {
-                var win_win = _platform_window as WinWindowInfo;
+                var win_win = PlatformWindow as WinWindowInfo;
                 if (win_win != null)
                 {
                     return win_win.DeviceContext;
@@ -104,7 +100,7 @@ namespace OpenTK.Platform.Egl
 
         public IntPtr Handle
         {
-            get { return _platform_window.Handle; }
+            get { return PlatformWindow.Handle; }
         }
 
         ~AngleWindowInfo()
@@ -120,7 +116,7 @@ namespace OpenTK.Platform.Egl
             }
             if (!called_from_finalizer)
             {
-                _platform_window.Dispose();
+                PlatformWindow.Dispose();
             }
             // dispose unmanaged
 

--- a/src/OpenTK/Platform/Egl/EglWindowInfo.cs
+++ b/src/OpenTK/Platform/Egl/EglWindowInfo.cs
@@ -34,8 +34,6 @@ namespace OpenTK.Platform.Egl
     // Holds information about an EGL window.
     class EglWindowInfo : IWindowInfo
     {
-        IntPtr handle;
-        IntPtr display;
         IntPtr surface;
         bool disposed;
 
@@ -63,9 +61,9 @@ namespace OpenTK.Platform.Egl
             }
         }
 
-        public IntPtr Handle { get { return handle; } set { handle = value; } }
+        public IntPtr Handle { get; set; }
 
-        public IntPtr Display { get { return display; } private set { display = value; } }
+        public IntPtr Display { get; private set; }
 
         public IntPtr Surface { get { return surface; } private set { surface = value; } }
 

--- a/src/OpenTK/Platform/Factory.cs
+++ b/src/OpenTK/Platform/Factory.cs
@@ -34,9 +34,6 @@ namespace OpenTK.Platform
     sealed class Factory : IPlatformFactory
     {
         private bool disposed;
-        private static IPlatformFactory defaultImplementation;
-        private static IPlatformFactory embeddedImplementation;
-        private static IPlatformFactory angleImplementation;
 
         static Factory()
         {
@@ -112,73 +109,61 @@ namespace OpenTK.Platform
                 Default = Embedded;
         }
 
-        public static IPlatformFactory Default
-        {
-            get { return defaultImplementation; }
-            private set { defaultImplementation = value; }
-        }
+        public static IPlatformFactory Default { get; private set; }
 
-        public static IPlatformFactory Embedded
-        {
-            get { return embeddedImplementation; }
-            private set { embeddedImplementation = value; }
-        }
+        public static IPlatformFactory Embedded { get; private set; }
 
-        public static IPlatformFactory Angle
-        {
-            get { return angleImplementation; }
-            private set { angleImplementation = value; }
-        }
+        public static IPlatformFactory Angle { get; private set; }
 
         public INativeWindow CreateNativeWindow(int x, int y, int width, int height, string title,
             GraphicsMode mode, GameWindowFlags options, DisplayDevice device)
         {
-            return defaultImplementation.CreateNativeWindow(x, y, width, height, title, mode, options, device);
+            return Default.CreateNativeWindow(x, y, width, height, title, mode, options, device);
         }
 
         public IDisplayDeviceDriver CreateDisplayDeviceDriver()
         {
-            return defaultImplementation.CreateDisplayDeviceDriver();
+            return Default.CreateDisplayDeviceDriver();
         }
 
         public IGraphicsContext CreateGLContext(GraphicsMode mode, IWindowInfo window, IGraphicsContext shareContext, bool directRendering, int major, int minor, GraphicsContextFlags flags)
         {
-            return defaultImplementation.CreateGLContext(mode, window, shareContext, directRendering, major, minor, flags);
+            return Default.CreateGLContext(mode, window, shareContext, directRendering, major, minor, flags);
         }
 
         public IGraphicsContext CreateGLContext(ContextHandle handle, IWindowInfo window, IGraphicsContext shareContext, bool directRendering, int major, int minor, GraphicsContextFlags flags)
         {
-            return defaultImplementation.CreateGLContext(handle, window, shareContext, directRendering, major, minor, flags);
+            return Default.CreateGLContext(handle, window, shareContext, directRendering, major, minor, flags);
         }
 
         public GraphicsContext.GetCurrentContextDelegate CreateGetCurrentGraphicsContext()
         {
-            return defaultImplementation.CreateGetCurrentGraphicsContext();
+            return Default.CreateGetCurrentGraphicsContext();
         }
 
         public IKeyboardDriver2 CreateKeyboardDriver()
         {
-            return defaultImplementation.CreateKeyboardDriver();
+            return Default.CreateKeyboardDriver();
         }
 
         public IMouseDriver2 CreateMouseDriver()
         {
-            return defaultImplementation.CreateMouseDriver();
+            return Default.CreateMouseDriver();
         }
 
         public IGamePadDriver CreateGamePadDriver()
         {
-            return defaultImplementation.CreateGamePadDriver();
+            return Default.CreateGamePadDriver();
         }
 
         public IJoystickDriver2 CreateJoystickDriver()
         {
-            return defaultImplementation.CreateJoystickDriver();
+            return Default.CreateJoystickDriver();
         }
 
         public void RegisterResource(IDisposable resource)
         {
-            defaultImplementation.RegisterResource(resource);
+            Default.RegisterResource(resource);
         }
 
         class UnsupportedPlatform : PlatformFactoryBase

--- a/src/OpenTK/Platform/Linux/Bindings/LibInput.cs
+++ b/src/OpenTK/Platform/Linux/Bindings/LibInput.cs
@@ -214,14 +214,12 @@ namespace OpenTK.Platform.Linux
     [StructLayout(LayoutKind.Sequential)]
     struct KeyboardEvent
     {
-        IntPtr @event;
-
-        public IntPtr BaseEvent { get { return GetBaseEvent(@event); } }
-        public IntPtr Event { get { return @event; } }
-        public uint Time { get { return GetTime(@event); } }
-        public uint Key { get { return GetKey(@event); } }
-        public uint KeyCount { get { return GetSeatKeyCount(@event); } }
-        public KeyState KeyState { get { return GetKeyState(@event); } }
+        public IntPtr BaseEvent { get { return GetBaseEvent(Event); } }
+        public IntPtr Event { get; }
+        public uint Time { get { return GetTime(Event); } }
+        public uint Key { get { return GetKey(Event); } }
+        public uint KeyCount { get { return GetSeatKeyCount(Event); } }
+        public KeyState KeyState { get { return GetKeyState(Event); } }
 
         [DllImport(LibInput.lib, EntryPoint = "libinput_event_keyboard_get_time", CallingConvention = CallingConvention.Cdecl)]
         static extern uint GetTime(IntPtr @event);
@@ -243,22 +241,20 @@ namespace OpenTK.Platform.Linux
     [StructLayout(LayoutKind.Sequential)]
     struct PointerEvent
     {
-        IntPtr @event;
-
-        public IntPtr BaseEvent { get { return GetBaseEvent(@event); } }
-        public IntPtr Event { get { return @event; } }
-        public uint Time { get { return GetTime(@event); } }
-        public EvdevButton Button { get { return (EvdevButton)GetButton(@event); } }
-        public uint ButtonCount { get { return GetButtonCount(@event); } }
-        public ButtonState ButtonState { get { return GetButtonState(@event); } }
-        public bool HasAxis(PointerAxis axis) { return HasAxis(@event, axis) != 0; }
-        public double AxisValue(PointerAxis axis) { return GetAxisValue(@event, axis); }
-        public double DeltaX { get { return GetDX(@event); } }
-        public double DeltaY { get { return GetDY(@event); } }
-        public double X { get { return GetAbsX(@event); } }
-        public double Y { get { return GetAbsY(@event); } }
-        public double TransformedX(int width) { return GetAbsXTransformed(@event, width); }
-        public double TransformedY(int height) { return GetAbsYTransformed(@event, height); }
+        public IntPtr BaseEvent { get { return GetBaseEvent(Event); } }
+        public IntPtr Event { get; }
+        public uint Time { get { return GetTime(Event); } }
+        public EvdevButton Button { get { return (EvdevButton)GetButton(Event); } }
+        public uint ButtonCount { get { return GetButtonCount(Event); } }
+        public ButtonState ButtonState { get { return GetButtonState(Event); } }
+        public bool HasAxis(PointerAxis axis) { return HasAxis(Event, axis) != 0; }
+        public double AxisValue(PointerAxis axis) { return GetAxisValue(Event, axis); }
+        public double DeltaX { get { return GetDX(Event); } }
+        public double DeltaY { get { return GetDY(Event); } }
+        public double X { get { return GetAbsX(Event); } }
+        public double Y { get { return GetAbsY(Event); } }
+        public double TransformedX(int width) { return GetAbsXTransformed(Event, width); }
+        public double TransformedY(int height) { return GetAbsYTransformed(Event, height); }
 
         [DllImport(LibInput.lib, EntryPoint = "libinput_event_pointer_get_time", CallingConvention = CallingConvention.Cdecl)]
         static extern uint GetTime(IntPtr @event);

--- a/src/OpenTK/Platform/MacOS/CarbonWindowInfo.cs
+++ b/src/OpenTK/Platform/MacOS/CarbonWindowInfo.cs
@@ -36,15 +36,8 @@ namespace OpenTK.Platform.MacOS
     /// </summary>
     sealed class CarbonWindowInfo : IWindowInfo
     {
-        IntPtr windowRef;
         bool ownHandle = false;
         bool disposed = false;
-        bool isControl = true;
-        bool goFullScreenHack = false;
-        bool goWindowedHack = false;
-
-        GetInt xOffset;
-        GetInt yOffset;
 
         /// <summary>
         /// Constructs a new instance with the specified parameters.
@@ -54,44 +47,30 @@ namespace OpenTK.Platform.MacOS
         /// <param name="isControl"></param>
         public CarbonWindowInfo(IntPtr windowRef, bool ownHandle, bool isControl)
         {
-            this.windowRef = windowRef;
+            this.Handle = windowRef;
             this.ownHandle = ownHandle;
-            this.isControl = isControl;
+            this.IsControl = isControl;
         }
 
         public CarbonWindowInfo(IntPtr windowRef, bool ownHandle, bool isControl, GetInt getX, GetInt getY) : this(windowRef, ownHandle, isControl)
         {
-            this.xOffset = getX;
-            this.yOffset = getY;
+            this.XOffset = getX;
+            this.YOffset = getY;
         }
 
         /// <summary>
         /// Gets the window reference for this instance.
         /// </summary>
-        public IntPtr Handle
-        {
-            get { return this.windowRef; }
-            set { this.windowRef = value; }
-        }
+        public IntPtr Handle { get; set; }
 
-        internal bool GoFullScreenHack
-        {
-            get { return goFullScreenHack; }
-            set { goFullScreenHack = value; }
-        }
-        internal bool GoWindowedHack
-        {
-            get { return goWindowedHack; }
-            set { goWindowedHack = value; }
-        }
+        internal bool GoFullScreenHack { get; set; } = false;
+
+        internal bool GoWindowedHack { get; set; } = false;
 
         /// <summary>
         /// Gets a value indicating whether this instance refers to a System.Windows.Forms.Control.
         /// </summary>
-        public bool IsControl
-        {
-            get { return isControl; }
-        }
+        public bool IsControl { get; } = true;
 
         /// <summary>Returns a System.String that represents the current window.</summary>
         /// <returns>A System.String that represents the current window.</returns>
@@ -105,16 +84,10 @@ namespace OpenTK.Platform.MacOS
         // (e.g. MonoGame)
         public IntPtr WindowHandle { get { return Handle; } set { Handle = value; } }
 
-        public GetInt XOffset
-        {
-            get { return xOffset; }
-            set { xOffset = value; }
-        }
-        public GetInt YOffset
-        {
-            get { return yOffset; }
-            set { yOffset = value; }
-        }
+        public GetInt XOffset { get; set; }
+
+        public GetInt YOffset { get; set; }
+
         public void Dispose()
         {
             Dispose(true);
@@ -132,7 +105,7 @@ namespace OpenTK.Platform.MacOS
 
             if (ownHandle)
             {
-                windowRef = IntPtr.Zero;
+                Handle = IntPtr.Zero;
             }
 
             disposed = true;

--- a/src/OpenTK/Platform/MacOS/Cocoa/NSFloat.cs
+++ b/src/OpenTK/Platform/MacOS/Cocoa/NSFloat.cs
@@ -41,33 +41,27 @@ namespace OpenTK.Platform.MacOS
     // However, NSFloat is used internally in places where this precision loss does not matter.
     struct NSFloat
     {
-        IntPtr value;
+        private IntPtr _value;
 
         public IntPtr Value
         {
-            get
-            {
-                return value;
-            }
-            set
-            {
-                this.value = value;
-            }
+            get { return _value; }
+            set { _value = value; }
         }
 
         public static implicit operator NSFloat(float v)
         {
-            NSFloat f;
+            NSFloat f = new NSFloat();
             unsafe
             {
                 if (IntPtr.Size == 4)
                 {
-                    f.value = *(IntPtr*)&v;
+                    f.Value = *(IntPtr*)&v;
                 }
                 else
                 {
                     double d = v;
-                    f.value = *(IntPtr*)&d;
+                    f.Value = *(IntPtr*)&d;
                 }
             }
             return f;
@@ -75,17 +69,17 @@ namespace OpenTK.Platform.MacOS
 
         public static implicit operator NSFloat(double v)
         {
-            NSFloat f;
+            NSFloat f = new NSFloat();
             unsafe
             {
                 if (IntPtr.Size == 4)
                 {
                     float fv = (float)v;
-                    f.value = *(IntPtr*)&fv;
+                    f.Value = *(IntPtr*)&fv;
                 }
                 else
                 {
-                    f.value = *(IntPtr*)&v;
+                    f.Value = *(IntPtr*)&v;
                 }
             }
             return f;
@@ -97,11 +91,11 @@ namespace OpenTK.Platform.MacOS
             {
                 if (IntPtr.Size == 4)
                 {
-                    return *(float*)&f.value;
+                    return *(float*)f._value;
                 }
                 else
                 {
-                    return (float)*(double*)&f.value;
+                    return (float)*(double*)&f._value;
                 }
             }
         }
@@ -112,11 +106,11 @@ namespace OpenTK.Platform.MacOS
             {
                 if (IntPtr.Size == 4)
                 {
-                    return (double)*(float*)&f.value;
+                    return (double)*(float*)&f._value;
                 }
                 else
                 {
-                    return *(double*)&f.value;
+                    return *(double*)&f._value;
                 }
             }
         }

--- a/src/OpenTK/Platform/MacOS/CocoaWindowInfo.cs
+++ b/src/OpenTK/Platform/MacOS/CocoaWindowInfo.cs
@@ -40,9 +40,6 @@ namespace OpenTK.Platform.MacOS
     {
         static readonly IntPtr selContentView = Selector.Get("contentView");
 
-        IntPtr nsWindowRef;
-        IntPtr nsViewRef;
-
         bool disposed = false;
 
         /// <summary>
@@ -62,26 +59,26 @@ namespace OpenTK.Platform.MacOS
         /// <param name="nsViewRef">A valid NSView reference.</param>
         public CocoaWindowInfo(IntPtr nsWindowRef, IntPtr nsViewRef)
         {
-            this.nsWindowRef = nsWindowRef;
-            this.nsViewRef = nsViewRef;
+            this.Handle = nsWindowRef;
+            this.ViewHandle = nsViewRef;
             Cocoa.SendVoid(nsWindowRef, Selector.Retain);
         }
 
         /// <summary>
         /// Gets the window reference for this instance.
         /// </summary>
-        public IntPtr Handle { get { return nsWindowRef; } }
+        public IntPtr Handle { get; }
 
         /// <summary>
         /// Gets the view reference for this instance.
         /// </summary>
-        public IntPtr ViewHandle { get { return nsViewRef; } }
+        public IntPtr ViewHandle { get; }
 
         /// <summary>Returns a System.String that represents the current window.</summary>
         /// <returns>A System.String that represents the current window.</returns>
         public override string ToString()
         {
-            return String.Format("MacOS.CocoaWindowInfo: NSWindow {0}, NSView {1}", nsWindowRef, nsViewRef);
+            return String.Format("MacOS.CocoaWindowInfo: NSWindow {0}, NSView {1}", Handle, ViewHandle);
         }
 
         public void Dispose()
@@ -96,11 +93,11 @@ namespace OpenTK.Platform.MacOS
 
             if (disposing)
             {
-                Cocoa.SendVoid(nsWindowRef, Selector.Release);
+                Cocoa.SendVoid(Handle, Selector.Release);
             }
             else
             {
-                Debug.Print("CocoaWindowInfo:{0} leaked, did you forget to call Dispose()?", nsWindowRef);
+                Debug.Print("CocoaWindowInfo:{0} leaked, did you forget to call Dispose()?", Handle);
             }
 
             disposed = true;

--- a/src/OpenTK/Platform/MacOS/MacOSException.cs
+++ b/src/OpenTK/Platform/MacOS/MacOSException.cs
@@ -31,30 +31,25 @@ namespace OpenTK.Platform.MacOS
 {
     internal class MacOSException : Exception
     {
-        OSStatus errorCode;
-
         public MacOSException()
         {}
         public MacOSException(OSStatus errorCode)
             : base("Error Code " + ((int)errorCode).ToString() + ": " + errorCode.ToString())
         {
-            this.errorCode = errorCode;
+            this.ErrorCode = errorCode;
         }
         public MacOSException(OSStatus errorCode, string message)
             : base(message)
         {
-            this.errorCode = errorCode;
+            this.ErrorCode = errorCode;
         }
         internal MacOSException(int errorCode, string message)
             : base(message)
         {
-            this.errorCode = (OSStatus)errorCode;
+            this.ErrorCode = (OSStatus)errorCode;
         }
 
-        public OSStatus ErrorCode
-        {
-            get { return errorCode; }
-        }
+        public OSStatus ErrorCode { get; }
     }
 
     internal enum OSStatus

--- a/src/OpenTK/Platform/MacOS/Quartz/CoreFoundation.cs
+++ b/src/OpenTK/Platform/MacOS/Quartz/CoreFoundation.cs
@@ -41,17 +41,16 @@ namespace OpenTK.Platform.MacOS.Carbon
 
     struct CFArray
     {
-        IntPtr arrayRef;
-        public IntPtr Ref { get { return arrayRef; } set { arrayRef = value; } }
+        public IntPtr Ref { get; set; }
 
         public CFArray(IntPtr reference)
         {
-            arrayRef = reference;
+            Ref = reference;
         }
 
         public int Count
         {
-            get { return CF.CFArrayGetCount(arrayRef); }
+            get { return CF.CFArrayGetCount(Ref); }
         }
         public IntPtr this[int index]
         {
@@ -60,7 +59,7 @@ namespace OpenTK.Platform.MacOS.Carbon
                 if (index >= Count || index < 0)
                     throw new IndexOutOfRangeException();
 
-                return CF.CFArrayGetValueAtIndex(arrayRef, index);
+                return CF.CFArrayGetValueAtIndex(Ref, index);
             }
         }
     }
@@ -69,24 +68,23 @@ namespace OpenTK.Platform.MacOS.Carbon
     {
         public CFDictionary(IntPtr reference)
         {
-            dictionaryRef = reference;
+            Ref = reference;
         }
 
-        IntPtr dictionaryRef;
-        public IntPtr Ref { get { return dictionaryRef; } set { dictionaryRef = value; } }
+        public IntPtr Ref { get; set; }
 
         public int Count
         {
             get
             {
-                return CF.CFDictionaryGetCount(dictionaryRef);
+                return CF.CFDictionaryGetCount(Ref);
             }
         }
 
         public double GetNumberValue(string key)
         {
             double retval;
-            IntPtr cfnum = CF.CFDictionaryGetValue(dictionaryRef,
+            IntPtr cfnum = CF.CFDictionaryGetValue(Ref,
                 CF.CFSTR(key));
 
             CF.CFNumberGetValue(cfnum, CF.CFNumberType.kCFNumberDoubleType, out retval);

--- a/src/OpenTK/Platform/Windows/WinGLContext.cs
+++ b/src/OpenTK/Platform/Windows/WinGLContext.cs
@@ -23,7 +23,6 @@ namespace OpenTK.Platform.Windows
     {
         static readonly object LoadLock = new object();
 
-        IntPtr device_context;
         bool vsync_supported;
         bool vsync_tear_supported;
 
@@ -262,12 +261,12 @@ namespace OpenTK.Platform.Windows
                         throw new ArgumentException("window", "Must point to a valid window.");
 
                     success = Wgl.MakeCurrent(wnd.DeviceContext, Handle.Handle);
-                    device_context = wnd.DeviceContext;
+                    DeviceContext = wnd.DeviceContext;
                 }
                 else
                 {
                     success = Wgl.MakeCurrent(IntPtr.Zero, IntPtr.Zero);
-                    device_context = IntPtr.Zero;
+                    DeviceContext = IntPtr.Zero;
                 }
 
                 if (!success)
@@ -387,13 +386,7 @@ namespace OpenTK.Platform.Windows
             return mode;
         }
 
-        internal IntPtr DeviceContext
-        {
-            get
-            {
-                return device_context;
-            }
-        }
+        internal IntPtr DeviceContext { get; private set; }
 
         /// <summary>Returns a System.String describing this OpenGL context.</summary>
         /// <returns>A System.String describing this OpenGL context.</returns>

--- a/src/OpenTK/Platform/Windows/WinInputBase.cs
+++ b/src/OpenTK/Platform/Windows/WinInputBase.cs
@@ -38,9 +38,9 @@ namespace OpenTK.Platform.Windows
         readonly AutoResetEvent InputReady = new AutoResetEvent(false);
 
         IntPtr OldWndProc;
-        INativeWindow native;
 
-        protected INativeWindow Native { get { return native; } private set { native = value; } }
+        protected INativeWindow Native { get; private set; }
+
         protected WinWindowInfo Parent { get { return (WinWindowInfo)Native.WindowInfo; } }
 
         static readonly IntPtr Unhandled = new IntPtr(-1);

--- a/src/OpenTK/Platform/Windows/WinWindowInfo.cs
+++ b/src/OpenTK/Platform/Windows/WinWindowInfo.cs
@@ -36,7 +36,6 @@ namespace OpenTK.Platform.Windows
     sealed class WinWindowInfo : IWindowInfo
     {
         IntPtr handle, dc;
-        WinWindowInfo parent;
         bool disposed;
 
         /// <summary>
@@ -54,7 +53,7 @@ namespace OpenTK.Platform.Windows
         public WinWindowInfo(IntPtr handle, WinWindowInfo parent)
         {
             this.handle = handle;
-            this.parent = parent;
+            this.Parent = parent;
         }
 
         /// <summary>
@@ -65,7 +64,7 @@ namespace OpenTK.Platform.Windows
         /// <summary>
         /// Gets or sets the Parent of the window (may be null).
         /// </summary>
-        public WinWindowInfo Parent { get { return parent; } set { parent = value; } }
+        public WinWindowInfo Parent { get; set; }
 
         /// <summary>
         /// Gets the device context for this window instance.
@@ -132,8 +131,8 @@ namespace OpenTK.Platform.Windows
 
                 if (manual)
                 {
-                    if (parent != null)
-                        parent.Dispose();
+                    if (Parent != null)
+                        Parent.Dispose();
                 }
 
                 disposed = true;

--- a/src/OpenTK/Platform/X11/API.cs
+++ b/src/OpenTK/Platform/X11/API.cs
@@ -67,15 +67,14 @@ namespace OpenTK.Platform.X11
         private const string _dll_name = "libX11";
         private const string _dll_name_vid = "libXxf86vm";
 
-        static Display defaultDisplay;
-        static int defaultScreen;
         static Window rootWindow;
-        static int screenCount;
 
-        internal static Display DefaultDisplay { get { return defaultDisplay; } }
-        static int DefaultScreen { get { return defaultScreen; } }
+        internal static Display DefaultDisplay { get; private set; }
+
+        private static int DefaultScreen { get; set; }
+
         //internal static Window RootWindow { get { return rootWindow; } }
-        internal static int ScreenCount { get { return screenCount; } }
+        internal static int ScreenCount { get; }
 
         internal static object Lock = new object();
 
@@ -84,14 +83,14 @@ namespace OpenTK.Platform.X11
             int has_threaded_x = Functions.XInitThreads();
             Debug.Print("Initializing threaded X11: {0}.", has_threaded_x.ToString());
 
-            defaultDisplay = Functions.XOpenDisplay(IntPtr.Zero);
+            DefaultDisplay = Functions.XOpenDisplay(IntPtr.Zero);
 
-            if (defaultDisplay == IntPtr.Zero)
+            if (DefaultDisplay == IntPtr.Zero)
                 throw new PlatformException("Could not establish connection to the X-Server.");
 
-            using (new XLock(defaultDisplay))
+            using (new XLock(DefaultDisplay))
             {
-                screenCount = Functions.XScreenCount(DefaultDisplay);
+                ScreenCount = Functions.XScreenCount(DefaultDisplay);
             }
             Debug.Print("Display connection: {0}, Screen count: {1}", DefaultDisplay, ScreenCount);
 
@@ -100,11 +99,11 @@ namespace OpenTK.Platform.X11
 
         static void CurrentDomain_ProcessExit(object sender, EventArgs e)
         {
-            if (defaultDisplay != IntPtr.Zero)
+            if (DefaultDisplay != IntPtr.Zero)
             {
-                Functions.XCloseDisplay(defaultDisplay);
-                defaultDisplay = IntPtr.Zero;
-                defaultScreen = 0;
+                Functions.XCloseDisplay(DefaultDisplay);
+                DefaultDisplay = IntPtr.Zero;
+                DefaultScreen = 0;
                 rootWindow = IntPtr.Zero;
             }
         }

--- a/src/OpenTK/Platform/X11/X11Input.cs
+++ b/src/OpenTK/Platform/X11/X11Input.cs
@@ -36,7 +36,6 @@ namespace OpenTK.Platform.X11
         readonly X11Mouse mouse = new X11Mouse();
         readonly X11Keyboard keyboard = new X11Keyboard();
         readonly Linux.LinuxJoystick joystick = new Linux.LinuxJoystick();
-        readonly IGamePadDriver gamepad = new MappedGamePadDriver();
 
         internal X11Input()
         {
@@ -61,13 +60,7 @@ namespace OpenTK.Platform.X11
             }
         }
 
-        public IGamePadDriver GamePadDriver
-        {
-            get
-            {
-                return gamepad;
-            }
-        }
+        public IGamePadDriver GamePadDriver { get; } = new MappedGamePadDriver();
 
         public IJoystickDriver2 JoystickDriver
         {

--- a/src/OpenTK/Platform/X11/X11WindowInfo.cs
+++ b/src/OpenTK/Platform/X11/X11WindowInfo.cs
@@ -34,11 +34,8 @@ namespace OpenTK.Platform.X11
     /// <summary>Describes an X11 window.</summary>
     sealed class X11WindowInfo : IWindowInfo
     {
-        IntPtr handle, rootWindow, display;
-        X11WindowInfo parent;
-        int screen;
+        IntPtr handle, display;
         XVisualInfo visualInfo;
-        EventMask eventMask;
 
         /// <summary>Constructs a new X11WindowInfo class.</summary>
         public X11WindowInfo() { }
@@ -51,12 +48,12 @@ namespace OpenTK.Platform.X11
         public X11WindowInfo(IntPtr handle, X11WindowInfo parent)
         {
             this.handle = handle;
-            this.parent = parent;
+            this.Parent = parent;
             if (parent != null)
             {
-                this.rootWindow = parent.rootWindow;
+                this.RootWindow = parent.RootWindow;
                 this.display = parent.display;
-                this.screen = parent.screen;
+                this.Screen = parent.Screen;
                 this.visualInfo = parent.visualInfo;
             }
         }
@@ -64,13 +61,16 @@ namespace OpenTK.Platform.X11
         /// <summary>Gets or sets the handle of the window.</summary>
         public IntPtr Handle { get { return handle; } set { handle = value; } }
         /// <summary>Gets or sets the parent of the window.</summary>
-        public X11WindowInfo Parent { get { return parent; } set { parent = value; } }
+        public X11WindowInfo Parent { get; set; }
+
         /// <summary>Gets or sets the X11 root window.</summary>
-        public IntPtr RootWindow { get { return rootWindow; } set { rootWindow = value; } }
+        public IntPtr RootWindow { get; set; }
+
         /// <summary>Gets or sets the connection to the X11 display.</summary>
         public IntPtr Display { get { return display; } set { display = value; } }
         /// <summary>Gets or sets the X11 screen.</summary>
-        public int Screen { get { return screen; } set { screen = value; } }
+        public int Screen { get; set; }
+
         /// <summary>Gets or sets the X11 VisualInfo.</summary>
         public XVisualInfo VisualInfo
         {
@@ -84,7 +84,7 @@ namespace OpenTK.Platform.X11
             }
         }
         /// <summary>Gets or sets the X11 EventMask.</summary>
-        public EventMask EventMask { get { return eventMask; } set { eventMask = value; } }
+        public EventMask EventMask { get; set; }
 
         // For compatibility with whoever thought it would be
         // a good idea to access internal APIs through reflection

--- a/src/OpenTK/Platform/X11/XI2Input.cs
+++ b/src/OpenTK/Platform/X11/XI2Input.cs
@@ -35,7 +35,6 @@ namespace OpenTK.Platform.X11
     {
         readonly XI2MouseKeyboard mouse_keyboard = new XI2MouseKeyboard();
         readonly Linux.LinuxJoystick joystick = new Linux.LinuxJoystick();
-        readonly IGamePadDriver gamepad = new MappedGamePadDriver();
 
         internal XI2Input()
         {
@@ -58,13 +57,7 @@ namespace OpenTK.Platform.X11
             }
         }
 
-        public IGamePadDriver GamePadDriver
-        {
-            get
-            {
-                return gamepad;
-            }
-        }
+        public IGamePadDriver GamePadDriver { get; } = new MappedGamePadDriver();
 
         public IJoystickDriver2 JoystickDriver
         {

--- a/src/OpenTK/WindowIcon.cs
+++ b/src/OpenTK/WindowIcon.cs
@@ -36,10 +36,6 @@ namespace OpenTK
     /// </summary>
     public class WindowIcon
     {
-        byte[] data;
-        int width;
-        int height;
-
         /// \internal
         /// <summary>
         /// Initializes a new instance of the <see cref="OpenTK.WindowIcon"/> class.
@@ -53,8 +49,8 @@ namespace OpenTK
             if (width < 0 || width > 256 || height < 0 || height > 256)
                 throw new ArgumentOutOfRangeException();
 
-            this.width = width;
-            this.height = height;
+            this.Width = width;
+            this.Height = height;
         }
 
         internal WindowIcon(int width, int height, byte[] data)
@@ -65,7 +61,7 @@ namespace OpenTK
             if (data.Length < Width * Height * 4)
                 throw new ArgumentOutOfRangeException();
 
-            this.data = data;
+            this.Data = data;
         }
 
         internal WindowIcon(int width, int height, IntPtr data)
@@ -77,13 +73,13 @@ namespace OpenTK
             // We assume that width and height are correctly set.
             // If they are not, we will read garbage and probably
             // crash.
-            this.data = new byte[width * height * 4];
-            Marshal.Copy(data, this.data, 0, this.data.Length);
+            this.Data = new byte[width * height * 4];
+            Marshal.Copy(data, this.Data, 0, this.Data.Length);
         }
 
-        internal byte[] Data { get { return data; } }
-        internal int Width { get { return width; } }
-        internal int Height { get { return height; } }
+        internal byte[] Data { get; }
+        internal int Width { get; }
+        internal int Height { get; }
     }
 }
 


### PR DESCRIPTION
This PR changes all compatible properties with backing fields to auto-properties, eliminating redundant code.

One exception to this is the value field in Cocoa/NSFloat, for which the backing field has remained. This is due to a need to take the address of that value, which cannot be done for a property.