### PR TITLE
Fix cursor incorreclty moved out of window

### DIFF
--- a/src/OpenTK/Platform/SDL2/Sdl2.cs
+++ b/src/OpenTK/Platform/SDL2/Sdl2.cs
@@ -490,6 +490,10 @@ namespace OpenTK.Platform.SDL2
         [DllImport(lib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "SDL_WarpMouseInWindow", ExactSpelling = true)]
         public static extern void WarpMouseInWindow(IntPtr window, int x, int y);
 
+        [SuppressUnmanagedCodeSecurity]
+        [DllImport (lib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "SDL_WarpMouseGlobal", ExactSpelling = true)]
+        public static extern void WarpMouseGlobal(int x, int y);
+
         /// <summary>
         /// Retrieves driver-dependent window information.
         /// </summary>

--- a/src/OpenTK/Platform/SDL2/Sdl2Mouse.cs
+++ b/src/OpenTK/Platform/SDL2/Sdl2Mouse.cs
@@ -146,7 +146,7 @@ namespace OpenTK.Platform.SDL2
 
         public void SetPosition(double x, double y)
         {
-            SDL.WarpMouseInWindow(IntPtr.Zero, (int)x, (int)y);
+            SDL.WarpMouseGlobal((int)x, (int)y);
         }
     }
 }


### PR DESCRIPTION
Previous code cause mouse to move out of window. Other platform use screen coordiante system instead of window