### PR TITLE
Enforce the use of braces for conditional statements

### DIFF
--- a/src/Generator.Bind/BindStreamWriter.cs
+++ b/src/Generator.Bind/BindStreamWriter.cs
@@ -60,7 +60,9 @@ namespace Bind
         public void Unindent()
         {
             if (indent_level > 0)
+            {
                 --indent_level;
+            }
         }
 
         public void Write(WriteOptions options, string value)
@@ -144,7 +146,9 @@ namespace Bind
             if (options != WriteOptions.NoIndent)
             {
                 for (int i = indent_level; i > 0; i--)
+                {
                     sw.Write("    ");
+                }
             }
         }
 

--- a/src/Generator.Bind/CSharpSpecWriter.cs
+++ b/src/Generator.Bind/CSharpSpecWriter.cs
@@ -54,7 +54,9 @@ namespace Bind
             int top = Console.CursorTop;
             Console.Write(text);
             for (int i = text.Length; i < 80; i++)
+            {
                 Console.Write(" ");
+            }
             Console.WriteLine();
             Console.SetCursorPosition(left, top);
         }
@@ -63,7 +65,9 @@ namespace Bind
         {
             Console.WriteLine("Writing bindings to {0}", Settings.OutputPath);
             if (!Directory.Exists(Settings.OutputPath))
+            {
                 Directory.CreateDirectory(Settings.OutputPath);
+            }
 
             string temp_enums_file = Path.GetTempFileName();
             string temp_wrappers_file = Path.GetTempFileName();
@@ -84,7 +88,9 @@ namespace Bind
                     sw.WriteLine("static partial class {0}", Settings.OutputClass);
                 }
                 else
+                {
                     sw.WriteLine("namespace {0}", Settings.EnumsOutput);
+                }
 
                 sw.WriteLine("{");
 
@@ -124,10 +130,22 @@ namespace Bind
             string output_core = Path.Combine(Settings.OutputPath, Settings.ImportsFile);
             string output_wrappers = Path.Combine(Settings.OutputPath, Settings.WrappersFile);
 
-            if (File.Exists(output_enums)) File.Delete(output_enums);
-            if (File.Exists(output_delegates)) File.Delete(output_delegates);
-            if (File.Exists(output_core)) File.Delete(output_core);
-            if (File.Exists(output_wrappers)) File.Delete(output_wrappers);
+            if (File.Exists(output_enums))
+            {
+                File.Delete(output_enums);
+            }
+            if (File.Exists(output_delegates))
+            {
+                File.Delete(output_delegates);
+            }
+            if (File.Exists(output_core))
+            {
+                File.Delete(output_core);
+            }
+            if (File.Exists(output_wrappers))
+            {
+                File.Delete(output_wrappers);
+            }
 
             File.Move(temp_enums_file, output_enums);
             File.Move(temp_wrappers_file, output_wrappers);
@@ -296,9 +314,13 @@ namespace Bind
                 else if (!String.IsNullOrEmpty(f.Version))
                 {
                     if (f.Category.StartsWith("VERSION"))
+                    {
                         category = String.Format("[requires: {0}]", "v" + f.Version);
+                    }
                     else
+                    {
                         category = String.Format("[requires: {0}]", "v" + f.Version + " or " + f.Category);
+                    }
                 }
 
                 // Write function summary
@@ -413,7 +435,9 @@ namespace Bind
 
                 sw.Write(str);
                 if (!String.IsNullOrEmpty(str))
+                {
                     sw.WriteLine(",");
+                }
             }
         }
 
@@ -424,9 +448,13 @@ namespace Bind
             //sw.WriteLine();
 
             if ((Settings.Compatibility & Settings.Legacy.NestedEnums) != Settings.Legacy.None)
+            {
                 Trace.WriteLine(String.Format("Writing enums to:\t{0}.{1}.{2}", Settings.OutputNamespace, Settings.OutputClass, Settings.NestedEnumsClass));
+            }
             else
+            {
                 Trace.WriteLine(String.Format("Writing enums to:\t{0}", Settings.EnumsOutput));
+            }
 
             if ((Settings.Compatibility & Settings.Legacy.ConstIntEnums) == Settings.Legacy.None)
             {
@@ -480,11 +508,17 @@ namespace Bind
                     }
 
                     if (@enum.IsObsolete)
+                    {
                         sw.WriteLine("[Obsolete(\"{0}\")]", @enum.Obsolete);
+                    }
                     if (!@enum.CLSCompliant)
+                    {
                         sw.WriteLine("[CLSCompliant(false)]");
+                    }
                     if (@enum.IsFlagCollection)
+                    {
                         sw.WriteLine("[Flags]");
+                    }
                     sw.WriteLine("public enum " + @enum.Name + " : " + @enum.Type);
                     sw.WriteLine("{");
                     sw.Indent();
@@ -561,7 +595,9 @@ namespace Bind
 
             sb.Append(d.Unsafe ? "unsafe " : "");
             if (is_delegate)
+            {
                 sb.Append("delegate ");
+            }
             sb.Append(GetDeclarationString(d.ReturnType, Settings.Legacy.ConstIntEnums));
             sb.Append(" ");
             sb.Append(Settings.FunctionPrefix);
@@ -579,12 +615,16 @@ namespace Bind
             {
                 int ret = String.Compare(c1.Value, c2.Value);
                 if (ret == 0)
+                {
                     return String.Compare(c1.Name, c2.Name);
+                }
                 return ret;
             });
 
             if (e.IsFlagCollection)
+            {
                 sb.AppendLine("[Flags]");
+            }
             sb.Append("public enum ");
             sb.Append(e.Name);
             sb.Append(" : ");
@@ -597,7 +637,9 @@ namespace Bind
                 sb.Append("    ");
                 sb.Append(declaration);
                 if (!String.IsNullOrEmpty(declaration))
+                {
                     sb.AppendLine(",");
+                }
             }
             sb.Append("}");
 
@@ -640,7 +682,9 @@ namespace Bind
                 foreach (Parameter p in f.Parameters)
                 {
                     if (p.Generic)
+                    {
                         sb.AppendLine(String.Format("    where {0} : struct", p.CurrentType));
+                    }
                 }
             }
 
@@ -652,16 +696,24 @@ namespace Bind
             StringBuilder sb = new StringBuilder();
 
             if (p.Flow == FlowDirection.Out)
+            {
                 sb.Append("[OutAttribute] ");
+            }
             else if (p.Flow == FlowDirection.Undefined)
+            {
                 sb.Append("[InAttribute, OutAttribute] ");
+            }
 
             if (p.Reference)
             {
                 if (p.Flow == FlowDirection.Out)
+                {
                     sb.Append("out ");
+                }
                 else
+                {
                     sb.Append("ref ");
+                }
             }
 
             if (!override_unsafe_setting && ((Settings.Compatibility & Settings.Legacy.NoPublicUnsafeFunctions) != Settings.Legacy.None))

--- a/src/Generator.Bind/DocProcessor.cs
+++ b/src/Generator.Bind/DocProcessor.cs
@@ -42,7 +42,9 @@ namespace Bind
         public DocProcessor(IBind generator)
         {
             if (generator == null)
+            {
                 throw new ArgumentNullException();
+            }
 
             Generator = generator;
             foreach (string file in Directory.GetFiles(Settings.DocPath).Concat(
@@ -68,9 +70,13 @@ namespace Bind
             {
                 var file = Settings.FunctionPrefix + f.WrappedDelegate.Name + ".xml";
                 if (!DocumentationFiles.ContainsKey(file))
+                {
                     file = Settings.FunctionPrefix + f.TrimmedName + ".xml";
+                }
                 if (!DocumentationFiles.ContainsKey(file))
+                {
                     file = Settings.FunctionPrefix + f.TrimmedName.TrimEnd(numbers) + ".xml";
+                }
 
                 docs = 
                     (DocumentationFiles.ContainsKey(file) ? ProcessFile(DocumentationFiles[file], processor) : null) ??
@@ -96,7 +102,9 @@ namespace Bind
             string text;
 
             if (LastFile == file)
+            {
                 return Cached;
+            }
 
             LastFile = file;
             text = File.ReadAllText(file);
@@ -155,7 +163,9 @@ namespace Bind
         private Documentation ToInlineDocs(XDocument doc, EnumProcessor enum_processor)
         {
             if (doc == null || enum_processor == null)
+            {
                 throw new ArgumentNullException();
+            }
 
             var no_const_processing = Settings.Legacy.NoAdvancedEnumProcessing | Settings.Legacy.ConstIntEnums;
             if (!Generator.Settings.IsEnabled(no_const_processing))

--- a/src/Generator.Bind/EnumProcessor.cs
+++ b/src/Generator.Bind/EnumProcessor.cs
@@ -45,9 +45,13 @@ namespace Bind
         public EnumProcessor(IBind generator, IEnumerable<string> overrides)
         {
             if (generator == null)
+            {
                 throw new ArgumentNullException("generator");
+            }
             if (overrides == null)
+            {
                 throw new ArgumentNullException("overrides");
+            }
 
             Generator = generator;
             Overrides = overrides;
@@ -69,7 +73,9 @@ namespace Bind
         public static string GetOverridesPath(string apiname, string enumeration)
         {
             if (enumeration == null)
+            {
                 throw new ArgumentNullException("enumeration");
+            }
 
             var path = new StringBuilder();
             path.Append("/signatures/replace");
@@ -149,15 +155,21 @@ namespace Bind
         public string TranslateEnumName(string name)
         {
             if (String.IsNullOrEmpty(name))
+            {
                 return name;
+            }
 
             if (Utilities.CSharpKeywords.Contains(name))
+            {
                 return name;
+            }
 
             if (!IsAlreadyProcessed(name))
             {
                 if (Char.IsDigit(name[0]))
+                {
                     name = Settings.ConstantPrefix + name;
+                }
 
                 StringBuilder translator = new StringBuilder(name);
 
@@ -194,11 +206,17 @@ namespace Bind
                     }
 
                     if (is_after_underscore_or_number)
+                    {
                         char_to_add = Char.ToUpper(c);
+                    }
                     else if (is_previous_uppercase)
+                    {
                         char_to_add = Char.ToLower(c);
+                    }
                     else
+                    {
                         char_to_add = c;
+                    }
 
                     translator.Append(char_to_add);
 
@@ -219,7 +237,9 @@ namespace Bind
 
                 name = translator.ToString();
                 if (name.StartsWith(Settings.EnumPrefix))
+                {
                     name = name.Substring(Settings.EnumPrefix.Length);
+                }
             }
 
             return name;
@@ -282,7 +302,9 @@ namespace Bind
         public string TranslateConstantName(string s, bool isValue)
         {
             if (String.IsNullOrEmpty(s))
+            {
                 return s;
+            }
 
             StringBuilder translator = new StringBuilder(s.Length);
 
@@ -302,7 +324,9 @@ namespace Bind
                     bool is_after_digit = false;
 
                     if (!isValue && Char.IsDigit(s[0]))
+                    {
                         s = Settings.ConstantPrefix + s;
+                    }
 
                     foreach (char c in s)
                     {
@@ -333,7 +357,9 @@ namespace Bind
                     translator[0] = Char.ToUpper(translator[0]);
                 }
                 else
+                {
                     translator.Append(s);
+                }
             }
 
             return translator.ToString();
@@ -346,14 +372,20 @@ namespace Bind
             {
                 // Trim the unsigned or long specifiers used in C constants ('u' or 'ull').
                 if (value.ToLower().EndsWith("ull"))
+                {
                     value = value.Substring(0, value.Length - 3);
+                }
                 if (value.ToLower().EndsWith("u"))
+                {
                     value = value.Substring(0, value.Length - 1);
+                }
             }
 
             // Strip the prefix, if any.
             if (value.StartsWith(Settings.ConstantPrefix))
+            {
                 value = value.Substring(Settings.ConstantPrefix.Length);
+            }
 
             return TranslateConstantName(value, IsValue(value));
         }

--- a/src/Generator.Bind/FuncProcessor.cs
+++ b/src/Generator.Bind/FuncProcessor.cs
@@ -62,9 +62,13 @@ namespace Bind
         public FuncProcessor(IBind generator, IEnumerable<string> overrides)
         {
             if (generator == null)
+            {
                 throw new ArgumentNullException("generator");
+            }
             if (overrides == null)
+            {
                 throw new ArgumentNullException("overrides");
+            }
 
             Generator = generator;
             Overrides = overrides;
@@ -351,15 +355,23 @@ namespace Bind
             {
                 // For consistency - many overrides use string instead of String.
                 if (enum_override.Value == "string")
+                {
                     type.QualifiedType = "String";
+                }
                 else if (enum_override.Value == "StringBuilder")
+                {
                     type.QualifiedType = "StringBuilder";
+                }
                 else
+                {
                     type.CurrentType = enum_override.Value;
+                }
             }
 
             if (type.CurrentType == "IntPtr" && String.IsNullOrEmpty(type.PreviousType))
+            {
                 type.Pointer = 0;
+            }
 
             if (type.Pointer >= 3)
             {
@@ -455,13 +467,19 @@ namespace Bind
                 string extensionless_name = GetTrimmedExtension(d.Name, ext);
                 function_overload = nav.Select(GetOverloadsPath(apiname, apiversion, d.Name, ext));
                 if (function_overload.Count != 0)
+                {
                     break;
+                }
                 function_overload = nav.Select(GetOverloadsPath(apiname, apiversion, extensionless_name, ext));
                 if (function_overload.Count != 0)
+                {
                     break;
+                }
                 function_overload = nav.Select(GetOverloadsPath(apiname, apiversion, trimmed_name, ext));
                 if (function_overload.Count != 0)
+                {
                     break;
+                }
             }
             return function_overload;
         }
@@ -522,7 +540,9 @@ namespace Bind
                                 case "count":
                                     int count;
                                     if (Int32.TryParse(node.Value, out count))
+                                    {
                                         d.Parameters[i].ElementCount = count;
+                                    }
                                     break;
                             }
                         }
@@ -583,10 +603,14 @@ namespace Bind
             if (d.ReturnType.CurrentType.Contains("GLenum"))
             {
                 if ((Settings.Compatibility & Settings.Legacy.ConstIntEnums) == Settings.Legacy.None)
+                {
                     d.ReturnType.QualifiedType = String.Format("{0}{1}{2}",
                         Settings.EnumsOutput, Settings.NamespaceSeparator, Settings.CompleteEnumName);
+                }
                 else
+                {
                     d.ReturnType.QualifiedType = "int";
+                }
             }
 
             if (d.ReturnType.CurrentType.ToLower().Contains("bool"))
@@ -623,7 +647,9 @@ namespace Bind
             {
                 TranslateParameter(d.Parameters[i], function_override, nav, enum_processor, enums, d.Category, apiname);
                 if (d.Parameters[i].CurrentType == "UInt16" && d.Name.Contains("LineStipple"))
+                {
                     d.Parameters[i].WrapperType |= WrapperTypes.UncheckedParameter;
+                }
             }
         }
 
@@ -693,7 +719,9 @@ namespace Bind
             }
 
             if (Utilities.CSharpKeywords.Contains(p.Name))
+            {
                 p.Name = Settings.KeywordEscapeCharacter + p.Name;
+            }
 
             // This causes problems with bool arrays
             //if (CurrentType.ToLower().Contains("bool"))
@@ -793,7 +821,9 @@ namespace Bind
                         {
                             cls.Parameters[i].CurrentType = GetCLSCompliantType(cls.Parameters[i]);
                             if (cls.Parameters[i].CurrentType != f.Parameters[i].CurrentType)
+                            {
                                 modified = true;
+                            }
                         }
 
                         // Only add a cls-compliant overload if we have
@@ -840,21 +870,33 @@ namespace Bind
                             for (k = 0; k < wrappers[i].Parameters.Count; k++)
                             {
                                 if (wrappers[i].Parameters[k].CurrentType != wrappers[j].Parameters[k].CurrentType)
+                                {
                                     break;
+                                }
 
                                 if (wrappers[i].Parameters[k].DiffersOnlyOnReference(wrappers[j].Parameters[k]))
+                                {
                                     if (wrappers[i].Parameters[k].Reference)
+                                    {
                                         function_i_is_problematic = true;
+                                    }
                                     else
+                                    {
                                         function_j_is_problematic = true;
+                                    }
+                                }
                             }
 
                             if (k == wrappers[i].Parameters.Count)
                             {
                                 if (function_i_is_problematic)
+                                {
                                     must_remove.Add(i);
+                                }
                                 if (function_j_is_problematic)
+                                {
                                     must_remove.Add(j);
+                                }
                             }
                         }
                     }
