### PR TITLE
Enable XML documentation output for supporting projects

### DIFF
--- a/src/Generator.Bind/Generator.Bind.csproj
+++ b/src/Generator.Bind/Generator.Bind.csproj
@@ -64,7 +64,7 @@
     <ConfigurationOverrideFile>
     </ConfigurationOverrideFile>
     <DefineConstants>TRACE;</DefineConstants>
-    <DocumentationFile>bin\Debug\Bind.xml</DocumentationFile>
+    <DocumentationFile>bin\Release\Bind.xml</DocumentationFile>
     <FileAlignment>4096</FileAlignment>
     <Optimize>True</Optimize>
     <OutputPath>bin\Release\</OutputPath>

--- a/src/Generator.Bind/Generator.Bind.csproj
+++ b/src/Generator.Bind/Generator.Bind.csproj
@@ -49,6 +49,7 @@
     <ConfigurationOverrideFile>
     </ConfigurationOverrideFile>
     <DefineConstants>DEBUG;TRACE;</DefineConstants>
+    <DocumentationFile>bin\Debug\Bind.xml</DocumentationFile>
     <DebugSymbols>True</DebugSymbols>
     <FileAlignment>4096</FileAlignment>
     <Optimize>False</Optimize>
@@ -63,6 +64,7 @@
     <ConfigurationOverrideFile>
     </ConfigurationOverrideFile>
     <DefineConstants>TRACE;</DefineConstants>
+    <DocumentationFile>bin\Debug\Bind.xml</DocumentationFile>
     <FileAlignment>4096</FileAlignment>
     <Optimize>True</Optimize>
     <OutputPath>bin\Release\</OutputPath>

--- a/src/Generator.Bind/Structures/Constant.cs
+++ b/src/Generator.Bind/Structures/Constant.cs
@@ -108,7 +108,6 @@ namespace Bind.Structures
         /// </summary>
         /// <param name="c">The Constant to translate</param>
         /// <param name="enums">The list of enums to check.</param>
-        /// <param name="auxEnums">The list of auxilliary enums to check.</param>
         /// <returns>True if the reference was found; false otherwise.</returns>
         public static bool TranslateConstantWithReference(Constant c, EnumCollection enums)
         {

--- a/src/Generator.Bind/Structures/FlowDirection.cs
+++ b/src/Generator.Bind/Structures/FlowDirection.cs
@@ -25,14 +25,25 @@
 
 namespace Bind.Structures
 {
+    /// <summary>
+    /// Enumarates the possible flows of a parameter (ie. is this parameter
+    /// used as input or as output?)
+    /// </summary>
+    public enum FlowDirection
+    {
         /// <summary>
-        /// Enumarates the possible flows of a parameter (ie. is this parameter
-        /// used as input or as output?)
+        /// No defined flow.
         /// </summary>
-        public enum FlowDirection
-        {
-            Undefined = 0,
-            In,
-            Out
-        }
+        Undefined = 0,
+
+        /// <summary>
+        /// Input parameter.
+        /// </summary>
+        In,
+
+        /// <summary>
+        /// Output parameter, typically decorated with the out keyword.
+        /// </summary>
+        Out
+    }
 }

--- a/src/Generator.Bind/Structures/Function.cs
+++ b/src/Generator.Bind/Structures/Function.cs
@@ -92,12 +92,23 @@ namespace Bind.Structures
         }
     }
 
