### PR TITLE
Fix OpenTK.NT compilation errors

### DIFF
--- a/src/OpenTK.NT/Native/User32/Structs/BroadcastDeviceInterface.cs
+++ b/src/OpenTK.NT/Native/User32/Structs/BroadcastDeviceInterface.cs
@@ -49,7 +49,7 @@ namespace OpenTK.NT.Native
         /// <summary>
         /// The first character of the <see cref="Name"/>.
         /// </summary>
-        private readonly char _name;
+        private char _name;
 
         /// <summary>
         /// The size of this structure in bytes.

--- a/src/OpenTK.NT/Native/User32/Structs/DeviceMode.cs
+++ b/src/OpenTK.NT/Native/User32/Structs/DeviceMode.cs
@@ -139,7 +139,7 @@ namespace OpenTK.NT.Native
         /// property exists.
         /// </summary>
         [FieldOffset(102)]
-        private readonly char _formName;
+        private char _formName;
 
         /// <summary>
         /// For displays, specifies the number of logical pixels per inch of a display device and should be equal


### PR DESCRIPTION
Two fields in NT were declared as readonly, but their address need to be taken at runtime. This is not valid. The readonly modifiers have been removed.