@@ -879,7 +921,9 @@ namespace Bind
             if (!type.CLSCompliant)
             {
                 if (type.Pointer != 0 && Settings.Compatibility == Settings.Legacy.Tao)
+                {
                     return "IntPtr";
+                }
 
                 switch (type.CurrentType)
                 {

--- a/src/Generator.Bind/GL2/Generator.cs
+++ b/src/Generator.Bind/GL2/Generator.cs
@@ -55,7 +55,9 @@ namespace Bind.GL2
         public Generator(Settings settings)
         {
             if (settings == null)
+            {
                 throw new ArgumentNullException("settings");
+            }
 
             Settings = settings.Clone();
 

--- a/src/Generator.Bind/Main.cs
+++ b/src/Generator.Bind/Main.cs
@@ -99,7 +99,9 @@ namespace Bind
                                 val = val.ToLower();
                                 bool enable = !opt.StartsWith("-");
                                 if (val.StartsWith("+") || val.StartsWith("-"))
+                                {
                                     val = val.Substring(1);
+                                }
 
                                 var settings = Settings.Legacy.None;
                                 switch (val)

--- a/src/Generator.Bind/Settings.cs
+++ b/src/Generator.Bind/Settings.cs
@@ -84,9 +84,13 @@ namespace Bind
             get
             {
                 if ((Compatibility & Legacy.NestedEnums) != Legacy.None)
+                {
                     return OutputNamespace + NamespaceSeparator + OutputClass + NamespaceSeparator + NestedEnumsClass;
+                }
                 else
+                {
                     return String.IsNullOrEmpty(EnumsNamespace) ? OutputNamespace : OutputNamespace + NamespaceSeparator + EnumsNamespace;
+                }
             }
         }
 
@@ -95,9 +99,13 @@ namespace Bind
             get
             {
                 if ((Compatibility & Legacy.NestedEnums) != Legacy.None)
+                {
                     return OutputNamespace + NamespaceSeparator + GLClass + NamespaceSeparator + NestedEnumsClass;
+                }
                 else
+                {
                     return OutputNamespace + NamespaceSeparator + EnumsNamespace;
+                }
             }
         }
 
@@ -199,7 +207,15 @@ namespace Bind
         public bool DropMultipleTokens
         {
             get { return (Compatibility & Legacy.NoDropMultipleTokens) == Legacy.None; }
-            set { if (value) Compatibility |= Legacy.NoDropMultipleTokens; else Compatibility &= ~Legacy.NoDropMultipleTokens; }
+            set { if (value)
+                {
+                    Compatibility |= Legacy.NoDropMultipleTokens;
+                }
+                else
+                {
+                    Compatibility &= ~Legacy.NoDropMultipleTokens;
+                }
+            }
         }
 
         public string WindowsGDI = "OpenTK.Platform.Windows.API";

--- a/src/Generator.Bind/Structures/Constant.cs
+++ b/src/Generator.Bind/Structures/Constant.cs
@@ -32,10 +32,14 @@ namespace Bind.Structures
             set
             {
                 if (String.IsNullOrEmpty(value))
+                {
                     throw new ArgumentNullException("value");
+                }
 
                 if (OriginalName == null)
+                {
                     OriginalName = _name;
+                }
 
                 _name = value;
             }
@@ -55,7 +59,9 @@ namespace Bind.Structures
             set
             {
                 if (String.IsNullOrEmpty(value))
+                {
                     throw new ArgumentNullException("value");
+                }
 
                 _value = value;
             }
@@ -108,9 +114,13 @@ namespace Bind.Structures
         public static bool TranslateConstantWithReference(Constant c, EnumCollection enums)
         {
             if (c == null)
+            {
                 throw new ArgumentNullException("c");
+            }
             if (enums == null)
+            {
                 throw new ArgumentNullException("enums");
+            }
 
             if (!String.IsNullOrEmpty(c.Reference))
             {
@@ -165,7 +175,9 @@ namespace Bind.Structures
         {
             int ret = Value.CompareTo(other.Value);
             if (ret == 0)
+            {
                 return Name.CompareTo(other.Name);
+            }
             return ret;
         }
     }

--- a/src/Generator.Bind/Structures/Delegate.cs
+++ b/src/Generator.Bind/Structures/Delegate.cs
@@ -61,18 +61,26 @@ namespace Bind.Structures
             get
             {
                 if (cls_compliance_overriden != null)
+                {
                     return (bool)cls_compliance_overriden;
+                }
 
                 if (Unsafe)
+                {
                     return false;
+                }
 
                 if (!ReturnType.CLSCompliant)
+                {
                     return false;
+                }
 
                 foreach (Parameter p in Parameters)
                 {
                     if (!p.CLSCompliant)
+                    {
                         return false;
+                    }
                 }
                 return true;
             }
@@ -96,12 +104,16 @@ namespace Bind.Structures
                 // TODO: Add special cases for (Get)ShaderSource.
 
                 if (ReturnType.WrapperType != WrapperTypes.None)
+                {
                     return true;
+                }
 
                 foreach (Parameter p in Parameters)
                 {
                     if (p.WrapperType != WrapperTypes.None)
+                    {
                         return true;
+                    }
                 }
 
                 return false;
@@ -121,7 +133,9 @@ namespace Bind.Structures
                 //    return false;
 
                 if (ReturnType.Pointer != 0)
+                {
                     return true;
+                }
 
                 foreach (Parameter p in Parameters)
                 {
@@ -198,9 +212,13 @@ namespace Bind.Structures
         {
             int ret = Name.CompareTo(other.Name);
             if (ret == 0)
+            {
                 ret = Parameters.CompareTo(other.Parameters);
+            }
             if (ret == 0)
+            {
                 ret = ReturnType.CompareTo(other.ReturnType);
+            }
             return ret;
         }
 

--- a/src/Generator.Bind/Structures/Enum.cs
+++ b/src/Generator.Bind/Structures/Enum.cs
@@ -47,7 +47,9 @@ namespace Bind.Structures
             set
             {
                 if (value == null)
+                {
                     throw new ArgumentNullException("value");
+                }
 
                 _constant_collection.Clear();
                 foreach (var item in value)
@@ -89,12 +91,16 @@ namespace Bind.Structures
             // empty check, let's try to remove first Arb, then Ext from the strings.
             int ret = PreferEmpty(ext1, ext2);
             if (ret != 0)
+            {
                 return ret;
+            }
 
             ext1 = ext1.Replace("Arb", ""); ext2 = ext2.Replace("Arb", "");
             ret = PreferEmpty(ext1, ext2);
             if (ret != 0)
+            {
                 return ret;
+            }
 
             ext1 = ext1.Replace("Ext", ""); ext2 = ext2.Replace("Ext", "");
             return PreferEmpty(ext1, ext2);
@@ -104,11 +110,17 @@ namespace Bind.Structures
         private int PreferEmpty(string ext1, string ext2)
         {
             if (String.IsNullOrEmpty(ext1) && !String.IsNullOrEmpty(ext2))
+            {
                 return -1;
+            }
             else if (String.IsNullOrEmpty(ext2) && !String.IsNullOrEmpty(ext1))
+            {
                 return 1;
+            }
             else
+            {
                 return 0;
+            }
         }
 
         public void Add(Enum e)

--- a/src/Generator.Bind/Structures/Function.cs
+++ b/src/Generator.Bind/Structures/Function.cs
@@ -81,9 +81,13 @@ namespace Bind.Structures
         {
             int ret = Name.CompareTo(other.Name);
             if (ret == 0)
+            {
                 ret = Parameters.CompareTo(other.Parameters);
+            }
             if (ret == 0)
+            {
                 ret = ReturnType.CompareTo(other.ReturnType);
+            }
             return ret;
         }
     }
@@ -112,9 +116,13 @@ namespace Bind.Structures
         public void Unindent()
         {
             if (indent.Length > 4)
+            {
                 indent = indent.Substring(4);
+            }
             else
+            {
                 indent = String.Empty;
+            }
         }
 
         new public void Add(string s)
@@ -133,7 +141,9 @@ namespace Bind.Structures
         public override string ToString()
         {
             if (Count == 0)
+            {
                 return String.Empty;
+            }
 
             StringBuilder sb = new StringBuilder(Count);
 

--- a/src/Generator.Bind/Structures/Parameter.cs
+++ b/src/Generator.Bind/Structures/Parameter.cs
@@ -33,7 +33,9 @@ namespace Bind.Structures
             : base(p)
         {
             if (p == null)
+            {
                 return;
+            }
 
             Name = p.Name;
             Unchecked = p.Unchecked;
@@ -164,7 +166,9 @@ namespace Bind.Structures
         {
             int result = base.CompareTo(other);
             if (result == 0)
+            {
                 result = Name.CompareTo(other.Name);
+            }
             return result;
         }
 
@@ -218,7 +222,9 @@ namespace Bind.Structures
         public ParameterCollection(IEnumerable<Parameter> parameters)
         {
             foreach (Parameter p in parameters)
+            {
                 Add(new Parameter(p));
+            }
         }
 
         private void BuildCache()
@@ -285,16 +291,24 @@ namespace Bind.Structures
             foreach (Parameter p in this)
             {
                 if (p.Pointer != 0 || p.CurrentType.Contains("IntPtr"))
+                {
                     hasPointerParameters = true;
+                }
 
                 if (p.Reference)
+                {
                     hasReferenceParameters = true;
+                }
 
                 if (p.Unsigned)
+                {
                     hasUnsignedParameters = true;
+                }
 
                 if (p.Generic)
+                {
                     hasGenericParameters = true;
+                }
             }
         }
 
@@ -313,7 +327,9 @@ namespace Bind.Structures
                 sb.Replace(", ", ")", sb.Length - 2, 2);
             }
             else
+            {
                 sb.Append(")");
+            }
 
             return sb.ToString();
         }
@@ -321,8 +337,12 @@ namespace Bind.Structures
         public bool ContainsType(string type)
         {
             foreach (Parameter p in this)
+            {
                 if (p.CurrentType == type)
+                {
                     return true;
+                }
+            }
             return false;
         }
 
@@ -423,7 +443,9 @@ namespace Bind.Structures
                 {
                     int result = this[i].CompareTo(other[i]);
                     if (result != 0)
+                    {
                         return result;
+                    }
                 }
                 return 0;
             }
@@ -432,7 +454,9 @@ namespace Bind.Structures
         public bool Equals(ParameterCollection other)
         {
             if (Count != other.Count)
+            {
                 return false;
+            }
 
             bool result = true;
             for (int i = 0; i < Count && result; i++)

--- a/src/Generator.Bind/Structures/Type.cs
+++ b/src/Generator.Bind/Structures/Type.cs
@@ -54,7 +54,9 @@ namespace Bind.Structures
             set
             {
                 if (String.IsNullOrEmpty(value))
+                {
                     throw new ArgumentNullException();
+                }
 
                 int qualifier_end = value.LastIndexOf('.');
                 if (qualifier_end > -1)
@@ -83,12 +85,18 @@ namespace Bind.Structures
             set
             {
                 if (String.IsNullOrEmpty(value))
+                {
                     throw new ArgumentException();
+                }
 
                 if (!String.IsNullOrEmpty(type))
+                {
                     PreviousType = type;
+                }
                 if (!String.IsNullOrEmpty(value))
+                {
                     type = value.Trim();
+                }
 
                 while (type.EndsWith("*"))
                 {
@@ -228,19 +236,29 @@ namespace Bind.Structures
             // DelegateCollection.Add that depends on this fact.
             int result = this.CurrentType.CompareTo(other.CurrentType);
             if (result == 0)
+            {
                 result = Pointer.CompareTo(other.Pointer); // Must come after array/ref, see issue [#1098]
+            }
             if (result == 0)
+            {
                 result = Reference.CompareTo(other.Reference);
+            }
             if (result == 0)
+            {
                 result = Array.CompareTo(other.Array);
+            }
             // Note: CLS-compliance and element counts
             // are used for comparison calculations, in order
             // to maintain a stable sorting order, even though
             // they are not used in equality calculations.
             if (result == 0)
+            {
                 result = CLSCompliant.CompareTo(other.CLSCompliant);
+            }
             if (result == 0)
+            {
                 result = ElementCount.CompareTo(other.ElementCount);
+            }
             return result;
         }
 

--- a/src/Generator.Bind/Utilities.cs
+++ b/src/Generator.Bind/Utilities.cs
@@ -146,7 +146,9 @@ namespace Bind
         internal static StreamReader OpenSpecFile(string folder, string file)
         {
             if (String.IsNullOrEmpty(folder) || String.IsNullOrEmpty(file))
+            {
                 return null;
+            }
 
             Console.WriteLine(folder);
             Console.WriteLine(file);

--- a/src/Generator.Bind/XmlSpecReader.cs
+++ b/src/Generator.Bind/XmlSpecReader.cs
@@ -44,7 +44,9 @@ namespace Bind
         public XmlSpecReader(Settings settings)
         {
             if (settings == null)
+            {
                 throw new ArgumentNullException("settings");
+            }
             Settings = settings;
         }
 
@@ -71,7 +73,9 @@ namespace Bind
                 foreach (XPathNavigator nav in specs.CreateNavigator().Select(xpath_delete))
                 {
                     foreach (XPathNavigator node in nav.SelectChildren("function", String.Empty))
+                    {
                         delegates.Remove(node.GetAttribute("name", String.Empty));
+                    }
                 }
                 foreach (XPathNavigator nav in specs.CreateNavigator().Select(xpath_add))
                 {
@@ -105,7 +109,9 @@ namespace Bind
                 foreach (XPathNavigator nav in specs.CreateNavigator().Select(xpath_delete))
                 {
                     foreach (XPathNavigator node in nav.SelectChildren("enum", String.Empty))
+                    {
                         enums.Remove(node.GetAttribute("name", String.Empty));
+                    }
                 }
                 foreach (XPathNavigator nav in specs.CreateNavigator().Select(xpath_add))
                 {
@@ -122,14 +128,18 @@ namespace Bind
                 Dictionary<string, string> GLTypes = new Dictionary<string, string>();
 
                 if (sr == null)
+                {
                     return GLTypes;
+                }
 
                 do
                 {
                     string line = sr.ReadLine();
 
                     if (String.IsNullOrEmpty(line) || line.StartsWith("#"))
+                    {
                         continue;
+                    }
 
                     string[] words = line.Split(" ,*\t".ToCharArray(), StringSplitOptions.RemoveEmptyEntries);
 
@@ -190,14 +200,20 @@ namespace Bind
                 {
                     string line = sr.ReadLine();
                     if (String.IsNullOrEmpty(line) || line.StartsWith("#"))
+                    {
                         continue;
+                    }
 
                     string[] words = line.Split(" ,\t".ToCharArray(), StringSplitOptions.RemoveEmptyEntries);
                     if (words.Length < 2)
+                    {
                         continue;
+                    }
 
                     if (((Settings.Compatibility & Settings.Legacy.NoBoolParameters) != Settings.Legacy.None) && words[1] == "bool")
+                    {
                         words[1] = "Int32";
+                    }
 
                     CSTypes.Add(words[0], words[1]);
                 }
@@ -257,7 +273,9 @@ namespace Bind
                 // so we add them anyway (which is desirable).
                 if (!String.IsNullOrEmpty(version) && !String.IsNullOrEmpty(apiversion) &&
                     Decimal.Parse(version) > Decimal.Parse(apiversion))
+                {
                     continue;
+                }
 
                 // Check whether we are adding to an existing delegate or creating a new one.
                 var d = new Delegate
@@ -272,7 +290,9 @@ namespace Bind
                     Obsolete = node.GetAttribute("obsolete", String.Empty).Trim()
                 };
                 if (!extensions.Contains(d.Extension))
+                {
                     extensions.Add(d.Extension);
+                }
 
                 foreach (XPathNavigator param in node.SelectChildren(XPathNodeType.Element))
                 {
@@ -344,7 +364,9 @@ namespace Bind
                     e.Obsolete = node.GetAttribute("obsolete", String.Empty).Trim();
 
                     if (String.IsNullOrEmpty(e.Name))
+                    {
                         throw new InvalidOperationException(String.Format("Empty name for enum element {0}", node.ToString()));
+                    }
 
                     // It seems that all flag collections contain "Mask" in their names.
                     // This looks like a heuristic, but it holds 100% in practice

--- a/src/Generator.Converter/GLXmlParser.cs
+++ b/src/Generator.Converter/GLXmlParser.cs
@@ -61,9 +61,13 @@ namespace OpenTK.Convert
                 var version = (e.Attribute("version") ?? new XAttribute("version", String.Empty)).Value;
                 var key = name + version;
                 if (!elements.ContainsKey(key))
+                {
                     elements.Add(key, e);
+                }
                 else
+                {
                     elements[key].Add(e.Elements());
+                }
             }
 
             return elements.Values;
@@ -124,7 +128,9 @@ namespace OpenTK.Convert
             {
                 var api = (e.Attribute("api") ?? new XAttribute("api", "default")).Value;
                 if (!enums.ContainsKey(api))
+                {
                     enums.Add(api, new SortedDictionary<string, string>());
+                }
 
                 enums[api].Add(
                     TrimName(e.Attribute("name").Value),
@@ -151,12 +157,14 @@ namespace OpenTK.Convert
                 {
                     var key = apiname + version;
                     if (!APIs.ContainsKey(key))
+                    {
                         APIs.Add(
                             key,
                             new XElement(
                                 "api",
                                 new XAttribute("name", apiname),
                                 String.IsNullOrEmpty(version) ? null : new XAttribute("version", version)));
+                    }
                     var api = APIs[key];
 
                     var enum_name = TrimName(feature.Attribute("name").Value);
@@ -267,12 +275,14 @@ namespace OpenTK.Convert
 
                     var key = apiname + cmd_version;
                     if (!APIs.ContainsKey(key))
+                    {
                         APIs.Add(
                             key,
                             new XElement(
-                            "api",
-                            new XAttribute("name", apiname),
-                            new XAttribute("version", cmd_version)));
+                                "api",
+                                new XAttribute("name", apiname),
+                                new XAttribute("version", cmd_version)));
+                    }
                     var api = APIs[key];
 
                     foreach (var command in feature.Elements("require").Elements("command"))
@@ -282,13 +292,17 @@ namespace OpenTK.Convert
                             ExtensionRegex.Match(cmd_name).Value ??
                             (feature.Name == "extension" ? category.Substring(0, category.IndexOf("_")) : "Core");
                         if (String.IsNullOrEmpty(cmd_extension))
+                        {
                             cmd_extension = "Core";
+                        }
 
                         XElement function = TranslateCommand(commands[cmd_name]);
                         function.Add(new XAttribute("category", cmd_category));
                         function.Add(new XAttribute("extension", cmd_extension));
                         if (!String.IsNullOrEmpty(cmd_version))
+                        {
                             function.Add(new XAttribute("version", cmd_version));
+                        }
 
                         Merge(api, function);
                     }
@@ -345,8 +359,9 @@ namespace OpenTK.Convert
 
                 // Sanity check: one function cannot belong to two different extensions
                 if (f.Attribute("extension").Value != function.Attribute("extension").Value)
+                {
                     throw new InvalidOperationException("Different extensions for the same function");
-
+                }
             }
             else
             {
@@ -434,9 +449,13 @@ namespace OpenTK.Convert
             {
                 var words = ret.Split(" ".ToCharArray(), StringSplitOptions.RemoveEmptyEntries);
                 if (words[0] == "struct" || words[0] == "const")
-                    words[1] = group.Value;
+                {
+                    words[1] = @group.Value;
+                }
                 else
-                    words[0] = group.Value;
+                {
+                    words[0] = @group.Value;
+                }
 
                 ret = String.Join(" ", words);
             }
@@ -447,13 +466,21 @@ namespace OpenTK.Convert
         private static string Join(string left, string right)
         {
             if (!String.IsNullOrEmpty(left) && !String.IsNullOrEmpty(right))
+            {
                 return left + "|" + right;
+            }
             else if (!String.IsNullOrEmpty(left))
+            {
                 return left;
+            }
             else if (!String.IsNullOrEmpty(right))
+            {
                 return right;
+            }
             else
+            {
                 return String.Empty;
+            }
         }
 
         private static XAttribute Lookup(IDictionary<string, XElement> categories, string cmd_name, string attribute)

--- a/src/Generator.Converter/GLXmlParser.cs
+++ b/src/Generator.Converter/GLXmlParser.cs
@@ -450,11 +450,11 @@ namespace OpenTK.Convert
                 var words = ret.Split(" ".ToCharArray(), StringSplitOptions.RemoveEmptyEntries);
                 if (words[0] == "struct" || words[0] == "const")
                 {
-                    words[1] = @group.Value;
+                    words[1] = group.Value;
                 }
                 else
                 {
-                    words[0] = @group.Value;
+                    words[0] = group.Value;
                 }
 
                 ret = String.Join(" ", words);

--- a/src/Generator.Converter/Main.cs
+++ b/src/Generator.Converter/Main.cs
@@ -136,7 +136,9 @@ namespace OpenTK.Convert
             foreach (var e in entries)
             {
                 if (e.Value.Name.LocalName != "enum")
+                {
                     continue;
+                }
                 var tokens = e.Value.Elements()
                     .OrderBy(t => (string)t.Attribute("name"))
                     .ToList();

--- a/src/Generator.Converter/XmlParser.cs
+++ b/src/Generator.Converter/XmlParser.cs
@@ -85,11 +85,17 @@ namespace OpenTK.Convert
         public string TrimName(string name)
         {
             if (name.StartsWith(EnumPrefix))
+            {
                 return name.Remove(0, EnumPrefix.Length);
+            }
             else if (name.StartsWith(FuncPrefix))
+            {
                 return name.Remove(0, FuncPrefix.Length);
+            }
             else
+            {
                 return name;
+            }
         }
     }
 }

--- a/src/Generator.Rewrite/Program.cs
+++ b/src/Generator.Rewrite/Program.cs
@@ -182,7 +182,9 @@ namespace OpenTK.Rewrite
         {
             // Pretend there is no slots if we want to force everything to work through DllImport (Android & iOS)
             if (dllimport)
+            {
                 return -1;
+            }
 
             var slot_attribute = signature.CustomAttributes
                         .FirstOrDefault(a => a.AttributeType.Name == "SlotAttribute");

--- a/src/OpenTK.GLControl/Agl.cs
+++ b/src/OpenTK.GLControl/Agl.cs
@@ -355,9 +355,13 @@ namespace OpenTK.Platform.MacOS
             byte retval = _aglSetCurrentContext(context);
 
             if (retval != 0)
+            {
                 return true;
+            }
             else
+            {
                 return false;
+            }
         }
 
         [DllImport(agl)] internal static extern AGLContext aglGetCurrentContext();

--- a/src/OpenTK.GLControl/AglContext.cs
+++ b/src/OpenTK.GLControl/AglContext.cs
@@ -143,13 +143,21 @@ namespace OpenTK.Platform.MacOS
             int[] glrect = new int[4];
 
             if (XOffset != null)
+            {
                 glrect[0] = rect.X + XOffset();
+            }
             else
+            {
                 glrect[0] = rect.X;
+            }
             if (YOffset != null)
+            {
                 glrect[1] = rect.Y + YOffset();
+            }
             else
+            {
                 glrect[1] = rect.Y;
+            }
             glrect[2] = rect.Width;
             glrect[3] = rect.Height;
 
@@ -190,9 +198,11 @@ namespace OpenTK.Platform.MacOS
             Agl.AglError err = Agl.GetError();
 
             if (err != Agl.AglError.NoError)
+            {
                 throw new Exception(String.Format(
                     "AGL Error from function {0}: {1}  {2}",
                     function, err, Agl.ErrorString(err)));
+            }
         }
 
         private bool firstSwap = true;
@@ -215,7 +225,9 @@ namespace OpenTK.Platform.MacOS
         public void MakeCurrent(IWindowInfo window)
         {
             if (Agl.aglSetCurrentContext(Context.Handle) == false)
+            {
                 MyAGLReportError("aglSetCurrentContext");
+            }
         }
 
         public bool IsCurrent
@@ -241,7 +253,9 @@ namespace OpenTK.Platform.MacOS
             set
             {
                 if (!Agl.aglSetInteger(Context.Handle, Agl.ParameterNames.AGL_SWAP_INTERVAL, ref value))
+                {
                     MyAGLReportError("aglSetInteger");
+                }
             }
         }
 
@@ -289,7 +303,9 @@ namespace OpenTK.Platform.MacOS
         private void Dispose(bool disposing)
         {
             if (IsDisposed || Context.Handle == IntPtr.Zero)
+            {
                 return;
+            }
 
             Debug.Print("Disposing of AGL context.");
             Agl.aglSetCurrentContext(IntPtr.Zero);

--- a/src/OpenTK.GLControl/GLControl.cs
+++ b/src/OpenTK.GLControl/GLControl.cs
@@ -88,7 +88,9 @@ namespace OpenTK
         public GLControl(GraphicsMode mode, int major, int minor, GraphicsContextFlags flags)
         {
             if (mode == null)
+            {
                 throw new ArgumentNullException("mode");
+            }
 
             // SDL does not currently support embedding
             // on external windows. If Open.Toolkit is not yet
@@ -144,13 +146,19 @@ namespace OpenTK
         private void ValidateState()
         {
             if (IsDisposed)
+            {
                 throw new ObjectDisposedException(GetType().Name);
+            }
 
             if (!IsHandleCreated)
+            {
                 CreateControl();
+            }
 
             if (implementation == null || context == null || context.IsDisposed)
+            {
                 RecreateHandle();
+            }
         }
 
         /// <summary>
@@ -179,21 +187,31 @@ namespace OpenTK
         protected override void OnHandleCreated(EventArgs e)
         {
             if (context != null)
+            {
                 context.Dispose();
+            }
 
             if (implementation != null)
+            {
                 implementation.WindowInfo.Dispose();
+            }
 
             if (design_mode)
+            {
                 implementation = new DummyGLControl();
+            }
             else
+            {
                 implementation = new GLControlFactory().CreateGLControl(format, this);
+            }
 
             context = implementation.CreateContext(major, minor, flags);
             MakeCurrent();
 
             if (!design_mode)
+            {
                 ((IGraphicsContextInternal)Context).LoadAll();
+            }
 
             // Deferred setting of vsync mode. See VSync property for more information.
             if (initial_vsync_value.HasValue)
@@ -242,7 +260,9 @@ namespace OpenTK
             ValidateState();
 
             if (design_mode)
+            {
                 e.Graphics.Clear(BackColor);
+            }
 
             base.OnPaint(e);
         }
@@ -268,7 +288,9 @@ namespace OpenTK
                 BeginInvoke(delay); //Need the native window to resize first otherwise our control will be in the wrong place.
             }
             else if (context != null)
+            {
                 context.Update (Implementation.WindowInfo);
+            }
 
             base.OnResize(e);
         }
@@ -283,7 +305,9 @@ namespace OpenTK
         public void PerformContextUpdate()
         {
             if (context != null)
+            {
                 context.Update (Implementation.WindowInfo);
+            }
         }
 
         /// <summary>
@@ -293,7 +317,9 @@ namespace OpenTK
         protected override void OnParentChanged(EventArgs e)
         {
             if (context != null)
+            {
                 context.Update(Implementation.WindowInfo);
+            }
 
             base.OnParentChanged(e);
         }

--- a/src/OpenTK.GLControl/GLControlFactory.cs
+++ b/src/OpenTK.GLControl/GLControlFactory.cs
@@ -37,15 +37,34 @@ namespace OpenTK
         public IGLControl CreateGLControl(GraphicsMode mode, Control control)
         {
             if (mode == null)
+            {
                 throw new ArgumentNullException("mode");
+            }
             if (control == null)
+            {
                 throw new ArgumentNullException("control");
+            }
 
-            if (Configuration.RunningOnSdl2) return new Sdl2GLControl(mode, control);
-            else if (Configuration.RunningOnWindows) return new WinGLControl(mode, control);
-            else if (Configuration.RunningOnMacOS) return new CarbonGLControl(mode, control);
-            else if (Configuration.RunningOnX11) return new X11GLControl(mode, control);
-            else throw new PlatformNotSupportedException();
+            if (Configuration.RunningOnSdl2)
+            {
+                return new Sdl2GLControl(mode, control);
+            }
+            else if (Configuration.RunningOnWindows)
+            {
+                return new WinGLControl(mode, control);
+            }
+            else if (Configuration.RunningOnMacOS)
+            {
+                return new CarbonGLControl(mode, control);
+            }
+            else if (Configuration.RunningOnX11)
+            {
+                return new X11GLControl(mode, control);
+            }
+            else
+            {
+                throw new PlatformNotSupportedException();
+            }
         }
     }
 }

--- a/src/OpenTK.GLControl/NS.cs
+++ b/src/OpenTK.GLControl/NS.cs
@@ -85,7 +85,9 @@ namespace OpenTK.Platform.MacOS
             {
                 symbol = NSLookupAndBindSymbol(function);
                 if (symbol != IntPtr.Zero)
+                {
                     symbol = NSAddressOfSymbol(symbol);
+                }
             }
             return symbol;
         }

--- a/src/OpenTK.GLControl/X11GLControl.cs
+++ b/src/OpenTK.GLControl/X11GLControl.cs
@@ -62,9 +62,13 @@ namespace OpenTK
         internal X11GLControl(GraphicsMode mode, Control control)
         {
             if (mode == null)
+            {
                 throw new ArgumentNullException("mode");
+            }
             if (control == null)
+            {
                 throw new ArgumentNullException("control");
+            }
 
             // Note: the X11 window is created with a default XVisualInfo,
             // that is not necessarily compatible with the desired GraphicsMode.
@@ -83,8 +87,11 @@ namespace OpenTK
                 mode.Buffers,
                 mode.Stereo);
 
-            if (xplatui == null) throw new PlatformNotSupportedException(
+            if (xplatui == null)
+            {
+                throw new PlatformNotSupportedException(
                     "System.Windows.Forms.XplatUIX11 missing. Unsupported platform or Mono runtime version, aborting.");
+            }
 
             // get the required handles from the X11 API.
             display = (IntPtr)GetStaticFieldValue(xplatui, "DisplayHandle");

--- a/src/OpenTK.GLWidget/GLWidget.cs
+++ b/src/OpenTK.GLWidget/GLWidget.cs
@@ -191,7 +191,9 @@ namespace OpenTK
         private static void OnGraphicsContextInitialized()
         {
             if (GraphicsContextInitialized != null)
+            {
                 GraphicsContextInitialized(null, EventArgs.Empty);
+            }
         }
 
         /// <summary>
@@ -206,7 +208,9 @@ namespace OpenTK
         private static void OnGraphicsContextShuttingDown()
         {
             if (GraphicsContextShuttingDown != null)
+            {
                 GraphicsContextShuttingDown(null, EventArgs.Empty);
+            }
         }
 
         /// <summary>
@@ -221,7 +225,9 @@ namespace OpenTK
         protected virtual void OnInitialized()
         {
             if (Initialized != null)
+            {
                 Initialized(this, EventArgs.Empty);
+            }
         }
 
         /// <summary>
@@ -235,7 +241,9 @@ namespace OpenTK
         protected virtual void OnRenderFrame()
         {
             if (RenderFrame != null)
+            {
                 RenderFrame(this, EventArgs.Empty);
+            }
         }
 
         /// <summary>
@@ -249,7 +257,9 @@ namespace OpenTK
         protected virtual void OnShuttingDown()
         {
             if (ShuttingDown != null)
+            {
                 ShuttingDown(this, EventArgs.Empty);
+            }
         }
 
 #if GTK3
@@ -269,9 +279,13 @@ namespace OpenTK
 #endif
         {
             if (!_Initialized)
+            {
                 Initialize();
+            }
             else
+            {
                 _GraphicsContext.MakeCurrent(_WindowInfo);
+            }
 
 #if GTK3
             var result = base.OnDrawn(cr);
@@ -300,7 +314,9 @@ namespace OpenTK
             bool result = base.OnConfigureEvent(evnt);
 
             if (_GraphicsContext != null)
+            {
                 _GraphicsContext.Update(_WindowInfo);
+            }
 
             return result;
         }
@@ -318,7 +334,9 @@ namespace OpenTK
                 ColorBPP = 32;
 
                 if (DepthBPP == 0)
+                {
                     DepthBPP = 16;
+                }
             }
 
             ColorFormat colorBufferColorFormat = new ColorFormat(ColorBPP);
@@ -327,16 +345,24 @@ namespace OpenTK
 
             int buffers = 2;
             if (SingleBuffer)
+            {
                 buffers--;
+            }
 
             GraphicsMode graphicsMode = new GraphicsMode(colorBufferColorFormat, DepthBPP, StencilBPP, Samples, accumulationColorFormat, buffers, Stereo);
 
             if (Configuration.RunningOnWindows)
+            {
                 Console.WriteLine("OpenTK running on windows");
+            }
             else if (Configuration.RunningOnMacOS)
+            {
                 Console.WriteLine("OpenTK running on OSX");
+            }
             else
+            {
                 Console.WriteLine("OpenTK running on X11");
+            }
 
 #if GTK3
             IntPtr widgetWindowHandle = this.Window.Handle;
@@ -346,11 +372,17 @@ namespace OpenTK
 
             // IWindowInfo
             if (Configuration.RunningOnWindows)
+            {
                 _WindowInfo = WinWindowsInfoInitializer.Initialize(widgetWindowHandle);
+            }
             else if (Configuration.RunningOnMacOS)
+            {
                 _WindowInfo = OSXWindowInfoInitializer.Initialize(widgetWindowHandle);
+            }
             else
+            {
                 _WindowInfo = XWindowInfoInitializer.Initialize(graphicsMode, this.Display.Handle, this.Screen.Number, widgetWindowHandle, this.Screen.RootWindow.Handle);
+            }
 
             // GraphicsContext
             _GraphicsContext = new GraphicsContext(graphicsMode, _WindowInfo, GlVersionMajor, GlVersionMinor, GraphicsContextFlags);

--- a/src/OpenTK/Audio/AudioCapture.cs
+++ b/src/OpenTK/Audio/AudioCapture.cs
@@ -69,11 +69,17 @@ namespace OpenTK.Audio
         public AudioCapture(string deviceName, int frequency, ALFormat sampleFormat, int bufferSize)
         {
             if (!AudioDeviceEnumerator.IsOpenALSupported)
+            {
                 throw new DllNotFoundException("openal32.dll");
+            }
             if (frequency <= 0)
+            {
                 throw new ArgumentOutOfRangeException("frequency");
+            }
             if (bufferSize <= 0)
+            {
                 throw new ArgumentOutOfRangeException("bufferSize");
+            }
 
             // Try to open specified device. If it fails, try to open default device.
             CurrentDevice = deviceName;
@@ -205,7 +211,9 @@ namespace OpenTK.Audio
             where TBuffer : struct
         {
             if (buffer == null)
+            {
                 throw new ArgumentNullException("buffer");
+            }
 
             int buffer_size = BlittableValueType<TBuffer>.Stride * buffer.Length;
             // This is more of a heuristic than a 100% valid check. However, it will work
@@ -214,7 +222,9 @@ namespace OpenTK.Audio
             // be produced with compressed sample formats (which are very rare).
             // Still, this is better than no check at all.
             if (sampleCount * GetSampleSize(SampleFormat) > buffer_size)
+            {
                 throw new ArgumentOutOfRangeException("sampleCount");
+            }
 
             GCHandle buffer_ptr = GCHandle.Alloc(buffer, GCHandleType.Pinned);
             try { ReadSamples(buffer_ptr.AddrOfPinnedObject(), sampleCount); }
@@ -320,7 +330,9 @@ namespace OpenTK.Audio
                 if (this.Handle != IntPtr.Zero)
                 {
                     if (this.IsRunning)
+                    {
                         this.Stop();
+                    }
 
                     Alc.CaptureCloseDevice(this.Handle);
                 }

--- a/src/OpenTK/Audio/AudioContext.cs
+++ b/src/OpenTK/Audio/AudioContext.cs
@@ -205,13 +205,26 @@ namespace OpenTK.Audio
         private void CreateContext(string device, int freq, int refresh, bool sync, bool enableEfx, MaxAuxiliarySends efxAuxiliarySends)
         {
             if (!AudioDeviceEnumerator.IsOpenALSupported)
+            {
                 throw new DllNotFoundException("openal32.dll");
+            }
 
             if (AudioDeviceEnumerator.Version == AudioDeviceEnumerator.AlcVersion.Alc1_1 && AudioDeviceEnumerator.AvailablePlaybackDevices.Count == 0)    // Alc 1.0 does not support device enumeration.
+            {
                 throw new NotSupportedException("No audio hardware is available.");
-            if (context_exists) throw new NotSupportedException("Multiple AudioContexts are not supported.");
-            if (freq < 0) throw new ArgumentOutOfRangeException("freq", freq, "Should be greater than zero.");
-            if (refresh < 0) throw new ArgumentOutOfRangeException("refresh", refresh, "Should be greater than zero.");
+            }
+            if (context_exists)
+            {
+                throw new NotSupportedException("Multiple AudioContexts are not supported.");
+            }
+            if (freq < 0)
+            {
+                throw new ArgumentOutOfRangeException("freq", freq, "Should be greater than zero.");
+            }
+            if (refresh < 0)
+            {
+                throw new ArgumentOutOfRangeException("refresh", refresh, "Should be greater than zero.");
+            }
 
 
             if (!String.IsNullOrEmpty(device))
@@ -292,7 +305,9 @@ namespace OpenTK.Audio
             // an old OpenAL version is detect - it may affect outdated OpenAL versions different than OpenAL SI,
             // but it looks like a good compromise for now.
             if (AudioDeviceEnumerator.AvailablePlaybackDevices.Count > 0)
+            {
                 MakeCurrent();
+            }
 
             CheckErrors();
 
@@ -320,9 +335,11 @@ namespace OpenTK.Audio
             lock (audio_context_lock)
             {
                 if (!Alc.MakeContextCurrent(context != null ? context.context_handle : ContextHandle.Zero))
+                {
                     throw new AudioContextException(String.Format("ALC {0} error detected at {1}.",
                         Alc.GetError(context != null ? (IntPtr)context.context_handle : IntPtr.Zero).ToString(),
                         context != null ? context.ToString() : "null"));
+                }
             }
         }
 
@@ -341,7 +358,9 @@ namespace OpenTK.Audio
                 lock (audio_context_lock)
                 {
                     if (available_contexts.Count == 0)
+                    {
                         return false;
+                    }
                     else
                     {
                         return AudioContext.CurrentContext == this;
@@ -350,8 +369,14 @@ namespace OpenTK.Audio
             }
             set
             {
-                if (value) AudioContext.MakeCurrent(this);
-                else AudioContext.MakeCurrent(null);
+                if (value)
+                {
+                    AudioContext.MakeCurrent(this);
+                }
+                else
+                {
+                    AudioContext.MakeCurrent(null);
+                }
             }
         }
 
@@ -367,7 +392,9 @@ namespace OpenTK.Audio
         public void CheckErrors()
         {
             if (disposed)
+            {
                 throw new ObjectDisposedException(this.GetType().FullName);
+            }
 
             new AudioDeviceErrorChecker(Device).Dispose();
         }
@@ -380,7 +407,9 @@ namespace OpenTK.Audio
             get
             {
                 if (disposed)
+                {
                     throw new ObjectDisposedException(this.GetType().FullName);
+                }
 
                 return Alc.GetError(Device);
             }
@@ -400,7 +429,9 @@ namespace OpenTK.Audio
         public void MakeCurrent()
         {
             if (disposed)
+            {
                 throw new ObjectDisposedException(this.GetType().FullName);
+            }
 
             AudioContext.MakeCurrent(this);
         }
@@ -416,7 +447,9 @@ namespace OpenTK.Audio
             get
             {
                 if (disposed)
+                {
                     throw new ObjectDisposedException(this.GetType().FullName);
+                }
 
                 return is_processing;
             }
@@ -433,7 +466,9 @@ namespace OpenTK.Audio
             get
             {
                 if (disposed)
+                {
                     throw new ObjectDisposedException(this.GetType().FullName);
+                }
 
                 return is_synchronized;
             }
@@ -461,7 +496,9 @@ namespace OpenTK.Audio
         public void Process()
         {
             if (disposed)
+            {
                 throw new ObjectDisposedException(this.GetType().FullName);
+            }
 
             Alc.ProcessContext(this.context_handle);
             IsProcessing = true;
@@ -490,7 +527,9 @@ namespace OpenTK.Audio
         public void Suspend()
         {
             if (disposed)
+            {
                 throw new ObjectDisposedException(this.GetType().FullName);
+            }
 
             Alc.SuspendContext(this.context_handle);
             IsProcessing = false;
@@ -504,7 +543,9 @@ namespace OpenTK.Audio
         public bool SupportsExtension(string extension)
         {
             if (disposed)
+            {
                 throw new ObjectDisposedException(this.GetType().FullName);
+            }
 
             return Alc.IsExtensionPresent(this.Device, extension);
         }
@@ -517,7 +558,9 @@ namespace OpenTK.Audio
             get
             {
                 if (disposed)
+                {
                     throw new ObjectDisposedException(this.GetType().FullName);
+                }
 
                 return device_name;
             }
@@ -537,7 +580,9 @@ namespace OpenTK.Audio
                 lock (audio_context_lock)
                 {
                     if (available_contexts.Count == 0)
+                    {
                         return null;
+                    }
                     else
                     {
                         AudioContext context;
@@ -585,7 +630,9 @@ namespace OpenTK.Audio
             if (!disposed)
             {
                 if (this.IsCurrent)
+                {
                     this.IsCurrent = false;
+                }
 
                 if (context_handle != ContextHandle.Zero)
                 {
@@ -594,7 +641,9 @@ namespace OpenTK.Audio
                 }
 
                 if (Device != IntPtr.Zero)
+                {
                     Alc.CloseDevice(Device);
+                }
 
                 if (manual)
                 {

--- a/src/OpenTK/Audio/AudioDeviceEnumerator.cs
+++ b/src/OpenTK/Audio/AudioDeviceEnumerator.cs
@@ -112,7 +112,9 @@ namespace OpenTK.Audio
                 }
                 AlcError playback_err = Alc.GetError(dummy_device);
                 if (playback_err != AlcError.NoError)
+                {
                     throw new AudioContextException("Alc Error occured when querying available playback devices. " + playback_err.ToString());
+                }
 
                 // Get a list of all known recording devices, at least ALC_ENUMERATION_EXT is needed too
                 if (Version == AlcVersion.Alc1_1 && Alc.IsExtensionPresent(IntPtr.Zero, "ALC_EXT_CAPTURE"))
@@ -126,18 +128,24 @@ namespace OpenTK.Audio
                 }
                 AlcError record_err = Alc.GetError(dummy_device);
                 if (record_err != AlcError.NoError)
+                {
                     throw new AudioContextException("Alc Error occured when querying available recording devices. " + record_err.ToString());
+                }
 
 #if DEBUG
                 Debug.WriteLine("Found playback devices:");
                 foreach (string s in available_playback_devices)
+                {
                     Debug.WriteLine(s);
+                }
 
                 Debug.WriteLine("Default playback device: " + DefaultPlaybackDevice);
 
                 Debug.WriteLine("Found recording devices:");
                 foreach (string s in available_recording_devices)
+                {
                     Debug.WriteLine(s);
+                }
 
                 Debug.WriteLine("Default recording device: " + DefaultRecordingDevice);
 #endif
@@ -163,9 +171,13 @@ namespace OpenTK.Audio
                         // clean up the dummy context
                         Alc.MakeContextCurrent(ContextHandle.Zero);
                         if (dummy_context != ContextHandle.Zero && dummy_context.Handle != IntPtr.Zero)
+                        {
                             Alc.DestroyContext(dummy_context);
+                        }
                         if (dummy_device != IntPtr.Zero)
+                        {
                             Alc.CloseDevice(dummy_device);
+                        }
                     }
                     catch
                     {

--- a/src/OpenTK/Audio/AudioDeviceErrorChecker.cs
+++ b/src/OpenTK/Audio/AudioDeviceErrorChecker.cs
@@ -39,7 +39,9 @@ namespace OpenTK.Audio
         public AudioDeviceErrorChecker(IntPtr device)
         {
             if (device == IntPtr.Zero)
+            {
                 throw new AudioDeviceException();
+            }
 
             Device = device;
         }

--- a/src/OpenTK/Audio/OpenAL/AL/AL.cs
+++ b/src/OpenTK/Audio/OpenAL/AL/AL.cs
@@ -461,8 +461,14 @@ namespace OpenTK.Audio.OpenAL
         [CLSCompliant(false)]
         public static void DeleteSources(uint[] sources)
         {
-            if (sources == null) throw new ArgumentNullException();
-            if (sources.Length == 0) throw new ArgumentOutOfRangeException();
+            if (sources == null)
+            {
+                throw new ArgumentNullException();
+            }
+            if (sources.Length == 0)
+            {
+                throw new ArgumentOutOfRangeException();
+            }
             DeleteBuffers(sources.Length, ref sources[0]);
         }
 
@@ -470,8 +476,14 @@ namespace OpenTK.Audio.OpenAL
         /// <param name="sources">An array of source names identifying the sources to be deleted.</param>
         public static void DeleteSources(int[] sources)
         {
-            if (sources == null) throw new ArgumentNullException();
-            if (sources.Length == 0) throw new ArgumentOutOfRangeException();
+            if (sources == null)
+            {
+                throw new ArgumentNullException();
+            }
+            if (sources.Length == 0)
+            {
+                throw new ArgumentOutOfRangeException();
+            }
             DeleteBuffers(sources.Length, ref sources[0]);
         }
 
@@ -1107,7 +1119,10 @@ namespace OpenTK.Audio.OpenAL
         /// <param name="numEntries">The number of buffers to be unqueued.</param>
         public static int[] SourceUnqueueBuffers(int sid, int numEntries)
         {
-            if (numEntries <= 0) throw new ArgumentOutOfRangeException("numEntries", "Must be greater than zero.");
+            if (numEntries <= 0)
+            {
+                throw new ArgumentOutOfRangeException("numEntries", "Must be greater than zero.");
+            }
             int[] buf = new int[numEntries];
             SourceUnqueueBuffers(sid, numEntries, buf);
             return buf;
@@ -1247,8 +1262,14 @@ namespace OpenTK.Audio.OpenAL
         [CLSCompliant(false)]
         public static void DeleteBuffers(uint[] buffers)
         {
-            if (buffers == null) throw new ArgumentNullException();
-            if (buffers.Length == 0) throw new ArgumentOutOfRangeException();
+            if (buffers == null)
+            {
+                throw new ArgumentNullException();
+            }
+            if (buffers.Length == 0)
+            {
+                throw new ArgumentOutOfRangeException();
+            }
             DeleteBuffers(buffers.Length, ref buffers[0]);
         }
 
@@ -1256,8 +1277,14 @@ namespace OpenTK.Audio.OpenAL
         /// <param name="buffers">Pointer to an array of buffer names identifying the buffers to be deleted.</param>
         public static void DeleteBuffers(int[] buffers)
         {
-            if (buffers == null) throw new ArgumentNullException();
-            if (buffers.Length == 0) throw new ArgumentOutOfRangeException();
+            if (buffers == null)
+            {
+                throw new ArgumentNullException();
+            }
+            if (buffers.Length == 0)
+            {
+                throw new ArgumentOutOfRangeException();
+            }
             DeleteBuffers(buffers.Length, ref buffers[0]);
         }
 
@@ -1323,7 +1350,9 @@ namespace OpenTK.Audio.OpenAL
             where TBuffer : struct
         {
             if (!BlittableValueType.Check(buffer))
+            {
                 throw new ArgumentException("buffer");
+            }
 
             GCHandle handle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
             try { BufferData(bid, format, handle.AddrOfPinnedObject(), size, freq); }

--- a/src/OpenTK/Audio/OpenAL/AL/EffectsExtension.cs
+++ b/src/OpenTK/Audio/OpenAL/AL/EffectsExtension.cs
@@ -141,7 +141,10 @@ namespace OpenTK.Audio.OpenAL
         /// </remarks>
         public int[] GenEffects(int n)
         {
-            if (n <= 0) throw new ArgumentOutOfRangeException("n", "Must be higher than 0.");
+            if (n <= 0)
+            {
+                throw new ArgumentOutOfRangeException("n", "Must be higher than 0.");
+            }
             int[] effects = new int[n];
             GenEffects(n, out effects[0]);
             return effects;
@@ -216,7 +219,10 @@ namespace OpenTK.Audio.OpenAL
         /// <param name="effects">Pointer to n Effect object identifiers.</param>
         public void DeleteEffects(int[] effects)
         {
-            if (effects == null) throw new ArgumentNullException("effects");
+            if (effects == null)
+            {
+                throw new ArgumentNullException("effects");
+            }
             DeleteEffects(effects.Length, ref effects[0]);
         }
 
@@ -225,7 +231,10 @@ namespace OpenTK.Audio.OpenAL
         [CLSCompliant(false)]
         public void DeleteEffects(uint[] effects)
         {
-            if (effects == null) throw new ArgumentNullException("effects");
+            if (effects == null)
+            {
+                throw new ArgumentNullException("effects");
+            }
             DeleteEffects(effects.Length, ref effects[0]);
         }
 
@@ -516,7 +525,10 @@ namespace OpenTK.Audio.OpenAL
         public int[] GenFilters(int n)
         {
 
-            if (n <= 0) throw new ArgumentOutOfRangeException("n", "Must be higher than 0.");
+            if (n <= 0)
+            {
+                throw new ArgumentOutOfRangeException("n", "Must be higher than 0.");
+            }
             int[] filters = new int[n];
             GenFilters(filters.Length, out filters[0]);
             return filters;
@@ -587,7 +599,10 @@ namespace OpenTK.Audio.OpenAL
         [CLSCompliant(false)]
         public void DeleteFilters(uint[] filters)
         {
-            if (filters == null) throw new ArgumentNullException("filters");
+            if (filters == null)
+            {
+                throw new ArgumentNullException("filters");
+            }
             DeleteFilters(filters.Length, ref filters[0]);
         }
 
@@ -595,7 +610,10 @@ namespace OpenTK.Audio.OpenAL
         /// <param name="filters">Pointer to an filter name/handle identifying the Filter Object to be deleted.</param>
         public void DeleteFilters(int[] filters)
         {
-            if (filters == null) throw new ArgumentNullException("filters");
+            if (filters == null)
+            {
+                throw new ArgumentNullException("filters");
+            }
             DeleteFilters(filters.Length, ref filters[0]);
         }
 
@@ -817,7 +835,10 @@ namespace OpenTK.Audio.OpenAL
         /// <returns>Pointer addressing sufficient memory to store n Effect Slot object identifiers.</returns>
         public int[] GenAuxiliaryEffectSlots(int n)
         {
-            if (n <= 0) throw new ArgumentOutOfRangeException("n", "Must be higher than 0.");
+            if (n <= 0)
+            {
+                throw new ArgumentOutOfRangeException("n", "Must be higher than 0.");
+            }
             int[] slots = new int[n];
             GenAuxiliaryEffectSlots(slots.Length, out slots[0]);
             return slots;
@@ -885,7 +906,10 @@ namespace OpenTK.Audio.OpenAL
         /// <param name="slots">Pointer to n Effect Slot object identifiers.</param>
         public void DeleteAuxiliaryEffectSlots(int[] slots)
         {
-            if (slots == null) throw new ArgumentNullException("slots");
+            if (slots == null)
+            {
+                throw new ArgumentNullException("slots");
+            }
             DeleteAuxiliaryEffectSlots(slots.Length, ref slots[0]);
         }
 
@@ -894,7 +918,10 @@ namespace OpenTK.Audio.OpenAL
         [CLSCompliant(false)]
         public void DeleteAuxiliaryEffectSlots(uint[] slots)
         {
-            if (slots == null) throw new ArgumentNullException("slots");
+            if (slots == null)
+            {
+                throw new ArgumentNullException("slots");
+            }
             DeleteAuxiliaryEffectSlots(slots.Length, ref slots[0]);
         }
 
@@ -1081,7 +1108,9 @@ namespace OpenTK.Audio.OpenAL
             IsInitialized = false;
 
             if (AudioContext.CurrentContext == null)
+            {
                 throw new InvalidOperationException("AL.LoadAll() needs a current AudioContext.");
+            }
 
             if (!AudioContext.CurrentContext.SupportsExtension("ALC_EXT_EFX"))
             {

--- a/src/OpenTK/Audio/OpenAL/AL/XRamExtension.cs
+++ b/src/OpenTK/Audio/OpenAL/AL/XRamExtension.cs
@@ -45,7 +45,9 @@ namespace OpenTK.Audio.OpenAL
         { // Query if Extension supported and retrieve Tokens/Pointers if it is.
             IsInitialized = false;
             if (AL.IsExtensionPresent("EAX-RAM") == false)
+            {
                 return;
+            }
 
             AL_EAX_RAM_SIZE = AL.GetEnumValue("AL_EAX_RAM_SIZE");
             AL_EAX_RAM_FREE = AL.GetEnumValue("AL_EAX_RAM_FREE");
@@ -150,9 +152,13 @@ namespace OpenTK.Audio.OpenAL
             int tempresult = Imported_GetBufferMode(buffer, IntPtr.Zero); // IntPtr.Zero due to the parameter being unused/reserved atm
 
             if (tempresult == AL_STORAGE_ACCESSIBLE)
+            {
                 return XRamStorage.Accessible;
+            }
             if (tempresult == AL_STORAGE_HARDWARE)
+            {
                 return XRamStorage.Hardware;
+            }
             // default:
             return XRamStorage.Automatic;
         }

--- a/src/OpenTK/BindingsBase.cs
+++ b/src/OpenTK/BindingsBase.cs
@@ -83,9 +83,13 @@ namespace OpenTK
         protected static void MarshalPtrToStringBuilder(IntPtr ptr, StringBuilder sb)
         {
             if (ptr == IntPtr.Zero)
+            {
                 throw new ArgumentException("ptr");
+            }
             if (sb == null)
+            {
                 throw new ArgumentNullException("sb");
+            }
 
             sb.Length = 0;
             for (int i = 0; ; i++)

--- a/src/OpenTK/BlittableValueType.cs
+++ b/src/OpenTK/BlittableValueType.cs
@@ -80,7 +80,9 @@ namespace OpenTK
         public static bool Check(Type type)
         {
             if (!CheckStructLayoutAttribute(type))
+            {
                 Debug.Print("Warning: type {0} does not specify a StructLayoutAttribute with Pack=1. The memory layout of the struct may change between platforms.", type.Name);
+            }
 
             return CheckType(type);
         }
@@ -91,17 +93,23 @@ namespace OpenTK
         {
             //Debug.Print("Checking type {0} (size: {1} bytes).", type.Name, Marshal.SizeOf(type));
             if (type.IsPrimitive)
+            {
                 return true;
+            }
 
             if (!type.IsValueType)
+            {
                 return false;
+            }
 
             FieldInfo[] fields = type.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
             Debug.Indent();
             foreach (FieldInfo field in fields)
             {
                 if (!CheckType(field.FieldType))
+                {
                     return false;
+                }
             }
             Debug.Unindent();
 
@@ -117,7 +125,9 @@ namespace OpenTK
 
             if ((attr == null) ||
                 (attr != null && attr.Length > 0 && attr[0].Value != LayoutKind.Explicit && attr[0].Pack != 1))
+            {
                 return false;
+            }
 
             return true;
         }
@@ -196,7 +206,9 @@ namespace OpenTK
         public static int StrideOf<T>(T type)
         {
             if (!Check(type))
+            {
                 throw new ArgumentException("type");
+            }
 
             return BlittableValueType<T>.Stride;
         }
@@ -212,7 +224,9 @@ namespace OpenTK
         public static int StrideOf<T>(T[] type)
         {
             if (!Check(type))
+            {
                 throw new ArgumentException("type");
+            }
 
             return BlittableValueType<T>.Stride;
         }
@@ -228,7 +242,9 @@ namespace OpenTK
         public static int StrideOf<T>(T[,] type)
         {
             if (!Check(type))
+            {
                 throw new ArgumentException("type");
+            }
 
             return BlittableValueType<T>.Stride;
         }
@@ -244,7 +260,9 @@ namespace OpenTK
         public static int StrideOf<T>(T[, ,] type)
         {
             if (!Check(type))
+            {
                 throw new ArgumentException("type");
+            }
 
             return BlittableValueType<T>.Stride;
         }

--- a/src/OpenTK/ContextHandle.cs
+++ b/src/OpenTK/ContextHandle.cs
@@ -48,7 +48,9 @@ namespace OpenTK
         public override bool Equals(object obj)
         {
             if (obj is ContextHandle)
+            {
                 return this.Equals((ContextHandle)obj);
+            }
             return false;
         }
 

--- a/src/OpenTK/DisplayDevice.cs
+++ b/src/OpenTK/DisplayDevice.cs
@@ -122,13 +122,17 @@ namespace OpenTK
             internal set
             {
                 if (value && primary_display != null && primary_display != this)
+                {
                     primary_display.IsPrimary = false;
+                }
 
                 lock (display_lock)
                 {
                     primary = value;
                     if (value)
+                    {
                         primary_display = this;
+                    }
                 }
             }
         }
@@ -153,11 +157,17 @@ namespace OpenTK
         {
             DisplayResolution resolution = FindResolution(width, height, bitsPerPixel, refreshRate);
             if (resolution == null)
+            {
                 resolution = FindResolution(width, height, bitsPerPixel, 0);
+            }
             if (resolution == null)
+            {
                 resolution = FindResolution(width, height, 0, 0);
+            }
             if (resolution == null)
+            {
                 return current_resolution;
+            }
             return resolution;
         }
 
@@ -181,21 +191,30 @@ namespace OpenTK
         public void ChangeResolution(DisplayResolution resolution)
         {
             if (resolution == null)
+            {
                 this.RestoreResolution();
+            }
 
             if (resolution == current_resolution)
+            {
                 return;
+            }
 
             //effect.FadeOut();
 
             if (implementation.TryChangeResolution(this, resolution))
             {
                 if (OriginalResolution == null)
+                {
                     OriginalResolution = current_resolution;
+                }
                 current_resolution = resolution;
             }
-            else throw new Graphics.GraphicsModeException(String.Format("Device {0}: Failed to change resolution to {1}.",
+            else
+            {
+                throw new Graphics.GraphicsModeException(String.Format("Device {0}: Failed to change resolution to {1}.",
                     this, resolution));
+            }
 
             //effect.FadeIn();
         }
@@ -224,7 +243,10 @@ namespace OpenTK
                     current_resolution = OriginalResolution;
                     OriginalResolution = null;
                 }
-                else throw new Graphics.GraphicsModeException(String.Format("Device {0}: Failed to restore resolution.", this));
+                else
+                {
+                    throw new Graphics.GraphicsModeException(String.Format("Device {0}: Failed to restore resolution.", this));
+                }
 
                 //effect.FadeIn();
             }

--- a/src/OpenTK/DisplayResolution.cs
+++ b/src/OpenTK/DisplayResolution.cs
@@ -25,10 +25,22 @@ namespace OpenTK
         internal DisplayResolution(int x, int y, int width, int height, int bitsPerPixel, float refreshRate)
         {
             // Refresh rate may be zero, since this information may not be available on some platforms.
-            if (width <= 0) throw new ArgumentOutOfRangeException("width", "Must be greater than zero.");
-            if (height <= 0) throw new ArgumentOutOfRangeException("height", "Must be greater than zero.");
-            if (bitsPerPixel <= 0) throw new ArgumentOutOfRangeException("bitsPerPixel", "Must be greater than zero.");
-            if (refreshRate < 0) throw new ArgumentOutOfRangeException("refreshRate", "Must be greater than, or equal to zero.");
+            if (width <= 0)
+            {
+                throw new ArgumentOutOfRangeException("width", "Must be greater than zero.");
+            }
+            if (height <= 0)
+            {
+                throw new ArgumentOutOfRangeException("height", "Must be greater than zero.");
+            }
+            if (bitsPerPixel <= 0)
+            {
+                throw new ArgumentOutOfRangeException("bitsPerPixel", "Must be greater than zero.");
+            }
+            if (refreshRate < 0)
+            {
+                throw new ArgumentOutOfRangeException("refreshRate", "Must be greater than, or equal to zero.");
+            }
 
             this.bounds = new Rectangle(x, y, width, height);
             this.BitsPerPixel = bitsPerPixel;
@@ -112,7 +124,10 @@ namespace OpenTK
         /// <returns>True if the System.Object is an equal DisplayResolution; false otherwise.</returns>
         public override bool Equals(object obj)
         {
-            if (obj == null) return false;
+            if (obj == null)
+            {
+                return false;
+            }
             if (this.GetType() == obj.GetType())
             {
                 DisplayResolution res = (DisplayResolution)obj;
@@ -144,10 +159,14 @@ namespace OpenTK
         public static bool operator== (DisplayResolution left, DisplayResolution right)
         {
             if (((object)left) == null && ((object)right) == null)
+            {
                 return true;
+            }
             else if ((((object)left) == null && ((object)right) != null) ||
                      (((object)left) != null && ((object)right) == null))
+            {
                 return false;
+            }
             return left.Equals(right);
         }
 

--- a/src/OpenTK/FrameEventArgs.cs
+++ b/src/OpenTK/FrameEventArgs.cs
@@ -60,7 +60,9 @@ namespace OpenTK
             internal set
             {
                 if (value <= 0)
+                {
                     throw new ArgumentOutOfRangeException();
+                }
                 elapsed = value;
             }
         }

--- a/src/OpenTK/GameWindow.cs
+++ b/src/OpenTK/GameWindow.cs
@@ -310,11 +310,15 @@ namespace OpenTK
             try
             {
                 if (updates_per_second < 0.0 || updates_per_second > 200.0)
+                {
                     throw new ArgumentOutOfRangeException("updates_per_second", updates_per_second,
-                                                          "Parameter should be inside the range [0.0, 200.0]");
+                        "Parameter should be inside the range [0.0, 200.0]");
+                }
                 if (frames_per_second < 0.0 || frames_per_second > 200.0)
+                {
                     throw new ArgumentOutOfRangeException("frames_per_second", frames_per_second,
-                                                          "Parameter should be inside the range [0.0, 200.0]");
+                        "Parameter should be inside the range [0.0, 200.0]");
+                }
 
                 if (updates_per_second != 0)
                 {
@@ -342,9 +346,13 @@ namespace OpenTK
                 {
                     ProcessEvents();
                     if (Exists && !IsExiting)
+                    {
                         DispatchUpdateAndRenderFrame(this, EventArgs.Empty);
+                    }
                     else
+                    {
                         return;
+                    }
                 }
             }
             finally
@@ -494,7 +502,9 @@ namespace OpenTK
             {
                 EnsureUndisposed();
                 if (render_period == 0.0)
+                {
                     return 1.0;
+                }
                 return 1.0 / render_period;
             }
         }
@@ -541,7 +551,9 @@ namespace OpenTK
             {
                 EnsureUndisposed();
                 if (TargetRenderPeriod == 0.0)
+                {
                     return 0.0;
+                }
                 return 1.0 / TargetRenderPeriod;
             }
             set
@@ -555,7 +567,10 @@ namespace OpenTK
                 {
                     TargetRenderPeriod = 1.0 / value;
                 }
-                else Debug.Print("Target render frequency clamped to {0}Hz.", MaxFrequency);
+                else
+                {
+                    Debug.Print("Target render frequency clamped to {0}Hz.", MaxFrequency);
+                }
             }
         }
 
@@ -584,7 +599,10 @@ namespace OpenTK
                 {
                     target_render_period = value;
                 }
-                else Debug.Print("Target render period clamped to 1.0 seconds.");
+                else
+                {
+                    Debug.Print("Target render period clamped to 1.0 seconds.");
+                }
             }
         }
 
@@ -601,7 +619,9 @@ namespace OpenTK
             {
                 EnsureUndisposed();
                 if (TargetUpdatePeriod == 0.0)
+                {
                     return 0.0;
+                }
                 return 1.0 / TargetUpdatePeriod;
             }
             set
@@ -615,7 +635,10 @@ namespace OpenTK
                 {
                     TargetUpdatePeriod = 1.0 / value;
                 }
-                else Debug.Print("Target render frequency clamped to {0}Hz.", MaxFrequency);
+                else
+                {
+                    Debug.Print("Target render frequency clamped to {0}Hz.", MaxFrequency);
+                }
             }
         }
 
@@ -644,7 +667,10 @@ namespace OpenTK
                 {
                     target_update_period = value;
                 }
-                else Debug.Print("Target update period clamped to 1.0 seconds.");
+                else
+                {
+                    Debug.Print("Target update period clamped to 1.0 seconds.");
+                }
             }
         }
 
@@ -657,7 +683,9 @@ namespace OpenTK
             {
                 EnsureUndisposed();
                 if (update_period == 0.0)
+                {
                     return 1.0;
+                }
                 return 1.0 / update_period;
             }
         }
@@ -744,7 +772,9 @@ namespace OpenTK
                 Debug.Print("Updating Context after setting WindowState to {0}", value);
 
                 if (Context != null)
+                {
                     Context.Update(WindowInfo);
+                }
             }
         }
         /// <summary>
@@ -823,11 +853,19 @@ namespace OpenTK
             OnLoad(e);
         }
 
-        private void OnRenderFrameInternal(FrameEventArgs e) { if (Exists && !isExiting) OnRenderFrame(e); }
+        private void OnRenderFrameInternal(FrameEventArgs e) { if (Exists && !isExiting)
+            {
+                OnRenderFrame(e);
+            }
+        }
 
         private void OnUnloadInternal(EventArgs e) { OnUnload(e); }
 
-        private void OnUpdateFrameInternal(FrameEventArgs e) { if (Exists && !isExiting) OnUpdateFrame(e); }
+        private void OnUpdateFrameInternal(FrameEventArgs e) { if (Exists && !isExiting)
+            {
+                OnUpdateFrame(e);
+            }
+        }
 
         private void OnWindowInfoChangedInternal(EventArgs e)
         {

--- a/src/OpenTK/GameWindow.cs
+++ b/src/OpenTK/GameWindow.cs
@@ -853,15 +853,22 @@ namespace OpenTK
             OnLoad(e);
         }
 
-        private void OnRenderFrameInternal(FrameEventArgs e) { if (Exists && !isExiting)
+        private void OnRenderFrameInternal(FrameEventArgs e) 
+        { 
+            if (Exists && !isExiting)
             {
                 OnRenderFrame(e);
             }
         }
 
-        private void OnUnloadInternal(EventArgs e) { OnUnload(e); }
+        private void OnUnloadInternal(EventArgs e)
+        {
+            OnUnload(e);
+        }
 
-        private void OnUpdateFrameInternal(FrameEventArgs e) { if (Exists && !isExiting)
+        private void OnUpdateFrameInternal(FrameEventArgs e) 
+        { 
+            if (Exists && !isExiting)
             {
                 OnUpdateFrame(e);
             }

--- a/src/OpenTK/Graphics/Color4.cs
+++ b/src/OpenTK/Graphics/Color4.cs
@@ -159,7 +159,9 @@ namespace OpenTK.Graphics
         public override bool Equals(object obj)
         {
             if (!(obj is Color4))
+            {
                 return false;
+            }
 
             return Equals((Color4)obj);
         }

--- a/src/OpenTK/Graphics/ColorFormat.cs
+++ b/src/OpenTK/Graphics/ColorFormat.cs
@@ -45,7 +45,9 @@ namespace OpenTK.Graphics
         public ColorFormat(int bpp)
         {
             if (bpp < 0)
+            {
                 throw new ArgumentOutOfRangeException("bpp", "Must be greater or equal to zero.");
+            }
             red = green = blue = alpha = 0;
             BitsPerPixel = bpp;
             IsIndexed = false;
@@ -96,7 +98,9 @@ namespace OpenTK.Graphics
         public ColorFormat(int red, int green, int blue, int alpha)
         {
             if (red < 0 || green < 0 || blue < 0 || alpha < 0)
+            {
                 throw new ArgumentOutOfRangeException("Arguments must be greater or equal to zero.");
+            }
             this.red = (byte)red;
             this.green = (byte)green;
             this.blue = (byte)blue;
@@ -104,7 +108,9 @@ namespace OpenTK.Graphics
             this.BitsPerPixel = red + green + blue + alpha;
             this.IsIndexed = false;
             if (this.BitsPerPixel < 15 && this.BitsPerPixel != 0)
+            {
                 this.IsIndexed = true;
+            }
         }
 
         /// <summary>Gets the bits per pixel for the Red channel.</summary>
@@ -154,10 +160,14 @@ namespace OpenTK.Graphics
         {
             int result = BitsPerPixel.CompareTo(other.BitsPerPixel);
             if (result != 0)
+            {
                 return result;
+            }
             result = IsIndexed.CompareTo(other.IsIndexed);
             if (result != 0)
+            {
                 return result;
+            }
             result = Alpha.CompareTo(other.Alpha);
             return result;
         }

--- a/src/OpenTK/Graphics/ES10/ErrorHelper.cs
+++ b/src/OpenTK/Graphics/ES10/ErrorHelper.cs
@@ -52,13 +52,17 @@ namespace OpenTK.Graphics.ES10
         public ErrorHelper(IGraphicsContext context)
         {
             if (context == null)
+            {
                 throw new GraphicsContextMissingException();
+            }
 
             Context = (GraphicsContext)context;
             lock (SyncRoot)
             {
                 if (!ContextErrors.ContainsKey(Context))
+                {
                     ContextErrors.Add(Context, new List<ErrorCode>());
+                }
             }
             ResetErrors();
         }
@@ -101,7 +105,9 @@ namespace OpenTK.Graphics.ES10
                             sb.Append(", ");
                         }
                         else
+                        {
                             break;
+                        }
                     }
                     sb.Remove(sb.Length - 2, 2); // Remove the last comma
 

--- a/src/OpenTK/Graphics/ES11/ErrorHelper.cs
+++ b/src/OpenTK/Graphics/ES11/ErrorHelper.cs
@@ -52,13 +52,17 @@ namespace OpenTK.Graphics.ES11
         public ErrorHelper(IGraphicsContext context)
         {
             if (context == null)
+            {
                 throw new GraphicsContextMissingException();
+            }
 
             Context = (GraphicsContext)context;
             lock (SyncRoot)
             {
                 if (!ContextErrors.ContainsKey(Context))
+                {
                     ContextErrors.Add(Context, new List<ErrorCode>());
+                }
             }
             ResetErrors();
         }
@@ -101,7 +105,9 @@ namespace OpenTK.Graphics.ES11
                             sb.Append(", ");
                         }
                         else
+                        {
                             break;
+                        }
                     }
                     sb.Remove(sb.Length - 2, 2); // Remove the last comma
 

--- a/src/OpenTK/Graphics/ES20/ErrorHelper.cs
+++ b/src/OpenTK/Graphics/ES20/ErrorHelper.cs
@@ -52,13 +52,17 @@ namespace OpenTK.Graphics.ES20
         public ErrorHelper(IGraphicsContext context)
         {
             if (context == null)
+            {
                 throw new GraphicsContextMissingException();
+            }
 
             Context = (GraphicsContext)context;
             lock (SyncRoot)
             {
                 if (!ContextErrors.ContainsKey(Context))
+                {
                     ContextErrors.Add(Context, new List<ErrorCode>());
+                }
             }
             ResetErrors();
         }
@@ -101,7 +105,9 @@ namespace OpenTK.Graphics.ES20
                             sb.Append(", ");
                         }
                         else
