### PR TITLE
Don't execute Normalize() when length of Vector is zero

### DIFF
--- a/src/OpenTK/Math/Vector2.cs
+++ b/src/OpenTK/Math/Vector2.cs
@@ -179,6 +179,9 @@ namespace OpenTK
         /// </summary>
         public void Normalize()
         {
+            if (Length == 0)
+                return;
+
             float scale = 1.0f / this.Length;
             X *= scale;
             Y *= scale;

--- a/src/OpenTK/Math/Vector2d.cs
+++ b/src/OpenTK/Math/Vector2d.cs
@@ -177,6 +177,9 @@ namespace OpenTK
         /// </summary>
         public void Normalize()
         {
+            if (Length == 0)
+                return;
+
             double scale = 1.0 / Length;
             X *= scale;
             Y *= scale;

--- a/src/OpenTK/Math/Vector3.cs
+++ b/src/OpenTK/Math/Vector3.cs
@@ -209,6 +209,9 @@ namespace OpenTK
         /// </summary>
         public void Normalize()
         {
+            if (Length == 0)
+                return;
+
             float scale = 1.0f / this.Length;
             X *= scale;
             Y *= scale;

--- a/src/OpenTK/Math/Vector3d.cs
+++ b/src/OpenTK/Math/Vector3d.cs
@@ -207,6 +207,9 @@ namespace OpenTK
         /// </summary>
         public void Normalize()
         {
+            if (Length == 0)
+                return;
+
             double scale = 1.0 / this.Length;
             X *= scale;
             Y *= scale;

--- a/src/OpenTK/Math/Vector4.cs
+++ b/src/OpenTK/Math/Vector4.cs
@@ -275,6 +275,9 @@ namespace OpenTK
         /// </summary>
         public void Normalize()
         {
+            if (Length == 0)
+                return;
+
             float scale = 1.0f / this.Length;
             X *= scale;
             Y *= scale;

--- a/src/OpenTK/Math/Vector4d.cs
+++ b/src/OpenTK/Math/Vector4d.cs
@@ -271,6 +271,9 @@ namespace OpenTK
         /// </summary>
         public void Normalize()
         {
+            if (Length == 0)
+                return;
+
             double scale = 1.0 / this.Length;
             X *= scale;
             Y *= scale;


### PR DESCRIPTION
Affects "Math":
When using .Normalize() we should check for Length == 0. A null vector must not be normalized, since dividing by zero is obviously not defined.

This could of course be checked by the application which is using OpenTK, however since it's mathmatically not defined I think OpenTK should handle it. Otherwise I would propose at least something like a "safe normalize" method.