### PR TITLE
Fixed incorrect Quaternion/Vector rotation

### DIFF
--- a/src/OpenTK.Mathematics/Vector/Vector3.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3.cs
@@ -987,9 +987,9 @@ namespace OpenTK.Mathematics
             Cross(ref xyz, ref vec, out temp);
             Multiply(ref vec, quat.W, out temp2);
             Add(ref temp, ref temp2, out temp);
-            Cross(ref xyz, ref temp, out temp);
-            Multiply(ref temp, 2, out temp);
-            Add(ref vec, ref temp, out result);
+            Cross(ref xyz, ref temp, out temp2);
+            Multiply(ref temp2, 2f, out temp2);
+            Add(ref vec, ref temp2, out result);
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Vector/Vector3d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3d.cs
@@ -987,9 +987,9 @@ namespace OpenTK.Mathematics
             Cross(ref xyz, ref vec, out temp);
             Multiply(ref vec, quat.W, out temp2);
             Add(ref temp, ref temp2, out temp);
-            Cross(ref xyz, ref temp, out temp);
-            Multiply(ref temp, 2, out temp);
-            Add(ref vec, ref temp, out result);
+            Cross(ref xyz, ref temp, out temp2);
+            Multiply(ref temp2, 2f, out temp2);
+            Add(ref vec, ref temp2, out result);
         }
 
         /// <summary>


### PR DESCRIPTION
The issue was related to referencing...
In OpenTK 2.0, Vector3.Transform(Quaternion) actually returned a new instance of the rotated vector, which was then changed in 3.0 so that no new vector instances were created for better performance. In short, this is what caused the issue at Vector3.Transform(Quaternion), returning incorrectly rotated vectors.