+                        {
                             break;
+                        }
                     }
                     sb.Remove(sb.Length - 2, 2); // Remove the last comma
 

--- a/src/OpenTK/Graphics/ES20/Helper.cs
+++ b/src/OpenTK/Graphics/ES20/Helper.cs
@@ -302,7 +302,9 @@ namespace OpenTK.Graphics.ES20
             unsafe
             {
                 fixed (Vector2* ptr = &vector)
+                {
                     GetFloat(pname, (float*)ptr);
+                }
             }
         }
 
@@ -311,7 +313,9 @@ namespace OpenTK.Graphics.ES20
             unsafe
             {
                 fixed (Vector3* ptr = &vector)
+                {
                     GetFloat(pname, (float*)ptr);
+                }
             }
         }
 
@@ -320,7 +324,9 @@ namespace OpenTK.Graphics.ES20
             unsafe
             {
                 fixed (Vector4* ptr = &vector)
+                {
                     GetFloat(pname, (float*)ptr);
+                }
             }
         }
 
@@ -329,7 +335,9 @@ namespace OpenTK.Graphics.ES20
             unsafe
             {
                 fixed (Matrix4* ptr = &matrix)
+                {
                     GetFloat(pname, (float*)ptr);
+                }
             }
         }
 

--- a/src/OpenTK/Graphics/ES30/ErrorHelper.cs
+++ b/src/OpenTK/Graphics/ES30/ErrorHelper.cs
@@ -52,13 +52,17 @@ namespace OpenTK.Graphics.ES30
         public ErrorHelper(IGraphicsContext context)
         {
             if (context == null)
+            {
                 throw new GraphicsContextMissingException();
+            }
 
             Context = (GraphicsContext)context;
             lock (SyncRoot)
             {
                 if (!ContextErrors.ContainsKey(Context))
+                {
                     ContextErrors.Add(Context, new List<ErrorCode>());
+                }
             }
             ResetErrors();
         }
@@ -101,7 +105,9 @@ namespace OpenTK.Graphics.ES30
                             sb.Append(", ");
                         }
                         else
+                        {
                             break;
+                        }
                     }
                     sb.Remove(sb.Length - 2, 2); // Remove the last comma
 

--- a/src/OpenTK/Graphics/ES30/Helper.cs
+++ b/src/OpenTK/Graphics/ES30/Helper.cs
@@ -297,7 +297,9 @@ namespace OpenTK.Graphics.ES30
             unsafe
             {
                 fixed (Vector2* ptr = &vector)
+                {
                     GetFloat(pname, (float*)ptr);
+                }
             }
         }
 
@@ -306,7 +308,9 @@ namespace OpenTK.Graphics.ES30
             unsafe
             {
                 fixed (Vector3* ptr = &vector)
+                {
                     GetFloat(pname, (float*)ptr);
+                }
             }
         }
 
@@ -315,7 +319,9 @@ namespace OpenTK.Graphics.ES30
             unsafe
             {
                 fixed (Vector4* ptr = &vector)
+                {
                     GetFloat(pname, (float*)ptr);
+                }
             }
         }
 
@@ -324,7 +330,9 @@ namespace OpenTK.Graphics.ES30
             unsafe
             {
                 fixed (Matrix4* ptr = &matrix)
+                {
                     GetFloat(pname, (float*)ptr);
+                }
             }
         }
 

--- a/src/OpenTK/Graphics/GraphicsBindingsBase.cs
+++ b/src/OpenTK/Graphics/GraphicsBindingsBase.cs
@@ -57,7 +57,9 @@ namespace OpenTK.Graphics
         {
             var context = GraphicsContext.CurrentContext as IGraphicsContextInternal;
             if (context == null)
+            {
                 throw new GraphicsContextMissingException();
+            }
             return context != null ? context.GetAddress(funcname) : IntPtr.Zero;
         }
 
@@ -71,7 +73,9 @@ namespace OpenTK.Graphics
 
             IGraphicsContext context = GraphicsContext.CurrentContext;
             if (context == null)
+            {
                 throw new GraphicsContextMissingException();
+            }
 
             IGraphicsContextInternal context_internal = context as IGraphicsContextInternal;
             unsafe

--- a/src/OpenTK/Graphics/GraphicsContext.cs
+++ b/src/OpenTK/Graphics/GraphicsContext.cs
@@ -110,15 +110,27 @@ namespace OpenTK.Graphics
             {
                 bool designMode = false;
                 if (mode == null && window == null)
+                {
                     designMode = true;
-                else if (mode == null) throw new ArgumentNullException("mode", "Must be a valid GraphicsMode.");
-                else if (window == null) throw new ArgumentNullException("window", "Must point to a valid window.");
+                }
+                else if (mode == null)
+                {
+                    throw new ArgumentNullException("mode", "Must be a valid GraphicsMode.");
+                }
+                else if (window == null)
+                {
+                    throw new ArgumentNullException("window", "Must point to a valid window.");
+                }
 
                 // Silently ignore invalid major and minor versions.
                 if (major <= 0)
+                {
                     major = 1;
+                }
                 if (minor < 0)
+                {
                     minor = 0;
+                }
 
                 // Angle needs an embedded context
                 const GraphicsContextFlags useAngleFlag = GraphicsContextFlags.Angle
@@ -209,7 +221,9 @@ namespace OpenTK.Graphics
         public GraphicsContext(ContextHandle handle, GetAddressDelegate getAddress, GetCurrentContextDelegate getCurrent)
         {
             if (getAddress == null || getCurrent == null)
+            {
                 throw new ArgumentNullException();
+            }
 
             // Make sure OpenTK has been initialized.
             // Fixes https://github.com/opentk/opentk/issues/52
@@ -334,7 +348,9 @@ namespace OpenTK.Graphics
                     // making this return null even if another valid context exists.
                     // The workaround is to simply ignore null targets.
                     if (target != null)
+                    {
                         return target;
+                    }
                 }
             }
             return null;
@@ -347,7 +363,9 @@ namespace OpenTK.Graphics
         public static void Assert()
         {
             if (GraphicsContext.CurrentContext == null)
+            {
                 throw new GraphicsContextMissingException();
+            }
         }
 
         internal static GetCurrentContextDelegate GetCurrentContext;
@@ -377,7 +395,9 @@ namespace OpenTK.Graphics
                     {
                         ContextHandle handle = CurrentContextHandle;
                         if (handle.Handle != IntPtr.Zero)
+                        {
                             return (IGraphicsContext)available_contexts[handle];
+                        }
                     }
                     return null;
                 }
@@ -483,7 +503,9 @@ namespace OpenTK.Graphics
         public void LoadAll()
         {
             if (GraphicsContext.CurrentContext != this)
+            {
                 throw new GraphicsContextException();
+            }
 
             implementation.LoadAll();
         }
@@ -578,7 +600,9 @@ namespace OpenTK.Graphics
                 {
                     Debug.Print("Disposing context {0}.", (this as IGraphicsContextInternal).Context.ToString());
                     if (implementation != null)
+                    {
                         implementation.Dispose();
+                    }
                 }
                 else
                 {

--- a/src/OpenTK/Graphics/GraphicsContextBase.cs
+++ b/src/OpenTK/Graphics/GraphicsContextBase.cs
@@ -53,9 +53,13 @@ namespace OpenTK.Graphics
             set
             {
                 if (value && SwapInterval <= 0)
+                {
                     SwapInterval = 1;
+                }
                 else if (!value && SwapInterval > 0)
+                {
                     SwapInterval = 0;
+                }
             }
         }
 

--- a/src/OpenTK/Graphics/GraphicsMode.cs
+++ b/src/OpenTK/Graphics/GraphicsMode.cs
@@ -28,10 +28,22 @@ namespace OpenTK.Graphics
         internal GraphicsMode(IntPtr? index, ColorFormat color, int depth, int stencil, int samples, ColorFormat accum,
                               int buffers, bool stereo)
         {
-            if (depth < 0) throw new ArgumentOutOfRangeException("depth", "Must be greater than, or equal to zero.");
-            if (stencil < 0) throw new ArgumentOutOfRangeException("stencil", "Must be greater than, or equal to zero.");
-            if (buffers < 0) throw new ArgumentOutOfRangeException("buffers", "Must be greater than, or equal to zero.");
-            if (samples < 0) throw new ArgumentOutOfRangeException("samples", "Must be greater than, or equal to zero.");
+            if (depth < 0)
+            {
+                throw new ArgumentOutOfRangeException("depth", "Must be greater than, or equal to zero.");
+            }
+            if (stencil < 0)
+            {
+                throw new ArgumentOutOfRangeException("stencil", "Must be greater than, or equal to zero.");
+            }
+            if (buffers < 0)
+            {
+                throw new ArgumentOutOfRangeException("buffers", "Must be greater than, or equal to zero.");
+            }
+            if (samples < 0)
+            {
+                throw new ArgumentOutOfRangeException("samples", "Must be greater than, or equal to zero.");
+            }
 
             this.Index = index;
             this.ColorFormat = color;

--- a/src/OpenTK/Graphics/GraphicsModeComparer.cs
+++ b/src/OpenTK/Graphics/GraphicsModeComparer.cs
@@ -35,22 +35,34 @@ namespace OpenTK.Graphics
         {
             int result = x.ColorFormat.CompareTo(y.ColorFormat);
             if (result != 0)
+            {
                 return result;
+            }
             result = x.Depth.CompareTo(y.Depth);
             if (result != 0)
+            {
                 return result;
+            }
             result = x.Stencil.CompareTo(y.Stencil);
             if (result != 0)
+            {
                 return result;
+            }
             result = x.Samples.CompareTo(y.Samples);
             if (result != 0)
+            {
                 return result;
+            }
             result = x.Stereo.CompareTo(y.Stereo);
             if (result != 0)
+            {
                 return result;
+            }
             result = x.Buffers.CompareTo(y.Buffers);
             if (result != 0)
+            {
                 return result;
+            }
             return x.AccumulatorFormat.CompareTo(y.AccumulatorFormat);
         }
     }

--- a/src/OpenTK/Graphics/OpenGL/ErrorHelper.cs
+++ b/src/OpenTK/Graphics/OpenGL/ErrorHelper.cs
@@ -52,13 +52,17 @@ namespace OpenTK.Graphics.OpenGL
         public ErrorHelper(IGraphicsContext context)
         {
             if (context == null)
+            {
                 throw new GraphicsContextMissingException();
+            }
 
             Context = (GraphicsContext)context;
             lock (SyncRoot)
             {
                 if (!ContextErrors.ContainsKey(Context))
+                {
                     ContextErrors.Add(Context, new List<ErrorCode>());
+                }
             }
             ResetErrors();
         }
@@ -101,7 +105,9 @@ namespace OpenTK.Graphics.OpenGL
                             sb.Append(", ");
                         }
                         else
+                        {
                             break;
+                        }
                     }
                     sb.Remove(sb.Length - 2, 2); // Remove the last comma
 

--- a/src/OpenTK/Graphics/OpenGL/GLHelper.cs
+++ b/src/OpenTK/Graphics/OpenGL/GLHelper.cs
@@ -1132,7 +1132,9 @@ namespace OpenTK.Graphics.OpenGL
             unsafe
             {
                 fixed (Vector2* ptr = &vector)
+                {
                     GetFloat(pname, (float*)ptr);
+                }
             }
         }
 
@@ -1141,7 +1143,9 @@ namespace OpenTK.Graphics.OpenGL
             unsafe
             {
                 fixed (Vector3* ptr = &vector)
+                {
                     GetFloat(pname, (float*)ptr);
+                }
             }
         }
 
@@ -1150,7 +1154,9 @@ namespace OpenTK.Graphics.OpenGL
             unsafe
             {
                 fixed (Vector4* ptr = &vector)
+                {
                     GetFloat(pname, (float*)ptr);
+                }
             }
         }
 
@@ -1159,7 +1165,9 @@ namespace OpenTK.Graphics.OpenGL
             unsafe
             {
                 fixed (Matrix4* ptr = &matrix)
+                {
                     GetFloat(pname, (float*)ptr);
+                }
             }
         }
 
