### PR TITLE
Quaternion

### DIFF
--- a/src/OpenTK/Math/Quaternion.cs
+++ b/src/OpenTK/Math/Quaternion.cs
@@ -66,8 +66,9 @@ namespace OpenTK
         { }
 
         /// <summary>
-        /// Construct a new Quaternion from given Euler angles. The rotations will get applied in following order:
-        /// 1. Around X, 2. Around Y, 3. Around Z
+        /// Construct a new Quaternion from given Euler angles in radians. 
+        /// The rotations will get applied in following order:
+        /// 1. around X axis, 2. around Y axis, 3. around Z axis
         /// </summary>
         /// <param name="rotationX">Counterclockwise rotation around X axis in radian</param>
         /// <param name="rotationY">Counterclockwise rotation around Y axis in radian</param>
@@ -409,7 +410,7 @@ namespace OpenTK
         }
 
         /// <summary>
-        /// Build a quaternion from the given axis and angle
+        /// Build a quaternion from the given axis and angle in radians
         /// </summary>
         /// <param name="axis">The axis to rotate about</param>
         /// <param name="angle">The rotation angle in radians</param>
@@ -432,9 +433,9 @@ namespace OpenTK
         }
 
         /// <summary>
-        /// Builds a Quaternion from the given euler angles
+        /// Builds a Quaternion from the given euler angles in radians
         /// The rotations will get applied in following order:
-        /// 1. pitch, 2. yaw, 3. roll
+        /// 1. pitch (X axis), 2. yaw (Y axis), 3. roll (Z axis)
         /// </summary>
         /// <param name="pitch">The pitch (attitude), counterclockwise rotation around X axis</param>
         /// <param name="yaw">The yaw (heading), counterclockwise rotation around Y axis</param>
@@ -446,9 +447,9 @@ namespace OpenTK
         }
 
         /// <summary>
-        /// Builds a Quaternion from the given euler angles
+        /// Builds a Quaternion from the given euler angles in radians.
         /// The rotations will get applied in following order:
-        /// 1. Around X, 2. Around Y, 3. Around Z
+        /// 1. X axis, 2. Y axis, 3. Z axis
         /// </summary>
         /// <param name="eulerAngles">The counterclockwise euler angles as a vector</param>
         /// <returns>The equivalent Quaternion</returns>

--- a/src/OpenTK/Math/Quaternion.cs
+++ b/src/OpenTK/Math/Quaternion.cs
@@ -66,34 +66,36 @@ namespace OpenTK
         { }
 
         /// <summary>
-        /// Construct a new Quaternion from given Euler angles
+        /// Construct a new Quaternion from given Euler angles. The rotations will get applied in following order:
+        /// 1. Around X, 2. Around Y, 3. Around Z
         /// </summary>
-        /// <param name="pitch">The pitch (attitude), rotation around X axis</param>
-        /// <param name="yaw">The yaw (heading), rotation around Y axis</param>
-        /// <param name="roll">The roll (bank), rotation around Z axis</param>
-        public Quaternion(float pitch, float yaw, float roll)
+        /// <param name="rotationX">Counterclockwise rotation around X axis in radian</param>
+        /// <param name="rotationY">Counterclockwise rotation around Y axis in radian</param>
+        /// <param name="rotationZ">Counterclockwise rotation around Z axis in radian</param>
+        public Quaternion(float rotationX, float rotationY, float rotationZ)
         {
-            yaw *= 0.5f;
-            pitch *= 0.5f;
-            roll *= 0.5f;
+            rotationX *= 0.5f;
+            rotationY *= 0.5f;
+            rotationZ *= 0.5f;
 
-            float c1 = (float)Math.Cos(yaw);
-            float c2 = (float)Math.Cos(pitch);
-            float c3 = (float)Math.Cos(roll);
-            float s1 = (float)Math.Sin(yaw);
-            float s2 = (float)Math.Sin(pitch);
-            float s3 = (float)Math.Sin(roll);
+            float c1 = (float)Math.Cos(rotationX);
+            float c2 = (float)Math.Cos(rotationY);
+            float c3 = (float)Math.Cos(rotationZ);
+            float s1 = (float)Math.Sin(rotationX);
+            float s2 = (float)Math.Sin(rotationY);
+            float s3 = (float)Math.Sin(rotationZ);
 
             W = c1 * c2 * c3 - s1 * s2 * s3;
-            Xyz.X = s1 * s2 * c3 + c1 * c2 * s3;
-            Xyz.Y = s1 * c2 * c3 + c1 * s2 * s3;
-            Xyz.Z = c1 * s2 * c3 - s1 * c2 * s3;
+            Xyz.X = s1 * c2 * c3 + c1 * s2 * s3;
+            Xyz.Y = c1 * s2 * c3 - s1 * c2 * s3;
+            Xyz.Z = c1 * c2 * s3 + s1 * s2 * c3;
         }
 
         /// <summary>
-        /// Construct a new Quaternion from given Euler angles
+        /// Construct a new Quaternion from given Euler angles. The rotations will get applied in following order:
+        /// 1. Around X, 2. Around Y, 3. Around Z
         /// </summary>
-        /// <param name="eulerAngles">The euler angles as a Vector3</param>
+        /// <param name="eulerAngles">The counterclockwise euler angles as a Vector3</param>
         public Quaternion(Vector3 eulerAngles)
             : this(eulerAngles.X, eulerAngles.Y, eulerAngles.Z)
         { }
@@ -431,10 +433,12 @@ namespace OpenTK
 
         /// <summary>
         /// Builds a Quaternion from the given euler angles
+        /// The rotations will get applied in following order:
+        /// 1. pitch, 2. yaw, 3. roll
         /// </summary>
