### PR TITLE
Fix csproj references to target netstandard2.0 instead of net461.

### DIFF
--- a/src/Generator.Bind/Generator.Bind.csproj
+++ b/src/Generator.Bind/Generator.Bind.csproj
@@ -3,7 +3,7 @@
     <OutputType>Exe</OutputType>
     <AssemblyName>Bind</AssemblyName>
     <RootNamespace>Bind</RootNamespace>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Deterministic>true</Deterministic>
   </PropertyGroup>
 

--- a/src/OpenTK.OpenAL/OpenTK.OpenAL.csproj
+++ b/src/OpenTK.OpenAL/OpenTK.OpenAL.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Deterministic>true</Deterministic>
   </PropertyGroup>


### PR DESCRIPTION
`Generator.Bind.csproj` and `OpenTK.OpenAL.csproj` both still target `net461`. Both were able to build after transitioning to `netstandard2.0`.