@@ -1168,7 +1176,9 @@ namespace OpenTK.Graphics.OpenGL
             unsafe
             {
                 fixed (Vector2d* ptr = &vector)
+                {
                     GetDouble(pname, (double*)ptr);
+                }
             }
         }
 
@@ -1177,7 +1187,9 @@ namespace OpenTK.Graphics.OpenGL
             unsafe
             {
                 fixed (Vector3d* ptr = &vector)
+                {
                     GetDouble(pname, (double*)ptr);
+                }
             }
         }
 
@@ -1186,7 +1198,9 @@ namespace OpenTK.Graphics.OpenGL
             unsafe
             {
                 fixed (Vector4d* ptr = &vector)
+                {
                     GetDouble(pname, (double*)ptr);
+                }
             }
         }
 
@@ -1195,7 +1209,9 @@ namespace OpenTK.Graphics.OpenGL
             unsafe
             {
                 fixed (Matrix4d* ptr = &matrix)
+                {
                     GetDouble(pname, (double*)ptr);
+                }
             }
         }
 

--- a/src/OpenTK/Graphics/OpenGL4/ErrorHelper.cs
+++ b/src/OpenTK/Graphics/OpenGL4/ErrorHelper.cs
@@ -52,13 +52,17 @@ namespace OpenTK.Graphics.OpenGL4
         public ErrorHelper(IGraphicsContext context)
         {
             if (context == null)
+            {
                 throw new GraphicsContextMissingException();
+            }
 
             Context = (GraphicsContext)context;
             lock (SyncRoot)
             {
                 if (!ContextErrors.ContainsKey(Context))
+                {
                     ContextErrors.Add(Context, new List<ErrorCode>());
+                }
             }
             ResetErrors();
         }
@@ -101,7 +105,9 @@ namespace OpenTK.Graphics.OpenGL4
                             sb.Append(", ");
                         }
                         else
+                        {
                             break;
+                        }
                     }
                     sb.Remove(sb.Length - 2, 2); // Remove the last comma
 

--- a/src/OpenTK/Graphics/OpenGL4/Helper.cs
+++ b/src/OpenTK/Graphics/OpenGL4/Helper.cs
@@ -373,7 +373,9 @@ namespace OpenTK.Graphics.OpenGL4
             unsafe
             {
                 fixed (Vector2* ptr = &vector)
+                {
                     GetFloat(pname, (float*)ptr);
+                }
             }
         }
 
@@ -382,7 +384,9 @@ namespace OpenTK.Graphics.OpenGL4
             unsafe
             {
                 fixed (Vector3* ptr = &vector)
+                {
                     GetFloat(pname, (float*)ptr);
+                }
             }
         }
 
@@ -391,7 +395,9 @@ namespace OpenTK.Graphics.OpenGL4
             unsafe
             {
                 fixed (Vector4* ptr = &vector)
+                {
                     GetFloat(pname, (float*)ptr);
+                }
             }
         }
 
@@ -400,7 +406,9 @@ namespace OpenTK.Graphics.OpenGL4
             unsafe
             {
                 fixed (Matrix4* ptr = &matrix)
+                {
                     GetFloat(pname, (float*)ptr);
+                }
             }
         }
 

--- a/src/OpenTK/Input/GamePad.cs
+++ b/src/OpenTK/Input/GamePad.cs
@@ -59,7 +59,9 @@ namespace OpenTK.Input
         public static GamePadCapabilities GetCapabilities(int index)
         {
             if (index < 0)
+            {
                 throw new IndexOutOfRangeException();
+            }
 
             return driver.GetCapabilities(index);
         }

--- a/src/OpenTK/Input/GamePadButtons.cs
+++ b/src/OpenTK/Input/GamePadButtons.cs
@@ -171,29 +171,53 @@ namespace OpenTK.Input
         {
             System.Text.StringBuilder sb = new System.Text.StringBuilder();
             if (A == ButtonState.Pressed)
+            {
                 sb.Append("A");
+            }
             if (B == ButtonState.Pressed)
+            {
                 sb.Append("B");
+            }
             if (X == ButtonState.Pressed)
+            {
                 sb.Append("X");
+            }
             if (Y == ButtonState.Pressed)
+            {
                 sb.Append("Y");
+            }
             if (Back == ButtonState.Pressed)
+            {
                 sb.Append("Bk");
+            }
             if (Start == ButtonState.Pressed)
+            {
                 sb.Append("St");
+            }
             if (BigButton == ButtonState.Pressed)
+            {
                 sb.Append("Gd");
+            }
             if (Back == ButtonState.Pressed)
+            {
                 sb.Append("Bk");
+            }
             if (LeftShoulder == ButtonState.Pressed)
+            {
                 sb.Append("L");
+            }
             if (RightShoulder == ButtonState.Pressed)
+            {
                 sb.Append("R");
+            }
             if (LeftStick == ButtonState.Pressed)
+            {
                 sb.Append("Ls");
+            }
             if (RightStick == ButtonState.Pressed)
+            {
                 sb.Append("Rs");
+            }
 
             return sb.ToString();
         }

--- a/src/OpenTK/Input/JoystickCapabilities.cs
+++ b/src/OpenTK/Input/JoystickCapabilities.cs
@@ -44,14 +44,20 @@ namespace OpenTK.Input
         internal JoystickCapabilities(int axis_count, int button_count, int hat_count, bool is_connected)
         {
             if (axis_count < 0 || axis_count > JoystickState.MaxAxes)
+            {
                 Debug.Print("[{0}] Axis count {1} out of range (0, {2})",
                     typeof(JoystickCapabilities).Name, axis_count, JoystickState.MaxAxes);
+            }
             if (button_count < 0 || button_count > JoystickState.MaxButtons)
+            {
                 Debug.Print("[{0}] Button count {1} out of range (0, {2})",
                     typeof(JoystickCapabilities).Name, button_count, JoystickState.MaxButtons);
+            }
             if (hat_count < 0 || hat_count > JoystickState.MaxHats)
+            {
                 Debug.Print("[{0}] Hat count {1} out of range (0, {2})",
                     typeof(JoystickCapabilities).Name, hat_count, JoystickState.MaxHats);
+            }
 
             axis_count = MathHelper.Clamp(axis_count, 0, JoystickState.MaxAxes);
             button_count = MathHelper.Clamp(button_count, 0, JoystickState.MaxButtons);

--- a/src/OpenTK/Input/JoystickDevice.cs
+++ b/src/OpenTK/Input/JoystickDevice.cs
@@ -39,10 +39,14 @@ namespace OpenTK.Input
         internal JoystickDevice(int id, int axes, int buttons)
         {
             if (axes < 0)
+            {
                 throw new ArgumentOutOfRangeException("axes");
+            }
 
             if (buttons < 0)
+            {
                 throw new ArgumentOutOfRangeException("buttons");
+            }
 
             Id = id;
             Axis = new JoystickAxisCollection(axes);
@@ -112,9 +116,13 @@ namespace OpenTK.Input
                     button_args.Button = button;
                     Button[button] = button_args.Pressed = @value;
                     if (@value)
+                    {
                         ButtonDown(this, button_args);
+                    }
                     else
+                    {
                         ButtonUp(this, button_args);
+                    }
                 }
             }
         }
@@ -211,7 +219,9 @@ namespace OpenTK.Input
         internal JoystickButtonCollection(int numButtons)
         {
             if (numButtons < 0)
+            {
                 throw new ArgumentOutOfRangeException("numButtons");
+            }
 
             button_state = new bool[numButtons];
         }
@@ -246,7 +256,9 @@ namespace OpenTK.Input
         internal JoystickAxisCollection(int numAxes)
         {
             if (numAxes < 0)
+            {
                 throw new ArgumentOutOfRangeException("numAxes");
+            }
 
             axis_state = new float[numAxes];
         }

--- a/src/OpenTK/Input/JoystickState.cs
+++ b/src/OpenTK/Input/JoystickState.cs
@@ -204,7 +204,9 @@ namespace OpenTK.Input
         {
             int index = axis;
             if (index < 0 || index >= MaxAxes)
+            {
                 throw new ArgumentOutOfRangeException("axis");
+            }
 
             unsafe
             {
@@ -223,7 +225,9 @@ namespace OpenTK.Input
         internal void SetButton(int button, bool value)
         {
             if (button < 0 || button >= MaxButtons)
+            {
                 throw new ArgumentOutOfRangeException("button");
+            }
 
             if (value)
             {

--- a/src/OpenTK/Input/Keyboard.cs
+++ b/src/OpenTK/Input/Keyboard.cs
@@ -59,7 +59,9 @@ namespace OpenTK.Input
         public static KeyboardState GetState(int index)
         {
             if (index < 0)
+            {
                 throw new ArgumentOutOfRangeException("index");
+            }
 
             lock (SyncRoot)
             {

--- a/src/OpenTK/Input/KeyboardState.cs
+++ b/src/OpenTK/Input/KeyboardState.cs
@@ -215,7 +215,9 @@ namespace OpenTK.Input
                 {
                     int hashcode = 0;
                     for (int i = 0; i < NumInts; i++)
+                    {
                         hashcode ^= (k + i)->GetHashCode();
+                    }
                     return hashcode;
                 }
             }
@@ -277,7 +279,9 @@ namespace OpenTK.Input
                 fixed (int* k1 = Keys)
                 {
                     for (int i = 0; i < NumInts; i++)
+                    {
                         *(k1 + i) |= *(k2 + i);
+                    }
                 }
             }
             IsConnected |= other.IsConnected;
@@ -291,7 +295,9 @@ namespace OpenTK.Input
         private static void ValidateOffset(int offset)
         {
             if (offset < 0 || offset >= NumInts * IntSize)
+            {
                 throw new ArgumentOutOfRangeException();
+            }
         }
 
         /// <summary>
@@ -308,7 +314,9 @@ namespace OpenTK.Input
                 fixed (int* k1 = Keys)
                 {
                     for (int i = 0; equal && i < NumInts; i++)
+                    {
                         equal &= *(k1 + i) == *(k2 + i);
+                    }
                 }
             }
             return equal;

--- a/src/OpenTK/Input/Mouse.cs
+++ b/src/OpenTK/Input/Mouse.cs
@@ -71,7 +71,9 @@ namespace OpenTK.Input
         public static MouseState GetState(int index)
         {
             if (index < 0)
+            {
                 throw new ArgumentOutOfRangeException("index");
+            }
 
             lock (SyncRoot)
             {

--- a/src/OpenTK/Input/MouseEventArgs.cs
+++ b/src/OpenTK/Input/MouseEventArgs.cs
@@ -78,7 +78,9 @@ namespace OpenTK.Input
         internal void SetButton(MouseButton button, ButtonState state)
         {
             if (button < 0 || button > MouseButton.LastButton)
+            {
                 throw new ArgumentOutOfRangeException();
+            }
 
             switch (state)
             {
@@ -95,7 +97,9 @@ namespace OpenTK.Input
         internal ButtonState GetButton(MouseButton button)
         {
             if (button < 0 || button > MouseButton.LastButton)
+            {
                 throw new ArgumentOutOfRangeException();
+            }
 
             return
                 state.ReadBit((int)button) ?

--- a/src/OpenTK/Input/MouseState.cs
+++ b/src/OpenTK/Input/MouseState.cs
@@ -51,9 +51,13 @@ namespace OpenTK.Input
             internal set
             {
                 if (value)
+                {
                     EnableBit((int)button);
+                }
                 else
+                {
                     DisableBit((int)button);
+                }
             }
         }
 
@@ -322,7 +326,9 @@ namespace OpenTK.Input
         private static void ValidateOffset(int offset)
         {
             if (offset < 0 || offset >= 16)
+            {
                 throw new ArgumentOutOfRangeException("offset");
+            }
         }
 
         /// <summary>

--- a/src/OpenTK/Math/BezierCurve.cs
+++ b/src/OpenTK/Math/BezierCurve.cs
@@ -48,7 +48,9 @@ namespace OpenTK
         public BezierCurve(IEnumerable<Vector2> points)
         {
             if (points == null)
+            {
                 throw new ArgumentNullException("points", "Must point to a valid list of Vector2 structures.");
+            }
 
             this.points = new List<Vector2>(points);
             this.Parallel = 0.0f;
@@ -61,7 +63,9 @@ namespace OpenTK
         public BezierCurve(params Vector2[] points)
         {
             if (points == null)
+            {
                 throw new ArgumentNullException("points", "Must point to a valid list of Vector2 structures.");
+            }
 
             this.points = new List<Vector2>(points);
             this.Parallel = 0.0f;
@@ -75,7 +79,9 @@ namespace OpenTK
         public BezierCurve(float parallel, params Vector2[] points)
         {
             if (points == null)
+            {
                 throw new ArgumentNullException("points", "Must point to a valid list of Vector2 structures.");
+            }
 
             this.Parallel = parallel;
             this.points = new List<Vector2>(points);
@@ -89,7 +95,9 @@ namespace OpenTK
         public BezierCurve(float parallel, IEnumerable<Vector2> points)
         {
             if (points == null)
+            {
                 throw new ArgumentNullException("points", "Must point to a valid list of Vector2 structures.");
+            }
 
             this.Parallel = parallel;
             this.points = new List<Vector2>(points);
@@ -198,14 +206,20 @@ namespace OpenTK
             }
 
             if (parallel == 0.0f)
+            {
                 return r;
+            }
 
             Vector2 perpendicular = new Vector2();
 
             if (t != 0.0f)
+            {
                 perpendicular = r - BezierCurve.CalculatePointOfDerivative(points, t);
+            }
             else
+            {
                 perpendicular = points[1] - points[0];
+            }
 
             return r + Vector2.Normalize(perpendicular).PerpendicularRight * parallel;
         }

--- a/src/OpenTK/Math/BezierCurveCubic.cs
+++ b/src/OpenTK/Math/BezierCurveCubic.cs
@@ -96,14 +96,20 @@ namespace OpenTK
                 + EndAnchor.Y * t * t * t;
 
             if (Parallel == 0.0f)
+            {
                 return r;
+            }
 
             Vector2 perpendicular = new Vector2();
 
             if (t == 0.0f)
+            {
                 perpendicular = FirstControlPoint - StartAnchor;
+            }
             else
+            {
                 perpendicular = r - CalculatePointOfDerivative(t);
+            }
 
             return r + Vector2.Normalize(perpendicular).PerpendicularRight * Parallel;
         }

--- a/src/OpenTK/Math/BezierCurveQuadric.cs
+++ b/src/OpenTK/Math/BezierCurveQuadric.cs
@@ -85,14 +85,20 @@ namespace OpenTK
             r.Y = (c * c * StartAnchor.Y) + (2 * t * c * ControlPoint.Y) + (t * t * EndAnchor.Y);
 
             if (Parallel == 0.0f)
+            {
                 return r;
+            }
 
             Vector2 perpendicular = new Vector2();
 
             if (t == 0.0f)
+            {
                 perpendicular = ControlPoint - StartAnchor;
+            }
             else
+            {
                 perpendicular = r - CalculatePointOfDerivative(t);
+            }
 
             return r + Vector2.Normalize(perpendicular).PerpendicularRight * Parallel;
         }

--- a/src/OpenTK/Math/Half.cs
+++ b/src/OpenTK/Math/Half.cs
@@ -114,13 +114,28 @@ namespace OpenTK
             if (throwOnError)
             {
                 // handle cases that cause overflow rather than silently ignoring it
-                if (f > Half.MaxValue) throw new ArithmeticException("Half: Positive maximum value exceeded.");
-                if (f < -Half.MaxValue) throw new ArithmeticException("Half: Negative minimum value exceeded.");
+                if (f > Half.MaxValue)
+                {
+                    throw new ArithmeticException("Half: Positive maximum value exceeded.");
+                }
+                if (f < -Half.MaxValue)
+                {
+                    throw new ArithmeticException("Half: Negative minimum value exceeded.");
+                }
 
                 // handle cases that make no sense
-                if (Single.IsNaN(f)) throw new ArithmeticException("Half: Input is not a number (NaN).");
-                if (Single.IsPositiveInfinity(f)) throw new ArithmeticException("Half: Input is positive infinity.");
-                if (Single.IsNegativeInfinity(f)) throw new ArithmeticException("Half: Input is negative infinity.");
+                if (Single.IsNaN(f))
+                {
+                    throw new ArithmeticException("Half: Input is not a number (NaN).");
+                }
+                if (Single.IsPositiveInfinity(f))
+                {
+                    throw new ArithmeticException("Half: Input is positive infinity.");
+                }
+                if (Single.IsNegativeInfinity(f))
+                {
+                    throw new ArithmeticException("Half: Input is negative infinity.");
+                }
             }
         }
 
@@ -219,7 +234,10 @@ namespace OpenTK
                 }
 
                 // exponent overflow
-                if (exponent > 30) throw new ArithmeticException("Half: Hardware floating-point overflow.");
+                if (exponent > 30)
+                {
+                    throw new ArithmeticException("Half: Hardware floating-point overflow.");
+                }
 
                 // Assemble the half from S, E and M.
 
@@ -412,16 +430,22 @@ namespace OpenTK
 
             // Make aInt lexicographically ordered as a twos-complement int
             if (aInt < 0)
+            {
                 aInt = (short)(0x8000 - aInt);
+            }
 
             // Make bInt lexicographically ordered as a twos-complement int
             if (bInt < 0)
+            {
                 bInt = (short)(0x8000 - bInt);
+            }
 
             short intDiff = System.Math.Abs((short)(aInt - bInt));
 
             if (intDiff <= maxUlps)
+            {
                 return true;
+            }
 
             return false;
         }

--- a/src/OpenTK/Math/MathHelper.cs
+++ b/src/OpenTK/Math/MathHelper.cs
@@ -75,7 +75,10 @@ namespace OpenTK
         /// <returns>The next power of two.</returns>
         public static long NextPowerOfTwo(long n)
         {
-            if (n < 0) throw new ArgumentOutOfRangeException("n", "Must be positive.");
+            if (n < 0)
+            {
+                throw new ArgumentOutOfRangeException("n", "Must be positive.");
+            }
             return (long)System.Math.Pow(2, System.Math.Ceiling(System.Math.Log((double)n, 2)));
         }
 
@@ -86,7 +89,10 @@ namespace OpenTK
         /// <returns>The next power of two.</returns>
         public static int NextPowerOfTwo(int n)
         {
-            if (n < 0) throw new ArgumentOutOfRangeException("n", "Must be positive.");
+            if (n < 0)
+            {
+                throw new ArgumentOutOfRangeException("n", "Must be positive.");
+            }
             return (int)System.Math.Pow(2, System.Math.Ceiling(System.Math.Log((double)n, 2)));
         }
 
@@ -97,7 +103,10 @@ namespace OpenTK
         /// <returns>The next power of two.</returns>
         public static float NextPowerOfTwo(float n)
         {
-            if (n < 0) throw new ArgumentOutOfRangeException("n", "Must be positive.");
+            if (n < 0)
+            {
+                throw new ArgumentOutOfRangeException("n", "Must be positive.");
+            }
             return (float)System.Math.Pow(2, System.Math.Ceiling(System.Math.Log((double)n, 2)));
         }
 
@@ -108,7 +117,10 @@ namespace OpenTK
         /// <returns>The next power of two.</returns>
         public static double NextPowerOfTwo(double n)
         {
-            if (n < 0) throw new ArgumentOutOfRangeException("n", "Must be positive.");
+            if (n < 0)
+            {
+                throw new ArgumentOutOfRangeException("n", "Must be positive.");
+            }
             return System.Math.Pow(2, System.Math.Ceiling(System.Math.Log((double)n, 2)));
         }
 
@@ -121,7 +133,9 @@ namespace OpenTK
             long result = 1;
 
             for (; n > 1; n--)
+            {
                 result *= n;
+            }
 
             return result;
         }
@@ -311,11 +325,15 @@ namespace OpenTK
             // we use longs here, otherwise we run into a two's complement problem, causing this to fail with -2 and 2.0
             long aInt = FloatToInt32Bits(a);
             if (aInt < 0)
+            {
                 aInt = Int32.MinValue - aInt;
+            }
 
             long bInt = FloatToInt32Bits(b);
             if (bInt < 0)
+            {
                 bInt = Int32.MinValue - bInt;
+            }
 
             long intDiff = Math.Abs(aInt - bInt);
             return intDiff <= (1 << maxDeltaBits);

--- a/src/OpenTK/Math/Matrix2.cs
+++ b/src/OpenTK/Math/Matrix2.cs
@@ -156,15 +156,30 @@ namespace OpenTK
         {
             get
             {
-                if (rowIndex == 0) return Row0[columnIndex];
-                else if (rowIndex == 1) return Row1[columnIndex];
+                if (rowIndex == 0)
+                {
+                    return Row0[columnIndex];
+                }
+                else if (rowIndex == 1)
+                {
+                    return Row1[columnIndex];
+                }
                 throw new IndexOutOfRangeException("You tried to access this matrix at: (" + rowIndex + ", " + columnIndex + ")");
             }
             set
             {
-                if (rowIndex == 0) Row0[columnIndex] = value;
-                else if (rowIndex == 1) Row1[columnIndex] = value;
-                else throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
+                if (rowIndex == 0)
+                {
+                    Row0[columnIndex] = value;
+                }
+                else if (rowIndex == 1)
+                {
+                    Row1[columnIndex] = value;
+                }
+                else
+                {
+                    throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
+                }
             }
         }
 
@@ -483,7 +498,9 @@ namespace OpenTK
             float det = mat.Determinant;
 
             if (det == 0)
+            {
                 throw new InvalidOperationException("Matrix is singular and cannot be inverted.");
+            }
 
             float invDet = 1f / det;
 
@@ -660,7 +677,9 @@ namespace OpenTK
         public override bool Equals(object obj)
         {
             if (!(obj is Matrix2))
+            {
                 return false;
+            }
 
             return this.Equals((Matrix2)obj);
         }

--- a/src/OpenTK/Math/Matrix2d.cs
+++ b/src/OpenTK/Math/Matrix2d.cs
@@ -156,15 +156,30 @@ namespace OpenTK
         {
             get
             {
-                if (rowIndex == 0) return Row0[columnIndex];
-                else if (rowIndex == 1) return Row1[columnIndex];
+                if (rowIndex == 0)
+                {
+                    return Row0[columnIndex];
+                }
+                else if (rowIndex == 1)
+                {
+                    return Row1[columnIndex];
+                }
                 throw new IndexOutOfRangeException("You tried to access this matrix at: (" + rowIndex + ", " + columnIndex + ")");
             }
             set
             {
-                if (rowIndex == 0) Row0[columnIndex] = value;
-                else if (rowIndex == 1) Row1[columnIndex] = value;
-                else throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
+                if (rowIndex == 0)
+                {
+                    Row0[columnIndex] = value;
+                }
+                else if (rowIndex == 1)
+                {
+                    Row1[columnIndex] = value;
+                }
+                else
+                {
+                    throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
+                }
             }
         }
 
@@ -483,7 +498,9 @@ namespace OpenTK
             double det = mat.Determinant;
 
             if (det == 0)
+            {
                 throw new InvalidOperationException("Matrix is singular and cannot be inverted.");
+            }
 
             double invDet = 1f / det;
 
@@ -659,7 +676,9 @@ namespace OpenTK
         public override bool Equals(object obj)
         {
             if (!(obj is Matrix2d))
+            {
                 return false;
+            }
 
             return this.Equals((Matrix2d)obj);
         }

--- a/src/OpenTK/Math/Matrix2x3.cs
+++ b/src/OpenTK/Math/Matrix2x3.cs
@@ -158,15 +158,30 @@ namespace OpenTK
         {
             get
             {
-                if (rowIndex == 0) return Row0[columnIndex];
-                else if (rowIndex == 1) return Row1[columnIndex];
+                if (rowIndex == 0)
+                {
+                    return Row0[columnIndex];
+                }
+                else if (rowIndex == 1)
+                {
+                    return Row1[columnIndex];
+                }
                 throw new IndexOutOfRangeException("You tried to access this matrix at: (" + rowIndex + ", " + columnIndex + ")");
             }
             set
             {
-                if (rowIndex == 0) Row0[columnIndex] = value;
-                else if (rowIndex == 1) Row1[columnIndex] = value;
-                else throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
+                if (rowIndex == 0)
+                {
+                    Row0[columnIndex] = value;
+                }
+                else if (rowIndex == 1)
+                {
+                    Row1[columnIndex] = value;
+                }
+                else
+                {
+                    throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
+                }
             }
         }
 
@@ -630,7 +645,9 @@ namespace OpenTK
         public override bool Equals(object obj)
         {
             if (!(obj is Matrix2x3))
+            {
                 return false;
+            }
 
             return this.Equals((Matrix2x3)obj);
         }

--- a/src/OpenTK/Math/Matrix2x3d.cs
+++ b/src/OpenTK/Math/Matrix2x3d.cs
@@ -158,15 +158,30 @@ namespace OpenTK
         {
             get
             {
-                if (rowIndex == 0) return Row0[columnIndex];
-                else if (rowIndex == 1) return Row1[columnIndex];
+                if (rowIndex == 0)
+                {
+                    return Row0[columnIndex];
+                }
+                else if (rowIndex == 1)
+                {
+                    return Row1[columnIndex];
+                }
                 throw new IndexOutOfRangeException("You tried to access this matrix at: (" + rowIndex + ", " + columnIndex + ")");
             }
             set
             {
-                if (rowIndex == 0) Row0[columnIndex] = value;
-                else if (rowIndex == 1) Row1[columnIndex] = value;
-                else throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
+                if (rowIndex == 0)
+                {
+                    Row0[columnIndex] = value;
+                }
+                else if (rowIndex == 1)
+                {
+                    Row1[columnIndex] = value;
+                }
+                else
+                {
+                    throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
+                }
             }
         }
 
@@ -630,7 +645,9 @@ namespace OpenTK
         public override bool Equals(object obj)
         {
             if (!(obj is Matrix2x3d))
+            {
                 return false;
+            }
 
             return this.Equals((Matrix2x3d)obj);
         }

--- a/src/OpenTK/Math/Matrix2x4.cs
+++ b/src/OpenTK/Math/Matrix2x4.cs
@@ -179,15 +179,30 @@ namespace OpenTK
         {
             get
             {
-                if (rowIndex == 0) return Row0[columnIndex];
-                else if (rowIndex == 1) return Row1[columnIndex];
+                if (rowIndex == 0)
+                {
+                    return Row0[columnIndex];
+                }
+                else if (rowIndex == 1)
+                {
+                    return Row1[columnIndex];
+                }
                 throw new IndexOutOfRangeException("You tried to access this matrix at: (" + rowIndex + ", " + columnIndex + ")");
             }
             set
             {
-                if (rowIndex == 0) Row0[columnIndex] = value;
-                else if (rowIndex == 1) Row1[columnIndex] = value;
-                else throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
+                if (rowIndex == 0)
+                {
+                    Row0[columnIndex] = value;
+                }
+                else if (rowIndex == 1)
+                {
+                    Row1[columnIndex] = value;
+                }
+                else
+                {
+                    throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
+                }
             }
         }
 
@@ -670,7 +685,9 @@ namespace OpenTK
         public override bool Equals(object obj)
         {
             if (!(obj is Matrix2x4))
+            {
                 return false;
+            }
 
             return this.Equals((Matrix2x4)obj);
         }

--- a/src/OpenTK/Math/Matrix2x4d.cs
+++ b/src/OpenTK/Math/Matrix2x4d.cs
@@ -179,15 +179,30 @@ namespace OpenTK
         {
             get
             {
-                if (rowIndex == 0) return Row0[columnIndex];
-                else if (rowIndex == 1) return Row1[columnIndex];
+                if (rowIndex == 0)
+                {
+                    return Row0[columnIndex];
+                }
+                else if (rowIndex == 1)
+                {
+                    return Row1[columnIndex];
+                }
                 throw new IndexOutOfRangeException("You tried to access this matrix at: (" + rowIndex + ", " + columnIndex + ")");
             }
             set
             {
-                if (rowIndex == 0) Row0[columnIndex] = value;
-                else if (rowIndex == 1) Row1[columnIndex] = value;
-                else throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
+                if (rowIndex == 0)
+                {
+                    Row0[columnIndex] = value;
+                }
+                else if (rowIndex == 1)
+                {
+                    Row1[columnIndex] = value;
+                }
+                else
+                {
+                    throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
+                }
             }
         }
 
@@ -670,7 +685,9 @@ namespace OpenTK
         public override bool Equals(object obj)
         {
             if (!(obj is Matrix2x4d))
+            {
                 return false;
+            }
 
             return this.Equals((Matrix2x4d)obj);
         }

--- a/src/OpenTK/Math/Matrix3.cs
+++ b/src/OpenTK/Math/Matrix3.cs
@@ -223,17 +223,38 @@ namespace OpenTK
         {
             get
             {
-                if (rowIndex == 0) return Row0[columnIndex];
-                else if (rowIndex == 1) return Row1[columnIndex];
-                else if (rowIndex == 2) return Row2[columnIndex];
+                if (rowIndex == 0)
+                {
+                    return Row0[columnIndex];
+                }
+                else if (rowIndex == 1)
+                {
+                    return Row1[columnIndex];
+                }
+                else if (rowIndex == 2)
+                {
+                    return Row2[columnIndex];
+                }
                 throw new IndexOutOfRangeException("You tried to access this matrix at: (" + rowIndex + ", " + columnIndex + ")");
             }
             set
             {
-                if (rowIndex == 0) Row0[columnIndex] = value;
-                else if (rowIndex == 1) Row1[columnIndex] = value;
-                else if (rowIndex == 2) Row2[columnIndex] = value;
-                else throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
+                if (rowIndex == 0)
+                {
+                    Row0[columnIndex] = value;
+                }
+                else if (rowIndex == 1)
+                {
+                    Row1[columnIndex] = value;
+                }
+                else if (rowIndex == 2)
+                {
+                    Row2[columnIndex] = value;
+                }
+                else
+                {
+                    throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
+                }
             }
         }
 
@@ -284,7 +305,9 @@ namespace OpenTK
         {
             Matrix3 m = this;
             if (m.Determinant != 0)
+            {
                 m.Invert();
+            }
             return m;
         }
 
@@ -774,7 +797,9 @@ namespace OpenTK
                 float oneOverPivot = 1.0f / pivot;
                 inverse[icol, icol] = 1.0f;
                 for (int k = 0; k < 3; ++k)
+                {
                     inverse[icol, k] *= oneOverPivot;
+                }
 
                 for (int j = 0; j < 3; ++j)
                 {
@@ -783,7 +808,9 @@ namespace OpenTK
                         float f = inverse[j, icol];
                         inverse[j, icol] = 0.0f;
                         for (int k = 0; k < 3; ++k)
+                        {
                             inverse[j, k] -= inverse[icol, k] * f;
+                        }
                     }
                 }
             }
@@ -929,7 +956,9 @@ namespace OpenTK
         public override bool Equals(object obj)
         {
             if (!(obj is Matrix3))
+            {
                 return false;
+            }
 
             return this.Equals((Matrix3)obj);
         }

--- a/src/OpenTK/Math/Matrix3d.cs
+++ b/src/OpenTK/Math/Matrix3d.cs
@@ -217,17 +217,38 @@ namespace OpenTK
         {
             get
             {
-                if (rowIndex == 0) return Row0[columnIndex];
-                else if (rowIndex == 1) return Row1[columnIndex];
-                else if (rowIndex == 2) return Row2[columnIndex];
+                if (rowIndex == 0)
+                {
+                    return Row0[columnIndex];
+                }
+                else if (rowIndex == 1)
+                {
+                    return Row1[columnIndex];
+                }
+                else if (rowIndex == 2)
+                {
+                    return Row2[columnIndex];
+                }
                 throw new IndexOutOfRangeException("You tried to access this matrix at: (" + rowIndex + ", " + columnIndex + ")");
             }
             set
             {
-                if (rowIndex == 0) Row0[columnIndex] = value;
-                else if (rowIndex == 1) Row1[columnIndex] = value;
-                else if (rowIndex == 2) Row2[columnIndex] = value;
-                else throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
+                if (rowIndex == 0)
+                {
+                    Row0[columnIndex] = value;
+                }
+                else if (rowIndex == 1)
+                {
+                    Row1[columnIndex] = value;
+                }
+                else if (rowIndex == 2)
+                {
+                    Row2[columnIndex] = value;
+                }
+                else
+                {
+                    throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
+                }
             }
         }
 
@@ -278,7 +299,9 @@ namespace OpenTK
         {
             Matrix3d m = this;
             if (m.Determinant != 0)
+            {
                 m.Invert();
+            }
             return m;
         }
 
@@ -769,7 +792,9 @@ namespace OpenTK
                 double oneOverPivot = 1.0 / pivot;
                 inverse[icol, icol] = 1.0;
                 for (int k = 0; k < 3; ++k)
+                {
                     inverse[icol, k] *= oneOverPivot;
+                }
 
                 for (int j = 0; j < 3; ++j)
                 {
@@ -778,7 +803,9 @@ namespace OpenTK
                         double f = inverse[j, icol];
                         inverse[j, icol] = 0.0;
                         for (int k = 0; k < 3; ++k)
+                        {
                             inverse[j, k] -= inverse[icol, k] * f;
+                        }
                     }
                 }
             }
@@ -918,7 +945,9 @@ namespace OpenTK
         public override bool Equals(object obj)
         {
             if (!(obj is Matrix3d))
+            {
                 return false;
+            }
 
             return this.Equals((Matrix3d)obj);
         }

