### PR TITLE
Replace NativeWindow cursor_visible field with implementation's CursorVisible

### DIFF
--- a/src/OpenTK/NativeWindow.cs
+++ b/src/OpenTK/NativeWindow.cs
@@ -47,7 +47,6 @@ namespace OpenTK
         private readonly INativeWindow implementation;
 
         private bool events;
-        private bool cursor_visible = true;
         private bool previous_cursor_visible = true;
 
         /// <summary>
@@ -476,10 +475,10 @@ namespace OpenTK
         /// </summary>
         public bool CursorVisible
         {
-            get { return cursor_visible; }
+            get { return implementation.CursorVisible; }
             set
             {
-                cursor_visible = value;
+                if (value == implementation.CursorVisible) return;
                 implementation.CursorVisible = value;
             }
         }

--- a/src/OpenTK/NativeWindow.cs
+++ b/src/OpenTK/NativeWindow.cs
@@ -476,11 +476,7 @@ namespace OpenTK
         public bool CursorVisible
         {
             get { return implementation.CursorVisible; }
-            set
-            {
-                if (value == implementation.CursorVisible) return;
-                implementation.CursorVisible = value;
-            }
+            set { implementation.CursorVisible = value; }
         }
 
         /// <summary>

--- a/src/OpenTK/NativeWindow.cs
+++ b/src/OpenTK/NativeWindow.cs
@@ -475,8 +475,14 @@ namespace OpenTK
         /// </summary>
         public bool CursorVisible
         {
-            get { return implementation.CursorVisible; }
-            set { implementation.CursorVisible = value; }
+            get
+            {
+                return implementation.CursorVisible;
+            }
+            set
+            {
+                implementation.CursorVisible = value;
+            }
         }
 
         /// <summary>

