### PR TITLE
Add common.props for use in all projects

### DIFF
--- a/build/targets/common.props
+++ b/build/targets/common.props
@@ -1,0 +1,5 @@
+<Project>
+    <PropertyGroup>
+        <Copyright>Copyright (c) 2006 - 2016 Stefanos Apostolopoulos (stapostol@gmail.com) for the Open Toolkit library.</Copyright>
+    <PropertyGroup>
+</Project>

--- a/build/targets/common.props
+++ b/build/targets/common.props
@@ -1,5 +1,5 @@
 <Project>
     <PropertyGroup>
-        <Copyright>Copyright (c) 2006 - 2016 Stefanos Apostolopoulos (stapostol@gmail.com) for the Open Toolkit library.</Copyright>
+        <Copyright>Copyright (c) 2006 - 2018 Stefanos Apostolopoulos (stapostol@gmail.com) for the Open Toolkit library.</Copyright>
     <PropertyGroup>
 </Project>

--- a/build/targets/nuget-common.props
+++ b/build/targets/nuget-common.props
@@ -1,7 +1,6 @@
 <Project>
     <PropertyGroup>
         <Authors>The OpenTK team.</Authors>
-        <Copyright>Copyright (c) 2006 - 2016 Stefanos Apostolopoulos (stapostol@gmail.com) for the Open Toolkit library.</Copyright>
         <PackageIconUrl>https://raw.githubusercontent.com/opentk/opentk/master/docs/files/img/logo.png</PackageIconUrl>
         <PackageLicenseUrl>https://opensource.org/licenses/MIT</PackageLicenseUrl>
         <PackageReleaseNotes>Initial 4.0 release.</PackageReleaseNotes>

--- a/src/Generator.Bind/Generator.Bind.csproj
+++ b/src/Generator.Bind/Generator.Bind.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="System.CodeDom" Version="4.5.0-preview2-26406-04" />
   </ItemGroup>
 
+  <Import Project="..\..\build\targets\common.props" />
   <Import Project="..\..\build\targets\netfx-mono.props" />
   <Import Project="..\..\build\targets\stylecop.props" />
 </Project>

--- a/src/Generator.Converter/Generator.Convert.csproj
+++ b/src/Generator.Converter/Generator.Convert.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="CommandLineParser" Version="2.2.1" />
   </ItemGroup>
 
+  <Import Project="..\..\build\targets\common.props" />
   <Import Project="..\..\build\targets\netfx-mono.props" />
   <Import Project="..\..\build\targets\stylecop.props" />
 </Project>

--- a/src/Generator.Rewrite/Generator.Rewrite.csproj
+++ b/src/Generator.Rewrite/Generator.Rewrite.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Mono.Cecil" Version="0.10.0" />
   </ItemGroup>
 
+  <Import Project="..\..\build\targets\common.props" />
   <Import Project="..\..\build\targets\netfx-mono.props" />
   <Import Project="..\..\build\targets\stylecop.props" />
 </Project>

--- a/src/OpenTK.Core/OpenTK.Core.csproj
+++ b/src/OpenTK.Core/OpenTK.Core.csproj
@@ -9,6 +9,7 @@
     <Description>Core shared functionality for the OpenTK library.</Description>
   </PropertyGroup>
 
+  <Import Project="..\..\build\targets\common.props" />
   <Import Project="..\..\build\targets\nuget-common.props" />
   <Import Project="..\..\build\targets\stylecop.props" />
 </Project>

--- a/src/OpenTK.GLControl/OpenTK.GLControl.csproj
+++ b/src/OpenTK.GLControl/OpenTK.GLControl.csproj
@@ -21,6 +21,7 @@
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
 
+  <Import Project="..\..\build\targets\common.props" />
   <Import Project="..\..\build\targets\nuget-common.props" />
   <Import Project="..\..\build\targets\netfx-mono.props" />
   <Import Project="..\..\build\targets\stylecop.props" />

--- a/src/OpenTK.GLWidget/OpenTK.GLWidget.csproj
+++ b/src/OpenTK.GLWidget/OpenTK.GLWidget.csproj
@@ -20,6 +20,7 @@
     <ProjectReference Include="..\..\src\OpenTK\OpenTK.csproj" />
   </ItemGroup>
 
+  <Import Project="..\..\build\targets\common.props" />
   <Import Project="..\..\build\targets\nuget-common.props" />
   <Import Project="..\..\build\targets\netfx-mono.props" />
   <Import Project="..\..\build\targets\stylecop.props" />

--- a/src/OpenTK.Mathematics/OpenTK.Mathematics.csproj
+++ b/src/OpenTK.Mathematics/OpenTK.Mathematics.csproj
@@ -11,6 +11,7 @@
     <Description>Mathematical structures and algorithms, provided and used by OpenTK.</Description>
   </PropertyGroup>
 
+  <Import Project="..\..\build\targets\common.props" />
   <Import Project="..\..\build\targets\nuget-common.props" />
   <Import Project="..\..\build\targets\stylecop.props" />
 </Project>

--- a/src/OpenTK.OpenAL/OpenTK.OpenAL.csproj
+++ b/src/OpenTK.OpenAL/OpenTK.OpenAL.csproj
@@ -16,6 +16,7 @@
     <ProjectReference Include="..\OpenTK.Mathematics\OpenTK.Mathematics.csproj" />
   </ItemGroup>
 
+  <Import Project="..\..\build\targets\common.props" />
   <Import Project="..\..\build\targets\nuget-common.props" />
   <Import Project="..\..\build\targets\stylecop.props" />
 </Project>

--- a/src/OpenTK/OpenTK.csproj
+++ b/src/OpenTK/OpenTK.csproj
@@ -24,6 +24,7 @@
     <Exec Condition="$(OS) != 'Windows_NT' and $(Configuration) == 'Release'" Command="mono $(ProjectDir)..\..\src\Generator.Rewrite/bin/Release/net461\Rewrite.exe --assembly $(OutputPath)OpenTK.dll" />
   </Target>
 
+  <Import Project="..\..\build\targets\common.props" />
   <Import Project="..\..\build\targets\nuget-common.props" />
   <Import Project="..\..\build\targets\netfx-mono.props" />
   <Import Project="..\..\build\targets\stylecop.props" />


### PR DESCRIPTION
### Purpose of this PR

* Adds a `common.props` that contains properties that should be in every project (currently only copyright)

### Comments

- No clue about the state of .iOS and .Android, they don't seem to have any of the other props files imported. I ignored them for now.