### PR TITLE
Windows HID: Implement generic Consumer device which returns a button collection

### DIFF
--- a/src/OpenTK/Platform/Common/Hid.cs
+++ b/src/OpenTK/Platform/Common/Hid.cs
@@ -141,7 +141,8 @@ namespace OpenTK.Platform.Common
     // Consumer electronic devices
     internal enum HIDUsageCD
     {
-        ACPan = 0x0238
+        ACPan = 0x0238,
+        ConsumerControl = 0x01
     }
 
     // Generic desktop usage

--- a/src/OpenTK/Platform/Windows/API.cs
+++ b/src/OpenTK/Platform/Windows/API.cs
@@ -2126,6 +2126,14 @@ namespace OpenTK.Platform.Windows
             Target = target;
         }
 
+        public RawInputDevice(HIDUsageCD usage, RawInputDeviceFlags flags, HWND target)
+        {
+            UsagePage = HIDPage.Consumer;
+            Usage = (short)usage;
+            Flags = flags;
+            Target = target;
+        }
+
         public RawInputDevice(HIDUsageSim usage, RawInputDeviceFlags flags, HWND target)
         {
             UsagePage = HIDPage.Simulation;

--- a/src/OpenTK/Platform/Windows/WinRawJoystick.cs
+++ b/src/OpenTK/Platform/Windows/WinRawJoystick.cs
@@ -194,6 +194,7 @@ namespace OpenTK.Platform.Windows
             {
                 new RawInputDevice(HIDUsageGD.Joystick, RawInputDeviceFlags.DEVNOTIFY | RawInputDeviceFlags.INPUTSINK, window),
                 new RawInputDevice(HIDUsageGD.GamePad, RawInputDeviceFlags.DEVNOTIFY | RawInputDeviceFlags.INPUTSINK, window),
+                new RawInputDevice(HIDUsageCD.ConsumerControl, RawInputDeviceFlags.DEVNOTIFY | RawInputDeviceFlags.INPUTSINK, window),
             };
 
             if (!Functions.RegisterRawInputDevices(DeviceTypes, DeviceTypes.Length, API.RawInputDeviceSize))


### PR DESCRIPTION
This commit implements basic support for a generic device on the Consumer HID page (0x00), returning a generic Consumer Control (0x01) with a Button Collection.

This allows partial support for the RailDriver and other X-Keys based products from PI Engineering ( http://raildriver.com/ & http://piengineering.com/ )
