### PR TITLE
Change: Make Command a valid modifier on OS-X

### DIFF
--- a/src/OpenTK/Input/Key.cs
+++ b/src/OpenTK/Input/Key.cs
@@ -121,6 +121,10 @@ namespace OpenTK.Input
         /// </summary>
         Menu,
 
+        /// <summary>The Command key.</summary>
+        /// <remarks>Valid on OS-X only</remarks>
+        Command,
+
         // Function keys (hopefully enough for most keyboards - mine has 26)
         // <keysymdef.h> on X11 reports up to 35 function keys.
         /// <summary>

--- a/src/OpenTK/Input/KeyModifiers.cs
+++ b/src/OpenTK/Input/KeyModifiers.cs
@@ -48,6 +48,11 @@ namespace OpenTK.Input
         /// <summary>
         /// The shift key modifier.
         /// </summary>
-        Shift = 1 << 2
+        Shift = 1 << 2,
+
+        /// <summary>
+        /// The command key modifier on a Mac
+        /// </summary>
+        Command = 1 << 3
     }
 }

--- a/src/OpenTK/Platform/MacOS/CocoaNativeWindow.cs
+++ b/src/OpenTK/Platform/MacOS/CocoaNativeWindow.cs
@@ -786,6 +786,11 @@ namespace OpenTK.Platform.MacOS
                 modifiers |= KeyModifiers.Alt;
             }
 
+            if ((mask & NSEventModifierMask.CommandKeyMask) != 0)
+            {
+                modifiers |= OpenTK.Input.KeyModifiers.Command;
+            }
+
             return modifiers;
         }
 

--- a/src/OpenTK/Platform/MacOS/MacOSKeyMap.cs
+++ b/src/OpenTK/Platform/MacOS/MacOSKeyMap.cs
@@ -240,7 +240,7 @@ namespace OpenTK.Platform.MacOS
                 case MacOSKeyCode.W:
                     return Key.W;
                 case MacOSKeyCode.Command:
-                    return Key.WinLeft;
+                    return Key.Command;
                 // WinKeyRight
                 case MacOSKeyCode.X:
                     return Key.X;

--- a/src/OpenTK/Platform/NativeWindowBase.cs
+++ b/src/OpenTK/Platform/NativeWindowBase.cs
@@ -293,6 +293,7 @@ namespace OpenTK.Platform
             var alt = (mods & KeyModifiers.Alt) != 0;
             var control = (mods & KeyModifiers.Control) != 0;
             var shift = (mods & KeyModifiers.Shift) != 0;
+            var command = (mods & KeyModifiers.Command) != 0;
 
             if (alt)
             {
@@ -345,6 +346,18 @@ namespace OpenTK.Platform
                 if (KeyboardState[Key.ShiftRight])
                 {
                     OnKeyUp(Key.ShiftRight);
+                }
+            }
+
+            if (command)
+            {
+                OnKeyDown(Key.Command, KeyboardState[Key.AltLeft]);
+            }
+            else
+            {
+                if (KeyboardState[Key.Command])
+                {
+                    OnKeyUp(Key.Command);
                 }
             }
         }


### PR DESCRIPTION
### Purpose of this PR

* Adds the Command key to be a valid key modifer.
* OS-X native window only.

### Testing status

* ~~Untested- I've got no physical hardware, but assuming the NSEventModifierMask for Command is correct it's a simple change.~~ See below.

### Comments

* This is Mac native platform specific only. This *may* make it too narrow to be merged into the main library, but on Mac, the Command modifier is the standard, and hence what users expect......

https://github.com/opentk/opentk/issues/757