+    /// <summary>
+    /// The <see cref="FunctionBody"/> class acts as a wrapper around a block of source code that makes up the body
+    /// of a function.
+    /// </summary>
     public class FunctionBody : List<string>
     {
+        /// <summary>
+        /// Initializes an empty <see cref="FunctionBody"/>.
+        /// </summary>
         public FunctionBody()
         {
         }
 
+        /// <summary>
+        /// Initializes a <see cref="FunctionBody"/> from an existing FunctionBody.
+        /// </summary>
+        /// <param name="fb">The body to copy from.</param>
         public FunctionBody(FunctionBody fb)
         {
             foreach (string s in fb)
@@ -108,11 +119,17 @@ namespace Bind.Structures
 
         private string indent = "";
 
+        /// <summary>
+        /// Indents this <see cref="FunctionBody"/> another level.
+        /// </summary>
         public void Indent()
         {
             indent += "    ";
         }
 
+        /// <summary>
+        /// Removes a level of indentation from this <see cref="FunctionBody"/>.
+        /// </summary>
         public void Unindent()
         {
             if (indent.Length > 4)
@@ -125,11 +142,19 @@ namespace Bind.Structures
             }
         }
 
+        /// <summary>
+        /// Adds a line of source code to the body at the current indentation level.
+        /// </summary>
+        /// <param name="s">The line to add.</param>
         new public void Add(string s)
         {
             base.Add(indent + s.TrimEnd('\r', '\n'));
         }
 
+        /// <summary>
+        /// Adds a range of source code lines to the body at the current indentation level.
+        /// </summary>
+        /// <param name="collection"></param>
         new public void AddRange(IEnumerable<string> collection)
         {
             foreach (string t in collection)
@@ -138,6 +163,10 @@ namespace Bind.Structures
             }
         }
 
