### PR TITLE
Fix leaking Cocoa Machports on macOS

### DIFF
--- a/src/OpenTK/OpenTK.csproj
+++ b/src/OpenTK/OpenTK.csproj
@@ -137,6 +137,7 @@
     <Compile Include="Platform\Egl\EglUnixContext.cs" />
     <Compile Include="Platform\Egl\EglWinContext.cs" />
     <Compile Include="Platform\Egl\EglAnglePlatformFactory.cs" />
+    <Compile Include="Platform\MacOS\Cocoa\NSAutoreleasePool.cs" />
     <Compile Include="Platform\MappedGamePadDriver.cs" />
     <Compile Include="Platform\Windows\Bindings\HidProtocol.cs" />
     <Compile Include="Platform\Windows\WinInputBase.cs" />

--- a/src/OpenTK/Platform/MacOS/Cocoa/NSAutoreleasePool.cs
+++ b/src/OpenTK/Platform/MacOS/Cocoa/NSAutoreleasePool.cs
@@ -16,8 +16,8 @@ namespace OpenTK.Platform.MacOS
         /// </summary>
         public NSAutoreleasePool()
         {
-            _autoreleasePool = Cocoa.SendIntPtr(Class.NSAutoreleasePool, Selector.Alloc);
-            _autoreleasePool = Cocoa.SendIntPtr(_autoreleasePool, Selector.Init);
+            var uninitializedPool = Cocoa.SendIntPtr(Class.NSAutoreleasePool, Selector.Alloc);
+            _autoreleasePool = Cocoa.SendIntPtr(uninitializedPool, Selector.Init);
         }
 
         /// <summary>

--- a/src/OpenTK/Platform/MacOS/Cocoa/NSAutoreleasePool.cs
+++ b/src/OpenTK/Platform/MacOS/Cocoa/NSAutoreleasePool.cs
@@ -16,8 +16,8 @@ namespace OpenTK.Platform.MacOS
         /// </summary>
         public NSAutoreleasePool()
         {
-            _autoreleasePool = Cocoa.SendIntPtr(Class.NSAutoreleasePool, Selector.Get("alloc"));
-            _autoreleasePool = Cocoa.SendIntPtr(_autoreleasePool, Selector.Get("init"));
+            _autoreleasePool = Cocoa.SendIntPtr(Class.NSAutoreleasePool, Selector.Alloc);
+            _autoreleasePool = Cocoa.SendIntPtr(_autoreleasePool, Selector.Init);
         }
 
         /// <summary>

--- a/src/OpenTK/Platform/MacOS/Cocoa/NSAutoreleasePool.cs
+++ b/src/OpenTK/Platform/MacOS/Cocoa/NSAutoreleasePool.cs
@@ -1,0 +1,34 @@
+﻿using System;
+
+namespace OpenTK.Platform.MacOS
+{
+    /// <summary>
+    /// The <see cref="NSAutoreleasePool"/> class is a wrapper around the native objective-C NSAutoreleasePool.
+    /// In particular, this construct mimics the usage of an @autorelease block and can be used in much the same way,
+    /// only with a C# using block instead.
+    /// </summary>
+    public sealed class NSAutoreleasePool : IDisposable
+    {
+        private readonly IntPtr _autoreleasePool;
+
+        /// <summary>
+        /// Allocates and initializes a new <see cref="NSAutoreleasePool"/>.
+        /// </summary>
+        public NSAutoreleasePool()
+        {
+            _autoreleasePool = Cocoa.SendIntPtr(Class.NSAutoreleasePool, Selector.Get("alloc"));
+            _autoreleasePool = Cocoa.SendIntPtr(_autoreleasePool, Selector.Get("init"));
+        }
+
+        /// <summary>
+        /// Disposes of the <see cref="NSAutoreleasePool"/> instance, draining it.
+        /// </summary>
+        public void Dispose()
+        {
+            if (_autoreleasePool != IntPtr.Zero)
+            {
+                Cocoa.SendVoid(_autoreleasePool, Selector.Get("drain"));
+            }
+        }
+    }
+}