-        /// <param name="pitch">The pitch (attitude), rotation around X axis</param>
-        /// <param name="yaw">The yaw (heading), rotation around Y axis</param>
-        /// <param name="roll">The roll (bank), rotation around Z axis</param>
+        /// <param name="pitch">The pitch (attitude), counterclockwise rotation around X axis</param>
+        /// <param name="yaw">The yaw (heading), counterclockwise rotation around Y axis</param>
+        /// <param name="roll">The roll (bank), counterclockwise rotation around Z axis</param>
         /// <returns></returns>
         public static Quaternion FromEulerAngles(float pitch, float yaw, float roll)
         {
@@ -443,8 +447,10 @@ namespace OpenTK
 
         /// <summary>
         /// Builds a Quaternion from the given euler angles
+        /// The rotations will get applied in following order:
+        /// 1. Around X, 2. Around Y, 3. Around Z
         /// </summary>
-        /// <param name="eulerAngles">The euler angles as a vector</param>
+        /// <param name="eulerAngles">The counterclockwise euler angles as a vector</param>
         /// <returns>The equivalent Quaternion</returns>
         public static Quaternion FromEulerAngles(Vector3 eulerAngles)
         {
@@ -452,23 +458,26 @@ namespace OpenTK
         }
 
         /// <summary>
-        /// Builds a Quaternion from the given euler angles
+        /// Builds a Quaternion from the given euler angles in radians.
+        /// The rotations will get applied in following order:
+        /// 1. Around X, 2. Around Y, 3. Around Z
         /// </summary>
-        /// <param name="eulerAngles">The euler angles a vector</param>
+        /// <param name="eulerAngles">The counterclockwise euler angles a vector</param>
         /// <param name="result">The equivalent Quaternion</param>
         public static void FromEulerAngles(ref Vector3 eulerAngles, out Quaternion result)
         {
-            float c1 = (float)Math.Cos(eulerAngles.Y * 0.5f);
-            float c2 = (float)Math.Cos(eulerAngles.X * 0.5f);
+
+            float c1 = (float)Math.Cos(eulerAngles.X * 0.5f);
+            float c2 = (float)Math.Cos(eulerAngles.Y * 0.5f);
             float c3 = (float)Math.Cos(eulerAngles.Z * 0.5f);
-            float s1 = (float)Math.Sin(eulerAngles.Y * 0.5f);
-            float s2 = (float)Math.Sin(eulerAngles.X * 0.5f);
+            float s1 = (float)Math.Sin(eulerAngles.X * 0.5f);
+            float s2 = (float)Math.Sin(eulerAngles.Y * 0.5f);
             float s3 = (float)Math.Sin(eulerAngles.Z * 0.5f);
 
             result.W = c1 * c2 * c3 - s1 * s2 * s3;
-            result.Xyz.X = s1 * s2 * c3 + c1 * c2 * s3;
-            result.Xyz.Y = s1 * c2 * c3 + c1 * s2 * s3;
-            result.Xyz.Z = c1 * s2 * c3 - s1 * c2 * s3;
+            result.Xyz.X = s1 * c2 * c3 + c1 * s2 * s3;
+            result.Xyz.Y = c1 * s2 * c3 - s1 * c2 * s3;
+            result.Xyz.Z = c1 * c2 * s3 + s1 * s2 * c3;
         }
 
         /// <summary>

--- a/tests/OpenTK.Tests.Math/DataProviders/QuaternionTestDataGenerator.cs
+++ b/tests/OpenTK.Tests.Math/DataProviders/QuaternionTestDataGenerator.cs
@@ -11,28 +11,26 @@ namespace OpenTK.Tests.Math.DataProviders
 		/// Returns the single axis test cases.
 		/// 1. param: rotation in euler angles
 		/// 2. param: expected result of xyz-component of quaternion
-		/// 3. param: test name (Don't found a working way how to pass this to xUnit runner). I let it here for test documentation
 		/// </summary>
 		/// <value>The single axis test cases.</value>
 		public static IEnumerable<object> SingleAxisTestCases()
 		{
-			yield return new object[] { new Vector3(1, 0, 0), Vector3.UnitX, "Rotate around x axis" };
-			yield return new object[] { new Vector3(0, 1, 0), Vector3.UnitY, "Rotate around y axis" };
-			yield return new object[] { new Vector3(0, 0, 1), Vector3.UnitZ, "Rotate around z axis" };
+			yield return new object[] { new Vector3(1, 0, 0), Vector3.UnitX}; //"Rotate around x axis"
+			yield return new object[] { new Vector3(0, 1, 0), Vector3.UnitY}; //"Rotate around y axis" 
+			yield return new object[] { new Vector3(0, 0, 1), Vector3.UnitZ}; //"Rotate around z axis" 
 		}
 
 		/// <summary>
 		/// Returns the single ToAxisAngle test cases.
 		/// 1. param: Quaternion which a definied value of xyz-component.
 		/// 2. param: expected result of xyz-component of quaternion
-		/// 3. param: test name (Don't found a working way how to pass this to xUnit runner). I let it here for test documentation
 		/// </summary>
 		/// <value>The single axis test cases.</value>
 		public static IEnumerable<object[]> ToAxisAngleTestCases()
 		{
-			yield return new object[] { new Quaternion(Vector3.UnitX, 0), Vector3.UnitX, "Rotate around x axis" };
-			yield return new object[] { new Quaternion(Vector3.UnitY, 0), Vector3.UnitY, "Rotate around y axis" };
-			yield return new object[] { new Quaternion(Vector3.UnitZ, 0), Vector3.UnitZ, "Rotate around z axis" };
+			yield return new object[] { new Quaternion(Vector3.UnitX, 0), Vector3.UnitX}; //"Rotate around x axis"
+			yield return new object[] { new Quaternion(Vector3.UnitY, 0), Vector3.UnitY}; //"Rotate around y axis"
+			yield return new object[] { new Quaternion(Vector3.UnitZ, 0), Vector3.UnitZ}; //"Rotate around z axis"
 		}
 	}
 	

--- a/tests/OpenTK.Tests.Math/DataProviders/QuaternionTestDataGenerator.cs
+++ b/tests/OpenTK.Tests.Math/DataProviders/QuaternionTestDataGenerator.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+
+namespace OpenTK.Tests.Math.DataProviders
+{
+	/// <summary>
+	/// Generates/Provides Quaternion test data.
+	/// </summary>
+	public class QuaternionTestDataGenerator
+	{
+		/// <summary>
+		/// Returns the single axis test cases.
+		/// 1. param: rotation in euler angles
+		/// 2. param: expected result of xyz-component of quaternion
+		/// 3. param: test name (Don't found a working way how to pass this to xUnit runner). I let it here for test documentation
+		/// </summary>
+		/// <value>The single axis test cases.</value>
+		public static IEnumerable<object> SingleAxisTestCases()
+		{
+			yield return new object[] { new Vector3(1, 0, 0), Vector3.UnitX, "Rotate around x axis" };
+			yield return new object[] { new Vector3(0, 1, 0), Vector3.UnitY, "Rotate around y axis" };
+			yield return new object[] { new Vector3(0, 0, 1), Vector3.UnitZ, "Rotate around z axis" };
+		}
+
+		/// <summary>
+		/// Returns the single ToAxisAngle test cases.
+		/// 1. param: Quaternion which a definied value of xyz-component.
+		/// 2. param: expected result of xyz-component of quaternion
+		/// 3. param: test name (Don't found a working way how to pass this to xUnit runner). I let it here for test documentation
+		/// </summary>
+		/// <value>The single axis test cases.</value>
+		public static IEnumerable<object[]> ToAxisAngleTestCases()
+		{
+			yield return new object[] { new Quaternion(Vector3.UnitX, 0), Vector3.UnitX, "Rotate around x axis" };
+			yield return new object[] { new Quaternion(Vector3.UnitY, 0), Vector3.UnitY, "Rotate around y axis" };
+			yield return new object[] { new Quaternion(Vector3.UnitZ, 0), Vector3.UnitZ, "Rotate around z axis" };
+		}
+	}
+	
+}

--- a/tests/OpenTK.Tests.Math/Helpers/QuaternionTestHelper.cs
+++ b/tests/OpenTK.Tests.Math/Helpers/QuaternionTestHelper.cs
@@ -1,0 +1,61 @@
+using Xunit;
+using System;
+using System.Collections.Generic;
+
+namespace OpenTK.Tests.Math.Helpers
+{
+
+	/// <summary>
+	/// Provides some methods which helps to verify test results
+	/// </summary>
+	internal static class QuaternionTestHelper
+	{
+		/// <summary>
+		/// Verifies the direction of an given <see cref="Vector3"/>.
+		/// </summary>
+		/// <returns>false: When <paramref name="toTest"/> does contain xyz values, when it should be 0,
+		/// or does not contain 0 when it should be</returns>
+		/// <param name="toTest">To test</param>
+		/// <param name="expected">Expected directions. Values getting only 0 checked</param>
+		public static bool VerifyEqualSingleDirection(Vector3 toTest, Vector3 expected)
+		{
+			//To verify the direction of an vector, just respect the 0 values and check against these.
+			//The length of the vectors are ignored.
+			if (expected.X == 0)
+			{
+				if (toTest.X != 0)
+					return false;
+			}
+			else
+			{
+				if (toTest.X == 0)
+					return false;
+			}
+
+			if (expected.Y == 0)
+			{
+				if (toTest.Y != 0)
+					return false;
+			}
+			else
+			{
+				if (toTest.Y == 0)
+					return false;
+			}
+
+			if (expected.Z == 0)
+			{
+				if (toTest.Z != 0)
+					return false;
+			}
+			else
+			{
+				if (toTest.Z == 0)
+					return false;
+			}
+
+			return true;
+		}
+	}
+	
+}

--- a/tests/OpenTK.Tests.Math/OpenTK.Tests.Math.csproj
+++ b/tests/OpenTK.Tests.Math/OpenTK.Tests.Math.csproj
@@ -48,9 +48,15 @@
     <Compile Include="BezierCurveTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="QuaternionTests.cs" />
+    <Compile Include="Helpers\QuaternionTestHelper.cs" />
+    <Compile Include="DataProviders\QuaternionTestDataGenerator.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="paket.references" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Helpers\" />
+    <Folder Include="Generators\" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/tests/OpenTK.Tests.Math/OpenTK.Tests.Math.csproj
+++ b/tests/OpenTK.Tests.Math/OpenTK.Tests.Math.csproj
@@ -47,6 +47,7 @@
   <ItemGroup>
     <Compile Include="BezierCurveTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="QuaternionTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="paket.references" />

