### PR TITLE
Prevent crash when XInput is not present

### DIFF
--- a/src/OpenTK/Platform/Windows/XInputJoystick.cs
+++ b/src/OpenTK/Platform/Windows/XInputJoystick.cs
@@ -381,7 +381,7 @@ namespace OpenTK.Platform.Windows
                 }
                 if (dll == IntPtr.Zero)
                 {
-                  //XInput was not found on this platform
+                   Debug.Print("XInput was not found on this platform");
                    return;
                 }
 

--- a/src/OpenTK/Platform/Windows/XInputJoystick.cs
+++ b/src/OpenTK/Platform/Windows/XInputJoystick.cs
@@ -381,7 +381,8 @@ namespace OpenTK.Platform.Windows
                 }
                 if (dll == IntPtr.Zero)
                 {
-                    throw new NotSupportedException("XInput was not found on this platform");
+                  //XInput was not found on this platform
+                   return;
                 }
 
                 // Load the entry points we are interested in from that dll


### PR DESCRIPTION
Now returns from the function instead of throwing an exception