### PR TITLE
Add missing XML comments for GLHelper.

### DIFF
--- a/src/OpenTK/Graphics/OpenGL/GLHelper.cs
+++ b/src/OpenTK/Graphics/OpenGL/GLHelper.cs
@@ -94,136 +94,332 @@ namespace OpenTK.Graphics.OpenGL
         // Note: Mono 1.9.1 truncates StringBuilder results (for 'out string' parameters).
         // We work around this issue by doubling the StringBuilder capacity.
 
+        /// <summary>
+        /// [requires: v1.0][deprecated: v3.2]
+        /// Set the RGB values of the current color.
+        /// </summary>
+        /// <param name="color">The color to set.</param>
         public static void Color3(Color color)
         {
             GL.Color3(color.R, color.G, color.B);
         }
 
+        /// <summary>
+        /// [requires: v1.0][deprecated: v3.2]
+        /// Set the current color.
+        /// </summary>
+        /// <param name="color">The color to set.</param>
         public static void Color4(Color color)
         {
             GL.Color4(color.R, color.G, color.B, color.A);
         }
 
+        /// <summary>
+        /// [requires: v1.0][deprecated: v3.2]
+        /// Set the RGB values of the current color.
+        /// </summary>
+        /// <param name="color">The color to set.</param>
         public static void Color3(Vector3 color)
         {
             GL.Color3(color.X, color.Y, color.Z);
         }
 
+        /// <summary>
+        /// [requires: v1.0][deprecated: v3.2]
+        /// Set the current color.
+        /// </summary>
+        /// <param name="color">The color to set.</param>
         public static void Color4(Vector4 color)
         {
             GL.Color4(color.X, color.Y, color.Z, color.W);
         }
 
+        /// <summary>
+        /// [requires: v1.0][deprecated: v3.2]
+        /// Set the current color.
+        /// </summary>
+        /// <param name="color">The color to set.</param>
         public static void Color4(Color4 color)
         {
             GL.Color4(color.R, color.G, color.B, color.A);
         }
 
+        /// <summary>
+        /// [requires: v1.0]
+        /// Specify clear values for the color buffers.
+        /// </summary>
+        /// <param name="color">The color to set as the clear value.</param>
         public static void ClearColor(Color color)
         {
             GL.ClearColor(color.R / 255.0f, color.G / 255.0f, color.B / 255.0f, color.A / 255.0f);
         }
 
+        /// <summary>
+        /// [requires: v1.0]
+        /// Specify clear values for the color buffers.
+        /// </summary>
+        /// <param name="color">The color to set as the clear value.</param>
         public static void ClearColor(Color4 color)
         {
             GL.ClearColor(color.R, color.G, color.B, color.A);
         }
 
+        /// <summary>
+        /// [requires: v1.4 or ARB_imaging|VERSION_1_4]
+        /// Set the blend color.
+        /// </summary>
+        /// <param name="color">The blend color to set.</param>
         public static void BlendColor(Color color)
         {
             GL.BlendColor(color.R / 255.0f, color.G / 255.0f, color.B / 255.0f, color.A / 255.0f);
         }
 
+        /// <summary>
+        /// [requires: v1.4 or ARB_imaging|VERSION_1_4]
+        /// Set the blend color.
+        /// </summary>
+        /// <param name="color">The blend color to set.</param>
         public static void BlendColor(Color4 color)
         {
             GL.BlendColor(color.R, color.G, color.B, color.A);
         }
 
+        /// <summary>
+        /// [requires: v1.0][deprecated: v3.2]
+        /// Specify material parameters for the lighting model.
+        /// </summary>
+        /// <param name="face">
+        /// Specifies which face or faces are being updated. Must be one of Front, Back, or FrontAndBack.
+        /// </param>
+        /// <param name="pname">
+        /// Specifies the single-valued material parameter of the face or faces that is being updated. Must be Shininess.
+        /// </param>
+        /// <param name="params">[length: pname]
+        /// Specifies the value that parameter Shininess will be set to.
+        /// </param>
         public static void Material(MaterialFace face, MaterialParameter pname, Vector4 @params)
         {
             unsafe { Material(face, pname, (float*)&@params.X); }
         }
 
+        /// <summary>
+        /// [requires: v1.0][deprecated: v3.2]
+        /// Specify material parameters for the lighting model.
+        /// </summary>
+        /// <param name="face">
+        /// Specifies which face or faces are being updated. Must be one of Front, Back, or FrontAndBack.
+        /// </param>
+        /// <param name="pname">
+        /// Specifies the single-valued material parameter of the face or faces that is being updated. Must be Shininess.
+        /// </param>
+        /// <param name="params">[length: pname]
+        /// Specifies the value that parameter Shininess will be set to.
+        /// </param>
         public static void Material(MaterialFace face, MaterialParameter pname, Color4 @params)
         {
             unsafe { GL.Material(face, pname, (float*)&@params); }
         }
 
+        /// <summary>[requires: v1.0][deprecated: v3.2]
+        /// Set light source parameters
+        /// </summary>
+        /// <param name="name">
+        /// Specifies a light. The number of lights depends on the implementation, but at least eight lights are supported. They are identified by symbolic names of the form Light , where i ranges from 0 to the value of MaxLights - 1.
+        /// </param>
+        /// <param name="pname">
+        /// Specifies a single-valued light source parameter for light. SpotExponent, SpotCutoff, ConstantAttenuation, LinearAttenuation, and QuadraticAttenuation are accepted.
+        /// </param>
+        /// <param name="params">[length: pname]
+        /// Specifies the value that parameter pname of light source light will be set to.
+        /// </param>
         public static void Light(LightName name, LightParameter pname, Vector4 @params)
         {
             unsafe { GL.Light(name, pname, (float*)&@params.X); }
         }
 
+        /// <summary>[requires: v1.0][deprecated: v3.2]
+        /// Set light source parameters
+        /// </summary>
+        /// <param name="name">
+        /// Specifies a light. The number of lights depends on the implementation, but at least eight lights are supported. They are identified by symbolic names of the form Light , where i ranges from 0 to the value of MaxLights - 1.
+        /// </param>
+        /// <param name="pname">
+        /// Specifies a single-valued light source parameter for light. SpotExponent, SpotCutoff, ConstantAttenuation, LinearAttenuation, and QuadraticAttenuation are accepted.
+        /// </param>
+        /// <param name="params">[length: pname]
+        /// Specifies the value that parameter pname of light source light will be set to.
+        /// </param>
         public static void Light(LightName name, LightParameter pname, Color4 @params)
         {
             unsafe { GL.Light(name, pname, (float*)&@params); }
         }
 
+        /// <summary>
+        /// [requires: v1.0][deprecated: v3.2]
+        /// Set the current normal vector.
+        /// </summary>
+        /// <param name="normal">
+        /// Specify the x, y, and z coordinates of the new current normal. The initial value of the current normal is the unit vector, (0, 0, 1).
+        /// </param>
         public static void Normal3(Vector3 normal)
         {
             GL.Normal3(normal.X, normal.Y, normal.Z);
         }
 
+        /// <summary>
+        /// [requires: v1.0][deprecated: v3.2]
+        /// Specify the raster position for pixel operations.
+        /// </summary>
+        /// <param name="pos">
+        /// Specify the x and y object coordinates (if present) for the raster position.
+        /// </param>
         public static void RasterPos2(Vector2 pos)
         {
             GL.RasterPos2(pos.X, pos.Y);
         }
 
+        /// <summary>
+        /// [requires: v1.0][deprecated: v3.2]
+        /// Specify the raster position for pixel operations.
+        /// </summary>
+        /// <param name="pos">
+        /// Specify the x, y, and z object coordinates (if present) for the raster position.
+        /// </param>
         public static void RasterPos3(Vector3 pos)
         {
             GL.RasterPos3(pos.X, pos.Y, pos.Z);
         }
 
+        /// <summary>
+        /// [requires: v1.0][deprecated: v3.2]
+        /// Specify the raster position for pixel operations.
+        /// </summary>
+        /// <param name="pos">
+        /// Specify the x, y, z, and w object coordinates (if present) for the raster position.
+        /// </param>
         public static void RasterPos4(Vector4 pos)
         {
             GL.RasterPos4(pos.X, pos.Y, pos.Z, pos.W);
         }
 
+        /// <summary>
+        /// [requires: v1.0][deprecated: v3.2]
+        /// Specify a vertex.
+        /// </summary>
+        /// <param name="v">
+        /// Specifies the x and y coordinates of a vertex.
+        /// </param>
         public static void Vertex2(Vector2 v)
         {
             GL.Vertex2(v.X, v.Y);
         }
 
+        /// <summary>
+        /// [requires: v1.0][deprecated: v3.2]
+        /// Specify a vertex.
+        /// </summary>
+        /// <param name="v">
+        /// Specifies the x, y and z coordinates of a vertex.
+        /// </param>
         public static void Vertex3(Vector3 v)
         {
             GL.Vertex3(v.X, v.Y, v.Z);
         }
 
+        /// <summary>
+        /// [requires: v1.0][deprecated: v3.2]
+        /// Specify a vertex.
+        /// </summary>
+        /// <param name="v">
+        /// Specifies the x, y, z and w coordinates of a vertex.
+        /// </param>
         public static void Vertex4(Vector4 v)
         {
             GL.Vertex4(v.X, v.Y, v.Z, v.W);
         }
 
+        /// <summary>
+        /// [requires: v1.0][deprecated: v3.2]
+        /// Set the current texture coordinates.
+        /// </summary>
+        /// <param name="v">
+        /// Specifies the s and t texture coordinates.
+        /// </param>
         public static void TexCoord2(Vector2 v)
         {
             GL.TexCoord2(v.X, v.Y);
         }
-
+        
+        /// <summary>
+        /// [requires: v1.0][deprecated: v3.2]
+        /// Set the current texture coordinates.
+        /// </summary>
+        /// <param name="v">
+        /// Specifies the s, t and r texture coordinates.
+        /// </param>
         public static void TexCoord3(Vector3 v)
         {
             GL.TexCoord3(v.X, v.Y, v.Z);
         }
 
+        /// <summary>
+        /// [requires: v1.0][deprecated: v3.2]
+        /// Set the current texture coordinates.
+        /// </summary>
+        /// <param name="v">
+        /// Specifies the s, t, r and q texture coordinates.
+        /// </param>
         public static void TexCoord4(Vector4 v)
         {
             GL.TexCoord4(v.X, v.Y, v.Z, v.W);
         }
 
+        /// <summary>
+        /// [requires: v1.0][deprecated: v3.2]
+        /// Multiply the current matrix by a rotation matrix.
+        /// </summary>
+        /// <param name="angle">
+        /// Specifies the angle of rotation, in degrees.
+        /// </param>
+        /// <param name="axis">
+        /// Specifies the axis of rotation.
+        /// </param>
         public static void Rotate(Single angle, Vector3 axis)
         {
             GL.Rotate((Single)angle, axis.X, axis.Y, axis.Z);
         }
 
+        /// <summary>
+        /// [requires: v1.0][deprecated: v3.2]
+        /// Multiply the current matrix by a general scaling matrix.
+        /// </summary>
+        /// <param name="scale">
+        /// Specifies scale factors along the x, y, and z axes.
+        /// </param>
         public static void Scale(Vector3 scale)
         {
             GL.Scale(scale.X, scale.Y, scale.Z);
         }
 
+        /// <summary>
+        /// [requires: v1.0][deprecated: v3.2]
+        /// Multiply the current matrix by a translation matrix.
+        /// </summary>
+        /// <param name="trans">
+        /// Specifies the x, y, and z coordinates with which to translate.
+        /// </param>
         public static void Translate(Vector3 trans)
         {
             GL.Translate(trans.X, trans.Y, trans.Z);
         }
 
