### PR TITLE
Remove unused backing field from FileDropEventArgs.

### DIFF
--- a/src/OpenTK/Input/FileDropEventArgs.cs
+++ b/src/OpenTK/Input/FileDropEventArgs.cs
@@ -7,8 +7,6 @@ namespace OpenTK.Input
     /// </summary>
     public class FileDropEventArgs : EventArgs
     {
-        private string fileName;
-
         /// <summary>
         /// Gets the name of the file.
         /// </summary>


### PR DESCRIPTION
This PR removes a now unused field from FileDropEventArgs. The field was left behind after auto-properties were introduced.