### PR TITLE
Add some tests for the Half type

### DIFF
--- a/tests/OpenTK.Tests/HalfTests.fs
+++ b/tests/OpenTK.Tests/HalfTests.fs
@@ -1,0 +1,40 @@
+namespace OpenTK.Tests
+
+open Xunit
+open FsCheck
+open FsCheck.Xunit
+open System
+open System.Runtime.InteropServices
+open OpenTK
+
+module Half =
+    [<Fact>]
+    let ``Casting Half to Single and back to Half is lossless`` () =
+        for bits = int System.Int16.MinValue to int System.Int16.MaxValue do
+            let bytes = System.BitConverter.GetBytes(int16 bits)
+            let half = Half.FromBytes(bytes, 0)
+            let single = float32 half
+            let roundtrip = Half single
+
+            Assert.True((half.IsNaN && roundtrip.IsNaN) || half = roundtrip)
+
+    [<Fact>]
+    let ``Half.ToString and Single.ToString return same string for same value`` () =
+        for bits = int System.Int16.MinValue to int System.Int16.MaxValue do
+            let bytes = System.BitConverter.GetBytes(int16 bits)
+            let half = Half.FromBytes(bytes, 0)
+            let single = float32 half
+            Assert.Equal(half.ToString(), single.ToString())
+
+    [<Fact>]
+    let ``Half can represent all integers from -2048 to 2048 exactly`` () =
+        for i = -2048 to 2048 do
+            let single = float32 i
+            let half = Half single
+            Assert.Equal(single, float32 half)
+
+    [<Fact>]
+    let ``Single NaN and inifnity can be cast to Half NaN and infinity`` () =
+        Assert.True((Half System.Single.NaN).IsNaN)
+        Assert.True((Half System.Single.PositiveInfinity).IsPositiveInfinity)
+        Assert.True((Half System.Single.NegativeInfinity).IsNegativeInfinity)

--- a/tests/OpenTK.Tests/OpenTK.Tests.fsproj
+++ b/tests/OpenTK.Tests/OpenTK.Tests.fsproj
@@ -69,6 +69,7 @@
     <Compile Include="Vector2Tests.fs" />
     <Compile Include="Vector3Tests.fs" />
     <Compile Include="Vector4Tests.fs" />
+    <Compile Include="HalfTests.fs" />
     <Content Include="App.config" />
     <None Include="paket.references" />
   </ItemGroup>


### PR DESCRIPTION
### Purpose of this PR

* Some simple tests to ensure we don't regress the basics of the Half type

### Testing status

* New automated tests
** Test that can cast Half to float and back again lossless
** Test that singles and halfs with the same value result in the same strings
** Test that every exact integer Half can represent (-2048..2048) is correct
** Test that float infinities and NaNs can be cast to Halfs correctly
