### PR TITLE
Optimize assignment to vector math out parameters

### DIFF
--- a/src/OpenTK/Math/Vector2.cs
+++ b/src/OpenTK/Math/Vector2.cs
@@ -239,7 +239,8 @@ namespace OpenTK
         /// <param name="result">Result of operation.</param>
         public static void Add(ref Vector2 a, ref Vector2 b, out Vector2 result)
         {
-            result = new Vector2(a.X + b.X, a.Y + b.Y);
+            result.X = a.X + b.X;
+            result.Y = a.Y + b.Y;
         }
 
         /// <summary>
@@ -262,7 +263,8 @@ namespace OpenTK
         /// <param name="result">Result of subtraction</param>
         public static void Subtract(ref Vector2 a, ref Vector2 b, out Vector2 result)
         {
-            result = new Vector2(a.X - b.X, a.Y - b.Y);
+            result.X = a.X - b.X;
+            result.Y = a.Y - b.Y;
         }
 
         /// <summary>
@@ -285,7 +287,8 @@ namespace OpenTK
         /// <param name="result">Result of the operation.</param>
         public static void Multiply(ref Vector2 vector, float scale, out Vector2 result)
         {
-            result = new Vector2(vector.X * scale, vector.Y * scale);
+            result.X = vector.X * scale;
+            result.Y = vector.Y * scale;
         }
 
         /// <summary>
@@ -308,7 +311,8 @@ namespace OpenTK
         /// <param name="result">Result of the operation.</param>
         public static void Multiply(ref Vector2 vector, ref Vector2 scale, out Vector2 result)
         {
-            result = new Vector2(vector.X * scale.X, vector.Y * scale.Y);
+            result.X = vector.X * scale.X;
+            result.Y = vector.Y * scale.Y;
         }
 
         /// <summary>
@@ -355,7 +359,8 @@ namespace OpenTK
         /// <param name="result">Result of the operation.</param>
         public static void Divide(ref Vector2 vector, ref Vector2 scale, out Vector2 result)
         {
-            result = new Vector2(vector.X / scale.X, vector.Y / scale.Y);
+            result.X = vector.X / scale.X;
+            result.Y = vector.Y / scale.Y;
         }
 
         /// <summary>
@@ -692,7 +697,8 @@ namespace OpenTK
             Quaternion.Multiply(ref quat, ref v, out t);
             Quaternion.Multiply(ref t, ref i, out v);
 
-            result = new Vector2(v.X, v.Y);
+            result.X = v.X;
+            result.Y = v.Y;
         }
 
         /// <summary>

--- a/src/OpenTK/Math/Vector2d.cs
+++ b/src/OpenTK/Math/Vector2d.cs
@@ -202,7 +202,8 @@ namespace OpenTK
         /// <param name="result">Result of operation.</param>
         public static void Add(ref Vector2d a, ref Vector2d b, out Vector2d result)
         {
-            result = new Vector2d(a.X + b.X, a.Y + b.Y);
+            result.X = a.X + b.X;
+            result.Y = a.Y + b.Y;
         }
 
         /// <summary>
@@ -225,7 +226,8 @@ namespace OpenTK
         /// <param name="result">Result of subtraction</param>
         public static void Subtract(ref Vector2d a, ref Vector2d b, out Vector2d result)
         {
-            result = new Vector2d(a.X - b.X, a.Y - b.Y);
+            result.X = a.X - b.X;
+            result.Y = a.Y - b.Y;
         }
 
         /// <summary>
@@ -248,7 +250,8 @@ namespace OpenTK
         /// <param name="result">Result of the operation.</param>
         public static void Multiply(ref Vector2d vector, double scale, out Vector2d result)
         {
-            result = new Vector2d(vector.X * scale, vector.Y * scale);
+            result.X = vector.X * scale;
+            result.Y = vector.Y * scale;
         }
 
         /// <summary>
@@ -271,7 +274,8 @@ namespace OpenTK
         /// <param name="result">Result of the operation.</param>
         public static void Multiply(ref Vector2d vector, ref Vector2d scale, out Vector2d result)
         {
-            result = new Vector2d(vector.X * scale.X, vector.Y * scale.Y);
+            result.X = vector.X * scale.X;
+            result.Y = vector.Y * scale.Y;
         }
 
         /// <summary>
