### PR TITLE
Immediately return after restoring resolution

### DIFF
--- a/src/OpenTK/DisplayDevice.cs
+++ b/src/OpenTK/DisplayDevice.cs
@@ -223,6 +223,7 @@ namespace OpenTK
             if (resolution == null)
             {
                 RestoreResolution();
+                return;
             }
 
             if (resolution == current_resolution)


### PR DESCRIPTION
Without this return statement user can pass null object into function and get exception because it will be used later without checking