### PR TITLE
Set NuGet packages to always build when building via MyGet

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -16,6 +16,7 @@ IF NOT EXIST build.fsx (
   packages\FAKE\tools\FAKE.exe init.fsx
 )
 
+SET BuildTarget=
 if "%BuildRunner%" == "MyGet" (
   SET BuildTarget=NuGet
 )

--- a/build.cmd
+++ b/build.cmd
@@ -15,4 +15,9 @@ IF NOT EXIST build.fsx (
   .paket\paket.exe update
   packages\FAKE\tools\FAKE.exe init.fsx
 )
-packages\FAKE\tools\FAKE.exe build.fsx %*
+
+if "%BuildRunner%" == "MyGet" (
+  SET BuildTarget=NuGet
+)
+
+packages\FAKE\tools\FAKE.exe build.fsx %* %BuildTarget%

--- a/build.sh
+++ b/build.sh
@@ -34,4 +34,3 @@ run .paket/paket.exe restore
 [ ! -e build.fsx ] && run .paket/paket.exe update
 [ ! -e build.fsx ] && run packages/FAKE/tools/FAKE.exe init.fsx
 run packages/FAKE/tools/FAKE.exe "$@" $FSIARGS build.fsx
-


### PR DESCRIPTION
This PR adds a short workaround to enforce building of NuGet packages when running automated builds through MyGet. Furthermore, it strips the trailing newlines from the build script files.

This change is unique to the Windows script, as MyGet does not support bash.