@@ -318,7 +322,8 @@ namespace OpenTK
         /// <param name="result">Result of the operation.</param>
         public static void Divide(ref Vector2d vector, ref Vector2d scale, out Vector2d result)
         {
-            result = new Vector2d(vector.X / scale.X, vector.Y / scale.Y);
+            result.X = vector.X / scale.X;
+            result.Y = vector.Y / scale.Y;
         }
 
         /// <summary>
@@ -663,7 +668,8 @@ namespace OpenTK
             Quaterniond.Multiply(ref quat, ref v, out t);
             Quaterniond.Multiply(ref t, ref i, out v);
 
-            result = new Vector2d(v.X, v.Y);
+            result.X = v.X;
+            result.Y = v.Y;
         }
 
         /// <summary>

--- a/src/OpenTK/Math/Vector2h.cs
+++ b/src/OpenTK/Math/Vector2h.cs
@@ -315,10 +315,9 @@ namespace OpenTK
         /// <returns>A new Half2 instance.</returns>
         public static Vector2h FromBytes(byte[] value, int startIndex)
         {
-            Vector2h h2 = new Vector2h();
-            h2.X = Half.FromBytes(value, startIndex);
-            h2.Y = Half.FromBytes(value, startIndex + 2);
-            return h2;
+            return new Vector2h(
+                Half.FromBytes(value, startIndex),
+                Half.FromBytes(value, startIndex + 2));
         }
     }
 }

--- a/src/OpenTK/Math/Vector3.cs
+++ b/src/OpenTK/Math/Vector3.cs
@@ -655,6 +655,11 @@ namespace OpenTK
         /// <summary>
         /// Caclulate the cross (vector) product of two vectors
         /// </summary>
+        /// <remarks>
+        /// It is incorrect to call this method passing the same variable for
+        /// <paramref name="result"/> as for <paramref name="left"/> or
+        /// <paramref name="right"/>.
+        /// </remarks>
         /// <param name="left">First operand</param>
         /// <param name="right">Second operand</param>
         /// <returns>The cross product of the two inputs</returns>
@@ -747,6 +752,10 @@ namespace OpenTK
         /// <summary>Transform a direction vector by the given Matrix
         /// Assumes the matrix has a bottom row of (0,0,0,1), that is the translation part is ignored.
         /// </summary>
+        /// <remarks>
+        /// It is incorrect to call this method passing the same variable for
+        /// <paramref name="result"/> as for <paramref name="vec"/>.
+        /// </remarks>
         /// <param name="vec">The vector to transform</param>
         /// <param name="mat">The desired transformation</param>
         /// <param name="result">The transformed vector</param>

--- a/src/OpenTK/Math/Vector3.cs
+++ b/src/OpenTK/Math/Vector3.cs
@@ -276,7 +276,9 @@ namespace OpenTK
         /// <param name="result">Result of operation.</param>
         public static void Add(ref Vector3 a, ref Vector3 b, out Vector3 result)
         {
-            result = new Vector3(a.X + b.X, a.Y + b.Y, a.Z + b.Z);
+            result.X = a.X + b.X;
+            result.Y = a.Y + b.Y;
+            result.Z = a.Z + b.Z;
         }
 
         /// <summary>
@@ -299,7 +301,9 @@ namespace OpenTK
         /// <param name="result">Result of subtraction</param>
         public static void Subtract(ref Vector3 a, ref Vector3 b, out Vector3 result)
         {
-            result = new Vector3(a.X - b.X, a.Y - b.Y, a.Z - b.Z);
+            result.X = a.X - b.X;
+            result.Y = a.Y - b.Y;
+            result.Z = a.Z - b.Z;
         }
 
         /// <summary>
@@ -322,7 +326,9 @@ namespace OpenTK
         /// <param name="result">Result of the operation.</param>
         public static void Multiply(ref Vector3 vector, float scale, out Vector3 result)
         {
-            result = new Vector3(vector.X * scale, vector.Y * scale, vector.Z * scale);
+            result.X = vector.X * scale;
+            result.Y = vector.Y * scale;
+            result.Z = vector.Z * scale;
         }
 
         /// <summary>
