### PR TITLE
Fix: Some joystick hats not returning centered correctly on Windows HID

### DIFF
--- a/src/OpenTK/Platform/Windows/WinRawJoystick.cs
+++ b/src/OpenTK/Platform/Windows/WinRawJoystick.cs
@@ -341,6 +341,12 @@ namespace OpenTK.Platform.Windows
 
         HatPosition GetHatPosition(uint value, HidProtocolValueCaps caps)
         {
+            if (value > caps.LogicalMax)
+            {
+                //Return zero if our value is out of bounds ==> e.g.
+                //Thrustmaster T-Flight Hotas X returns 15 for the centered position
+                return HatPosition.Centered;
+            }
             if (caps.LogicalMax == 3)
             {
                 //4-way hat switch as per the example in Appendix C
@@ -355,8 +361,6 @@ namespace OpenTK.Platform.Windows
                         return HatPosition.Right;
                     case 3: 
                         return HatPosition.Down;
-                    default:
-                        return HatPosition.Centered;
                 }
             }
             if (caps.LogicalMax == 8)
@@ -364,23 +368,12 @@ namespace OpenTK.Platform.Windows
                 //Hat states are represented as a plain number from 0-8
                 //with centered being zero
                 //Padding should have already been stripped out, so just cast
-                if (value > 8)
-                {
-                    //Value out of bounds, so return centered
-                    return HatPosition.Centered;
-                }
                 return (HatPosition)value;
             }
             if (caps.LogicalMax == 7)
             {
                 //Hat states are represented as a plain number from 0-7
                 //with centered being 8
-                if (value > 8)
-                {
-                    //Return zero if our value is out of bounds ==> e.g.
-                    //Thrustmaster T-Flight Hotas X returns 15 for the centered position
-                    return HatPosition.Centered;
-                }
                 value++;
                 value %= 9;
                 return (HatPosition)value;

--- a/src/OpenTK/Platform/Windows/WinRawJoystick.cs
+++ b/src/OpenTK/Platform/Windows/WinRawJoystick.cs
@@ -341,6 +341,24 @@ namespace OpenTK.Platform.Windows
 
         HatPosition GetHatPosition(uint value, HidProtocolValueCaps caps)
         {
+            if (caps.LogicalMax == 3)
+            {
+                //4-way hat switch as per the example in Appendix C
+                //http://www.usb.org/developers/hidpage/Hut1_12v2.pdf
+                switch (value)
+                {
+                    case 0:
+                        return HatPosition.Left;
+                    case 1:
+                        return HatPosition.Up;
+                    case 2:
+                        return HatPosition.Right;
+                    case 3: 
+                        return HatPosition.Down;
+                    default:
+                        return HatPosition.Centered;
+                }
+            }
             if (caps.LogicalMax == 8)
             {
                 //Hat states are represented as a plain number from 0-8

--- a/src/OpenTK/Platform/Windows/WinRawJoystick.cs
+++ b/src/OpenTK/Platform/Windows/WinRawJoystick.cs
@@ -342,15 +342,33 @@ namespace OpenTK.Platform.Windows
         HatPosition GetHatPosition(uint value, HidProtocolValueCaps caps)
         {
             if (caps.LogicalMax == 8)
-                return (HatPosition)value;
-            else if (caps.LogicalMax == 7)
             {
+                //Hat states are represented as a plain number from 0-8
+                //with centered being zero
+                //Padding should have already been stripped out, so just cast
+                if (value > 8)
+                {
+                    //Value out of bounds, so return centered
+                    return HatPosition.Centered;
+                }
+                return (HatPosition)value;
+            }
+            if (caps.LogicalMax == 7)
+            {
+                //Hat states are represented as a plain number from 0-7
+                //with centered being 8
+                if (value > 8)
+                {
+                    //Return zero if our value is out of bounds ==> e.g.
+                    //Thrustmaster T-Flight Hotas X returns 15 for the centered position
+                    return HatPosition.Centered;
+                }
                 value++;
                 value %= 9;
                 return (HatPosition)value;
             }
-            else
-                return HatPosition.Centered;
+            //The HID report length is unsupported
+            return HatPosition.Centered;
         }
 
         unsafe void UpdateAxes(RawInput* rin, Device stick)


### PR DESCRIPTION
This fixes the hat on the Thrustmaster T-Flight HOTAS-X, which returns 15 as opposed to 9 for it's centered position. (9 & multiples thereof are the only things that the current code will regard as centered)

I *strongly suspect* any value of 8 or over when our stick returns a Caps.LogicalMax of 7 should be interpreted as centered, but that's only a suspicion, hence why I've only added in 15 ATM.
However. the remainder operation seems like overkill if this is the case, so I wonder if this isn't right..... 
Is there a database anywhere of HID reports?

Any maintainers have a view?