### PR TITLE
Change Matrix4 to use unsafe code for invert

### DIFF
--- a/src/OpenTK/Math/Matrix4.cs
+++ b/src/OpenTK/Math/Matrix4.cs
@@ -30,33 +30,27 @@ namespace OpenTK
     /// </summary>
     /// <seealso cref="Matrix4d"/>
     [Serializable]
-    [StructLayout(LayoutKind.Explicit)]
-    public unsafe struct Matrix4 : IEquatable<Matrix4>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix4 : IEquatable<Matrix4>
     {
-        [FieldOffset (0)]
-        fixed float vals [16];
         /// <summary>
         /// Top row of the matrix.
         /// </summary>
-        [FieldOffset (0)]
         public Vector4 Row0;
 
         /// <summary>
         /// 2nd row of the matrix.
         /// </summary>
-        [FieldOffset (4 * sizeof(float))]
         public Vector4 Row1;
 
         /// <summary>
         /// 3rd row of the matrix.
         /// </summary>
-        [FieldOffset (8 * sizeof(float))]
         public Vector4 Row2;
 
         /// <summary>
         /// Bottom row of the matrix.
         /// </summary>
-        [FieldOffset (12 * sizeof(float))]
         public Vector4 Row3;
 
         /// <summary>
@@ -1242,11 +1236,14 @@ namespace OpenTK
         /// <param name="mat">The matrix to invert</param>
         /// <param name="result">The inverse of the given matrix if it has one, or the input if it is singular</param>
         /// <exception cref="InvalidOperationException">Thrown if the Matrix4 is singular.</exception>
-        public static void Invert(ref Matrix4 mat, out Matrix4 result)
+        public static unsafe void Invert(ref Matrix4 mat, out Matrix4 result)
         {
             result = mat;
             float* inv = stackalloc float [16];
-            fixed (float* m = mat.vals, invOut = result.vals) {
+
+            fixed (Matrix4* m0 = &mat, m1 = &result) {
+                var m = (float*)m0;
+                var invOut = (float*)m1;
                 float det;
                 inv [0] = m [5] * m [10] * m [15] -
                          m [5] * m [11] * m [14] -

--- a/src/OpenTK/Math/Matrix4.cs
+++ b/src/OpenTK/Math/Matrix4.cs
@@ -30,27 +30,33 @@ namespace OpenTK
     /// </summary>
     /// <seealso cref="Matrix4d"/>
     [Serializable]
-    [StructLayout(LayoutKind.Sequential)]
-    public struct Matrix4 : IEquatable<Matrix4>
+    [StructLayout(LayoutKind.Explicit)]
+    public unsafe struct Matrix4 : IEquatable<Matrix4>
     {
+        [FieldOffset (0)]
+        fixed float vals [16];
         /// <summary>
         /// Top row of the matrix.
         /// </summary>
+        [FieldOffset (0)]
         public Vector4 Row0;
 
         /// <summary>
         /// 2nd row of the matrix.
         /// </summary>
+        [FieldOffset (4 * sizeof (float))]
         public Vector4 Row1;
 
         /// <summary>
         /// 3rd row of the matrix.
         /// </summary>
+        [FieldOffset (8 * sizeof (float))]
         public Vector4 Row2;
 
         /// <summary>
         /// Bottom row of the matrix.
         /// </summary>
+        [FieldOffset (12 * sizeof (float))]
         public Vector4 Row3;
 
         /// <summary>
@@ -1238,121 +1244,136 @@ namespace OpenTK
         /// <exception cref="InvalidOperationException">Thrown if the Matrix4 is singular.</exception>
         public static void Invert(ref Matrix4 mat, out Matrix4 result)
         {
-            int[] colIdx = { 0, 0, 0, 0 };
-            int[] rowIdx = { 0, 0, 0, 0 };
-            int[] pivotIdx = { -1, -1, -1, -1 };
+            result = mat;
+            float* inv = stackalloc float [16];
+            fixed (float* m = mat.vals, invOut = result.vals) {
+                float det;
+                inv [0] = m [5] * m [10] * m [15] -
+                         m [5] * m [11] * m [14] -
+                         m [9] * m [6] * m [15] +
+                         m [9] * m [7] * m [14] +
+                         m [13] * m [6] * m [11] -
+                         m [13] * m [7] * m [10];
 
-            // convert the matrix to an array for easy looping
-            float[,] inverse = {{mat.Row0.X, mat.Row0.Y, mat.Row0.Z, mat.Row0.W},
-                                {mat.Row1.X, mat.Row1.Y, mat.Row1.Z, mat.Row1.W},
-                                {mat.Row2.X, mat.Row2.Y, mat.Row2.Z, mat.Row2.W},
-                                {mat.Row3.X, mat.Row3.Y, mat.Row3.Z, mat.Row3.W} };
-            int icol = 0;
-            int irow = 0;
-            for (int i = 0; i < 4; i++)
-            {
-                // Find the largest pivot value
-                float maxPivot = 0.0f;
-                for (int j = 0; j < 4; j++)
+                inv [4] = -m [4] * m [10] * m [15] +
+                          m [4] * m [11] * m [14] +
+                          m [8] * m [6] * m [15] -
+                          m [8] * m [7] * m [14] -
+                          m [12] * m [6] * m [11] +
+                          m [12] * m [7] * m [10];
+
+                inv [8] = m [4] * m [9] * m [15] -
+                         m [4] * m [11] * m [13] -
+                         m [8] * m [5] * m [15] +
+                         m [8] * m [7] * m [13] +
+                         m [12] * m [5] * m [11] -
+                         m [12] * m [7] * m [9];
+
+                inv [12] = -m [4] * m [9] * m [14] +
+                           m [4] * m [10] * m [13] +
+                           m [8] * m [5] * m [14] -
+                           m [8] * m [6] * m [13] -
+                           m [12] * m [5] * m [10] +
+                           m [12] * m [6] * m [9];
+
+                inv [1] = -m [1] * m [10] * m [15] +
+                          m [1] * m [11] * m [14] +
+                          m [9] * m [2] * m [15] -
+                          m [9] * m [3] * m [14] -
+                          m [13] * m [2] * m [11] +
+                          m [13] * m [3] * m [10];
+
+                inv [5] = m [0] * m [10] * m [15] -
+                         m [0] * m [11] * m [14] -
+                         m [8] * m [2] * m [15] +
+                         m [8] * m [3] * m [14] +
+                         m [12] * m [2] * m [11] -
+                         m [12] * m [3] * m [10];
+
+                inv [9] = -m [0] * m [9] * m [15] +
+                          m [0] * m [11] * m [13] +
+                          m [8] * m [1] * m [15] -
+                          m [8] * m [3] * m [13] -
+                          m [12] * m [1] * m [11] +
+                          m [12] * m [3] * m [9];
+
+                inv [13] = m [0] * m [9] * m [14] -
+                          m [0] * m [10] * m [13] -
+                          m [8] * m [1] * m [14] +
+                          m [8] * m [2] * m [13] +
+                          m [12] * m [1] * m [10] -
+                          m [12] * m [2] * m [9];
+
+                inv [2] = m [1] * m [6] * m [15] -
+                         m [1] * m [7] * m [14] -
+                         m [5] * m [2] * m [15] +
+                         m [5] * m [3] * m [14] +
+                         m [13] * m [2] * m [7] -
+                         m [13] * m [3] * m [6];
+
+                inv [6] = -m [0] * m [6] * m [15] +
+                          m [0] * m [7] * m [14] +
+                          m [4] * m [2] * m [15] -
+                          m [4] * m [3] * m [14] -
+                          m [12] * m [2] * m [7] +
+                          m [12] * m [3] * m [6];
+
+                inv [10] = m [0] * m [5] * m [15] -
+                          m [0] * m [7] * m [13] -
+                          m [4] * m [1] * m [15] +
+                          m [4] * m [3] * m [13] +
+                          m [12] * m [1] * m [7] -
+                          m [12] * m [3] * m [5];
+
+                inv [14] = -m [0] * m [5] * m [14] +
+                           m [0] * m [6] * m [13] +
+                           m [4] * m [1] * m [14] -
+                           m [4] * m [2] * m [13] -
+                           m [12] * m [1] * m [6] +
+                           m [12] * m [2] * m [5];
+
+                inv [3] = -m [1] * m [6] * m [11] +
+                          m [1] * m [7] * m [10] +
+                          m [5] * m [2] * m [11] -
+                          m [5] * m [3] * m [10] -
+                          m [9] * m [2] * m [7] +
+                          m [9] * m [3] * m [6];
+
+                inv [7] = m [0] * m [6] * m [11] -
+                         m [0] * m [7] * m [10] -
+                         m [4] * m [2] * m [11] +
+                         m [4] * m [3] * m [10] +
+                         m [8] * m [2] * m [7] -
+                         m [8] * m [3] * m [6];
+
+                inv [11] = -m [0] * m [5] * m [11] +
+                           m [0] * m [7] * m [9] +
+                           m [4] * m [1] * m [11] -
+                           m [4] * m [3] * m [9] -
+                           m [8] * m [1] * m [7] +
+                           m [8] * m [3] * m [5];
+
+                inv [15] = m [0] * m [5] * m [10] -
+                          m [0] * m [6] * m [9] -
+                          m [4] * m [1] * m [10] +
+                          m [4] * m [2] * m [9] +
+                          m [8] * m [1] * m [6] -
+                          m [8] * m [2] * m [5];
+
+                det = m [0] * inv [0] + m [1] * inv [4] + m [2] * inv [8] + m [3] * inv [12];
+
+                if (det == 0) 
                 {
-                    if (pivotIdx[j] != 0)
-                    {
-                        for (int k = 0; k < 4; ++k)
-                        {
-                            if (pivotIdx[k] == -1)
-                            {
-                                float absVal = System.Math.Abs(inverse[j, k]);
-                                if (absVal > maxPivot)
-                                {
-                                    maxPivot = absVal;
-                                    irow = j;
-                                    icol = k;
-                                }
-                            }
-                            else if (pivotIdx[k] > 0)
-                            {
-                                result = mat;
-                                return;
-                            }
-                        }
-                    }
-                }
-
-                ++(pivotIdx[icol]);
-
-                // Swap rows over so pivot is on diagonal
-                if (irow != icol)
+                    throw new InvalidOperationException ("Matrix is singular and cannot be inverted.");
+                } 
+                else 
                 {
-                    for (int k = 0; k < 4; ++k)
-                    {
-                        float f = inverse[irow, k];
-                        inverse[irow, k] = inverse[icol, k];
-                        inverse[icol, k] = f;
-                    }
-                }
+                    det = 1.0f / det;
 
-                rowIdx[i] = irow;
-                colIdx[i] = icol;
-
-                float pivot = inverse[icol, icol];
-                // check for singular matrix
-                if (pivot == 0.0f)
-                {
-                    throw new InvalidOperationException("Matrix is singular and cannot be inverted.");
-                }
-
-                // Scale row so it has a unit diagonal
-                float oneOverPivot = 1.0f / pivot;
-                inverse[icol, icol] = 1.0f;
-                for (int k = 0; k < 4; ++k)
-                {
-                    inverse[icol, k] *= oneOverPivot;
-                }
-
-                // Do elimination of non-diagonal elements
-                for (int j = 0; j < 4; ++j)
-                {
-                    // check this isn't on the diagonal
-                    if (icol != j)
-                    {
-                        float f = inverse[j, icol];
-                        inverse[j, icol] = 0.0f;
-                        for (int k = 0; k < 4; ++k)
-                        {
-                            inverse[j, k] -= inverse[icol, k] * f;
-                        }
-                    }
+                    for (int i = 0; i < 16; i++)
+                        invOut [i] = inv [i] * det;
                 }
             }
-
-            for (int j = 3; j >= 0; --j)
-            {
-                int ir = rowIdx[j];
-                int ic = colIdx[j];
-                for (int k = 0; k < 4; ++k)
-                {
-                    float f = inverse[k, ir];
-                    inverse[k, ir] = inverse[k, ic];
-                    inverse[k, ic] = f;
-                }
-            }
-
-            result.Row0.X = inverse[0, 0];
-            result.Row0.Y = inverse[0, 1];
-            result.Row0.Z = inverse[0, 2];
-            result.Row0.W = inverse[0, 3];
-            result.Row1.X = inverse[1, 0];
-            result.Row1.Y = inverse[1, 1];
-            result.Row1.Z = inverse[1, 2];
-            result.Row1.W = inverse[1, 3];
-            result.Row2.X = inverse[2, 0];
-            result.Row2.Y = inverse[2, 1];
-            result.Row2.Z = inverse[2, 2];
-            result.Row2.W = inverse[2, 3];
-            result.Row3.X = inverse[3, 0];
-            result.Row3.Y = inverse[3, 1];
-            result.Row3.Z = inverse[3, 2];
-            result.Row3.W = inverse[3, 3];
         }
 
         /// <summary>

--- a/src/OpenTK/Math/Matrix4.cs
+++ b/src/OpenTK/Math/Matrix4.cs
@@ -1236,139 +1236,143 @@ namespace OpenTK
         /// <param name="mat">The matrix to invert</param>
         /// <param name="result">The inverse of the given matrix if it has one, or the input if it is singular</param>
         /// <exception cref="InvalidOperationException">Thrown if the Matrix4 is singular.</exception>
-        public static unsafe void Invert(ref Matrix4 mat, out Matrix4 result)
+        public static void Invert(ref Matrix4 mat, out Matrix4 result)
         {
             result = mat;
-            float* inv = stackalloc float [16];
+            unsafe
+            {
+                float* inv = stackalloc float[16];
 
-            fixed (Matrix4* m0 = &mat, m1 = &result) {
-                var m = (float*)m0;
-                var invOut = (float*)m1;
-                float det;
-                inv [0] = m [5] * m [10] * m [15] -
-                         m [5] * m [11] * m [14] -
-                         m [9] * m [6] * m [15] +
-                         m [9] * m [7] * m [14] +
-                         m [13] * m [6] * m [11] -
-                         m [13] * m [7] * m [10];
-
-                inv [4] = -m [4] * m [10] * m [15] +
-                          m [4] * m [11] * m [14] +
-                          m [8] * m [6] * m [15] -
-                          m [8] * m [7] * m [14] -
-                          m [12] * m [6] * m [11] +
-                          m [12] * m [7] * m [10];
-
-                inv [8] = m [4] * m [9] * m [15] -
-                         m [4] * m [11] * m [13] -
-                         m [8] * m [5] * m [15] +
-                         m [8] * m [7] * m [13] +
-                         m [12] * m [5] * m [11] -
-                         m [12] * m [7] * m [9];
-
-                inv [12] = -m [4] * m [9] * m [14] +
-                           m [4] * m [10] * m [13] +
-                           m [8] * m [5] * m [14] -
-                           m [8] * m [6] * m [13] -
-                           m [12] * m [5] * m [10] +
-                           m [12] * m [6] * m [9];
-
-                inv [1] = -m [1] * m [10] * m [15] +
-                          m [1] * m [11] * m [14] +
-                          m [9] * m [2] * m [15] -
-                          m [9] * m [3] * m [14] -
-                          m [13] * m [2] * m [11] +
-                          m [13] * m [3] * m [10];
-
-                inv [5] = m [0] * m [10] * m [15] -
-                         m [0] * m [11] * m [14] -
-                         m [8] * m [2] * m [15] +
-                         m [8] * m [3] * m [14] +
-                         m [12] * m [2] * m [11] -
-                         m [12] * m [3] * m [10];
-
-                inv [9] = -m [0] * m [9] * m [15] +
-                          m [0] * m [11] * m [13] +
-                          m [8] * m [1] * m [15] -
-                          m [8] * m [3] * m [13] -
-                          m [12] * m [1] * m [11] +
-                          m [12] * m [3] * m [9];
-
-                inv [13] = m [0] * m [9] * m [14] -
-                          m [0] * m [10] * m [13] -
-                          m [8] * m [1] * m [14] +
-                          m [8] * m [2] * m [13] +
-                          m [12] * m [1] * m [10] -
-                          m [12] * m [2] * m [9];
-
-                inv [2] = m [1] * m [6] * m [15] -
-                         m [1] * m [7] * m [14] -
-                         m [5] * m [2] * m [15] +
-                         m [5] * m [3] * m [14] +
-                         m [13] * m [2] * m [7] -
-                         m [13] * m [3] * m [6];
-
-                inv [6] = -m [0] * m [6] * m [15] +
-                          m [0] * m [7] * m [14] +
-                          m [4] * m [2] * m [15] -
-                          m [4] * m [3] * m [14] -
-                          m [12] * m [2] * m [7] +
-                          m [12] * m [3] * m [6];
-
-                inv [10] = m [0] * m [5] * m [15] -
-                          m [0] * m [7] * m [13] -
-                          m [4] * m [1] * m [15] +
-                          m [4] * m [3] * m [13] +
-                          m [12] * m [1] * m [7] -
-                          m [12] * m [3] * m [5];
-
-                inv [14] = -m [0] * m [5] * m [14] +
-                           m [0] * m [6] * m [13] +
-                           m [4] * m [1] * m [14] -
-                           m [4] * m [2] * m [13] -
-                           m [12] * m [1] * m [6] +
-                           m [12] * m [2] * m [5];
-
-                inv [3] = -m [1] * m [6] * m [11] +
-                          m [1] * m [7] * m [10] +
-                          m [5] * m [2] * m [11] -
-                          m [5] * m [3] * m [10] -
-                          m [9] * m [2] * m [7] +
-                          m [9] * m [3] * m [6];
-
-                inv [7] = m [0] * m [6] * m [11] -
-                         m [0] * m [7] * m [10] -
-                         m [4] * m [2] * m [11] +
-                         m [4] * m [3] * m [10] +
-                         m [8] * m [2] * m [7] -
-                         m [8] * m [3] * m [6];
-
-                inv [11] = -m [0] * m [5] * m [11] +
-                           m [0] * m [7] * m [9] +
-                           m [4] * m [1] * m [11] -
-                           m [4] * m [3] * m [9] -
-                           m [8] * m [1] * m [7] +
-                           m [8] * m [3] * m [5];
-
-                inv [15] = m [0] * m [5] * m [10] -
-                          m [0] * m [6] * m [9] -
-                          m [4] * m [1] * m [10] +
-                          m [4] * m [2] * m [9] +
-                          m [8] * m [1] * m [6] -
-                          m [8] * m [2] * m [5];
-
-                det = m [0] * inv [0] + m [1] * inv [4] + m [2] * inv [8] + m [3] * inv [12];
-
-                if (det == 0) 
+                fixed (Matrix4* m0 = &mat, m1 = &result)
                 {
-                    throw new InvalidOperationException ("Matrix is singular and cannot be inverted.");
-                } 
-                else 
-                {
-                    det = 1.0f / det;
+                    var m = (float*)m0;
+                    var invOut = (float*)m1;
+                    float det;
+                    inv[0] = m[5] * m[10] * m[15] -
+                             m[5] * m[11] * m[14] -
+                             m[9] * m[6] * m[15] +
+                             m[9] * m[7] * m[14] +
+                             m[13] * m[6] * m[11] -
+                             m[13] * m[7] * m[10];
 
-                    for (int i = 0; i < 16; i++)
-                        invOut [i] = inv [i] * det;
+                    inv[4] = -m[4] * m[10] * m[15] +
+                              m[4] * m[11] * m[14] +
+                              m[8] * m[6] * m[15] -
+                              m[8] * m[7] * m[14] -
+                              m[12] * m[6] * m[11] +
+                              m[12] * m[7] * m[10];
+
+                    inv[8] = m[4] * m[9] * m[15] -
+                             m[4] * m[11] * m[13] -
+                             m[8] * m[5] * m[15] +
+                             m[8] * m[7] * m[13] +
+                             m[12] * m[5] * m[11] -
+                             m[12] * m[7] * m[9];
+
+                    inv[12] = -m[4] * m[9] * m[14] +
+                               m[4] * m[10] * m[13] +
+                               m[8] * m[5] * m[14] -
+                               m[8] * m[6] * m[13] -
+                               m[12] * m[5] * m[10] +
+                               m[12] * m[6] * m[9];
+
+                    inv[1] = -m[1] * m[10] * m[15] +
+                              m[1] * m[11] * m[14] +
+                              m[9] * m[2] * m[15] -
+                              m[9] * m[3] * m[14] -
+                              m[13] * m[2] * m[11] +
+                              m[13] * m[3] * m[10];
+
+                    inv[5] = m[0] * m[10] * m[15] -
+                             m[0] * m[11] * m[14] -
+                             m[8] * m[2] * m[15] +
+                             m[8] * m[3] * m[14] +
+                             m[12] * m[2] * m[11] -
+                             m[12] * m[3] * m[10];
+
+                    inv[9] = -m[0] * m[9] * m[15] +
+                              m[0] * m[11] * m[13] +
+                              m[8] * m[1] * m[15] -
+                              m[8] * m[3] * m[13] -
+                              m[12] * m[1] * m[11] +
+                              m[12] * m[3] * m[9];
+
+                    inv[13] = m[0] * m[9] * m[14] -
+                              m[0] * m[10] * m[13] -
+                              m[8] * m[1] * m[14] +
+                              m[8] * m[2] * m[13] +
+                              m[12] * m[1] * m[10] -
+                              m[12] * m[2] * m[9];
+
+                    inv[2] = m[1] * m[6] * m[15] -
+                             m[1] * m[7] * m[14] -
+                             m[5] * m[2] * m[15] +
+                             m[5] * m[3] * m[14] +
+                             m[13] * m[2] * m[7] -
+                             m[13] * m[3] * m[6];
+
+                    inv[6] = -m[0] * m[6] * m[15] +
+                              m[0] * m[7] * m[14] +
+                              m[4] * m[2] * m[15] -
+                              m[4] * m[3] * m[14] -
+                              m[12] * m[2] * m[7] +
+                              m[12] * m[3] * m[6];
+
+                    inv[10] = m[0] * m[5] * m[15] -
+                              m[0] * m[7] * m[13] -
+                              m[4] * m[1] * m[15] +
+                              m[4] * m[3] * m[13] +
+                              m[12] * m[1] * m[7] -
+                              m[12] * m[3] * m[5];
+
+                    inv[14] = -m[0] * m[5] * m[14] +
+                               m[0] * m[6] * m[13] +
+                               m[4] * m[1] * m[14] -
+                               m[4] * m[2] * m[13] -
+                               m[12] * m[1] * m[6] +
+                               m[12] * m[2] * m[5];
+
+                    inv[3] = -m[1] * m[6] * m[11] +
+                              m[1] * m[7] * m[10] +
+                              m[5] * m[2] * m[11] -
+                              m[5] * m[3] * m[10] -
+                              m[9] * m[2] * m[7] +
+                              m[9] * m[3] * m[6];
+
+                    inv[7] = m[0] * m[6] * m[11] -
+                             m[0] * m[7] * m[10] -
+                             m[4] * m[2] * m[11] +
+                             m[4] * m[3] * m[10] +
+                             m[8] * m[2] * m[7] -
+                             m[8] * m[3] * m[6];
+
+                    inv[11] = -m[0] * m[5] * m[11] +
+                               m[0] * m[7] * m[9] +
+                               m[4] * m[1] * m[11] -
+                               m[4] * m[3] * m[9] -
+                               m[8] * m[1] * m[7] +
+                               m[8] * m[3] * m[5];
+
+                    inv[15] = m[0] * m[5] * m[10] -
+                              m[0] * m[6] * m[9] -
+                              m[4] * m[1] * m[10] +
+                              m[4] * m[2] * m[9] +
+                              m[8] * m[1] * m[6] -
+                              m[8] * m[2] * m[5];
+
+                    det = m[0] * inv[0] + m[1] * inv[4] + m[2] * inv[8] + m[3] * inv[12];
+
+                    if (det == 0)
+                    {
+                        throw new InvalidOperationException("Matrix is singular and cannot be inverted.");
+                    }
+                    else
+                    {
+                        det = 1.0f / det;
+
+                        for (int i = 0; i < 16; i++)
+                            invOut[i] = inv[i] * det;
+                    }
                 }
             }
         }

--- a/src/OpenTK/Math/Matrix4.cs
+++ b/src/OpenTK/Math/Matrix4.cs
@@ -44,19 +44,19 @@ namespace OpenTK
         /// <summary>
         /// 2nd row of the matrix.
         /// </summary>
-        [FieldOffset (4 * sizeof (float))]
+        [FieldOffset (4 * sizeof(float))]
         public Vector4 Row1;
 
         /// <summary>
         /// 3rd row of the matrix.
         /// </summary>
-        [FieldOffset (8 * sizeof (float))]
+        [FieldOffset (8 * sizeof(float))]
         public Vector4 Row2;
 
         /// <summary>
         /// Bottom row of the matrix.
         /// </summary>
-        [FieldOffset (12 * sizeof (float))]
+        [FieldOffset (12 * sizeof(float))]
         public Vector4 Row3;
 
         /// <summary>


### PR DESCRIPTION
### Purpose of this PR

* Optimise Matrix4.Invert to be more performant and eliminate allocations
* This involves modifying Matrix4 to use `StructLayout.Explicit` and a fixed array of 16 floats to alias the Vector4s. It also makes use of `stackalloc` in the inversion method.

### Testing status

Manual test program (not included in commit):

    using System;
    using System.Diagnostics;
    using OpenTK;

    class Tester
    {	
	    const int ITERATIONS = 1000000;
	    const int ACCURACY = 18;
	    public static void Main()
	    {
		    var rnd = new Random();
		    var sw = Stopwatch.StartNew();
		    for(int i = 0; i < ACCURACY; i++)
		    {
			    for(int j = 0; j < ITERATIONS; j++) 
			    {
				    var matrix = Matrix4.CreateRotationX((float)rnd.NextDouble());
				    matrix.Invert();
			    }
		    }
		    sw.Stop();
		    Console.WriteLine("Average for {0} Inverts = {1}", ITERATIONS, (double)sw.ElapsedMilliseconds / ACCURACY);
	    }
    }

Results on my Ryzen 3 1200 @ 3.7GHz:
Old Code - "Average for 1000000 Inverts = 1017.83333333333"
New Code - "Average for 1000000 Inverts = 338.666666666667" 

This is a speedup of approximately 3x for this method.

