### PR TITLE
Fixed OpenGL 3.2+ Context Creation (Mixed up Profile Mask / Flags)

### DIFF
--- a/src/OpenTK/Platform/Windows/WinGLContext.cs
+++ b/src/OpenTK/Platform/Windows/WinGLContext.cs
@@ -225,16 +225,16 @@ namespace OpenTK.Platform.Windows
         private static ArbCreateContext GetARBContextFlags(GraphicsContextFlags flags)
         {
             ArbCreateContext result = 0;
-            result |= (flags & GraphicsContextFlags.ForwardCompatible) != 0
-                ? ArbCreateContext.CoreProfileBit
-                : ArbCreateContext.CompatibilityProfileBit;
+            result |= (flags & GraphicsContextFlags.Debug) != 0 ? ArbCreateContext.DebugBit : 0;
             return result;
         }
 
         private static ArbCreateContext GetARBContextProfile(GraphicsContextFlags flags)
         {
             ArbCreateContext result = 0;
-            result |= (flags & GraphicsContextFlags.Debug) != 0 ? ArbCreateContext.DebugBit : 0;
+            result |= (flags & GraphicsContextFlags.ForwardCompatible) != 0
+                ? ArbCreateContext.CoreProfileBit
+                : ArbCreateContext.CompatibilityProfileBit;
             return result;
         }
 


### PR DESCRIPTION
Checking out an OpenTK based application I'm developing with the latest [RenderDoc](https://renderdoc.org/), an error pops up noting that only OpenGL 3.2+ is supported, because wglCreateContext was used instead of wglCreateContextAttributesARB - even when the OpenTK GameWindow is created with OpenGL 3.2 explicitly.

A more thorough look revealed that the [modern context creation fails](https://github.com/opentk/opentk/blob/a9ede77dc761780263b1cf9d69d80ea8277e2348/src/OpenTK/Platform/Windows/WinGLContext.cs#L72-L114), so [a fallback with the old / GL2 wglCreateContext](https://github.com/opentk/opentk/blob/a9ede77dc761780263b1cf9d69d80ea8277e2348/src/OpenTK/Platform/Windows/WinGLContext.cs#L116-L131) is used. Context creation does not fail when specifying the debug flag in the GameWindow constructor.

According to [this specification](https://www.khronos.org/registry/OpenGL/extensions/ARB/WGL_ARB_create_context.txt), it seems OpenTK got the usage of profile mask (core, compatibility) and flags (forward, debug) mixed up, which just happened to work when the debug flag was set, because the flags have similar numerical values.

The profile mask (`WGL_CONTEXT_PROFILE_MASK_ARB` / `0x9126`) specifies:

- `WGL_CONTEXT_CORE_PROFILE_BIT_ARB` / `0x00000001`
- `WGL_CONTEXT_COMPATIBILITY_PROFILE_BIT_ARB` / `0x00000002`

which were previously determined in `GetARBContextFlags`. On the other hand, the context flags (`WGL_CONTEXT_FLAGS_ARB` / `0x2094`) specify:

- `WGL_CONTEXT_DEBUG_BIT_ARB` / `0x0001`
- `WGL_CONTEXT_FORWARD_COMPATIBLE_BIT_ARB` / `0x0002` (Note: Unused in OpenTK and not the same as the OpenTK ForwardCompatible flag, which actually maps o selecting the core profile, but I believe this is intended. The actual OpenGL forward compatible bit should, apparently, never be set in production anyway.)

So it seems the two context attributes just got mixed up. After testing my application with the changes in this PR, it seemed to work just fine. I'll monitor it, but would be interested in your thoughts.