--- a/src/OpenTK/Math/Matrix3x2.cs
+++ b/src/OpenTK/Math/Matrix3x2.cs
@@ -158,17 +158,38 @@ namespace OpenTK
         {
             get
             {
-                if (rowIndex == 0) return Row0[columnIndex];
-                else if (rowIndex == 1) return Row1[columnIndex];
-                else if (rowIndex == 2) return Row2[columnIndex];
+                if (rowIndex == 0)
+                {
+                    return Row0[columnIndex];
+                }
+                else if (rowIndex == 1)
+                {
+                    return Row1[columnIndex];
+                }
+                else if (rowIndex == 2)
+                {
+                    return Row2[columnIndex];
+                }
                 throw new IndexOutOfRangeException("You tried to access this matrix at: (" + rowIndex + ", " + columnIndex + ")");
             }
             set
             {
-                if (rowIndex == 0) Row0[columnIndex] = value;
-                else if (rowIndex == 1) Row1[columnIndex] = value;
-                else if (rowIndex == 2) Row2[columnIndex] = value;
-                else throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
+                if (rowIndex == 0)
+                {
+                    Row0[columnIndex] = value;
+                }
+                else if (rowIndex == 1)
+                {
+                    Row1[columnIndex] = value;
+                }
+                else if (rowIndex == 2)
+                {
+                    Row2[columnIndex] = value;
+                }
+                else
+                {
+                    throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
+                }
             }
         }
 
@@ -644,7 +665,9 @@ namespace OpenTK
         public override bool Equals(object obj)
         {
             if (!(obj is Matrix3x2))
+            {
                 return false;
+            }
 
             return this.Equals((Matrix3x2)obj);
         }

--- a/src/OpenTK/Math/Matrix3x2d.cs
+++ b/src/OpenTK/Math/Matrix3x2d.cs
@@ -158,17 +158,38 @@ namespace OpenTK
         {
             get
             {
-                if (rowIndex == 0) return Row0[columnIndex];
-                else if (rowIndex == 1) return Row1[columnIndex];
-                else if (rowIndex == 2) return Row2[columnIndex];
+                if (rowIndex == 0)
+                {
+                    return Row0[columnIndex];
+                }
+                else if (rowIndex == 1)
+                {
+                    return Row1[columnIndex];
+                }
+                else if (rowIndex == 2)
+                {
+                    return Row2[columnIndex];
+                }
                 throw new IndexOutOfRangeException("You tried to access this matrix at: (" + rowIndex + ", " + columnIndex + ")");
             }
             set
             {
-                if (rowIndex == 0) Row0[columnIndex] = value;
-                else if (rowIndex == 1) Row1[columnIndex] = value;
-                else if (rowIndex == 2) Row2[columnIndex] = value;
-                else throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
+                if (rowIndex == 0)
+                {
+                    Row0[columnIndex] = value;
+                }
+                else if (rowIndex == 1)
+                {
+                    Row1[columnIndex] = value;
+                }
+                else if (rowIndex == 2)
+                {
+                    Row2[columnIndex] = value;
+                }
+                else
+                {
+                    throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
+                }
             }
         }
 
@@ -644,7 +665,9 @@ namespace OpenTK
         public override bool Equals(object obj)
         {
             if (!(obj is Matrix3x2d))
+            {
                 return false;
+            }
 
             return this.Equals((Matrix3x2d)obj);
         }

--- a/src/OpenTK/Math/Matrix3x4.cs
+++ b/src/OpenTK/Math/Matrix3x4.cs
@@ -211,17 +211,38 @@ namespace OpenTK
         {
             get
             {
-                if (rowIndex == 0) return Row0[columnIndex];
-                else if (rowIndex == 1) return Row1[columnIndex];
-                else if (rowIndex == 2) return Row2[columnIndex];
+                if (rowIndex == 0)
+                {
+                    return Row0[columnIndex];
+                }
+                else if (rowIndex == 1)
+                {
+                    return Row1[columnIndex];
+                }
+                else if (rowIndex == 2)
+                {
+                    return Row2[columnIndex];
+                }
                 throw new IndexOutOfRangeException("You tried to access this matrix at: (" + rowIndex + ", " + columnIndex + ")");
             }
             set
             {
-                if (rowIndex == 0) Row0[columnIndex] = value;
-                else if (rowIndex == 1) Row1[columnIndex] = value;
-                else if (rowIndex == 2) Row2[columnIndex] = value;
-                else throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
+                if (rowIndex == 0)
+                {
+                    Row0[columnIndex] = value;
+                }
+                else if (rowIndex == 1)
+                {
+                    Row1[columnIndex] = value;
+                }
+                else if (rowIndex == 2)
+                {
+                    Row2[columnIndex] = value;
+                }
+                else
+                {
+                    throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
+                }
             }
         }
 
@@ -887,7 +908,9 @@ namespace OpenTK
         public override bool Equals(object obj)
         {
             if (!(obj is Matrix3x4))
+            {
                 return false;
+            }
 
             return this.Equals((Matrix3x4)obj);
         }

--- a/src/OpenTK/Math/Matrix3x4d.cs
+++ b/src/OpenTK/Math/Matrix3x4d.cs
@@ -211,17 +211,38 @@ namespace OpenTK
         {
             get
             {
-                if (rowIndex == 0) return Row0[columnIndex];
-                else if (rowIndex == 1) return Row1[columnIndex];
-                else if (rowIndex == 2) return Row2[columnIndex];
+                if (rowIndex == 0)
+                {
+                    return Row0[columnIndex];
+                }
+                else if (rowIndex == 1)
+                {
+                    return Row1[columnIndex];
+                }
+                else if (rowIndex == 2)
+                {
+                    return Row2[columnIndex];
+                }
                 throw new IndexOutOfRangeException("You tried to access this matrix at: (" + rowIndex + ", " + columnIndex + ")");
             }
             set
             {
-                if (rowIndex == 0) Row0[columnIndex] = value;
-                else if (rowIndex == 1) Row1[columnIndex] = value;
-                else if (rowIndex == 2) Row2[columnIndex] = value;
-                else throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
+                if (rowIndex == 0)
+                {
+                    Row0[columnIndex] = value;
+                }
+                else if (rowIndex == 1)
+                {
+                    Row1[columnIndex] = value;
+                }
+                else if (rowIndex == 2)
+                {
+                    Row2[columnIndex] = value;
+                }
+                else
+                {
+                    throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
+                }
             }
         }
 
@@ -887,7 +908,9 @@ namespace OpenTK
         public override bool Equals(object obj)
         {
             if (!(obj is Matrix3x4d))
+            {
                 return false;
+            }
 
             return this.Equals((Matrix3x4d)obj);
         }

--- a/src/OpenTK/Math/Matrix4.cs
+++ b/src/OpenTK/Math/Matrix4.cs
@@ -301,19 +301,46 @@ namespace OpenTK
         {
             get
             {
-                if (rowIndex == 0) return Row0[columnIndex];
-                else if (rowIndex == 1) return Row1[columnIndex];
-                else if (rowIndex == 2) return Row2[columnIndex];
-                else if (rowIndex == 3) return Row3[columnIndex];
+                if (rowIndex == 0)
+                {
+                    return Row0[columnIndex];
+                }
+                else if (rowIndex == 1)
+                {
+                    return Row1[columnIndex];
+                }
+                else if (rowIndex == 2)
+                {
+                    return Row2[columnIndex];
+                }
+                else if (rowIndex == 3)
+                {
+                    return Row3[columnIndex];
+                }
                 throw new IndexOutOfRangeException("You tried to access this matrix at: (" + rowIndex + ", " + columnIndex + ")");
             }
             set
             {
-                if (rowIndex == 0) Row0[columnIndex] = value;
-                else if (rowIndex == 1) Row1[columnIndex] = value;
-                else if (rowIndex == 2) Row2[columnIndex] = value;
-                else if (rowIndex == 3) Row3[columnIndex] = value;
-                else throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
+                if (rowIndex == 0)
+                {
+                    Row0[columnIndex] = value;
+                }
+                else if (rowIndex == 1)
+                {
+                    Row1[columnIndex] = value;
+                }
+                else if (rowIndex == 2)
+                {
+                    Row2[columnIndex] = value;
+                }
+                else if (rowIndex == 3)
+                {
+                    Row3[columnIndex] = value;
+                }
+                else
+                {
+                    throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
+                }
             }
         }
 
@@ -362,7 +389,9 @@ namespace OpenTK
         {
             Matrix4 m = this;
             if (m.Determinant != 0)
+            {
                 m.Invert();
+            }
             return m;
         }
 
@@ -887,13 +916,21 @@ namespace OpenTK
         public static void CreatePerspectiveFieldOfView(float fovy, float aspect, float zNear, float zFar, out Matrix4 result)
         {
             if (fovy <= 0 || fovy > Math.PI)
+            {
                 throw new ArgumentOutOfRangeException("fovy");
+            }
             if (aspect <= 0)
+            {
                 throw new ArgumentOutOfRangeException("aspect");
+            }
             if (zNear <= 0)
+            {
                 throw new ArgumentOutOfRangeException("zNear");
+            }
             if (zFar <= 0)
+            {
                 throw new ArgumentOutOfRangeException("zFar");
+            }
 
             float yMax = zNear * (float)System.Math.Tan(0.5f * fovy);
             float yMin = -yMax;
@@ -949,11 +986,17 @@ namespace OpenTK
         public static void CreatePerspectiveOffCenter(float left, float right, float bottom, float top, float zNear, float zFar, out Matrix4 result)
         {
             if (zNear <= 0)
+            {
                 throw new ArgumentOutOfRangeException("zNear");
+            }
             if (zFar <= 0)
+            {
                 throw new ArgumentOutOfRangeException("zFar");
+            }
             if (zNear >= zFar)
+            {
                 throw new ArgumentOutOfRangeException("zNear");
+            }
 
             float x = (2.0f * zNear) / (right - left);
             float y = (2.0f * zNear) / (top - bottom);
@@ -1262,7 +1305,9 @@ namespace OpenTK
                 float oneOverPivot = 1.0f / pivot;
                 inverse[icol, icol] = 1.0f;
                 for (int k = 0; k < 4; ++k)
+                {
                     inverse[icol, k] *= oneOverPivot;
+                }
 
                 // Do elimination of non-diagonal elements
                 for (int j = 0; j < 4; ++j)
@@ -1273,7 +1318,9 @@ namespace OpenTK
                         float f = inverse[j, icol];
                         inverse[j, icol] = 0.0f;
                         for (int k = 0; k < 4; ++k)
+                        {
                             inverse[j, k] -= inverse[icol, k] * f;
+                        }
                     }
                 }
             }
@@ -1444,7 +1491,9 @@ namespace OpenTK
         public override bool Equals(object obj)
         {
             if (!(obj is Matrix4))
+            {
                 return false;
+            }
 
             return this.Equals((Matrix4)obj);
         }

--- a/src/OpenTK/Math/Matrix4d.cs
+++ b/src/OpenTK/Math/Matrix4d.cs
@@ -288,19 +288,46 @@ namespace OpenTK
         {
             get
             {
-                if (rowIndex == 0) return Row0[columnIndex];
-                else if (rowIndex == 1) return Row1[columnIndex];
-                else if (rowIndex == 2) return Row2[columnIndex];
-                else if (rowIndex == 3) return Row3[columnIndex];
+                if (rowIndex == 0)
+                {
+                    return Row0[columnIndex];
+                }
+                else if (rowIndex == 1)
+                {
+                    return Row1[columnIndex];
+                }
+                else if (rowIndex == 2)
+                {
+                    return Row2[columnIndex];
+                }
+                else if (rowIndex == 3)
+                {
+                    return Row3[columnIndex];
+                }
                 throw new IndexOutOfRangeException("You tried to access this matrix at: (" + rowIndex + ", " + columnIndex + ")");
             }
             set
             {
-                if (rowIndex == 0) Row0[columnIndex] = value;
-                else if (rowIndex == 1) Row1[columnIndex] = value;
-                else if (rowIndex == 2) Row2[columnIndex] = value;
-                else if (rowIndex == 3) Row3[columnIndex] = value;
-                else throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
+                if (rowIndex == 0)
+                {
+                    Row0[columnIndex] = value;
+                }
+                else if (rowIndex == 1)
+                {
+                    Row1[columnIndex] = value;
+                }
+                else if (rowIndex == 2)
+                {
+                    Row2[columnIndex] = value;
+                }
+                else if (rowIndex == 3)
+                {
+                    Row3[columnIndex] = value;
+                }
+                else
+                {
+                    throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
+                }
             }
         }
 
@@ -349,7 +376,9 @@ namespace OpenTK
         {
             Matrix4d m = this;
             if (m.Determinant != 0)
+            {
                 m.Invert();
+            }
             return m;
         }
 
@@ -765,13 +794,21 @@ namespace OpenTK
         public static void CreatePerspectiveFieldOfView(double fovy, double aspect, double zNear, double zFar, out Matrix4d result)
         {
             if (fovy <= 0 || fovy > Math.PI)
+            {
                 throw new ArgumentOutOfRangeException("fovy");
+            }
             if (aspect <= 0)
+            {
                 throw new ArgumentOutOfRangeException("aspect");
+            }
             if (zNear <= 0)
+            {
                 throw new ArgumentOutOfRangeException("zNear");
+            }
             if (zFar <= 0)
+            {
                 throw new ArgumentOutOfRangeException("zFar");
+            }
 
             double yMax = zNear * System.Math.Tan(0.5 * fovy);
             double yMin = -yMax;
@@ -827,11 +864,17 @@ namespace OpenTK
         public static void CreatePerspectiveOffCenter(double left, double right, double bottom, double top, double zNear, double zFar, out Matrix4d result)
         {
             if (zNear <= 0)
+            {
                 throw new ArgumentOutOfRangeException("zNear");
+            }
             if (zFar <= 0)
+            {
                 throw new ArgumentOutOfRangeException("zFar");
+            }
             if (zNear >= zFar)
+            {
                 throw new ArgumentOutOfRangeException("zNear");
+            }
 
             double x = (2.0 * zNear) / (right - left);
             double y = (2.0 * zNear) / (top - bottom);
@@ -1305,7 +1348,9 @@ namespace OpenTK
                 double oneOverPivot = 1.0 / pivot;
                 inverse[icol, icol] = 1.0;
                 for (int k = 0; k < 4; ++k)
+                {
                     inverse[icol, k] *= oneOverPivot;
+                }
 
                 // Do elimination of non-diagonal elements
                 for (int j = 0; j < 4; ++j)
@@ -1316,7 +1361,9 @@ namespace OpenTK
                         double f = inverse[j, icol];
                         inverse[j, icol] = 0.0;
                         for (int k = 0; k < 4; ++k)
+                        {
                             inverse[j, k] -= inverse[icol, k] * f;
+                        }
                     }
                 }
             }
@@ -1463,7 +1510,9 @@ namespace OpenTK
         public override bool Equals(object obj)
         {
             if (!(obj is Matrix4d))
+            {
                 return false;
+            }
 
             return this.Equals((Matrix4d)obj);
         }

--- a/src/OpenTK/Math/Matrix4x2.cs
+++ b/src/OpenTK/Math/Matrix4x2.cs
@@ -180,19 +180,46 @@ namespace OpenTK
         {
             get
             {
-                if (rowIndex == 0) return Row0[columnIndex];
-                else if (rowIndex == 1) return Row1[columnIndex];
-                else if (rowIndex == 2) return Row2[columnIndex];
-                else if (rowIndex == 3) return Row3[columnIndex];
+                if (rowIndex == 0)
+                {
+                    return Row0[columnIndex];
+                }
+                else if (rowIndex == 1)
+                {
+                    return Row1[columnIndex];
+                }
+                else if (rowIndex == 2)
+                {
+                    return Row2[columnIndex];
+                }
+                else if (rowIndex == 3)
+                {
+                    return Row3[columnIndex];
+                }
                 throw new IndexOutOfRangeException("You tried to access this matrix at: (" + rowIndex + ", " + columnIndex + ")");
             }
             set
             {
-                if (rowIndex == 0) Row0[columnIndex] = value;
-                else if (rowIndex == 1) Row1[columnIndex] = value;
-                else if (rowIndex == 2) Row2[columnIndex] = value;
-                else if (rowIndex == 3) Row3[columnIndex] = value;
-                else throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
+                if (rowIndex == 0)
+                {
+                    Row0[columnIndex] = value;
+                }
+                else if (rowIndex == 1)
+                {
+                    Row1[columnIndex] = value;
+                }
+                else if (rowIndex == 2)
+                {
+                    Row2[columnIndex] = value;
+                }
+                else if (rowIndex == 3)
+                {
+                    Row3[columnIndex] = value;
+                }
+                else
+                {
+                    throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
+                }
             }
         }
 
@@ -697,7 +724,9 @@ namespace OpenTK
         public override bool Equals(object obj)
         {
             if (!(obj is Matrix4x2))
+            {
                 return false;
+            }
 
             return this.Equals((Matrix4x2)obj);
         }

--- a/src/OpenTK/Math/Matrix4x2d.cs
+++ b/src/OpenTK/Math/Matrix4x2d.cs
@@ -180,19 +180,46 @@ namespace OpenTK
         {
             get
             {
-                if (rowIndex == 0) return Row0[columnIndex];
-                else if (rowIndex == 1) return Row1[columnIndex];
-                else if (rowIndex == 2) return Row2[columnIndex];
-                else if (rowIndex == 3) return Row3[columnIndex];
+                if (rowIndex == 0)
+                {
+                    return Row0[columnIndex];
+                }
+                else if (rowIndex == 1)
+                {
+                    return Row1[columnIndex];
+                }
+                else if (rowIndex == 2)
+                {
+                    return Row2[columnIndex];
+                }
+                else if (rowIndex == 3)
+                {
+                    return Row3[columnIndex];
+                }
                 throw new IndexOutOfRangeException("You tried to access this matrix at: (" + rowIndex + ", " + columnIndex + ")");
             }
             set
             {
-                if (rowIndex == 0) Row0[columnIndex] = value;
-                else if (rowIndex == 1) Row1[columnIndex] = value;
-                else if (rowIndex == 2) Row2[columnIndex] = value;
-                else if (rowIndex == 3) Row3[columnIndex] = value;
-                else throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
+                if (rowIndex == 0)
+                {
+                    Row0[columnIndex] = value;
+                }
+                else if (rowIndex == 1)
+                {
+                    Row1[columnIndex] = value;
+                }
+                else if (rowIndex == 2)
+                {
+                    Row2[columnIndex] = value;
+                }
+                else if (rowIndex == 3)
+                {
+                    Row3[columnIndex] = value;
+                }
+                else
+                {
+                    throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
+                }
             }
         }
 
@@ -697,7 +724,9 @@ namespace OpenTK
         public override bool Equals(object obj)
         {
             if (!(obj is Matrix4x2d))
+            {
                 return false;
+            }
 
             return this.Equals((Matrix4x2d)obj);
         }

--- a/src/OpenTK/Math/Matrix4x3.cs
+++ b/src/OpenTK/Math/Matrix4x3.cs
@@ -212,19 +212,46 @@ namespace OpenTK
         {
             get
             {
-                if (rowIndex == 0) return Row0[columnIndex];
-                else if (rowIndex == 1) return Row1[columnIndex];
-                else if (rowIndex == 2) return Row2[columnIndex];
-                else if (rowIndex == 3) return Row3[columnIndex];
+                if (rowIndex == 0)
+                {
+                    return Row0[columnIndex];
+                }
+                else if (rowIndex == 1)
+                {
+                    return Row1[columnIndex];
+                }
+                else if (rowIndex == 2)
+                {
+                    return Row2[columnIndex];
+                }
+                else if (rowIndex == 3)
+                {
+                    return Row3[columnIndex];
+                }
                 throw new IndexOutOfRangeException("You tried to access this matrix at: (" + rowIndex + ", " + columnIndex + ")");
             }
             set
             {
-                if (rowIndex == 0) Row0[columnIndex] = value;
-                else if (rowIndex == 1) Row1[columnIndex] = value;
-                else if (rowIndex == 2) Row2[columnIndex] = value;
-                else if (rowIndex == 3) Row3[columnIndex] = value;
-                else throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
+                if (rowIndex == 0)
+                {
+                    Row0[columnIndex] = value;
+                }
+                else if (rowIndex == 1)
+                {
+                    Row1[columnIndex] = value;
+                }
+                else if (rowIndex == 2)
+                {
+                    Row2[columnIndex] = value;
+                }
+                else if (rowIndex == 3)
+                {
+                    Row3[columnIndex] = value;
+                }
+                else
+                {
+                    throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
+                }
             }
         }
 
@@ -896,7 +923,9 @@ namespace OpenTK
         public override bool Equals(object obj)
         {
             if (!(obj is Matrix4x3))
+            {
                 return false;
+            }
 
             return this.Equals((Matrix4x3)obj);
         }

--- a/src/OpenTK/Math/Matrix4x3d.cs
+++ b/src/OpenTK/Math/Matrix4x3d.cs
@@ -212,19 +212,46 @@ namespace OpenTK
         {
             get
             {
-                if (rowIndex == 0) return Row0[columnIndex];
-                else if (rowIndex == 1) return Row1[columnIndex];
-                else if (rowIndex == 2) return Row2[columnIndex];
-                else if (rowIndex == 3) return Row3[columnIndex];
+                if (rowIndex == 0)
+                {
+                    return Row0[columnIndex];
+                }
+                else if (rowIndex == 1)
+                {
+                    return Row1[columnIndex];
+                }
+                else if (rowIndex == 2)
+                {
+                    return Row2[columnIndex];
+                }
+                else if (rowIndex == 3)
+                {
+                    return Row3[columnIndex];
+                }
                 throw new IndexOutOfRangeException("You tried to access this matrix at: (" + rowIndex + ", " + columnIndex + ")");
             }
             set
             {
-                if (rowIndex == 0) Row0[columnIndex] = value;
-                else if (rowIndex == 1) Row1[columnIndex] = value;
-                else if (rowIndex == 2) Row2[columnIndex] = value;
-                else if (rowIndex == 3) Row3[columnIndex] = value;
-                else throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
+                if (rowIndex == 0)
+                {
+                    Row0[columnIndex] = value;
+                }
+                else if (rowIndex == 1)
+                {
+                    Row1[columnIndex] = value;
+                }
+                else if (rowIndex == 2)
+                {
+                    Row2[columnIndex] = value;
+                }
+                else if (rowIndex == 3)
+                {
+                    Row3[columnIndex] = value;
+                }
+                else
+                {
+                    throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
+                }
             }
         }
 
@@ -896,7 +923,9 @@ namespace OpenTK
         public override bool Equals(object obj)
         {
             if (!(obj is Matrix4x3d))
+            {
                 return false;
+            }
 
             return this.Equals((Matrix4x3d)obj);
         }

--- a/src/OpenTK/Math/Quaternion.cs
+++ b/src/OpenTK/Math/Quaternion.cs
@@ -137,7 +137,9 @@ namespace OpenTK
         {
             Quaternion q = this;
             if (Math.Abs(q.W) > 1.0f)
+            {
                 q.Normalize();
+            }
 
             Vector4 result = new Vector4();
 
@@ -414,7 +416,9 @@ namespace OpenTK
         public static Quaternion FromAxisAngle(Vector3 axis, float angle)
         {
             if (axis.LengthSquared == 0.0f)
+            {
                 return Identity;
+            }
 
             Quaternion result = Identity;
 
@@ -594,9 +598,13 @@ namespace OpenTK
 
             Quaternion result = new Quaternion(blendA * q1.Xyz + blendB * q2.Xyz, blendA * q1.W + blendB * q2.W);
             if (result.LengthSquared > 0.0f)
+            {
                 return Normalize(result);
+            }
             else
+            {
                 return Identity;
+            }
         }
 
         /// <summary>
@@ -698,8 +706,11 @@ namespace OpenTK
         /// <returns>True if both objects are Quaternions of equal value. Otherwise it returns false.</returns>
         public override bool Equals(object other)
         {
-            if (other is Quaternion == false) return false;
-               return this == (Quaternion)other;
+            if (other is Quaternion == false)
+            {
+                return false;
+            }
+            return this == (Quaternion)other;
         }
 
         /// <summary>

--- a/src/OpenTK/Math/Quaterniond.cs
+++ b/src/OpenTK/Math/Quaterniond.cs
@@ -137,7 +137,9 @@ namespace OpenTK
         {
             Quaterniond q = this;
             if (Math.Abs(q.W) > 1.0f)
+            {
                 q.Normalize();
+            }
 
             Vector4d result = new Vector4d();
 
@@ -414,7 +416,9 @@ namespace OpenTK
         public static Quaterniond FromAxisAngle(Vector3d axis, double angle)
         {
             if (axis.LengthSquared == 0.0f)
+            {
                 return Identity;
+            }
 
             Quaterniond result = Identity;
 
@@ -594,9 +598,13 @@ namespace OpenTK
 
             Quaterniond result = new Quaterniond(blendA * q1.Xyz + blendB * q2.Xyz, blendA * q1.W + blendB * q2.W);
             if (result.LengthSquared > 0.0f)
+            {
                 return Normalize(result);
+            }
             else
+            {
                 return Identity;
+            }
         }
 
         /// <summary>
@@ -698,7 +706,10 @@ namespace OpenTK
         /// <returns>True if both objects are Quaternions of equal value. Otherwise it returns false.</returns>
         public override bool Equals(object other)
         {
-            if (other is Quaterniond == false) return false;
+            if (other is Quaterniond == false)
+            {
+                return false;
+            }
             return this == (Quaterniond)other;
         }
 

--- a/src/OpenTK/Math/Vector2.cs
+++ b/src/OpenTK/Math/Vector2.cs
@@ -70,13 +70,28 @@ namespace OpenTK
         /// </summary>
         public float this[int index] {
             get{
-                if(index == 0) return X;
-                else if(index == 1) return Y;
+                if(index == 0)
+                {
+                    return X;
+                }
+                else if(index == 1)
+                {
+                    return Y;
+                }
                 throw new IndexOutOfRangeException("You tried to access this vector at index: " + index);
             } set{
-                if(index == 0) X = value;
-                else if(index == 1) Y = value;
-                else throw new IndexOutOfRangeException("You tried to set this vector at index: " + index);
+                if(index == 0)
+                {
+                    X = value;
+                }
+                else if(index == 1)
+                {
+                    Y = value;
+                }
+                else
+                {
+                    throw new IndexOutOfRangeException("You tried to set this vector at index: " + index);
+                }
             }
         }
 
@@ -828,7 +843,9 @@ namespace OpenTK
         public override bool Equals(object obj)
         {
             if (!(obj is Vector2))
+            {
                 return false;
+            }
 
             return this.Equals((Vector2)obj);
         }

--- a/src/OpenTK/Math/Vector2d.cs
+++ b/src/OpenTK/Math/Vector2d.cs
@@ -86,13 +86,28 @@ namespace OpenTK
         /// </summary>
         public double this[int index] {
             get{
-                if(index == 0) return X;
-                else if(index == 1) return Y;
+                if(index == 0)
+                {
+                    return X;
+                }
+                else if(index == 1)
+                {
+                    return Y;
+                }
                 throw new IndexOutOfRangeException("You tried to access this vector at index: " + index);
             } set{
-                if(index == 0) X = value;
-                else if(index == 1) Y = value;
-                else throw new IndexOutOfRangeException("You tried to set this vector at index: " + index);
+                if(index == 0)
+                {
+                    X = value;
+                }
+                else if(index == 1)
+                {
+                    Y = value;
+                }
+                else
+                {
+                    throw new IndexOutOfRangeException("You tried to set this vector at index: " + index);
+                }
             }
         }
 
@@ -815,7 +830,9 @@ namespace OpenTK
         public override bool Equals(object obj)
         {
             if (!(obj is Vector2d))
+            {
                 return false;
+            }
 
             return this.Equals((Vector2d)obj);
         }

--- a/src/OpenTK/Math/Vector3.cs
+++ b/src/OpenTK/Math/Vector3.cs
@@ -114,15 +114,36 @@ namespace OpenTK
         /// </summary>
         public float this[int index] {
             get{
-                if(index == 0) return X;
-                else if(index == 1) return Y;
-                else if(index == 2) return Z;
+                if(index == 0)
+                {
+                    return X;
+                }
+                else if(index == 1)
+                {
+                    return Y;
+                }
+                else if(index == 2)
+                {
+                    return Z;
+                }
                 throw new IndexOutOfRangeException("You tried to access this vector at index: " + index);
             } set{
-                if(index == 0) X = value;
-                else if(index == 1) Y = value;
-                else if(index == 2) Z = value;
-                else throw new IndexOutOfRangeException("You tried to set this vector at index: " + index);
+                if(index == 0)
+                {
+                    X = value;
+                }
+                else if(index == 1)
+                {
+                    Y = value;
+                }
+                else if(index == 2)
+                {
+                    Z = value;
+                }
+                else
+                {
+                    throw new IndexOutOfRangeException("You tried to set this vector at index: " + index);
+                }
             }
         }
 
@@ -1329,7 +1350,9 @@ namespace OpenTK
         public override bool Equals(object obj)
         {
             if (!(obj is Vector3))
+            {
                 return false;
+            }
 
             return this.Equals((Vector3)obj);
         }

--- a/src/OpenTK/Math/Vector3d.cs
+++ b/src/OpenTK/Math/Vector3d.cs
@@ -111,15 +111,36 @@ namespace OpenTK
         /// </summary>
         public double this[int index] {
             get{
-                if(index == 0) return X;
-                else if(index == 1) return Y;
-                else if(index == 2) return Z;
+                if(index == 0)
+                {
+                    return X;
+                }
+                else if(index == 1)
+                {
+                    return Y;
+                }
+                else if(index == 2)
+                {
+                    return Z;
+                }
                 throw new IndexOutOfRangeException("You tried to access this vector at index: " + index);
             } set{
-                if(index == 0) X = value;
-                else if(index == 1) Y = value;
-                else if(index == 2) Z = value;
-                else throw new IndexOutOfRangeException("You tried to set this vector at index: " + index);
+                if(index == 0)
+                {
+                    X = value;
+                }
+                else if(index == 1)
+                {
+                    Y = value;
+                }
+                else if(index == 2)
+                {
+                    Z = value;
+                }
+                else
+                {
+                    throw new IndexOutOfRangeException("You tried to set this vector at index: " + index);
+                }
             }
         }
 
@@ -1170,7 +1191,9 @@ namespace OpenTK
         public override bool Equals(object obj)
         {
             if (!(obj is Vector3d))
+            {
                 return false;
+            }
 
             return this.Equals((Vector3d)obj);
         }

--- a/src/OpenTK/Math/Vector4.cs
+++ b/src/OpenTK/Math/Vector4.cs
@@ -172,17 +172,44 @@ namespace OpenTK
         /// </summary>
         public float this[int index] {
             get{
-                if(index == 0) return X;
-                else if(index == 1) return Y;
-                else if(index == 2) return Z;
-                else if(index == 3) return W;
+                if(index == 0)
+                {
+                    return X;
+                }
+                else if(index == 1)
+                {
+                    return Y;
+                }
+                else if(index == 2)
+                {
+                    return Z;
+                }
+                else if(index == 3)
+                {
+                    return W;
+                }
                 throw new IndexOutOfRangeException("You tried to access this vector at index: " + index);
             } set{
-                if(index == 0) X = value;
-                else if(index == 1) Y = value;
-                else if(index == 2) Z = value;
-                else if(index == 3) W = value;
-                else throw new IndexOutOfRangeException("You tried to set this vector at index: " + index);
+                if(index == 0)
+                {
+                    X = value;
+                }
+                else if(index == 1)
+                {
+                    Y = value;
+                }
+                else if(index == 2)
+                {
+                    Z = value;
+                }
+                else if(index == 3)
+                {
+                    W = value;
+                }
+                else
+                {
+                    throw new IndexOutOfRangeException("You tried to set this vector at index: " + index);
+                }
             }
         }
 
@@ -1433,7 +1460,9 @@ namespace OpenTK
         public override bool Equals(object obj)
         {
             if (!(obj is Vector4))
+            {
                 return false;
+            }
 
             return this.Equals((Vector4)obj);
         }

--- a/src/OpenTK/Math/Vector4d.cs
+++ b/src/OpenTK/Math/Vector4d.cs
@@ -169,17 +169,44 @@ namespace OpenTK
         /// </summary>
         public double this[int index] {
             get{
-                if(index == 0) return X;
-                else if(index == 1) return Y;
-                else if(index == 2) return Z;
-                else if(index == 3) return W;
+                if(index == 0)
+                {
+                    return X;
+                }
+                else if(index == 1)
+                {
+                    return Y;
+                }
+                else if(index == 2)
+                {
+                    return Z;
+                }
+                else if(index == 3)
+                {
+                    return W;
+                }
                 throw new IndexOutOfRangeException("You tried to access this vector at index: " + index);
             } set{
-                if(index == 0) X = value;
-                else if(index == 1) Y = value;
-                else if(index == 2) Z = value;
-                else if(index == 3) W = value;
-                else throw new IndexOutOfRangeException("You tried to set this vector at index: " + index);
+                if(index == 0)
+                {
+                    X = value;
+                }
+                else if(index == 1)
+                {
+                    Y = value;
+                }
+                else if(index == 2)
+                {
+                    Z = value;
+                }
+                else if(index == 3)
+                {
+                    W = value;
+                }
+                else
+                {
+                    throw new IndexOutOfRangeException("You tried to set this vector at index: " + index);
+                }
             }
         }
 
@@ -1379,7 +1406,9 @@ namespace OpenTK
         public override bool Equals(object obj)
         {
             if (!(obj is Vector4d))
+            {
                 return false;
+            }
 
             return this.Equals((Vector4d)obj);
         }

--- a/src/OpenTK/MouseCursor.cs
+++ b/src/OpenTK/MouseCursor.cs
@@ -62,7 +62,9 @@ namespace OpenTK
             : base(width, height, data)
         {
             if (hotx < 0 || hotx >= Width || hoty < 0 || hoty >= Height)
+            {
                 throw new ArgumentOutOfRangeException();
+            }
 
             X = hotx;
             Y = hoty;
@@ -91,7 +93,9 @@ namespace OpenTK
             : base(width, height, data)
         {
             if (hotx < 0 || hotx >= Width || hoty < 0 || hoty >= Height)
+            {
                 throw new ArgumentOutOfRangeException();
+            }
 
             X = hotx;
             Y = hoty;

--- a/src/OpenTK/NativeWindow.cs
+++ b/src/OpenTK/NativeWindow.cs
@@ -89,11 +89,17 @@ namespace OpenTK
         {
             // TODO: Should a constraint be added for the position?
             if (width < 1)
+            {
                 throw new ArgumentOutOfRangeException("width", "Must be greater than zero.");
+            }
             if (height < 1)
+            {
                 throw new ArgumentOutOfRangeException("height", "Must be greater than zero.");
+            }
             if (mode == null)
+            {
                 throw new ArgumentNullException("mode");
+            }
 
             this.options = options;
             this.device = device;
@@ -612,7 +618,10 @@ namespace OpenTK
         /// </exception>
         protected void EnsureUndisposed()
         {
-            if (IsDisposed) throw new ObjectDisposedException(GetType().Name);
+            if (IsDisposed)
+            {
+                throw new ObjectDisposedException(GetType().Name);
+            }
         }
 
         /// <summary>
@@ -851,7 +860,10 @@ namespace OpenTK
             {
                 throw new InvalidOperationException("ProcessEvents must be called on the same thread that created the window.");
             }
-            if (!retainEvents && !events) Events = true;
+            if (!retainEvents && !events)
+            {
+                Events = true;
+            }
             implementation.ProcessEvents();
         }
 

--- a/src/OpenTK/Platform/Common/Hid.cs
+++ b/src/OpenTK/Platform/Common/Hid.cs
@@ -48,7 +48,9 @@ namespace OpenTK.Platform.Common
             int result_min, int result_max)
         {
             if (value_min >= value_max || result_min >= result_max)
+            {
                 throw new ArgumentOutOfRangeException();
+            }
             MathHelper.Clamp(value, value_min, value_max);
 
             int range = result_max - result_min;

--- a/src/OpenTK/Platform/DisplayDeviceBase.cs
+++ b/src/OpenTK/Platform/DisplayDeviceBase.cs
@@ -41,11 +41,17 @@ namespace OpenTK.Platform
         public virtual DisplayDevice GetDisplay(DisplayIndex index)
         {
             if (index == DisplayIndex.Primary)
+            {
                 return Primary;
+            }
             else if ((int)index >= 0 && (int)index < AvailableDevices.Count)
+            {
                 return AvailableDevices[(int)index];
+            }
             else
+            {
                 return null;
+            }
         }
     }
 }

--- a/src/OpenTK/Platform/Egl/Egl.cs
+++ b/src/OpenTK/Platform/Egl/Egl.cs
@@ -327,7 +327,9 @@ namespace OpenTK.Platform.Egl
         {
             IntPtr ptr = eglCreateContext(dpy, config, share_context, attrib_list);
             if (ptr == IntPtr.Zero)
+            {
                 throw new GraphicsContextException(String.Format("Failed to create EGL context, error: {0}.", Egl.GetError()));
+            }
             return ptr;
         }
 

--- a/src/OpenTK/Platform/Egl/EglContext.cs
+++ b/src/OpenTK/Platform/Egl/EglContext.cs
@@ -44,9 +44,13 @@ namespace OpenTK.Platform.Egl
             int major, int minor, GraphicsContextFlags flags)
         {
             if (mode == null)
+            {
                 throw new ArgumentNullException("mode");
+            }
             if (window == null)
+            {
                 throw new ArgumentNullException("window");
+            }
 
             EglContext shared = GetSharedEglContext(sharedContext);
 
@@ -92,7 +96,9 @@ namespace OpenTK.Platform.Egl
                     Renderable);
 
             if (!Mode.Index.HasValue)
+            {
                 throw new GraphicsModeException("Invalid or unsupported GraphicsMode.");
+            }
             IntPtr config = Mode.Index.Value;
 
             if (window.Surface == IntPtr.Zero)
@@ -118,9 +124,13 @@ namespace OpenTK.Platform.Egl
             int major, int minor, GraphicsContextFlags flags)
         {
             if (handle == ContextHandle.Zero)
+            {
                 throw new ArgumentException("handle");
+            }
             if (window == null)
+            {
                 throw new ArgumentNullException("window");
+            }
 
             Handle = handle;
         }
