### PR TITLE
Remove child_window to support exclusive full screen in more scenarios

### DIFF
--- a/src/OpenTK/Platform/Windows/WinGLNative.cs
+++ b/src/OpenTK/Platform/Windows/WinGLNative.cs
@@ -55,7 +55,7 @@ namespace OpenTK.Platform.Windows
         private bool class_registered;
         private bool disposed;
         private bool exists;
-        private WinWindowInfo window, child_window;
+        private WinWindowInfo window;
         private WindowBorder windowBorder = WindowBorder.Resizable;
         private Nullable<WindowBorder> previous_window_border; // Set when changing to fullscreen state.
         private Nullable<WindowBorder> deferred_window_border; // Set to avoid changing borders during fullscreen state.
@@ -128,18 +128,11 @@ namespace OpenTK.Platform.Windows
                     scale_y = ScaleY(y);
                 }
 
-                // To avoid issues with Ati drivers on Windows 6+ with compositing enabled, the context will not be
-                // bound to the top-level window, but rather to a child window docked in the parent.
                 window = new WinWindowInfo(
                     CreateWindow(
                         scale_x, scale_y, scale_width, scale_height,
                         title, options, device, IntPtr.Zero),
                     null);
-                child_window = new WinWindowInfo(
-                    CreateWindow(
-                        0, 0, ClientSize.Width, ClientSize.Height,
-                        title, options, device, window.Handle),
-                    window);
                 Functions.DragAcceptFiles(window.Handle, true);
 
                 exists = true;
@@ -276,7 +269,7 @@ namespace OpenTK.Platform.Windows
                         Functions.GetClientRect(handle, out rect);
                         client_rectangle = rect.ToRectangle();
 
-                        Functions.SetWindowPos(child_window.Handle, IntPtr.Zero, 0, 0, ClientRectangle.Width, ClientRectangle.Height,
+                        Functions.SetWindowPos(window.Handle, IntPtr.Zero, bounds.X, bounds.Y, bounds.Width, bounds.Height,
                             SetWindowPosFlags.NOZORDER | SetWindowPosFlags.NOOWNERZORDER |
                             SetWindowPosFlags.NOACTIVATE | SetWindowPosFlags.NOSENDCHANGING);
 
@@ -535,7 +528,7 @@ namespace OpenTK.Platform.Windows
         {
             // If the mouse is captured we get spurious MOUSELEAVE events.
             // So ignore WM_MOUSELEAVE if capture count != 0.
-            if (mouse_capture_count == 0 )
+            if (mouse_capture_count == 0)
             {
                 mouse_outside_window = true;
                 // Mouse tracking is disabled automatically by the OS
@@ -688,7 +681,6 @@ namespace OpenTK.Platform.Windows
                 Functions.UnregisterClass(ClassName, Instance);
             }
             window.Dispose();
-            child_window.Dispose();
 
             OnClosed(EventArgs.Empty);
         }
@@ -855,7 +847,7 @@ namespace OpenTK.Platform.Windows
         {
             if (mouse_capture_count == 0)
             {
-                Functions.SetCapture(child_window.Handle);
+                Functions.SetCapture(window.Handle);
             }
             mouse_capture_count++;
         }
@@ -875,7 +867,7 @@ namespace OpenTK.Platform.Windows
         {
             TrackMouseEventStructure me = new TrackMouseEventStructure();
             me.Size = TrackMouseEventStructure.SizeInBytes;
-            me.TrackWindowHandle = child_window.Handle;
+            me.TrackWindowHandle = window.Handle;
             me.Flags = TrackMouseEventFlags.LEAVE;
 
             if (!Functions.TrackMouseEvent(ref me))
@@ -1161,7 +1153,7 @@ namespace OpenTK.Platform.Windows
             }
         }
 
-        public override  bool Exists { get { return exists; } }
+        public override bool Exists { get { return exists; } }
 
         public override MouseCursor Cursor
         {
@@ -1441,7 +1433,7 @@ namespace OpenTK.Platform.Windows
 
                 // Make sure client size doesn't change when changing the border style.
                 Size client_size = ClientSize;
-                Win32Rectangle rect = Win32Rectangle.From(client_size);
+                Win32Rectangle rect = Win32Rectangle.From(bounds);
                 Functions.AdjustWindowRectEx(ref rect, new_style, false, ParentStyleEx);
 
                 // This avoids leaving garbage on the background window.
@@ -1522,7 +1514,7 @@ namespace OpenTK.Platform.Windows
 
         public override IWindowInfo WindowInfo
         {
-            get { return child_window; }
+            get { return window; }
         }
 
         protected override void Dispose(bool calledManually)


### PR DESCRIPTION
OpenTK has a compatibility fix for "Ati drivers on Windows 6+ with compositing enabled" which involves nesting a window inside a window. Unfortunately, this causes a likely more widespread issue of breaking exclusive full screen rendering support on intel integrated graphics (current hardware, current drivers).

We applied this [back some time](https://github.com/ppy/opentk/commit/dcad4aadc59399c99100bf23207aa5b737449d04) on our fork, and have been using it for years on our stable release of osu! (closed-source) without seeing any regressions with compatibility, but even so this should likely be cross-referenced with any historical information on the fix it was added to fix.

If it is deemed that the `child_window` fix is still required for compatibility, then I propose we find a way to detect the environment for which it is required and only create it under those circumstances.