@@ -345,7 +351,9 @@ namespace OpenTK
         /// <param name="result">Result of the operation.</param>
         public static void Multiply(ref Vector3 vector, ref Vector3 scale, out Vector3 result)
         {
-            result = new Vector3(vector.X * scale.X, vector.Y * scale.Y, vector.Z * scale.Z);
+            result.X = vector.X * scale.X;
+            result.Y = vector.Y * scale.Y;
+            result.Z = vector.Z * scale.Z;
         }
 
         /// <summary>
@@ -393,7 +401,9 @@ namespace OpenTK
         /// <param name="result">Result of the operation.</param>
         public static void Divide(ref Vector3 vector, ref Vector3 scale, out Vector3 result)
         {
-            result = new Vector3(vector.X / scale.X, vector.Y / scale.Y, vector.Z / scale.Z);
+            result.X = vector.X / scale.X;
+            result.Y = vector.Y / scale.Y;
+            result.Z = vector.Z / scale.Z;
         }
 
         /// <summary>
@@ -651,9 +661,9 @@ namespace OpenTK
         /// <param name="result">The cross product of the two inputs</param>
         public static void Cross(ref Vector3 left, ref Vector3 right, out Vector3 result)
         {
-            result = new Vector3(left.Y * right.Z - left.Z * right.Y,
-                left.Z * right.X - left.X * right.Z,
-                left.X * right.Y - left.Y * right.X);
+            result.X = left.Y * right.Z - left.Z * right.Y;
+            result.Y = left.Z * right.X - left.X * right.Z;
+            result.Z = left.X * right.Y - left.Y * right.X;
         }
 
         /// <summary>
@@ -729,11 +739,9 @@ namespace OpenTK
         /// <returns>The transformed vector</returns>
         public static Vector3 TransformVector(Vector3 vec, Matrix4 mat)
         {
-            Vector3 v;
-            v.X = Vector3.Dot(vec, new Vector3(mat.Column0));
-            v.Y = Vector3.Dot(vec, new Vector3(mat.Column1));
-            v.Z = Vector3.Dot(vec, new Vector3(mat.Column2));
-            return v;
+            Vector3 result;
+            TransformVector(ref vec, ref mat, out result);
+            return result;
         }
 
         /// <summary>Transform a direction vector by the given Matrix
@@ -767,8 +775,9 @@ namespace OpenTK
         /// <returns>The transformed normal</returns>
         public static Vector3 TransformNormal(Vector3 norm, Matrix4 mat)
         {
-            mat.Invert();
-            return TransformNormalInverse(norm, mat);
+            Vector3 result;
+            TransformNormal(ref norm, ref mat, out result);
+            return result;
         }
 
         /// <summary>Transform a Normal by the given Matrix</summary>
@@ -795,11 +804,9 @@ namespace OpenTK
         /// <returns>The transformed normal</returns>
         public static Vector3 TransformNormalInverse(Vector3 norm, Matrix4 invMat)
         {
-            Vector3 n;
-            n.X = Vector3.Dot(norm, new Vector3(invMat.Row0));
-            n.Y = Vector3.Dot(norm, new Vector3(invMat.Row1));
-            n.Z = Vector3.Dot(norm, new Vector3(invMat.Row2));
-            return n;
+            Vector3 result;
+            TransformNormalInverse(ref norm, ref invMat, out result);
+            return result;
         }
 
         /// <summary>Transform a Normal by the (transpose of the) given Matrix</summary>
@@ -831,11 +838,9 @@ namespace OpenTK
         /// <returns>The transformed position</returns>
         public static Vector3 TransformPosition(Vector3 pos, Matrix4 mat)
         {
-            Vector3 p;
-            p.X = Vector3.Dot(pos, new Vector3(mat.Column0)) + mat.Row3.X;
-            p.Y = Vector3.Dot(pos, new Vector3(mat.Column1)) + mat.Row3.Y;
-            p.Z = Vector3.Dot(pos, new Vector3(mat.Column2)) + mat.Row3.Z;
-            return p;
+            Vector3 result;
+            TransformPosition(ref pos, ref mat, out result);
+            return result;
         }
 
         /// <summary>Transform a Position by the given Matrix</summary>
