### PR TITLE
Ensure that all projects bundle their debugging symbols

### DIFF
--- a/src/OpenTK.GLControl/OpenTK.GLControl.csproj
+++ b/src/OpenTK.GLControl/OpenTK.GLControl.csproj
@@ -73,7 +73,7 @@
     <RemoveIntegerChecks>False</RemoveIntegerChecks>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-    <DebugType>none</DebugType>
+    <DebugType>pdbonly</DebugType>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>True</SignAssembly>

--- a/src/OpenTK.GLControl/paket.template
+++ b/src/OpenTK.GLControl/paket.template
@@ -21,3 +21,4 @@ summary
 description
     The Open Toolkit is set of fast, low-level C# bindings for OpenGL, OpenGL ES and OpenAL. It runs on all major platforms and powers hundreds of apps, games and scientific research. 
     OpenTK provides several utility libraries, including a math/linear algebra package, a windowing system, and input handling.
+include-pdbs true

--- a/src/OpenTK.GLWidget/OpenTK.GLWidget.csproj
+++ b/src/OpenTK.GLWidget/OpenTK.GLWidget.csproj
@@ -76,7 +76,7 @@
     <RemoveIntegerChecks>False</RemoveIntegerChecks>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-    <DebugType>none</DebugType>
+    <DebugType>pdbonly</DebugType>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/OpenTK.GLWidget/paket.template
+++ b/src/OpenTK.GLWidget/paket.template
@@ -21,3 +21,4 @@ summary
 description
     The Open Toolkit is set of fast, low-level C# bindings for OpenGL, OpenGL ES and OpenAL. It runs on all major platforms and powers hundreds of apps, games and scientific research. 
     OpenTK provides several utility libraries, including a math/linear algebra package, a windowing system, and input handling.
+include-pdbs true

--- a/src/OpenTK/OpenTK.Android.csproj.paket.template
+++ b/src/OpenTK/OpenTK.Android.csproj.paket.template
@@ -21,3 +21,4 @@ summary
 description
     The Open Toolkit is set of fast, low-level C# bindings for OpenGL, OpenGL ES and OpenAL. It runs on all major platforms and powers hundreds of apps, games and scientific research. 
     OpenTK provides several utility libraries, including a math/linear algebra package, a windowing system, and input handling.
+include-pdbs true

--- a/src/OpenTK/OpenTK.csproj.paket.template
+++ b/src/OpenTK/OpenTK.csproj.paket.template
@@ -23,4 +23,4 @@ description
     OpenTK provides several utility libraries, including a math/linear algebra package, a windowing system, and input handling.
 files
     OpenTK.dll.config => content/
-    ../../bin/OpenTK/OpenTK.pdb => lib/net20/
+include-pdbs true

--- a/src/OpenTK/OpenTK.iOS.csproj.paket.template
+++ b/src/OpenTK/OpenTK.iOS.csproj.paket.template
@@ -21,3 +21,4 @@ summary
 description
     The Open Toolkit is set of fast, low-level C# bindings for OpenGL, OpenGL ES and OpenAL. It runs on all major platforms and powers hundreds of apps, games and scientific research. 
     OpenTK provides several utility libraries, including a math/linear algebra package, a windowing system, and input handling.
+include-pdbs true


### PR DESCRIPTION
This PR ensures that debugging symbols are included in NuGet packages, replacing the previous manual copying. Furthermore, it also enables debugging symbol output for GLWidget and GLControl.