### PR TITLE
Add namespace (xmlns=) to Project

### DIFF
--- a/build/StyleCop.props
+++ b/build/StyleCop.props
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <BuildWithStyleCop Condition=" '$(BuildWithStyleCop)' == ''">true</BuildWithStyleCop>
   </PropertyGroup>


### PR DESCRIPTION
### Purpose of this PR

Without this, msbuild fails with the following error in my development setup:

`.../opentk/build/StyleCop.props(2,1): error MSB4041: The default XML namespace of the project must be the MSBuild XML namespace. If the project is authored in the MSBuild 2003 format, please add xmlns="http://schemas.microsoft.com/developer/msbuild/2003" to the <Project> element. If theproject has been authored in the old 1.0 or 1.2 format, please convert it to MSBuild 2003 format. [.../opentk/src/Generator.Bind/Generator.Bind.csproj]`

Credits go to @VPeruS who suggested I'd try this change in [this comment](https://github.com/opentk/opentk/issues/710#issuecomment-355544518).

### Testing status

After this change, `msbuild` is able to get as far as `xbuild` did, though both currently fail with the same issue for me. See #710. I doubt existing setups will fail with this addition, though it would make sense to ensure that the project still builds.