@@ -877,10 +882,9 @@ namespace OpenTK
         /// <param name="result">The transformed vector</param>
         public static void Transform(ref Vector3 vec, ref Matrix3 mat, out Vector3 result)
         {
-            result = new Vector3(
-                vec.X * mat.Row0.X + vec.Y * mat.Row1.X + vec.Z * mat.Row2.X,
-                vec.X * mat.Row0.Y + vec.Y * mat.Row1.Y + vec.Z * mat.Row2.Y,
-                vec.X * mat.Row0.Z + vec.Y * mat.Row1.Z + vec.Z * mat.Row2.Z);
+            result.X = vec.X * mat.Row0.X + vec.Y * mat.Row1.X + vec.Z * mat.Row2.X;
+            result.Y = vec.X * mat.Row0.Y + vec.Y * mat.Row1.Y + vec.Z * mat.Row2.Y;
+            result.Z = vec.X * mat.Row0.Z + vec.Y * mat.Row1.Z + vec.Z * mat.Row2.Z;
         }
 
         /// <summary>
@@ -931,10 +935,9 @@ namespace OpenTK
         /// <param name="result">The transformed vector</param>
         public static void Transform(ref Matrix3 mat, ref Vector3 vec, out Vector3 result)
         {
-            result = new Vector3(
-                mat.Row0.X * vec.X + mat.Row0.Y * vec.Y + mat.Row0.Z * vec.Z,
-                mat.Row1.X * vec.X + mat.Row1.Y * vec.Y + mat.Row1.Z * vec.Z,
-                mat.Row2.X * vec.X + mat.Row2.Y * vec.Y + mat.Row2.Z * vec.Z);
+            result.X = mat.Row0.X * vec.X + mat.Row0.Y * vec.Y + mat.Row0.Z * vec.Z;
+            result.Y = mat.Row1.X * vec.X + mat.Row1.Y * vec.Y + mat.Row1.Z * vec.Z;
+            result.Z = mat.Row2.X * vec.X + mat.Row2.Y * vec.Y + mat.Row2.Z * vec.Z;
         }
 
         /// <summary>Transform a Vector3 by the given Matrix, and project the resulting Vector4 back to a Vector3</summary>
