### PR TITLE
Remove GLWidget exclusion from nuget packing

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -177,7 +177,7 @@ Target "NuGet" (fun _ ->
     Paket.Pack(fun p ->
         { p with
             OutputPath = "bin"
-            ExcludedTemplates = "OpenTK.GLWidget" :: xamExcludes
+            ExcludedTemplates = xamExcludes
             Version = release.NugetVersion
             ReleaseNotes = toLines release.Notes})
 )


### PR DESCRIPTION
This PR reenables nuget package creation for GLWidget. It's been building fine for a while now, and since we brought all packages up to speed in terms of debugging symbols there's no reason not to let it build as well.