### PR TITLE
Mark methods and classes in GLWidget with their CLS compliance

### DIFF
--- a/src/OpenTK.GLWidget/GLWidget.cs
+++ b/src/OpenTK.GLWidget/GLWidget.cs
@@ -15,6 +15,7 @@ namespace OpenTK
     /// <summary>
     /// The <see cref="GLWidget"/> is a GTK widget for which an OpenGL context can be used to draw arbitrary graphics.
     /// </summary>
+    [CLSCompliant(false)]
     [ToolboxItem(true)]
     public class GLWidget: DrawingArea
     {
@@ -268,6 +269,7 @@ namespace OpenTK
         /// </summary>
         /// <param name="cr"></param>
         /// <returns></returns>
+        [CLSCompliant(false)]
         protected override bool OnDrawn(Cairo.Context cr)
 #else
         /// <summary>
@@ -275,6 +277,7 @@ namespace OpenTK
         /// </summary>
         /// <param name="cr"></param>
         /// <returns></returns>
+        [CLSCompliant(false)]
         protected override bool OnExposeEvent(Gdk.EventExpose evnt)
 #endif
         {
@@ -309,6 +312,7 @@ namespace OpenTK
         /// </summary>
         /// <param name="evnt"></param>
         /// <returns></returns>
+        [CLSCompliant(false)]
         protected override bool OnConfigureEvent(Gdk.EventConfigure evnt)
         {
             bool result = base.OnConfigureEvent(evnt);

--- a/src/OpenTK.GLWidget/GLWidget.cs
+++ b/src/OpenTK.GLWidget/GLWidget.cs
@@ -269,7 +269,6 @@ namespace OpenTK
         /// </summary>
         /// <param name="cr"></param>
         /// <returns></returns>
-        [CLSCompliant(false)]
         protected override bool OnDrawn(Cairo.Context cr)
 #else
         /// <summary>
@@ -277,7 +276,6 @@ namespace OpenTK
         /// </summary>
         /// <param name="cr"></param>
         /// <returns></returns>
-        [CLSCompliant(false)]
         protected override bool OnExposeEvent(Gdk.EventExpose evnt)
 #endif
         {
@@ -312,7 +310,6 @@ namespace OpenTK
         /// </summary>
         /// <param name="evnt"></param>
         /// <returns></returns>
-        [CLSCompliant(false)]
         protected override bool OnConfigureEvent(Gdk.EventConfigure evnt)
         {
             bool result = base.OnConfigureEvent(evnt);


### PR DESCRIPTION
This PR marks one class and two methods which are not CLS-compliant as such. This eliminates some compiler warnings.