@@ -954,7 +957,7 @@ namespace OpenTK
         /// <param name="result">The transformed vector</param>
         public static void TransformPerspective(ref Vector3 vec, ref Matrix4 mat, out Vector3 result)
         {
-            Vector4 v = new Vector4(vec, 1);
+            Vector4 v = new Vector4(vec.X, vec.Y, vec.Z, 1);
             Vector4.Transform(ref v, ref mat, out v);
             result.X = v.X / v.W;
             result.Y = v.Y / v.W;

--- a/src/OpenTK/Math/Vector3d.cs
+++ b/src/OpenTK/Math/Vector3d.cs
@@ -274,7 +274,9 @@ namespace OpenTK
         /// <param name="result">Result of operation.</param>
         public static void Add(ref Vector3d a, ref Vector3d b, out Vector3d result)
         {
-            result = new Vector3d(a.X + b.X, a.Y + b.Y, a.Z + b.Z);
+            result.X = a.X + b.X;
+            result.Y = a.Y + b.Y;
+            result.Z = a.Z + b.Z;
         }
 
         /// <summary>
@@ -297,7 +299,9 @@ namespace OpenTK
         /// <param name="result">Result of subtraction</param>
         public static void Subtract(ref Vector3d a, ref Vector3d b, out Vector3d result)
         {
-            result = new Vector3d(a.X - b.X, a.Y - b.Y, a.Z - b.Z);
+            result.X = a.X - b.X;
+            result.Y = a.Y - b.Y;
+            result.Z = a.Z - b.Z;
         }
 
         /// <summary>
@@ -320,7 +324,9 @@ namespace OpenTK
         /// <param name="result">Result of the operation.</param>
         public static void Multiply(ref Vector3d vector, double scale, out Vector3d result)
         {
-            result = new Vector3d(vector.X * scale, vector.Y * scale, vector.Z * scale);
+            result.X = vector.X * scale;
+            result.Y = vector.Y * scale;
+            result.Z = vector.Z * scale;
         }
 
         /// <summary>
@@ -343,7 +349,9 @@ namespace OpenTK
         /// <param name="result">Result of the operation.</param>
         public static void Multiply(ref Vector3d vector, ref Vector3d scale, out Vector3d result)
         {
-            result = new Vector3d(vector.X * scale.X, vector.Y * scale.Y, vector.Z * scale.Z);
+            result.X = vector.X * scale.X;
+            result.Y = vector.Y * scale.Y;
+            result.Z = vector.Z * scale.Z;
         }
 
         /// <summary>
@@ -391,7 +399,9 @@ namespace OpenTK
         /// <param name="result">Result of the operation.</param>
         public static void Divide(ref Vector3d vector, ref Vector3d scale, out Vector3d result)
         {
-            result = new Vector3d(vector.X / scale.X, vector.Y / scale.Y, vector.Z / scale.Z);
+            result.X = vector.X / scale.X;
+            result.Y = vector.Y / scale.Y;
+            result.Z = vector.Z / scale.Z;
         }
 
         /// <summary>
@@ -645,9 +655,9 @@ namespace OpenTK
         /// <param name="result">The cross product of the two inputs</param>
         public static void Cross(ref Vector3d left, ref Vector3d right, out Vector3d result)
         {
-            result = new Vector3d(left.Y * right.Z - left.Z * right.Y,
-                left.Z * right.X - left.X * right.Z,
-                left.X * right.Y - left.Y * right.X);
+            result.X = left.Y * right.Z - left.Z * right.Y;
+            result.Y = left.Z * right.X - left.X * right.Z;
+            result.Z = left.X * right.Y - left.Y * right.X;
         }
 
         /// <summary>
@@ -723,10 +733,9 @@ namespace OpenTK
         /// <returns>The transformed vector</returns>
         public static Vector3d TransformVector(Vector3d vec, Matrix4d mat)
         {
-            return new Vector3d(
-                Vector3d.Dot(vec, new Vector3d(mat.Column0)),
-                Vector3d.Dot(vec, new Vector3d(mat.Column1)),
-                Vector3d.Dot(vec, new Vector3d(mat.Column2)));
+            Vector3d result;
+            TransformVector(ref vec, ref mat, out result);
+            return result;
         }
 
         /// <summary>Transform a direction vector by the given Matrix
@@ -788,10 +797,9 @@ namespace OpenTK
         /// <returns>The transformed normal</returns>
         public static Vector3d TransformNormalInverse(Vector3d norm, Matrix4d invMat)
         {
-            return new Vector3d(
-                Vector3d.Dot(norm, new Vector3d(invMat.Row0)),
-                Vector3d.Dot(norm, new Vector3d(invMat.Row1)),
-                Vector3d.Dot(norm, new Vector3d(invMat.Row2)));
+            Vector3d result;
+            TransformNormalInverse(ref norm, ref invMat, out result);
+            return result;
         }
 
         /// <summary>Transform a Normal by the (transpose of the) given Matrix</summary>
@@ -823,10 +831,9 @@ namespace OpenTK
         /// <returns>The transformed position</returns>
         public static Vector3d TransformPosition(Vector3d pos, Matrix4d mat)
         {
-            return new Vector3d(
-                Vector3d.Dot(pos, new Vector3d(mat.Column0)) + mat.Row3.X,
-                Vector3d.Dot(pos, new Vector3d(mat.Column1)) + mat.Row3.Y,
-                Vector3d.Dot(pos, new Vector3d(mat.Column2)) + mat.Row3.Z);
+            Vector3d result;
+            TransformPosition(ref pos, ref mat, out result);
+            return result;
         }
 
         /// <summary>Transform a Position by the given Matrix</summary>
@@ -870,7 +877,9 @@ namespace OpenTK
         {
             Vector4d v4 = new Vector4d(vec.X, vec.Y, vec.Z, 1.0);
             Vector4d.Transform(ref v4, ref mat, out v4);
-            result = v4.Xyz;
+            result.X = v4.X;
+            result.Y = v4.Y;
+            result.Z = v4.Z;
         }
 
         /// <summary>
@@ -924,7 +933,7 @@ namespace OpenTK
         /// <param name="result">The transformed vector</param>
         public static void TransformPerspective(ref Vector3d vec, ref Matrix4d mat, out Vector3d result)
         {
-            Vector4d v = new Vector4d(vec, 1);
+            Vector4d v = new Vector4d(vec.X, vec.Y, vec.Z, 1);
             Vector4d.Transform(ref v, ref mat, out v);
             result.X = v.X / v.W;
             result.Y = v.Y / v.W;

--- a/src/OpenTK/Math/Vector3d.cs
+++ b/src/OpenTK/Math/Vector3d.cs
@@ -649,6 +649,11 @@ namespace OpenTK
         /// <summary>
         /// Caclulate the cross (vector) product of two vectors
         /// </summary>
+        /// <remarks>
+        /// It is incorrect to call this method passing the same variable for
+        /// <paramref name="result"/> as for <paramref name="left"/> or
+        /// <paramref name="right"/>.
+        /// </remarks>
         /// <param name="left">First operand</param>
         /// <param name="right">Second operand</param>
         /// <returns>The cross product of the two inputs</returns>
@@ -741,6 +746,10 @@ namespace OpenTK
         /// <summary>Transform a direction vector by the given Matrix
         /// Assumes the matrix has a bottom row of (0,0,0,1), that is the translation part is ignored.
         /// </summary>
+        /// <remarks>
+        /// It is incorrect to call this method passing the same variable for
+        /// <paramref name="result"/> as for <paramref name="vec"/>.
+        /// </remarks>
         /// <param name="vec">The vector to transform</param>
         /// <param name="mat">The desired transformation</param>
         /// <param name="result">The transformed vector</param>
@@ -870,6 +879,11 @@ namespace OpenTK
         }
 
         /// <summary>Transform a Vector by the given Matrix</summary>
+        /// <remarks>
+        /// It is incorrect to call this method passing the same variable for
+        /// <paramref name="result"/> as for <paramref name="left"/> or
+        /// <paramref name="right"/>.
+        /// </remarks>
         /// <param name="vec">The vector to transform</param>
         /// <param name="mat">The desired transformation</param>
         /// <param name="result">The transformed vector</param>

--- a/src/OpenTK/Math/Vector3h.cs
+++ b/src/OpenTK/Math/Vector3h.cs
@@ -310,11 +310,10 @@ namespace OpenTK
         /// <returns>The resulting Vector3.</returns>
         public static explicit operator Vector3(Vector3h h3)
         {
-            Vector3 result = new Vector3();
-            result.X = h3.X.ToSingle();
-            result.Y = h3.Y.ToSingle();
-            result.Z = h3.Z.ToSingle();
-            return result;
+            return new Vector3(
+                h3.X.ToSingle(),
+                h3.Y.ToSingle(),
+                h3.Z.ToSingle());
         }
 
         /// <summary>Converts OpenTK.Half3 to OpenTK.Vector3d.</summary>
@@ -322,11 +321,10 @@ namespace OpenTK
         /// <returns>The resulting Vector3d.</returns>
         public static explicit operator Vector3d(Vector3h h3)
         {
-            Vector3d result = new Vector3d();
-            result.X = h3.X.ToSingle();
-            result.Y = h3.Y.ToSingle();
-            result.Z = h3.Z.ToSingle();
-            return result;
+            return new Vector3d(
+                h3.X.ToSingle(),
+                h3.Y.ToSingle(),
+                h3.Z.ToSingle());
         }
 
         /// <summary>The size in bytes for an instance of the Half3 struct is 6.</summary>
@@ -411,11 +409,10 @@ namespace OpenTK
         /// <returns>A new Half3 instance.</returns>
         public static Vector3h FromBytes(byte[] value, int startIndex)
         {
-            Vector3h h3 = new Vector3h();
-            h3.X = Half.FromBytes(value, startIndex);
-            h3.Y = Half.FromBytes(value, startIndex + 2);
-            h3.Z = Half.FromBytes(value, startIndex + 4);
-            return h3;
+            return new Vector3h(
+                Half.FromBytes(value, startIndex),
+                Half.FromBytes(value, startIndex + 2),
+                Half.FromBytes(value, startIndex + 4));
         }
     }
 }

