### PR TITLE
Fix mouse up event didn't fired

### DIFF
--- a/src/OpenTK/Platform/SDL2/Sdl2NativeWindow.cs
+++ b/src/OpenTK/Platform/SDL2/Sdl2NativeWindow.cs
@@ -179,7 +179,7 @@ namespace OpenTK.Platform.SDL2
 
                     case EventType.MOUSEBUTTONDOWN:
                     case EventType.MOUSEBUTTONUP:
-                        if (windows.TryGetValue(ev.Button.WindowID, out window))
+                        if (windows.TryGetValue(window_id, out window))
                         {
                             ProcessMouseButtonEvent(window, ev.Button);
                             processed = true;
@@ -227,14 +227,6 @@ namespace OpenTK.Platform.SDL2
         private static void ProcessMouseButtonEvent(Sdl2NativeWindow window, MouseButtonEvent ev)
         {
             bool button_pressed = ev.State == State.Pressed;
-
-            // We need MouseUp events to be reported even if they occur
-            // outside the window. SetWindowGrab ensures we get them.
-            if (window.CursorVisible)
-            {
-                SDL.SetWindowGrab(window.window.Handle,
-                    button_pressed ? true : false);
-            }
 
             MouseButton button = Sdl2Mouse.TranslateButton(ev.Button);
             if (button_pressed)


### PR DESCRIPTION
### Purpose of this PR
Allow window to receive mouse up event when mouse was dragged out of window and released.

Affect: Platform.SDL2

### Testing status
On linux it starts to accept MOUSEBUTTONUP event.

### Comments
ev.Button.WindowID is window that has mouse cursor in it due to this previous code fails when mouse was released out of windows where it was pressed. 