### PR TITLE
Exit rewrite process if passed not existed file

### DIFF
--- a/src/Generator.Rewrite/Program.cs
+++ b/src/Generator.Rewrite/Program.cs
@@ -42,6 +42,7 @@ namespace OpenTK.Rewrite
             {
                 Console.Error.WriteLine($"Target assembly not found. \n" +
                                         $"Please check the given path ({Options.TargetAssembly}).");
+                return;
             }
 
             if (!File.Exists(Path.ChangeExtension(Options.TargetAssembly, "pdb")))


### PR DESCRIPTION
Immediately exit if path to assembly is incorrect.
