### PR TITLE
Stop taking X locks on display when attempting MakeCurrent() calls.

### DIFF
--- a/src/OpenTK/Platform/X11/X11GLContext.cs
+++ b/src/OpenTK/Platform/X11/X11GLContext.cs
@@ -346,10 +346,6 @@ namespace OpenTK.Platform.X11
                     currentWindow = w;
                 }
 
-
-
-
-
                 if (!result)
                 {
                     throw new GraphicsContextException("Failed to make context current.");
@@ -367,10 +363,7 @@ namespace OpenTK.Platform.X11
         {
             get
             {
-                using (new XLock(Display))
-                {
-                    return Glx.GetCurrentContext() == Handle.Handle;
-                }
+                return Glx.GetCurrentContext() == Handle.Handle;
             }
         }
 

--- a/src/OpenTK/Platform/X11/X11GLContext.cs
+++ b/src/OpenTK/Platform/X11/X11GLContext.cs
@@ -319,14 +319,12 @@ namespace OpenTK.Platform.X11
                         Handle, System.Threading.Thread.CurrentThread.ManagedThreadId, Display));
 
                 bool result;
-                using (new XLock(Display))
+                result = Glx.MakeCurrent(Display, IntPtr.Zero, IntPtr.Zero);
+                if (result)
                 {
-                    result = Glx.MakeCurrent(Display, IntPtr.Zero, IntPtr.Zero);
-                    if (result)
-                    {
-                        currentWindow = null;
-                    }
+                    currentWindow = null;
                 }
+
                 Debug.Print("{0}", result ? "done!" : "failed.");
             }
             else
@@ -342,14 +340,15 @@ namespace OpenTK.Platform.X11
                     throw new InvalidOperationException("Invalid display, window or context.");
                 }
 
-                using (new XLock(Display))
+                result = Glx.MakeCurrent(Display, w.Handle, Handle);
+                if (result)
                 {
-                    result = Glx.MakeCurrent(Display, w.Handle, Handle);
-                    if (result)
-                    {
-                        currentWindow = w;
-                    }
+                    currentWindow = w;
                 }
+
+
+
+
 
                 if (!result)
                 {
@@ -488,10 +487,7 @@ namespace OpenTK.Platform.X11
 
                     if (IsCurrent)
                     {
-                        using (new XLock(display))
-                        {
-                            Glx.MakeCurrent(display, IntPtr.Zero, IntPtr.Zero);
-                        }
+                        Glx.MakeCurrent(display, IntPtr.Zero, IntPtr.Zero);
                     }
                     using (new XLock(display))
                     {


### PR DESCRIPTION
### Purpose of this PR

* Remove ```using (new XLock(display)) { <stuff...> }``` wrappers from ```Glx.MakeCurrent()``` calls.
* Affects OpenTK/Platform/X11/X11GLContext.cs

### Testing status

* Automated tests still work
* Simple application that renders a color-gradient triangle still works, too.

### Comments

* Attempting to take the X lock on the display will prevent glXMakeCurrent in the driver to take the internal lock that it needs, which leads to deadlocks. Since there's no apparent valid reason for this, it should be removed.
