### PR TITLE
Disable superfluous warnings in native interop code.

### DIFF
--- a/src/OpenTK/Platform/Egl/Egl.cs
+++ b/src/OpenTK/Platform/Egl/Egl.cs
@@ -29,6 +29,10 @@ using System.Collections.Generic;
 using System.Text;
 using OpenTK.Graphics;
 
+// ReSharper disable InconsistentNaming
+// ReSharper disable UnusedMember.Global
+#pragma warning disable 1591
+
 namespace OpenTK.Platform.Egl
 {
     using EGLNativeDisplayType = IntPtr;
@@ -394,7 +398,5 @@ namespace OpenTK.Platform.Egl
                 return true;
             }
         }
-
     }
-#pragma warning restore 0169
 }

--- a/src/OpenTK/Platform/Egl/Egl.cs
+++ b/src/OpenTK/Platform/Egl/Egl.cs
@@ -31,7 +31,8 @@ using OpenTK.Graphics;
 
 // ReSharper disable InconsistentNaming
 // ReSharper disable UnusedMember.Global
-#pragma warning disable 1591
+
+#pragma warning disable 1591 // Missing XML comments
 
 namespace OpenTK.Platform.Egl
 {

--- a/src/OpenTK/Platform/X11/API.cs
+++ b/src/OpenTK/Platform/X11/API.cs
@@ -9,6 +9,9 @@ using System.Text;
 using System.Runtime.InteropServices;
 using System.Diagnostics;
 
+// ReSharper disable UnusedMember.Global
+// ReSharper disable InconsistentNaming
+#pragma warning disable 1591    // Missing XML comments
 #pragma warning disable 3019    // CLS-compliance checking
 #pragma warning disable 0649    // struct members not explicitly initialized
 #pragma warning disable 0169    // field / method is never used.
@@ -1229,8 +1232,6 @@ XF86VidModeGetGammaRampSize(
          SunOpen = 0x1005ff73,
     }
 
-#pragma warning disable 1591
-
     public enum XVisualClass : int
     {
         StaticGray = 0,
@@ -1240,8 +1241,6 @@ XF86VidModeGetGammaRampSize(
         TrueColor = 4,
         DirectColor = 5,
     }
-
-#pragma warning restore 1591
 
     [Flags]
     public enum XVisualInfoMask
@@ -1616,8 +1615,3 @@ XF86VidModeGetGammaRampSize(
         SyncBoth
     }
 }
-
-#pragma warning restore 3019
-#pragma warning restore 0649
-#pragma warning restore 0169
-#pragma warning restore 0414


### PR DESCRIPTION
This PR disables a number of warnings for native interop code, such as unused members or inconsistent naming. Typically, these are made to match their native counterparts exactly, and are not subject to the ordinary naming rules.