### PR TITLE
Add continuous MyGet package feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Instructions
 ============
 
 The simplest way to use OpenTK in your project is to install the [NuGet package](http://www.nuget.org/packages/OpenTK/).
+If you want to try out the latest development build from the `develop` branch, we also have a [MyGet feed](https://www.myget.org/F/opentk-develop/api/v3/index.json).
 
 Note what installing NuGet package will add reference to OpenTK.dll, but OpenTK.dll.config 
 will not be copied to the project output directory automatically, so you need to add it to your project 

--- a/build.cmd
+++ b/build.cmd
@@ -19,6 +19,9 @@ IF NOT EXIST build.fsx (
 SET BuildTarget=
 if "%BuildRunner%" == "MyGet" (
   SET BuildTarget=NuGet
+
+  echo ### %PackageVersion% > RELEASE_NOTES.md
+  echo 	* git build >> RELEASE_NOTES.md
 )
 
 packages\FAKE\tools\FAKE.exe build.fsx %* %BuildTarget%

--- a/build.cmd
+++ b/build.cmd
@@ -20,6 +20,7 @@ SET BuildTarget=
 if "%BuildRunner%" == "MyGet" (
   SET BuildTarget=NuGet
 
+  :: Replace the existing release notes file with one for this build only
   echo ### %PackageVersion% > RELEASE_NOTES.md
   echo 	* git build >> RELEASE_NOTES.md
 )


### PR DESCRIPTION
This PR adds supporting features for a continuous MyGet package feed, built as we work on the `develop` branch. More specifically, it adds a reference to the feed in the README, and a MyGet-specific version override in the build script.

We will also need to add a webhook, so that MyGet is notified of new commits to the selected branch.