### PR TITLE
Allocate SystemDefaultCharSize instead of 1 byte per char for buffer used in WinGLNative.HandleDropFiles

### DIFF
--- a/src/OpenTK/Platform/Windows/WinGLNative.cs
+++ b/src/OpenTK/Platform/Windows/WinGLNative.cs
@@ -692,10 +692,11 @@ namespace OpenTK.Platform.Windows
             for (uint i = 0; i < filesCounter; ++i)
             {
                 // Don't forget about \0 at the end
-                uint fileNameSize = Functions.DragQueryFile(hDrop, i, IntPtr.Zero, 0) + 1;
-                IntPtr str = Marshal.AllocHGlobal((int)fileNameSize);
+                uint filenameChars = Functions.DragQueryFile(hDrop, i, IntPtr.Zero, 0) + 1;
+                int filenameSize = (int)(filenameChars * 2); // for unicode char set, 2 bytes per character
+                IntPtr str = Marshal.AllocHGlobal(filenameSize);
 
-                Functions.DragQueryFile(hDrop, i, str, fileNameSize);
+                Functions.DragQueryFile(hDrop, i, str, filenameChars);
 
                 string dropString = Marshal.PtrToStringAuto(str);
                 OnFileDrop(dropString);

--- a/src/OpenTK/Platform/Windows/WinGLNative.cs
+++ b/src/OpenTK/Platform/Windows/WinGLNative.cs
@@ -693,15 +693,14 @@ namespace OpenTK.Platform.Windows
             {
                 // Don't forget about \0 at the end
                 uint filenameChars = Functions.DragQueryFile(hDrop, i, IntPtr.Zero, 0) + 1;
-                int filenameSize = (int)(filenameChars * 2); // for unicode char set, 2 bytes per character
+                int filenameSize = (int)(filenameChars * Marshal.SystemDefaultCharSize);
                 IntPtr str = Marshal.AllocHGlobal(filenameSize);
 
                 Functions.DragQueryFile(hDrop, i, str, filenameChars);
 
                 string dropString = Marshal.PtrToStringAuto(str);
-                OnFileDrop(dropString);
-
                 Marshal.FreeHGlobal(str);
+                OnFileDrop(dropString);
             }
 
             Functions.DragFinish(hDrop);


### PR DESCRIPTION
DragQueryFile returns number of characters. Previously, a buffer of 'number of characters' bytes was being allocated.

This change fixes crashing when the platform uses a character set with more than one byte per character. (unicode charset has 2 bytes)

Fixes #626