### PR TITLE
Vector2 Matrix2 Multiplication Override Operators

### DIFF
--- a/src/OpenTK/Math/Matrix2.cs
+++ b/src/OpenTK/Math/Matrix2.cs
@@ -648,7 +648,7 @@ namespace OpenTK
         }
 
         /// <summary>
-        /// Returns a System.String that represents the current Matrix4.
+        /// Returns a System.String that represents the current Matrix2.
         /// </summary>
         /// <returns>The string representation of the matrix.</returns>
         public override string ToString()

--- a/src/OpenTK/Math/Matrix2d.cs
+++ b/src/OpenTK/Math/Matrix2d.cs
@@ -647,7 +647,7 @@ namespace OpenTK
         }
 
         /// <summary>
-        /// Returns a System.String that represents the current Matrix4.
+        /// Returns a System.String that represents the current Matrix2.
         /// </summary>
         /// <returns>The string representation of the matrix.</returns>
         public override string ToString()

--- a/src/OpenTK/Math/Vector2.cs
+++ b/src/OpenTK/Math/Vector2.cs
@@ -867,6 +867,73 @@ namespace OpenTK
             return !left.Equals(right);
         }
 
+        /// <summary>
+        /// Transform a Vector by the given Matrix.
+        /// </summary>
+        /// <param name="vec">The vector to transform</param>
+        /// <param name="mat">The desired transformation</param>
+        /// <returns>The transformed vector</returns>
+        public static Vector2 operator *(Vector2 vec, Matrix2 mat)
+        {
+            Vector2 result;
+            Vector2.Transform(ref vec, ref mat, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Transform a Vector by the given Matrix using right-handed notation
+        /// </summary>
+        /// <param name="mat">The desired transformation</param>
+        /// <param name="vec">The vector to transform</param>
+        /// <returns>The transformed vector</returns>
+        public static Vector2 operator *(Matrix2 mat, Vector2 vec)
+        {
+            Vector2 result;
+            Vector2.Transform(ref mat, ref vec, out result);
+            return result;
+        }
+
+        /// <summary>Transform a Vector by the given Matrix</summary>
+        /// <param name="vec">The vector to transform</param>
+        /// <param name="mat">The desired transformation</param>
+        /// <returns>The transformed vector</returns>
+        public static Vector2 Transform(Vector2 vec, Matrix2 mat)
+        {
+            Vector2 result;
+            Transform(ref vec, ref mat, out result);
+            return result;
+        }
+
+        /// <summary>Transform a Vector by the given Matrix</summary>
+        /// <param name="vec">The vector to transform</param>
+        /// <param name="mat">The desired transformation</param>
+        /// <param name="result">The transformed vector</param>
+        public static void Transform(ref Vector2 vec, ref Matrix2 mat, out Vector2 result)
+        {
+            result.X = vec.X * mat.Row0.X + vec.Y * mat.Row1.X;
+            result.Y = vec.X * mat.Row0.Y + vec.Y * mat.Row1.Y;
+        }
+
+        /// <summary>Transform a Vector by the given Matrix using right-handed notation</summary>
+        /// <param name="mat">The desired transformation</param>
+        /// <param name="vec">The vector to transform</param>
+        public static Vector2 Transform(Matrix2 mat, Vector2 vec)
+        {
+            Vector2 result;
+            Transform(ref mat, ref vec, out result);
+            return result;
+        }
+
+        /// <summary>Transform a Vector by the given Matrix using right-handed notation</summary>
+        /// <param name="mat">The desired transformation</param>
+        /// <param name="vec">The vector to transform</param>
+        /// <param name="result">The transformed vector</param>
+        public static void Transform(ref Matrix2 mat, ref Vector2 vec, out Vector2 result)
+        {
+            result.X = vec.X * mat.Row0.X + vec.Y * mat.Row0.Y;
+            result.Y = vec.X * mat.Row1.X + vec.Y * mat.Row1.Y;
+        }
+
         private static string listSeparator = System.Globalization.CultureInfo.CurrentCulture.TextInfo.ListSeparator;
         /// <summary>
         /// Returns a System.String that represents the current Vector2.

--- a/src/OpenTK/Math/Vector2d.cs
+++ b/src/OpenTK/Math/Vector2d.cs
@@ -838,6 +838,73 @@ namespace OpenTK
             return !left.Equals(right);
         }
 
+        /// <summary>
+        /// Transform a Vector by the given Matrix.
+        /// </summary>
+        /// <param name="vec">The vector to transform</param>
+        /// <param name="mat">The desired transformation</param>
+        /// <returns>The transformed vector</returns>
+        public static Vector2d operator *(Vector2d vec, Matrix2d mat)
+        {
+            Vector2d result;
+            Vector2d.Transform(ref vec, ref mat, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Transform a Vector by the given Matrix using right-handed notation
+        /// </summary>
+        /// <param name="mat">The desired transformation</param>
+        /// <param name="vec">The vector to transform</param>
+        /// <returns>The transformed vector</returns>
+        public static Vector2d operator *(Matrix2d mat, Vector2d vec)
+        {
+            Vector2d result;
+            Vector2d.Transform(ref mat, ref vec, out result);
+            return result;
+        }
+
+        /// <summary>Transform a Vector by the given Matrix</summary>
+        /// <param name="vec">The vector to transform</param>
+        /// <param name="mat">The desired transformation</param>
+        /// <returns>The transformed vector</returns>
+        public static Vector2d Transform(Vector2d vec, Matrix2d mat)
+        {
+            Vector2d result;
+            Transform(ref vec, ref mat, out result);
+            return result;
+        }
+
+        /// <summary>Transform a Vector by the given Matrix</summary>
+        /// <param name="vec">The vector to transform</param>
+        /// <param name="mat">The desired transformation</param>
+        /// <param name="result">The transformed vector</param>
+        public static void Transform(ref Vector2d vec, ref Matrix2d mat, out Vector2d result)
+        {
+            result.X = vec.X * mat.Row0.X + vec.Y * mat.Row1.X;
+            result.Y = vec.X * mat.Row0.Y + vec.Y * mat.Row1.Y;
+        }
+
+        /// <summary>Transform a Vector by the given Matrix using right-handed notation</summary>
+        /// <param name="mat">The desired transformation</param>
+        /// <param name="vec">The vector to transform</param>
+        public static Vector2d Transform(Matrix2d mat, Vector2d vec)
+        {
+            Vector2d result;
+            Transform(ref mat, ref vec, out result);
+            return result;
+        }
+
+        /// <summary>Transform a Vector by the given Matrix using right-handed notation</summary>
+        /// <param name="mat">The desired transformation</param>
+        /// <param name="vec">The vector to transform</param>
+        /// <param name="result">The transformed vector</param>
+        public static void Transform(ref Matrix2d mat, ref Vector2d vec, out Vector2d result)
+        {
+            result.X = vec.X * mat.Row0.X + vec.Y * mat.Row0.Y;
+            result.Y = vec.X * mat.Row1.X + vec.Y * mat.Row1.Y;
+        }
+
         /// <summary>Converts OpenTK.Vector2 to OpenTK.Vector2d.</summary>
         /// <param name="v2">The Vector2 to convert.</param>
         /// <returns>The resulting Vector2d.</returns>

--- a/src/OpenTK/Math/Vector3.cs
+++ b/src/OpenTK/Math/Vector3.cs
@@ -982,7 +982,7 @@ namespace OpenTK
         public static Vector3 Transform(Matrix3 mat, Vector3 vec)
         {
             Vector3 result;
-            Transform(ref vec, ref mat, out result);
+            Transform(ref mat, ref vec, out result);
             return result;
         }
 


### PR DESCRIPTION
### Purpose of this PR

* Vector3.cs - method `public static Vector3 Transform(Matrix3 mat, Vector3 vec)` - the documentation for this method claims to do right-handed notation transform.  The actual function pointed to the left-handed funciton.  I've changed these.  This bug did not appear in the Vector4 function with similar name.
* Vector2.cs - added operator override for Matrix Multiplication.  Used same structure as Vector3 / Vector4 operator overrides.

* This only affects OpenTK.Math

### Testing status

* No testing

### Comments

* Any other comments to help understand the change.