### PR TITLE
Fix the binding generator to match recent handmade changes

### DIFF
--- a/src/Generator.Bind/CSharpSpecWriter.cs
+++ b/src/Generator.Bind/CSharpSpecWriter.cs
@@ -252,7 +252,7 @@ namespace Bind
             {
                 sw.WriteLine("[Slot({0})]", d.Slot);
                 sw.WriteLine("[DllImport(Library, ExactSpelling = true, CallingConvention = CallingConvention.Winapi)]");
-                sw.WriteLine("static extern {0};", GetDeclarationString(d, false));
+                sw.WriteLine("private static extern {0};", GetDeclarationString(d, false));
                 current_signature++;
             }
 

--- a/src/Generator.Bind/CSharpSpecWriter.cs
+++ b/src/Generator.Bind/CSharpSpecWriter.cs
@@ -380,7 +380,7 @@ namespace Bind
                         }
                         if (!String.IsNullOrEmpty(docparam.Documentation))
                         {
-                            sw.WriteLine(WriteOptions.NoIndent, " ");
+                            sw.WriteLine(WriteOptions.NoIndent, "");
                             sw.WriteLine("/// {0}", docparam.Documentation);
                             sw.WriteLine("/// </param>");
                         }

--- a/src/Generator.Bind/Specifications/License.txt
+++ b/src/Generator.Bind/Specifications/License.txt
@@ -5,7 +5,7 @@
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights to 
+// in the Software without restriction, including without limitation the rights to
 // use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
 // the Software, and to permit persons to whom the Software is furnished to do
 // so, subject to the following conditions:


### PR DESCRIPTION
Some handmade changes recently got made to the bindings. These included marking all methods with an explicit modifier and removing trailing whitespace.

This pull request fixes the binding generator so when it is run again it won't just revert those improvements. Given the handmade edits didn't change all binding files the next run of the generator will update those files (mostly the ES bindings and enums) to match the new style.

In future we may want to consider some way of making it so generated files aren't checked into the repo so handmade edits can't be committed.