### PR TITLE
Fix: Custom cursors not working under OS-X and dotnet

### DIFF
--- a/src/OpenTK/Platform/MacOS/Cocoa/Cocoa.cs
+++ b/src/OpenTK/Platform/MacOS/Cocoa/Cocoa.cs
@@ -96,7 +96,7 @@ namespace OpenTK.Platform.MacOS
 
         [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
         public static extern IntPtr SendIntPtr(IntPtr receiver, IntPtr selector, IntPtr p1, int p2, int p3, int p4,
-            int p5, int p6, int p7, IntPtr p8, NSBitmapFormat p9, int p10, int p11);
+            int p5, bool p6, bool p7, IntPtr p8, NSBitmapFormat p9, int p10, int p11);
 
         [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
         public static extern bool SendBool(IntPtr receiver, IntPtr selector);

--- a/src/OpenTK/Platform/MacOS/CocoaNativeWindow.cs
+++ b/src/OpenTK/Platform/MacOS/CocoaNativeWindow.cs
@@ -1108,15 +1108,15 @@ namespace OpenTK.Platform.MacOS
                     cursor.Height,
                     8,
                     4,
-                    1,
-                    0,
+                    true,
+                    false,
                     NSDeviceRGBColorSpace,
                     NSBitmapFormat.AlphaFirst,
                     4 * cursor.Width,
                     32);
             if (imgdata == IntPtr.Zero)
             {
-                Debug.Print("Failed to create NSBitmapImageRep with size ({0},{1]})",
+                Debug.Print("Failed to create NSBitmapImageRep with size ({0},{1})",
                     cursor.Width, cursor.Height);
                 return IntPtr.Zero;
             }


### PR DESCRIPTION
Rebased version of https://github.com/opentk/opentk/pull/764

### Purpose of this PR

* Fixes custom cursors not working under dotnet on OS-X

### Testing status

* Tested by the original PR proposer. Basic test by myself also.

### Comments

Original proposer doesn't seem to be rebasing this, and it would appear to be correct. If I'm reading the Apple docs correctly, the two changed bools would be Alpha and IsPlanar.