### PR TITLE
[4.0] Build Cleanup

### DIFF
--- a/OpenTK.sln
+++ b/OpenTK.sln
@@ -20,6 +20,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{2E399A9C
 	ProjectSection(SolutionItems) = preProject
 		build/targets/netfx-mono.props = build/targets/netfx-mono.props
 		build/targets/stylecop.props = build/targets/stylecop.props
+		build/targets/nuget-common.props = build/targets/nuget-common.props
 	EndProjectSection
 EndProject
 

--- a/OpenTK.sln.DotSettings
+++ b/OpenTK.sln.DotSettings
@@ -30,6 +30,6 @@
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002ECSharpPlaceAttributeOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
-	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateInstanceFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="_" Suffix="" Style="aaBb" /&gt;</s:String>
-	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="_" Suffix="" Style="aaBb" /&gt;</s:String></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=NONINFRINGEMENT/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	

--- a/build/targets/nuget-common.props
+++ b/build/targets/nuget-common.props
@@ -1,0 +1,13 @@
+<Project>
+    <PropertyGroup>
+        <Authors>The OpenTK team.</Authors>
+        <Copyright>Copyright (c) 2006 - 2016 Stefanos Apostolopoulos (stapostol@gmail.com) for the Open Toolkit library.</Copyright>
+        <PackageIconUrl>https://raw.githubusercontent.com/opentk/opentk/master/docs/files/img/logo.png</PackageIconUrl>
+        <PackageLicenseUrl>https://opensource.org/licenses/MIT</PackageLicenseUrl>
+        <PackageReleaseNotes>Initial 4.0 release.</PackageReleaseNotes>
+        <PackageTags>opentk;opengl;cross-platform;openal;csharp;fsharp;vb;dotnet;mono;graphics;game;scientific;science;3d;2d;math;input;gamepad;joystick</PackageTags>
+        <PackageProjectUrl>https://github.com/opentk/opentk</PackageProjectUrl>
+        <IncludeSymbols>true</IncludeSymbols>
+        <IncludeSource>true</IncludeSource>
+    </PropertyGroup>
+</Project>

--- a/build/targets/stylecop.props
+++ b/build/targets/stylecop.props
@@ -1,6 +1,5 @@
 <Project>
     <PropertyGroup>
-        <RunCodeAnalysis>true</RunCodeAnalysis>
         <CodeAnalysisRuleSet>..\..\stylecop.ruleset</CodeAnalysisRuleSet>
     </PropertyGroup>
     <ItemGroup>
@@ -14,6 +13,6 @@
         </AdditionalFiles>
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta006" PrivateAssets="all" />
+        <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008" PrivateAssets="all" />
     </ItemGroup>
 </Project>

--- a/src/Generator.Bind/Generator.Bind.csproj
+++ b/src/Generator.Bind/Generator.Bind.csproj
@@ -7,11 +7,17 @@
     <Deterministic>true</Deterministic>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.2.1" />
     <PackageReference Include="Humanizer" Version="2.3.3" />
     <PackageReference Include="System.CodeDom" Version="4.5.0-preview2-26406-04" />
   </ItemGroup>
+
   <Import Project="..\..\build\targets\netfx-mono.props" />
   <Import Project="..\..\build\targets\stylecop.props" />
 </Project>

--- a/src/Generator.Bind/Generator.Bind.csproj
+++ b/src/Generator.Bind/Generator.Bind.csproj
@@ -6,13 +6,11 @@
     <TargetFramework>net461</TargetFramework>
     <Deterministic>true</Deterministic>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.2.1" />
     <PackageReference Include="Humanizer" Version="2.3.3" />
     <PackageReference Include="System.CodeDom" Version="4.5.0-preview2-26406-04" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta006" PrivateAssets="all" />
   </ItemGroup>
   <Import Project="..\..\build\targets\netfx-mono.props" />
   <Import Project="..\..\build\targets\stylecop.props" />

--- a/src/Generator.Converter/Generator.Convert.csproj
+++ b/src/Generator.Converter/Generator.Convert.csproj
@@ -7,9 +7,15 @@
     <Deterministic>true</Deterministic>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.2.1" />
   </ItemGroup>
+
   <Import Project="..\..\build\targets\netfx-mono.props" />
   <Import Project="..\..\build\targets\stylecop.props" />
 </Project>

--- a/src/Generator.Converter/Generator.Convert.csproj
+++ b/src/Generator.Converter/Generator.Convert.csproj
@@ -6,7 +6,6 @@
     <TargetFramework>net461</TargetFramework>
     <Deterministic>true</Deterministic>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.2.1" />

--- a/src/Generator.Rewrite/Generator.Rewrite.csproj
+++ b/src/Generator.Rewrite/Generator.Rewrite.csproj
@@ -6,7 +6,6 @@
     <TargetFramework>net461</TargetFramework>
     <Deterministic>true</Deterministic>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.2.1" />

--- a/src/Generator.Rewrite/Generator.Rewrite.csproj
+++ b/src/Generator.Rewrite/Generator.Rewrite.csproj
@@ -7,10 +7,16 @@
     <Deterministic>true</Deterministic>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.2.1" />
     <PackageReference Include="Mono.Cecil" Version="0.10.0" />
   </ItemGroup>
+
   <Import Project="..\..\build\targets\netfx-mono.props" />
   <Import Project="..\..\build\targets\stylecop.props" />
 </Project>

--- a/src/OpenTK.Core/OpenTK.Core.csproj
+++ b/src/OpenTK.Core/OpenTK.Core.csproj
@@ -3,20 +3,12 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
+
   <PropertyGroup>
     <Version>1.0.0</Version>
-    <Authors>OpenTK</Authors>
-    <Copyright>Copyright (c) 2006 - 2016 Stefanos Apostolopoulos (stapostol@gmail.com) for the Open Toolkit library.</Copyright>
     <Description>Core shared functionality for the OpenTK library.</Description>
   </PropertyGroup>
-  <PropertyGroup>
-    <PackageIconUrl>https://raw.githubusercontent.com/opentk/opentk/master/docs/files/img/logo.png</PackageIconUrl>
-    <PackageLicenseUrl>https://opensource.org/licenses/MIT</PackageLicenseUrl>
-    <PackageReleaseNotes>Initial 4.0 release.</PackageReleaseNotes>
-    <PackageTags>opentk;opengl;cross-platform;openal;csharp;fsharp;vb;dotnet;mono;graphics;game;scientific;science;3d;2d;math;input;gamepad;joystick</PackageTags>
-    <PackageProjectUrl>https://github.com/opentk/opentk</PackageProjectUrl>
-    <IncludeSymbols>true</IncludeSymbols>
-    <IncludeSource>true</IncludeSource>
-  </PropertyGroup>
+
+  <Import Project="..\..\build\targets\nuget-common.props" />
   <Import Project="..\..\build\targets\stylecop.props" />
 </Project>

--- a/src/OpenTK.GLControl/OpenTK.GLControl.csproj
+++ b/src/OpenTK.GLControl/OpenTK.GLControl.csproj
@@ -5,7 +5,6 @@
     <Deterministic>true</Deterministic>
     <LangVersion>7</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup>
     <Version>4.0.0</Version>

--- a/src/OpenTK.GLControl/OpenTK.GLControl.csproj
+++ b/src/OpenTK.GLControl/OpenTK.GLControl.csproj
@@ -5,27 +5,23 @@
     <Deterministic>true</Deterministic>
     <LangVersion>7</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
+
   <PropertyGroup>
     <Version>4.0.0</Version>
-    <Authors>OpenTK</Authors>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>OpenGL control for Windows.Forms.</Description>
   </PropertyGroup>
-  <PropertyGroup>
-    <PackageLicenseUrl>https://opensource.org/licenses/MIT</PackageLicenseUrl>
-    <PackageReleaseNotes>Initial 4.0 release.</PackageReleaseNotes>
-    <PackageTags>opentk;opengl;forms;windows</PackageTags>
-    <PackageProjectUrl>https://github.com/opentk/opentk</PackageProjectUrl>
-    <IncludeSymbols>true</IncludeSymbols>
-    <IncludeSource>true</IncludeSource>
-  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\OpenTK\OpenTK.csproj" />
   </ItemGroup>
+
   <ItemGroup>
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
+
+  <Import Project="..\..\build\targets\nuget-common.props" />
   <Import Project="..\..\build\targets\netfx-mono.props" />
   <Import Project="..\..\build\targets\stylecop.props" />
 </Project>

--- a/src/OpenTK.GLWidget/OpenTK.GLWidget.csproj
+++ b/src/OpenTK.GLWidget/OpenTK.GLWidget.csproj
@@ -5,7 +5,6 @@
     <Deterministic>true</Deterministic>
     <LangVersion>7</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup>
     <Version>4.0.0</Version>
@@ -24,7 +23,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="GtkSharp" Version="3.22.24.36" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta006" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\OpenTK\OpenTK.csproj" />

--- a/src/OpenTK.GLWidget/OpenTK.GLWidget.csproj
+++ b/src/OpenTK.GLWidget/OpenTK.GLWidget.csproj
@@ -6,27 +6,21 @@
     <LangVersion>7</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
+
   <PropertyGroup>
     <Version>4.0.0</Version>
-    <Authors>OpenTK</Authors>
-    <Copyright>Copyright (c) 2006 - 2016 Stefanos Apostolopoulos (stapostol@gmail.com) for the Open Toolkit library.</Copyright>
     <Description>OpenGL control for GtkSharp.</Description>
   </PropertyGroup>
-  <PropertyGroup>
-    <PackageIconUrl>https://raw.githubusercontent.com/opentk/opentk/master/docs/files/img/logo.png</PackageIconUrl>
-    <PackageLicenseUrl>https://opensource.org/licenses/MIT</PackageLicenseUrl>
-    <PackageReleaseNotes>Initial 4.0 release.</PackageReleaseNotes>
-    <PackageTags>opentk;opengl;gtk;cross-platform</PackageTags>
-    <PackageProjectUrl>https://github.com/opentk/opentk</PackageProjectUrl>
-    <IncludeSymbols>true</IncludeSymbols>
-    <IncludeSource>true</IncludeSource>
-  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="GtkSharp" Version="3.22.24.36" />
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\OpenTK\OpenTK.csproj" />
   </ItemGroup>
+
+  <Import Project="..\..\build\targets\nuget-common.props" />
   <Import Project="..\..\build\targets\netfx-mono.props" />
   <Import Project="..\..\build\targets\stylecop.props" />
 </Project>

--- a/src/OpenTK.Mathematics/OpenTK.Mathematics.csproj
+++ b/src/OpenTK.Mathematics/OpenTK.Mathematics.csproj
@@ -4,8 +4,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Deterministic>true</Deterministic>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <AssemblyName>OpenTK.Mathematics</AssemblyName>
-    <RootNamespace>OpenTK.Mathematics</RootNamespace>
   </PropertyGroup>
   <PropertyGroup>
     <Version>1.0.0</Version>

--- a/src/OpenTK.Mathematics/OpenTK.Mathematics.csproj
+++ b/src/OpenTK.Mathematics/OpenTK.Mathematics.csproj
@@ -5,20 +5,12 @@
     <Deterministic>true</Deterministic>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
+
   <PropertyGroup>
     <Version>1.0.0</Version>
-    <Authors>OpenTK</Authors>
-    <Copyright>Copyright (c) 2006 - 2016 Stefanos Apostolopoulos (stapostol@gmail.com) for the Open Toolkit library.</Copyright>
     <Description>Mathematical structures and algorithms, provided and used by OpenTK.</Description>
   </PropertyGroup>
-  <PropertyGroup>
-    <PackageIconUrl>https://raw.githubusercontent.com/opentk/opentk/master/docs/files/img/logo.png</PackageIconUrl>
-    <PackageLicenseUrl>https://opensource.org/licenses/MIT</PackageLicenseUrl>
-    <PackageReleaseNotes>Initial 4.0 release.</PackageReleaseNotes>
-    <PackageTags>opentk;opengl;cross-platform;openal;csharp;fsharp;vb;dotnet;mono;graphics;game;scientific;science;3d;2d;math;input;gamepad;joystick</PackageTags>
-    <PackageProjectUrl>https://github.com/opentk/opentk</PackageProjectUrl>
-    <IncludeSymbols>true</IncludeSymbols>
-    <IncludeSource>true</IncludeSource>
-  </PropertyGroup>
+
+  <Import Project="..\..\build\targets\nuget-common.props" />
   <Import Project="..\..\build\targets\stylecop.props" />
 </Project>

--- a/src/OpenTK.OpenAL/OpenTK.OpenAL.csproj
+++ b/src/OpenTK.OpenAL/OpenTK.OpenAL.csproj
@@ -5,24 +5,17 @@
     <Deterministic>true</Deterministic>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
+
   <PropertyGroup>
     <Version>1.0.0</Version>
-    <Authors>OpenTK.OpenAL</Authors>
-    <Copyright>Copyright (c) 2006 - 2016 Stefanos Apostolopoulos (stapostol@gmail.com) for the Open Toolkit library.</Copyright>
     <Description>OpenAL bindings, and audio utility classes.</Description>
   </PropertyGroup>
-  <PropertyGroup>
-    <PackageIconUrl>https://raw.githubusercontent.com/opentk/opentk/master/docs/files/img/logo.png</PackageIconUrl>
-    <PackageLicenseUrl>https://opensource.org/licenses/MIT</PackageLicenseUrl>
-    <PackageReleaseNotes>Initial 4.0 release.</PackageReleaseNotes>
-    <PackageTags>opentk;opengl;cross-platform;openal;csharp;fsharp;vb;dotnet;mono;graphics;game;scientific;science;3d;2d;math;input;gamepad;joystick</PackageTags>
-    <PackageProjectUrl>https://github.com/opentk/opentk</PackageProjectUrl>
-    <IncludeSymbols>true</IncludeSymbols>
-    <IncludeSource>true</IncludeSource>
-  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\OpenTK.Core\OpenTK.Core.csproj" />
     <ProjectReference Include="..\OpenTK.Mathematics\OpenTK.Mathematics.csproj" />
   </ItemGroup>
+
+  <Import Project="..\..\build\targets\nuget-common.props" />
   <Import Project="..\..\build\targets\stylecop.props" />
 </Project>

--- a/src/OpenTK.OpenAL/OpenTK.OpenAL.csproj
+++ b/src/OpenTK.OpenAL/OpenTK.OpenAL.csproj
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Deterministic>true</Deterministic>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <PropertyGroup>
     <Version>1.0.0</Version>

--- a/src/OpenTK.OpenAL/OpenTK.OpenAL.csproj.DotSettings
+++ b/src/OpenTK.OpenAL/OpenTK.OpenAL.csproj.DotSettings
@@ -1,3 +1,5 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=native_005Cal/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=native_005Calc/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=native_005Calc/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=native_005Calc_005Cenums/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=native_005Cal_005Cenums/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/OpenTK/OpenTK.csproj
+++ b/src/OpenTK/OpenTK.csproj
@@ -6,31 +6,25 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
+
   <PropertyGroup>
     <Version>4.0.0</Version>
-    <Authors>OpenTK</Authors>
-    <Copyright>Copyright (c) 2006 - 2016 Stefanos Apostolopoulos (stapostol@gmail.com) for the Open Toolkit library.</Copyright>
     <Description>A set of fast, low-level C# bindings for OpenGL, OpenGL ES and OpenAL.</Description>
   </PropertyGroup>
-  <PropertyGroup>
-    <PackageIconUrl>https://raw.githubusercontent.com/opentk/opentk/master/docs/files/img/logo.png</PackageIconUrl>
-    <PackageLicenseUrl>https://opensource.org/licenses/MIT</PackageLicenseUrl>
-    <PackageReleaseNotes>Initial 4.0 release.</PackageReleaseNotes>
-    <PackageTags>opentk;opengl;cross-platform;openal;csharp;fsharp;vb;dotnet;mono;graphics;game;scientific;science;3d;2d;math;input;gamepad;joystick</PackageTags>
-    <PackageProjectUrl>https://github.com/opentk/opentk</PackageProjectUrl>
-    <IncludeSymbols>true</IncludeSymbols>
-    <IncludeSource>true</IncludeSource>
-  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\OpenTK.Core\OpenTK.Core.csproj" />
     <ProjectReference Include="..\OpenTK.Mathematics\OpenTK.Mathematics.csproj" />
   </ItemGroup>
+
   <Target Name="Rewrite" AfterTargets="AfterBuild">
     <Exec Condition="$(OS) == 'Windows_NT' and $(Configuration) == 'Debug'" Command="$(ProjectDir)..\..\src\Generator.Rewrite\bin\Debug\net461\Rewrite.exe --assembly $(OutputPath)OpenTK.dll --debug" />
     <Exec Condition="$(OS) == 'Windows_NT' and $(Configuration) == 'Release'" Command="$(ProjectDir)..\..\src\Generator.Rewrite\bin\Release\net461\Rewrite.exe --assembly $(OutputPath)OpenTK.dll" />
     <Exec Condition="$(OS) != 'Windows_NT' and $(Configuration) == 'Debug'" Command="mono $(ProjectDir)..\..\src\Generator.Rewrite/bin/Debug/net461\Rewrite.exe --assembly $(OutputPath)OpenTK.dll --debug" />
     <Exec Condition="$(OS) != 'Windows_NT' and $(Configuration) == 'Release'" Command="mono $(ProjectDir)..\..\src\Generator.Rewrite/bin/Release/net461\Rewrite.exe --assembly $(OutputPath)OpenTK.dll" />
   </Target>
+
+  <Import Project="..\..\build\targets\nuget-common.props" />
   <Import Project="..\..\build\targets\netfx-mono.props" />
   <Import Project="..\..\build\targets\stylecop.props" />
 </Project>

--- a/src/OpenTK/OpenTK.csproj
+++ b/src/OpenTK/OpenTK.csproj
@@ -22,9 +22,6 @@
     <IncludeSource>true</IncludeSource>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta006" PrivateAssets="all" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\OpenTK.Core\OpenTK.Core.csproj" />
     <ProjectReference Include="..\OpenTK.Mathematics\OpenTK.Mathematics.csproj" />
   </ItemGroup>

--- a/src/OpenTK/OpenTK.csproj.DotSettings
+++ b/src/OpenTK/OpenTK.csproj.DotSettings
@@ -1,0 +1,15 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces10_005Cenums/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces10_005Cwrappers/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces11_005Cenums/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces11_005Cwrappers/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces20_005Cenums/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces20_005Cwrappers/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces30_005Cenums/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces30_005Cwrappers/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces31_005Cenums/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces31_005Cwrappers/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Copengl4_005Cenums/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Copengl4_005Cwrappers/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Copengl_005Cenums/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Copengl_005Cwrappers/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/OpenTK/OpenTK.csproj.DotSettings
+++ b/src/OpenTK/OpenTK.csproj.DotSettings
@@ -1,15 +1,104 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces10_005Cenums/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces10_005Cwrappers/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces10_005Cwrappers_005Capple/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces10_005Cwrappers_005Ccore/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces10_005Cwrappers_005Cext/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces10_005Cwrappers_005Cimg/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces10_005Cwrappers_005Ckhr/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces10_005Cwrappers_005Cnv/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces10_005Cwrappers_005Coes/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces10_005Cwrappers_005Cqcom/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces11_005Cenums/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces11_005Cwrappers/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces11_005Cwrappers_005Capple/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces11_005Cwrappers_005Ccore/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces11_005Cwrappers_005Cext/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces11_005Cwrappers_005Cimg/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces11_005Cwrappers_005Ckhr/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces11_005Cwrappers_005Cnv/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces11_005Cwrappers_005Coes/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces11_005Cwrappers_005Cqcom/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces20_005Cenums/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces20_005Cwrappers/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces20_005Cwrappers_005Camd/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces20_005Cwrappers_005Cangle/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces20_005Cwrappers_005Capple/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces20_005Cwrappers_005Ccmaaintel/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces20_005Cwrappers_005Ccore/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces20_005Cwrappers_005Cext/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces20_005Cwrappers_005Cimg/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces20_005Cwrappers_005Cintel/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces20_005Cwrappers_005Ckhr/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces20_005Cwrappers_005Cnv/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces20_005Cwrappers_005Coes/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces20_005Cwrappers_005Covr/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces20_005Cwrappers_005Cqcom/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces30_005Cenums/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces30_005Cwrappers/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces30_005Cwrappers_005Camd/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces30_005Cwrappers_005Cangle/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces30_005Cwrappers_005Capple/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces30_005Cwrappers_005Ccmaaintel/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces30_005Cwrappers_005Ccore/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces30_005Cwrappers_005Cext/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces30_005Cwrappers_005Cimg/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces30_005Cwrappers_005Cintel/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces30_005Cwrappers_005Ckhr/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces30_005Cwrappers_005Cnv/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces30_005Cwrappers_005Coes/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces30_005Cwrappers_005Covr/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces30_005Cwrappers_005Cqcom/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces31_005Cenums/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces31_005Cwrappers/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces31_005Cwrappers_005Camd/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces31_005Cwrappers_005Cangle/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces31_005Cwrappers_005Capple/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces31_005Cwrappers_005Ccmaaintel/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces31_005Cwrappers_005Ccore/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces31_005Cwrappers_005Cext/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces31_005Cwrappers_005Cimg/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces31_005Cwrappers_005Cintel/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces31_005Cwrappers_005Ckhr/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces31_005Cwrappers_005Cnv/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces31_005Cwrappers_005Coes/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces31_005Cwrappers_005Covr/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Ces31_005Cwrappers_005Cqcom/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Copengl4_005Cenums/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Copengl4_005Cwrappers/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Copengl4_005Cwrappers_005Camd/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Copengl4_005Cwrappers_005Carb/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Copengl4_005Cwrappers_005Ccmaaintel/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Copengl4_005Cwrappers_005Ccore/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Copengl4_005Cwrappers_005Cext/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Copengl4_005Cwrappers_005Cintel/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Copengl4_005Cwrappers_005Ckhr/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Copengl4_005Cwrappers_005Cnv/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Copengl4_005Cwrappers_005Covr/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Copengl_005Cenums/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Copengl_005Cwrappers/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Copengl_005Cwrappers/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Copengl_005Cwrappers_005C3dfx/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Copengl_005Cwrappers_005Camd/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Copengl_005Cwrappers_005Capple/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Copengl_005Cwrappers_005Carb/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Copengl_005Cwrappers_005Cati/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Copengl_005Cwrappers_005Ccmaaintel/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Copengl_005Cwrappers_005Ccore/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Copengl_005Cwrappers_005Cext/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Copengl_005Cwrappers_005Cgremedy/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Copengl_005Cwrappers_005Chp/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Copengl_005Cwrappers_005Cibm/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Copengl_005Cwrappers_005Cingr/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Copengl_005Cwrappers_005Cintel/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Copengl_005Cwrappers_005Ckhr/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Copengl_005Cwrappers_005Cmesa/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Copengl_005Cwrappers_005Cnv/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Copengl_005Cwrappers_005Cnvx/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Copengl_005Cwrappers_005Coes/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Copengl_005Cwrappers_005Covr/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Copengl_005Cwrappers_005Cpgi/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Copengl_005Cwrappers_005Csgi/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Copengl_005Cwrappers_005Csgis/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Copengl_005Cwrappers_005Csgix/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Copengl_005Cwrappers_005Csun/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=graphics_005Copengl_005Cwrappers_005Csunx/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/stylecop.ruleset
+++ b/stylecop.ruleset
@@ -10,189 +10,190 @@
     <Rule Id="SA1001" Action="Error" /> <!-- Commas must be spaced correctly -->
     <Rule Id="SA1002" Action="Error" /> <!-- Semicolons must be spaced correctly -->
     <Rule Id="SA1003" Action="Error" /> <!-- Symbols must be spaced correctly -->
-    <Rule Id="SA1004" Action="None" /> <!-- Documentation lines must begin with single space -->
-    <Rule Id="SA1005" Action="None" /> <!-- Single line comments must begin with single space -->
+    <Rule Id="SA1004" Action="Error" /> <!-- Documentation lines must begin with single space -->
+    <Rule Id="SA1005" Action="Warning" Intentional="true" Reason="Used for quick debugging"/> <!-- Single line comments must begin with single space -->
     <Rule Id="SA1006" Action="Error" /> <!-- Preprocessor keywords must not be preceded by space -->
-    <Rule Id="SA1007" Action="None" /> <!-- Operator keyword must be followed by space -->
-    <Rule Id="SA1008" Action="None" /> <!-- Opening parenthesis must be spaced correctly -->
-    <Rule Id="SA1009" Action="None" /> <!-- Closing parenthesis must be spaced correctly -->
-    <Rule Id="SA1010" Action="None" /> <!-- Opening square brackets must be spaced correctly -->
-    <Rule Id="SA1011" Action="None" /> <!-- Closing square brackets must be spaced correctly -->
-    <Rule Id="SA1012" Action="None" /> <!-- Opening braces must be spaced correctly -->
-    <Rule Id="SA1013" Action="None" /> <!-- Closing braces must be spaced correctly -->
+    <Rule Id="SA1007" Action="Error" /> <!-- Operator keyword must be followed by space -->
+    <Rule Id="SA1008" Action="Error" /> <!-- Opening parenthesis must be spaced correctly -->
+    <Rule Id="SA1009" Action="None" Intentional="true" Reason="Used for alignment"/> <!-- Closing parenthesis must be spaced correctly -->
+    <Rule Id="SA1010" Action="Error" /> <!-- Opening square brackets must be spaced correctly -->
+    <Rule Id="SA1011" Action="Error" /> <!-- Closing square brackets must be spaced correctly -->
+    <Rule Id="SA1012" Action="Error" /> <!-- Opening braces must be spaced correctly -->
+    <Rule Id="SA1013" Action="Error" /> <!-- Closing braces must be spaced correctly -->
     <Rule Id="SA1014" Action="Error" /> <!-- Opening generic brackets must be spaced correctly -->
     <Rule Id="SA1015" Action="Error" /> <!-- Closing generic brackets must be spaced correctly -->
     <Rule Id="SA1016" Action="Error" /> <!-- Opening attribute brackets must be spaced correctly -->
     <Rule Id="SA1017" Action="Error" /> <!-- Closing attribute brackets must be spaced correctly -->
     <Rule Id="SA1018" Action="Error" /> <!-- Nullable type symbols must be spaced correctly -->
-    <Rule Id="SA1019" Action="None" /> <!-- Member access symbols must be spaced correctly -->
+    <Rule Id="SA1019" Action="Error" /> <!-- Member access symbols must be spaced correctly -->
     <Rule Id="SA1020" Action="Error" /> <!-- Increment decrement symbols must be spaced correctly -->
     <Rule Id="SA1021" Action="Error" /> <!-- Negative signs must be spaced correctly -->
     <Rule Id="SA1022" Action="Error" /> <!-- Positive signs must be spaced correctly -->
-    <Rule Id="SA1023" Action="None" /> <!-- Dereference and access of symbols must be spaced correctly -->
-    <Rule Id="SA1024" Action="None" /> <!-- Colons Must Be Spaced Correctly -->
-    <Rule Id="SA1025" Action="None" /> <!-- Code must not contain multiple whitespace in a row -->
-    <Rule Id="SA1026" Action="None" /> <!-- Code must not contain space after new keyword in implicitly typed array allocation -->
+    <Rule Id="SA1023" Action="Error" /> <!-- Dereference and access of symbols must be spaced correctly -->
+    <Rule Id="SA1024" Action="Error" /> <!-- Colons must be spaced correctly -->
+    <Rule Id="SA1025" Action="Error" /> <!-- Code must not contain multiple whitespace in a row -->
+    <Rule Id="SA1026" Action="Error" /> <!-- Code must not contain space after new keyword in implicitly typed array allocation -->
     <Rule Id="SA1027" Action="Error" /> <!-- Use tabs correctly -->
-    <Rule Id="SA1028" Action="None" /> <!-- Code must not contain trailing whitespace -->
+    <Rule Id="SA1028" Action="Error" /> <!-- Code must not contain trailing whitespace -->
 
     <!-- Readability rules -->
-    <Rule Id="SA1100" Action="None" /> <!-- Do not prefix calls with base unless local implementation exists -->
-    <Rule Id="SA1101" Action="None" Intentional="true" /> <!-- Prefix local calls with this -->
-    <Rule Id="SX1101" Action="None" /> <!-- Do not prefix local calls with this. -->
+    <Rule Id="SA1100" Action="Error" /> <!-- Do not prefix calls with base unless local implementation exists -->
+    <Rule Id="SA1101" Action="None"/> <!-- Prefix local calls with this -->
+    <Rule Id="SX1101" Action="None" Intentional="true" /> <!-- Do not prefix local calls with this. -->
     <Rule Id="SA1102" Action="Error" /> <!-- Query clause must follow previous clause -->
     <Rule Id="SA1103" Action="Error" /> <!-- Query clauses must be on separate lines or all on one line -->
     <Rule Id="SA1104" Action="Error" /> <!-- Query clause must begin on new line when previous clause spans multiple lines -->
     <Rule Id="SA1105" Action="Error" /> <!-- Query clauses spanning multiple lines must begin on own line -->
-    <Rule Id="SA1106" Action="None" /> <!-- Code must not contain empty statements -->
-    <Rule Id="SA1107" Action="None" /> <!-- Code must not contain multiple statements on one line -->
-    <Rule Id="SA1108" Action="None" /> <!-- Block statements must not contain embedded comments -->
+    <Rule Id="SA1106" Action="Error" /> <!-- Code must not contain empty statements -->
+    <Rule Id="SA1107" Action="Error" /> <!-- Code must not contain multiple statements on one line -->
+    <Rule Id="SA1108" Action="Error" /> <!-- Block statements must not contain embedded comments -->
     <Rule Id="SA1110" Action="None" Intentional="true" /> <!-- Opening parenthesis or bracket must be on declaration line -->
     <Rule Id="SA1111" Action="None" Intentional="true" /> <!-- Closing parenthesis must be on line of last parameter -->
     <Rule Id="SA1112" Action="Error" /> <!-- Closing parenthesis must be on line of opening parenthesis -->
     <Rule Id="SA1113" Action="Error" /> <!-- Comma must be on the same line as previous parameter -->
     <Rule Id="SA1114" Action="Error" /> <!-- Parameter list must follow declaration -->
-    <Rule Id="SA1115" Action="None" /> <!-- Parameter must follow comma -->
-    <Rule Id="SA1116" Action="None" /> <!-- Split parameters must start on line after declaration -->
-    <Rule Id="SA1117" Action="None" /> <!-- Parameters must be on same line or separate lines -->
-    <Rule Id="SA1118" Action="None" /> <!-- Parameter must not span multiple lines -->
-    <Rule Id="SA1119" Action="None" /> <!-- Statement must not use unnecessary parenthesis -->
-    <Rule Id="SA1120" Action="None" /> <!-- Comments must contain text -->
-    <Rule Id="SA1121" Action="None" /> <!-- Use built-in type alias -->
-    <Rule Id="SA1122" Action="None" /> <!-- Use string.Empty for empty strings -->
+    <Rule Id="SA1115" Action="Error" /> <!-- Parameter must follow comma -->
+    <Rule Id="SA1116" Action="Error" /> <!-- Split parameters must start on line after declaration -->
+    <Rule Id="SA1117" Action="Error" /> <!-- Parameters must be on same line or separate lines -->
+    <Rule Id="SA1118" Action="Error" /> <!-- Parameter must not span multiple lines -->
+    <Rule Id="SA1119" Action="Error" /> <!-- Statement must not use unnecessary parenthesis -->
+    <Rule Id="SA1120" Action="None" Intentional="true" Reason="Used for spacing in license header"/> <!-- Comments must contain text -->
+    <Rule Id="SA1121" Action="Error" /> <!-- Use built-in type alias -->
+    <Rule Id="SA1122" Action="Error" /> <!-- Use string.Empty for empty strings -->
     <Rule Id="SA1123" Action="Error" /> <!-- Do not place regions within elements -->
     <Rule Id="SA1124" Action="Error" /> <!-- Do not use regions -->
-    <Rule Id="SA1125" Action="None" /> <!-- Use shorthand for nullable types -->
-    <Rule Id="SA1127" Action="None" /> <!-- Generic type constraints must be on their own line -->
-    <Rule Id="SA1128" Action="None" /> <!-- Put constructor initializers on their own line -->
-    <Rule Id="SA1129" Action="None" /> <!-- Do not use default value type constructor -->
-    <Rule Id="SA1130" Action="None" /> <!-- Use lambda syntax -->
-    <Rule Id="SA1131" Action="None" /> <!-- Use readable conditions -->
-    <Rule Id="SA1132" Action="None" /> <!-- Do not combine fields -->
-    <Rule Id="SA1133" Action="None" /> <!-- Do not combine attributes -->
-    <Rule Id="SA1134" Action="None" /> <!-- Attributes must not share line -->
+    <Rule Id="SA1125" Action="Error" /> <!-- Use shorthand for nullable types -->
+    <Rule Id="SA1127" Action="None" Intentional="true" /> <!-- Generic type constraints must be on their own line -->
+    <Rule Id="SA1128" Action="Error" /> <!-- Put constructor initializers on their own line -->
+    <Rule Id="SA1129" Action="Error" /> <!-- Do not use default value type constructor -->
+    <Rule Id="SA1130" Action="Error" /> <!-- Use lambda syntax -->
+    <Rule Id="SA1131" Action="Error" /> <!-- Use readable conditions -->
+    <Rule Id="SA1132" Action="Error" /> <!-- Do not combine fields -->
+    <Rule Id="SA1133" Action="None" Intentional="true" /> <!-- Do not combine attributes -->
+    <Rule Id="SA1134" Action="Error" /> <!-- Attributes must not share line -->
     <Rule Id="SA1136" Action="Error" /> <!-- Enum values should be on separate lines -->
     <Rule Id="SA1137" Action="Error" /> <!-- Elements should have the same indentation -->
-    <Rule Id="SA1139" Action="Warning" /> <!-- Use literals suffix notation instead of casting -->
+    <Rule Id="SA1139" Action="Error" /> <!-- Use literals suffix notation instead of casting -->
 
     <!-- Ordering rules -->
-    <Rule Id="SA1200" Action="None" /> <!-- Using directives must be placed correctly -->
-    <Rule Id="SA1201" Action="None" /> <!-- Elements must appear in the correct order -->
-    <Rule Id="SA1202" Action="None" /> <!-- Elements must be ordered by access -->
-    <Rule Id="SA1203" Action="None" /> <!-- Constants must appear before fields -->
-    <Rule Id="SA1204" Action="None" /> <!-- Static elements must appear before instance elements -->
-    <Rule Id="SA1205" Action="None" /> <!-- Partial elements must declare access -->
-    <Rule Id="SA1206" Action="None" /> <!-- Declaration keywords must follow order -->
-    <Rule Id="SA1207" Action="None" /> <!-- Protected must come before internal -->
-    <Rule Id="SA1208" Action="None" /> <!-- System using directives must be placed before other using directives -->
-    <Rule Id="SA1209" Action="None" /> <!-- Using alias directives must be placed after other using directives -->
-    <Rule Id="SA1210" Action="None" /> <!-- Using directives must be ordered alphabetically by namespace -->
-    <Rule Id="SA1211" Action="None" /> <!-- Using alias directives must be ordered alphabetically by alias name -->
+    <Rule Id="SA1200" Action="Error" /> <!-- Using directives must be placed correctly -->
+    <Rule Id="SA1201" Action="None" Intentional="true" /> <!-- Elements must appear in the correct order -->
+    <Rule Id="SA1202" Action="None" Intentional="true" /> <!-- Elements must be ordered by access -->
+    <Rule Id="SA1203" Action="Error" /> <!-- Constants must appear before fields -->
+    <Rule Id="SA1204" Action="None" Intentional="true" /> <!-- Static elements must appear before instance elements -->
+    <Rule Id="SA1205" Action="Error" /> <!-- Partial elements must declare access -->
+    <Rule Id="SA1206" Action="Error" /> <!-- Declaration keywords must follow order -->
+    <Rule Id="SA1207" Action="Error" /> <!-- Protected must come before internal -->
+    <Rule Id="SA1208" Action="Error" /> <!-- System using directives must be placed before other using directives -->
+    <Rule Id="SA1209" Action="Error" /> <!-- Using alias directives must be placed after other using directives -->
+    <Rule Id="SA1210" Action="Error" /> <!-- Using directives must be ordered alphabetically by namespace -->
+    <Rule Id="SA1210" Action="Error" /> <!-- Using directives must be ordered alphabetically by namespace -->
+    <Rule Id="SA1211" Action="Error" /> <!-- Using alias directives must be ordered alphabetically by alias name -->
     <Rule Id="SA1212" Action="Error" /> <!-- Property accessors must follow order -->
     <Rule Id="SA1213" Action="Error" /> <!-- Event accessors must follow order -->
-    <Rule Id="SA1214" Action="None" /> <!-- Readonly fields must appear before non-readonly fields -->
+    <Rule Id="SA1214" Action="Error" /> <!-- Readonly fields must appear before non-readonly fields -->
     <Rule Id="SA1216" Action="Error" /> <!-- Using static directives must be placed at the correct location. -->
     <Rule Id="SA1217" Action="Error" /> <!-- Using static directives must be ordered alphabetically -->
 
     <!-- Naming rules -->
-    <Rule Id="SA1300" Action="None" /> <!-- Element must begin with upper-case letter -->
+    <Rule Id="SA1300" Action="Error" /> <!-- Element must begin with upper-case letter -->
     <Rule Id="SA1302" Action="Error" /> <!-- Interface names must begin with I -->
-    <Rule Id="SA1303" Action="None" /> <!-- Const field names must begin with upper-case letter -->
-    <Rule Id="SA1304" Action="None" /> <!-- Non-private readonly fields must begin with upper-case letter -->
-    <Rule Id="SA1305" Action="None" /> <!-- Field names must not use Hungarian notation -->
-    <Rule Id="SA1306" Action="None" /> <!-- Field names must begin with lower-case letter -->
-    <Rule Id="SA1307" Action="None" /> <!-- Accessible fields must begin with upper-case letter -->
+    <Rule Id="SA1303" Action="Error" /> <!-- Const field names must begin with upper-case letter -->
+    <Rule Id="SA1304" Action="Error" /> <!-- Non-private readonly fields must begin with upper-case letter -->
+    <Rule Id="SA1305" Action="Error" /> <!-- Field names must not use Hungarian notation -->
+    <Rule Id="SA1306" Action="None" Intentional="true" Reason="Field names should begin with upper-case latter"/> <!-- Field names must begin with lower-case letter -->
+    <Rule Id="SA1307" Action="Error" /> <!-- Accessible fields must begin with upper-case letter -->
     <Rule Id="SA1308" Action="Error" /> <!-- Variable names must not be prefixed -->
-    <Rule Id="SA1309" Action="None" /> <!-- Field names must not begin with underscore -->
-    <Rule Id="SX1309" Action="None" /> <!-- Field names must begin with underscore -->
-    <Rule Id="SX1309S" Action="None" /> <!-- Static field names must begin with underscore -->
-    <Rule Id="SA1310" Action="None" /> <!-- Field names must not contain underscore -->
-    <Rule Id="SA1311" Action="None" /> <!-- Static readonly fields must begin with upper-case letter -->
-    <Rule Id="SA1312" Action="None" /> <!-- Variable names must begin with lower-case letter -->
-    <Rule Id="SA1313" Action="None" /> <!-- Parameter names must begin with lower-case letter -->
-    <Rule Id="SA1314" Action="None" /> <!-- Type name parameters must begin with T -->
+    <Rule Id="SA1309" Action="Error" /> <!-- Field names must not begin with underscore -->
+    <Rule Id="SX1309" Action="None" Intentional="true" /> <!-- Field names must begin with underscore -->
+    <Rule Id="SX1309S" Action="None" Intentional="true" /> <!-- Static field names must begin with underscore -->
+    <Rule Id="SA1310" Action="Error" /> <!-- Field names must not contain underscore -->
+    <Rule Id="SA1311" Action="Error" /> <!-- Static readonly fields must begin with upper-case letter -->
+    <Rule Id="SA1312" Action="Error" /> <!-- Variable names must begin with lower-case letter -->
+    <Rule Id="SA1313" Action="Error" /> <!-- Parameter names must begin with lower-case letter -->
+    <Rule Id="SA1314" Action="Error" /> <!-- Type name parameters must begin with T -->
 
     <!-- Maintainability rules -->
-    <Rule Id="SA1400" Action="None" /> <!-- Access modifier must be declared -->
-    <Rule Id="SA1401" Action="None" /> <!-- Fields must be private -->
-    <Rule Id="SA1402" Action="None" /> <!-- File may only contain a single class -->
-    <Rule Id="SA1403" Action="None" /> <!-- File may only contain a single namespace -->
-    <Rule Id="SA1404" Action="None" /> <!-- Code analysis suppression must have justification -->
-    <Rule Id="SA1405" Action="None" /> <!-- Debug.Assert must provide message text -->
+    <Rule Id="SA1400" Action="Error" /> <!-- Access modifier must be declared -->
+    <Rule Id="SA1401" Action="Error" /> <!-- Fields must be private -->
+    <Rule Id="SA1402" Action="Error" /> <!-- File may only contain a single class -->
+    <Rule Id="SA1403" Action="Error" /> <!-- File may only contain a single namespace -->
+    <Rule Id="SA1404" Action="Error" /> <!-- Code analysis suppression must have justification -->
+    <Rule Id="SA1405" Action="Error" /> <!-- Debug.Assert must provide message text -->
     <Rule Id="SA1406" Action="Error" /> <!-- Debug.Fail must provide message text -->
-    <Rule Id="SA1407" Action="None" /> <!-- Arithmetic expressions must declare precedence -->
-    <Rule Id="SA1408" Action="None" /> <!-- Conditional expressions must declare precedence -->
+    <Rule Id="SA1407" Action="Error" /> <!-- Arithmetic expressions must declare precedence -->
+    <Rule Id="SA1408" Action="Error" /> <!-- Conditional expressions must declare precedence -->
     <Rule Id="SA1410" Action="Error" /> <!-- Remove delegate parenthesis when possible -->
-    <Rule Id="SA1411" Action="None" /> <!-- Attribute constructor must not use unnecessary parenthesis -->
-    <Rule Id="SA1412" Action="None" /> <!-- Store files as UTF-8 with byte order mark -->
-    <Rule Id="SA1413" Action="None" /> <!-- Use trailing comma in multi-line initializers -->
+    <Rule Id="SA1411" Action="Error" /> <!-- Attribute constructor must not use unnecessary parenthesis -->
+    <Rule Id="SA1412" Action="None" Intentional="true" /> <!-- Store files as UTF-8 with byte order mark -->
+    <Rule Id="SA1413" Action="None" Intentional="true" /> <!-- Use trailing comma in multi-line initializers -->
 
     <!-- Layout rules -->
-    <Rule Id="SA1500" Action="None" /> <!-- Braces for multi-line statements must not share line -->
-    <Rule Id="SA1501" Action="None" /> <!-- Statement must not be on a single line -->
-    <Rule Id="SA1502" Action="None" /> <!-- Element must not be on a single line -->
-    <Rule Id="SA1503" Action="None" /> <!-- Braces must not be omitted -->
-    <Rule Id="SA1504" Action="None" /> <!-- All accessors must be single-line or multi-line -->
-    <Rule Id="SA1505" Action="None" /> <!-- Opening braces must not be followed by blank line -->
-    <Rule Id="SA1506" Action="None" /> <!-- Element documentation headers must not be followed by blank line -->
-    <Rule Id="SA1507" Action="None" /> <!-- Code must not contain multiple blank lines in a row -->
-    <Rule Id="SA1508" Action="None" /> <!-- Closing braces must not be preceded by blank line -->
-    <Rule Id="SA1509" Action="None" /> <!-- Opening braces must not be preceded by blank line -->
+    <Rule Id="SA1500" Action="Error" /> <!-- Braces for multi-line statements must not share line -->
+    <Rule Id="SA1501" Action="Error" /> <!-- Statement must not be on a single line -->
+    <Rule Id="SA1502" Action="Error" /> <!-- Element must not be on a single line -->
+    <Rule Id="SA1503" Action="Error" /> <!-- Braces must not be omitted -->
+    <Rule Id="SA1504" Action="Error" /> <!-- All accessors must be single-line or multi-line -->
+    <Rule Id="SA1505" Action="Error" /> <!-- Opening braces must not be followed by blank line -->
+    <Rule Id="SA1506" Action="Error" /> <!-- Element documentation headers must not be followed by blank line -->
+    <Rule Id="SA1507" Action="Error" /> <!-- Code must not contain multiple blank lines in a row -->
+    <Rule Id="SA1508" Action="Error" /> <!-- Closing braces must not be preceded by blank line -->
+    <Rule Id="SA1509" Action="Error" /> <!-- Opening braces must not be preceded by blank line -->
     <Rule Id="SA1510" Action="Error" /> <!-- Chained statement blocks must not be preceded by blank line -->
-    <Rule Id="SA1511" Action="None" /> <!-- While-do footer must not be preceded by blank line -->
-    <Rule Id="SA1512" Action="None" /> <!-- Single-line comments must not be followed by blank line -->
-    <Rule Id="SA1513" Action="None" /> <!-- Closing brace must be followed by blank line -->
-    <Rule Id="SA1514" Action="None" /> <!-- Element documentation header must be preceded by blank line -->
-    <Rule Id="SA1515" Action="None" /> <!-- Single-line comment must be preceded by blank line -->
-    <Rule Id="SA1516" Action="None" /> <!-- Elements must be separated by blank line -->
-    <Rule Id="SA1517" Action="None" /> <!-- Code must not contain blank lines at start of file -->
-    <Rule Id="SA1518" Action="None" /> <!-- Use line endings correctly at end of file -->
-    <Rule Id="SA1519" Action="None" /> <!-- Braces must not be omitted from multi-line child statement -->
-    <Rule Id="SA1520" Action="None" /> <!-- Use braces consistently -->
+    <Rule Id="SA1511" Action="Error" /> <!-- While-do footer must not be preceded by blank line -->
+    <Rule Id="SA1512" Action="Warning" Intentional="true" Reason="Used for spacing"/> <!-- Single-line comments must not be followed by blank line -->
+    <Rule Id="SA1513" Action="None" Intentional="true" Reason="Waiting for configurable option for enums"/> <!-- Closing brace must be followed by blank line -->
+    <Rule Id="SA1514" Action="Error" /> <!-- Element documentation header must be preceded by blank line -->
+    <Rule Id="SA1515" Action="Warning" Intentional="true" Reason="Used for spacing"/> <!-- Single-line comment must be preceded by blank line -->
+    <Rule Id="SA1516" Action="Error" /> <!-- Elements must be separated by blank line -->
+    <Rule Id="SA1517" Action="Error" /> <!-- Code must not contain blank lines at start of file -->
+    <Rule Id="SA1518" Action="Error" /> <!-- Use line endings correctly at end of file -->
+    <Rule Id="SA1519" Action="Error" /> <!-- Braces must not be omitted from multi-line child statement -->
+    <Rule Id="SA1520" Action="Error" /> <!-- Use braces consistently -->
 
     <!-- Documentation rules -->
-    <Rule Id="SA1600" Action="None" /> <!-- Elements must be documented -->
-    <Rule Id="SA1601" Action="None" /> <!-- Partial elements must be documented -->
-    <Rule Id="SA1602" Action="None" /> <!-- Enumeration items must be documented -->
-    <Rule Id="SA1604" Action="None" /> <!-- Element documentation must have summary -->
-    <Rule Id="SA1605" Action="None" /> <!-- Partial element documentation must have summary -->
-    <Rule Id="SA1606" Action="None" /> <!-- Element documentation must have summary text -->
-    <Rule Id="SA1607" Action="None" /> <!-- Partial element documentation must have summary text -->
-    <Rule Id="SA1608" Action="None" /> <!-- Element documentation must not have default summary -->
-    <Rule Id="SA1609" Action="None" /> <!-- Property documentation must have value -->
-    <Rule Id="SA1610" Action="None" /> <!-- Property documentation must have value text -->
-    <Rule Id="SA1611" Action="None" /> <!-- Element parameters must be documented -->
-    <Rule Id="SA1612" Action="None" /> <!-- Element parameter documentation must match element parameters -->
-    <Rule Id="SA1613" Action="None" /> <!-- Element parameter documentation must declare parameter name -->
-    <Rule Id="SA1614" Action="None" /> <!-- Element parameter documentation must have text -->
-    <Rule Id="SA1615" Action="None" /> <!-- Element return value must be documented -->
-    <Rule Id="SA1616" Action="None" /> <!-- Element return value documentation must have text -->
-    <Rule Id="SA1617" Action="None" /> <!-- Void return value must not be documented -->
-    <Rule Id="SA1618" Action="None" /> <!-- Generic type parameters must be documented -->
-    <Rule Id="SA1619" Action="None" /> <!-- Generic type parameters must be documented partial class -->
-    <Rule Id="SA1620" Action="None" /> <!-- Generic type parameter documentation must match type parameters -->
-    <Rule Id="SA1621" Action="None" /> <!-- Generic type parameter documentation must declare parameter name -->
-    <Rule Id="SA1622" Action="None" /> <!-- Generic type parameter documentation must have text -->
-    <Rule Id="SA1623" Action="None" /> <!-- Property summary documentation must match accessors -->
-    <Rule Id="SA1624" Action="None" /> <!-- Property summary documentation must omit accessor with restricted access -->
-    <Rule Id="SA1625" Action="None" /> <!-- Element documentation must not be copied and pasted -->
-    <Rule Id="SA1626" Action="None" /> <!-- Single-line comments must not use documentation style slashes -->
-    <Rule Id="SA1627" Action="None" /> <!-- Documentation text must not be empty -->
-    <Rule Id="SA1629" Action="None" /> <!-- Documentation text must end with a period -->
-    <Rule Id="SA1633" Action="None" /> <!-- File must have header -->
-    <Rule Id="SA1634" Action="None" /> <!-- File header must show copyright -->
-    <Rule Id="SA1635" Action="None" /> <!-- File header must have copyright text -->
-    <Rule Id="SA1636" Action="None" /> <!-- File header copyright text must match -->
-    <Rule Id="SA1637" Action="None" /> <!-- File header must contain file name -->
-    <Rule Id="SA1638" Action="None" /> <!-- File header file name documentation must match file name -->
-    <Rule Id="SA1639" Action="None" /> <!-- File header must have summary -->
-    <Rule Id="SA1640" Action="None" /> <!-- File header must have valid company text -->
-    <Rule Id="SA1641" Action="None" /> <!-- File header company name text must match -->
-    <Rule Id="SA1642" Action="None" /> <!-- Constructor summary documentation must begin with standard text -->
-    <Rule Id="SA1643" Action="None" /> <!-- Destructor summary documentation must begin with standard text -->
-    <Rule Id="SA1644" Action="None" /> <!-- Documentation header must not contain blank lines -->
-    <Rule Id="SA1648" Action="None" /> <!-- inheritdoc must be used with inheriting class -->
-    <Rule Id="SA1649" Action="None" /> <!-- File name must match first type name -->
-    <Rule Id="SA1651" Action="None" /> <!-- Do not use placeholder elements -->
+    <Rule Id="SA1600" Action="Error" /> <!-- Elements must be documented -->
+    <Rule Id="SA1601" Action="None" Intentional="true" /> <!-- Partial elements must be documented -->
+    <Rule Id="SA1602" Action="Error" /> <!-- Enumeration items must be documented -->
+    <Rule Id="SA1604" Action="Error" /> <!-- Element documentation must have summary -->
+    <Rule Id="SA1605" Action="Error" /> <!-- Partial element documentation must have summary -->
+    <Rule Id="SA1606" Action="Error" /> <!-- Element documentation must have summary text -->
+    <Rule Id="SA1607" Action="Error" /> <!-- Partial element documentation must have summary text -->
+    <Rule Id="SA1608" Action="Error" /> <!-- Element documentation must not have default summary -->
+    <Rule Id="SA1609" Action="None" Intentional="true" /> <!-- Property documentation must have value -->
+    <Rule Id="SA1610" Action="None" Intentional="true "/> <!-- Property documentation must have value text -->
+    <Rule Id="SA1611" Action="Error" /> <!-- Element parameters must be documented -->
+    <Rule Id="SA1612" Action="Error" /> <!-- Element parameter documentation must match element parameters -->
+    <Rule Id="SA1613" Action="Error" /> <!-- Element parameter documentation must declare parameter name -->
+    <Rule Id="SA1614" Action="Error" /> <!-- Element parameter documentation must have text -->
+    <Rule Id="SA1615" Action="Error" /> <!-- Element return value must be documented -->
+    <Rule Id="SA1616" Action="Error" /> <!-- Element return value documentation must have text -->
+    <Rule Id="SA1617" Action="Error" /> <!-- Void return value must not be documented -->
+    <Rule Id="SA1618" Action="Error" /> <!-- Generic type parameters must be documented -->
+    <Rule Id="SA1619" Action="Error" /> <!-- Generic type parameters must be documented partial class -->
+    <Rule Id="SA1620" Action="Error" /> <!-- Generic type parameter documentation must match type parameters -->
+    <Rule Id="SA1621" Action="Error" /> <!-- Generic type parameter documentation must declare parameter name -->
+    <Rule Id="SA1622" Action="Error" /> <!-- Generic type parameter documentation must have text -->
+    <Rule Id="SA1623" Action="Error" /> <!-- Property summary documentation must match accessors -->
+    <Rule Id="SA1624" Action="Error" /> <!-- Property summary documentation must omit accessor with restricted access -->
+    <Rule Id="SA1625" Action="Error" /> <!-- Element documentation must not be copied and pasted -->
+    <Rule Id="SA1626" Action="Error" /> <!-- Single-line comments must not use documentation style slashes -->
+    <Rule Id="SA1627" Action="Error" /> <!-- Documentation text must not be empty -->
+    <Rule Id="SA1629" Action="Error" /> <!-- Documentation text must end with a period -->
+    <Rule Id="SA1633" Action="None" Intentional="true" Reason="Temporarily disabled." /> <!-- File must have header -->
+    <Rule Id="SA1634" Action="Error" /> <!-- File header must show copyright -->
+    <Rule Id="SA1635" Action="Error" /> <!-- File header must have copyright text -->
+    <Rule Id="SA1636" Action="Error" Intentional="true" /> <!-- File header copyright text must match -->
+    <Rule Id="SA1637" Action="Error" /> <!-- File header must contain file name -->
+    <Rule Id="SA1638" Action="Error" /> <!-- File header file name documentation must match file name -->
+    <Rule Id="SA1639" Action="Error" /> <!-- File header must have summary -->
+    <Rule Id="SA1640" Action="Error" /> <!-- File header must have valid company text -->
+    <Rule Id="SA1641" Action="Error" /> <!-- File header company name text must match -->
+    <Rule Id="SA1642" Action="Error" /> <!-- Constructor summary documentation must begin with standard text -->
+    <Rule Id="SA1643" Action="Error" /> <!-- Destructor summary documentation must begin with standard text -->
+    <Rule Id="SA1644" Action="None" Intentional="true" /> <!-- Documentation header must not contain blank lines -->
+    <Rule Id="SA1648" Action="Error" /> <!-- inheritdoc must be used with inheriting class -->
+    <Rule Id="SA1649" Action="Error" /> <!-- File name must match first type name -->
+    <Rule Id="SA1651" Action="Error" /> <!-- Do not use placeholder elements -->
   </Rules>
 </RuleSet>

--- a/tests/OpenTK.Tests.Integration/OpenTK.Tests.Integration.fsproj
+++ b/tests/OpenTK.Tests.Integration/OpenTK.Tests.Integration.fsproj
@@ -2,16 +2,22 @@
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
     <Name>OpenTK.Tests.Integration</Name>
-    <Deterministic>true</Deterministic>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="GameWindowTests.fs" />
   </ItemGroup>
+
   <ItemGroup>
     <Reference Include="System.Runtime"/>
     <Reference Include="System.Threading.Tasks"/>
   </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="FsCheck.Xunit" Version="2.10.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
@@ -19,8 +25,10 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\OpenTK\OpenTK.csproj" />
   </ItemGroup>
+
   <Import Project="..\..\build\targets\netfx-mono.props" />
 </Project>

--- a/tests/OpenTK.Tests.Math/OpenTK.Tests.Math.csproj
+++ b/tests/OpenTK.Tests.Math/OpenTK.Tests.Math.csproj
@@ -1,20 +1,27 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
+
   <ItemGroup>
     <Reference Include="System.Runtime"/>
     <Reference Include="System.Threading.Tasks"/>
   </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\OpenTK\OpenTK.csproj" />
   </ItemGroup>
+
   <Import Project="..\..\build\targets\netfx-mono.props"/>
 </Project>

--- a/tests/OpenTK.Tests/OpenTK.Tests.fsproj
+++ b/tests/OpenTK.Tests/OpenTK.Tests.fsproj
@@ -2,8 +2,12 @@
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
     <Deterministic>true</Deterministic>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
+
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="Assertions.fs" />
@@ -15,10 +19,12 @@
     <Compile Include="Vector3Tests.fs" />
     <Compile Include="Vector4Tests.fs" />
   </ItemGroup>
+
   <ItemGroup>
     <Reference Include="System.Runtime"/>
     <Reference Include="System.Threading.Tasks"/>
   </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="FsCheck.Xunit" Version="2.10.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
@@ -26,8 +32,10 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\OpenTK\OpenTK.csproj" />
   </ItemGroup>
+
   <Import Project="..\..\build\targets\netfx-mono.props" />
 </Project>


### PR DESCRIPTION
This PR cleans up the build system and sets some ground rules for future contributions by enabling almost every single StyleCop rule.

On top of that, it introduces better organization in the project files by moving as many shared properties into importable files. A number of folders have also been added to the namespace provider exclusion list.
