### PR TITLE
Fix white flash when starting GameWindow based application on windows

### DIFF
--- a/src/OpenTK/Platform/Windows/API.cs
+++ b/src/OpenTK/Platform/Windows/API.cs
@@ -1421,9 +1421,8 @@ namespace OpenTK.Platform.Windows
             }
         }
 
-
         [DllImport("gdi32.dll", SetLastError = true)]
-        internal static extern IntPtr GetStockObject(int index);
+        internal static extern IntPtr GetStockObject(StockObjects fnObject);
 
         [DllImport("gdi32.dll", SetLastError = true)]
         internal static extern BOOL DeleteObject([In]IntPtr hObject);
@@ -3934,6 +3933,33 @@ namespace OpenTK.Platform.Windows
         Russian = 204,
         Mac = 77,
         Baltic = 186,
+    }
+
+    /// <summary>
+    /// Identifiers for the GetStockObject method.
+    /// </summary>
+    internal enum StockObjects
+    {
+        WHITE_BRUSH = 0,
+        LTGRAY_BRUSH = 1,
+        GRAY_BRUSH = 2,
+        DKGRAY_BRUSH = 3,
+        BLACK_BRUSH = 4,
+        NULL_BRUSH = 5,
+        HOLLOW_BRUSH = NULL_BRUSH,
+        WHITE_PEN = 6,
+        BLACK_PEN = 7,
+        NULL_PEN = 8,
+        OEM_FIXED_FONT = 10,
+        ANSI_FIXED_FONT = 11,
+        ANSI_VAR_FONT = 12,
+        SYSTEM_FONT = 13,
+        DEVICE_DEFAULT_FONT = 14,
+        DEFAULT_PALETTE = 15,
+        SYSTEM_FIXED_FONT = 16,
+        DEFAULT_GUI_FONT = 17,
+        DC_BRUSH = 18,
+        DC_PEN = 19,
     }
 
     internal enum MapVirtualKeyType

--- a/src/OpenTK/Platform/Windows/WinGLNative.cs
+++ b/src/OpenTK/Platform/Windows/WinGLNative.cs
@@ -942,6 +942,7 @@ namespace OpenTK.Platform.Windows
             {
                 ExtendedWindowClass wc = new ExtendedWindowClass();
                 wc.Size = ExtendedWindowClass.SizeInBytes;
+                // Setting the background here ensures the window doesn't flash gray/white until the first frame is rendered.
                 wc.Background = Functions.GetStockObject(StockObjects.BLACK_BRUSH);
                 wc.Style = DefaultClassStyle;
                 wc.Instance = Instance;

--- a/src/OpenTK/Platform/Windows/WinGLNative.cs
+++ b/src/OpenTK/Platform/Windows/WinGLNative.cs
@@ -735,7 +735,7 @@ namespace OpenTK.Platform.Windows
                     break;
 
                 case WindowMessage.ERASEBKGND:
-                    return new IntPtr(1);
+                    break;
 
                 case WindowMessage.WINDOWPOSCHANGED:
                     HandleWindowPositionChanged(handle, message, wParam, lParam);
@@ -942,6 +942,7 @@ namespace OpenTK.Platform.Windows
             {
                 ExtendedWindowClass wc = new ExtendedWindowClass();
                 wc.Size = ExtendedWindowClass.SizeInBytes;
+                wc.Background = Functions.GetStockObject(StockObjects.BLACK_BRUSH);
                 wc.Style = DefaultClassStyle;
                 wc.Instance = Instance;
                 wc.WndProc = WindowProcedureDelegate;

--- a/src/OpenTK/Platform/Windows/WinGLNative.cs
+++ b/src/OpenTK/Platform/Windows/WinGLNative.cs
@@ -735,6 +735,8 @@ namespace OpenTK.Platform.Windows
                     break;
 
                 case WindowMessage.ERASEBKGND:
+                    // This is triggered only when the client area changes.
+                    // As such it does not affect steady-state performance.
                     break;
 
                 case WindowMessage.WINDOWPOSCHANGED:


### PR DESCRIPTION
When loading, GameWindow (in windows) would be painted white until the first GL frame was painted to the window, which could be quite disconcerting. This change paints the window black at first opportunity. Not sure if we need/want further customisation of this colour, but black seems like an objectively better default than white.