--- a/tests/OpenTK.Tests.Math/QuaternionTests.cs
+++ b/tests/OpenTK.Tests.Math/QuaternionTests.cs
@@ -1,96 +1,9 @@
 ﻿using Xunit;
-using System;
-using System.Collections.Generic;
+using OpenTK.Tests.Math.Helpers;
+using OpenTK.Tests.Math.DataProviders;
 
 namespace OpenTK.Tests.Math
 {
-	/// <summary>
-	/// Generates Quaternion test data.
-	/// </summary>
-	public class QuaternionTestDataGenerator
-	{
-		/// <summary>
-		/// Returns the single axis test cases.
-		/// 1. param: rotation in euler angles
-		/// 2. param: expected result of xyz-component of quaternion
-		/// 3. param: test name (Don't found a working way how to pass this to xUnit runner). I let it here for test documentation
-		/// </summary>
-		/// <value>The single axis test cases.</value>
-		public static IEnumerable<object> SingleAxisTestCases()
-		{
-			yield return new object[] { new Vector3(1, 0, 0), Vector3.UnitX, "Rotate around x axis" };
-			yield return new object[] { new Vector3(0, 1, 0), Vector3.UnitY, "Rotate around y axis" };
-			yield return new object[] { new Vector3(0, 0, 1), Vector3.UnitZ, "Rotate around z axis" };
-		}
-
-		/// <summary>
-		/// Returns the single ToAxisAngle test cases.
-		/// 1. param: Quaternion which a definied value of xyz-component.
-		/// 2. param: expected result of xyz-component of quaternion
-		/// 3. param: test name (Don't found a working way how to pass this to xUnit runner). I let it here for test documentation
-		/// </summary>
-		/// <value>The single axis test cases.</value>
-		public static IEnumerable<object[]> ToAxisAngleTestCases()
-		{
-			yield return new object[] { new Quaternion(Vector3.UnitX, 0), Vector3.UnitX, "Rotate around x axis" };
-			yield return new object[] { new Quaternion(Vector3.UnitY, 0), Vector3.UnitY, "Rotate around y axis" };
-			yield return new object[] { new Quaternion(Vector3.UnitZ, 0), Vector3.UnitZ, "Rotate around z axis" };
-		}
-	}
-
-	/// <summary>
-	/// Provides some methods which helps to verify test results
-	/// </summary>
-	internal static class QuaternionTestHelper
-	{
-		/// <summary>
-		/// Verifies the direction of an given <see cref="Vector3"/>.
-		/// </summary>
-		/// <returns>false: When <paramref name="toTest"/> does contain xyz values, when it should be 0,
-		/// or does not contain 0 when it should be</returns>
-		/// <param name="toTest">To test</param>
-		/// <param name="expected">Expected directions. Values getting only 0 checked</param>
-		public static bool VerifyEqualSingleDirection(Vector3 toTest, Vector3 expected)
-		{
-			//To verify the direction of an vector, just respect the 0 values and check against these.
-			//The length of the vectors are ignored.
-			if (expected.X == 0)
-			{
-				if (toTest.X != 0)
-					return false;
-			}
-			else
-			{
-				if (toTest.X == 0)
-					return false;
-			}
-
-			if (expected.Y == 0)
-			{
-				if (toTest.Y != 0)
-					return false;
-			}
-			else
-			{
-				if (toTest.Y == 0)
-					return false;
-			}
-
-			if (expected.Z == 0)
-			{
-				if (toTest.Z != 0)
-					return false;
-			}
-			else
-			{
-				if (toTest.Z == 0)
-					return false;
-			}
-
-			return true;
-		}
-	}
-
 	public class Quaternion_Tests
 	{
 		/// <summary>
@@ -101,7 +14,7 @@ namespace OpenTK.Tests.Math
 		/// <param name="testName">Taken from nUnit test data. Don't know how to name data driven tests for xUnit which actually works.</param>
 		[Theory]
 		[MemberData(nameof(QuaternionTestDataGenerator.SingleAxisTestCases), MemberType = typeof(QuaternionTestDataGenerator))]
-		public void CtorEulerAnglesFloat_SingleEulerAngleSet_RotateCorrectAxis(Vector3 eulerValues, Vector3 expectedResult, String testName)
+		public void CtorEulerAnglesFloat_SingleEulerAngleSet_RotateCorrectAxis(Vector3 eulerValues, Vector3 expectedResult, string testName)
 		{
 			//Arrange + Act: Create Quaternion with "pitch/yaw/roll"
 			var cut = new Quaternion(eulerValues.X, eulerValues.Y, eulerValues.Z);
@@ -120,10 +33,10 @@ namespace OpenTK.Tests.Math
 		/// <param name="testName">Taken from nUnit test data. Don't know how to name data driven tests for xUnit which actually works.</param>
 		[Theory]
 		[MemberData(nameof(QuaternionTestDataGenerator.SingleAxisTestCases), MemberType = typeof(QuaternionTestDataGenerator))]
-		public void CtorEulerAnglesVector3_SingleEulerAngleSet_RotateCorrectAxis(Vector3 eulerValues, Vector3 expectedResult, String testName)
+		public void CtorEulerAnglesVector3_SingleEulerAngleSet_RotateCorrectAxis(Vector3 eulerValues, Vector3 expectedResult, string testName)
 		{
 			//Arrange + Act: Create Quaternion with "pitch/yaw/roll"
-			var cut = new Quaternion(eulerValues.X, eulerValues.Y, eulerValues.Z);
+			var cut = new Quaternion(eulerValues);
 
 			//Assert: Use helper, to check if part of the two correct axis is zero. I just want check the direction
 			Vector3 resultXYZ = cut.Xyz;
@@ -139,7 +52,7 @@ namespace OpenTK.Tests.Math
 		/// <param name="testName">Taken from nUnit test data. Don't know how to name data driven tests for xUnit which actually works.</param>
 		[Theory]
 		[MemberData(nameof(QuaternionTestDataGenerator.SingleAxisTestCases), MemberType = typeof(QuaternionTestDataGenerator))]
-		public void FromEulerAnglesFloat_SingleEulerAngleSet_RotateCorrectAxis(Vector3 eulerValues, Vector3 expectedResult, String testName)
+		public void FromEulerAnglesFloat_SingleEulerAngleSet_RotateCorrectAxis(Vector3 eulerValues, Vector3 expectedResult, string testName)
 		{
 			//Arrange + Act: Create Quaternion with "pitch/yaw/roll"
 			var cut = Quaternion.FromEulerAngles(eulerValues.X, eulerValues.Y, eulerValues.Z);
@@ -158,7 +71,7 @@ namespace OpenTK.Tests.Math
 		/// <param name="testName">Taken from nUnit test data. Don't know how to name data driven tests for xUnit which actually works.</param>
 		[Theory]
 		[MemberData(nameof(QuaternionTestDataGenerator.SingleAxisTestCases), MemberType = typeof(QuaternionTestDataGenerator))]
-		public void FromEulerAnglesVector3_SingleEulerAngleSet_RotateCorrectAxis(Vector3 eulerValues, Vector3 expectedResult, String testName)
+		public void FromEulerAnglesVector3_SingleEulerAngleSet_RotateCorrectAxis(Vector3 eulerValues, Vector3 expectedResult, string testName)
 		{
 			//Arrange + Act: Create Quaternion with "pitch/yaw/roll"
 			var cut = Quaternion.FromEulerAngles(eulerValues);
@@ -177,7 +90,7 @@ namespace OpenTK.Tests.Math
 		/// <param name="testName">Taken from nUnit test data. Don't know how to name data driven tests for xUnit which actually works.</param>
 		[Theory]
 		[MemberData(nameof(QuaternionTestDataGenerator.SingleAxisTestCases), MemberType = typeof(QuaternionTestDataGenerator))]
-		public void FromEulerAnglesOut_SingleEulerAngleSet_RotateCorrectAxis(Vector3 eulerValues, Vector3 expectedResult, String testName)
+		public void FromEulerAnglesOut_SingleEulerAngleSet_RotateCorrectAxis(Vector3 eulerValues, Vector3 expectedResult, string testName)
 		{
 			//Arrange + Act: Create Quaternion with "pitch/yaw/roll"
 			var cut = Quaternion.Identity;
@@ -197,7 +110,7 @@ namespace OpenTK.Tests.Math
 		/// <param name="testName">Taken from nUnit test data. Don't know how to name data driven tests for xUnit which actually works.</param>
 		[Theory]
 		[MemberData(nameof(QuaternionTestDataGenerator.ToAxisAngleTestCases), MemberType = typeof(QuaternionTestDataGenerator))]
-		public void ToAxisAngle_SingleAxisSetAndAngleIgnored_RotateCorrectAxis(Quaternion cut, Vector3 expectedResult, String testName)
+		public void ToAxisAngle_SingleAxisSetAndAngleIgnored_RotateCorrectAxis(Quaternion cut, Vector3 expectedResult, string testName)
 		{
 			//Arrange + Act: Create Quaternion with rotation about X/Y/Z axis
 			Vector3 resultXYZ;

--- a/tests/OpenTK.Tests.Math/QuaternionTests.cs
+++ b/tests/OpenTK.Tests.Math/QuaternionTests.cs
@@ -50,7 +50,7 @@ namespace OpenTK.Tests.Math
 		/// or does not contain 0 when it should be</returns>
 		/// <param name="toTest">To test</param>
 		/// <param name="expected">Expected directions. Values getting only 0 checked</param>
-		public static bool VerifyEuqalSignleDirection(Vector3 toTest, Vector3 expected)
+		public static bool VerifyEqualSingleDirection(Vector3 toTest, Vector3 expected)
 		{
 			//To verify the direction of an vector, just respect the 0 values and check against these.
 			//The length of the vectors are ignored.
@@ -109,7 +109,7 @@ namespace OpenTK.Tests.Math
 			//Assert: Use helper, to check if part of the two correct axis is zero. I just want check the direction
 			Vector3 resultXYZ = cut.Xyz;
 
-			Assert.True(QuaternionTestHelper.VerifyEuqalSignleDirection(resultXYZ, expectedResult));
+			Assert.True(QuaternionTestHelper.VerifyEqualSingleDirection(resultXYZ, expectedResult));
 		}
 
 		/// <summary>
@@ -128,7 +128,7 @@ namespace OpenTK.Tests.Math
 			//Assert: Use helper, to check if part of the two correct axis is zero. I just want check the direction
 			Vector3 resultXYZ = cut.Xyz;
 
-			Assert.True(QuaternionTestHelper.VerifyEuqalSignleDirection(resultXYZ, expectedResult));
+			Assert.True(QuaternionTestHelper.VerifyEqualSingleDirection(resultXYZ, expectedResult));
 		}
 
 		/// <summary>
@@ -147,7 +147,7 @@ namespace OpenTK.Tests.Math
 			//Assert: Use helper, to check if part of the two correct axis is zero. I just want check the direction
 			Vector3 resultXYZ = cut.Xyz;
 
-			Assert.True(QuaternionTestHelper.VerifyEuqalSignleDirection(resultXYZ, expectedResult));
+			Assert.True(QuaternionTestHelper.VerifyEqualSingleDirection(resultXYZ, expectedResult));
 		}
 
 		/// <summary>
@@ -166,7 +166,7 @@ namespace OpenTK.Tests.Math
 			//Assert: Use helper, to check if part of the two correct axis is zero. I just want check the direction
 			Vector3 resultXYZ = cut.Xyz;
 
-			Assert.True(QuaternionTestHelper.VerifyEuqalSignleDirection(resultXYZ, expectedResult));
+			Assert.True(QuaternionTestHelper.VerifyEqualSingleDirection(resultXYZ, expectedResult));
 		}
 
 		/// <summary>
@@ -186,7 +186,7 @@ namespace OpenTK.Tests.Math
 			//Assert: Use helper, to check if part of the two correct axis is zero. I just want check the direction
 			Vector3 resultXYZ = cut.Xyz;
 
-			Assert.True(QuaternionTestHelper.VerifyEuqalSignleDirection(resultXYZ, expectedResult));
+			Assert.True(QuaternionTestHelper.VerifyEqualSingleDirection(resultXYZ, expectedResult));
 		}
 
 		/// <summary>
@@ -205,7 +205,7 @@ namespace OpenTK.Tests.Math
 			cut.ToAxisAngle(out resultXYZ, out dontCare);
 
 			//Assert: Use helper, to check if part of the two correct axis is zero. I just want check the direction
-			Assert.True(QuaternionTestHelper.VerifyEuqalSignleDirection(resultXYZ, expectedResult));
+			Assert.True(QuaternionTestHelper.VerifyEqualSingleDirection(resultXYZ, expectedResult));
 		}
 
 		//TODO: Make also checks with rotation angle

--- a/tests/OpenTK.Tests.Math/QuaternionTests.cs
+++ b/tests/OpenTK.Tests.Math/QuaternionTests.cs
@@ -1,0 +1,214 @@
+﻿using Xunit;
+using System;
+using System.Collections.Generic;
+
+namespace OpenTK.Tests.Math
+{
+	/// <summary>
+	/// Generates Quaternion test data.
+	/// </summary>
+	public class QuaternionTestDataGenerator
+	{
+		/// <summary>
+		/// Returns the single axis test cases.
+		/// 1. param: rotation in euler angles
+		/// 2. param: expected result of xyz-component of quaternion
+		/// 3. param: test name (Don't found a working way how to pass this to xUnit runner). I let it here for test documentation
+		/// </summary>
+		/// <value>The single axis test cases.</value>
+		public static IEnumerable<object> SingleAxisTestCases()
+		{
+			yield return new object[] { new Vector3(1, 0, 0), Vector3.UnitX, "Rotate around x axis" };
+			yield return new object[] { new Vector3(0, 1, 0), Vector3.UnitY, "Rotate around y axis" };
+			yield return new object[] { new Vector3(0, 0, 1), Vector3.UnitZ, "Rotate around z axis" };
+		}
+
+		/// <summary>
+		/// Returns the single ToAxisAngle test cases.
+		/// 1. param: Quaternion which a definied value of xyz-component.
+		/// 2. param: expected result of xyz-component of quaternion
+		/// 3. param: test name (Don't found a working way how to pass this to xUnit runner). I let it here for test documentation
+		/// </summary>
+		/// <value>The single axis test cases.</value>
+		public static IEnumerable<object[]> ToAxisAngleTestCases()
+		{
+			yield return new object[] { new Quaternion(Vector3.UnitX, 0), Vector3.UnitX, "Rotate around x axis" };
+			yield return new object[] { new Quaternion(Vector3.UnitY, 0), Vector3.UnitY, "Rotate around y axis" };
+			yield return new object[] { new Quaternion(Vector3.UnitZ, 0), Vector3.UnitZ, "Rotate around z axis" };
+		}
+	}
+
+	/// <summary>
+	/// Provides some methods which helps to verify test results
+	/// </summary>
+	internal static class QuaternionTestHelper
+	{
+		/// <summary>
+		/// Verifies the direction of an given <see cref="Vector3"/>.
+		/// </summary>
+		/// <returns>false: When <paramref name="toTest"/> does contain xyz values, when it should be 0,
+		/// or does not contain 0 when it should be</returns>
+		/// <param name="toTest">To test</param>
+		/// <param name="expected">Expected directions. Values getting only 0 checked</param>
+		public static bool VerifyEuqalSignleDirection(Vector3 toTest, Vector3 expected)
+		{
+			//To verify the direction of an vector, just respect the 0 values and check against these.
+			//The length of the vectors are ignored.
+			if (expected.X == 0)
+			{
+				if (toTest.X != 0)
+					return false;
+			}
+			else
+			{
+				if (toTest.X == 0)
+					return false;
+			}
+
+			if (expected.Y == 0)
+			{
+				if (toTest.Y != 0)
+					return false;
+			}
+			else
+			{
+				if (toTest.Y == 0)
+					return false;
+			}
+
+			if (expected.Z == 0)
+			{
+				if (toTest.Z != 0)
+					return false;
+			}
+			else
+			{
+				if (toTest.Z == 0)
+					return false;
+			}
+
+			return true;
+		}
+	}
+
+	public class Quaternion_Tests
+	{
+		/// <summary>
+		/// Checks if a single given value (either pitch, yaw or roll) get converted into correct x,y,z value of quaternion.
+		/// </summary>
+		/// <param name="eulerValues">euler angle values</param>
+		/// <param name="expectedResult">expected xyz component of quaternion</param>
+		/// <param name="testName">Taken from nUnit test data. Don't know how to name data driven tests for xUnit which actually works.</param>
+		[Theory]
+		[MemberData(nameof(QuaternionTestDataGenerator.SingleAxisTestCases), MemberType = typeof(QuaternionTestDataGenerator))]
+		public void CtorEulerAnglesFloat_SingleEulerAngleSet_RotateCorrectAxis(Vector3 eulerValues, Vector3 expectedResult, String testName)
+		{
+			//Arrange + Act: Create Quaternion with "pitch/yaw/roll"
+			var cut = new Quaternion(eulerValues.X, eulerValues.Y, eulerValues.Z);
+
+			//Assert: Use helper, to check if part of the two correct axis is zero. I just want check the direction
+			Vector3 resultXYZ = cut.Xyz;
+
+			Assert.True(QuaternionTestHelper.VerifyEuqalSignleDirection(resultXYZ, expectedResult));
+		}
+
+		/// <summary>
+		/// Checks if a single given value (either pitch, yaw or roll) get converted into correct x,y,z value of quaternion.
+		/// </summary>
+		/// <param name="eulerValues">euler angle values</param>
+		/// <param name="expectedResult">expected xyz component of quaternion</param>
+		/// <param name="testName">Taken from nUnit test data. Don't know how to name data driven tests for xUnit which actually works.</param>
+		[Theory]
+		[MemberData(nameof(QuaternionTestDataGenerator.SingleAxisTestCases), MemberType = typeof(QuaternionTestDataGenerator))]
+		public void CtorEulerAnglesVector3_SingleEulerAngleSet_RotateCorrectAxis(Vector3 eulerValues, Vector3 expectedResult, String testName)
+		{
+			//Arrange + Act: Create Quaternion with "pitch/yaw/roll"
+			var cut = new Quaternion(eulerValues.X, eulerValues.Y, eulerValues.Z);
+
+			//Assert: Use helper, to check if part of the two correct axis is zero. I just want check the direction
+			Vector3 resultXYZ = cut.Xyz;
+
+			Assert.True(QuaternionTestHelper.VerifyEuqalSignleDirection(resultXYZ, expectedResult));
+		}
+
+		/// <summary>
+		/// Checks if a single given value (either pitch, yaw or roll) get converted into correct x,y,z value of quaternion.
+		/// </summary>
+		/// <param name="eulerValues">euler angle values</param>
+		/// <param name="expectedResult">expected xyz component of quaternion</param>
+		/// <param name="testName">Taken from nUnit test data. Don't know how to name data driven tests for xUnit which actually works.</param>
+		[Theory]
+		[MemberData(nameof(QuaternionTestDataGenerator.SingleAxisTestCases), MemberType = typeof(QuaternionTestDataGenerator))]
+		public void FromEulerAnglesFloat_SingleEulerAngleSet_RotateCorrectAxis(Vector3 eulerValues, Vector3 expectedResult, String testName)
+		{
+			//Arrange + Act: Create Quaternion with "pitch/yaw/roll"
+			var cut = Quaternion.FromEulerAngles(eulerValues.X, eulerValues.Y, eulerValues.Z);
+
+			//Assert: Use helper, to check if part of the two correct axis is zero. I just want check the direction
+			Vector3 resultXYZ = cut.Xyz;
+
+			Assert.True(QuaternionTestHelper.VerifyEuqalSignleDirection(resultXYZ, expectedResult));
+		}
+
+		/// <summary>
+		/// Checks if a single given value (either pitch, yaw or roll) get converted into correct x,y,z value of quaternion.
+		/// </summary>
+		/// <param name="eulerValues">euler angle values</param>
+		/// <param name="expectedResult">expected xyz component of quaternion</param>
+		/// <param name="testName">Taken from nUnit test data. Don't know how to name data driven tests for xUnit which actually works.</param>
+		[Theory]
+		[MemberData(nameof(QuaternionTestDataGenerator.SingleAxisTestCases), MemberType = typeof(QuaternionTestDataGenerator))]
+		public void FromEulerAnglesVector3_SingleEulerAngleSet_RotateCorrectAxis(Vector3 eulerValues, Vector3 expectedResult, String testName)
+		{
+			//Arrange + Act: Create Quaternion with "pitch/yaw/roll"
+			var cut = Quaternion.FromEulerAngles(eulerValues);
+
+			//Assert: Use helper, to check if part of the two correct axis is zero. I just want check the direction
+			Vector3 resultXYZ = cut.Xyz;
+
+			Assert.True(QuaternionTestHelper.VerifyEuqalSignleDirection(resultXYZ, expectedResult));
+		}
+
+		/// <summary>
+		/// Checks if a single given value (either pitch, yaw or roll) get converted into correct x,y,z value of quaternion.
+		/// </summary>
+		/// <param name="eulerValues">euler angle values</param>
+		/// <param name="expectedResult">expected xyz component of quaternion</param>
+		/// <param name="testName">Taken from nUnit test data. Don't know how to name data driven tests for xUnit which actually works.</param>
+		[Theory]
+		[MemberData(nameof(QuaternionTestDataGenerator.SingleAxisTestCases), MemberType = typeof(QuaternionTestDataGenerator))]
+		public void FromEulerAnglesOut_SingleEulerAngleSet_RotateCorrectAxis(Vector3 eulerValues, Vector3 expectedResult, String testName)
+		{
+			//Arrange + Act: Create Quaternion with "pitch/yaw/roll"
+			var cut = Quaternion.Identity;
+			Quaternion.FromEulerAngles(ref eulerValues, out cut);
+
+			//Assert: Use helper, to check if part of the two correct axis is zero. I just want check the direction
+			Vector3 resultXYZ = cut.Xyz;
+
+			Assert.True(QuaternionTestHelper.VerifyEuqalSignleDirection(resultXYZ, expectedResult));
+		}
+
+		/// <summary>
+		/// Check if a quaternion returns a a rotation about the correct coordinate axis
+		/// </summary>
+		/// <param name="cut">Prepared Quaternion</param>
+		/// <param name="expectedResult">Expected result.</param>
+		/// <param name="testName">Taken from nUnit test data. Don't know how to name data driven tests for xUnit which actually works.</param>
+		[Theory]
+		[MemberData(nameof(QuaternionTestDataGenerator.ToAxisAngleTestCases), MemberType = typeof(QuaternionTestDataGenerator))]
+		public void ToAxisAngle_SingleAxisSetAndAngleIgnored_RotateCorrectAxis(Quaternion cut, Vector3 expectedResult, String testName)
+		{
+			//Arrange + Act: Create Quaternion with rotation about X/Y/Z axis
+			Vector3 resultXYZ;
+			float dontCare;
+			cut.ToAxisAngle(out resultXYZ, out dontCare);
+
+			//Assert: Use helper, to check if part of the two correct axis is zero. I just want check the direction
+			Assert.True(QuaternionTestHelper.VerifyEuqalSignleDirection(resultXYZ, expectedResult));
+		}
+
+		//TODO: Make also checks with rotation angle
+	}
+}
+

--- a/tests/OpenTK.Tests.Math/QuaternionTests.cs
+++ b/tests/OpenTK.Tests.Math/QuaternionTests.cs
@@ -7,121 +7,152 @@ namespace OpenTK.Tests.Math
 	public class Quaternion_Tests
 	{
 		/// <summary>
-		/// Checks if a single given value (either pitch, yaw or roll) get converted into correct x,y,z value of quaternion.
+		/// Contains all tests which cover the ctor of Quaternion.
 		/// </summary>
-		/// <param name="eulerValues">euler angle values</param>
-		/// <param name="expectedResult">expected xyz component of quaternion</param>
-		/// <param name="testName">Taken from nUnit test data. Don't know how to name data driven tests for xUnit which actually works.</param>
-		[Theory]
-		[MemberData(nameof(QuaternionTestDataGenerator.SingleAxisTestCases), MemberType = typeof(QuaternionTestDataGenerator))]
-		public void CtorEulerAnglesFloat_SingleEulerAngleSet_RotateCorrectAxis(Vector3 eulerValues, Vector3 expectedResult, string testName)
+		public class Constructor_Tests
 		{
-			//Arrange + Act: Create Quaternion with "pitch/yaw/roll"
-			var cut = new Quaternion(eulerValues.X, eulerValues.Y, eulerValues.Z);
+			/// <summary>
+			/// Checks if a single given value (either pitch, yaw or roll) get converted into correct x,y,z value of quaternion.
+			/// </summary>
+			/// <param name="eulerValues">euler angle values</param>
+			/// <param name="expectedResult">expected xyz component of quaternion</param>
+			/// <param name="testName">Taken from nUnit test data. Don't know how to name data driven tests for xUnit which actually works.</param>
+			[Theory]
+			[MemberData(nameof(QuaternionTestDataGenerator.SingleAxisTestCases), MemberType = typeof(QuaternionTestDataGenerator))]
+			public void SingleAxisAsEulerAnglesInFloatsIsConvertedToCorrectValueInQuaternion
+			(Vector3 eulerValues, Vector3 expectedResult, string testName)
+			{
+				//Arrange + Act: Create Quaternion with "pitch/yaw/roll"
+				var cut = new Quaternion(eulerValues.X, eulerValues.Y, eulerValues.Z);
 
-			//Assert: Use helper, to check if part of the two correct axis is zero. I just want check the direction
-			Vector3 resultXYZ = cut.Xyz;
+				//Assert: Use helper, to check if part of the two correct axis is zero. I just want check the direction
+				Vector3 resultXYZ = cut.Xyz;
 
-			Assert.True(QuaternionTestHelper.VerifyEqualSingleDirection(resultXYZ, expectedResult));
+				Assert.True(QuaternionTestHelper.VerifyEqualSingleDirection(resultXYZ, expectedResult));
+			}
+
+			/// <summary>
+			/// Checks if a single given value (either pitch, yaw or roll) get converted into correct x,y,z value of quaternion.
+			/// </summary>
+			/// <param name="eulerValues">euler angle values</param>
+			/// <param name="expectedResult">expected xyz component of quaternion</param>
+			/// <param name="testName">Taken from nUnit test data. Don't know how to name data driven tests for xUnit which actually works.</param>
+			[Theory]
+			[MemberData(nameof(QuaternionTestDataGenerator.SingleAxisTestCases), MemberType = typeof(QuaternionTestDataGenerator))]
+			public void SingleAxisAsEulerAnglesInVector3IsConvertedToCorrectValueInQuaternion
+			(Vector3 eulerValues, Vector3 expectedResult, string testName)
+			{
+				//Arrange + Act: Create Quaternion with "pitch/yaw/roll"
+				var cut = new Quaternion(eulerValues);
+
+				//Assert: Use helper, to check if part of the two correct axis is zero. I just want check the direction
+				Vector3 resultXYZ = cut.Xyz;
+
+				Assert.True(QuaternionTestHelper.VerifyEqualSingleDirection(resultXYZ, expectedResult));
+			}
+
+			//TODO: Make also checks with ccw rotation angle and correct applied rotation order of multiple axis
 		}
 
 		/// <summary>
-		/// Checks if a single given value (either pitch, yaw or roll) get converted into correct x,y,z value of quaternion.
+		/// Contains all tests for FromEulerAngles
 		/// </summary>
-		/// <param name="eulerValues">euler angle values</param>
-		/// <param name="expectedResult">expected xyz component of quaternion</param>
-		/// <param name="testName">Taken from nUnit test data. Don't know how to name data driven tests for xUnit which actually works.</param>
-		[Theory]
-		[MemberData(nameof(QuaternionTestDataGenerator.SingleAxisTestCases), MemberType = typeof(QuaternionTestDataGenerator))]
-		public void CtorEulerAnglesVector3_SingleEulerAngleSet_RotateCorrectAxis(Vector3 eulerValues, Vector3 expectedResult, string testName)
+		public class FromEulerAngles_Tests
 		{
-			//Arrange + Act: Create Quaternion with "pitch/yaw/roll"
-			var cut = new Quaternion(eulerValues);
+			/// <summary>
+			/// Checks if a single given value (either pitch, yaw or roll) get converted into correct x,y,z value of quaternion.
+			/// </summary>
+			/// <param name="eulerValues">euler angle values</param>
+			/// <param name="expectedResult">expected xyz component of quaternion</param>
+			/// <param name="testName">Taken from nUnit test data. Don't know how to name data driven tests for xUnit which actually works.</param>
+			[Theory]
+			[MemberData(nameof(QuaternionTestDataGenerator.SingleAxisTestCases), MemberType = typeof(QuaternionTestDataGenerator))]
+			public void SingleAxisAsEulerAnglesInFloatsIsConvertedToCorrectValueInQuaternion
+			(Vector3 eulerValues, Vector3 expectedResult, string testName)
+			{
+				//Arrange + Act: Create Quaternion with "pitch/yaw/roll"
+				var cut = Quaternion.FromEulerAngles(eulerValues.X, eulerValues.Y, eulerValues.Z);
 
-			//Assert: Use helper, to check if part of the two correct axis is zero. I just want check the direction
-			Vector3 resultXYZ = cut.Xyz;
+				//Assert: Use helper, to check if part of the two correct axis is zero. I just want check the direction
+				Vector3 resultXYZ = cut.Xyz;
 
-			Assert.True(QuaternionTestHelper.VerifyEqualSingleDirection(resultXYZ, expectedResult));
+				Assert.True(QuaternionTestHelper.VerifyEqualSingleDirection(resultXYZ, expectedResult));
+			}
+
+			/// <summary>
+			/// Checks if a single given value (either pitch, yaw or roll) get converted into correct x,y,z value of quaternion.
+			/// </summary>
+			/// <param name="eulerValues">euler angle values</param>
+			/// <param name="expectedResult">expected xyz component of quaternion</param>
+			/// <param name="testName">Taken from nUnit test data. Don't know how to name data driven tests for xUnit which actually works.</param>
+			[Theory]
+			[MemberData(nameof(QuaternionTestDataGenerator.SingleAxisTestCases), MemberType = typeof(QuaternionTestDataGenerator))]
+			public void SingleAxisAsEulerAnglesInVector3IsConvertedToCorrectValueInQuaternion
+			(Vector3 eulerValues, Vector3 expectedResult, string testName)
+			{
+				//Arrange + Act: Create Quaternion with "pitch/yaw/roll"
+				var cut = Quaternion.FromEulerAngles(eulerValues);
+
+				//Assert: Use helper, to check if part of the two correct axis is zero. I just want check the direction
+				Vector3 resultXYZ = cut.Xyz;
+
+				Assert.True(QuaternionTestHelper.VerifyEqualSingleDirection(resultXYZ, expectedResult));
+			}
+
+			/// <summary>
+			/// Checks if a single given value (either pitch, yaw or roll) get converted into correct x,y,z value of quaternion.
+			/// </summary>
+			/// <param name="eulerValues">euler angle values</param>
+			/// <param name="expectedResult">expected xyz component of quaternion</param>
+			/// <param name="testName">Taken from nUnit test data. Don't know how to name data driven tests for xUnit which actually works.</param>
+			[Theory]
+			[MemberData(nameof(QuaternionTestDataGenerator.SingleAxisTestCases), MemberType = typeof(QuaternionTestDataGenerator))]
+			public void SingleAxisAsEulerAnglesInVector3IsConvertedToCorrectValueInQuaternionAsOutParam
+			(Vector3 eulerValues, Vector3 expectedResult, string testName)
+			{
+				//Arrange + Act: Create Quaternion with "pitch/yaw/roll"
+				var cut = Quaternion.Identity;
+				Quaternion.FromEulerAngles(ref eulerValues, out cut);
+
+				//Assert: Use helper, to check if part of the two correct axis is zero. I just want check the direction
+				Vector3 resultXYZ = cut.Xyz;
+
+				Assert.True(QuaternionTestHelper.VerifyEqualSingleDirection(resultXYZ, expectedResult));
+			}
+
+			//TODO: Make also checks with ccw rotation angle and correct applied rotation order of multiple axis
 		}
+
 
 		/// <summary>
-		/// Checks if a single given value (either pitch, yaw or roll) get converted into correct x,y,z value of quaternion.
+		/// Contains all test for ToAxisAngle
 		/// </summary>
-		/// <param name="eulerValues">euler angle values</param>
-		/// <param name="expectedResult">expected xyz component of quaternion</param>
-		/// <param name="testName">Taken from nUnit test data. Don't know how to name data driven tests for xUnit which actually works.</param>
-		[Theory]
-		[MemberData(nameof(QuaternionTestDataGenerator.SingleAxisTestCases), MemberType = typeof(QuaternionTestDataGenerator))]
-		public void FromEulerAnglesFloat_SingleEulerAngleSet_RotateCorrectAxis(Vector3 eulerValues, Vector3 expectedResult, string testName)
+		public class ToAxisAngle
 		{
-			//Arrange + Act: Create Quaternion with "pitch/yaw/roll"
-			var cut = Quaternion.FromEulerAngles(eulerValues.X, eulerValues.Y, eulerValues.Z);
+			/// <summary>
+			/// Check if a quaternion returns a a rotation about the correct coordinate axis
+			/// </summary>
+			/// <param name="cut">Prepared Quaternion</param>
+			/// <param name="expectedResult">Expected result.</param>
+			/// <param name="testName">Taken from nUnit test data. Don't know how to name data driven tests for xUnit which actually works.</param>
+			[Theory]
+			[MemberData(nameof(QuaternionTestDataGenerator.ToAxisAngleTestCases), MemberType = typeof(QuaternionTestDataGenerator))]
+			public void PreparedSingleRotationAxisQuaternionConvertsToCorrectAxisAngleRepresentation(Quaternion cut, Vector3 expectedResult, string testName)
+			{
+				//Arrange + Act: Create Quaternion with rotation about X/Y/Z axis
+				Vector3 resultXYZ;
+				float dontCare;
+				cut.ToAxisAngle(out resultXYZ, out dontCare);
 
-			//Assert: Use helper, to check if part of the two correct axis is zero. I just want check the direction
-			Vector3 resultXYZ = cut.Xyz;
+				//Assert: Use helper, to check if part of the two correct axis is zero. I just want check the direction
+				Assert.True(QuaternionTestHelper.VerifyEqualSingleDirection(resultXYZ, expectedResult));
+			}
 
-			Assert.True(QuaternionTestHelper.VerifyEqualSingleDirection(resultXYZ, expectedResult));
+			//TODO: Make also checks with ccw rotation angle and correct applied rotation order of multiple axis
 		}
 
-		/// <summary>
-		/// Checks if a single given value (either pitch, yaw or roll) get converted into correct x,y,z value of quaternion.
-		/// </summary>
-		/// <param name="eulerValues">euler angle values</param>
-		/// <param name="expectedResult">expected xyz component of quaternion</param>
-		/// <param name="testName">Taken from nUnit test data. Don't know how to name data driven tests for xUnit which actually works.</param>
-		[Theory]
-		[MemberData(nameof(QuaternionTestDataGenerator.SingleAxisTestCases), MemberType = typeof(QuaternionTestDataGenerator))]
-		public void FromEulerAnglesVector3_SingleEulerAngleSet_RotateCorrectAxis(Vector3 eulerValues, Vector3 expectedResult, string testName)
-		{
-			//Arrange + Act: Create Quaternion with "pitch/yaw/roll"
-			var cut = Quaternion.FromEulerAngles(eulerValues);
 
-			//Assert: Use helper, to check if part of the two correct axis is zero. I just want check the direction
-			Vector3 resultXYZ = cut.Xyz;
 
-			Assert.True(QuaternionTestHelper.VerifyEqualSingleDirection(resultXYZ, expectedResult));
-		}
-
-		/// <summary>
-		/// Checks if a single given value (either pitch, yaw or roll) get converted into correct x,y,z value of quaternion.
-		/// </summary>
-		/// <param name="eulerValues">euler angle values</param>
-		/// <param name="expectedResult">expected xyz component of quaternion</param>
-		/// <param name="testName">Taken from nUnit test data. Don't know how to name data driven tests for xUnit which actually works.</param>
-		[Theory]
-		[MemberData(nameof(QuaternionTestDataGenerator.SingleAxisTestCases), MemberType = typeof(QuaternionTestDataGenerator))]
-		public void FromEulerAnglesOut_SingleEulerAngleSet_RotateCorrectAxis(Vector3 eulerValues, Vector3 expectedResult, string testName)
-		{
-			//Arrange + Act: Create Quaternion with "pitch/yaw/roll"
-			var cut = Quaternion.Identity;
-			Quaternion.FromEulerAngles(ref eulerValues, out cut);
-
-			//Assert: Use helper, to check if part of the two correct axis is zero. I just want check the direction
-			Vector3 resultXYZ = cut.Xyz;
-
-			Assert.True(QuaternionTestHelper.VerifyEqualSingleDirection(resultXYZ, expectedResult));
-		}
-
-		/// <summary>
-		/// Check if a quaternion returns a a rotation about the correct coordinate axis
-		/// </summary>
-		/// <param name="cut">Prepared Quaternion</param>
-		/// <param name="expectedResult">Expected result.</param>
-		/// <param name="testName">Taken from nUnit test data. Don't know how to name data driven tests for xUnit which actually works.</param>
-		[Theory]
-		[MemberData(nameof(QuaternionTestDataGenerator.ToAxisAngleTestCases), MemberType = typeof(QuaternionTestDataGenerator))]
-		public void ToAxisAngle_SingleAxisSetAndAngleIgnored_RotateCorrectAxis(Quaternion cut, Vector3 expectedResult, string testName)
-		{
-			//Arrange + Act: Create Quaternion with rotation about X/Y/Z axis
-			Vector3 resultXYZ;
-			float dontCare;
-			cut.ToAxisAngle(out resultXYZ, out dontCare);
-
-			//Assert: Use helper, to check if part of the two correct axis is zero. I just want check the direction
-			Assert.True(QuaternionTestHelper.VerifyEqualSingleDirection(resultXYZ, expectedResult));
-		}
-
-		//TODO: Make also checks with rotation angle
 	}
 }
 

--- a/tests/OpenTK.Tests.Math/QuaternionTests.cs
+++ b/tests/OpenTK.Tests.Math/QuaternionTests.cs
@@ -4,23 +4,22 @@ using OpenTK.Tests.Math.DataProviders;
 
 namespace OpenTK.Tests.Math
 {
-	public class Quaternion_Tests
+	public class QuaternionTests
 	{
 		/// <summary>
-		/// Contains all tests which cover the ctor of Quaternion.
+		/// Contains all tests which cover the constructor of Quaternion.
 		/// </summary>
-		public class Constructor_Tests
+		public class Constructor
 		{
 			/// <summary>
 			/// Checks if a single given value (either pitch, yaw or roll) get converted into correct x,y,z value of quaternion.
 			/// </summary>
 			/// <param name="eulerValues">euler angle values</param>
 			/// <param name="expectedResult">expected xyz component of quaternion</param>
-			/// <param name="testName">Taken from nUnit test data. Don't know how to name data driven tests for xUnit which actually works.</param>
 			[Theory]
 			[MemberData(nameof(QuaternionTestDataGenerator.SingleAxisTestCases), MemberType = typeof(QuaternionTestDataGenerator))]
-			public void SingleAxisAsEulerAnglesInFloatsIsConvertedToCorrectValueInQuaternion
-			(Vector3 eulerValues, Vector3 expectedResult, string testName)
+			public void SingleAxisAsEulerAnglesInFloatsIsConvertedToCorrectQuaternionComponents
+			(Vector3 eulerValues, Vector3 expectedResult)
 			{
 				//Arrange + Act: Create Quaternion with "pitch/yaw/roll"
 				var cut = new Quaternion(eulerValues.X, eulerValues.Y, eulerValues.Z);
@@ -36,11 +35,10 @@ namespace OpenTK.Tests.Math
 			/// </summary>
 			/// <param name="eulerValues">euler angle values</param>
 			/// <param name="expectedResult">expected xyz component of quaternion</param>
-			/// <param name="testName">Taken from nUnit test data. Don't know how to name data driven tests for xUnit which actually works.</param>
 			[Theory]
 			[MemberData(nameof(QuaternionTestDataGenerator.SingleAxisTestCases), MemberType = typeof(QuaternionTestDataGenerator))]
-			public void SingleAxisAsEulerAnglesInVector3IsConvertedToCorrectValueInQuaternion
-			(Vector3 eulerValues, Vector3 expectedResult, string testName)
+			public void SingleAxisAsEulerAnglesInVector3IsConvertedToCorrectQuaternionComponents
+			(Vector3 eulerValues, Vector3 expectedResult)
 			{
 				//Arrange + Act: Create Quaternion with "pitch/yaw/roll"
 				var cut = new Quaternion(eulerValues);
@@ -57,18 +55,17 @@ namespace OpenTK.Tests.Math
 		/// <summary>
 		/// Contains all tests for FromEulerAngles
 		/// </summary>
-		public class FromEulerAngles_Tests
+		public class FromEulerAngles
 		{
 			/// <summary>
 			/// Checks if a single given value (either pitch, yaw or roll) get converted into correct x,y,z value of quaternion.
 			/// </summary>
 			/// <param name="eulerValues">euler angle values</param>
 			/// <param name="expectedResult">expected xyz component of quaternion</param>
-			/// <param name="testName">Taken from nUnit test data. Don't know how to name data driven tests for xUnit which actually works.</param>
 			[Theory]
 			[MemberData(nameof(QuaternionTestDataGenerator.SingleAxisTestCases), MemberType = typeof(QuaternionTestDataGenerator))]
-			public void SingleAxisAsEulerAnglesInFloatsIsConvertedToCorrectValueInQuaternion
-			(Vector3 eulerValues, Vector3 expectedResult, string testName)
+			public void SingleAxisAsEulerAnglesInFloatsIsConvertedToCorrectQuaternionComponents
+			(Vector3 eulerValues, Vector3 expectedResult)
 			{
 				//Arrange + Act: Create Quaternion with "pitch/yaw/roll"
 				var cut = Quaternion.FromEulerAngles(eulerValues.X, eulerValues.Y, eulerValues.Z);
@@ -84,11 +81,10 @@ namespace OpenTK.Tests.Math
 			/// </summary>
 			/// <param name="eulerValues">euler angle values</param>
 			/// <param name="expectedResult">expected xyz component of quaternion</param>
-			/// <param name="testName">Taken from nUnit test data. Don't know how to name data driven tests for xUnit which actually works.</param>
 			[Theory]
 			[MemberData(nameof(QuaternionTestDataGenerator.SingleAxisTestCases), MemberType = typeof(QuaternionTestDataGenerator))]
-			public void SingleAxisAsEulerAnglesInVector3IsConvertedToCorrectValueInQuaternion
-			(Vector3 eulerValues, Vector3 expectedResult, string testName)
+			public void SingleAxisAsEulerAnglesInVector3IsConvertedToCorrectQuaternionComponents
+			(Vector3 eulerValues, Vector3 expectedResult)
 			{
 				//Arrange + Act: Create Quaternion with "pitch/yaw/roll"
 				var cut = Quaternion.FromEulerAngles(eulerValues);
@@ -104,11 +100,10 @@ namespace OpenTK.Tests.Math
 			/// </summary>
 			/// <param name="eulerValues">euler angle values</param>
 			/// <param name="expectedResult">expected xyz component of quaternion</param>
-			/// <param name="testName">Taken from nUnit test data. Don't know how to name data driven tests for xUnit which actually works.</param>
 			[Theory]
 			[MemberData(nameof(QuaternionTestDataGenerator.SingleAxisTestCases), MemberType = typeof(QuaternionTestDataGenerator))]
-			public void SingleAxisAsEulerAnglesInVector3IsConvertedToCorrectValueInQuaternionAsOutParam
-			(Vector3 eulerValues, Vector3 expectedResult, string testName)
+			public void SingleAxisAsEulerAnglesInVector3IsConvertedToCorrectQuaternionComponentsAsOutParam
+			(Vector3 eulerValues, Vector3 expectedResult)
 			{
 				//Arrange + Act: Create Quaternion with "pitch/yaw/roll"
 				var cut = Quaternion.Identity;
@@ -134,10 +129,9 @@ namespace OpenTK.Tests.Math
 			/// </summary>
 			/// <param name="cut">Prepared Quaternion</param>
 			/// <param name="expectedResult">Expected result.</param>
-			/// <param name="testName">Taken from nUnit test data. Don't know how to name data driven tests for xUnit which actually works.</param>
 			[Theory]
 			[MemberData(nameof(QuaternionTestDataGenerator.ToAxisAngleTestCases), MemberType = typeof(QuaternionTestDataGenerator))]
-			public void PreparedSingleRotationAxisQuaternionConvertsToCorrectAxisAngleRepresentation(Quaternion cut, Vector3 expectedResult, string testName)
+			public void PreparedSingleRotationAxisQuaternionConvertsToCorrectAxisAngleRepresentation(Quaternion cut, Vector3 expectedResult)
 			{
 				//Arrange + Act: Create Quaternion with rotation about X/Y/Z axis
 				Vector3 resultXYZ;

--- a/tests/OpenTK.Tests.Math/QuaternionTests.cs
+++ b/tests/OpenTK.Tests.Math/QuaternionTests.cs
@@ -144,9 +144,6 @@ namespace OpenTK.Tests.Math
 
 			//TODO: Make also checks with ccw rotation angle and correct applied rotation order of multiple axis
 		}
-
-
-
 	}
 }
 


### PR DESCRIPTION
Rebase and squash of #692

### Purpose of this PR
I suspect that the conversion from euler angles to quaternion representation is wrong, based on the parameter description of Quaternion.cs

Step: Adding test project which covers functionality of class Quaternion.
Step: Reveal potential bugs of Quaternion.
Step: Provide potential bugfix

### Which part of OpenTK does this affect (Math, OpenGL, Platform, Input, etc). 
OpenTK.Math.Quaternion

### Testing status
Still in progress. Covering API of Quaternion with unit tests.
To run these tests just execute "build.sh RunTests"

### Comments
This is still in progress. The original PR #692 was rebased/squashed and accidently deleted by me...
However, I applied suggested changes from @Frassle (at #692)  and @copygirl 

Now at this state, code of `Quaternion.cs` improved, but I am not finished yet. I think I have found the wrong code and all affected API, but I can not give you 100% guarantee yet that everything works as expected (proven by testcode). Still open points (at least to me)

1.  Verify the applied rotation order. First should be xAxis, second yAxis, third zAxis. Cover this with unit tests. There could be potential an issue still, but I don't think that.

2. Verify the counter clockwise rotation, given by the right hand rule. That means, if you view to the positive axis, the rotation is applied counter clockwise. 

3. Improve unit test code: After applying some "rotation"-math, it is not easy to verify the result against the expected result in terms of precision loss. I added a helper method which helps  me in a crumble way to determine if a rotation about a **single** axis was calculated correctly. I'm not happy about this. Maybe it worth to get something like `MathHelper.ApproximatelyEqual`into the game, but I don't like this either. It works against the idea of **unit** testing.
However, I will need something like this, at least when I will start to test the rotation math with multiple rotation axis. Any ideas are welcome!

4. Check also class 'Quaterniond'. I haven't had a glance yet, if this suffers under the same problems.