### PR TITLE
macOS Initial Window Focus

### DIFF
--- a/src/OpenTK/Platform/MacOS/Cocoa/Cocoa.cs
+++ b/src/OpenTK/Platform/MacOS/Cocoa/Cocoa.cs
@@ -101,6 +101,9 @@ namespace OpenTK.Platform.MacOS
         public extern static void SendVoid(IntPtr receiver, IntPtr selector, uint uint1);
 
         [DllImport(LibObjC, EntryPoint="objc_msgSend")]
+        public extern static void SendVoid(IntPtr receiver, IntPtr selector, uint uint1, IntPtr intPtr1);
+
+        [DllImport(LibObjC, EntryPoint="objc_msgSend")]
         public extern static void SendVoid(IntPtr receiver, IntPtr selector, IntPtr intPtr1);
 
         [DllImport(LibObjC, EntryPoint="objc_msgSend")]

--- a/src/OpenTK/Platform/MacOS/Cocoa/NSApplication.cs
+++ b/src/OpenTK/Platform/MacOS/Cocoa/NSApplication.cs
@@ -57,6 +57,7 @@ namespace OpenTK.Platform.MacOS
 
             // Setup the application
             Cocoa.SendBool(Handle, Selector.Get("setActivationPolicy:"), (int)NSApplicationActivationPolicy.Regular);
+            Cocoa.SendVoid(Handle, Selector.Get("discardEventsMatchingMask:beforeEvent:"), uint.MaxValue, IntPtr.Zero);
             Cocoa.SendVoid(Handle, Selector.Get("activateIgnoringOtherApps:"), true);
 
             if (Cocoa.SendIntPtr(Handle, Selector.Get("mainMenu")) == IntPtr.Zero)


### PR DESCRIPTION
### Purpose of this PR

Fixes an issue where the application would enter a partially-activated state on startup if there were unprocessed events in the queue (such as mouse movements).  If the mouse cursor is held still while the app starts, the window focuses correctly.

Prior to this change, the window would become key (receiving keyboard events), but not receive any mouse events.  AppKit would not darken the window title to show it is the key window, and the mono menu would be unclickable.  The only fix was to app-switch to something else, then back to the game.

### Testing status

Tested manually with osu! by moving the mouse cursor while the game starts.
https://github.com/ppy/osu

### Comments

The events must be discarded before the first call to `activateIgnoringOtherApps:` otherwise the change will have no effect.