### PR TITLE
Use Wgl::GetAddress instead of Wgl::GetProcAddress in Utilities

### DIFF
--- a/src/OpenTK/Platform/Utilities.cs
+++ b/src/OpenTK/Platform/Utilities.cs
@@ -182,7 +182,7 @@ namespace OpenTK.Platform
             #if WIN32
             if (Configuration.RunningOnWindows)
             {
-                return Platform.Windows.Wgl.GetProcAddress;
+                return Platform.Windows.Wgl.GetAddress;
             }
             #endif
             #if X11

--- a/src/OpenTK/Platform/Windows/WglHelper.cs
+++ b/src/OpenTK/Platform/Windows/WglHelper.cs
@@ -94,7 +94,7 @@ namespace OpenTK.Platform.Windows
             get { return sync; }
         }
 
-        private IntPtr GetAddress(string function_string)
+        internal static IntPtr GetAddress(string function_string)
         {
             IntPtr address = Wgl.GetProcAddress(function_string);
             if (!IsValid(address))


### PR DESCRIPTION
### Purpose of this PR

This PR fixes function pointer loading for external contexts created on Windows. Previously, `Utilities::CreateGetAddress` would return a handle to `Wgl::GetProcAddress` - this excludes any functions in OpenGL 1.1 or earlier from being loaded. The [wglGetProcAddress specification](https://msdn.microsoft.com/en-us/library/windows/desktop/dd374386(v=vs.85).aspx) states that 

    The wglGetProcAddress function returns the address of an OpenGL extension function for use with the current OpenGL rendering context.

This, in typical Microsoft fashion, does not refer to true OpenGL extension functions, but rather anything that was introduced after OpenGL 1.1. This, then, excludes critical functions such as `glEnable` or `glDrawArrays`.

The `Wgl` class has a private method that uses the correct approach of attempting to load these functions directly from the `opengl32.dll` library if `wglGetProcAddress` does not return a valid pointer. This method has been made internal, `Utilities::CreateGetAddress` now returns that instead of the raw `Wgl::GetProcAddress` function.

This is only an issue for foreign OpenGL contexts on Windows, which rely on loader selection outside of the factory classes. It is a reasonable assumption that this bug has remained under the radar due to the rarity of that requirement.

### Testing status

* Thoroughly tested under an emulated Windows 7 machine.