### PR TITLE
Fix some simple build warnings

### DIFF
--- a/src/Generator.Rewrite/Program.cs
+++ b/src/Generator.Rewrite/Program.cs
@@ -150,6 +150,7 @@ namespace OpenTK.Rewrite
             catch (InvalidOperationException inex)
             {
                 Console.WriteLine("Failed to load the assembly. It may already have been rewritten, and the debug symbols no longer match.");
+                Console.WriteLine(inex);
             }
         }
 

--- a/src/OpenTK/Input/MouseDevice.cs
+++ b/src/OpenTK/Input/MouseDevice.cs
@@ -1,5 +1,4 @@
-﻿#define COMPAT_REV1519 // Keeps compatibility with revision 1519
- //
+﻿ //
  // The Open Toolkit Library License
  //
  // Copyright (c) 2006 - 2009 the Open Toolkit library.
@@ -40,10 +39,6 @@ namespace OpenTK.Input
         private IntPtr id;
 
         private MouseState state;
-#if COMPAT_REV1519
-        private int wheel_last_accessed = 0;
-        private Point pos_last_accessed = new Point();
-#endif
 
         /// <summary>
         /// Gets a string describing this MouseDevice.


### PR DESCRIPTION
Fixes the following build warnings:

```
Program.cs(150,46): warning CS0168: The variable 'inex' is declared but never used
```

```
Input\MouseDevice.cs(45,23): warning CS0414: The field 'MouseDevice.pos_last_accessed' is assigned but its value is never used
Input\MouseDevice.cs(44,21): warning CS0414: The field 'MouseDevice.wheel_last_accessed' is assigned but its value is never used
```