--- a/src/OpenTK/Platform/Linux/LinuxNativeWindow.cs
+++ b/src/OpenTK/Platform/Linux/LinuxNativeWindow.cs
@@ -508,7 +508,6 @@ namespace OpenTK.Platform.Linux
             }
             set
             {
-                if (value == is_cursor_visible) return;
                 if (value && !is_cursor_visible)
                 {
                     SetCursor(cursor_current);

--- a/src/OpenTK/Platform/Linux/LinuxNativeWindow.cs
+++ b/src/OpenTK/Platform/Linux/LinuxNativeWindow.cs
@@ -508,6 +508,7 @@ namespace OpenTK.Platform.Linux
             }
             set
             {
+                if (value == is_cursor_visible) return;
                 if (value && !is_cursor_visible)
                 {
                     SetCursor(cursor_current);

--- a/src/OpenTK/Platform/MacOS/CocoaNativeWindow.cs
+++ b/src/OpenTK/Platform/MacOS/CocoaNativeWindow.cs
@@ -1239,6 +1239,7 @@ namespace OpenTK.Platform.MacOS
             get { return cursorVisible; }
             set
             {
+                if (value == cursorVisible) return;
                 if (value && !cursorVisible)
                 {
                     SetCursorVisible(true);

--- a/src/OpenTK/Platform/MacOS/CocoaNativeWindow.cs
+++ b/src/OpenTK/Platform/MacOS/CocoaNativeWindow.cs
@@ -1236,19 +1236,17 @@ namespace OpenTK.Platform.MacOS
 
         public override bool CursorVisible
         {
-            get { return cursorVisible; }
+            get
+            {
+                return cursorVisible;
+            }
             set
             {
-                if (value == cursorVisible) return;
-                if (value && !cursorVisible)
+                if (value != cursorVisible)
                 {
-                    SetCursorVisible(true);
+                    SetCursorVisible(value);
+                    cursorVisible = value;
                 }
-                else if (!value && cursorVisible)
-                {
-                    SetCursorVisible(false);
-                }
-                cursorVisible = value;
             }
         }
 

--- a/src/OpenTK/Platform/SDL2/Sdl2NativeWindow.cs
+++ b/src/OpenTK/Platform/SDL2/Sdl2NativeWindow.cs
@@ -933,10 +933,9 @@ namespace OpenTK.Platform.SDL2
             }
             set
             {
-                if (value == is_cursor_visible) return;
                 lock (sync)
                 {
-                    if (Exists)
+                    if (Exists && value != is_cursor_visible)
                     {
                         GrabCursor(!value);
                         is_cursor_visible = value;

--- a/src/OpenTK/Platform/SDL2/Sdl2NativeWindow.cs
+++ b/src/OpenTK/Platform/SDL2/Sdl2NativeWindow.cs
@@ -933,6 +933,7 @@ namespace OpenTK.Platform.SDL2
             }
             set
             {
+                if (value == is_cursor_visible) return;
                 lock (sync)
                 {
                     if (Exists)

--- a/src/OpenTK/Platform/Windows/WinGLNative.cs
+++ b/src/OpenTK/Platform/Windows/WinGLNative.cs
@@ -1256,7 +1256,7 @@ namespace OpenTK.Platform.Windows
 
         public override bool CursorVisible
         {
-            get { return cursor_visible_count >= 0; } // Not used
+            get { return cursor_visible_count >= 0; }
             set
             {
                 if (value && cursor_visible_count < 0)

--- a/src/OpenTK/Platform/Windows/WinGLNative.cs
+++ b/src/OpenTK/Platform/Windows/WinGLNative.cs
@@ -1256,10 +1256,17 @@ namespace OpenTK.Platform.Windows
 
         public override bool CursorVisible
         {
-            get { return cursor_visible_count >= 0; }
+            get
+            {
+                return cursor_visible_count >= 0;
+            }
             set
             {
-                if (value && cursor_visible_count < 0)
+                if (value == CursorVisible)
+                {
+                    return;
+                }
+                if (value)
                 {
                     do
                     {
@@ -1269,7 +1276,7 @@ namespace OpenTK.Platform.Windows
 
                     UngrabCursor();
                 }
-                else if (!value && cursor_visible_count >= 0)
+                else
                 {
                     do
                     {

--- a/src/OpenTK/Platform/X11/X11GLNative.cs
+++ b/src/OpenTK/Platform/X11/X11GLNative.cs
@@ -1684,12 +1684,19 @@ namespace OpenTK.Platform.X11
 
         public override bool CursorVisible
         {
-            get { return cursor_visible; }
+            get
+            {
+                return cursor_visible;
+            }
             set
             {
-                if (value && !cursor_visible)
+                if (value == cursor_visible)
                 {
-                    using (new XLock(window.Display))
+                    return;
+                }
+                using (new XLock(window.Display))
+                {
+                    if (value)
                     {
                         UngrabMouse();
 
@@ -1699,16 +1706,12 @@ namespace OpenTK.Platform.X11
                         // Note: if cursorHandle = IntPtr.Zero, this restores the default cursor
                         // (equivalent to calling XUndefineCursor)
                         Functions.XDefineCursor(window.Display, window.Handle, cursorHandle);
-                        cursor_visible = true;
                     }
-                }
-                else if (!value && cursor_visible)
-                {
-                    using (new XLock(window.Display))
+                    else
                     {
                         GrabMouse();
-                        cursor_visible = false;
                     }
+                    cursor_visible = value;
                 }
             }
         }


### PR DESCRIPTION
### Purpose of this PR

As briefly mentioned in #696 ([comment](https://github.com/opentk/opentk/issues/696#issuecomment-354670649)), `INativeWindow` implementations already have their own private fields storing cursor visibility state. This change gets rid of the unneeded field and prevents side effects from the implementation's `CursorVisible` property being set when it doesn't need to (such as setting it to `true` when it is already set to `true`).

I'm unsure if the check should be pushed into the implementations directly or stay in `NativeWindow`, though I figured I'd touch as few files as possible for now, until I can at least test my changes. Input and thoughts are welcome.
**edit:** Received feedback, moved check into implementation classes.

### Testing status

Due to [being unable to build](https://github.com/opentk/opentk/issues/710), I could not verify myself if the changes had the intended effect.