--- a/src/OpenTK/Math/Vector4.cs
+++ b/src/OpenTK/Math/Vector4.cs
@@ -314,7 +314,10 @@ namespace OpenTK
         /// <param name="result">Result of operation.</param>
         public static void Add(ref Vector4 a, ref Vector4 b, out Vector4 result)
         {
-            result = new Vector4(a.X + b.X, a.Y + b.Y, a.Z + b.Z, a.W + b.W);
+            result.X = a.X + b.X;
+            result.Y = a.Y + b.Y;
+            result.Z = a.Z + b.Z;
+            result.W = a.W + b.W;
         }
 
         /// <summary>
@@ -337,7 +340,10 @@ namespace OpenTK
         /// <param name="result">Result of subtraction</param>
         public static void Subtract(ref Vector4 a, ref Vector4 b, out Vector4 result)
         {
-            result = new Vector4(a.X - b.X, a.Y - b.Y, a.Z - b.Z, a.W - b.W);
+            result.X = a.X - b.X;
+            result.Y = a.Y - b.Y;
+            result.Z = a.Z - b.Z;
+            result.W = a.W - b.W;
         }
 
         /// <summary>
@@ -360,7 +366,10 @@ namespace OpenTK
         /// <param name="result">Result of the operation.</param>
         public static void Multiply(ref Vector4 vector, float scale, out Vector4 result)
         {
-            result = new Vector4(vector.X * scale, vector.Y * scale, vector.Z * scale, vector.W * scale);
+            result.X = vector.X * scale;
+            result.Y = vector.Y * scale;
+            result.Z = vector.Z * scale;
+            result.W = vector.W * scale;
         }
 
         /// <summary>