+        /// <summary>
+        /// [requires: v1.0][deprecated: v3.2]
+        /// Multiply the current matrix with the specified matrix.
+        /// </summary>
+        /// <param name="mat">
+        /// The matrix to multiply the current one with.
+        /// </param>
         public static void MultMatrix(ref Matrix4 mat)
         {
             unsafe
@@ -235,6 +431,12 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
 
+        /// <summary>[requires: v1.0][deprecated: v3.2]
+        /// Replace the current matrix with the specified matrix
+        /// </summary>
+        /// <param name="mat">
+        /// The matrix to replace the current one with.
+        /// </param>
         public static void LoadMatrix(ref Matrix4 mat)
         {
             unsafe
@@ -246,6 +448,13 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
 
+        /// <summary>
+        /// [requires: v1.3][deprecated: v3.2]
+        /// Replace the current matrix with the specified row-major ordered matrix.
+        /// </summary>
+        /// <param name="mat">
+        /// The matrix to replace the current one with.
+        /// </param>
         public static void LoadTransposeMatrix(ref Matrix4 mat)
         {
             unsafe
@@ -257,6 +466,13 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
 
+        /// <summary>
+        /// [requires: v1.3][deprecated: v3.2]
+        /// Multiply the current matrix with the specified row-major ordered matrix
+        /// </summary>
+        /// <param name="mat">
+        /// The matrix to multiply the current one with.
+        /// </param>
         public static void MultTransposeMatrix(ref Matrix4 mat)
         {
             unsafe
@@ -268,71 +484,172 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
 
+        /// <summary>
+        /// [requires: v1.0][deprecated: v3.2]
+        /// Set the current normal vector.
+        /// </summary>
+        /// <param name="normal">
+        /// Specify the x, y, and z coordinates of the new current normal. The initial value of the current normal is the unit vector, (0, 0, 1).
+        /// </param>
         public static void Normal3(Vector3d normal)
         {
             GL.Normal3(normal.X, normal.Y, normal.Z);
         }
 
+        /// <summary>
+        /// [requires: v1.0][deprecated: v3.2]
+        /// Specify the raster position for pixel operations.
+        /// </summary>
+        /// <param name="pos">
+        /// Specify the x and y object coordinates (if present) for the raster position.
+        /// </param>
         public static void RasterPos2(Vector2d pos)
         {
             GL.RasterPos2(pos.X, pos.Y);
         }
 
+        /// <summary>
+        /// [requires: v1.0][deprecated: v3.2]
+        /// Specify the raster position for pixel operations.
+        /// </summary>
+        /// <param name="pos">
+        /// Specify the x, y and z object coordinates (if present) for the raster position.
+        /// </param>
         public static void RasterPos3(Vector3d pos)
         {
             GL.RasterPos3(pos.X, pos.Y, pos.Z);
         }
 
+        /// <summary>
+        /// [requires: v1.0][deprecated: v3.2]
+        /// Specify the raster position for pixel operations.
+        /// </summary>
+        /// <param name="pos">
+        /// Specify the x, y, z and w object coordinates (if present) for the raster position.
+        /// </param>
         public static void RasterPos4(Vector4d pos)
         {
             GL.RasterPos4(pos.X, pos.Y, pos.Z, pos.W);
         }
 
+        /// <summary>
+        /// [requires: v1.0][deprecated: v3.2]
+        /// Specify a vertex.
+        /// </summary>
+        /// <param name="v">
+        /// Specifies the x and y coordinates of a vertex.
+        /// </param>
         public static void Vertex2(Vector2d v)
         {
             GL.Vertex2(v.X, v.Y);
         }
 
+        /// <summary>
+        /// [requires: v1.0][deprecated: v3.2]
+        /// Specify a vertex.
+        /// </summary>
+        /// <param name="v">
+        /// Specifies the x, y and z coordinates of a vertex.
+        /// </param>
         public static void Vertex3(Vector3d v)
         {
             GL.Vertex3(v.X, v.Y, v.Z);
         }
 
+        /// <summary>
+        /// [requires: v1.0][deprecated: v3.2]
+        /// Specify a vertex.
+        /// </summary>
+        /// <param name="v">
+        /// Specifies the x, y, z and w coordinates of a vertex.
+        /// </param>
         public static void Vertex4(Vector4d v)
         {
             GL.Vertex4(v.X, v.Y, v.Z, v.W);
         }
 
+        /// <summary>
+        /// [requires: v1.0][deprecated: v3.2]
+        /// Set the current texture coordinates.
+        /// </summary>
+        /// <param name="v">
+        /// Specifies the s and t texture coordinates.
+        /// </param>
         public static void TexCoord2(Vector2d v)
         {
             GL.TexCoord2(v.X, v.Y);
         }
 
+        /// <summary>
+        /// [requires: v1.0][deprecated: v3.2]
+        /// Set the current texture coordinates.
+        /// </summary>
+        /// <param name="v">
+        /// Specifies the s, t and r texture coordinates.
+        /// </param>
         public static void TexCoord3(Vector3d v)
         {
             GL.TexCoord3(v.X, v.Y, v.Z);
         }
 
+        /// <summary>
+        /// [requires: v1.0][deprecated: v3.2]
+        /// Set the current texture coordinates.
+        /// </summary>
+        /// <param name="v">
+        /// Specifies the s, t, r and q texture coordinates.
+        /// </param>
         public static void TexCoord4(Vector4d v)
         {
             GL.TexCoord4(v.X, v.Y, v.Z, v.W);
         }
 
+        /// <summary>
+        /// [requires: v1.0][deprecated: v3.2]
+        /// Multiply the current matrix by a rotation matrix.
+        /// </summary>
+        /// <param name="angle">
+        /// Specifies the angle of rotation, in degrees.
+        /// </param>
+        /// <param name="axis">
+        /// Specifies the axis of rotation.
+        /// </param>
         public static void Rotate(double angle, Vector3d axis)
         {
             GL.Rotate((double)angle, axis.X, axis.Y, axis.Z);
         }
 
+        /// <summary>
+        /// [requires: v1.0][deprecated: v3.2]
+        /// Multiply the current matrix by a general scaling matrix.
+        /// </summary>
+        /// <param name="scale">
+        /// Specifies scale factors along the x, y, and z axes.
+        /// </param>
         public static void Scale(Vector3d scale)
         {
             GL.Scale(scale.X, scale.Y, scale.Z);
         }
 
+        /// <summary>
+        /// [requires: v1.0][deprecated: v3.2]
+        /// Multiply the current matrix by a translation matrix.
+        /// </summary>
+        /// <param name="trans">
+        /// Specifies the x, y, and z coordinates with which to translate.
+        /// </param>
         public static void Translate(Vector3d trans)
         {
             GL.Translate(trans.X, trans.Y, trans.Z);
         }
 
+        /// <summary>
+        /// [requires: v1.0][deprecated: v3.2]
+        /// Multiply the current matrix with the specified matrix.
+        /// </summary>
+        /// <param name="mat">
+        /// The matrix to multiply the current one with.
+        /// </param>
         public static void MultMatrix(ref Matrix4d mat)
         {
             unsafe
@@ -344,6 +661,12 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
 
+        /// <summary>[requires: v1.0][deprecated: v3.2]
+        /// Replace the current matrix with the specified matrix
+        /// </summary>
+        /// <param name="mat">
+        /// The matrix to replace the current one with.
+        /// </param>
         public static void LoadMatrix(ref Matrix4d mat)
         {
             unsafe
@@ -355,6 +678,13 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
 
+        /// <summary>
+        /// [requires: v1.3][deprecated: v3.2]
+        /// Replace the current matrix with the specified row-major ordered matrix.
+        /// </summary>
+        /// <param name="mat">
+        /// The matrix to replace the current one with.
+        /// </param>
         public static void LoadTransposeMatrix(ref Matrix4d mat)
         {
             unsafe
@@ -366,6 +696,13 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
 
+        /// <summary>
+        /// [requires: v1.3][deprecated: v3.2]
+        /// Multiply the current matrix with the specified row-major ordered matrix
+        /// </summary>
+        /// <param name="mat">
+        /// The matrix to multiply the current one with.
+        /// </param>
         public static void MultTransposeMatrix(ref Matrix4d mat)
         {
             unsafe
@@ -377,49 +714,143 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
 
+        /// <summary>
+        /// [requires: v2.0]
+        /// Specify the value of a <see cref="Vector2"/> uniform variable for the current program object.
+        /// </summary>
+        /// <param name="location">
+        /// Specifies the location of the uniform variable to be modified.
+        /// </param>
+        /// <param name="vector">
+        /// Specifies the new vector to be used for the specified uniform variable.
+        /// </param>
         [CLSCompliant(false)]
         public static void Uniform2(int location, ref Vector2 vector)
         {
             GL.Uniform2(location, vector.X, vector.Y);
         }
 
+        /// <summary>
+        /// [requires: v2.0]
+        /// Specify the value of a <see cref="Vector3"/> uniform variable for the current program object.
+        /// </summary>
+        /// <param name="location">
+        /// Specifies the location of the uniform variable to be modified.
+        /// </param>
+        /// <param name="vector">
+        /// Specifies the new vector to be used for the specified uniform variable.
+        /// </param>
         [CLSCompliant(false)]
         public static void Uniform3(int location, ref Vector3 vector)
         {
             GL.Uniform3(location, vector.X, vector.Y, vector.Z);
         }
 
+        /// <summary>
+        /// [requires: v2.0]
+        /// Specify the value of a <see cref="Vector4"/> uniform variable for the current program object.
+        /// </summary>
+        /// <param name="location">
+        /// Specifies the location of the uniform variable to be modified.
+        /// </param>
+        /// <param name="vector">
+        /// Specifies the new vector to be used for the specified uniform variable.
+        /// </param>
         [CLSCompliant(false)]
         public static void Uniform4(int location, ref Vector4 vector)
         {
             GL.Uniform4(location, vector.X, vector.Y, vector.Z, vector.W);
         }
 
+        /// <summary>
+        /// [requires: v2.0]
+        /// Specify the value of a <see cref="Vector2"/> uniform variable for the current program object.
+        /// </summary>
+        /// <param name="location">
+        /// Specifies the location of the uniform variable to be modified.
+        /// </param>
+        /// <param name="vector">
+        /// Specifies the new vector to be used for the specified uniform variable.
+        /// </param>
         public static void Uniform2(int location, Vector2 vector)
         {
             GL.Uniform2(location, vector.X, vector.Y);
         }
 
+        /// <summary>
+        /// [requires: v2.0]
+        /// Specify the value of a <see cref="Vector3"/> uniform variable for the current program object.
+        /// </summary>
+        /// <param name="location">
+        /// Specifies the location of the uniform variable to be modified.
+        /// </param>
+        /// <param name="vector">
+        /// Specifies the new vector to be used for the specified uniform variable.
+        /// </param>
         public static void Uniform3(int location, Vector3 vector)
         {
             GL.Uniform3(location, vector.X, vector.Y, vector.Z);
         }
 
+        /// <summary>
+        /// [requires: v2.0]
+        /// Specify the value of a <see cref="Vector4"/> uniform variable for the current program object.
+        /// </summary>
+        /// <param name="location">
+        /// Specifies the location of the uniform variable to be modified.
+        /// </param>
+        /// <param name="vector">
+        /// Specifies the new vector to be used for the specified uniform variable.
+        /// </param>
         public static void Uniform4(int location, Vector4 vector)
         {
             GL.Uniform4(location, vector.X, vector.Y, vector.Z, vector.W);
         }
 
+        /// <summary>
+        /// [requires: v2.0]
+        /// Specify the value of a <see cref="OpenTK.Graphics.Color4"/> uniform variable for the current program object.
+        /// In shader code, this is represented as a <see cref="Vector4"/>.
+        /// </summary>
+        /// <param name="location">
+        /// Specifies the location of the uniform variable to be modified.
+        /// </param>
+        /// <param name="color">
+        /// Specifies the new vector to be used for the specified uniform variable.
+        /// </param>
         public static void Uniform4(int location, Color4 color)
         {
             GL.Uniform4(location, color.R, color.G, color.B, color.A);
         }
 
+        /// <summary>
+        /// [requires: v2.0]
+        /// Specify the value of a <see cref="Quaternion"/> uniform variable for the current program object.
+        /// In shader code, this is represented as a <see cref="Vector4"/>.
+        /// </summary>
+        /// <param name="location">
+        /// Specifies the location of the uniform variable to be modified.
+        /// </param>
+        /// <param name="quaternion">
+        /// Specifies the new vector to be used for the specified uniform variable.
+        /// </param>
         public static void Uniform4(int location, Quaternion quaternion)
         {
             GL.Uniform4(location, quaternion.X, quaternion.Y, quaternion.Z, quaternion.W);
         }
 
+        /// <summary>
+        /// [requires: v2.0]
+        /// Specify the value of a <see cref="Matrix2"/> uniform variable for the current program object.
+        /// </summary>
+        /// <param name="location">
+        /// Specifies the location of the uniform variable to be modified.
+        /// </param>
+        /// <param name="transpose">
+        /// Whether or not the matrix should be transposed.</param>
+        /// <param name="matrix">
+        /// Specifies the new vector to be used for the specified uniform variable.
+        /// </param>
         public static void UniformMatrix2(int location, bool transpose, ref Matrix2 matrix)
         {
             unsafe
@@ -431,6 +862,18 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
 
+        /// <summary>
+        /// [requires: v4.0 or ARB_gpu_shader_fp64|VERSION_4_0]
+        /// Specify the value of a <see cref="Matrix2d"/> uniform variable for the current program object.
+        /// </summary>
+        /// <param name="location">
+        /// Specifies the location of the uniform variable to be modified.
+        /// </param>
+        /// <param name="transpose">
+        /// Whether or not the matrix should be transposed.</param>
+        /// <param name="matrix">
+        /// Specifies the new vector to be used for the specified uniform variable.
+        /// </param>
         public static void UniformMatrix2(int location, bool transpose, ref Matrix2d matrix)
         {
             unsafe
@@ -442,6 +885,18 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
 
+        /// <summary>
+        /// [requires: v2.0]
+        /// Specify the value of a <see cref="Matrix2x3"/> uniform variable for the current program object.
+        /// </summary>
+        /// <param name="location">
+        /// Specifies the location of the uniform variable to be modified.
+        /// </param>
+        /// <param name="transpose">
+        /// Whether or not the matrix should be transposed.</param>
+        /// <param name="matrix">
+        /// Specifies the new vector to be used for the specified uniform variable.
+        /// </param>
         public static void UniformMatrix2x3(int location, bool transpose, ref Matrix2x3 matrix)
         {
             unsafe
@@ -453,6 +908,18 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
 
+        /// <summary>
+        /// [requires: v4.0 or ARB_gpu_shader_fp64|VERSION_4_0]
+        /// Specify the value of a <see cref="Matrix2x3d"/> uniform variable for the current program object.
+        /// </summary>
+        /// <param name="location">
+        /// Specifies the location of the uniform variable to be modified.
+        /// </param>
+        /// <param name="transpose">
+        /// Whether or not the matrix should be transposed.</param>
+        /// <param name="matrix">
+        /// Specifies the new vector to be used for the specified uniform variable.
+        /// </param>
         public static void UniformMatrix2x3(int location, bool transpose, ref Matrix2x3d matrix)
         {
             unsafe
@@ -464,6 +931,18 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
 
+        /// <summary>
+        /// [requires: v2.1]
+        /// Specify the value of a <see cref="Matrix2x4"/> uniform variable for the current program object.
+        /// </summary>
+        /// <param name="location">
+        /// Specifies the location of the uniform variable to be modified.
+        /// </param>
+        /// <param name="transpose">
+        /// Whether or not the matrix should be transposed.</param>
+        /// <param name="matrix">
+        /// Specifies the new vector to be used for the specified uniform variable.
+        /// </param>
         public static void UniformMatrix2x4(int location, bool transpose, ref Matrix2x4 matrix)
         {
             unsafe
@@ -475,6 +954,18 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
 
+        /// <summary>
+        /// [requires: v4.0 or ARB_gpu_shader_fp64|VERSION_4_0]
+        /// Specify the value of a <see cref="Matrix2x4d"/> uniform variable for the current program object.
+        /// </summary>
+        /// <param name="location">
+        /// Specifies the location of the uniform variable to be modified.
+        /// </param>
+        /// <param name="transpose">
+        /// Whether or not the matrix should be transposed.</param>
+        /// <param name="matrix">
+        /// Specifies the new vector to be used for the specified uniform variable.
+        /// </param>
         public static void UniformMatrix2x4(int location, bool transpose, ref Matrix2x4d matrix)
         {
             unsafe
@@ -486,6 +977,18 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
 
+        /// <summary>
+        /// [requires: v2.1]
+        /// Specify the value of a <see cref="Matrix3x2"/> uniform variable for the current program object.
+        /// </summary>
+        /// <param name="location">
+        /// Specifies the location of the uniform variable to be modified.
+        /// </param>
+        /// <param name="transpose">
+        /// Whether or not the matrix should be transposed.</param>
+        /// <param name="matrix">
+        /// Specifies the new vector to be used for the specified uniform variable.
+        /// </param>
         public static void UniformMatrix3x2(int location, bool transpose, ref Matrix3x2 matrix)
         {
             unsafe
@@ -497,6 +1000,18 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
 
+        /// <summary>
+        /// [requires: v4.0 or ARB_gpu_shader_fp64|VERSION_4_0]
+        /// Specify the value of a <see cref="Matrix3x2d"/> uniform variable for the current program object.
+        /// </summary>
+        /// <param name="location">
+        /// Specifies the location of the uniform variable to be modified.
+        /// </param>
+        /// <param name="transpose">
+        /// Whether or not the matrix should be transposed.</param>
+        /// <param name="matrix">
+        /// Specifies the new vector to be used for the specified uniform variable.
+        /// </param>
         public static void UniformMatrix3x2(int location, bool transpose, ref Matrix3x2d matrix)
         {
             unsafe
@@ -508,6 +1023,18 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
 
+        /// <summary>
+        /// [requires: v2.0]
+        /// Specify the value of a <see cref="Matrix3"/> uniform variable for the current program object.
+        /// </summary>
+        /// <param name="location">
+        /// Specifies the location of the uniform variable to be modified.
+        /// </param>
+        /// <param name="transpose">
+        /// Whether or not the matrix should be transposed.</param>
+        /// <param name="matrix">
+        /// Specifies the new vector to be used for the specified uniform variable.
+        /// </param>
         public static void UniformMatrix3(int location, bool transpose, ref Matrix3 matrix)
         {
             unsafe
@@ -519,6 +1046,18 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
 
+        /// <summary>
+        /// [requires: v4.0 or ARB_gpu_shader_fp64|VERSION_4_0]
+        /// Specify the value of a <see cref="Matrix3"/> uniform variable for the current program object.
+        /// </summary>
+        /// <param name="location">
+        /// Specifies the location of the uniform variable to be modified.
+        /// </param>
+        /// <param name="transpose">
+        /// Whether or not the matrix should be transposed.</param>
+        /// <param name="matrix">
+        /// Specifies the new vector to be used for the specified uniform variable.
+        /// </param>
         public static void UniformMatrix3(int location, bool transpose, ref Matrix3d matrix)
         {
             unsafe
@@ -530,6 +1069,18 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
 
+        /// <summary>
+        /// [requires: v2.1]
+        /// Specify the value of a <see cref="Matrix3"/> uniform variable for the current program object.
+        /// </summary>
+        /// <param name="location">
+        /// Specifies the location of the uniform variable to be modified.
+        /// </param>
+        /// <param name="transpose">
+        /// Whether or not the matrix should be transposed.</param>
+        /// <param name="matrix">
+        /// Specifies the new vector to be used for the specified uniform variable.
+        /// </param>
         public static void UniformMatrix3x4(int location, bool transpose, ref Matrix3x4 matrix)
         {
             unsafe
@@ -541,6 +1092,18 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
 
+        /// <summary>
+        /// [requires: v4.0 or ARB_gpu_shader_fp64|VERSION_4_0]
+        /// Specify the value of a <see cref="Matrix3x4d"/> uniform variable for the current program object.
+        /// </summary>
+        /// <param name="location">
+        /// Specifies the location of the uniform variable to be modified.
+        /// </param>
+        /// <param name="transpose">
+        /// Whether or not the matrix should be transposed.</param>
+        /// <param name="matrix">
+        /// Specifies the new vector to be used for the specified uniform variable.
+        /// </param>
         public static void UniformMatrix3x4(int location, bool transpose, ref Matrix3x4d matrix)
         {
             unsafe
@@ -552,6 +1115,18 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
 
+        /// <summary>
+        /// [requires: v2.1]
+        /// Specify the value of a <see cref="Matrix4x2"/> uniform variable for the current program object.
+        /// </summary>
+        /// <param name="location">
+        /// Specifies the location of the uniform variable to be modified.
+        /// </param>
+        /// <param name="transpose">
+        /// Whether or not the matrix should be transposed.</param>
+        /// <param name="matrix">
+        /// Specifies the new vector to be used for the specified uniform variable.
+        /// </param>
         public static void UniformMatrix4x2(int location, bool transpose, ref Matrix4x2 matrix)
         {
             unsafe
@@ -563,6 +1138,18 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
 
+        /// <summary>
+        /// [requires: v4.0 or ARB_gpu_shader_fp64|VERSION_4_0]
+        /// Specify the value of a <see cref="Matrix4x2d"/> uniform variable for the current program object.
+        /// </summary>
+        /// <param name="location">
+        /// Specifies the location of the uniform variable to be modified.
+        /// </param>
+        /// <param name="transpose">
+        /// Whether or not the matrix should be transposed.</param>
+        /// <param name="matrix">
+        /// Specifies the new vector to be used for the specified uniform variable.
+        /// </param>
         public static void UniformMatrix4x2(int location, bool transpose, ref Matrix4x2d matrix)
         {
             unsafe
@@ -574,6 +1161,18 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
 
+        /// <summary>
+        /// [requires: v2.1]
+        /// Specify the value of a <see cref="Matrix4x3"/> uniform variable for the current program object.
+        /// </summary>
+        /// <param name="location">
+        /// Specifies the location of the uniform variable to be modified.
+        /// </param>
+        /// <param name="transpose">
+        /// Whether or not the matrix should be transposed.</param>
+        /// <param name="matrix">
+        /// Specifies the new vector to be used for the specified uniform variable.
+        /// </param>
         public static void UniformMatrix4x3(int location, bool transpose, ref Matrix4x3 matrix)
         {
             unsafe
@@ -585,6 +1184,18 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
 
+        /// <summary>
+        /// [requires: v4.0 or ARB_gpu_shader_fp64|VERSION_4_0]
+        /// Specify the value of a <see cref="Matrix4x3d"/> uniform variable for the current program object.
+        /// </summary>
+        /// <param name="location">
+        /// Specifies the location of the uniform variable to be modified.
+        /// </param>
+        /// <param name="transpose">
+        /// Whether or not the matrix should be transposed.</param>
+        /// <param name="matrix">
+        /// Specifies the new vector to be used for the specified uniform variable.
+        /// </param>
         public static void UniformMatrix4x3(int location, bool transpose, ref Matrix4x3d matrix)
         {
             unsafe
@@ -596,6 +1207,18 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
 
+        /// <summary>
+        /// [requires: v2.0]
+        /// Specify the value of a <see cref="Matrix4"/> uniform variable for the current program object.
+        /// </summary>
+        /// <param name="location">
+        /// Specifies the location of the uniform variable to be modified.
+        /// </param>
+        /// <param name="transpose">
+        /// Whether or not the matrix should be transposed.</param>
+        /// <param name="matrix">
+        /// Specifies the new vector to be used for the specified uniform variable.
+        /// </param>
         public static void UniformMatrix4(int location, bool transpose, ref Matrix4 matrix)
         {
             unsafe
@@ -607,6 +1230,18 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
 
+        /// <summary>
+        /// [requires: v4.0 or ARB_gpu_shader_fp64|VERSION_4_0]
+        /// Specify the value of a <see cref="Matrix4d"/> uniform variable for the current program object.
+        /// </summary>
+        /// <param name="location">
+        /// Specifies the location of the uniform variable to be modified.
+        /// </param>
+        /// <param name="transpose">
+        /// Whether or not the matrix should be transposed.</param>
+        /// <param name="matrix">
+        /// Specifies the new vector to be used for the specified uniform variable.
+        /// </param>
         public static void UniformMatrix4(int location, bool transpose, ref Matrix4d matrix)
         {
             unsafe
@@ -618,49 +1253,170 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
 
+        /// <summary>
+        /// [requires: v4.1 or ARB_separate_shader_objects|VERSION_4_1]
+        /// Specify the value of a <see cref="Vector2"/> uniform variable for the specified program object.
+        /// </summary>
+        /// <param name="program">
+        /// Specifies the handle of the program containing the uniform variable to be modified.
+        /// </param>
+        /// <param name="location">
+        /// Specifies the location of the uniform variable to be modified.
+        /// </param>
+        /// <param name="vector">
+        /// Specifies the new vector to be used for the specified uniform variable.
+        /// </param>
         [CLSCompliant(false)]
         public static void ProgramUniform2(int program, int location, ref Vector2 vector)
         {
             GL.ProgramUniform2(program, location, vector.X, vector.Y);
         }
 
+        /// <summary>
+        /// [requires: v4.1 or ARB_separate_shader_objects|VERSION_4_1]
+        /// Specify the value of a <see cref="Vector3"/> uniform variable for the specified program object.
+        /// </summary>
+        /// <param name="program">
+        /// Specifies the handle of the program containing the uniform variable to be modified.
+        /// </param>
+        /// <param name="location">
+        /// Specifies the location of the uniform variable to be modified.
+        /// </param>
+        /// <param name="vector">
+        /// Specifies the new vector to be used for the specified uniform variable.
+        /// </param>
         [CLSCompliant(false)]
         public static void ProgramUniform3(int program, int location, ref Vector3 vector)
         {
             GL.ProgramUniform3(program, location, vector.X, vector.Y, vector.Z);
         }
 
+        /// <summary>
+        /// [requires: v4.1 or ARB_separate_shader_objects|VERSION_4_1]
+        /// Specify the value of a <see cref="Vector4"/> uniform variable for the specified program object.
+        /// </summary>
+        /// <param name="program">
+        /// Specifies the handle of the program containing the uniform variable to be modified.
+        /// </param>
+        /// <param name="location">
+        /// Specifies the location of the uniform variable to be modified.
+        /// </param>
+        /// <param name="vector">
+        /// Specifies the new vector to be used for the specified uniform variable.
+        /// </param>
         [CLSCompliant(false)]
         public static void ProgramUniform4(int program, int location, ref Vector4 vector)
         {
             GL.ProgramUniform4(program, location, vector.X, vector.Y, vector.Z, vector.W);
         }
 
+        /// <summary>
+        /// [requires: v4.1 or ARB_separate_shader_objects|VERSION_4_1]
+        /// Specify the value of a <see cref="Vector2"/> uniform variable for the specified program object.
+        /// </summary>
+        /// <param name="program">
+        /// Specifies the handle of the program containing the uniform variable to be modified.
+        /// </param>
+        /// <param name="location">
+        /// Specifies the location of the uniform variable to be modified.
+        /// </param>
+        /// <param name="vector">
+        /// Specifies the new vector to be used for the specified uniform variable.
+        /// </param>
         public static void ProgramUniform2(int program, int location, Vector2 vector)
         {
             GL.ProgramUniform2(program, location, vector.X, vector.Y);
         }
 
+        /// <summary>
+        /// [requires: v4.1 or ARB_separate_shader_objects|VERSION_4_1]
+        /// Specify the value of a <see cref="Vector3"/> uniform variable for the specified program object.
+        /// </summary>
+        /// <param name="program">
+        /// Specifies the handle of the program containing the uniform variable to be modified.
+        /// </param>
+        /// <param name="location">
+        /// Specifies the location of the uniform variable to be modified.
+        /// </param>
+        /// <param name="vector">
+        /// Specifies the new vector to be used for the specified uniform variable.
+        /// </param>
         public static void ProgramUniform3(int program, int location, Vector3 vector)
         {
             GL.ProgramUniform3(program, location, vector.X, vector.Y, vector.Z);
         }
 
+        /// <summary>
+        /// [requires: v4.1 or ARB_separate_shader_objects|VERSION_4_1]
+        /// Specify the value of a <see cref="Vector4"/> uniform variable for the specified program object.
+        /// </summary>
+        /// <param name="program">
+        /// Specifies the handle of the program containing the uniform variable to be modified.
+        /// </param>
+        /// <param name="location">
+        /// Specifies the location of the uniform variable to be modified.
+        /// </param>
+        /// <param name="vector">
+        /// Specifies the new vector to be used for the specified uniform variable.
+        /// </param>
         public static void ProgramUniform4(int program, int location, Vector4 vector)
         {
             GL.ProgramUniform4(program, location, vector.X, vector.Y, vector.Z, vector.W);
         }
 
+        /// <summary>
+        /// [requires: v4.1 or ARB_separate_shader_objects|VERSION_4_1]
+        /// Specify the value of a <see cref="OpenTK.Graphics.Color4"/> uniform variable for the specified program object.
+        /// In shader code, this is represented as a <see cref="Vector4"/>.
+        /// </summary>
+        /// <param name="program">
+        /// Specifies the handle of the program containing the uniform variable to be modified.
+        /// </param>
+        /// <param name="location">
+        /// Specifies the location of the uniform variable to be modified.
+        /// </param>
+        /// <param name="color">
+        /// Specifies the new vector to be used for the specified uniform variable.
+        /// </param>
         public static void ProgramUniform4(int program, int location, Color4 color)
         {
             GL.ProgramUniform4(program, location, color.R, color.G, color.B, color.A);
         }
 
+        /// <summary>
+        /// [requires: v4.1 or ARB_separate_shader_objects|VERSION_4_1]
+        /// Specify the value of a <see cref="Quaternion"/> uniform variable for the specified program object.
+        /// In shader code, this is represented as a <see cref="Vector4"/>.
+        /// </summary>
+        /// <param name="program">
+        /// Specifies the handle of the program containing the uniform variable to be modified.
+        /// </param>
+        /// <param name="location">
+        /// Specifies the location of the uniform variable to be modified.
+        /// </param>
+        /// <param name="quaternion">
+        /// Specifies the new vector to be used for the specified uniform variable.
+        /// </param>
         public static void ProgramUniform4(int program, int location, Quaternion quaternion)
         {
             GL.ProgramUniform4(program, location, quaternion.X, quaternion.Y, quaternion.Z, quaternion.W);
         }
 
+        /// <summary>
+        /// [requires: v4.1 or ARB_separate_shader_objects|VERSION_4_1]
+        /// Specify the value of a <see cref="Matrix2"/> uniform variable for the current program object.
+        /// </summary>
+        /// <param name="program">
+        /// Specifies the handle of the program containing the uniform variable to be modified.
+        /// </param>
+        /// <param name="location">
+        /// Specifies the location of the uniform variable to be modified.
+        /// </param>
+        /// <param name="transpose">
+        /// Whether or not the matrix should be transposed.</param>
+        /// <param name="matrix">
+        /// Specifies the new vector to be used for the specified uniform variable.
+        /// </param>
         public static void ProgramUniformMatrix2(int program, int location, bool transpose, ref Matrix2 matrix)
         {
             unsafe
@@ -672,6 +1428,21 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
 
+        /// <summary>
+        /// [requires: v4.1 or ARB_separate_shader_objects|VERSION_4_1]
+        /// Specify the value of a <see cref="Matrix2d"/> uniform variable for the current program object.
+        /// </summary>
+        /// <param name="program">
+        /// Specifies the handle of the program containing the uniform variable to be modified.
+        /// </param>
+        /// <param name="location">
+        /// Specifies the location of the uniform variable to be modified.
+        /// </param>
+        /// <param name="transpose">
+        /// Whether or not the matrix should be transposed.</param>
+        /// <param name="matrix">
+        /// Specifies the new vector to be used for the specified uniform variable.
+        /// </param>
         public static void ProgramUniformMatrix2(int program, int location, bool transpose, ref Matrix2d matrix)
         {
             unsafe
@@ -683,6 +1454,21 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
 
+        /// <summary>
+        /// [requires: v4.1 or ARB_separate_shader_objects|VERSION_4_1]
+        /// Specify the value of a <see cref="Matrix2x3"/> uniform variable for the current program object.
+        /// </summary>
+        /// <param name="program">
+        /// Specifies the handle of the program containing the uniform variable to be modified.
+        /// </param>
+        /// <param name="location">
+        /// Specifies the location of the uniform variable to be modified.
+        /// </param>
+        /// <param name="transpose">
+        /// Whether or not the matrix should be transposed.</param>
+        /// <param name="matrix">
+        /// Specifies the new vector to be used for the specified uniform variable.
+        /// </param>
         public static void ProgramUniformMatrix2x3(int program, int location, bool transpose, ref Matrix2x3 matrix)
         {
             unsafe
@@ -694,6 +1480,21 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
 
+        /// <summary>
+        /// [requires: v4.1 or ARB_separate_shader_objects|VERSION_4_1]
+        /// Specify the value of a <see cref="Matrix2x3d"/> uniform variable for the current program object.
+        /// </summary>
+        /// <param name="program">
+        /// Specifies the handle of the program containing the uniform variable to be modified.
+        /// </param>
+        /// <param name="location">
+        /// Specifies the location of the uniform variable to be modified.
+        /// </param>
+        /// <param name="transpose">
+        /// Whether or not the matrix should be transposed.</param>
+        /// <param name="matrix">
+        /// Specifies the new vector to be used for the specified uniform variable.
+        /// </param>
         public static void ProgramUniformMatrix2x3(int program, int location, bool transpose, ref Matrix2x3d matrix)
         {
             unsafe
@@ -705,6 +1506,21 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
 
+        /// <summary>
+        /// [requires: v4.1 or ARB_separate_shader_objects|VERSION_4_1]
+        /// Specify the value of a <see cref="Matrix2x4"/> uniform variable for the current program object.
+        /// </summary>
+        /// <param name="program">
+        /// Specifies the handle of the program containing the uniform variable to be modified.
+        /// </param>
+        /// <param name="location">
+        /// Specifies the location of the uniform variable to be modified.
+        /// </param>
+        /// <param name="transpose">
+        /// Whether or not the matrix should be transposed.</param>
+        /// <param name="matrix">
+        /// Specifies the new vector to be used for the specified uniform variable.
+        /// </param>
         public static void ProgramUniformMatrix2x4(int program, int location, bool transpose, ref Matrix2x4 matrix)
         {
             unsafe
@@ -716,6 +1532,21 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
 
+        /// <summary>
+        /// [requires: v4.1 or ARB_separate_shader_objects|VERSION_4_1]
+        /// Specify the value of a <see cref="Matrix2x4d"/> uniform variable for the current program object.
+        /// </summary>
+        /// <param name="program">
+        /// Specifies the handle of the program containing the uniform variable to be modified.
+        /// </param>
+        /// <param name="location">
+        /// Specifies the location of the uniform variable to be modified.
+        /// </param>
+        /// <param name="transpose">
+        /// Whether or not the matrix should be transposed.</param>
+        /// <param name="matrix">
+        /// Specifies the new vector to be used for the specified uniform variable.
+        /// </param>
         public static void ProgramUniformMatrix2x4(int program, int location, bool transpose, ref Matrix2x4d matrix)
         {
             unsafe
@@ -727,6 +1558,21 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
 
+        /// <summary>
+        /// [requires: v4.1 or ARB_separate_shader_objects|VERSION_4_1]
+        /// Specify the value of a <see cref="Matrix3x2"/> uniform variable for the current program object.
+        /// </summary>
+        /// <param name="program">
+        /// Specifies the handle of the program containing the uniform variable to be modified.
+        /// </param>
+        /// <param name="location">
+        /// Specifies the location of the uniform variable to be modified.
+        /// </param>
+        /// <param name="transpose">
+        /// Whether or not the matrix should be transposed.</param>
+        /// <param name="matrix">
+        /// Specifies the new vector to be used for the specified uniform variable.
+        /// </param>
         public static void ProgramUniformMatrix3x2(int program, int location, bool transpose, ref Matrix3x2 matrix)
         {
             unsafe
@@ -738,6 +1584,21 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
 
+        /// <summary>
+        /// [requires: v4.1 or ARB_separate_shader_objects|VERSION_4_1]
+        /// Specify the value of a <see cref="Matrix3x2d"/> uniform variable for the current program object.
+        /// </summary>
+        /// <param name="program">
+        /// Specifies the handle of the program containing the uniform variable to be modified.
+        /// </param>
+        /// <param name="location">
+        /// Specifies the location of the uniform variable to be modified.
+        /// </param>
+        /// <param name="transpose">
+        /// Whether or not the matrix should be transposed.</param>
+        /// <param name="matrix">
+        /// Specifies the new vector to be used for the specified uniform variable.
+        /// </param>
         public static void ProgramUniformMatrix3x2(int program, int location, bool transpose, ref Matrix3x2d matrix)
         {
             unsafe
@@ -749,6 +1610,21 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
 
+        /// <summary>
+        /// [requires: v4.1 or ARB_separate_shader_objects|VERSION_4_1]
+        /// Specify the value of a <see cref="Matrix3"/> uniform variable for the current program object.
+        /// </summary>
+        /// <param name="program">
+        /// Specifies the handle of the program containing the uniform variable to be modified.
+        /// </param>
+        /// <param name="location">
+        /// Specifies the location of the uniform variable to be modified.
+        /// </param>
+        /// <param name="transpose">
+        /// Whether or not the matrix should be transposed.</param>
+        /// <param name="matrix">
+        /// Specifies the new vector to be used for the specified uniform variable.
+        /// </param>
         public static void ProgramUniformMatrix3(int program, int location, bool transpose, ref Matrix3 matrix)
         {
             unsafe
@@ -760,6 +1636,21 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
 
+        /// <summary>
+        /// [requires: v4.1 or ARB_separate_shader_objects|VERSION_4_1]
+        /// Specify the value of a <see cref="Matrix3d"/> uniform variable for the current program object.
+        /// </summary>
+        /// <param name="program">
+        /// Specifies the handle of the program containing the uniform variable to be modified.
+        /// </param>
+        /// <param name="location">
+        /// Specifies the location of the uniform variable to be modified.
+        /// </param>
+        /// <param name="transpose">
+        /// Whether or not the matrix should be transposed.</param>
+        /// <param name="matrix">
+        /// Specifies the new vector to be used for the specified uniform variable.
+        /// </param>
         public static void ProgramUniformMatrix3(int program, int location, bool transpose, ref Matrix3d matrix)
         {
             unsafe
@@ -771,6 +1662,21 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
 
+        /// <summary>
+        /// [requires: v4.1 or ARB_separate_shader_objects|VERSION_4_1]
+        /// Specify the value of a <see cref="Matrix3x4"/> uniform variable for the current program object.
+        /// </summary>
+        /// <param name="program">
+        /// Specifies the handle of the program containing the uniform variable to be modified.
+        /// </param>
+        /// <param name="location">
+        /// Specifies the location of the uniform variable to be modified.
+        /// </param>
+        /// <param name="transpose">
+        /// Whether or not the matrix should be transposed.</param>
+        /// <param name="matrix">
+        /// Specifies the new vector to be used for the specified uniform variable.
+        /// </param>
         public static void ProgramUniformMatrix3x4(int program, int location, bool transpose, ref Matrix3x4 matrix)
         {
             unsafe
@@ -782,6 +1688,21 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
 
+        /// <summary>
+        /// [requires: v4.1 or ARB_separate_shader_objects|VERSION_4_1]
+        /// Specify the value of a <see cref="Matrix3x4d"/> uniform variable for the current program object.
+        /// </summary>
+        /// <param name="program">
+        /// Specifies the handle of the program containing the uniform variable to be modified.
+        /// </param>
+        /// <param name="location">
+        /// Specifies the location of the uniform variable to be modified.
+        /// </param>
+        /// <param name="transpose">
+        /// Whether or not the matrix should be transposed.</param>
+        /// <param name="matrix">
+        /// Specifies the new vector to be used for the specified uniform variable.
+        /// </param>
         public static void ProgramUniformMatrix3x4(int program, int location, bool transpose, ref Matrix3x4d matrix)
         {
             unsafe
@@ -793,6 +1714,21 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
 
+        /// <summary>
+        /// [requires: v4.1 or ARB_separate_shader_objects|VERSION_4_1]
+        /// Specify the value of a <see cref="Matrix4x2"/> uniform variable for the current program object.
+        /// </summary>
+        /// <param name="program">
+        /// Specifies the handle of the program containing the uniform variable to be modified.
+        /// </param>
+        /// <param name="location">
+        /// Specifies the location of the uniform variable to be modified.
+        /// </param>
+        /// <param name="transpose">
+        /// Whether or not the matrix should be transposed.</param>
+        /// <param name="matrix">
+        /// Specifies the new vector to be used for the specified uniform variable.
+        /// </param>
         public static void ProgramUniformMatrix4x2(int program, int location, bool transpose, ref Matrix4x2 matrix)
         {
             unsafe
@@ -804,6 +1740,21 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
 
+        /// <summary>
+        /// [requires: v4.1 or ARB_separate_shader_objects|VERSION_4_1]
+        /// Specify the value of a <see cref="Matrix4x2d"/> uniform variable for the current program object.
+        /// </summary>
+        /// <param name="program">
+        /// Specifies the handle of the program containing the uniform variable to be modified.
+        /// </param>
+        /// <param name="location">
+        /// Specifies the location of the uniform variable to be modified.
+        /// </param>
+        /// <param name="transpose">
+        /// Whether or not the matrix should be transposed.</param>
+        /// <param name="matrix">
+        /// Specifies the new vector to be used for the specified uniform variable.
+        /// </param>
         public static void ProgramUniformMatrix4x2(int program, int location, bool transpose, ref Matrix4x2d matrix)
         {
             unsafe
@@ -815,6 +1766,21 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
 
+        /// <summary>
+        /// [requires: v4.1 or ARB_separate_shader_objects|VERSION_4_1]
+        /// Specify the value of a <see cref="Matrix4x3"/> uniform variable for the current program object.
+        /// </summary>
+        /// <param name="program">
+        /// Specifies the handle of the program containing the uniform variable to be modified.
+        /// </param>
+        /// <param name="location">
+        /// Specifies the location of the uniform variable to be modified.
+        /// </param>
+        /// <param name="transpose">
+        /// Whether or not the matrix should be transposed.</param>
+        /// <param name="matrix">
+        /// Specifies the new vector to be used for the specified uniform variable.
+        /// </param>
         public static void ProgramUniformMatrix4x3(int program, int location, bool transpose, ref Matrix4x3 matrix)
         {
             unsafe
@@ -826,6 +1792,21 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
 
+        /// <summary>
+        /// [requires: v4.1 or ARB_separate_shader_objects|VERSION_4_1]
+        /// Specify the value of a <see cref="Matrix4x3d"/> uniform variable for the current program object.
+        /// </summary>
+        /// <param name="program">
+        /// Specifies the handle of the program containing the uniform variable to be modified.
+        /// </param>
+        /// <param name="location">
+        /// Specifies the location of the uniform variable to be modified.
+        /// </param>
+        /// <param name="transpose">
+        /// Whether or not the matrix should be transposed.</param>
+        /// <param name="matrix">
+        /// Specifies the new vector to be used for the specified uniform variable.
+        /// </param>
         public static void ProgramUniformMatrix4x3(int program, int location, bool transpose, ref Matrix4x3d matrix)
         {
             unsafe
@@ -837,6 +1818,21 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
 
+        /// <summary>
+        /// [requires: v4.1 or ARB_separate_shader_objects|VERSION_4_1]
+        /// Specify the value of a <see cref="Matrix4"/> uniform variable for the current program object.
+        /// </summary>
+        /// <param name="program">
+        /// Specifies the handle of the program containing the uniform variable to be modified.
+        /// </param>
+        /// <param name="location">
+        /// Specifies the location of the uniform variable to be modified.
+        /// </param>
+        /// <param name="transpose">
+        /// Whether or not the matrix should be transposed.</param>
+        /// <param name="matrix">
+        /// Specifies the new vector to be used for the specified uniform variable.
+        /// </param>
         public static void ProgramUniformMatrix4(int program, int location, bool transpose, ref Matrix4 matrix)
         {
             unsafe
@@ -848,6 +1844,21 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
 
+        /// <summary>
+        /// [requires: v4.1 or ARB_separate_shader_objects|VERSION_4_1]
+        /// Specify the value of a <see cref="Matrix4d"/> uniform variable for the current program object.
+        /// </summary>
+        /// <param name="program">
+        /// Specifies the handle of the program containing the uniform variable to be modified.
+        /// </param>
+        /// <param name="location">
+        /// Specifies the location of the uniform variable to be modified.
+        /// </param>
+        /// <param name="transpose">
+        /// Whether or not the matrix should be transposed.</param>
+        /// <param name="matrix">
+        /// Specifies the new vector to be used for the specified uniform variable.
+        /// </param>
         public static void ProgramUniformMatrix4(int program, int location, bool transpose, ref Matrix4d matrix)
         {
             unsafe
@@ -859,6 +1870,25 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
 
+        /// <summary>
+        /// [requires: v2.0]
+        /// Returns information about an active attribute variable for the specified program object.
+        /// </summary>
+        /// <param name="program">
+        /// Specifies the program object to be queried.
+        /// </param>
+        /// <param name="index">
+        /// Specifies the index of the attribute variable to be queried.
+        /// </param>
+        /// <param name="size">
+        /// Returns the size of the attribute variable.
+        /// </param>
+        /// <param name="type">
+        /// Returns the data type of the attribute variable.
+        /// </param>
+        /// <returns>
+        /// The name of the attribute variable.
+        /// </returns>
         public static string GetActiveAttrib(int program, int index, out int size, out ActiveAttribType type)
         {
             int length;
@@ -869,6 +1899,25 @@ namespace OpenTK.Graphics.OpenGL
             return sb.ToString();
         }
 
+        /// <summary>
+        /// [requires: v2.0]
+        /// Returns information about an active uniform variable for the specified program object.
+        /// </summary>
+        /// <param name="program">
+        /// Specifies the program object to be queried.
+        /// </param>
+        /// <param name="uniformIndex">
+        /// Specifies the index of the uniform variable to be queried.
+        /// </param>
+        /// <param name="size">[length: 1]
+        /// Returns the size of the uniform variable.
+        /// </param>
+        /// <param name="type">[length: 1]
+        /// Returns the data type of the uniform variable.
+        /// </param>
+        /// <returns>[length: bufSize]
+        /// The name of the uniform variable.
+        /// </returns>
         public static string GetActiveUniform(int program, int uniformIndex, out int size, out ActiveUniformType type)
         {
             int length;
@@ -879,6 +1928,19 @@ namespace OpenTK.Graphics.OpenGL
             return sb.ToString();
         }
 
+        /// <summary>
+        /// [requires: v3.1 or ARB_uniform_buffer_object|VERSION_3_1]
+        /// Query the name of an active uniform.
+        /// </summary>
+        /// <param name="program">
+        /// Specifies the program containing the active uniform index uniformIndex.
+        /// </param>
+        /// <param name="uniformIndex">
+        /// Specifies the index of the active uniform whose name to query.
+        /// </param>
+        /// <returns>
+        /// The name of the active uniform at uniformIndex within program.
+        /// </returns>
         public static string GetActiveUniformName(int program, int uniformIndex)
         {
             int length;
@@ -889,6 +1951,19 @@ namespace OpenTK.Graphics.OpenGL
             return sb.ToString();
         }
 
+        /// <summary>
+        /// [requires: v3.1 or ARB_uniform_buffer_object|VERSION_3_1]
+        /// Retrieve the name of an active uniform block.
+        /// </summary>
+        /// <param name="program">
+        /// Specifies the name of a program containing the uniform block.
+        /// </param>
+        /// <param name="uniformIndex">
+        /// Specifies the index of the uniform block within program.
+        /// </param>
+        /// <returns>
+        /// The name of the uniform block at uniformIndex.
+        /// </returns>
         public static string GetActiveUniformBlockName(int program, int uniformIndex)
         {
             int length;
@@ -899,6 +1974,16 @@ namespace OpenTK.Graphics.OpenGL
             return sb.ToString();
         }
 
+        /// <summary>
+        /// [requires: v2.0]
+        /// Replaces the source code in a shader object.
+        /// </summary>
+        /// <param name="shader">
+        /// Specifies the handle of the shader object whose source code is to be replaced.
+        /// </param>
+        /// <param name="string">
+        /// Specifies a string containing the source code to be loaded into the shader.
+        /// </param>
         public static void ShaderSource(Int32 shader, System.String @string)
         {
             unsafe
@@ -908,6 +1993,16 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
 
+        /// <summary>
+        /// [requires: v2.0]
+        /// Returns the information log for a shader object.
+        /// </summary>
+        /// <param name="shader">
+        /// Specifies the shader object whose information log is to be queried.
+        /// </param>
+        /// <returns>
+        /// The information log.
+        /// </returns>
         public static string GetShaderInfoLog(Int32 shader)
         {
             string info;
@@ -915,6 +2010,16 @@ namespace OpenTK.Graphics.OpenGL
             return info;
         }
 
+        /// <summary>
+        /// [requires: v2.0]
+        /// Returns the information log for a shader object.
+        /// </summary>
+        /// <param name="shader">
+        /// Specifies the shader object whose information log is to be queried.
+        /// </param>
+        /// <param name="info">[length: bufSize]
+        /// Specifies a string that is used to return the information log.
+        /// </param>
         public static void GetShaderInfoLog(Int32 shader, out string info)
         {
             unsafe
@@ -932,6 +2037,16 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
 
+        /// <summary>
+        /// [requires: v2.0]
+        /// Returns the information log for a program object.
+        /// </summary>
+        /// <param name="program">
+        /// Specifies the program object whose information log is to be queried.
+        /// </param>
+        /// <returns>
+        /// The information log.
+        /// </returns>
         public static string GetProgramInfoLog(Int32 program)
         {
             string info;
@@ -939,6 +2054,16 @@ namespace OpenTK.Graphics.OpenGL
             return info;
         }
 
+        /// <summary>
+        /// [requires: v2.0]
+        /// Returns the information log for a program object.
+        /// </summary>
+        /// <param name="program">
+        /// Specifies the program object whose information log is to be queried.
+        /// </param>
+        /// <param name="info">[length: bufSize]
+        /// Specifies a string that is used to return the information log.
+        /// </param>
         public static void GetProgramInfoLog(Int32 program, out string info)
         {
             unsafe
@@ -967,166 +2092,537 @@ namespace OpenTK.Graphics.OpenGL
             GL.PointParameter(PointParameterName.PointSpriteCoordOrigin, (int)param);
         }
 
+        /// <summary>
+        /// [requires: v2.0]
+        /// Specifies the value of a generic vertex attribute.
+        /// </summary>
+        /// <param name="index">
+        /// Specifies the index of the generic vertex attribute to be modified.
+        /// </param>
+        /// <param name="v">
+        /// Specifies the new x and y values to be used for the specified vertex attribute.
+        /// </param>
         [CLSCompliant(false)]
         public static void VertexAttrib2(Int32 index, ref Vector2 v)
         {
             GL.VertexAttrib2(index, v.X, v.Y);
         }
 
+        /// <summary>
+        /// [requires: v2.0]
+        /// Specifies the value of a generic vertex attribute.
+        /// </summary>
+        /// <param name="index">
+        /// Specifies the index of the generic vertex attribute to be modified.
+        /// </param>
+        /// <param name="v">
+        /// Specifies the new x, y and z values to be used for the specified vertex attribute.
+        /// </param>
         [CLSCompliant(false)]
         public static void VertexAttrib3(Int32 index, ref Vector3 v)
         {
             GL.VertexAttrib3(index, v.X, v.Y, v.Z);
         }
 
+        /// <summary>
+        /// [requires: v2.0]
+        /// Specifies the value of a generic vertex attribute.
+        /// </summary>
+        /// <param name="index">
+        /// Specifies the index of the generic vertex attribute to be modified.
+        /// </param>
+        /// <param name="v">
+        /// Specifies the new x, y, z and w values to be used for the specified vertex attribute.
+        /// </param>
         [CLSCompliant(false)]
         public static void VertexAttrib4(Int32 index, ref Vector4 v)
         {
             GL.VertexAttrib4(index, v.X, v.Y, v.Z, v.W);
         }
 
+        /// <summary>
+        /// [requires: v2.0]
+        /// Specifies the value of a generic vertex attribute.
+        /// </summary>
+        /// <param name="index">
+        /// Specifies the index of the generic vertex attribute to be modified.
+        /// </param>
+        /// <param name="v">
+        /// Specifies the new x and y values to be used for the specified vertex attribute.
+        /// </param>
         public static void VertexAttrib2(Int32 index, Vector2 v)
         {
             GL.VertexAttrib2(index, v.X, v.Y);
         }
 
+        /// <summary>
+        /// [requires: v2.0]
+        /// Specifies the value of a generic vertex attribute.
+        /// </summary>
+        /// <param name="index">
+        /// Specifies the index of the generic vertex attribute to be modified.
+        /// </param>
+        /// <param name="v">
+        /// Specifies the new x, y and z values to be used for the specified vertex attribute.
+        /// </param>
         public static void VertexAttrib3(Int32 index, Vector3 v)
         {
             GL.VertexAttrib3(index, v.X, v.Y, v.Z);
         }
 
+        /// <summary>
+        /// [requires: v2.0]
+        /// Specifies the value of a generic vertex attribute.
+        /// </summary>
+        /// <param name="index">
+        /// Specifies the index of the generic vertex attribute to be modified.
+        /// </param>
+        /// <param name="v">
+        /// Specifies the new x, y, z and w values to be used for the specified vertex attribute.
+        /// </param>
         public static void VertexAttrib4(Int32 index, Vector4 v)
         {
             GL.VertexAttrib4(index, v.X, v.Y, v.Z, v.W);
         }
 
+        /// <summary>
+        /// [requires: v1.3][deprecated: v3.2]
+        /// Set the current texture coordinates.
+        /// </summary>
+        /// <param name="target">
+        /// Specifies the texture unit whose coordinates should be modified. The number of texture units is 
+        /// implementation dependent, but must be at least two. Symbolic constant must be one of Texture, where i 
+        /// ranges from 0 to MaxTextureCoords - 1, which is an implementation-dependent value.
+        /// </param>
+        /// <param name="v">
+        /// Specifies the s and t texture coordinates for target texture unit.
+        /// </param>
         public static void MultiTexCoord2(TextureUnit target, ref Vector2 v)
         {
             GL.MultiTexCoord2(target, v.X, v.Y);
         }
 
+        /// <summary>
+        /// [requires: v1.3][deprecated: v3.2]
+        /// Set the current texture coordinates.
+        /// </summary>
+        /// <param name="target">
+        /// Specifies the texture unit whose coordinates should be modified. The number of texture units is 
+        /// implementation dependent, but must be at least two. Symbolic constant must be one of Texture, where i 
+        /// ranges from 0 to MaxTextureCoords - 1, which is an implementation-dependent value.
+        /// </param>
+        /// <param name="v">
+        /// Specifies the s, t, and r texture coordinates for target texture unit.
+        /// </param>
         public static void MultiTexCoord3(TextureUnit target, ref Vector3 v)
         {
             GL.MultiTexCoord3(target, v.X, v.Y, v.Z);
         }
 
+        /// <summary>
+        /// [requires: v1.3][deprecated: v3.2]
+        /// Set the current texture coordinates.
+        /// </summary>
+        /// <param name="target">
+        /// Specifies the texture unit whose coordinates should be modified. The number of texture units is 
+        /// implementation dependent, but must be at least two. Symbolic constant must be one of Texture, where i 
+        /// ranges from 0 to MaxTextureCoords - 1, which is an implementation-dependent value.
+        /// </param>
+        /// <param name="v">
+        /// Specifies the s, t, r, and q texture coordinates for target texture unit.
+        /// </param>
         public static void MultiTexCoord4(TextureUnit target, ref Vector4 v)
         {
             GL.MultiTexCoord4(target, v.X, v.Y, v.Z, v.W);
         }
 
+        /// <summary>
+        /// [requires: v2.0]
+        /// Specifies the value of a generic vertex attribute.
+        /// </summary>
+        /// <param name="index">
+        /// Specifies the index of the generic vertex attribute to be modified.
+        /// </param>
+        /// <param name="v">
+        /// Specifies the new x and y values to be used for the specified vertex attribute.
+        /// </param>
         [CLSCompliant(false)]
         public static void VertexAttrib2(Int32 index, ref Vector2d v)
         {
             GL.VertexAttrib2(index, v.X, v.Y);
         }
 
+        /// <summary>
+        /// [requires: v2.0]
+        /// Specifies the value of a generic vertex attribute.
+        /// </summary>
+        /// <param name="index">
+        /// Specifies the index of the generic vertex attribute to be modified.
+        /// </param>
+        /// <param name="v">
+        /// Specifies the new x, y and z values to be used for the specified vertex attribute.
+        /// </param>
         [CLSCompliant(false)]
         public static void VertexAttrib3(Int32 index, ref Vector3d v)
         {
             GL.VertexAttrib3(index, v.X, v.Y, v.Z);
         }
 
+        /// <summary>
+        /// [requires: v2.0]
+        /// Specifies the value of a generic vertex attribute.
+        /// </summary>
+        /// <param name="index">
+        /// Specifies the index of the generic vertex attribute to be modified.
+        /// </param>
+        /// <param name="v">
+        /// Specifies the new x, y, z and w values to be used for the specified vertex attribute.
+        /// </param>
         [CLSCompliant(false)]
         public static void VertexAttrib4(Int32 index, ref Vector4d v)
         {
             GL.VertexAttrib4(index, v.X, v.Y, v.Z, v.W);
         }
 
+        /// <summary>
+        /// [requires: v2.0]
+        /// Specifies the value of a generic vertex attribute.
+        /// </summary>
+        /// <param name="index">
+        /// Specifies the index of the generic vertex attribute to be modified.
+        /// </param>
+        /// <param name="v">
+        /// Specifies the new x and y values to be used for the specified vertex attribute.
+        /// </param>
         public static void VertexAttrib2(Int32 index, Vector2d v)
         {
             GL.VertexAttrib2(index, v.X, v.Y);
         }
 
+        /// <summary>
+        /// [requires: v2.0]
+        /// Specifies the value of a generic vertex attribute.
+        /// </summary>
+        /// <param name="index">
+        /// Specifies the index of the generic vertex attribute to be modified.
+        /// </param>
+        /// <param name="v">
+        /// Specifies the new x, y and z values to be used for the specified vertex attribute.
+        /// </param>
         public static void VertexAttrib3(Int32 index, Vector3d v)
         {
             GL.VertexAttrib3(index, v.X, v.Y, v.Z);
         }
 
+        /// <summary>
+        /// [requires: v2.0]
+        /// Specifies the value of a generic vertex attribute.
+        /// </summary>
+        /// <param name="index">
+        /// Specifies the index of the generic vertex attribute to be modified.
+        /// </param>
+        /// <param name="v">
+        /// Specifies the new x, y, z and w values to be used for the specified vertex attribute.
+        /// </param>
         public static void VertexAttrib4(Int32 index, Vector4d v)
         {
             GL.VertexAttrib4(index, v.X, v.Y, v.Z, v.W);
         }
 
+        /// <summary>
+        /// [requires: v1.3][deprecated: v3.2]
+        /// Set the current texture coordinates.
+        /// </summary>
+        /// <param name="target">
+        /// Specifies the texture unit whose coordinates should be modified. The number of texture units is 
+        /// implementation dependent, but must be at least two. Symbolic constant must be one of Texture, where i 
+        /// ranges from 0 to MaxTextureCoords - 1, which is an implementation-dependent value.
+        /// </param>
+        /// <param name="v">
+        /// Specifies the s and t texture coordinates for target texture unit.
+        /// </param>
         public static void MultiTexCoord2(TextureUnit target, ref Vector2d v)
         {
             GL.MultiTexCoord2(target, v.X, v.Y);
         }
 
+        /// <summary>
+        /// [requires: v1.3][deprecated: v3.2]
+        /// Set the current texture coordinates.
+        /// </summary>
+        /// <param name="target">
+        /// Specifies the texture unit whose coordinates should be modified. The number of texture units is 
+        /// implementation dependent, but must be at least two. Symbolic constant must be one of Texture, where i 
+        /// ranges from 0 to MaxTextureCoords - 1, which is an implementation-dependent value.
+        /// </param>
+        /// <param name="v">
+        /// Specifies the s, t, and r texture coordinates for target texture unit.
+        /// </param>
         public static void MultiTexCoord3(TextureUnit target, ref Vector3d v)
         {
             GL.MultiTexCoord3(target, v.X, v.Y, v.Z);
         }
 
+        /// <summary>
+        /// [requires: v1.3][deprecated: v3.2]
+        /// Set the current texture coordinates.
+        /// </summary>
+        /// <param name="target">
+        /// Specifies the texture unit whose coordinates should be modified. The number of texture units is 
+        /// implementation dependent, but must be at least two. Symbolic constant must be one of Texture, where i 
+        /// ranges from 0 to MaxTextureCoords - 1, which is an implementation-dependent value.
+        /// </param>
+        /// <param name="v">
+        /// Specifies the s, t, r, and q texture coordinates for target texture unit.
+        /// </param>
         public static void MultiTexCoord4(TextureUnit target, ref Vector4d v)
         {
             GL.MultiTexCoord4(target, v.X, v.Y, v.Z, v.W);
         }
 
+        /// <summary>
+        /// [requires: v1.0][deprecated: v3.2]
+        /// Draw a rectangle.
+        /// </summary>
+        /// <param name="rect">
+        /// Specifies the vertices of the rectangle.
+        /// </param>
         [CLSCompliant(false)]
         public static void Rect(RectangleF rect)
         {
             GL.Rect(rect.Left, rect.Top, rect.Right, rect.Bottom);
         }
 
+        /// <summary>
+        /// [requires: v1.0][deprecated: v3.2]
+        /// Draw a rectangle.
+        /// </summary>
+        /// <param name="rect">
+        /// Specifies the vertices of the rectangle.
+        /// </param>
         [CLSCompliant(false)]
         public static void Rect(Rectangle rect)
         {
             GL.Rect(rect.Left, rect.Top, rect.Right, rect.Bottom);
         }
 
+        /// <summary>
+        /// [requires: v1.0][deprecated: v3.2]
+        /// Draw a rectangle.
+        /// </summary>
+        /// <param name="rect">
+        /// Specifies the vertices of the rectangle.
+        /// </param>
         [CLSCompliant(false)]
         public static void Rect(ref RectangleF rect)
         {
             GL.Rect(rect.Left, rect.Top, rect.Right, rect.Bottom);
         }
 
+        /// <summary>
+        /// [requires: v1.0][deprecated: v3.2]
+        /// Draw a rectangle.
+        /// </summary>
+        /// <param name="rect">
+        /// Specifies the vertices of the rectangle.
+        /// </param>
         [CLSCompliant(false)]
         public static void Rect(ref Rectangle rect)
         {
             GL.Rect(rect.Left, rect.Top, rect.Right, rect.Bottom);
         }
 
+        /// <summary>
+        /// [requires: v1.1][deprecated: v3.2]
+        /// Define an array of vertex data.
+        /// </summary>
+        /// <param name="size">
+        /// Specifies the number of coordinates per vertex. Must be 2, 3, or 4. The initial value is 4.
+        /// </param>
+        /// <param name="type">
+        /// Specifies the data type of each coordinate in the array. Symbolic constants Short, Int, Float, or Double 
+        /// are accepted. The initial value is Float.
+        /// </param>
+        /// <param name="stride">
+        /// Specifies the byte offset between consecutive vertices. If stride is 0, the vertices are understood to 
+        /// be tightly packed in the array. The initial value is 0.
+        /// </param>
+        /// <param name="offset">
+        /// Specifies the first coordinate of the first vertex in the array. The initial value is 0.
+        /// </param>
         public static void VertexPointer(int size, VertexPointerType type, int stride, int offset)
         {
             VertexPointer(size, type, stride, (IntPtr)offset);
         }
 
+        /// <summary>
+        /// [requires: v1.1][deprecated: v3.2]
+        /// Define an array of normals.
+        /// </summary>
+        /// <param name="type">
+        /// Specifies the data type of each coordinate in the array. Symbolic constants Byte, Short, Int, Float, and 
+        /// Double are accepted. The initial value is Float.
+        /// </param>
+        /// <param name="stride">
+        /// Specifies the byte offset between consecutive normals. If stride is 0, the normals are understood to be 
+        /// tightly packed in the array. The initial value is 0.
+        /// </param>
+        /// <param name="offset">[length: type,stride]
+        /// Specifies the first coordinate of the first normal in the array. The initial value is 0.
+        /// </param>
         public static void NormalPointer(NormalPointerType type, int stride, int offset)
         {
             NormalPointer(type, stride, (IntPtr)offset);
         }
 
+        /// <summary>
+        /// [requires: v1.1][deprecated: v3.2]
+        /// Define an array of color indexes.
+        /// </summary>
+        /// <param name="type">
+        /// Specifies the data type of each color index in the array. Symbolic constants UnsignedByte, Short, Int, 
+        /// Float, and Double are accepted. The initial value is Float.
+        /// </param>
+        /// <param name="stride">
+        /// Specifies the byte offset between consecutive color indexes. If stride is 0, the color indexes are 
+        /// understood to be tightly packed in the array. The initial value is 0.
+        /// </param>
+        /// <param name="offset">
+        /// Specifies the first index in the array. The initial value is 0.
+        /// </param>
         public static void IndexPointer(IndexPointerType type, int stride, int offset)
         {
             IndexPointer(type, stride, (IntPtr)offset);
         }
 
+        /// <summary>
+        ///[requires: v1.1][deprecated: v3.2]
+        /// Define an array of colors.
+        /// </summary>
+        /// <param name="size">
+        /// Specifies the number of components per color. Must be 3 or 4. The initial value is 4.
+        /// </param>
+        /// <param name="type">
+        /// Specifies the data type of each color component in the array. Symbolic constants Byte, UnsignedByte, Short, 
+        /// UnsignedShort, Int, UnsignedInt, Float, and Double are accepted. The initial value is Float.
+        /// </param>
+        /// <param name="stride">
+        /// Specifies the byte offset between consecutive colors. If stride is 0, the colors are understood to be 
+        /// tightly packed in the array. The initial value is 0.
+        /// </param>
+        /// <param name="offset">
+        /// Specifies the first component of the first color element in the array. The initial value is 0.
+        /// </param>
         public static void ColorPointer(int size, ColorPointerType type, int stride, int offset)
         {
             ColorPointer(size, type, stride, (IntPtr)offset);
         }
 
+        /// <summary>
+        /// [requires: v1.4][deprecated: v3.2]
+        /// Define an array of fog coordinates.
+        /// </summary>
+        /// <param name="type">
+        /// Specifies the data type of each fog coordinate. Symbolic constants Float, or Double are accepted. 
+        /// The initial value is Float.
+        /// </param>
+        /// <param name="stride">
+        /// Specifies the byte offset between consecutive fog coordinates. If stride is 0, the array elements are 
+        /// understood to be tightly packed. The initial value is 0.
+        /// </param>
+        /// <param name="offset">
+        /// Specifies the first coordinate of the first fog coordinate in the array. The initial value is 0.
+        /// </param>
         public static void FogCoordPointer(FogPointerType type, int stride, int offset)
         {
             FogCoordPointer(type, stride, (IntPtr)offset);
         }
 
+        /// <summary>
+        /// [requires: v1.1][deprecated: v3.2]
+        /// Define an array of edge flags.
+        /// </summary>
+        /// <param name="stride">
+        /// Specifies the byte offset between consecutive edge flags. If stride is 0, the edge flags are understood to
+        ///  be tightly packed in the array. The initial value is 0.
+        /// </param>
+        /// <param name="offset">
+        /// Specifies the first edge flag in the array. The initial value is 0.
+        /// </param>
         public static void EdgeFlagPointer(int stride, int offset)
         {
             EdgeFlagPointer(stride, (IntPtr)offset);
         }
 
+        /// <summary>
+        /// [requires: v1.1][deprecated: v3.2]
+        /// Define an array of texture coordinates.
+        /// </summary>
+        /// <param name="size">
+        /// Specifies the number of coordinates per array element. Must be 1, 2, 3, or 4. The initial value is 4.
+        /// </param>
+        /// <param name="type">
+        /// Specifies the data type of each texture coordinate. Symbolic constants Short, Int, Float, or Double are 
+        /// accepted. The initial value is Float.
+        /// </param>
+        /// <param name="stride">
+        /// Specifies the byte offset between consecutive texture coordinate sets. If stride is 0, the array 
+        /// elements are understood to be tightly packed. The initial value is 0.
+        /// </param>
+        /// <param name="offset">
+        /// Specifies the first coordinate of the first texture coordinate set in the array. The initial value is 0.
+        /// </param>
         public static void TexCoordPointer(int size, TexCoordPointerType type, int stride, int offset)
         {
             TexCoordPointer(size, type, stride, (IntPtr)offset);
         }
 
+        /// <summary>
+        /// [requires: v2.0]
+        /// Define an array of generic vertex attribute data.
+        /// </summary>
+        /// <param name="index">
+        /// Specifies the index of the generic vertex attribute to be modified.
+        /// </param>
+        /// <param name="size">
+        /// Specifies the number of components per generic vertex attribute. Must be 1, 2, 3, 4. Additionally, the 
+        /// symbolic constant Bgra is accepted by glVertexAttribPointer. The initial value is 4.
+        /// </param>
+        /// <param name="type">
+        /// Specifies the data type of each component in the array. The symbolic constants Byte, UnsignedByte, Short, 
+        /// UnsignedShort, Int, and UnsignedInt are accepted by glVertexAttribPointer and glVertexAttribIPointer. 
+        /// Additionally HalfFloat, Float, Double, Fixed, Int2101010Rev, UnsignedInt2101010Rev and 
+        /// UnsignedInt10F11F11FRev are accepted by glVertexAttribPointer. Double is also accepted by 
+        /// glVertexAttribLPointer and is the only token accepted by the type parameter for that function. 
+        /// The initial value is Float.
+        /// </param>
+        /// <param name="normalized">
+        /// For glVertexAttribPointer, specifies whether fixed-point data values should be normalized (True) or 
+        /// converted directly as fixed-point values (False) when they are accessed.
+        /// </param>
+        /// <param name="stride">
+        /// Specifies the byte offset between consecutive generic vertex attributes. If stride is 0, the generic vertex 
+        /// attributes are understood to be tightly packed in the array. The initial value is 0.
+        /// </param>
+        /// <param name="offset">
+        /// Specifies the first component of the first generic vertex attribute in the array in the data store of the 
+        /// buffer currently bound to the ArrayBuffer target. The initial value is 0.
+        /// </param>
         public static void VertexAttribPointer(int index, int size, VertexAttribPointerType type, bool normalized, int stride, int offset)
         {
             VertexAttribPointer(index, size, type, normalized, stride, (IntPtr)offset);
         }
 
+        /// <summary>
+        /// [requires: v1.0]
+        /// Gets a series of consequtive float values as a vector.
+        /// </summary>
+        /// <param name="pname">
+        /// The name of the property that holds the values.
+        /// </param>
+        /// <param name="vector">
+        /// The vector which will hold the values.
+        /// </param>
         public static void GetFloat(GetPName pname, out Vector2 vector)
         {
             unsafe
@@ -1136,6 +2632,16 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
 
+        /// <summary>
+        /// [requires: v1.0]
+        /// Gets a series of consequtive float values as a vector.
+        /// </summary>
+        /// <param name="pname">
+        /// The name of the property that holds the values.
+        /// </param>
+        /// <param name="vector">
+        /// The vector which will hold the values.
+        /// </param>
         public static void GetFloat(GetPName pname, out Vector3 vector)
         {
             unsafe
@@ -1145,6 +2651,16 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
 
+        /// <summary>
+        /// [requires: v1.0]
+        /// Gets a series of consequtive float values as a vector.
+        /// </summary>
+        /// <param name="pname">
+        /// The name of the property that holds the values.
+        /// </param>
+        /// <param name="vector">
+        /// The vector which will hold the values.
+        /// </param>
         public static void GetFloat(GetPName pname, out Vector4 vector)
         {
             unsafe
@@ -1154,6 +2670,16 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
 
+        /// <summary>
+        /// [requires: v1.0]
+        /// Gets a series of consequtive float values as a matrix.
+        /// </summary>
+        /// <param name="pname">
+        /// The name of the property that holds the values.
+        /// </param>
+        /// <param name="matrix">
+        /// The matrix which will hold the values.
+        /// </param>
         public static void GetFloat(GetPName pname, out Matrix4 matrix)
         {
             unsafe
@@ -1163,6 +2689,16 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
 
+        /// <summary>
+        /// [requires: v1.0]
+        /// Gets a series of consequtive 64-bit float values as a vector.
+        /// </summary>
+        /// <param name="pname">
+        /// The name of the property that holds the values.
+        /// </param>
+        /// <param name="vector">
+        /// The vector which will hold the values.
+        /// </param>
         public static void GetDouble(GetPName pname, out Vector2d vector)
         {
             unsafe
@@ -1172,6 +2708,16 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
 
+        /// <summary>
+        /// [requires: v1.0]
+        /// Gets a series of consequtive 64-bit float values as a vector.
+        /// </summary>
+        /// <param name="pname">
+        /// The name of the property that holds the values.
+        /// </param>
+        /// <param name="vector">
+        /// The vector which will hold the values.
+        /// </param>
         public static void GetDouble(GetPName pname, out Vector3d vector)
         {
             unsafe
@@ -1181,6 +2727,16 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
 
+        /// <summary>
+        /// [requires: v1.0]
+        /// Gets a series of consequtive 64-bit float values as a vector.
+        /// </summary>
+        /// <param name="pname">
+        /// The name of the property that holds the values.
+        /// </param>
+        /// <param name="vector">
+        /// The vector which will hold the values.
+        /// </param>
         public static void GetDouble(GetPName pname, out Vector4d vector)
         {
             unsafe
@@ -1190,6 +2746,16 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
 
+        /// <summary>
+        /// [requires: v1.0]
+        /// Gets a series of consequtive 64-bit float values as a matrix.
+        /// </summary>
+        /// <param name="pname">
+        /// The name of the property that holds the values.
+        /// </param>
+        /// <param name="matrix">
+        /// The matrix which will hold the values.
+        /// </param>
         public static void GetDouble(GetPName pname, out Matrix4d matrix)
         {
             unsafe
@@ -1199,32 +2765,94 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
 
+        /// <summary>
+        /// [requires: v1.0]
+        /// Set the viewport. This function assumes a lower left corner of (0, 0).
+        /// </summary>
+        /// <param name="size">
+        /// Specifies the width and height of the viewport. When a GL context is first attached to a window, 
+        /// width and height are set to the dimensions of that window.
+        /// </param>
         public static void Viewport(Size size)
         {
             GL.Viewport(0, 0, size.Width, size.Height);
         }
 
+        /// <summary>
+        /// [requires: v1.0]
+        /// Set the viewport.
+        /// </summary>
+        /// <param name="location">
+        /// Specifies the lower left corner of the viewport.
+        /// </param>
+        /// <param name="size">
+        /// Specifies the width and height of the viewport. When a GL context is first attached to a window, 
+        /// width and height are set to the dimensions of that window.
+        /// </param>
         public static void Viewport(Point location, Size size)
         {
             GL.Viewport(location.X, location.Y, size.Width, size.Height);
         }
 
+        /// <summary>
+        /// [requires: v1.0]
+        /// Set the viewport.
+        /// </summary>
+        /// <param name="rectangle">
+        /// Specifies the lower left corner, as well as the width and height of the viewport. When a GL context is 
+        /// first attached to a window, width and height are set to the dimensions of that window.
+        /// </param>
         public static void Viewport(Rectangle rectangle)
         {
             GL.Viewport(rectangle.X, rectangle.Y, rectangle.Width, rectangle.Height);
         }
 #if MINIMAL
+        /// <summary>
+        /// [requires: v1.0]
+        /// Set the viewport.
+        /// </summary>
+        /// <param name="location">
+        /// Specifies the lower left corner of the viewport.
+        /// </param>
+        /// <param name="size">
+        /// Specifies the width and height of the viewport. When a GL context is first attached to a window, 
+        /// width and height are set to the dimensions of that window.
+        /// </param>
         public static void Viewport(OpenTK.Point location, OpenTK.Size size)
         {
             GL.Viewport(location.X, location.Y, size.Width, size.Height);
         }
 
+        /// <summary>
+        /// [requires: v1.0]
+        /// Set the viewport.
+        /// </summary>
+        /// <param name="rectangle">
+        /// Specifies the lower left corner, as well as the width and height of the viewport. When a GL context is 
+        /// first attached to a window, width and height are set to the dimensions of that window.
+        /// </param>
         public static void Viewport(OpenTK.Rectangle rectangle)
         {
             GL.Viewport(rectangle.X, rectangle.Y, rectangle.Width, rectangle.Height);
         }
 #endif
 
+        /// <summary>
+        /// [requires: v1.0][deprecated: v3.2]
+        /// Set texture environment parameters.
+        /// </summary>
+        /// <param name="target">
+        /// Specifies a texture environment. May be TextureEnv, TextureFilterControl or PointSprite.
+        /// </param>
+        /// <param name="pname">
+        /// Specifies the symbolic name of a single-valued texture environment parameter. May be either TextureEnvMode, 
+        /// TextureLodBias, CombineRgb, CombineAlpha, Src0Rgb, Src1Rgb, Src2Rgb, Src0Alpha, Src1Alpha, Src2Alpha, 
+        /// Operand0Rgb, Operand1Rgb, Operand2Rgb, Operand0Alpha, Operand1Alpha, Operand2Alpha, RgbScale, AlphaScale, 
+        /// or CoordReplace.
+        /// </param>
+        /// <param name="color">
+        /// Specifies the color to apply.
+        /// </param>
         public static void TexEnv(TextureEnvTarget target, TextureEnvParameter pname, Color color)
         {
             Color4 c = new Color4(color.R, color.G, color.B, color.A);
@@ -1234,6 +2862,22 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
 
+        /// <summary>
+        /// [requires: v1.0][deprecated: v3.2]
+        /// Set texture environment parameters.
+        /// </summary>
+        /// <param name="target">
+        /// Specifies a texture environment. May be TextureEnv, TextureFilterControl or PointSprite.
+        /// </param>
+        /// <param name="pname">
+        /// Specifies the symbolic name of a single-valued texture environment parameter. May be either TextureEnvMode, 
+        /// TextureLodBias, CombineRgb, CombineAlpha, Src0Rgb, Src1Rgb, Src2Rgb, Src0Alpha, Src1Alpha, Src2Alpha, 
+        /// Operand0Rgb, Operand1Rgb, Operand2Rgb, Operand0Alpha, Operand1Alpha, Operand2Alpha, RgbScale, AlphaScale, 
+        /// or CoordReplace.
+        /// </param>
+        /// <param name="color">
+        /// Specifies the color to apply.
+        /// </param>
         public static void TexEnv(TextureEnvTarget target, TextureEnvParameter pname, Color4 color)
         {
             unsafe


### PR DESCRIPTION
This PR adds a number of missing XML documentation comments for wrapper functions in GLHelper. The underlying OpenGL functions had documentation, while the wrappers did not.