### PR TITLE
Increase compatibility creating Graphics Mode

### DIFF
--- a/src/OpenTK/Platform/Windows/WinFactory.cs
+++ b/src/OpenTK/Platform/Windows/WinFactory.cs
@@ -45,11 +45,6 @@ namespace OpenTK.Platform.Windows
 
         public WinFactory()
         {
-            if (System.Environment.OSVersion.Version.Major <= 4)
-            {
-                throw new PlatformNotSupportedException("OpenTK requires Windows XP or higher");
-            }
-
             // Dynamically load opengl32.dll in order to use the extension loading capabilities of Wgl.
             // Note: opengl32.dll must be loaded before gdi32.dll, otherwise strange failures may occur
             // (such as "error: 2000" when calling wglSetPixelFormat or slowness/lag on specific GPUs).

--- a/src/OpenTK/Platform/Windows/WinGraphicsMode.cs
+++ b/src/OpenTK/Platform/Windows/WinGraphicsMode.cs
@@ -70,7 +70,8 @@ namespace OpenTK.Platform.Windows
 
             if (created_mode == null)
             {
-                throw new GraphicsModeException("The requested GraphicsMode is not supported");
+                Debug.WriteLine("Quite the odd graphics hardware");
+                created_mode = SelectGraphicsModePFD(Device, color, depth, stencil, samples, accum, buffers, stereo);
             }
 
             return created_mode;
@@ -252,7 +253,68 @@ namespace OpenTK.Platform.Windows
             }
             return type;
         }
+        GraphicsMode SelectGraphicsModePFD(IntPtr device, ColorFormat color, int depth, int stencil, int samples, ColorFormat accum,
+            int buffers, bool stereo)
+        {
 
+            // using (Control native_window = new Control())
+            //    using (WinWindowInfo window = new WinWindowInfo(native_window.Handle, null))
+            {
+                IntPtr deviceContext = device; //((WinWindowInfo)window).DeviceContext;
+                Debug.WriteLine(String.Format("Device context: {0}", deviceContext));
+
+                Debug.Write("Selecting pixel format... ");
+                PixelFormatDescriptor pixelFormat = new PixelFormatDescriptor();
+                pixelFormat.Size = API.PixelFormatDescriptorSize;
+                pixelFormat.Version = API.PixelFormatDescriptorVersion;
+                pixelFormat.Flags =
+                    PixelFormatDescriptorFlags.SUPPORT_OPENGL |
+                    PixelFormatDescriptorFlags.DRAW_TO_WINDOW;
+                pixelFormat.ColorBits = (byte)(color.Red + color.Green + color.Blue);
+
+                pixelFormat.PixelType = color.IsIndexed ? PixelType.INDEXED : PixelType.RGBA;
+                pixelFormat.RedBits = (byte)color.Red;
+                pixelFormat.GreenBits = (byte)color.Green;
+                pixelFormat.BlueBits = (byte)color.Blue;
+                pixelFormat.AlphaBits = (byte)color.Alpha;
+
+                if (accum.BitsPerPixel > 0)
+                {
+                    pixelFormat.AccumBits = (byte)(accum.Red + accum.Green + accum.Blue);
+                    pixelFormat.AccumRedBits = (byte)accum.Red;
+                    pixelFormat.AccumGreenBits = (byte)accum.Green;
+                    pixelFormat.AccumBlueBits = (byte)accum.Blue;
+                    pixelFormat.AccumAlphaBits = (byte)accum.Alpha;
+                }
+
+                pixelFormat.DepthBits = (byte)depth;
+                pixelFormat.StencilBits = (byte)stencil;
+
+                if (depth <= 0) pixelFormat.Flags |= PixelFormatDescriptorFlags.DEPTH_DONTCARE;
+                if (stereo) pixelFormat.Flags |= PixelFormatDescriptorFlags.STEREO;
+                if (buffers > 1) pixelFormat.Flags |= PixelFormatDescriptorFlags.DOUBLEBUFFER;
+
+                int pixel = Functions.ChoosePixelFormat(deviceContext, ref pixelFormat);
+                if (pixel == 0)
+                    throw new GraphicsModeException("The requested GraphicsMode is not available.");
+
+                // Find out what we really got as a format:
+                PixelFormatDescriptor pfd = new PixelFormatDescriptor();
+                pixelFormat.Size = API.PixelFormatDescriptorSize;
+                pixelFormat.Version = API.PixelFormatDescriptorVersion;
+                Functions.DescribePixelFormat(deviceContext, pixel, API.PixelFormatDescriptorSize, ref pfd);
+                GraphicsMode fmt = new GraphicsMode((IntPtr)pixel,
+                    new ColorFormat(pfd.RedBits, pfd.GreenBits, pfd.BlueBits, pfd.AlphaBits),
+                    pfd.DepthBits,
+                    pfd.StencilBits,
+                    0,
+                    new ColorFormat(pfd.AccumBits),
+                    (pfd.Flags & PixelFormatDescriptorFlags.DOUBLEBUFFER) != 0 ? 2 : 1,
+                    (pfd.Flags & PixelFormatDescriptorFlags.STEREO) != 0);
+
+                return fmt;
+            }
+        }
         private GraphicsMode ChoosePixelFormatPFD(IntPtr device, GraphicsMode mode, AccelerationType requested_acceleration_type)
         {
             PixelFormatDescriptor pfd = new PixelFormatDescriptor();

--- a/src/OpenTK/Platform/Windows/WinGraphicsMode.cs
+++ b/src/OpenTK/Platform/Windows/WinGraphicsMode.cs
@@ -70,8 +70,7 @@ namespace OpenTK.Platform.Windows
 
             if (created_mode == null)
             {
-                Debug.WriteLine("Quite the odd graphics hardware");
-                created_mode = SelectGraphicsModePFD(Device, color, depth, stencil, samples, accum, buffers, stereo);
+                created_mode = SelectGraphicsModePixelFormatDescriptor(Device, color, depth, stencil, samples, accum, buffers, stereo);
             }
 
             return created_mode;
@@ -253,67 +252,60 @@ namespace OpenTK.Platform.Windows
             }
             return type;
         }
