### PR TITLE
[4.0] Fix StyleCop analysis not working on Windows

### DIFF
--- a/build/targets/stylecop.props
+++ b/build/targets/stylecop.props
@@ -1,6 +1,5 @@
 <Project>
     <PropertyGroup>
-        <RunCodeAnalysis>true</RunCodeAnalysis>
         <CodeAnalysisRuleSet>..\..\stylecop.ruleset</CodeAnalysisRuleSet>
     </PropertyGroup>
     <ItemGroup>
@@ -14,6 +13,6 @@
         </AdditionalFiles>
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta006" PrivateAssets="all" />
+        <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008" PrivateAssets="all" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
### Purpose of this PR

- Remove the `RunCodeAnalysis` MSBuild property as it is considered legacy ([source](https://github.com/dotnet/roslyn-analyzers/issues/1313#issuecomment-354491017)) and will run the old code analysis tool which does not work for .NET Core or Standard ([source](https://github.com/dotnet/roslyn-analyzers/issues/1313#issuecomment-369763951))
- Update StyleCop version to beta1.1.0-008

This seems to only be an issue on Windows, probably because the "oldschool" code analysis tool never existed for other platforms and thus can only run on Windows.