@@ -142,11 +152,15 @@ namespace OpenTK.Platform.Egl
             if (window != null)
             {
                 if (window is EglWindowInfo)
+                {
                     WindowInfo = (EglWindowInfo) window;
-                #if !ANDROID
+                }
+#if !ANDROID
                 else if (window is IAngleWindowInfoInternal)
+                {
                     WindowInfo = ((IAngleWindowInfoInternal) window).EglWindowInfo;
-                #endif
+                }
+#endif
 
                 if (!Egl.MakeCurrent(WindowInfo.Display, WindowInfo.Surface, WindowInfo.Surface, HandleAsEGLContext))
                 {
@@ -181,10 +195,14 @@ namespace OpenTK.Platform.Egl
                 }
 
                 if (Egl.SwapInterval(WindowInfo.Display, value))
+                {
                     swap_interval = value;
+                }
                 else
+                {
                     Debug.Print("[Warning] Egl.SwapInterval({0}, {1}) failed. Error: {2}",
                         WindowInfo.Display, value, Egl.GetError());
+                }
             }
         }
 
@@ -227,7 +245,9 @@ namespace OpenTK.Platform.Egl
                 if (manual)
                 {
                     if (IsCurrent)
+                    {
                         Egl.MakeCurrent(WindowInfo.Display, WindowInfo.Surface, WindowInfo.Surface, IntPtr.Zero);
+                    }
                     Egl.DestroyContext(WindowInfo.Display, HandleAsEGLContext);
                 }
                 IsDisposed = true;

--- a/src/OpenTK/Platform/Egl/EglWinPlatformFactory.cs
+++ b/src/OpenTK/Platform/Egl/EglWinPlatformFactory.cs
@@ -63,7 +63,9 @@ namespace OpenTK.Platform.Egl
         {
             IntPtr display = Egl.GetDisplay(dc);
             if (display == IntPtr.Zero)
+            {
                 display = Egl.GetDisplay(IntPtr.Zero);
+            }
 
             return display;
         }

--- a/src/OpenTK/Platform/Egl/EglWindowInfo.cs
+++ b/src/OpenTK/Platform/Egl/EglWindowInfo.cs
@@ -151,7 +151,9 @@ namespace OpenTK.Platform.Egl
             if (Display != IntPtr.Zero)
             {
                 if (!Egl.Terminate(Display))
+                {
                     Debug.Print("[Warning] Failed to terminate display {0}.", Display);
+                }
                 Display = IntPtr.Zero;
             }
         }

--- a/src/OpenTK/Platform/Factory.cs
+++ b/src/OpenTK/Platform/Factory.cs
@@ -46,25 +46,25 @@ namespace OpenTK.Platform
             Toolkit.Init();
 
             // Create regular platform backend
-            #if SDL2
+#if SDL2
             if (Configuration.RunningOnSdl2)
             {
                 Default = new SDL2.Sdl2Factory();
             }
 #endif
-            #if WIN32
+#if WIN32
             else if (Configuration.RunningOnWindows)
             {
                 Default = new Windows.WinFactory();
             }
 #endif
-            #if CARBON
+#if CARBON
             else if (Configuration.RunningOnMacOS)
             {
                 Default = new MacOS.MacOSFactory();
             }
 #endif
-            #if X11
+#if X11
             else if (Configuration.RunningOnX11)
             {
                 Default = new X11.X11Factory();
@@ -89,9 +89,9 @@ namespace OpenTK.Platform
                 // using the same API.
                 Embedded = Default;
             }
-            #if IPHONE
+#if IPHONE
             else if (Configuration.RunningOnIOS) Embedded = new iPhoneOS.iPhoneFactory();
-            #else
+#else
             else if (Egl.Egl.IsSupported)
             {
                 if (Configuration.RunningOnLinux)
@@ -104,21 +104,21 @@ namespace OpenTK.Platform
                     Embedded = new Egl.EglX11PlatformFactory();
                 }
 #endif
-                #if WIN32
+#if WIN32
                 else if (Configuration.RunningOnWindows)
                 {
                     Embedded = new Egl.EglWinPlatformFactory();
                 }
 #endif
-                #if CARBON
+#if CARBON
                 else if (Configuration.RunningOnMacOS)
                 {
                     Embedded = new Egl.EglMacPlatformFactory();
                 }
 #endif
-                #if ANDROID
+#if ANDROID
                 else if (Configuration.RunningOnAndroid) Embedded = new Android.AndroidFactory();
-                #endif
+#endif
                 else
                 {
                     Embedded = new UnsupportedPlatform();
@@ -126,11 +126,11 @@ namespace OpenTK.Platform
 
 #if ANDROID
                 Angle = new UnsupportedPlatform();
-                #else
+#else
                 Angle = new Egl.EglAnglePlatformFactory(Embedded);
-                #endif
+#endif
             }
-            #endif
+#endif
             else
             {
                 Embedded = new UnsupportedPlatform();

--- a/src/OpenTK/Platform/Factory.cs
+++ b/src/OpenTK/Platform/Factory.cs
@@ -47,20 +47,37 @@ namespace OpenTK.Platform
 
             // Create regular platform backend
             #if SDL2
-            if (Configuration.RunningOnSdl2) Default = new SDL2.Sdl2Factory();
-            #endif
+            if (Configuration.RunningOnSdl2)
+            {
+                Default = new SDL2.Sdl2Factory();
+            }
+#endif
             #if WIN32
-            else if (Configuration.RunningOnWindows) Default = new Windows.WinFactory();
-            #endif
+            else if (Configuration.RunningOnWindows)
+            {
+                Default = new Windows.WinFactory();
+            }
+#endif
             #if CARBON
-            else if (Configuration.RunningOnMacOS) Default = new MacOS.MacOSFactory();
-            #endif
+            else if (Configuration.RunningOnMacOS)
+            {
+                Default = new MacOS.MacOSFactory();
+            }
+#endif
             #if X11
-            else if (Configuration.RunningOnX11) Default = new X11.X11Factory();
-            else if (Configuration.RunningOnLinux) Default = new Linux.LinuxFactory();
-            #endif
+            else if (Configuration.RunningOnX11)
+            {
+                Default = new X11.X11Factory();
+            }
+            else if (Configuration.RunningOnLinux)
+            {
+                Default = new Linux.LinuxFactory();
+            }
+#endif
             if (Default == null)
+            {
                 Default = new UnsupportedPlatform();
+            }
 
             // Create embedded platform backend for EGL / OpenGL ES.
             // Todo: we could probably delay this until the embedded
@@ -77,22 +94,37 @@ namespace OpenTK.Platform
             #else
             else if (Egl.Egl.IsSupported)
             {
-                if (Configuration.RunningOnLinux) Embedded = Default;
-                #if X11
-                else if (Configuration.RunningOnX11) Embedded = new Egl.EglX11PlatformFactory();
-                #endif
+                if (Configuration.RunningOnLinux)
+                {
+                    Embedded = Default;
+                }
+#if X11
+                else if (Configuration.RunningOnX11)
+                {
+                    Embedded = new Egl.EglX11PlatformFactory();
+                }
+#endif
                 #if WIN32
-                else if (Configuration.RunningOnWindows) Embedded = new Egl.EglWinPlatformFactory();
-                #endif
+                else if (Configuration.RunningOnWindows)
+                {
+                    Embedded = new Egl.EglWinPlatformFactory();
+                }
+#endif
                 #if CARBON
-                else if (Configuration.RunningOnMacOS) Embedded = new Egl.EglMacPlatformFactory();
-                #endif
+                else if (Configuration.RunningOnMacOS)
+                {
+                    Embedded = new Egl.EglMacPlatformFactory();
+                }
+#endif
                 #if ANDROID
                 else if (Configuration.RunningOnAndroid) Embedded = new Android.AndroidFactory();
                 #endif
-                else Embedded = new UnsupportedPlatform();
+                else
+                {
+                    Embedded = new UnsupportedPlatform();
+                }
 
-                #if ANDROID
+#if ANDROID
                 Angle = new UnsupportedPlatform();
                 #else
                 Angle = new Egl.EglAnglePlatformFactory(Embedded);
@@ -106,7 +138,9 @@ namespace OpenTK.Platform
             }
 
             if (Default is UnsupportedPlatform && !(Embedded is UnsupportedPlatform))
+            {
                 Default = Embedded;
+            }
         }
 
         public static IPlatformFactory Default { get; private set; }

--- a/src/OpenTK/Platform/Linux/Bindings/LibInput.cs
+++ b/src/OpenTK/Platform/Linux/Bindings/LibInput.cs
@@ -204,7 +204,9 @@ namespace OpenTK.Platform.Linux
             CloseRestrictedCallback close_restricted)
         {
             if (open_restricted == null || close_restricted == null)
+            {
                 throw new ArgumentNullException();
+            }
 
             open = Marshal.GetFunctionPointerForDelegate(open_restricted);
             close = Marshal.GetFunctionPointerForDelegate(close_restricted);

--- a/src/OpenTK/Platform/Linux/LinuxDisplayDriver.cs
+++ b/src/OpenTK/Platform/Linux/LinuxDisplayDriver.cs
@@ -70,7 +70,9 @@ namespace OpenTK.Platform.Linux
             get
             {
                 if (Crtc == IntPtr.Zero)
+                {
                     throw new InvalidOperationException();
+                }
 
                 unsafe
                 {
@@ -325,11 +327,15 @@ namespace OpenTK.Platform.Linux
             // Find corresponding encoder
             ModeEncoder* encoder = GetEncoder(fd, c);
             if (encoder == null)
+            {
                 return false;
+            }
 
             ModeCrtc* crtc = GetCrtc(fd, encoder);
             if (crtc == null)
+            {
                 return false;
+            }
 
             display = new LinuxDisplay(fd, (IntPtr)c, (IntPtr)encoder, (IntPtr)crtc);
             return true;

--- a/src/OpenTK/Platform/Linux/LinuxGraphicsContext.cs
+++ b/src/OpenTK/Platform/Linux/LinuxGraphicsContext.cs
@@ -54,7 +54,9 @@ namespace OpenTK.Platform.Linux
             : base(mode, window, sharedContext, major, minor, flags)
         {
             if (mode.Buffers < 1)
+            {
                 throw new ArgumentException();
+            }
             fd = window.FD;
 
             PageFlip = HandlePageFlip;
@@ -127,15 +129,23 @@ namespace OpenTK.Platform.Linux
             {
                 fds.revents = 0;
                 if (Libc.poll(ref fds, 1, timeout) < 0)
+                {
                     break;
+                }
 
                 if ((fds.revents & (PollFlags.Hup | PollFlags.Error)) != 0)
+                {
                     break;
+                }
 
                 if ((fds.revents & PollFlags.In) != 0)
+                {
                     Drm.HandleEvent(fd, ref evctx);
+                }
                 else
+                {
                     break;
+                }
             }
 
             // Page flip has taken place, update buffer objects
@@ -151,7 +161,9 @@ namespace OpenTK.Platform.Linux
         {
             LinuxWindowInfo wnd = WindowInfo as LinuxWindowInfo;
             if (wnd == null)
+            {
                 throw new InvalidOperationException();
+            }
 
             unsafe
             {
@@ -171,7 +183,9 @@ namespace OpenTK.Platform.Linux
         {
             LinuxWindowInfo wnd = WindowInfo as LinuxWindowInfo;
             if (wnd == null)
+            {
                 throw new InvalidOperationException();
+            }
 
             unsafe
             {
@@ -202,7 +216,9 @@ namespace OpenTK.Platform.Linux
         private int GetFramebuffer(BufferObject bo)
         {
             if (bo == BufferObject.Zero)
+            {
                 goto fail;
+            }
 
             int bo_handle = bo.Handle;
             if (bo_handle == 0)

--- a/src/OpenTK/Platform/Linux/LinuxJoystick.cs
+++ b/src/OpenTK/Platform/Linux/LinuxJoystick.cs
@@ -267,7 +267,9 @@ namespace OpenTK.Platform.Linux
                 {
                     fd = Libc.open(path, OpenFlags.NonBlock);
                     if (fd == -1)
+                    {
                         return null;
+                    }
 
                     unsafe
                     {
@@ -364,7 +366,9 @@ namespace OpenTK.Platform.Linux
                 {
                     length = (long)Libc.read(js.FileDescriptor, (void*)events, (UIntPtr)(sizeof(InputEvent) * EventCount));
                     if (length <= 0)
+                    {
                         break;
+                    }
 
                     // Only mark the joystick as connected when we actually start receiving events.
                     // Otherwise, the Xbox wireless receiver will register 4 joysticks even if no

--- a/src/OpenTK/Platform/Linux/LinuxNativeWindow.cs
+++ b/src/OpenTK/Platform/Linux/LinuxNativeWindow.cs
@@ -175,7 +175,9 @@ namespace OpenTK.Platform.Linux
             else
             {
                 if (cursor_custom != BufferObject.Zero)
+                {
                     cursor_custom.Dispose();
+                }
                 cursor_custom = CreateCursor(window.BufferManager, cursor);
                 bo = cursor_custom;
             }
@@ -203,7 +205,9 @@ namespace OpenTK.Platform.Linux
             Egl.GetConfigAttrib(display, mode.Index.Value,
                 Egl.NATIVE_VISUAL_ID, out format);
             if ((SurfaceFormat)format != 0)
+            {
                 return (SurfaceFormat)format;
+            }
 
             Debug.Print("[KMS] Failed to retrieve EGL visual from GBM surface. Error: {0}",
                 Egl.GetError());
@@ -215,23 +219,41 @@ namespace OpenTK.Platform.Linux
             int a = mode.ColorFormat.Alpha;
 
             if (mode.ColorFormat.IsIndexed)
+            {
                 return SurfaceFormat.C8;
+            }
             if (r == 3 && g == 3 && b == 2 && a == 0)
+            {
                 return SurfaceFormat.RGB332;
+            }
             if (r == 5 && g == 6 && b == 5 && a == 0)
+            {
                 return SurfaceFormat.RGB565;
+            }
             if (r == 5 && g == 6 && b == 5 && a == 0)
+            {
                 return SurfaceFormat.RGB565;
+            }
             if (r == 8 && g == 8 && b == 8 && a == 0)
+            {
                 return SurfaceFormat.RGB888;
+            }
             if (r == 5 && g == 5 && b == 5 && a == 1)
+            {
                 return SurfaceFormat.RGBA5551;
+            }
             if (r == 10 && g == 10 && b == 10 && a == 2)
+            {
                 return SurfaceFormat.RGBA1010102;
+            }
             if (r == 4 && g == 4 && b == 4 && a == 4)
+            {
                 return SurfaceFormat.RGBA4444;
+            }
             if (r == 8 && g == 8 && b == 8 && a == 8)
+            {
                 return SurfaceFormat.RGBA8888;
+            }
 
             return SurfaceFormat.RGBA8888;
         }

--- a/src/OpenTK/Platform/Linux/LinuxWindowInfo.cs
+++ b/src/OpenTK/Platform/Linux/LinuxWindowInfo.cs
@@ -41,7 +41,9 @@ namespace OpenTK.Platform.Linux
             : base(IntPtr.Zero, display, IntPtr.Zero)
         {
             if (display_device == null)
+            {
                 throw new ArgumentNullException();
+            }
 
             FD = fd;
             BufferManager = gbm;

--- a/src/OpenTK/Platform/MacOS/CarbonWindowInfo.cs
+++ b/src/OpenTK/Platform/MacOS/CarbonWindowInfo.cs
@@ -96,7 +96,9 @@ namespace OpenTK.Platform.MacOS
         private void Dispose(bool disposing)
         {
             if (disposed)
+            {
                 return;
+            }
 
             if (disposing)
             {

--- a/src/OpenTK/Platform/MacOS/Cocoa/Cocoa.cs
+++ b/src/OpenTK/Platform/MacOS/Cocoa/Cocoa.cs
@@ -212,7 +212,9 @@ namespace OpenTK.Platform.MacOS
         public static IntPtr ToNSString(string str)
         {
             if (str == null)
+            {
                 return IntPtr.Zero;
+            }
 
             unsafe
             {
@@ -255,11 +257,15 @@ namespace OpenTK.Platform.MacOS
         {
             var indirect = NS.GetSymbol(handle, symbol);
             if (indirect == IntPtr.Zero)
+            {
                 return IntPtr.Zero;
+            }
 
             var actual = Marshal.ReadIntPtr(indirect);
             if (actual == IntPtr.Zero)
+            {
                 return IntPtr.Zero;
+            }
 
             return actual;
         }

--- a/src/OpenTK/Platform/MacOS/CocoaContext.cs
+++ b/src/OpenTK/Platform/MacOS/CocoaContext.cs
@@ -67,7 +67,9 @@ namespace OpenTK
             cocoaWindow = (CocoaWindowInfo)window;
 
             if (shareContext is CocoaContext)
+            {
                 shareContextRef = ((CocoaContext)shareContext).Handle.Handle;
+            }
 
             if (shareContext is GraphicsContext)
             {
@@ -86,9 +88,13 @@ namespace OpenTK
         public CocoaContext(ContextHandle handle, IWindowInfo window, IGraphicsContext shareContext, int majorVersion, int minorVersion)
         {
             if (handle == ContextHandle.Zero)
+            {
                 throw new ArgumentException("handle");
+            }
             if (window == null)
+            {
                 throw new ArgumentNullException("window");
+            }
 
             Handle = handle;
             cocoaWindow = (CocoaWindowInfo)window;
@@ -210,7 +216,9 @@ namespace OpenTK
 
             Debug.Write("Attribute array:  ");
             for (int i = 0; i < attributes.Count; i++)
+            {
                 Debug.Write(attributes[i].ToString() + "  ");
+            }
             Debug.WriteLine("");
 
             // Create pixel format
@@ -326,15 +334,21 @@ namespace OpenTK
         protected override void Dispose(bool disposing)
         {
             if (IsDisposed || Handle.Handle == IntPtr.Zero)
+            {
                 return;
+            }
 
             Debug.Print("Disposing of Cocoa context.");
 
             if (!NSApplication.IsUIThread)
+            {
                 return;
+            }
 
             if (IsCurrent)
+            {
                 Cocoa.SendVoid(NSOpenGLContext, Selector.Get("clearCurrentContext"));
+            }
             Cocoa.SendVoid(Handle.Handle, Selector.Get("clearDrawable"));
             Cocoa.SendVoid(Handle.Handle, Selector.Get("release"));
 

--- a/src/OpenTK/Platform/MacOS/CocoaNativeWindow.cs
+++ b/src/OpenTK/Platform/MacOS/CocoaNativeWindow.cs
@@ -393,7 +393,9 @@ namespace OpenTK.Platform.MacOS
             }
 
             if (suppressResize == 0)
+            {
                 OnResize(EventArgs.Empty);
+            }
         }
 
         private void ApplicationQuit(object sender, CancelEventArgs e)
@@ -590,19 +592,39 @@ namespace OpenTK.Platform.MacOS
         private KeyModifiers GetModifiers(NSEventModifierMask mask)
         {
             OpenTK.Input.KeyModifiers modifiers = 0;
-            if ((mask & NSEventModifierMask.ControlKeyMask) != 0) modifiers |= OpenTK.Input.KeyModifiers.Control;
-            if ((mask & NSEventModifierMask.ShiftKeyMask) != 0) modifiers |= OpenTK.Input.KeyModifiers.Shift;
-            if ((mask & NSEventModifierMask.AlternateKeyMask) != 0) modifiers |= OpenTK.Input.KeyModifiers.Alt;
+            if ((mask & NSEventModifierMask.ControlKeyMask) != 0)
+            {
+                modifiers |= OpenTK.Input.KeyModifiers.Control;
+            }
+            if ((mask & NSEventModifierMask.ShiftKeyMask) != 0)
+            {
+                modifiers |= OpenTK.Input.KeyModifiers.Shift;
+            }
+            if ((mask & NSEventModifierMask.AlternateKeyMask) != 0)
+            {
+                modifiers |= OpenTK.Input.KeyModifiers.Alt;
+            }
             return modifiers;
         }
 
         private MouseButton GetMouseButton(int cocoaButtonIndex)
         {
-            if (cocoaButtonIndex == 0) return MouseButton.Left;
-            if (cocoaButtonIndex == 1) return MouseButton.Right;
-            if (cocoaButtonIndex == 2) return MouseButton.Middle;
+            if (cocoaButtonIndex == 0)
+            {
+                return MouseButton.Left;
+            }
+            if (cocoaButtonIndex == 1)
+            {
+                return MouseButton.Right;
+            }
+            if (cocoaButtonIndex == 2)
+            {
+                return MouseButton.Middle;
+            }
             if (cocoaButtonIndex >= (int)MouseButton.LastButton)
+            {
                 return MouseButton.LastButton;
+            }
 
             return (MouseButton)cocoaButtonIndex;
         }
@@ -616,7 +638,9 @@ namespace OpenTK.Platform.MacOS
                 var e = Cocoa.SendIntPtr(NSApplication.Handle, selNextEventMatchingMask, uint.MaxValue, IntPtr.Zero, NSDefaultRunLoopMode, true);
 
                 if (e == IntPtr.Zero)
+                {
                     break;
+                }
 
                 var type = (NSEventType)Cocoa.SendInt(e, selType);
                 switch (type)
@@ -953,7 +977,9 @@ namespace OpenTK.Platform.MacOS
             {
                 var oldState = windowState;
                 if (oldState == value)
+                {
                     return;
+                }
 
                 RestoreWindowState();
 
@@ -1011,7 +1037,9 @@ namespace OpenTK.Platform.MacOS
                 }
 
                 if (windowBorder == value)
+                {
                     return;
+                }
 
                 SetWindowBorder(value);
                 OnWindowBorderChanged(EventArgs.Empty);
@@ -1225,12 +1253,16 @@ namespace OpenTK.Platform.MacOS
         protected override void Dispose(bool disposing)
         {
             if (disposed)
+            {
                 return;
+            }
 
             Debug.Print("Disposing of CocoaNativeWindow (disposing={0}).", disposing);
 
             if (!NSApplication.IsUIThread)
+            {
                 return;
+            }
 
             NSApplication.Quit -= ApplicationQuit;
 
@@ -1351,7 +1383,9 @@ namespace OpenTK.Platform.MacOS
         private void CloseWindow(bool shutdown)
         {
             if (!Exists)
+            {
                 return;
+            }
 
             exists = false;
 

--- a/src/OpenTK/Platform/MacOS/CocoaWindowInfo.cs
+++ b/src/OpenTK/Platform/MacOS/CocoaWindowInfo.cs
@@ -89,7 +89,9 @@ namespace OpenTK.Platform.MacOS
         private void Dispose(bool disposing)
         {
             if (disposed)
+            {
                 return;
+            }
 
             if (disposing)
             {

--- a/src/OpenTK/Platform/MacOS/HIDInput.cs
+++ b/src/OpenTK/Platform/MacOS/HIDInput.cs
@@ -189,7 +189,9 @@ namespace OpenTK.Platform.MacOS
 
             RunLoop = CF.CFRunLoopGetMain();
             if (RunLoop == IntPtr.Zero)
+            {
                 RunLoop = CF.CFRunLoopGetCurrent();
+            }
             if (RunLoop == IntPtr.Zero)
             {
                 Debug.Print("[Error] No CFRunLoop found for {0}", GetType().FullName);

--- a/src/OpenTK/Platform/MacOS/NS.cs
+++ b/src/OpenTK/Platform/MacOS/NS.cs
@@ -138,7 +138,9 @@ namespace OpenTK.Platform.MacOS
             {
                 symbol = LookupAndBindSymbol(function);
                 if (symbol != IntPtr.Zero)
+                {
                     symbol = AddressOfSymbol(symbol);
+                }
             }
             return symbol;
         }

--- a/src/OpenTK/Platform/MacOS/Quartz/CoreFoundation.cs
+++ b/src/OpenTK/Platform/MacOS/Quartz/CoreFoundation.cs
@@ -57,7 +57,9 @@ namespace OpenTK.Platform.MacOS.Carbon
             get
             {
                 if (index >= Count || index < 0)
+                {
                     throw new IndexOutOfRangeException();
+                }
 
                 return CF.CFArrayGetValueAtIndex(Ref, index);
             }

--- a/src/OpenTK/Platform/MacOS/QuartzDisplayDeviceDriver.cs
+++ b/src/OpenTK/Platform/MacOS/QuartzDisplayDeviceDriver.cs
@@ -103,8 +103,9 @@ namespace OpenTK.Platform.MacOS
                         opentk_dev_available_res.Add(thisRes);
 
                         if (current)
+                        {
                             opentk_dev_current_res = thisRes;
-
+                        }
                     }
 
                     NSRect bounds = CG.DisplayBounds(currentDisplay);
@@ -118,7 +119,9 @@ namespace OpenTK.Platform.MacOS
                     AvailableDevices.Add(opentk_dev);
 
                     if (primary)
+                    {
                         Primary = opentk_dev;
+                    }
                 }
 
                 Debug.Unindent();

--- a/src/OpenTK/Platform/SDL2/Sdl2.cs
+++ b/src/OpenTK/Platform/SDL2/Sdl2.cs
@@ -395,9 +395,13 @@ namespace OpenTK.Platform.SDL2
         public static int PeepEvents(Event[] e, int count, EventAction action, EventType min, EventType max)
         {
             if (e == null)
+            {
                 throw new ArgumentNullException();
+            }
             if (count <= 0 || count > e.Length)
+            {
                 throw new ArgumentOutOfRangeException();
+            }
 
             unsafe
             {

--- a/src/OpenTK/Platform/SDL2/Sdl2DisplayDeviceDriver.cs
+++ b/src/OpenTK/Platform/SDL2/Sdl2DisplayDeviceDriver.cs
@@ -69,7 +69,9 @@ namespace OpenTK.Platform.SDL2
 
                 AvailableDevices.Add(device);
                 if (d == 0)
+                {
                     Primary = device;
+                }
             }
         }
 

--- a/src/OpenTK/Platform/SDL2/Sdl2Factory.cs
+++ b/src/OpenTK/Platform/SDL2/Sdl2Factory.cs
@@ -120,7 +120,9 @@ namespace OpenTK.Platform.SDL2
                 {
                     // Check again inside the lock
                     if (inputDriver == null)
+                    {
                         inputDriver = new Sdl2InputDriver();
+                    }
                 }
             }
 

--- a/src/OpenTK/Platform/SDL2/Sdl2JoystickDriver.cs
+++ b/src/OpenTK/Platform/SDL2/Sdl2JoystickDriver.cs
@@ -126,28 +126,44 @@ namespace OpenTK.Platform.SDL2
         private OpenTK.Input.HatPosition TranslateHat(HatPosition value)
         {
             if ((value & HatPosition.LeftUp) == HatPosition.LeftUp)
+            {
                 return OpenTK.Input.HatPosition.UpLeft;
+            }
 
             if ((value & HatPosition.RightUp) == HatPosition.RightUp)
+            {
                 return OpenTK.Input.HatPosition.UpRight;
+            }
 
             if ((value & HatPosition.LeftDown) == HatPosition.LeftDown)
+            {
                 return OpenTK.Input.HatPosition.DownLeft;
+            }
 
             if ((value & HatPosition.RightDown) == HatPosition.RightDown)
+            {
                 return OpenTK.Input.HatPosition.DownRight;
+            }
 
             if ((value & HatPosition.Up) == HatPosition.Up)
+            {
                 return OpenTK.Input.HatPosition.Up;
+            }
 
             if ((value & HatPosition.Right) == HatPosition.Right)
+            {
                 return OpenTK.Input.HatPosition.Right;
+            }
 
             if ((value & HatPosition.Down) == HatPosition.Down)
+            {
                 return OpenTK.Input.HatPosition.Down;
+            }
 
             if ((value & HatPosition.Left) == HatPosition.Left)
+            {
                 return OpenTK.Input.HatPosition.Left;
+            }
 
             return OpenTK.Input.HatPosition.Centered;
         }

--- a/src/OpenTK/Platform/SDL2/Sdl2Keyboard.cs
+++ b/src/OpenTK/Platform/SDL2/Sdl2Keyboard.cs
@@ -86,9 +86,13 @@ namespace OpenTK.Platform.SDL2
         {
             //UpdateModifiers(); // Fixme
             if (index == 0)
+            {
                 return state;
+            }
             else
+            {
                 return new KeyboardState();
+            }
         }
 
         public string GetDeviceName(int index)

--- a/src/OpenTK/Platform/SDL2/Sdl2Mouse.cs
+++ b/src/OpenTK/Platform/SDL2/Sdl2Mouse.cs
@@ -112,9 +112,13 @@ namespace OpenTK.Platform.SDL2
         public MouseState GetState(int index)
         {
             if (index == 0)
+            {
                 return GetState();
+            }
             else
+            {
                 return new MouseState();
+            }
         }
 
         public MouseState GetCursorState()

--- a/src/OpenTK/Platform/SDL2/Sdl2NativeWindow.cs
+++ b/src/OpenTK/Platform/SDL2/Sdl2NativeWindow.cs
@@ -86,10 +86,14 @@ namespace OpenTK.Platform.SDL2
 
                 if ((flags & WindowFlags.FULLSCREEN_DESKTOP) != 0 ||
                     (flags & WindowFlags.FULLSCREEN) != 0)
+                {
                     window_state = WindowState.Fullscreen;
+                }
 
                 if ((flags & WindowFlags.RESIZABLE) == 0)
+                {
                     window_border = WindowBorder.Fixed;
+                }
 
                 IntPtr handle;
                 lock (SDL.Sync)
@@ -111,13 +115,19 @@ namespace OpenTK.Platform.SDL2
             if ((flags & GameWindowFlags.Fullscreen) != 0)
             {
                 if (Sdl2Factory.UseFullscreenDesktop)
+                {
                     windowFlags |= WindowFlags.FULLSCREEN_DESKTOP;
+                }
                 else
+                {
                     windowFlags |= WindowFlags.FULLSCREEN;
+                }
             }
 
             if ((flags & GameWindowFlags.FixedWindow) == 0)
+            {
                 windowFlags |= WindowFlags.RESIZABLE;
+            }
 
             return windowFlags;
         }
@@ -257,7 +267,9 @@ namespace OpenTK.Platform.SDL2
             // Calculate the length of the typed text string
             int length;
             for (length = 0; length < TextInputEvent.TextSize && ev.Text[length] != '\0'; length++)
+            {
                 ;
+            }
 
             // Make sure we have enough space to decode this string
             int decoded_length = Encoding.UTF8.GetCharCount(ev.Text, length);
@@ -693,9 +705,13 @@ namespace OpenTK.Platform.SDL2
                     if (Exists)
                     {
                         if (value)
+                        {
                             SDL.ShowWindow(window.Handle);
+                        }
                         else
+                        {
                             SDL.HideWindow(window.Handle);
+                        }
                     }
                 }
             }
@@ -768,7 +784,9 @@ namespace OpenTK.Platform.SDL2
                             }
 
                             if (!CursorVisible)
+                            {
                                 GrabCursor(true);
+                            }
                         }
                     }
                 }

--- a/src/OpenTK/Platform/Utilities.cs
+++ b/src/OpenTK/Platform/Utilities.cs
@@ -76,15 +76,21 @@ namespace OpenTK.Platform
             int supported = 0;
             Type extensions_class = type.GetNestedType("Delegates", BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public);
             if (extensions_class == null)
+            {
                 throw new InvalidOperationException("The specified type does not have any loadable extensions.");
+            }
 
             FieldInfo[] delegates = extensions_class.GetFields(BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public);
             if (delegates == null)
+            {
                 throw new InvalidOperationException("The specified type does not have any loadable extensions.");
+            }
 
             MethodInfo load_delegate_method_info = type.GetMethod("LoadDelegate", BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public);
             if (load_delegate_method_info == null)
+            {
                 throw new InvalidOperationException(type.ToString() + " does not contain a static LoadDelegate method.");
+            }
             LoadDelegateFunction LoadDelegate = (LoadDelegateFunction)Delegate.CreateDelegate(
                 typeof(LoadDelegateFunction), load_delegate_method_info);
 
@@ -98,14 +104,18 @@ namespace OpenTK.Platform
             {
                 Delegate d = LoadDelegate(f.Name, f.FieldType);
                 if (d != null)
+                {
                     ++supported;
+                }
 
                 f.SetValue(null, d);
             }
 
             FieldInfo rebuildExtensionList = type.GetField("rebuildExtensionList", BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public);
             if (rebuildExtensionList != null)
+            {
                 rebuildExtensionList.SetValue(null, true);
+            }
 
             time.Stop();
             Debug.Print("{0} extensions loaded in {1} ms.", supported, time.ElapsedMilliseconds);
@@ -157,7 +167,9 @@ namespace OpenTK.Platform
                 f.SetValue(null, @new);
                 FieldInfo rebuildExtensionList = type.GetField("rebuildExtensionList", BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public);
                 if (rebuildExtensionList != null)
+                {
                     rebuildExtensionList.SetValue(null, true);
+                }
             }
             return @new != null;
         }

--- a/src/OpenTK/Platform/Windows/API.cs
+++ b/src/OpenTK/Platform/Windows/API.cs
@@ -462,9 +462,6 @@ namespace OpenTK.Platform.Windows
         [DllImport("user32.dll")]
         internal static extern IntPtr GetDC(IntPtr hwnd);
 
-        [DllImport("user32.dll")]
-        internal static extern IntPtr GetWindowDC(IntPtr hwnd);
-
         /// <summary>
         ///
         /// </summary>

--- a/src/OpenTK/Platform/Windows/API.cs
+++ b/src/OpenTK/Platform/Windows/API.cs
@@ -265,15 +265,21 @@ namespace OpenTK.Platform.Windows
             SetLastError(0);
 
             if (IntPtr.Size == 4)
+            {
                 retval = new IntPtr(SetWindowLongInternal(handle, item, newValue.ToInt32()));
+            }
             else
+            {
                 retval = SetWindowLongPtrInternal(handle, item, newValue);
+            }
 
             if (retval == IntPtr.Zero)
             {
                 int error = Marshal.GetLastWin32Error();
                 if (error != 0)
+                {
                     throw new PlatformException(String.Format("Failed to modify window border. Error: {0}", error));
+                }
             }
 
             return retval;
@@ -305,7 +311,9 @@ namespace OpenTK.Platform.Windows
         internal static UIntPtr GetWindowLong(IntPtr handle, GetWindowLongOffsets index)
         {
             if (IntPtr.Size == 4)
+            {
                 return (UIntPtr)GetWindowLongInternal(handle, index);
+            }
 
             return GetWindowLongPtrInternal(handle, index);
         }
@@ -2398,7 +2406,9 @@ namespace OpenTK.Platform.Windows
             get
             {
                 if (index < 0 || index > Size * Count)
+                {
                     throw new ArgumentOutOfRangeException("index");
+                }
                 unsafe
                 {
                     fixed (byte* data = &RawData)

--- a/src/OpenTK/Platform/Windows/WinDisplayDevice.cs
+++ b/src/OpenTK/Platform/Windows/WinDisplayDevice.cs
@@ -95,7 +95,9 @@ namespace OpenTK.Platform.Windows
                 while (Functions.EnumDisplayDevices(null, device_count++, dev1, 0))
                 {
                     if ((dev1.StateFlags & DisplayDeviceStateFlags.AttachedToDesktop) == DisplayDeviceStateFlags.None)
+                    {
                         continue;
+                    }
 
                     DeviceMode monitor_mode = new DeviceMode();
 
@@ -145,13 +147,19 @@ namespace OpenTK.Platform.Windows
 
                     // Set the original resolution if the DisplayDevice was previously available.
                     foreach (DisplayDevice existingDevice in previousDevices)
+                    {
                         if ((string)existingDevice.Id == (string)opentk_dev.Id)
+                        {
                             opentk_dev.OriginalResolution = existingDevice.OriginalResolution;
+                        }
+                    }
 
                     AvailableDevices.Add(opentk_dev);
 
                     if (opentk_dev_primary)
+                    {
                         Primary = opentk_dev;
+                    }
 
                     Debug.Print("DisplayDevice {0} ({1}) supports {2} resolutions.",
                         device_count, opentk_dev.IsPrimary ? "primary" : "secondary", opentk_dev.AvailableResolutions.Count);

--- a/src/OpenTK/Platform/Windows/WinGLContext.cs
+++ b/src/OpenTK/Platform/Windows/WinGLContext.cs
@@ -41,7 +41,9 @@ namespace OpenTK.Platform.Windows
                 Debug.WriteLine("[WGL] Creating temporary context to load extensions");
 
                 if (native == null)
+                {
                     throw new ArgumentNullException();
+                }
 
                 // Create temporary context and load WGL entry points
                 // First, set a compatible pixel format to the device context
@@ -102,9 +104,13 @@ namespace OpenTK.Platform.Windows
             lock (LoadLock)
             {
                 if (window == null)
+                {
                     throw new ArgumentNullException("window", "Must point to a valid window.");
+                }
                 if (window.Handle == IntPtr.Zero)
+                {
                     throw new ArgumentException("window", "Must be a valid window.");
+                }
 
                 IntPtr current_context = Wgl.GetCurrentContext();
                 INativeWindow temp_window = null;
@@ -160,7 +166,9 @@ namespace OpenTK.Platform.Windows
                                     sharedContext != null ? (sharedContext as IGraphicsContextInternal).Context.Handle : IntPtr.Zero,
                                     attributes.ToArray()));
                             if (Handle == ContextHandle.Zero)
+                            {
                                 Debug.Print("failed. (Error: {0})", Marshal.GetLastWin32Error());
+                            }
                         }
                         catch (Exception e) { Debug.Print(e.ToString()); }
                     }
@@ -171,11 +179,15 @@ namespace OpenTK.Platform.Windows
                         Debug.Write("Falling back to GL2... ");
                         Handle = new ContextHandle(Wgl.CreateContext(window.DeviceContext));
                         if (Handle == ContextHandle.Zero)
+                        {
                             Handle = new ContextHandle(Wgl.CreateContext(window.DeviceContext));
+                        }
                         if (Handle == ContextHandle.Zero)
+                        {
                             throw new GraphicsContextException(
                                 String.Format("Context creation failed. Wgl.CreateContext() error: {0}.",
                                     Marshal.GetLastWin32Error()));
+                        }
                     }
 
                     Debug.WriteLine(String.Format("success! (id: {0})", Handle));
@@ -234,9 +246,13 @@ namespace OpenTK.Platform.Windows
             int major, int minor, GraphicsContextFlags flags)
         {
             if (handle == ContextHandle.Zero)
+            {
                 throw new ArgumentException("handle");
+            }
             if (window == null)
+            {
                 throw new ArgumentNullException("window");
+            }
 
             Handle = handle;
         }
@@ -244,8 +260,10 @@ namespace OpenTK.Platform.Windows
         public override void SwapBuffers()
         {
             if (!Functions.SwapBuffers(DeviceContext))
+            {
                 throw new GraphicsContextException(String.Format(
                     "Failed to swap buffers for context {0} current. Error: {1}", this, Marshal.GetLastWin32Error()));
+            }
         }
 
         public override void MakeCurrent(IWindowInfo window)
@@ -258,7 +276,9 @@ namespace OpenTK.Platform.Windows
                 if (wnd != null)
                 {
                     if (wnd.Handle == IntPtr.Zero)
+                    {
                         throw new ArgumentException("window", "Must point to a valid window.");
+                    }
 
                     success = Wgl.MakeCurrent(wnd.DeviceContext, Handle.Handle);
                     DeviceContext = wnd.DeviceContext;
@@ -289,9 +309,13 @@ namespace OpenTK.Platform.Windows
                 lock (LoadLock)
                 {
                     if (vsync_supported)
+                    {
                         return Wgl.Ext.GetSwapInterval();
+                    }
                     else
+                    {
                         return 0;
+                    }
                 }
             }
             set
@@ -359,7 +383,9 @@ namespace OpenTK.Platform.Windows
         {
             Debug.Write("Setting pixel format... ");
             if (window == null)
+            {
                 throw new ArgumentNullException("window", "Must point to a valid window.");
+            }
 
             if (!mode.Index.HasValue)
             {
@@ -415,8 +441,10 @@ namespace OpenTK.Platform.Windows
                 {
                     // This will fail if the user calls Dispose() on thread X when the context is current on thread Y.
                     if (!Wgl.DeleteContext(Handle.Handle))
+                    {
                         Debug.Print("Failed to destroy OpenGL context {0}. Error: {1}",
                             Handle.ToString(), Marshal.GetLastWin32Error());
+                    }
                 }
                 catch (AccessViolationException e)
                 {

--- a/src/OpenTK/Platform/Windows/WinGLNative.cs
+++ b/src/OpenTK/Platform/Windows/WinGLNative.cs
@@ -213,12 +213,18 @@ namespace OpenTK.Platform.Windows
             // wParam: The low-order word specifies whether the window is being activated or deactivated.
             bool new_focused_state = Focused;
             if (IntPtr.Size == 4)
+            {
                 focused = (wParam.ToInt32() & 0xFFFF) != 0;
+            }
             else
+            {
                 focused = (wParam.ToInt64() & 0xFFFF) != 0;
+            }
 
             if (new_focused_state != Focused)
+            {
                 OnFocusedChanged(EventArgs.Empty);
+            }
         }
 
         private void HandleEnterModalLoop(IntPtr handle, WindowMessage message, IntPtr wParam, IntPtr lParam)
@@ -230,7 +236,9 @@ namespace OpenTK.Platform.Windows
             StartTimer(handle);
 
             if (!CursorVisible)
+            {
                 UngrabCursor();
+            }
         }
 
         private void HandleExitModalLoop(IntPtr handle, WindowMessage message, IntPtr wParam, IntPtr lParam)
@@ -242,7 +250,9 @@ namespace OpenTK.Platform.Windows
 
             // Ensure cursor remains grabbed
             if (!CursorVisible)
+            {
                 GrabCursor();
+            }
         }
 
         private void HandleWindowPositionChanged(IntPtr handle, WindowMessage message, IntPtr wParam, IntPtr lParam)
@@ -274,7 +284,9 @@ namespace OpenTK.Platform.Windows
                             SetWindowPosFlags.NOACTIVATE | SetWindowPosFlags.NOSENDCHANGING);
 
                         if (suppress_resize <= 0)
+                        {
                             OnResize(EventArgs.Empty);
+                        }
                     }
 
                     if (!is_in_modal_loop)
@@ -283,7 +295,9 @@ namespace OpenTK.Platform.Windows
                         // handled inside [ENTER|EXIT]SIZEMOVE case above.
                         // If not, then we have to handle cursor grabbing here.
                         if (!CursorVisible)
+                        {
                             GrabCursor();
+                        }
                     }
                 }
             }
@@ -301,11 +315,17 @@ namespace OpenTK.Platform.Windows
                 {
                     WindowStyle style = ((StyleStruct*)lParam)->New;
                     if ((style & WindowStyle.Popup) != 0)
+                    {
                         new_border = WindowBorder.Hidden;
+                    }
                     else if ((style & WindowStyle.ThickFrame) != 0)
+                    {
                         new_border = WindowBorder.Resizable;
+                    }
                     else if ((style & ~(WindowStyle.ThickFrame | WindowStyle.MaximizeBox)) != 0)
+                    {
                         new_border = WindowBorder.Fixed;
+                    }
                 }
             }
 
@@ -313,7 +333,9 @@ namespace OpenTK.Platform.Windows
             {
                 // Ensure cursor remains grabbed
                 if (!CursorVisible)
+                {
                     GrabCursor();
+                }
 
                 windowBorder = new_border;
                 OnWindowBorderChanged(EventArgs.Empty);
@@ -348,7 +370,9 @@ namespace OpenTK.Platform.Windows
 
                 // Ensure cursor remains grabbed
                 if (!CursorVisible)
+                {
                     GrabCursor();
+                }
             }
         }
 
