### PR TITLE
Lock keys detection

### DIFF
--- a/src/OpenTK/Input/KeyboardState.cs
+++ b/src/OpenTK/Input/KeyboardState.cs
@@ -40,6 +40,26 @@ namespace OpenTK.Input
         private unsafe fixed int Keys[NumInts];
 
         /// <summary>
+        /// Gets or sets a state for Caps Lock button.
+        /// </summary>
+        /// <value><c>true</c> if locked; otherwise, <c>false</c>.</value>
+        public bool CapsLock
+        {
+            get;
+            internal set;
+        }
+
+        /// <summary>
+        /// Gets or sets a state for Num Lock button.
+        /// </summary>
+        /// <value><c>true</c> if locked; otherwise, <c>false</c>.</value>
+        public bool NumLock
+        {
+            get;
+            internal set;
+        }
+
+        /// <summary>
         /// Gets a <see cref="System.Boolean"/> indicating whether the specified
         /// <see cref="OpenTK.Input.Key"/> is pressed.
         /// </summary>

--- a/src/OpenTK/Platform/SDL2/Sdl2.cs
+++ b/src/OpenTK/Platform/SDL2/Sdl2.cs
@@ -1000,7 +1000,6 @@ namespace OpenTK.Platform.SDL2
         SLEEP = (1 << 30) | (int)Scancode.SLEEP
     }
 
-    [Flags]
     internal enum Keymod : ushort
     {
         NONE = 0x0000,

--- a/src/OpenTK/Platform/SDL2/Sdl2Keyboard.cs
+++ b/src/OpenTK/Platform/SDL2/Sdl2Keyboard.cs
@@ -38,28 +38,12 @@ namespace OpenTK.Platform.SDL2
             state.IsConnected = true;
         }
 
-        // Unfortunately, SDL does not report KeyDown events
-        // when a modifier (e.g. shift, alt, etc) is first pressed.
-        // It reports a keydown+keyup event pair when the modifier
-        // is *released* - which means that we cannot use modifiers
-        // for regular input (e.g. press control to fire a weapon.)
-        // For that reason, we should also poll the keyboard directly
-        // as necessary.
-        // Fixme: this does not appear to work as expected.
         private void UpdateModifiers()
         {
             Keymod mod = SDL.GetModState();
 
-            state[Key.LAlt] = (mod & Keymod.LALT) != 0;
-            state[Key.RAlt] = (mod & Keymod.RALT) != 0;
-            state[Key.LControl] = (mod & Keymod.LCTRL) != 0;
-            state[Key.RControl] = (mod & Keymod.RCTRL) != 0;
-            state[Key.LShift] = (mod & Keymod.LSHIFT) != 0;
-            state[Key.RShift] = (mod & Keymod.RSHIFT) != 0;
-            state[Key.Menu] = (mod & Keymod.GUI) != 0;
-            state[Key.CapsLock] = (mod & Keymod.CAPS) != 0;
-            state[Key.NumLock] = (mod & Keymod.NUM) != 0;
-            //state[Key.] = (mod & Keymod.MODE) != 0;
+            state.CapsLock = (mod & Keymod.CAPS) != 0;
+            state.NumLock = (mod & Keymod.NUM) != 0;
         }
 
         internal void ProcessKeyboardEvent(KeyboardEvent e)
@@ -76,13 +60,13 @@ namespace OpenTK.Platform.SDL2
 
         public KeyboardState GetState()
         {
-            //UpdateModifiers(); // Fixme
+            UpdateModifiers();
             return state;
         }
 
         public KeyboardState GetState(int index)
         {
-            //UpdateModifiers(); // Fixme
+            UpdateModifiers();
             if (index == 0)
             {
                 return state;

--- a/src/OpenTK/Platform/Windows/WinRawKeyboard.cs
+++ b/src/OpenTK/Platform/Windows/WinRawKeyboard.cs
@@ -271,6 +271,7 @@ namespace OpenTK.Platform.Windows
                 {
                     master.MergeBits(ks);
                 }
+                UpdateModifiers(ref master);
                 return master;
             }
         }
@@ -281,7 +282,9 @@ namespace OpenTK.Platform.Windows
             {
                 if (keyboards.Count > index)
                 {
-                    return keyboards[index];
+                    var state = keyboards[index];
+                    UpdateModifiers(ref state);
+                    return state;
                 }
                 else
                 {
@@ -303,6 +306,12 @@ namespace OpenTK.Platform.Windows
                     return String.Empty;
                 }
             }
+        }
+        
+        private void UpdateModifiers(ref KeyboardState state)
+        {
+            state.CapsLock = (Functions.GetKeyState(VirtualKeys.CAPITAL) & 1) == 1;
+            state.NumLock = (Functions.GetKeyState(VirtualKeys.NUMLOCK) & 1) == 1;
         }
     }
 }

--- a/src/OpenTK/Platform/X11/Bindings/Xkb.cs
+++ b/src/OpenTK/Platform/X11/Bindings/Xkb.cs
@@ -78,6 +78,10 @@ namespace OpenTK.Platform.X11
         [DllImport(lib, EntryPoint = "XkbSetDetectableAutoRepeat")]
         internal extern static bool SetDetectableAutoRepeat(IntPtr display, bool detectable, out bool supported);
 
+        [DllImport (lib, EntryPoint = "XkbGetNamedIndicator")]
+        internal extern static bool GetNamedIndicator(
+            IntPtr display, Atom name, out int ndx_rtrn, out bool state_rtrn, out IntPtr map_rtrn, out bool real_rtrn);
+
         internal static bool IsSupported(IntPtr display)
         {
             // The XkbQueryExtension manpage says that we cannot

--- a/src/OpenTK/Platform/X11/XI2MouseKeyboard.cs
+++ b/src/OpenTK/Platform/X11/XI2MouseKeyboard.cs
@@ -180,6 +180,15 @@ namespace OpenTK.Platform.X11
             
             return state;
         }
+        
+        private void UpdateModifiers(ref KeyboardState state)
+        {
+            if (Xkb.IsSupported (API.DefaultDisplay))
+            {
+                state.CapsLock = GetIndicatorState("Caps Lock");
+                state.NumLock = GetIndicatorState("Num Lock");                     
+            }
+        }
 
         KeyboardState IKeyboardDriver2.GetState()
         {
@@ -187,16 +196,13 @@ namespace OpenTK.Platform.X11
             {
                 KeyboardState state = new KeyboardState();
 
-                if (Xkb.IsSupported (API.DefaultDisplay))
-                {
-                    state.CapsLock = GetIndicatorState("Caps Lock");
-                    state.NumLock = GetIndicatorState("Num Lock");                     
-                }
-
                 foreach (XIKeyboard k in keyboards)
                 {
                     state.MergeBits(k.State);
                 }
+                
+                UpdateModifiers(ref state);
+                
                 return state;
             }
         }
@@ -209,12 +215,8 @@ namespace OpenTK.Platform.X11
                 {
                     var state = keyboards[index].State;
                     
-                    if (Xkb.IsSupported (API.DefaultDisplay))
-                    {
-                        state.CapsLock = GetIndicatorState("Caps Lock");
-                        state.NumLock = GetIndicatorState("Num Lock");                     
-                    }
-                
+                    UpdateModifiers(ref state);
+                                    
                     return state;
                 }
                 return new KeyboardState();


### PR DESCRIPTION
Add ability to get lock keys(Num, Caps) through OpenTK.Input.Keyboard.GetStatus()."Proper name", OSX seems doesn't have num lock key.