### PR TITLE
Close display connection for X11 on dispose.

### DIFF
--- a/src/OpenTK/Platform/X11/X11GLNative.cs
+++ b/src/OpenTK/Platform/X11/X11GLNative.cs
@@ -1903,6 +1903,11 @@ namespace OpenTK.Platform.X11
                             DestroyWindow();
                         }
 
+                        if (window.Display != IntPtr.Zero)
+                        {
+                            Functions.XCloseDisplay(window.Display);
+                        }
+
                         window.Dispose();
                     }
                 }


### PR DESCRIPTION
### Purpose of this PR

'Connection to X (X11) display' should be also closed on GameWindow disposing. If not the 'System.Exception : Could not open connection to X' exception occurs at runtime after more than 100 GameWindows were created/disposed.