### PR TITLE
Add implementation for InverseSqrtFast(double x)

### DIFF
--- a/src/OpenTK/Math/MathHelper.cs
+++ b/src/OpenTK/Math/MathHelper.cs
@@ -186,19 +186,15 @@ namespace OpenTK
         /// </remarks>
         public static double InverseSqrtFast(double x)
         {
-            return InverseSqrtFast((float)x);
-            // TODO: The following code is wrong. Fix it, to improve precision.
-#if false
             unsafe
             {
                 double xhalf = 0.5f * x;
-                int i = *(int*)&x;              // Read bits as integer.
-                i = 0x5f375a86 - (i >> 1);      // Make an initial guess for Newton-Raphson approximation
-                x = *(float*)&i;                // Convert bits back to float
-                x = x * (1.5f - xhalf * x * x); // Perform left single Newton-Raphson step.
+                long i = *(long*)&x;               // Read bits as long integer.
+                i = 0x5fe6eb50c7b537a9 - (i >> 1); // Make an initial guess for Newton-Raphson approximation
+                x = *(double*)&i;                  // Convert bits back to double
+                x = x * (1.5f - xhalf * x * x);    // Perform left single Newton-Raphson step.
                 return x;
             }
-#endif
         }
 
         /// <summary>


### PR DESCRIPTION
### Purpose of this PR

Double precision when calculating with InverseSqrtFast()
This will affect OpenTK.Math and anything that uses Math.MathHelper.InverseSqrtFast(double x)

### Testing status
N/A

### Comments
I noticed a TODO and thought I'd contribute a solution. (Source: https://stackoverflow.com/a/11644533)