### PR TITLE
Use the Build target instead of Rebuild in FAKE

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -146,7 +146,7 @@ Target "Clean" (fun _ ->
 
 Target "Build" (fun _ ->
     activeProjects
-    |> MSBuildRelease "" "Rebuild"
+    |> MSBuildRelease "" "Build"
     |> ignore
 )
 


### PR DESCRIPTION
This PR changes the build target from Rebuild to Build in the fake script. Using Rebuild triggers a full rebuild of OpenTK three times when the script is invoked, and does not properly reuse already built dependencies for subprojects.

Since the script already cleans binaries as a part of the build process, using Rebuild is unnecessary and drastically increases build times. A benchmark shows this quite clearly:

```
Build:
    real	4m47.471s
    user	5m13.295s
    sys		0m3.204s

Rebuild:
    real	12m46.911s
    user	14m11.204s
    sys		0m5.174s
```
The build times are cut in three, since two full rebuilds of OpenTK are eliminated. This would have been an even greater improvement had OpenTK.Android and OpenTK.iOS been included in the build.