### PR TITLE
Fix RefreshRate return 0 on MacOS

### DIFF
--- a/src/OpenTK/OpenTK.csproj
+++ b/src/OpenTK/OpenTK.csproj
@@ -780,6 +780,7 @@
     <None Include="OpenTK.csproj.paket.template" />
     <None Include="paket.references" />
     <Compile Include="Platform\MacOS\Cocoa\NSDragOperation.cs" />
+    <Compile Include="Platform\MacOS\CoreVideo.cs" />
   </ItemGroup>
   <ItemGroup>
     <AdditionalFiles Include="$(SolutionDir)\stylecop.json">

--- a/src/OpenTK/Platform/MacOS/CoreVideo.cs
+++ b/src/OpenTK/Platform/MacOS/CoreVideo.cs
@@ -1,0 +1,34 @@
+﻿// See License.txt file for copyright details
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace OpenTK.Platform.MacOS
+{
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct CVTime
+    {
+        public Int64 timeValue;
+        public Int32 timeScale;
+        public Int32 flags;
+    }
+
+    internal class CV
+    {
+        private const string LibPath = "/System/Library/Frameworks/CoreVideo.framework/Versions/Current/CoreVideo";
+
+        internal enum TimeFlags : Int32
+        {
+            TimeIsIndefinite = 1 << 0
+        }
+
+        [DllImport(LibPath, EntryPoint = "CVDisplayLinkCreateWithCGDisplay")]
+        public extern static IntPtr DisplayLinkCreateWithCGDisplay(IntPtr currentDisplay, out IntPtr displayLink);
+
+        [DllImport(LibPath, EntryPoint = "CVDisplayLinkGetNominalOutputVideoRefreshPeriod")]
+        public extern static CVTime DisplayLinkGetNominalOutputVideoRefreshPeriod(IntPtr displayLink);
+
+        [DllImport(LibPath, EntryPoint = "CVDisplayLinkRelease")]
+        public extern static void DisplayLinkRelease(IntPtr displayLink);
+    }
+}

--- a/src/OpenTK/Platform/MacOS/QuartzDisplayDeviceDriver.cs
+++ b/src/OpenTK/Platform/MacOS/QuartzDisplayDeviceDriver.cs
@@ -94,6 +94,20 @@ namespace OpenTK.Platform.MacOS
                         double freq = dict.GetNumberValue("RefreshRate");
                         bool current = currentMode.Ref == dict.Ref;
 
+                        if (freq <= 0)
+                        {
+                            IntPtr displayLink;
+                            CV.DisplayLinkCreateWithCGDisplay(currentDisplay, out displayLink);
+
+                            CVTime t = CV.DisplayLinkGetNominalOutputVideoRefreshPeriod(displayLink);
+                            if ((t.flags & (Int32)CV.TimeFlags.TimeIsIndefinite) != (Int32)CV.TimeFlags.TimeIsIndefinite)
+                            {
+                                freq = (double)t.timeScale / t.timeValue;
+                            }
+
+                            CV.DisplayLinkRelease(displayLink);
+                        }
+
                         //if (current) Debug.Write("  * ");
                         //else Debug.Write("    ");
 


### PR DESCRIPTION
Use CoreVideo CVDisplayLink to get correct display refresh rate. Previous implementation can return 0 according to https://developer.apple.com/documentation/coregraphics/1454661-cgdisplaymodegetrefreshrate. Also it create way to transfer from deprecated API methods (https://developer.apple.com/documentation/coregraphics/1562062-cgdisplaycurrentmode line https://github.com/opentk/opentk/pull/637/files#diff-628365b39657ac0af3839bc85bd345c5L84).
