### PR TITLE
Support building OpenTK.Android on Linux

### DIFF
--- a/src/OpenTK/Minimal.cs
+++ b/src/OpenTK/Minimal.cs
@@ -1,6 +1,10 @@
 ﻿#if ANDROID || IPHONE || MINIMAL
 using System;
 
+#if !MINIMAL
+using System.Drawing;
+#endif
+
 namespace OpenTK
 {
     // Override a number of System.* classes when compiling for

--- a/src/OpenTK/OpenTK.Android.csproj
+++ b/src/OpenTK/OpenTK.Android.csproj
@@ -43,6 +43,12 @@
     <DocumentationFile>bin\Release\Android\OpenTK.xml</DocumentationFile>
     <DebugType>pdbonly</DebugType>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(OS)' == 'Unix' ">
+    <MonoAndroidToolsDirectory>/usr/lib/mono/mandroid</MonoAndroidToolsDirectory>
+    <MonoAndroidBinDirectory>/usr/lib/mono/xamarin-android/bin</MonoAndroidBinDirectory>
+    <AndroidSdkDirectory>$(ANDROID_SDK_PATH)</AndroidSdkDirectory>
+    <AndroidNdkDirectory>$(ANDROID_NDK_PATH)</AndroidNdkDirectory>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System.Xml" />
     <Reference Include="Mono.Android" />


### PR DESCRIPTION
This PR adds support for building OpenTK.Android if the Xamarin SDK is installed. While Xamarin doesn't officially support Linux, it's still possible to build and install the SDK on Linux on your own. See https://github.com/0xFireball/xamarin-android-linux.

Previously, OpenTK did not take this into account and looked in incorrect folders (Windows-specific ones). This PR corrects that.

Furthermore, System.Drawing had accidentally been removed from Minimal.cs. This prevented building, so it has been readded.