### PR TITLE
Fix #USE_SDL2_GAMECONTROLLER code path

### DIFF
--- a/src/OpenTK/Platform/SDL2/Sdl2Factory.cs
+++ b/src/OpenTK/Platform/SDL2/Sdl2Factory.cs
@@ -96,6 +96,14 @@ namespace OpenTK.Platform.SDL2
             return GetInputDriver().JoystickDriver;
         }
 
+
+#if USE_SDL2_GAMECONTROLLER
+        public override IGamePadDriver CreateGamePadDriver()
+        {
+            return GetInputDriver().GamePadDriver;
+        }
+#endif
+
         protected override void Dispose(bool manual)
         {
             if (!IsDisposed)

--- a/src/OpenTK/Platform/SDL2/Sdl2JoystickDriver.cs
+++ b/src/OpenTK/Platform/SDL2/Sdl2JoystickDriver.cs
@@ -475,7 +475,7 @@ namespace OpenTK.Platform.SDL2
                                 GamePadType.GamePad,
                                 GetBoundAxes(joystick),
                                 GetBoundButtons(joystick),
-                                true);
+                                true, true);
                             pad.State.SetConnected(true);
 
                             // Connect this device and add the relevant device index
@@ -554,7 +554,7 @@ namespace OpenTK.Platform.SDL2
         }
 #endif
 
-#if USE_SDL2_GAMECONTOLLER
+#if USE_SDL2_GAMECONTROLLER
         public GamePadCapabilities GetCapabilities(int index)
         {
             if (IsControllerValid(index))
@@ -575,7 +575,16 @@ namespace OpenTK.Platform.SDL2
 
         public string GetName(int index)
         {
-            return String.Empty;
+            if (IsControllerValid(index))
+            {
+                return SDL.GameControllerName(controllers[index].Handle);
+            }
+            return string.Empty;
+        }
+
+        public bool SetVibration(int index, float left, float right)
+        {
+            return false;
         }
 #else
         public GamePadCapabilities GetCapabilities(int index)


### PR DESCRIPTION
Fix #USE_SDL2_GAMECONTROLLER code path

The code path was not actually using the SDL2 GameController API.

Added override for CreateGamePadDriver to Sdl2Factory so that the code path is actually used.
Fixed some small typos.
Note these changes are only in effect if #USE_SDL2_GAMECONTROLLER is defined.

### Purpose of this PR

The #USE_SDL2_GAMECONTROLLER code path was broken.  Due to a missing override of CreateGamePadDriver() in Sdl2Factory, it was using the mapped game controller driver which falls back to the SDL2 joystick api instead of the game controller api.  Since the SDL2 GameController api supports steam controller configuration and also maps many more gamepads than OpenTK, this is a very useful #define to have working.

This affects only the input portion of OpenTK, and only if #USE_SDL2_GAMECONTROLLER is defined, which by default it is not.

### Testing status

I have tested this with a variety of gamepads including XBox One controllers on two windows 10 machines using SDL 2.0.8
