### PR TITLE
Fix pressing alt + [numpad numbers] raising OnKeyPress with '?'

### DIFF
--- a/src/OpenTK/Platform/Windows/API.cs
+++ b/src/OpenTK/Platform/Windows/API.cs
@@ -354,7 +354,7 @@ namespace OpenTK.Platform.Windows
         /// To get extended error information, call GetLastError.
         /// </returns>
         [System.Security.SuppressUnmanagedCodeSecurity]
-        [DllImport("User32.dll"), CLSCompliant(false)]
+        [DllImport("User32.dll", CharSet = CharSet.Auto), CLSCompliant(false)]
         //[return: MarshalAs(UnmanagedType.Bool)]
         internal static extern INT GetMessage(ref MSG msg,
             IntPtr windowHandle, int messageFilterMin, int messageFilterMax);
@@ -388,11 +388,11 @@ namespace OpenTK.Platform.Windows
         internal static extern void PostQuitMessage(int exitCode);
 
         [SuppressUnmanagedCodeSecurity]
-        [DllImport("User32.dll"), CLSCompliant(false)]
+        [DllImport("User32.dll", CharSet = CharSet.Auto), CLSCompliant(false)]
         internal static extern LRESULT DispatchMessage(ref MSG msg);
 
         [SuppressUnmanagedCodeSecurity]
-        [DllImport("User32.dll"), CLSCompliant(false)]
+        [DllImport("User32.dll", CharSet = CharSet.Auto), CLSCompliant(false)]
         internal static extern BOOL TranslateMessage(ref MSG lpMsg);
 
         /// <summary>


### PR DESCRIPTION
### Purpose of this PR

* Fix pressing alt + [numpad numbers] raising OnKeyPress with '?'.
 For example, pressing alt, then pressing numpad 1, then releasing alt.
* Affects Win32 platform code.

### Testing status

```
namespace CLITest {
	class Program {
		public static void Main(string[] args) {
			using (MyGameWindow g = new MyGameWindow()) { g.Run(); }
		}
	}
	
	class MyGameWindow : GameWindow {		
		protected override void OnKeyPress(KeyPressEventArgs e){
			base.OnKeyPress(e);
			Console.WriteLine(e.KeyChar + " - " + ((int)e.KeyChar));
		}
	}
}
```

_Old output:_ ? - 63
_New output:_ ☺ - 9786

### Comments

* I am using Windows 7, unsure if this issue occurs in more modern OS versions.
* Unsure if this will cause issues with backwards compatibility for apps using OpenTK.
* Unsure if any issues will occur with non-english keyboard layouts.
