### PR TITLE
Fix Mouse.SetPosition resetting cursor to 0/0 on Mac OS

### DIFF
--- a/src/OpenTK/Platform/MacOS/HIDInput.cs
+++ b/src/OpenTK/Platform/MacOS/HIDInput.cs
@@ -1029,7 +1029,7 @@ namespace OpenTK.Platform.MacOS
                 }
             }
 
-            CG.WarpMouseCursorPosition(p);
+            CG.DisplayMoveCursorToPoint(IntPtr.Zero, p);
         }
 
         KeyboardState IKeyboardDriver2.GetState()


### PR DESCRIPTION
### Purpose of this PR

This fixes #668 - `Mouse.SetPosition` always warping the cursor to `0,0` instead of the requested position. Change was suggested by @peppy [here](https://github.com/opentk/opentk/pull/589#pullrequestreview-93810302).

### Testing status

@tyronx Has successfully tested this on his Mac laptop.