@@ -381,9 +405,13 @@ namespace OpenTK.Platform.Windows
         {
             char c;
             if (IntPtr.Size == 4)
+            {
                 c = (char)wParam.ToInt32();
+            }
             else
+            {
                 c = (char)wParam.ToInt64();
+            }
 
             if (!Char.IsControl(c))
             {
@@ -474,11 +502,15 @@ namespace OpenTK.Platform.Windows
                     for (i = 0; i < points; ++i)
                     {
                         if (movePoints[i].Time < mouse_last_timestamp)
+                        {
                             break;
+                        }
                         if (movePoints[i].Time == mouse_last_timestamp &&
                             movePoints[i].X == currentScreenPosition.X &&
                             movePoints[i].Y == currentScreenPosition.Y)
+                        {
                             break;
+                        }
                     }
 
                     // Now move the mouse to each point before the one just found.
@@ -850,8 +882,10 @@ namespace OpenTK.Platform.Windows
             me.Flags = TrackMouseEventFlags.LEAVE;
 
             if (!Functions.TrackMouseEvent(ref me))
+            {
                 Debug.Print("[Warning] Failed to enable mouse tracking, error: {0}.",
                     Marshal.GetLastWin32Error());
+            }
         }
 
         private void StartTimer(IntPtr handle)
@@ -860,8 +894,10 @@ namespace OpenTK.Platform.Windows
             {
                 timer_handle = Functions.SetTimer(handle, new UIntPtr(1), ModalLoopTimerPeriod, null);
                 if (timer_handle == UIntPtr.Zero)
+                {
                     Debug.Print("[Warning] Failed to set modal loop timer callback ({0}:{1}->{2}).",
                         GetType().Name, handle, Marshal.GetLastWin32Error());
+                }
             }
         }
 
@@ -870,8 +906,10 @@ namespace OpenTK.Platform.Windows
             if (timer_handle != UIntPtr.Zero)
             {
                 if (!Functions.KillTimer(handle, timer_handle))
+                {
                     Debug.Print("[Warning] Failed to kill modal loop timer callback ({0}:{1}->{2}).",
                         GetType().Name, handle, Marshal.GetLastWin32Error());
+                }
                 timer_handle = UIntPtr.Zero;
             }
         }
@@ -918,7 +956,9 @@ namespace OpenTK.Platform.Windows
                 ushort atom = Functions.RegisterClassEx(ref wc);
 
                 if (atom == 0)
+                {
                     throw new PlatformException(String.Format("Failed to register window class. Error: {0}", Marshal.GetLastWin32Error()));
+                }
 
                 class_registered = true;
             }
@@ -930,7 +970,9 @@ namespace OpenTK.Platform.Windows
                 parentHandle, IntPtr.Zero, Instance, IntPtr.Zero);
 
             if (handle == IntPtr.Zero)
+            {
                 throw new PlatformException(String.Format("Failed to create window. Error: {0}", Marshal.GetLastWin32Error()));
+            }
 
             return handle;
         }
@@ -982,15 +1024,19 @@ namespace OpenTK.Platform.Windows
             rect.top = pos.Y;
             rect.bottom = pos.Y + ClientRectangle.Height;
             if (!Functions.ClipCursor(ref rect))
+            {
                 Debug.WriteLine(String.Format("Failed to grab cursor. Error: {0}",
                     Marshal.GetLastWin32Error()));
+            }
         }
 
         private void UngrabCursor()
         {
             if (!Functions.ClipCursor(IntPtr.Zero))
+            {
                 Debug.WriteLine(String.Format("Failed to ungrab cursor. Error: {0}",
                     Marshal.GetLastWin32Error()));
+            }
         }
 
         public override Rectangle Bounds
@@ -1071,7 +1117,9 @@ namespace OpenTK.Platform.Windows
             {
                 sb_title.Remove(0, sb_title.Length);
                 if (Functions.GetWindowText(window.Handle, sb_title, sb_title.Capacity) == 0)
+                {
                     Debug.Print("Failed to retrieve window title (window:{0}, reason:{1}).", window.Handle, Marshal.GetLastWin32Error());
+                }
                 return sb_title.ToString();
             }
             set
@@ -1079,7 +1127,9 @@ namespace OpenTK.Platform.Windows
                 if (Title != value)
                 {
                     if (!Functions.SetWindowText(window.Handle, value))
+                    {
                         Debug.Print("Failed to change window title (window:{0}, new title:{1}, reason:{2}).", window.Handle, value, Marshal.GetLastWin32Error());
+                    }
                     OnTitleChanged(EventArgs.Empty);
                 }
             }
@@ -1254,7 +1304,9 @@ namespace OpenTK.Platform.Windows
             set
             {
                 if (WindowState == value)
+                {
                     return;
+                }
 
                 ShowWindowCommand command = 0;
                 bool exiting_fullscreen = false;
@@ -1267,7 +1319,9 @@ namespace OpenTK.Platform.Windows
 
                         // If we are leaving fullscreen mode we need to restore the border.
                         if (WindowState == WindowState.Fullscreen)
+                        {
                             exiting_fullscreen = true;
+                        }
                         break;
 
                     case WindowState.Maximized:
@@ -1319,7 +1373,9 @@ namespace OpenTK.Platform.Windows
                 }
 
                 if (command != 0)
+                {
                     Functions.ShowWindow(window.Handle, command);
+                }
 
                 // Restore previous window border or apply pending border change when leaving fullscreen mode.
                 if (exiting_fullscreen)
@@ -1353,7 +1409,9 @@ namespace OpenTK.Platform.Windows
                 }
 
                 if (windowBorder == value)
+                {
                     return;
+                }
 
                 // We wish to avoid making an invisible window visible just to change the border.
                 // However, it's a good idea to make a visible window invisible temporarily, to
@@ -1391,7 +1449,9 @@ namespace OpenTK.Platform.Windows
 
                 // This avoids leaving garbage on the background window.
                 if (was_visible)
+                {
                     Visible = false;
+                }
 
                 Functions.SetWindowLong(window.Handle, GetWindowLongOffsets.STYLE, (IntPtr)(int)new_style);
                 Functions.SetWindowPos(window.Handle, IntPtr.Zero, 0, 0, rect.Width, rect.Height,
@@ -1402,7 +1462,9 @@ namespace OpenTK.Platform.Windows
                 // already visible (invisible windows will change borders when
                 // they become visible, so no need to make them visiable prematurely).
                 if (was_visible)
+                {
                     Visible = true;
+                }
 
                 WindowState = state;
 
@@ -1429,9 +1491,11 @@ namespace OpenTK.Platform.Windows
         public override Point PointToClient(Point point)
         {
             if (!Functions.ScreenToClient(window.Handle, ref point))
+            {
                 throw new InvalidOperationException(String.Format(
                     "Could not convert point {0} from screen to client coordinates. Windows error: {1}",
                     point.ToString(), Marshal.GetLastWin32Error()));
+            }
 
             return point;
         }
@@ -1439,9 +1503,11 @@ namespace OpenTK.Platform.Windows
         public override Point PointToScreen(Point point)
         {
             if (!Functions.ClientToScreen(window.Handle, ref point))
+            {
                 throw new InvalidOperationException(String.Format(
                     "Could not convert point {0} from screen to client coordinates. Windows error: {1}",
                     point.ToString(), Marshal.GetLastWin32Error()));
+            }
 
             return point;
         }
@@ -1477,7 +1543,9 @@ namespace OpenTK.Platform.Windows
                     // Safe to clean managed resources
                     DestroyWindow();
                     if (Icon != null)
+                    {
                         Icon.Dispose();
+                    }
                 }
                 else
                 {

--- a/src/OpenTK/Platform/Windows/WinGraphicsMode.cs
+++ b/src/OpenTK/Platform/Windows/WinGraphicsMode.cs
@@ -50,7 +50,9 @@ namespace OpenTK.Platform.Windows
         public WinGraphicsMode(IntPtr device)
         {
             if (device == IntPtr.Zero)
+            {
                 throw new ArgumentException();
+            }
 
             Device = device;
         }
@@ -291,7 +293,9 @@ namespace OpenTK.Platform.Windows
                 valid &= pfd.PixelType == PixelType.RGBA; // indexed modes not currently supported
                 // heavily penalize single-buffered modes when the user requests double buffering
                 if ((pfd.Flags & PixelFormatDescriptorFlags.DOUBLEBUFFER) == 0 && mode.Buffers > 1)
+                {
                     dist += 1000;
+                }
                 valid &= Compare(pfd.ColorBits, mode.ColorFormat.BitsPerPixel, ref dist);
                 valid &= Compare(pfd.RedBits, mode.ColorFormat.Red, ref dist);
                 valid &= Compare(pfd.GreenBits, mode.ColorFormat.Green, ref dist);

--- a/src/OpenTK/Platform/Windows/WinInputBase.cs
+++ b/src/OpenTK/Platform/Windows/WinInputBase.cs
@@ -106,9 +106,13 @@ namespace OpenTK.Platform.Windows
         {
             IntPtr ret =  WindowProcedure(handle, message, wParam, lParam);
             if (ret == Unhandled)
+            {
                 return Functions.CallWindowProc(OldWndProc, handle, message, wParam, lParam);
+            }
             else
+            {
                 return ret;
+            }
         }
 
         protected virtual IntPtr WindowProcedure(

--- a/src/OpenTK/Platform/Windows/WinKeyMap.cs
+++ b/src/OpenTK/Platform/Windows/WinKeyMap.cs
@@ -184,9 +184,13 @@ namespace OpenTK.Platform.Windows
                     case Key.Delete: key = Key.KeypadDecimal; break;
                     case Key.NumLock:
                         if (vkey == VirtualKeys.Last)
+                        {
                             is_valid = false;
+                        }
                         else if (vkey == VirtualKeys.PAUSE)
+                        {
                             key = Key.Pause;
+                        }
                         break;
                 }
             }

--- a/src/OpenTK/Platform/Windows/WinRawInput.cs
+++ b/src/OpenTK/Platform/Windows/WinRawInput.cs
@@ -61,7 +61,9 @@ namespace OpenTK.Platform.Windows
                     new IntPtr((void*)&bdi), DeviceNotification.WINDOW_HANDLE);
             }
             if (dev_notify_handle == IntPtr.Zero)
+            {
                 Debug.Print("[Warning] Failed to register for device notifications. Error: {0}", Marshal.GetLastWin32Error());
+            }
 
             return dev_notify_handle;
         }
@@ -85,17 +87,23 @@ namespace OpenTK.Platform.Windows
                                 {
                                     case RawInputDeviceType.KEYBOARD:
                                         if (((WinRawKeyboard)KeyboardDriver).ProcessKeyboardEvent(lParam))
+                                        {
                                             return IntPtr.Zero;
+                                        }
                                         break;
 
                                     case RawInputDeviceType.MOUSE:
                                         if (((WinRawMouse)MouseDriver).ProcessMouseEvent(lParam))
+                                        {
                                             return IntPtr.Zero;
+                                        }
                                         break;
 
                                     case RawInputDeviceType.HID:
                                         if (((WinRawJoystick)JoystickDriver).ProcessEvent(lParam))
+                                        {
                                             return IntPtr.Zero;
+                                        }
                                         break;
                                 }
                             }
@@ -149,7 +157,9 @@ namespace OpenTK.Platform.Windows
             int count = WinRawInput.DeviceCount;
             RawInputDeviceList[] ridl = new RawInputDeviceList[count];
             for (int i = 0; i < count; i++)
+            {
                 ridl[i] = new RawInputDeviceList();
+            }
             Functions.GetRawInputDeviceList(ridl, ref count, API.RawInputDeviceListSize);
             return ridl;
         }

--- a/src/OpenTK/Platform/Windows/WinRawJoystick.cs
+++ b/src/OpenTK/Platform/Windows/WinRawJoystick.cs
@@ -187,7 +187,9 @@ namespace OpenTK.Platform.Windows
             Debug.Indent();
 
             if (window == IntPtr.Zero)
+            {
                 throw new ArgumentNullException("window");
+            }
 
             DeviceTypes = new RawInputDevice[]
             {
@@ -225,7 +227,9 @@ namespace OpenTK.Platform.Windows
             {
                 // Skip non-joystick devices
                 if (dev.Type != RawInputDeviceType.HID)
+                {
                     continue;
+                }
 
                 // We use the device handle as the hardware id.
                 // This works, but the handle will change whenever the
@@ -641,7 +645,9 @@ namespace OpenTK.Platform.Windows
                     }
                 }
                 else
+                {
                     return false;
+                }
             }
             finally
             {

--- a/src/OpenTK/Platform/Windows/WinRawKeyboard.cs
+++ b/src/OpenTK/Platform/Windows/WinRawKeyboard.cs
@@ -68,7 +68,9 @@ namespace OpenTK.Platform.Windows
                 int count = WinRawInput.DeviceCount;
                 RawInputDeviceList[] ridl = new RawInputDeviceList[count];
                 for (int i = 0; i < count; i++)
+                {
                     ridl[i] = new RawInputDeviceList();
+                }
                 Functions.GetRawInputDeviceList(ridl, ref count, API.RawInputDeviceListSize);
 
                 // Discover keyboard devices:
@@ -96,7 +98,9 @@ namespace OpenTK.Platform.Windows
                         // keyboard device by qeurying the registry.
                         RegistryKey regkey = GetRegistryKey(name);
                         if (regkey == null)
+                        {
                             continue;
+                        }
 
                         string deviceDesc = (string)regkey.GetValue("DeviceDesc");
                         string deviceClass = (string)regkey.GetValue("Class");
@@ -171,7 +175,9 @@ namespace OpenTK.Platform.Windows
                 }
 
                 if (keyboards.Count == 0)
+                {
                     return false;
+                }
 
                 // Note:For some reason, my Microsoft Digital 3000 keyboard reports 0
                 // as rin.Header.Device for the "zoom-in/zoom-out" buttons.
@@ -201,14 +207,18 @@ namespace OpenTK.Platform.Windows
         private static RegistryKey GetRegistryKey(string name)
         {
             if (name.Length < 4)
+            {
                 return null;
+            }
 
             // remove the \??\
             name = name.Substring(4);
 
             string[] split = name.Split('#');
             if (split.Length < 3)
+            {
                 return null;
+            }
 
             string id_01 = split[0];    // ACPI (Class code)
             string id_02 = split[1];    // PNP0303 (SubClass code)
@@ -270,9 +280,13 @@ namespace OpenTK.Platform.Windows
             lock (UpdateLock)
             {
                 if (keyboards.Count > index)
+                {
                     return keyboards[index];
+                }
                 else
+                {
                     return new KeyboardState();
+                }
             }
         }
 
@@ -281,9 +295,13 @@ namespace OpenTK.Platform.Windows
             lock (UpdateLock)
             {
                 if (names.Count > index)
+                {
                     return names[index];
+                }
                 else
+                {
                     return String.Empty;
+                }
             }
         }
     }

--- a/src/OpenTK/Platform/Windows/WinRawMouse.cs
+++ b/src/OpenTK/Platform/Windows/WinRawMouse.cs
@@ -51,7 +51,9 @@ namespace OpenTK.Platform.Windows
             Debug.Indent();
 
             if (window == IntPtr.Zero)
+            {
                 throw new ArgumentNullException("window");
+            }
 
             Window = window;
             RefreshDevices();
@@ -98,7 +100,9 @@ namespace OpenTK.Platform.Windows
                         // mouse device by qeurying the registry.
                         RegistryKey regkey = FindRegistryKey(name);
                         if (regkey == null)
+                        {
                             continue;
+                        }
 
                         string deviceDesc = (string)regkey.GetValue("DeviceDesc");
                         string deviceClass = (string)regkey.GetValue("Class") as string;
@@ -114,9 +118,13 @@ namespace OpenTK.Platform.Windows
                         // Since the description is not vital information, use a dummy description
                         // when that happens.
                         if (String.IsNullOrEmpty(deviceDesc))
+                        {
                             deviceDesc = "Windows Mouse " + mice.Count;
+                        }
                         else
+                        {
                             deviceDesc = deviceDesc.Substring(deviceDesc.LastIndexOf(';') + 1);
+                        }
 
                         if (!String.IsNullOrEmpty(deviceClass) && deviceClass.ToLower().Equals("mouse"))
                         {
@@ -158,7 +166,9 @@ namespace OpenTK.Platform.Windows
                 }
 
                 if (mice.Count == 0)
+                {
                     return false;
+                }
 
                 // Note:For some reason, my Microsoft Digital 3000 keyboard reports 0
                 // as rin.Header.Device for the "zoom-in/zoom-out" buttons.
@@ -220,10 +230,14 @@ namespace OpenTK.Platform.Windows
                 }
 
                 if ((raw.ButtonFlags & RawInputMouseState.WHEEL) != 0)
+                {
                     mouse.SetScrollRelative(0, (short)raw.ButtonData / 120.0f);
+                }
 
                 if ((raw.ButtonFlags & RawInputMouseState.HWHEEL) != 0)
+                {
                     mouse.SetScrollRelative((short)raw.ButtonData / 120.0f, 0);
+                }
 
                 if ((raw.Flags & RawMouseFlags.MOUSE_MOVE_ABSOLUTE) != 0)
                 {
@@ -264,14 +278,18 @@ namespace OpenTK.Platform.Windows
         private static RegistryKey FindRegistryKey(string name)
         {
             if (name.Length < 4)
+            {
                 return null;
+            }
 
             // remove the \??\
             name = name.Substring(4);
 
             string[] split = name.Split('#');
             if (split.Length < 3)
+            {
                 return null;
+            }
 
             string id_01 = split[0];    // ACPI (Class code)
             string id_02 = split[1];    // PNP0303 (SubClass code)
@@ -322,9 +340,13 @@ namespace OpenTK.Platform.Windows
             lock (UpdateLock)
             {
                 if (mice.Count > index)
+                {
                     return mice[index];
+                }
                 else
+                {
                     return new MouseState();
+                }
             }
         }
 

--- a/src/OpenTK/Platform/Windows/WinWindowInfo.cs
+++ b/src/OpenTK/Platform/Windows/WinWindowInfo.cs
@@ -77,7 +77,7 @@ namespace OpenTK.Platform.Windows
                 {
                     dc = Functions.GetDC(this.Handle);
                 }
-                //dc = Functions.GetWindowDC(this.Handle);
+
                 return dc;
             }
         }