--- a/src/OpenTK/Platform/MacOS/CocoaContext.cs
+++ b/src/OpenTK/Platform/MacOS/CocoaContext.cs
@@ -341,15 +341,21 @@ namespace OpenTK
             Debug.Print("Disposing of Cocoa context.");
 
             using (var pool = new NSAutoreleasePool())
-            {if (!NSApplication.IsUIThread)
-            {    return;}
+            {
+                if (!NSApplication.IsUIThread)
+                {
+                    return;
 
-            if (IsCurrent)
-            {    Cocoa.SendVoid(NSOpenGLContext, Selector.Get("clearCurrentContext"));}
-            Cocoa.SendVoid(Handle.Handle, Selector.Get("clearDrawable"));
-            Cocoa.SendVoid(Handle.Handle, Selector.Get("release"));
+                }
 
+                if (IsCurrent)
+                {
+                    Cocoa.SendVoid(NSOpenGLContext, Selector.Get("clearCurrentContext"));
 
+                }
+
+                Cocoa.SendVoid(Handle.Handle, Selector.Get("clearDrawable"));
+                Cocoa.SendVoid(Handle.Handle, Selector.Get("release"));
             }
 
             Handle = ContextHandle.Zero;

--- a/src/OpenTK/Platform/MacOS/CocoaContext.cs
+++ b/src/OpenTK/Platform/MacOS/CocoaContext.cs
@@ -340,18 +340,16 @@ namespace OpenTK
 
             Debug.Print("Disposing of Cocoa context.");
 
+            if (!NSApplication.IsUIThread)
+            {
+                return;
+            }
+
             using (var pool = new NSAutoreleasePool())
             {
-                if (!NSApplication.IsUIThread)
-                {
-                    return;
-
-                }
-
                 if (IsCurrent)
                 {
                     Cocoa.SendVoid(NSOpenGLContext, Selector.Get("clearCurrentContext"));
-
                 }
 
                 Cocoa.SendVoid(Handle.Handle, Selector.Get("clearDrawable"));

--- a/src/OpenTK/Platform/MacOS/CocoaContext.cs
+++ b/src/OpenTK/Platform/MacOS/CocoaContext.cs
@@ -54,8 +54,6 @@ namespace OpenTK
             "/System/Library/Frameworks/OpenGL.framework/OpenGLES",
             AddImageFlags.ReturnOnError);
 
-        private IntPtr autoreleasePool;
-
         static CocoaContext()
         {
             Cocoa.Initialize();
@@ -119,10 +117,6 @@ namespace OpenTK
 
         private void CreateContext(GraphicsMode mode, CocoaWindowInfo cocoaWindow, IntPtr shareContextRef, int majorVersion, int minorVersion, bool fullscreen)
         {
-            // Create a new autorelease pool for allocations in this context (mach ports, etc)
-            autoreleasePool = Cocoa.SendIntPtr(Class.NSAutoreleasePool, Selector.Get("alloc"));
-            autoreleasePool = Cocoa.SendIntPtr(autoreleasePool, Selector.Get("init"));
-
             // Prepare attributes
             IntPtr pixelFormat = SelectPixelFormat(mode, majorVersion, minorVersion);
             if (pixelFormat == IntPtr.Zero)
@@ -346,22 +340,16 @@ namespace OpenTK
 
             Debug.Print("Disposing of Cocoa context.");
 
-            if (!NSApplication.IsUIThread)
-            {
-                return;
-            }
+            using (var pool = new NSAutoreleasePool())
+            {if (!NSApplication.IsUIThread)
+            {    return;}
 
             if (IsCurrent)
-            {
-                Cocoa.SendVoid(NSOpenGLContext, Selector.Get("clearCurrentContext"));
-            }
+            {    Cocoa.SendVoid(NSOpenGLContext, Selector.Get("clearCurrentContext"));}
             Cocoa.SendVoid(Handle.Handle, Selector.Get("clearDrawable"));
             Cocoa.SendVoid(Handle.Handle, Selector.Get("release"));
 
-            // Drain the autorelease pool for the context, closing mach ports (if there is one)
-            if (autoreleasePool != IntPtr.Zero)
-            {
-                Cocoa.SendVoid(autoreleasePool, Selector.Get("drain"));
+
             }
 
             Handle = ContextHandle.Zero;

--- a/src/OpenTK/Platform/MacOS/CocoaNativeWindow.cs
+++ b/src/OpenTK/Platform/MacOS/CocoaNativeWindow.cs
@@ -137,6 +137,7 @@ namespace OpenTK.Platform.MacOS
         }
 
         private CocoaWindowInfo windowInfo;
+        private IntPtr autoreleasePool;
         private IntPtr windowClass;
         private IntPtr trackingArea;
         private IntPtr current_icon_handle;
@@ -157,6 +158,10 @@ namespace OpenTK.Platform.MacOS
 
         public CocoaNativeWindow(int x, int y, int width, int height, string title, GraphicsMode mode, GameWindowFlags options, DisplayDevice device)
         {
+            // Create a new autorelease pool for allocations in this window (mach ports, etc)
+            autoreleasePool = Cocoa.SendIntPtr(Class.NSAutoreleasePool, Selector.Get("alloc"));
+            autoreleasePool = Cocoa.SendIntPtr(autoreleasePool, Selector.Get("init"));
+
             // Create callback methods. We need to store those,
             // otherwise the GC may collect them while they are
             // still active.
@@ -1283,6 +1288,9 @@ namespace OpenTK.Platform.MacOS
 
                 Debug.Print("[Mac] Disposing {0}", windowInfo);
                 windowInfo.Dispose();
+
+                // Drain the autorelease pool for the application, closing mach ports
+                Cocoa.SendVoid(autoreleasePool, Selector.Get("drain"));
             }
             else
             {

--- a/src/OpenTK/Platform/MacOS/CocoaNativeWindow.cs
+++ b/src/OpenTK/Platform/MacOS/CocoaNativeWindow.cs
@@ -137,7 +137,7 @@ namespace OpenTK.Platform.MacOS
         }
 
         private CocoaWindowInfo windowInfo;
-        private IntPtr autoreleasePool;
+
         private IntPtr windowClass;
         private IntPtr trackingArea;
         private IntPtr current_icon_handle;
@@ -158,10 +158,6 @@ namespace OpenTK.Platform.MacOS
 
         public CocoaNativeWindow(int x, int y, int width, int height, string title, GraphicsMode mode, GameWindowFlags options, DisplayDevice device)
         {
-            // Create a new autorelease pool for allocations in this window (mach ports, etc)
-            autoreleasePool = Cocoa.SendIntPtr(Class.NSAutoreleasePool, Selector.Get("alloc"));
-            autoreleasePool = Cocoa.SendIntPtr(autoreleasePool, Selector.Get("init"));
-
             // Create callback methods. We need to store those,
             // otherwise the GC may collect them while they are
             // still active.
@@ -1288,9 +1284,6 @@ namespace OpenTK.Platform.MacOS
 
                 Debug.Print("[Mac] Disposing {0}", windowInfo);
                 windowInfo.Dispose();
-
-                // Drain the autorelease pool for the application, closing mach ports
-                Cocoa.SendVoid(autoreleasePool, Selector.Get("drain"));
             }
             else
             {


### PR DESCRIPTION
This PR implements the discussed fix for leaking Machports on macOS. The main discussion of this problem was held in issue #407, and the included fix was shown to alleviate the problem.

The most substantial change is the introduction of a new helper class for Cocoa which mimicks the behaviour and usage of an [NSAutoreleasePool] (https://developer.apple.com/documentation/foundation/nsautoreleasepool) block in objective-C. The new NSAutoreleasePool class can be utilized with C# `using` statements to form similar nested stack-based pool constructs as is usually done in objective-C.

This construct has then been applied to the disposal method of CocoaContext, wherein the mach ports were being created but not successfully released. By wrapping the Cocoa functions therein with one of these pools, the mach ports are successfully released.

It is likely that the lack of these pools are the source of other hitherto unknown memory-related issues on macOS, but for now, this fix is sufficient to close #407.