+        /// <summary>
+        /// Builds the contents of the function body into a string and encloses it with braces.
+        /// </summary>
+        /// <returns>The body, enclosed in braces.</returns>
         public override string ToString()
         {
             if (Count == 0)

--- a/src/Generator.Bind/Utilities.cs
+++ b/src/Generator.Bind/Utilities.cs
@@ -13,6 +13,10 @@ using Enum=Bind.Structures.Enum;
 
 namespace Bind
 {
+    /// <summary>
+    /// Defines different types of parameter wrapper identifiers, which are used for hinting at how the method
+    /// signatures should be generated.
+    /// </summary>
     [Flags]
     public enum WrapperTypes
     {

--- a/src/Generator.Converter/Generator.Convert.csproj
+++ b/src/Generator.Converter/Generator.Convert.csproj
@@ -64,7 +64,7 @@
     <ConfigurationOverrideFile>
     </ConfigurationOverrideFile>
     <DefineConstants>TRACE;</DefineConstants>
-    <DocumentationFile>bin\Debug\Convert.xml</DocumentationFile>
+    <DocumentationFile>bin\Release\Convert.xml</DocumentationFile>
     <FileAlignment>4096</FileAlignment>
     <Optimize>True</Optimize>
     <OutputPath>bin\Release\</OutputPath>

--- a/src/Generator.Converter/Generator.Convert.csproj
+++ b/src/Generator.Converter/Generator.Convert.csproj
@@ -48,6 +48,7 @@
     <ConfigurationOverrideFile>
     </ConfigurationOverrideFile>
     <DefineConstants>DEBUG;TRACE;</DefineConstants>
+    <DocumentationFile>bin\Debug\Convert.xml</DocumentationFile>
     <DebugSymbols>True</DebugSymbols>
     <FileAlignment>4096</FileAlignment>
     <Optimize>False</Optimize>
@@ -63,6 +64,7 @@
     <ConfigurationOverrideFile>
     </ConfigurationOverrideFile>
     <DefineConstants>TRACE;</DefineConstants>
+    <DocumentationFile>bin\Debug\Convert.xml</DocumentationFile>
     <FileAlignment>4096</FileAlignment>
     <Optimize>True</Optimize>
     <OutputPath>bin\Release\</OutputPath>

--- a/src/Generator.Converter/Options.cs
+++ b/src/Generator.Converter/Options.cs
@@ -4,23 +4,38 @@ using CommandLine.Text;
 
 namespace OpenTK.Convert
 {
+    /// <summary>
+    /// A container class used by <see cref="CommandLine.Parser"/> to parse command line arguments.
+    /// </summary>
     public class Options
     {
+        /// <summary>
+        /// Gets or sets the prefix to remove from parsed functions and constants.
+        /// </summary>
         [Option('p', "prefix",
             HelpText = "The prefix to remove from parsed functions and constants.",
             Required = true,
             Default = "gl")]
         public string Prefix { get; set; }
 
+        /// <summary>
+        /// Gets or sets the path to the output file. Defaults to stdout if no path is provided.
+        /// </summary>
         [Option('o', "output-file",
             HelpText = "The path to the output file. Defaults to stdout if no path is provided.")]
         public string OutputFile { get; set; }
 
+        /// <summary>
+        /// Gets or sets a list of the Khronos XML files to parse into OpenTK XML. Remote resources in the form of URLs are supported.
+        /// </summary>
         [Option('i', "input-files",
             HelpText = "A list of the Khronos XML files to parse into OpenTK XML. Remote resources in the form of URLs are supported.",
             Required = true)]
         public IEnumerable<string> InputFiles { get; set; }
 
+        /// <summary>
+        /// Gets a set of usage examples which can be shown to the user.
+        /// </summary>
         [Usage(ApplicationAlias = "Convert.exe")]
         public static IEnumerable<Example> Examples
         {

--- a/src/Generator.Rewrite/GeneratedVariableIdentifier.cs
+++ b/src/Generator.Rewrite/GeneratedVariableIdentifier.cs
@@ -4,7 +4,7 @@ using Mono.Cecil.Cil;
 namespace OpenTK.Rewrite
 {
     /// <summary>
-    /// Acts as a unique identifier for a generated named variable that can be passed between methods. Replaces uses of 
+    /// Acts as a unique identifier for a generated named variable that can be passed between methods. Replaces uses of
     /// variable names from Mono.Cecil.
     /// </summary>
     internal sealed class GeneratedVariableIdentifier
@@ -13,7 +13,7 @@ namespace OpenTK.Rewrite
         /// The <see cref="MethodBody"/> which the variable is in.
         /// </summary>
         public MethodBody Body { get; }
-        
+
         /// <summary>
         /// The <see cref="VariableDefinition"/> which the variable idetifier maps to.
         /// </summary>
@@ -28,8 +28,8 @@ namespace OpenTK.Rewrite
         /// Initializes a new instance of the <see cref="GeneratedVariableIdentifier"/> class.
         /// </summary>
         /// <param name="body">The method body which the variable is in.</param>
+        /// <param name="definition">The definition of the generated variable.</param>
         /// <param name="name">The name of the generated variable.</param>
-        /// <param name="index">The index of the generated variable in its method.</param>
         /// <exception cref="ArgumentException"></exception>
         public GeneratedVariableIdentifier(MethodBody body, VariableDefinition definition, string name)
         {

--- a/src/Generator.Rewrite/Generator.Rewrite.csproj
+++ b/src/Generator.Rewrite/Generator.Rewrite.csproj
@@ -24,6 +24,7 @@
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DocumentationFile>bin\Debug\Rewrite.xml</DocumentationFile>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Commandlineparameters>../../OpenTK/Debug/OpenTK.dll ../../../OpenTK.snk -debug</Commandlineparameters>
@@ -34,6 +35,7 @@
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
+    <DocumentationFile>bin\Debug\Rewrite.xml</DocumentationFile>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Commandlineparameters>../../OpenTK/Release/OpenTK.dll ../../../OpenTK.snk</Commandlineparameters>

--- a/src/Generator.Rewrite/Generator.Rewrite.csproj
+++ b/src/Generator.Rewrite/Generator.Rewrite.csproj
@@ -35,7 +35,7 @@
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
-    <DocumentationFile>bin\Debug\Rewrite.xml</DocumentationFile>
+    <DocumentationFile>bin\Release\Rewrite.xml</DocumentationFile>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Commandlineparameters>../../OpenTK/Release/OpenTK.dll ../../../OpenTK.snk</Commandlineparameters>


### PR DESCRIPTION
This PR enables XML documentation output for the supporting projects, and corrects a number of compile-time warnings raised by incorrect or missing documentation.

This removes a substantial number of compiler warnings, and improves the documentation coverage.