-        GraphicsMode SelectGraphicsModePFD(IntPtr device, ColorFormat color, int depth, int stencil, int samples, ColorFormat accum,
+        GraphicsMode SelectGraphicsModePixelFormatDescriptor(IntPtr device, ColorFormat color, int depth, int stencil, int samples, ColorFormat accum,
             int buffers, bool stereo)
         {
+            IntPtr deviceContext = device;
 
-            // using (Control native_window = new Control())
-            //    using (WinWindowInfo window = new WinWindowInfo(native_window.Handle, null))
+            PixelFormatDescriptor pixelFormat = new PixelFormatDescriptor();
+            pixelFormat.Size = API.PixelFormatDescriptorSize;
+            pixelFormat.Version = API.PixelFormatDescriptorVersion;
+            pixelFormat.Flags =
+                PixelFormatDescriptorFlags.SUPPORT_OPENGL |
+                PixelFormatDescriptorFlags.DRAW_TO_WINDOW;
+            pixelFormat.ColorBits = (byte)(color.Red + color.Green + color.Blue);
+
+            pixelFormat.PixelType = color.IsIndexed ? PixelType.INDEXED : PixelType.RGBA;
+            pixelFormat.RedBits = (byte)color.Red;
+            pixelFormat.GreenBits = (byte)color.Green;
+            pixelFormat.BlueBits = (byte)color.Blue;
+            pixelFormat.AlphaBits = (byte)color.Alpha;
+
+            if (accum.BitsPerPixel > 0)
             {
-                IntPtr deviceContext = device; //((WinWindowInfo)window).DeviceContext;
-                Debug.WriteLine(String.Format("Device context: {0}", deviceContext));
-
-                Debug.Write("Selecting pixel format... ");
-                PixelFormatDescriptor pixelFormat = new PixelFormatDescriptor();
-                pixelFormat.Size = API.PixelFormatDescriptorSize;
-                pixelFormat.Version = API.PixelFormatDescriptorVersion;
-                pixelFormat.Flags =
-                    PixelFormatDescriptorFlags.SUPPORT_OPENGL |
-                    PixelFormatDescriptorFlags.DRAW_TO_WINDOW;
-                pixelFormat.ColorBits = (byte)(color.Red + color.Green + color.Blue);
-
-                pixelFormat.PixelType = color.IsIndexed ? PixelType.INDEXED : PixelType.RGBA;
-                pixelFormat.RedBits = (byte)color.Red;
-                pixelFormat.GreenBits = (byte)color.Green;
-                pixelFormat.BlueBits = (byte)color.Blue;
-                pixelFormat.AlphaBits = (byte)color.Alpha;
-
-                if (accum.BitsPerPixel > 0)
-                {
-                    pixelFormat.AccumBits = (byte)(accum.Red + accum.Green + accum.Blue);
-                    pixelFormat.AccumRedBits = (byte)accum.Red;
-                    pixelFormat.AccumGreenBits = (byte)accum.Green;
-                    pixelFormat.AccumBlueBits = (byte)accum.Blue;
-                    pixelFormat.AccumAlphaBits = (byte)accum.Alpha;
-                }
-
-                pixelFormat.DepthBits = (byte)depth;
-                pixelFormat.StencilBits = (byte)stencil;
-
-                if (depth <= 0) pixelFormat.Flags |= PixelFormatDescriptorFlags.DEPTH_DONTCARE;
-                if (stereo) pixelFormat.Flags |= PixelFormatDescriptorFlags.STEREO;
-                if (buffers > 1) pixelFormat.Flags |= PixelFormatDescriptorFlags.DOUBLEBUFFER;
-
-                int pixel = Functions.ChoosePixelFormat(deviceContext, ref pixelFormat);
-                if (pixel == 0)
-                    throw new GraphicsModeException("The requested GraphicsMode is not available.");
-
-                // Find out what we really got as a format:
-                PixelFormatDescriptor pfd = new PixelFormatDescriptor();
-                pixelFormat.Size = API.PixelFormatDescriptorSize;
-                pixelFormat.Version = API.PixelFormatDescriptorVersion;
-                Functions.DescribePixelFormat(deviceContext, pixel, API.PixelFormatDescriptorSize, ref pfd);
-                GraphicsMode fmt = new GraphicsMode((IntPtr)pixel,
-                    new ColorFormat(pfd.RedBits, pfd.GreenBits, pfd.BlueBits, pfd.AlphaBits),
-                    pfd.DepthBits,
-                    pfd.StencilBits,
-                    0,
-                    new ColorFormat(pfd.AccumBits),
-                    (pfd.Flags & PixelFormatDescriptorFlags.DOUBLEBUFFER) != 0 ? 2 : 1,
-                    (pfd.Flags & PixelFormatDescriptorFlags.STEREO) != 0);
-
-                return fmt;
+                pixelFormat.AccumBits = (byte)(accum.Red + accum.Green + accum.Blue);
+                pixelFormat.AccumRedBits = (byte)accum.Red;
+                pixelFormat.AccumGreenBits = (byte)accum.Green;
+                pixelFormat.AccumBlueBits = (byte)accum.Blue;
+                pixelFormat.AccumAlphaBits = (byte)accum.Alpha;
             }
+
+            pixelFormat.DepthBits = (byte)depth;
+            pixelFormat.StencilBits = (byte)stencil;
+
+            if (depth <= 0) pixelFormat.Flags |= PixelFormatDescriptorFlags.DEPTH_DONTCARE;
+            if (stereo) pixelFormat.Flags |= PixelFormatDescriptorFlags.STEREO;
+            if (buffers > 1) pixelFormat.Flags |= PixelFormatDescriptorFlags.DOUBLEBUFFER;
+
+            int pixel = Functions.ChoosePixelFormat(deviceContext, ref pixelFormat);
+            if (pixel == 0)
+                throw new GraphicsModeException("The requested GraphicsMode is not available.");
+
+            // Find out what we really got as a format:
+            PixelFormatDescriptor pfd = new PixelFormatDescriptor();
+            pixelFormat.Size = API.PixelFormatDescriptorSize;
+            pixelFormat.Version = API.PixelFormatDescriptorVersion;
+            Functions.DescribePixelFormat(deviceContext, pixel, API.PixelFormatDescriptorSize, ref pfd);
+            GraphicsMode fmt = new GraphicsMode((IntPtr)pixel,
+                new ColorFormat(pfd.RedBits, pfd.GreenBits, pfd.BlueBits, pfd.AlphaBits),
+                pfd.DepthBits,
+                pfd.StencilBits,
+                0,
+                new ColorFormat(pfd.AccumBits),
+                (pfd.Flags & PixelFormatDescriptorFlags.DOUBLEBUFFER) != 0 ? 2 : 1,
+                (pfd.Flags & PixelFormatDescriptorFlags.STEREO) != 0);
+
+            return fmt;
         }
         private GraphicsMode ChoosePixelFormatPFD(IntPtr device, GraphicsMode mode, AccelerationType requested_acceleration_type)
         {


### PR DESCRIPTION
There are OpenGL drivers and renderers who wouldnt give back a context because they aren't asked nicely enough. Those support shaders and at least OpenGL 2.1, or higher.

Also removing an arbitrary system version check. 