--- a/src/OpenTK/Platform/Windows/WinWindowInfo.cs
+++ b/src/OpenTK/Platform/Windows/WinWindowInfo.cs
@@ -74,8 +74,10 @@ namespace OpenTK.Platform.Windows
             get
             {
                 if (dc == IntPtr.Zero)
+                {
                     dc = Functions.GetDC(this.Handle);
-                    //dc = Functions.GetWindowDC(this.Handle);
+                }
+                //dc = Functions.GetWindowDC(this.Handle);
                 return dc;
             }
         }
@@ -98,11 +100,20 @@ namespace OpenTK.Platform.Windows
         /// <returns>True if <c>this</c> and <c>obj</c> reference the same win32 window; false otherwise.</returns>
         public override bool Equals(object obj)
         {
-            if (obj == null) return false;
-            if (this.GetType() != obj.GetType()) return false;
+            if (obj == null)
+            {
+                return false;
+            }
+            if (this.GetType() != obj.GetType())
+            {
+                return false;
+            }
             WinWindowInfo info = (WinWindowInfo)obj;
 
-            if (info == null) return false;
+            if (info == null)
+            {
+                return false;
+            }
             // TODO: Assumes windows will always have unique handles.
             return handle.Equals(info.handle);
         }
@@ -126,13 +137,19 @@ namespace OpenTK.Platform.Windows
             if (!disposed)
             {
                 if (this.dc != IntPtr.Zero)
+                {
                     if (!Functions.ReleaseDC(this.handle, this.dc))
+                    {
                         Debug.Print("[Warning] Failed to release device context {0}. Windows error: {1}.", this.dc, Marshal.GetLastWin32Error());
+                    }
+                }
 
                 if (manual)
                 {
                     if (Parent != null)
+                    {
                         Parent.Dispose();
+                    }
                 }
 
                 disposed = true;

--- a/src/OpenTK/Platform/Windows/XInputJoystick.cs
+++ b/src/OpenTK/Platform/Windows/XInputJoystick.cs
@@ -85,29 +85,45 @@ namespace OpenTK.Platform.Windows
 
             dir =XInputButtons.DPadUp | XInputButtons.DPadLeft;
             if ((buttons & dir) == dir)
+            {
                 return HatPosition.UpLeft;
+            }
             dir = XInputButtons.DPadUp | XInputButtons.DPadRight;
             if ((buttons & dir) == dir)
+            {
                 return HatPosition.UpRight;
+            }
             dir = XInputButtons.DPadDown | XInputButtons.DPadLeft;
             if ((buttons & dir) == dir)
+            {
                 return HatPosition.DownLeft;
+            }
             dir = XInputButtons.DPadDown | XInputButtons.DPadRight;
             if ((buttons & dir) == dir)
+            {
                 return HatPosition.DownRight;
+            }
 
             dir = XInputButtons.DPadUp;
             if ((buttons & dir) == dir)
+            {
                 return HatPosition.Up;
+            }
             dir = XInputButtons.DPadRight;
             if ((buttons & dir) == dir)
+            {
                 return HatPosition.Right;
+            }
             dir = XInputButtons.DPadDown;
             if ((buttons & dir) == dir)
+            {
                 return HatPosition.Down;
+            }
             dir = XInputButtons.DPadLeft;
             if ((buttons & dir) == dir)
+            {
                 return HatPosition.Left;
+            }
 
             return HatPosition.Centered;
         }
@@ -350,15 +366,25 @@ namespace OpenTK.Platform.Windows
                 // The delegates below will be loaded dynamically from that dll
                 dll = Functions.LoadLibrary("XINPUT1_4");
                 if (dll == IntPtr.Zero)
+                {
                     dll = Functions.LoadLibrary("XINPUT1_3");
+                }
                 if (dll == IntPtr.Zero)
+                {
                     dll = Functions.LoadLibrary("XINPUT1_2");
+                }
                 if (dll == IntPtr.Zero)
+                {
                     dll = Functions.LoadLibrary("XINPUT1_1");
+                }
                 if (dll == IntPtr.Zero)
+                {
                     dll = Functions.LoadLibrary("XINPUT9_1_0");
+                }
                 if (dll == IntPtr.Zero)
+                {
                     throw new NotSupportedException("XInput was not found on this platform");
+                }
 
                 // Load the entry points we are interested in from that dll
                 GetCapabilities = (XInputGetCapabilities)Load("XInputGetCapabilities", typeof(XInputGetCapabilities));
@@ -374,7 +400,9 @@ namespace OpenTK.Platform.Windows
             {
                 IntPtr pfunc = Functions.GetProcAddress(dll, (IntPtr)ordinal);
                 if (pfunc != IntPtr.Zero)
+                {
                     return Marshal.GetDelegateForFunctionPointer(pfunc, type);
+                }
                 return null;
             }
 
@@ -382,7 +410,9 @@ namespace OpenTK.Platform.Windows
             {
                 IntPtr pfunc = Functions.GetProcAddress(dll, name);
                 if (pfunc != IntPtr.Zero)
+                {
                     return Marshal.GetDelegateForFunctionPointer(pfunc, type);
+                }
                 return null;
             }
 

--- a/src/OpenTK/Platform/X11/API.cs
+++ b/src/OpenTK/Platform/X11/API.cs
@@ -86,7 +86,9 @@ namespace OpenTK.Platform.X11
             DefaultDisplay = Functions.XOpenDisplay(IntPtr.Zero);
 
             if (DefaultDisplay == IntPtr.Zero)
+            {
                 throw new PlatformException("Could not establish connection to the X-Server.");
+            }
 
             using (new XLock(DefaultDisplay))
             {
@@ -1470,7 +1472,9 @@ XF86VidModeGetGammaRampSize(
 
                 byte* data = (byte*)XRRSizes(dpy, screen, &count);//(byte*)ptr;
                 if (count == 0)
+                {
                     return null;
+                }
                 sizes = new XRRScreenSize[count];
                 for (int i = 0; i < count; i++)
                 {
@@ -1494,10 +1498,14 @@ XF86VidModeGetGammaRampSize(
             {
                 short* data = (short*)XRRRates(dpy, screen, size_index, &count);
                 if (count == 0)
+                {
                     return null;
+                }
                 rates = new short[count];
                 for (int i = 0; i < count; i++)
+                {
                     rates[i] = *(data + i);
+                }
             }
             return rates;
         }
@@ -1518,10 +1526,14 @@ XF86VidModeGetGammaRampSize(
                 int count;
                 int* data = XListDepths(display, screen_number, &count);
                 if (count == 0)
+                {
                     return null;
+                }
                 int[] depths = new int[count];
                 for (int i = 0; i < count; i++)
+                {
                     depths[i] = *(data + i);
+                }
 
                 return depths;
             }
@@ -1530,7 +1542,9 @@ XF86VidModeGetGammaRampSize(
         public static Pixmap XCreateBitmapFromData(Display display, Window d, byte[,] data)
         {
             if (data == null)
+            {
                 throw new ArgumentNullException("data");
+            }
 
             unsafe
             {
@@ -1579,13 +1593,17 @@ XF86VidModeGetGammaRampSize(
             get
             {
                 if (_display == IntPtr.Zero)
+                {
                     throw new InvalidOperationException("Internal error (XLockDisplay with IntPtr.Zero). Please report this at http://www.opentk.com/node/add/project-issue/opentk");
+                }
                 return _display;
             }
             set
             {
                 if (value == IntPtr.Zero)
+                {
                     throw new ArgumentException();
+                }
                 _display = value;
             }
         }

--- a/src/OpenTK/Platform/X11/Bindings/Xkb.cs
+++ b/src/OpenTK/Platform/X11/Bindings/Xkb.cs
@@ -175,7 +175,9 @@ namespace OpenTK.Platform.X11
                 get
                 {
                     if (i < 0 || i > 3)
+                    {
                         throw new IndexOutOfRangeException();
+                    }
 
                     unsafe
                     {
@@ -228,7 +230,9 @@ namespace OpenTK.Platform.X11
                 get
                 {
                     if (i < 0 || i > 31)
+                    {
                         throw new IndexOutOfRangeException();
+                    }
 
                     unsafe
                     {
@@ -264,7 +268,9 @@ namespace OpenTK.Platform.X11
                 get
                 {
                     if (i < 0 || i > 15)
+                    {
                         throw new IndexOutOfRangeException();
+                    }
 
                     unsafe
                     {

--- a/src/OpenTK/Platform/X11/Functions.cs
+++ b/src/OpenTK/Platform/X11/Functions.cs
@@ -607,7 +607,9 @@ namespace OpenTK.Platform.X11
                     int offset = y * stride + (x >> 3);
 
                     if (image.GetPixel(x, y).A >= 128)
+                    {
                         mask[offset] |= bit;
+                    }
                 }
             }
 

--- a/src/OpenTK/Platform/X11/Structs.cs
+++ b/src/OpenTK/Platform/X11/Structs.cs
@@ -1821,7 +1821,9 @@ namespace OpenTK.Platform.X11
             {
                 mask = (byte*)Marshal.AllocHGlobal(mask_len);
                 for (int i = 0; i < mask_len; i++)
+                {
                     mask[i] = (byte)((uint)m >> i*8);
+                }
             }
         }
 

--- a/src/OpenTK/Platform/X11/X11DisplayDevice.cs
+++ b/src/OpenTK/Platform/X11/X11DisplayDevice.cs
@@ -114,8 +114,12 @@ namespace OpenTK.Platform.X11
         private static DisplayDevice FindDefaultDevice(IEnumerable<DisplayDevice> devices)
         {
                 foreach (DisplayDevice dev in devices)
+                {
                     if (dev.IsPrimary)
+                    {
                         return dev;
+                    }
+                }
 
             throw new InvalidOperationException("No primary display found. Please file a bug at http://www.opentk.com");
         }
@@ -185,8 +189,12 @@ namespace OpenTK.Platform.X11
                         // Note: some X servers (like Xming on Windows) do not report any rates other than 0.
                         // If we only have 1 rate, add it even if it is 0.
                         if (rate != 0 || rates.Length == 1)
+                        {
                             foreach (int depth in depths)
+                            {
                                 available_res.Add(new DisplayResolution(0, 0, size.Width, size.Height, depth, (float)rate));
+                            }
+                        }
                     }
                     // Keep the index of this resolution - we will need it for resolution changes later.
                     foreach (int depth in depths)
@@ -197,7 +205,9 @@ namespace OpenTK.Platform.X11
                         // same resolution twice!
                         DisplayResolution res = new DisplayResolution(0, 0, size.Width, size.Height, depth, 0);
                         if (!screenResolutionToIndex[screen].ContainsKey(res))
+                        {
                             screenResolutionToIndex[screen].Add(res, resolution_count);
+                        }
                     }
 
                     ++resolution_count;
@@ -246,7 +256,9 @@ namespace OpenTK.Platform.X11
             try
             {
                 if (!API.XF86VidModeQueryVersion(API.DefaultDisplay, out major, out minor))
+                {
                     return false;
+                }
             }
             catch (DllNotFoundException)
             {
@@ -299,7 +311,9 @@ namespace OpenTK.Platform.X11
             XRRScreenSize[] resolutions = null;
             resolutions = Functions.XRRSizes(API.DefaultDisplay, screen);
             if (resolutions == null)
+            {
                 throw new NotSupportedException("XRandR extensions not available.");
+            }
             return resolutions;
         }
 
@@ -329,10 +343,14 @@ namespace OpenTK.Platform.X11
                 int current_resolution_index = Functions.XRRConfigCurrentConfiguration(screen_config, out current_rotation);
                 int new_resolution_index;
                 if (resolution != null)
+                {
                     new_resolution_index = screenResolutionToIndex[screen]
                         [new DisplayResolution(0, 0, resolution.Width, resolution.Height, resolution.BitsPerPixel, 0)];
+                }
                 else
+                {
                     new_resolution_index = deviceToDefaultResolution[device];
+                }
 
                 Debug.Print("Changing size of screen {0} from {1} to {2}",
                     screen, current_resolution_index, new_resolution_index);

--- a/src/OpenTK/Platform/X11/X11GLContext.cs
+++ b/src/OpenTK/Platform/X11/X11GLContext.cs
@@ -43,9 +43,13 @@ namespace OpenTK.Platform.X11
             int major, int minor, GraphicsContextFlags flags)
         {
             if (mode == null)
+            {
                 throw new ArgumentNullException("mode");
+            }
             if (window == null)
+            {
                 throw new ArgumentNullException("window");
+            }
 
             // Do not move this lower, as almost everything requires the Display
             // property to be correctly set.
@@ -117,14 +121,20 @@ namespace OpenTK.Platform.X11
             }
 
             if (Handle != ContextHandle.Zero)
+            {
                 Debug.Print("Context created (id: {0}).", Handle);
+            }
             else
+            {
                 throw new GraphicsContextException("Failed to create OpenGL context. Glx.CreateContext call returned 0.");
+            }
 
             using (new XLock(Display))
             {
                 if (!Glx.IsDirect(Display, Handle.Handle))
+                {
                     Debug.Print("Warning: Context is not direct.");
+                }
             }
         }
 
@@ -132,9 +142,13 @@ namespace OpenTK.Platform.X11
             int major, int minor, GraphicsContextFlags flags)
         {
             if (handle == ContextHandle.Zero)
+            {
                 throw new ArgumentException("handle");
+            }
             if (window == null)
+            {
                 throw new ArgumentNullException("window");
+            }
 
             Handle = handle;
             currentWindow = (X11WindowInfo)window;
@@ -181,9 +195,13 @@ namespace OpenTK.Platform.X11
                 }
 
                 if (context == IntPtr.Zero)
+                {
                     Debug.WriteLine("failed.");
+                }
                 else
+                {
                     Debug.WriteLine("success!");
+                }
             }
 
             return new ContextHandle(context);
@@ -214,9 +232,13 @@ namespace OpenTK.Platform.X11
             set
             {
                 if (value == IntPtr.Zero)
+                {
                     throw new ArgumentOutOfRangeException();
+                }
                 if (display != IntPtr.Zero)
+                {
                     throw new InvalidOperationException("The display connection may not be changed after being set.");
+                }
                 display = value;
             }
         }
@@ -239,11 +261,17 @@ namespace OpenTK.Platform.X11
         private bool SupportsExtension(IntPtr display, X11WindowInfo window, string e)
         {
             if (window == null)
+            {
                 throw new ArgumentNullException("window");
+            }
             if (e == null)
+            {
                 throw new ArgumentNullException("e");
+            }
             if (window.Display != display)
+            {
                 throw new InvalidOperationException();
+            }
 
             if (String.IsNullOrEmpty(extensions))
             {
@@ -265,8 +293,10 @@ namespace OpenTK.Platform.X11
         public override void SwapBuffers()
         {
             if (Display == IntPtr.Zero || currentWindow.Handle == IntPtr.Zero)
+            {
                 throw new InvalidOperationException(
                     String.Format("Window is invalid. Display ({0}), Handle ({1}).", Display, currentWindow.Handle));
+            }
             using (new XLock(Display))
             {
                 Glx.SwapBuffers(Display, currentWindow.Handle);
@@ -276,10 +306,14 @@ namespace OpenTK.Platform.X11
         public override void MakeCurrent(IWindowInfo window)
         {
             if (window == currentWindow && IsCurrent)
+            {
                 return;
+            }
 
             if (window != null && ((X11WindowInfo)window).Display != Display)
+            {
                 throw new InvalidOperationException("MakeCurrent() may only be called on windows originating from the same display that spawned this GL context.");
+            }
 
             if (window == null)
             {
@@ -306,7 +340,9 @@ namespace OpenTK.Platform.X11
                         Handle, System.Threading.Thread.CurrentThread.ManagedThreadId, Display, w.Screen, w.Handle));
 
                 if (Display == IntPtr.Zero || w.Handle == IntPtr.Zero || Handle == ContextHandle.Zero)
+                {
                     throw new InvalidOperationException("Invalid display, window or context.");
+                }
 
                 using (new XLock(Display))
                 {
@@ -318,9 +354,13 @@ namespace OpenTK.Platform.X11
                 }
 
                 if (!result)
+                {
                     throw new GraphicsContextException("Failed to make context current.");
+                }
                 else
+                {
                     Debug.WriteLine("done!");
+                }
             }
 
             currentWindow = (X11WindowInfo)window;
@@ -398,9 +438,13 @@ namespace OpenTK.Platform.X11
                 }
 
                 if (error_code == X11.ErrorCode.NO_ERROR)
+                {
                     sgi_swap_interval = value;
+                }
                 else
+                {
                     Debug.Print("VSync = {0} failed, error code: {1}.", value, error_code);
+                }
             }
         }
 

--- a/src/OpenTK/Platform/X11/X11GLNative.cs
+++ b/src/OpenTK/Platform/X11/X11GLNative.cs
@@ -163,9 +163,13 @@ namespace OpenTK.Platform.X11
             : this()
         {
             if (width <= 0)
+            {
                 throw new ArgumentOutOfRangeException("width", "Must be higher than zero.");
+            }
             if (height <= 0)
+            {
                 throw new ArgumentOutOfRangeException("height", "Must be higher than zero.");
+            }
 
             Debug.Indent();
 
@@ -203,10 +207,14 @@ namespace OpenTK.Platform.X11
                     CreateWindowArgs.InputOutput, window.VisualInfo.Visual, mask, attributes);
 
                 if (window.Handle == IntPtr.Zero)
+                {
                     throw new ApplicationException("XCreateWindow call failed (returned 0).");
+                }
 
                 if (title != null)
+                {
                     Functions.XStoreName(window.Display, window.Handle, title);
+                }
             }
 
             XSizeHints hints = new XSizeHints();
@@ -309,7 +317,9 @@ namespace OpenTK.Platform.X11
                 window.Display = Functions.XOpenDisplay(IntPtr.Zero);
                 //window.Display = API.DefaultDisplay;
                 if (window.Display == IntPtr.Zero)
+                {
                     throw new Exception("Could not open connection to X");
+                }
 
                 using (new XLock(window.Display))
                 {
@@ -439,7 +449,9 @@ namespace OpenTK.Platform.X11
                 hints.min_height = min_height;
             }
             else
+            {
                 hints.flags = (IntPtr)((int)hints.flags & ~(int)XSizeHintsFlags.PMinSize);
+            }
 
             if (max_width > 0 || max_height > 0)
             {
@@ -448,7 +460,9 @@ namespace OpenTK.Platform.X11
                 hints.max_height = max_height;
             }
             else
+            {
                 hints.flags = (IntPtr)((int)hints.flags & ~(int)XSizeHintsFlags.PMaxSize);
+            }
 
             if (hints.flags != IntPtr.Zero)
             {
@@ -492,7 +506,9 @@ namespace OpenTK.Platform.X11
                     {
                         // TODO: How to check if MotifWMHints decorations have been really disabled?
                         if (_decorations_hidden)
+                        {
                             return true;
+                        }
                     }
 
                     // Some WMs remove decorations when the transient_for hint is set. Most new ones do not (but those
@@ -501,7 +517,9 @@ namespace OpenTK.Platform.X11
                     IntPtr transient_for_parent;
                     Functions.XGetTransientForHint(window.Display, window.Handle, out transient_for_parent);
                     if (transient_for_parent != IntPtr.Zero)
+                    {
                         return true;
+                    }
 
                     return false;
                 }
@@ -837,7 +855,9 @@ namespace OpenTK.Platform.X11
                             bool previous_visible = visible;
                             visible = true;
                             if (visible != previous_visible)
+                            {
                                 OnVisibleChanged(EventArgs.Empty);
+                            }
                         }
                         return;
 
@@ -846,7 +866,9 @@ namespace OpenTK.Platform.X11
                             bool previous_visible = visible;
                             visible = false;
                             if (visible != previous_visible)
+                            {
                                 OnVisibleChanged(EventArgs.Empty);
+                            }
                         }
                         break;
 
@@ -1089,7 +1111,9 @@ namespace OpenTK.Platform.X11
                             bool previous_focus = has_focus;
                             has_focus = true;
                             if (has_focus != previous_focus)
+                            {
                                 OnFocusedChanged(EventArgs.Empty);
+                            }
 
                             if (Focused && !CursorVisible)
                             {
@@ -1103,7 +1127,9 @@ namespace OpenTK.Platform.X11
                             bool previous_focus = has_focus;
                             has_focus = false;
                             if (has_focus != previous_focus)
+                            {
                                 OnFocusedChanged(EventArgs.Empty);
+                            }
                         }
                         break;
 
@@ -1268,7 +1294,9 @@ namespace OpenTK.Platform.X11
             set
             {
                 if (value == icon)
+                {
                     return;
+                }
 
                 // Note: it seems that Gnome/Metacity does not respect the _NET_WM_ICON hint.
                 // For this reason, we'll also set the icon using XSetWMHints.
@@ -1293,7 +1321,9 @@ namespace OpenTK.Platform.X11
 
                     for (int y = 0; y < bitmap.Height; y++)
                         for (int x = 0; x < bitmap.Width; x++)
+                        {
                             data[index++] = (IntPtr)bitmap.GetPixel(x, y).ToArgb();
+                        }
 
                     using (new XLock(window.Display))
                     {
@@ -1309,7 +1339,9 @@ namespace OpenTK.Platform.X11
                         IntPtr wmHints_ptr = Functions.XGetWMHints(window.Display, window.Handle);
 
                         if (wmHints_ptr == IntPtr.Zero)
+                        {
                             wmHints_ptr = Functions.XAllocWMHints();
+                        }
 
                         XWMHints wmHints = (XWMHints)Marshal.PtrToStructure(wmHints_ptr, typeof(XWMHints));
 
@@ -1368,11 +1400,17 @@ namespace OpenTK.Platform.X11
 
                         if (atom == _atom_net_wm_state_maximized_horizontal ||
                             atom == _atom_net_wm_state_maximized_vertical)
+                        {
                             maximized++;
+                        }
                         else if (atom == _atom_net_wm_state_minimized)
+                        {
                             minimized = true;
+                        }
                         else if (atom == _atom_net_wm_state_fullscreen)
+                        {
                             fullscreen = true;
+                        }
                     }
                     using (new XLock(window.Display))
                     {
@@ -1381,11 +1419,17 @@ namespace OpenTK.Platform.X11
                 }
 
                 if (minimized)
+                {
                     return OpenTK.WindowState.Minimized;
+                }
                 else if (maximized == 2)
+                {
                     return OpenTK.WindowState.Maximized;
+                }
                 else if (fullscreen)
+                {
                     return OpenTK.WindowState.Fullscreen;
+                }
                 /*
                                 attributes = new XWindowAttributes();
                                 Functions.XGetWindowAttributes(window.Display, window.Handle, ref attributes);
@@ -1408,7 +1452,9 @@ namespace OpenTK.Platform.X11
                 }
 
                 if (current_state == value)
+                {
                     return;
+                }
 
                 Debug.Print("GameWindow {0} changing WindowState from {1} to {2}.", window.Handle.ToString(),
                     current_state.ToString(), value.ToString());
@@ -1507,18 +1553,28 @@ namespace OpenTK.Platform.X11
             get
             {
                 if (IsWindowBorderHidden || WindowState == OpenTK.WindowState.Fullscreen)
+                {
                     return WindowBorder.Hidden;
+                }
                 else if (!IsWindowBorderResizable)
+                {
                     return WindowBorder.Fixed;
+                }
                 else if (WindowState == OpenTK.WindowState.Maximized)
+                {
                     return _previous_window_border;
+                }
                 else
+                {
                     return WindowBorder.Resizable;
+                }
             }
             set
             {
                 if (WindowBorder == value)
+                {
                     return;
+                }
 
                 // We cannot change the border of a fullscreen window.
                 // Record the new value and set it on the next WindowState
@@ -1542,7 +1598,9 @@ namespace OpenTK.Platform.X11
         private void ChangeWindowBorder(WindowBorder value, int width, int height)
         {
             if (WindowBorder == WindowBorder.Hidden)
+            {
                 EnableWindowDecorations();
+            }
 
             switch (value)
             {
@@ -1578,7 +1636,9 @@ namespace OpenTK.Platform.X11
                 unsafe
                 {
                     if (value == cursor)
+                    {
                         return;
+                    }
 
                     using (new XLock(window.Display))
                     {
@@ -1697,7 +1757,9 @@ namespace OpenTK.Platform.X11
                     Functions.XFetchName(window.Display, window.Handle, ref name);
                 }
                 if (name != IntPtr.Zero)
+                {
                     return Marshal.PtrToStringAnsi(name);
+                }
 
                 return String.Empty;
             }

--- a/src/OpenTK/Platform/X11/X11GraphicsMode.cs
+++ b/src/OpenTK/Platform/X11/X11GraphicsMode.cs
@@ -39,16 +39,22 @@ namespace OpenTK.Platform.X11
                 // This is only supported on GLX 1.3 - if it fails, fall back to Glx.ChooseVisual.
                 fbconfig = SelectFBConfig(mode);
                 if (fbconfig != IntPtr.Zero)
+                {
                     visual = Glx.GetVisualFromFBConfig(display, fbconfig);
+                }
 
                 if (visual == IntPtr.Zero)
+                {
                     visual = SelectVisual(mode);
+                }
 
                 if (visual == IntPtr.Zero)
                 {
                     // Relax parameters and retry
                     if (!Utilities.RelaxGraphicsMode(ref mode))
+                    {
                         throw new GraphicsModeException("Requested GraphicsMode not available.");
+                    }
                 }
             }
             while (visual == IntPtr.Zero);
@@ -203,7 +209,9 @@ namespace OpenTK.Platform.X11
             if (mode.ColorFormat.BitsPerPixel > 0)
             {
                 if (!mode.ColorFormat.IsIndexed)
+                {
                     visualAttributes.Add((int)GLXAttribute.RGBA);
+                }
                 visualAttributes.Add((int)GLXAttribute.RED_SIZE);
                 visualAttributes.Add(mode.ColorFormat.Red);
                 visualAttributes.Add((int)GLXAttribute.GREEN_SIZE);
@@ -222,7 +230,9 @@ namespace OpenTK.Platform.X11
             }
 
             if (mode.Buffers > 1)
+            {
                 visualAttributes.Add((int)GLXAttribute.DOUBLEBUFFER);
+            }
 
             if (mode.Stencil > 1)
             {
@@ -251,7 +261,9 @@ namespace OpenTK.Platform.X11
             }
 
             if (mode.Stereo)
+            {
                 visualAttributes.Add((int)GLXAttribute.STEREO);
+            }
 
             visualAttributes.Add(0);
 

--- a/src/OpenTK/Platform/X11/X11Keyboard.cs
+++ b/src/OpenTK/Platform/X11/X11Keyboard.cs
@@ -82,17 +82,25 @@ namespace OpenTK.Platform.X11
             // X11Keyboard supports a single keyboard only
             ProcessEvents();
             if (index == 0)
+            {
                 return state;
+            }
             else
+            {
                 return new KeyboardState();
+            }
         }
 
         public string GetDeviceName(int index)
         {
             if (index == 0)
+            {
                 return name;
+            }
             else
+            {
                 return String.Empty;
+            }
         }
 
         private void ProcessEvents()

--- a/src/OpenTK/Platform/X11/X11Mouse.cs
+++ b/src/OpenTK/Platform/X11/X11Mouse.cs
@@ -74,9 +74,13 @@ namespace OpenTK.Platform.X11
             ProcessEvents();
             // X11Mouse supports only one device
             if (index == 0)
+            {
                 return mouse;
+            }
             else
+            {
                 return new MouseState();
+            }
         }
 
         public MouseState GetCursorState()

--- a/src/OpenTK/Platform/X11/X11WindowInfo.cs
+++ b/src/OpenTK/Platform/X11/X11WindowInfo.cs
@@ -115,11 +115,20 @@ namespace OpenTK.Platform.X11
         /// <returns>True if <c>this</c> and <c>obj</c> reference the same win32 window; false otherwise.</returns>
         public override bool Equals(object obj)
         {
-            if (obj == null) return false;
-            if (this.GetType() != obj.GetType()) return false;
+            if (obj == null)
+            {
+                return false;
+            }
+            if (this.GetType() != obj.GetType())
+            {
+                return false;
+            }
             X11WindowInfo info = (X11WindowInfo)obj;
 
-            if (info == null) return false;
+            if (info == null)
+            {
+                return false;
+            }
             // TODO: Assumes windows will have unique handles per X11 display.
             return object.Equals(display, info.display) &&
                    handle.Equals(info.handle);

--- a/src/OpenTK/Platform/X11/XI2MouseKeyboard.cs
+++ b/src/OpenTK/Platform/X11/XI2MouseKeyboard.cs
@@ -100,7 +100,9 @@ namespace OpenTK.Platform.X11
             }
 
             if (!IsSupported(window.Display))
+            {
                 throw new NotSupportedException("XInput2 not supported.");
+            }
 
             // Enable XI2 mouse/keyboard events
             // Note: the input event loop blocks waiting for these events
@@ -357,13 +359,17 @@ namespace OpenTK.Platform.X11
                                                     {
                                                         Debug.WriteLine("\tAbsolute X movement");
                                                         if (d.MotionX.number == -1)
+                                                        {
                                                             d.MotionX = *valuator;
+                                                        }
                                                     }
                                                     else if (valuator->label == XI.AbsoluteY)
                                                     {
                                                         Debug.WriteLine("\tAbsolute X movement");
                                                         if (d.MotionY.number == -1)
+                                                        {
                                                             d.MotionY = *valuator;
+                                                        }
                                                     }
                                                     else
                                                     {
@@ -479,7 +485,9 @@ namespace OpenTK.Platform.X11
                                 MouseButton button = X11KeyMap.TranslateButton(raw.detail, out dx, out dy);
                                 mouse.State[button] = raw.evtype == XIEventType.RawButtonPress;
                                 if (mouse.ScrollX.number == -1 && mouse.ScrollY.number == -1)
+                                {
                                     mouse.State.SetScrollRelative(dx, dy);
+                                }
                             }
                             break;
 
@@ -532,22 +540,38 @@ namespace OpenTK.Platform.X11
             double h = 0;
             double v = 0;
             if (d.MotionX.number != -1)
+            {
                 x = ReadRawValue(ref raw, d.MotionX.number);
+            }
             if (d.MotionY.number != -1)
+            {
                 y = ReadRawValue(ref raw, d.MotionY.number);
+            }
             if (d.ScrollX.number != -1)
+            {
                 h = ReadRawValue(ref raw, d.ScrollX.number) / d.ScrollX.increment;
+            }
             if (d.ScrollY.number != -1)
+            {
                 v = ReadRawValue(ref raw, d.ScrollY.number) / d.ScrollY.increment;
+            }
 
             if (d.MotionX.mode == XIMode.Relative)
+            {
                 d.State.X += (int)Math.Round(x);
+            }
             else
+            {
                 d.State.X = (int)Math.Round(x);
+            }
             if (d.MotionY.mode == XIMode.Relative)
+            {
                 d.State.Y += (int)Math.Round(y);
+            }
             else
+            {
                 d.State.Y = (int)Math.Round(y);
+            }
 
             // Note: OpenTK follows the windows scrolling convention where
             // (+h, +v) = (right, up). XI2 uses (+h, +v) = (right, down)

--- a/src/OpenTK/Toolkit.cs
+++ b/src/OpenTK/Toolkit.cs
@@ -45,7 +45,9 @@ namespace OpenTK
         private Toolkit(Factory factory)
         {
             if (factory == null)
+            {
                 throw new ArgumentNullException("factory");
+            }
             platform_factory = factory;
         }
 
@@ -118,7 +120,9 @@ namespace OpenTK
         public static Toolkit Init(ToolkitOptions options)
         {
             if (options == null)
+            {
                 throw new ArgumentNullException("options");
+            }
 
             lock (InitLock)
             {

--- a/src/OpenTK/WindowIcon.cs
+++ b/src/OpenTK/WindowIcon.cs
@@ -47,7 +47,9 @@ namespace OpenTK
         private WindowIcon(int width, int height)
         {
             if (width < 0 || width > 256 || height < 0 || height > 256)
+            {
                 throw new ArgumentOutOfRangeException();
+            }
 
             this.Width = width;
             this.Height = height;
@@ -57,9 +59,13 @@ namespace OpenTK
             : this(width, height)
         {
             if (data == null)
+            {
                 throw new ArgumentNullException();
+            }
             if (data.Length < Width * Height * 4)
+            {
                 throw new ArgumentOutOfRangeException();
+            }
 
             this.Data = data;
         }
@@ -68,7 +74,9 @@ namespace OpenTK
             : this(width, height)
         {
             if (data == IntPtr.Zero)
+            {
                 throw new ArgumentNullException();
+            }
 
             // We assume that width and height are correctly set.
             // If they are not, we will read garbage and probably


### PR DESCRIPTION
This PR enforces the use of braces for statements, disallowing their omitting for single-line expressions.

Discussions about this, and motivation thereof, can be viewed in #566.