### PR TITLE
X11DisplayDevice - Use XRRSizes array directly if dev.Bounds is empty

### DIFF
--- a/src/OpenTK/Platform/X11/X11DisplayDevice.cs
+++ b/src/OpenTK/Platform/X11/X11DisplayDevice.cs
@@ -232,7 +232,7 @@ namespace OpenTK.Platform.X11
                 dev.RefreshRate = current_refresh_rate;
                 dev.AvailableResolutions = available_res;
 
-                deviceToDefaultResolution.Add(dev, current_resolution_index);
+                deviceToDefaultResolution.Add(dev, current_sizes_index);
             }
 
             return true;

--- a/src/OpenTK/Platform/X11/X11DisplayDevice.cs
+++ b/src/OpenTK/Platform/X11/X11DisplayDevice.cs
@@ -171,7 +171,8 @@ namespace OpenTK.Platform.X11
                 int[] depths = FindAvailableDepths(screen);
 
                 int resolution_count = 0;
-                foreach (XRRScreenSize size in FindAvailableResolutions(screen))
+                XRRScreenSize[] sizes = FindAvailableResolutions(screen);
+                foreach (XRRScreenSize size in sizes)
                 {
                     if (size.Width == 0 || size.Height == 0)
                     {
@@ -221,22 +222,11 @@ namespace OpenTK.Platform.X11
                 int current_depth = FindCurrentDepth(screen);
                 IntPtr screen_config = Functions.XRRGetScreenInfo(API.DefaultDisplay, Functions.XRootWindow(API.DefaultDisplay, screen));
                 ushort current_rotation;  // Not needed.
-                int current_resolution_index = Functions.XRRConfigCurrentConfiguration(screen_config, out current_rotation);
+                int current_sizes_index = Functions.XRRConfigCurrentConfiguration(screen_config, out current_rotation);
 
                 if (dev.Bounds == Rectangle.Empty)
                 {
-                    // We have added depths.Length copies of each resolution
-                    // Adjust the return value of XRRGetScreenInfo to retrieve the correct resolution
-                    int index = current_resolution_index * depths.Length;
-
-                    // Make sure we are within the bounds of the available_res array
-                    if (index >= available_res.Count)
-                    {
-                        // If not, use the return value of XRRGetScreenInfo directly
-                        index = current_resolution_index;
-                    }
-                    DisplayResolution current_resolution = available_res[index];
-                    dev.Bounds = new Rectangle(0, 0, current_resolution.Width, current_resolution.Height);
+                    dev.Bounds = new Rectangle(0, 0, sizes[current_sizes_index].Width, sizes[current_sizes_index].Height);
                 }
                 dev.BitsPerPixel = current_depth;
                 dev.RefreshRate = current_refresh_rate;


### PR DESCRIPTION
Directly indexing into the array returned from XRRSizes is the way khronos recommends at https://www.khronos.org/opengl/wiki/Programming_OpenGL_in_Linux:_Changing_the_Screen_Resolution

The old way was multiplying that index by depths.Length, as an index into the available_res list. This is incorrect because it doesn't account for when a display device has multiple refresh rates.

**NOTE: Given the wide variations in linux distributions and gpu setups, this likely requires further testing**