@@ -383,7 +392,10 @@ namespace OpenTK
         /// <param name="result">Result of the operation.</param>
         public static void Multiply(ref Vector4 vector, ref Vector4 scale, out Vector4 result)
         {
-            result = new Vector4(vector.X * scale.X, vector.Y * scale.Y, vector.Z * scale.Z, vector.W * scale.W);
+            result.X = vector.X * scale.X;
+            result.Y = vector.Y * scale.Y;
+            result.Z = vector.Z * scale.Z;
+            result.W = vector.W * scale.W;
         }
 
         /// <summary>
@@ -432,7 +444,10 @@ namespace OpenTK
         /// <param name="result">Result of the operation.</param>
         public static void Divide(ref Vector4 vector, ref Vector4 scale, out Vector4 result)
         {
-            result = new Vector4(vector.X / scale.X, vector.Y / scale.Y, vector.Z / scale.Z, vector.W / scale.W);
+            result.X = vector.X / scale.X;
+            result.Y = vector.Y / scale.Y;
+            result.Z = vector.Z / scale.Z;
+            result.W = vector.W / scale.W;
         }
 
         /// <summary>
@@ -833,7 +848,10 @@ namespace OpenTK
             Quaternion.Multiply(ref quat, ref v, out t);
             Quaternion.Multiply(ref t, ref i, out v);
 
-            result = new Vector4(v.X, v.Y, v.Z, v.W);
+            result.X = v.X;
+            result.Y = v.Y;
+            result.Z = v.Z;
+            result.W = v.W;
         }
 
         /// <summary>Transform a Vector by the given Matrix using right-handed notation</summary>

--- a/src/OpenTK/Math/Vector4d.cs
+++ b/src/OpenTK/Math/Vector4d.cs
@@ -310,7 +310,10 @@ namespace OpenTK
         /// <param name="result">Result of operation.</param>
         public static void Add(ref Vector4d a, ref Vector4d b, out Vector4d result)
         {
-            result = new Vector4d(a.X + b.X, a.Y + b.Y, a.Z + b.Z, a.W + b.W);
+            result.X = a.X + b.X;
+            result.Y = a.Y + b.Y;
+            result.Z = a.Z + b.Z;
+            result.W = a.W + b.W;
         }
 
         /// <summary>
@@ -333,7 +336,10 @@ namespace OpenTK
         /// <param name="result">Result of subtraction</param>
         public static void Subtract(ref Vector4d a, ref Vector4d b, out Vector4d result)
         {
-            result = new Vector4d(a.X - b.X, a.Y - b.Y, a.Z - b.Z, a.W - b.W);
+            result.X = a.X - b.X;
+            result.Y = a.Y - b.Y;
+            result.Z = a.Z - b.Z;
+            result.W = a.W - b.W;
         }
 
         /// <summary>
@@ -356,7 +362,10 @@ namespace OpenTK
         /// <param name="result">Result of the operation.</param>
         public static void Multiply(ref Vector4d vector, double scale, out Vector4d result)
         {
-            result = new Vector4d(vector.X * scale, vector.Y * scale, vector.Z * scale, vector.W * scale);
+            result.X = vector.X * scale;
+            result.Y = vector.Y * scale;
+            result.Z = vector.Z * scale;
+            result.W = vector.W * scale;
         }
 
         /// <summary>
