### PR TITLE
Expose precise scrolling capability (macOS only)

### DIFF
--- a/src/OpenTK/Input/MouseState.cs
+++ b/src/OpenTK/Input/MouseState.cs
@@ -37,6 +37,8 @@ namespace OpenTK.Input
         private MouseScroll scroll;
         private ushort buttons;
 
+        public bool HasPreciseScroll { get; internal set; }
+
         /// <summary>
         /// Gets a <see cref="System.Boolean"/> indicating whether the specified
         /// <see cref="OpenTK.Input.MouseButton"/> is pressed.

--- a/src/OpenTK/Platform/Linux/LinuxNativeWindow.cs
+++ b/src/OpenTK/Platform/Linux/LinuxNativeWindow.cs
@@ -318,7 +318,7 @@ namespace OpenTK.Platform.Linux
             {
                 float dx = mouse.Scroll.X - previous_mouse.Scroll.X;
                 float dy = mouse.Scroll.Y - previous_mouse.Scroll.Y;
-                OnMouseWheel(dx, dy);
+                OnMouseWheel(dx, dy, false);
             }
 
             // Handle mouse focus

--- a/src/OpenTK/Platform/MacOS/CocoaNativeWindow.cs
+++ b/src/OpenTK/Platform/MacOS/CocoaNativeWindow.cs
@@ -761,7 +761,8 @@ namespace OpenTK.Platform.MacOS
                     case NSEventType.ScrollWheel:
                         {
                             float dx, dy;
-                            if (Cocoa.SendBool(e, selHasPreciseScrollingDeltas))
+                            bool isPrecise = Cocoa.SendBool(e, selHasPreciseScrollingDeltas);
+                            if (isPrecise)
                             {
                                 dx = Cocoa.SendFloat(e, selScrollingDeltaX) * MacOSFactory.ScrollFactor;
                                 dy = Cocoa.SendFloat(e, selScrollingDeltaY) * MacOSFactory.ScrollFactor;
@@ -778,7 +779,7 @@ namespace OpenTK.Platform.MacOS
                                 // Note: OpenTK follows the win32 convention, where
                                 // (+h, +v) = (right, up). MacOS reports (+h, +v) = (left, up)
                                 // so we need to flip the horizontal scroll direction.
-                                OnMouseWheel(-dx, dy);
+                                OnMouseWheel(-dx, dy, isPrecise);
                             }
                         }
                         break;
@@ -1151,6 +1152,7 @@ namespace OpenTK.Platform.MacOS
                     NSBitmapFormat.AlphaFirst,
                     4 * cursor.Width,
                     32);
+
             if (imgdata == IntPtr.Zero)
             {
                 Debug.Print("Failed to create NSBitmapImageRep with size ({0},{1]})",

--- a/src/OpenTK/Platform/NativeWindowBase.cs
+++ b/src/OpenTK/Platform/NativeWindowBase.cs
@@ -274,9 +274,10 @@ namespace OpenTK.Platform
             MouseMove(this, e);
         }
 
-        protected void OnMouseWheel(float dx, float dy)
+        protected void OnMouseWheel(float dx, float dy, bool isPrecise)
         {
             MouseState.SetScrollRelative(dx, dy);
+            MouseState.HasPreciseScroll = isPrecise;
 
             var e = MouseWheelArgs;
             e.Mouse = MouseState;

--- a/src/OpenTK/Platform/SDL2/Sdl2NativeWindow.cs
+++ b/src/OpenTK/Platform/SDL2/Sdl2NativeWindow.cs
@@ -300,7 +300,7 @@ namespace OpenTK.Platform.SDL2
 
         private static void ProcessMouseWheelEvent(Sdl2NativeWindow window, MouseWheelEvent ev)
         {
-            window.OnMouseWheel(ev.X, ev.Y);
+            window.OnMouseWheel(ev.X, ev.Y, false);
         }
 
         private static unsafe void ProcessDropEvent(Sdl2NativeWindow window, DropEvent ev)

--- a/src/OpenTK/Platform/Windows/WinGLNative.cs
+++ b/src/OpenTK/Platform/Windows/WinGLNative.cs
@@ -540,14 +540,14 @@ namespace OpenTK.Platform.Windows
         {
             // This is due to inconsistent behavior of the WParam value on 64bit arch, whese
             // wparam = 0xffffffffff880000 or wparam = 0x00000000ff100000
-            OnMouseWheel(0, ((long)wParam << 32 >> 48) / 120.0f);
+            OnMouseWheel(0, ((long)wParam << 32 >> 48) / 120.0f, false);
         }
 
         private void HandleMouseHWheel(IntPtr handle, WindowMessage message, IntPtr wParam, IntPtr lParam)
         {
             // This is due to inconsistent behavior of the WParam value on 64bit arch, whese
             // wparam = 0xffffffffff880000 or wparam = 0x00000000ff100000
-            OnMouseWheel(((long)wParam << 32 >> 48) / 120.0f, 0);
+            OnMouseWheel(((long)wParam << 32 >> 48) / 120.0f, 0, false);
         }
 
         private void HandleLButtonDown(IntPtr handle, WindowMessage message, IntPtr wParam, IntPtr lParam)

--- a/src/OpenTK/Platform/X11/X11GLNative.cs
+++ b/src/OpenTK/Platform/X11/X11GLNative.cs
@@ -1094,7 +1094,7 @@ namespace OpenTK.Platform.X11
                             {
                                 // High resolution scroll events not supported
                                 // fallback to the old Button4-7 scroll buttons
-                                OnMouseWheel(dx, dy);
+                                OnMouseWheel(dx, dy, false);
                             }
                         }
                         break;


### PR DESCRIPTION
### Purpose of this PR

* This PR exposes precise scrolling capabilities as a boolean `MouseState.HasPreciseScroll`. This value is populated on macOS only, but may also get correct values on other platforms in the future.
* In our program we use this property within a scrollable area to determine whether to apply smoothing when the user scrolls. If e.g. a mouse wheel with discrete scroll steps is used, then scrolling should be smoothly interpolated. If a precise scroll device such as a MacBook trackpad is used, then smoothing feels sluggish and should not be applied.
* This affects `OpenTK.Input` and is not a breaking change for consumers of OpenTK.

### Testing status

* This change was tested on a MacBook Pro 2017 on High Sierra. I tested the following 3 scenarios:

  1. With the trackpad, precise scroll is correctly detected.
  2. When using a mouse out-of-the-box, macOS already pre-applies smoothing, and precise scroll is correctly still reported.
  3. When using a third-party tool to perform e.g. linear scrolling (I used [SteerMouse](http://plentycom.jp/en/steermouse/)), then the scroll is correctly reported as _imprecise_.

### Comments

* None.