### PR TITLE
[4.0] Fix CI scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,4 @@
 language: csharp
-
-sudo: false  # use the new container-based Travis infrastructure
-
-before_install:
-  - chmod +x build.sh
-
-before_script:
- # Start a virtual framebuffer as described: https://docs.travis-ci.com/user/gui-and-headless-browsers/
- - "export DISPLAY=:99.0"
- - "sh -e /etc/init.d/xvfb start"
- - sleep 3 # give xvfb some time to start
-
-script:
-  - travis_wait ./build.sh NuGet
-  - mono .paket/paket.exe install
-  - git diff --exit-code
-
-after_script:
-  - mono --debug --profile=log:coverage,covfilter=+OpenTK,covfilter=-OpenTK.Tests,covfilter=-FSharp.Core,covfilter=-FsCheck,covfilter=-xunit.assert "packages/xunit.runner.console/tools/xunit.console.exe"  "tests/OpenTK.Tests/bin/Release/OpenTK.Tests.dll" -parallel none
-  - mprof-report --reports=coverage --coverage-out=coverage.xml output.mlpd
-  - bash <(curl -s https://codecov.io/bash)
+solution: OpenTK.sln
+install:
+  - nuget restore -Verbosity quiet $TRAVIS_SOLUTION

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: csharp
+
 mono: latest
 dotnet: 2.1.3
+
 solution: OpenTK.sln
+
 install:
   - dotnet restore -v quiet $TRAVIS_SOLUTION

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: csharp
+mono: latest
+dotnet: 2.1.3
 solution: OpenTK.sln
 install:
-  - nuget restore -Verbosity quiet $TRAVIS_SOLUTION
+  - dotnet restore -v quiet $TRAVIS_SOLUTION

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,11 +1,11 @@
 image: Visual Studio 2017
+version: 4.0.0.{build}
 init:
   - git config --global core.autocrlf input
-build_script:
-  - cmd: build.cmd NuGet
-  - cmd: .paket\paket.exe install
-  - cmd: git diff --exit-code
-test: off
-version: 0.0.1.{build}
-artifacts:
-  - path: 'bin\*.nupkg'
+before_build:
+  - cmd: nuget restore -Verbosity quiet OpenTK.sln
+configuration: Release
+build:
+  project: OpenTK.sln
+  parallel: true
+  verbosity: minimal

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,10 +1,15 @@
 image: Visual Studio 2017
+
 version: 4.0.0.{build}
+
 init:
   - git config --global core.autocrlf input
+
 before_build:
   - cmd: nuget restore -Verbosity quiet OpenTK.sln
+
 configuration: Release
+
 build:
   project: OpenTK.sln
   parallel: true


### PR DESCRIPTION
### Purpose of this PR

- Re-enables CI scripts to be run on AppVeyor (.NET Core) and Travis (Mono)
    - Currently missing test execution and code coverage tools of any sort, since there are no tests in the new .sln yet

### Testing status

- Tested in my fork, works perfectly from what I can tell (just check this PR for the CI status to see it)