@@ -379,7 +388,10 @@ namespace OpenTK
         /// <param name="result">Result of the operation.</param>
         public static void Multiply(ref Vector4d vector, ref Vector4d scale, out Vector4d result)
         {
-            result = new Vector4d(vector.X * scale.X, vector.Y * scale.Y, vector.Z * scale.Z, vector.W * scale.W);
+            result.X = vector.X * scale.X;
+            result.Y = vector.Y * scale.Y;
+            result.Z = vector.Z * scale.Z;
+            result.W = vector.W * scale.W;
         }
 
         /// <summary>
@@ -428,7 +440,10 @@ namespace OpenTK
         /// <param name="result">Result of the operation.</param>
         public static void Divide(ref Vector4d vector, ref Vector4d scale, out Vector4d result)
         {
-            result = new Vector4d(vector.X / scale.X, vector.Y / scale.Y, vector.Z / scale.Z, vector.W / scale.W);
+            result.X = vector.X / scale.X;
+            result.Y = vector.Y / scale.Y;
+            result.Z = vector.Z / scale.Z;
+            result.W = vector.W / scale.W;
         }
 
         /// <summary>
@@ -825,7 +840,10 @@ namespace OpenTK
             Quaterniond.Multiply(ref quat, ref v, out t);
             Quaterniond.Multiply(ref t, ref i, out v);
 
-            result = new Vector4d(v.X, v.Y, v.Z, v.W);
+            result.X = v.X;
+            result.Y = v.Y;
+            result.Z = v.Z;
+            result.W = v.W;
         }
 
         /// <summary>

--- a/src/OpenTK/Math/Vector4h.cs
+++ b/src/OpenTK/Math/Vector4h.cs
@@ -640,12 +640,11 @@ namespace OpenTK
         /// <returns>The resulting Vector4.</returns>
         public static explicit operator Vector4(Vector4h h4)
         {
-            Vector4 result = new Vector4();
-            result.X = h4.X.ToSingle();
-            result.Y = h4.Y.ToSingle();
-            result.Z = h4.Z.ToSingle();
-            result.W = h4.W.ToSingle();
-            return result;
+            return new Vector4(
+                h4.X.ToSingle(),
+                h4.Y.ToSingle(),
+                h4.Z.ToSingle(),
+                h4.W.ToSingle());
         }
 
         /// <summary>Converts OpenTK.Half4 to OpenTK.Vector4d.</summary>
@@ -653,12 +652,11 @@ namespace OpenTK
         /// <returns>The resulting Vector4d.</returns>
         public static explicit operator Vector4d(Vector4h h4)
         {
-            Vector4d result = new Vector4d();
-            result.X = h4.X.ToSingle();
-            result.Y = h4.Y.ToSingle();
-            result.Z = h4.Z.ToSingle();
-            result.W = h4.W.ToSingle();
-            return result;
+            return new Vector4d(
+                h4.X.ToSingle(),
+                h4.Y.ToSingle(),
+                h4.Z.ToSingle(),
+                h4.W.ToSingle());
         }
 
         /// <summary>The size in bytes for an instance of the Half4 struct is 8.</summary>
@@ -750,12 +748,11 @@ namespace OpenTK
         /// <returns>A new Half4 instance.</returns>
         public static Vector4h FromBytes(byte[] value, int startIndex)
         {
-            Vector4h h4 = new Vector4h();
-            h4.X = Half.FromBytes(value, startIndex);
-            h4.Y = Half.FromBytes(value, startIndex + 2);
-            h4.Z = Half.FromBytes(value, startIndex + 4);
-            h4.W = Half.FromBytes(value, startIndex + 6);
-            return h4;
+            return new Vector4h(
+                Half.FromBytes(value, startIndex),
+                Half.FromBytes(value, startIndex + 2),
+                Half.FromBytes(value, startIndex + 4),
+                Half.FromBytes(value, startIndex + 6));
         }
     }
 }


### PR DESCRIPTION
See #500 for more details.

Instead of using the pattern:
        result = new Vector(x, y, z)
Which would allocate and copy a vector instance, instead assign the fields
directly:
        result.X = x;
        result.Y = y;
        result.Z = z;
This should be a small improvment in performance.