### PR TITLE
 [4.0] refactored .Math stylecop errors

### DIFF
--- a/src/OpenTK.Core/Platform/PlatformException.cs
+++ b/src/OpenTK.Core/Platform/PlatformException.cs
@@ -8,14 +8,14 @@ namespace OpenTK.Core.Platform
     public class PlatformException : Exception
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="PlatformException" /> class.
+        /// Initializes a new instance of the <see cref="PlatformException"/> class.
         /// </summary>
         public PlatformException()
         {
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="PlatformException" /> class.
+        /// Initializes a new instance of the <see cref="PlatformException"/> class.
         /// </summary>
         /// <param name="message">A message explaining the cause for this exception.</param>
         public PlatformException(string message)

--- a/src/OpenTK.Core/Utility/BlittableValueType{T}.cs
+++ b/src/OpenTK.Core/Utility/BlittableValueType{T}.cs
@@ -1,4 +1,29 @@
-﻿using System;
+﻿//
+// The Open Toolkit Library License
+//
+// Copyright (c) 2006 - 2010 the Open Toolkit library.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do
+// so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;

--- a/src/OpenTK.Mathematics/Data/Color4.cs
+++ b/src/OpenTK.Mathematics/Data/Color4.cs
@@ -1345,7 +1345,7 @@ namespace OpenTK.Mathematics
                 b = 0.0f;
             }
 
-            var m = luminance - ((0.30f * r) + (0.59f * g) + (0.11f * b));
+            var m = luminance - (0.30f * r) + (0.59f * g) + (0.11f * b);
             return new Color4(r + m, g + m, b + m, hcy.W);
         }
 

--- a/src/OpenTK.Mathematics/Data/Half.cs
+++ b/src/OpenTK.Mathematics/Data/Half.cs
@@ -406,14 +406,14 @@ namespace OpenTK.Mathematics
         /// Initializes a new instance of the <see cref="Half"/> struct.
         /// Used by <see cref="ISerializable"/> to deserialize the object.
         /// </summary>
+        /// <param name="info">The object that contains a serialized <see cref="Half"/> struct.</param>
+        /// <param name="context">The destination for this serialization. (This parameter is not used; specify null.).</param>
         public Half(SerializationInfo info, StreamingContext context)
         {
             _bits = (ushort)info.GetValue("bits", typeof(ushort));
         }
 
-        /// <summary>
-        /// Used by <see cref="ISerializable"/> to serialize the object.
-        /// </summary>
+        /// <inheritdoc/>
         public void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             info.AddValue("bits", _bits);

--- a/src/OpenTK.Mathematics/Data/Quaternion.cs
+++ b/src/OpenTK.Mathematics/Data/Quaternion.cs
@@ -191,7 +191,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Returns a copy of the Quaternion scaled to unit length.
         /// </summary>
-        /// <returns>The normalized copy.</returns>
+        /// <returns>The normalized Quaternion.</returns>
         public Quaternion Normalized()
         {
             var q = this;
@@ -210,7 +210,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Returns a copy of this Quaterniond with its rotation angle reversed.
         /// </summary>
-        /// <returns>The inverted copy.</returns>
+        /// <returns>The inverted Quaternion.</returns>
         public Quaternion Inverted()
         {
             var q = this;

--- a/src/OpenTK.Mathematics/Data/Quaternion.cs
+++ b/src/OpenTK.Mathematics/Data/Quaternion.cs
@@ -210,7 +210,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Returns a copy of this Quaterniond with its rotation angle reversed.
         /// </summary>
-        /// <returns>The inverted Quaternion.</returns>
+        /// <returns>The inverted copy.</returns>
         public Quaternion Inverted()
         {
             var q = this;

--- a/src/OpenTK.Mathematics/Data/Quaternion.cs
+++ b/src/OpenTK.Mathematics/Data/Quaternion.cs
@@ -191,7 +191,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Returns a copy of the Quaternion scaled to unit length.
         /// </summary>
-        /// <returns>The normalized Quaternion.</returns>
+        /// <returns>The normalized copy.</returns>
         public Quaternion Normalized()
         {
             var q = this;
@@ -406,7 +406,7 @@ namespace OpenTK.Mathematics
         /// Scale the given quaternion to unit length.
         /// </summary>
         /// <param name="q">The quaternion to normalize.</param>
-        /// <returns>The normalized quaternion.</returns>
+        /// <returns>The normalized copy.</returns>
         public static Quaternion Normalize(Quaternion q)
         {
             Normalize(ref q, out Quaternion result);

--- a/src/OpenTK.Mathematics/Data/Quaterniond.cs
+++ b/src/OpenTK.Mathematics/Data/Quaterniond.cs
@@ -187,7 +187,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Returns a copy of the Quaterniond scaled to unit length.
         /// </summary>
-        /// <returns>The normalized quaternion.</returns>
+        /// <returns>The normalized copy.</returns>
         public Quaterniond Normalized()
         {
             var q = this;
@@ -206,7 +206,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Returns a copy of this Quaterniond with its rotation angle reversed.
         /// </summary>
-        /// <returns>The inverted quaternion.</returns>
+        /// <returns>The inverted copy.</returns>
         public Quaterniond Inverted()
         {
             var q = this;
@@ -402,7 +402,7 @@ namespace OpenTK.Mathematics
         /// Scale the given Quaterniond to unit length.
         /// </summary>
         /// <param name="q">The Quaterniond to normalize.</param>
-        /// <returns>The normalized Quaterniond.</returns>
+        /// <returns>The normalized copy.</returns>
         public static Quaterniond Normalize(Quaterniond q)
         {
             Normalize(ref q, out Quaterniond result);

--- a/src/OpenTK.Mathematics/MathHelper.cs
+++ b/src/OpenTK.Mathematics/MathHelper.cs
@@ -189,23 +189,20 @@ namespace OpenTK.Mathematics
         /// which is found in the Quake III source code. This implementation comes from
         /// http://www.codemaestro.com/reviews/review00000105.html. For the history of this method, see
         /// http://www.beyond3d.com/content/articles/8/.
+        /// double magic number from: https://cs.uwaterloo.ca/~m32rober/rsqrt.pdf
+        /// chapter 4.8.
         /// </remarks>
         public static double InverseSqrtFast(double x)
         {
-            return InverseSqrtFast((float)x);
-
-            // TODO: The following code is wrong. Fix it, to improve precision.
-#if false
             unsafe
             {
-                double xhalf = 0.5f * x;
-                int i = *(int*)&x;              // Read bits as integer.
-                i = 0x5f375a86 - (i >> 1);      // Make an initial guess for Newton-Raphson approximation
-                x = *(float*)&i;                // Convert bits back to float
-                x = x * (1.5f - xhalf * x * x); // Perform left single Newton-Raphson step.
+                double xhalf = 0.5 * x;
+                long i = *(long*)&x; // Read bits as long.
+                i = 0x5fe6eb50c7b537a9 - (i >> 1); // Make an initial guess for Newton-Raphson approximation
+                x = *(double*)&i; // Convert bits back to double
+                x = x * (1.5 - (xhalf * x * x)); // Perform left single Newton-Raphson step.
                 return x;
             }
-#endif
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Matrix/Matrix2.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix2.cs
@@ -21,6 +21,7 @@ SOFTWARE.
  */
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace OpenTK.Mathematics
 {
@@ -67,13 +68,10 @@ namespace OpenTK.Mathematics
         /// <param name="m01">Second item of the first row of the matrix.</param>
         /// <param name="m10">First item of the second row of the matrix.</param>
         /// <param name="m11">Second item of the second row of the matrix.</param>
-        public Matrix2
-        (
-            float m00,
-            float m01,
-            float m10,
-            float m11
-        )
+        [SuppressMessage("ReSharper", "SA1117", Justification = "For better readability of Matrix struct.")]
+        public Matrix2(
+            float m00, float m01,
+            float m10, float m11)
         {
             Row0 = new Vector2(m00, m01);
             Row1 = new Vector2(m10, m11);
@@ -180,6 +178,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="rowIndex">The index of the row.</param>
         /// <param name="columnIndex">The index of the column.</param>
+        /// <returns>The element at the given row and column index.</returns>
         public float this[int rowIndex, int columnIndex]
         {
             get
@@ -367,19 +366,19 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix2 left, ref Matrix2 right, out Matrix2 result)
         {
-            float lM11 = left.Row0.X,
-                lM12 = left.Row0.Y,
-                lM21 = left.Row1.X,
-                lM22 = left.Row1.Y,
-                rM11 = right.Row0.X,
-                rM12 = right.Row0.Y,
-                rM21 = right.Row1.X,
-                rM22 = right.Row1.Y;
+            float leftM11 = left.Row0.X,
+                leftM12 = left.Row0.Y,
+                leftM21 = left.Row1.X,
+                leftM22 = left.Row1.Y,
+                rightM11 = right.Row0.X,
+                rightM12 = right.Row0.Y,
+                rightM21 = right.Row1.X,
+                rightM22 = right.Row1.Y;
 
-            result.Row0.X = (lM11 * rM11) + (lM12 * rM21);
-            result.Row0.Y = (lM11 * rM12) + (lM12 * rM22);
-            result.Row1.X = (lM21 * rM11) + (lM22 * rM21);
-            result.Row1.Y = (lM21 * rM12) + (lM22 * rM22);
+            result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21);
+            result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22);
+            result.Row1.X = (leftM21 * rightM11) + (leftM22 * rightM21);
+            result.Row1.Y = (leftM21 * rightM12) + (leftM22 * rightM22);
         }
 
         /// <summary>
@@ -402,23 +401,23 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix2 left, ref Matrix2x3 right, out Matrix2x3 result)
         {
-            float lM11 = left.Row0.X,
-                lM12 = left.Row0.Y,
-                lM21 = left.Row1.X,
-                lM22 = left.Row1.Y,
-                rM11 = right.Row0.X,
-                rM12 = right.Row0.Y,
-                rM13 = right.Row0.Z,
-                rM21 = right.Row1.X,
-                rM22 = right.Row1.Y,
-                rM23 = right.Row1.Z;
+            float leftM11 = left.Row0.X,
+                leftM12 = left.Row0.Y,
+                leftM21 = left.Row1.X,
+                leftM22 = left.Row1.Y,
+                rightM11 = right.Row0.X,
+                rightM12 = right.Row0.Y,
+                rightM13 = right.Row0.Z,
+                rightM21 = right.Row1.X,
+                rightM22 = right.Row1.Y,
+                rightM23 = right.Row1.Z;
 
-            result.Row0.X = (lM11 * rM11) + (lM12 * rM21);
-            result.Row0.Y = (lM11 * rM12) + (lM12 * rM22);
-            result.Row0.Z = (lM11 * rM13) + (lM12 * rM23);
-            result.Row1.X = (lM21 * rM11) + (lM22 * rM21);
-            result.Row1.Y = (lM21 * rM12) + (lM22 * rM22);
-            result.Row1.Z = (lM21 * rM13) + (lM22 * rM23);
+            result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21);
+            result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22);
+            result.Row0.Z = (leftM11 * rightM13) + (leftM12 * rightM23);
+            result.Row1.X = (leftM21 * rightM11) + (leftM22 * rightM21);
+            result.Row1.Y = (leftM21 * rightM12) + (leftM22 * rightM22);
+            result.Row1.Z = (leftM21 * rightM13) + (leftM22 * rightM23);
         }
 
         /// <summary>
@@ -441,27 +440,27 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix2 left, ref Matrix2x4 right, out Matrix2x4 result)
         {
-            float lM11 = left.Row0.X,
-                lM12 = left.Row0.Y,
-                lM21 = left.Row1.X,
-                lM22 = left.Row1.Y,
-                rM11 = right.Row0.X,
-                rM12 = right.Row0.Y,
-                rM13 = right.Row0.Z,
-                rM14 = right.Row0.W,
-                rM21 = right.Row1.X,
-                rM22 = right.Row1.Y,
-                rM23 = right.Row1.Z,
-                rM24 = right.Row1.W;
+            float leftM11 = left.Row0.X,
+                leftM12 = left.Row0.Y,
+                leftM21 = left.Row1.X,
+                leftM22 = left.Row1.Y,
+                rightM11 = right.Row0.X,
+                rightM12 = right.Row0.Y,
+                rightM13 = right.Row0.Z,
+                rightM14 = right.Row0.W,
+                rightM21 = right.Row1.X,
+                rightM22 = right.Row1.Y,
+                rightM23 = right.Row1.Z,
+                rightM24 = right.Row1.W;
 
-            result.Row0.X = (lM11 * rM11) + (lM12 * rM21);
-            result.Row0.Y = (lM11 * rM12) + (lM12 * rM22);
-            result.Row0.Z = (lM11 * rM13) + (lM12 * rM23);
-            result.Row0.W = (lM11 * rM14) + (lM12 * rM24);
-            result.Row1.X = (lM21 * rM11) + (lM22 * rM21);
-            result.Row1.Y = (lM21 * rM12) + (lM22 * rM22);
-            result.Row1.Z = (lM21 * rM13) + (lM22 * rM23);
-            result.Row1.W = (lM21 * rM14) + (lM22 * rM24);
+            result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21);
+            result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22);
+            result.Row0.Z = (leftM11 * rightM13) + (leftM12 * rightM23);
+            result.Row0.W = (leftM11 * rightM14) + (leftM12 * rightM24);
+            result.Row1.X = (leftM21 * rightM11) + (leftM22 * rightM21);
+            result.Row1.Y = (leftM21 * rightM12) + (leftM22 * rightM22);
+            result.Row1.Z = (leftM21 * rightM13) + (leftM22 * rightM23);
+            result.Row1.W = (leftM21 * rightM14) + (leftM22 * rightM24);
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Matrix/Matrix2.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix2.cs
@@ -69,9 +69,11 @@ namespace OpenTK.Mathematics
         /// <param name="m10">First item of the second row of the matrix.</param>
         /// <param name="m11">Second item of the second row of the matrix.</param>
         [SuppressMessage("ReSharper", "SA1117", Justification = "For better readability of Matrix struct.")]
-        public Matrix2(
+        public Matrix2
+        (
             float m00, float m01,
-            float m10, float m11)
+            float m10, float m11
+        )
         {
             Row0 = new Vector2(m00, m01);
             Row1 = new Vector2(m10, m11);
@@ -84,10 +86,10 @@ namespace OpenTK.Mathematics
         {
             get
             {
-                float m11 = Row0.X,
-                    m12 = Row0.Y,
-                    m21 = Row1.X,
-                    m22 = Row1.Y;
+                float m11 = Row0.X;
+                float m12 = Row0.Y;
+                float m21 = Row1.X;
+                float m22 = Row1.Y;
 
                 return (m11 * m22) - (m12 * m21);
             }
@@ -366,14 +368,14 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix2 left, ref Matrix2 right, out Matrix2 result)
         {
-            float leftM11 = left.Row0.X,
-                leftM12 = left.Row0.Y,
-                leftM21 = left.Row1.X,
-                leftM22 = left.Row1.Y,
-                rightM11 = right.Row0.X,
-                rightM12 = right.Row0.Y,
-                rightM21 = right.Row1.X,
-                rightM22 = right.Row1.Y;
+            float leftM11 = left.Row0.X;
+            float leftM12 = left.Row0.Y;
+            float leftM21 = left.Row1.X;
+            float leftM22 = left.Row1.Y;
+            float rightM11 = right.Row0.X;
+            float rightM12 = right.Row0.Y;
+            float rightM21 = right.Row1.X;
+            float rightM22 = right.Row1.Y;
 
             result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21);
             result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22);
@@ -401,16 +403,16 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix2 left, ref Matrix2x3 right, out Matrix2x3 result)
         {
-            float leftM11 = left.Row0.X,
-                leftM12 = left.Row0.Y,
-                leftM21 = left.Row1.X,
-                leftM22 = left.Row1.Y,
-                rightM11 = right.Row0.X,
-                rightM12 = right.Row0.Y,
-                rightM13 = right.Row0.Z,
-                rightM21 = right.Row1.X,
-                rightM22 = right.Row1.Y,
-                rightM23 = right.Row1.Z;
+            float leftM11 = left.Row0.X;
+            float leftM12 = left.Row0.Y;
+            float leftM21 = left.Row1.X;
+            float leftM22 = left.Row1.Y;
+            float rightM11 = right.Row0.X;
+            float rightM12 = right.Row0.Y;
+            float rightM13 = right.Row0.Z;
+            float rightM21 = right.Row1.X;
+            float rightM22 = right.Row1.Y;
+            float rightM23 = right.Row1.Z;
 
             result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21);
             result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22);
@@ -440,18 +442,18 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix2 left, ref Matrix2x4 right, out Matrix2x4 result)
         {
-            float leftM11 = left.Row0.X,
-                leftM12 = left.Row0.Y,
-                leftM21 = left.Row1.X,
-                leftM22 = left.Row1.Y,
-                rightM11 = right.Row0.X,
-                rightM12 = right.Row0.Y,
-                rightM13 = right.Row0.Z,
-                rightM14 = right.Row0.W,
-                rightM21 = right.Row1.X,
-                rightM22 = right.Row1.Y,
-                rightM23 = right.Row1.Z,
-                rightM24 = right.Row1.W;
+            float leftM11 = left.Row0.X;
+            float leftM12 = left.Row0.Y;
+            float leftM21 = left.Row1.X;
+            float leftM22 = left.Row1.Y;
+            float rightM11 = right.Row0.X;
+            float rightM12 = right.Row0.Y;
+            float rightM13 = right.Row0.Z;
+            float rightM14 = right.Row0.W;
+            float rightM21 = right.Row1.X;
+            float rightM22 = right.Row1.Y;
+            float rightM23 = right.Row1.Z;
+            float rightM24 = right.Row1.W;
 
             result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21);
             result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22);
@@ -556,7 +558,7 @@ namespace OpenTK.Mathematics
         /// <param name="mat">The matrix to invert.</param>
         /// <returns>The inverse of the given matrix.</returns>
         /// <exception cref="InvalidOperationException">Thrown if the Matrix2 is singular.</exception>
-        /// <returns>The inverted matrix.</returns>
+        /// <returns>The inverted copy.</returns>
         public static Matrix2 Invert(Matrix2 mat)
         {
             Invert(ref mat, out Matrix2 result);

--- a/src/OpenTK.Mathematics/Matrix/Matrix2d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix2d.cs
@@ -69,9 +69,11 @@ namespace OpenTK.Mathematics
         /// <param name="m10">First item of the second row of the matrix.</param>
         /// <param name="m11">Second item of the second row of the matrix.</param>
         [SuppressMessage("ReSharper", "SA1117", Justification = "For better readability of Matrix struct.")]
-        public Matrix2d(
+        public Matrix2d
+        (
             double m00, double m01,
-            double m10, double m11)
+            double m10, double m11
+        )
         {
             Row0 = new Vector2d(m00, m01);
             Row1 = new Vector2d(m10, m11);
@@ -84,10 +86,10 @@ namespace OpenTK.Mathematics
         {
             get
             {
-                double m11 = Row0.X,
-                    m12 = Row0.Y,
-                    m21 = Row1.X,
-                    m22 = Row1.Y;
+                double m11 = Row0.X;
+                double m12 = Row0.Y;
+                double m21 = Row1.X;
+                double m22 = Row1.Y;
 
                 return (m11 * m22) - (m12 * m21);
             }
@@ -366,14 +368,14 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix2d left, ref Matrix2d right, out Matrix2d result)
         {
-            double leftM11 = left.Row0.X,
-                leftM12 = left.Row0.Y,
-                leftM21 = left.Row1.X,
-                leftM22 = left.Row1.Y,
-                rightM11 = right.Row0.X,
-                rightM12 = right.Row0.Y,
-                rightM21 = right.Row1.X,
-                rightM22 = right.Row1.Y;
+            double leftM11 = left.Row0.X;
+            double leftM12 = left.Row0.Y;
+            double leftM21 = left.Row1.X;
+            double leftM22 = left.Row1.Y;
+            double rightM11 = right.Row0.X;
+            double rightM12 = right.Row0.Y;
+            double rightM21 = right.Row1.X;
+            double rightM22 = right.Row1.Y;
 
             result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21);
             result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22);
@@ -401,16 +403,16 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix2d left, ref Matrix2x3d right, out Matrix2x3d result)
         {
-            double leftM11 = left.Row0.X,
-                leftM12 = left.Row0.Y,
-                leftM21 = left.Row1.X,
-                leftM22 = left.Row1.Y,
-                rightM11 = right.Row0.X,
-                rightM12 = right.Row0.Y,
-                rightM13 = right.Row0.Z,
-                rightM21 = right.Row1.X,
-                rightM22 = right.Row1.Y,
-                rightM23 = right.Row1.Z;
+            double leftM11 = left.Row0.X;
+            double leftM12 = left.Row0.Y;
+            double leftM21 = left.Row1.X;
+            double leftM22 = left.Row1.Y;
+            double rightM11 = right.Row0.X;
+            double rightM12 = right.Row0.Y;
+            double rightM13 = right.Row0.Z;
+            double rightM21 = right.Row1.X;
+            double rightM22 = right.Row1.Y;
+            double rightM23 = right.Row1.Z;
 
             result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21);
             result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22);
@@ -440,18 +442,18 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix2d left, ref Matrix2x4d right, out Matrix2x4d result)
         {
-            double leftM11 = left.Row0.X,
-                leftM12 = left.Row0.Y,
-                leftM21 = left.Row1.X,
-                leftM22 = left.Row1.Y,
-                rightM11 = right.Row0.X,
-                rightM12 = right.Row0.Y,
-                rightM13 = right.Row0.Z,
-                rightM14 = right.Row0.W,
-                rightM21 = right.Row1.X,
-                rightM22 = right.Row1.Y,
-                rightM23 = right.Row1.Z,
-                rightM24 = right.Row1.W;
+            double leftM11 = left.Row0.X;
+            double leftM12 = left.Row0.Y;
+            double leftM21 = left.Row1.X;
+            double leftM22 = left.Row1.Y;
+            double rightM11 = right.Row0.X;
+            double rightM12 = right.Row0.Y;
+            double rightM13 = right.Row0.Z;
+            double rightM14 = right.Row0.W;
+            double rightM21 = right.Row1.X;
+            double rightM22 = right.Row1.Y;
+            double rightM23 = right.Row1.Z;
+            double rightM24 = right.Row1.W;
 
             result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21);
             result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22);
@@ -556,7 +558,7 @@ namespace OpenTK.Mathematics
         /// <param name="mat">The matrix to invert.</param>
         /// <returns>The inverse of the given matrix.</returns>
         /// <exception cref="InvalidOperationException">Thrown if the Matrix2d is singular.</exception>
-        /// <returns>The inverted matrix.</returns>
+        /// <returns>The inverted copy.</returns>
         public static Matrix2d Invert(Matrix2d mat)
         {
             Invert(ref mat, out Matrix2d result);

--- a/src/OpenTK.Mathematics/Matrix/Matrix2d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix2d.cs
@@ -21,6 +21,7 @@ SOFTWARE.
  */
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace OpenTK.Mathematics
 {
@@ -67,13 +68,10 @@ namespace OpenTK.Mathematics
         /// <param name="m01">Second item of the first row of the matrix.</param>
         /// <param name="m10">First item of the second row of the matrix.</param>
         /// <param name="m11">Second item of the second row of the matrix.</param>
-        public Matrix2d
-        (
-            double m00,
-            double m01,
-            double m10,
-            double m11
-        )
+        [SuppressMessage("ReSharper", "SA1117", Justification = "For better readability of Matrix struct.")]
+        public Matrix2d(
+            double m00, double m01,
+            double m10, double m11)
         {
             Row0 = new Vector2d(m00, m01);
             Row1 = new Vector2d(m10, m11);
@@ -180,6 +178,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="rowIndex">The index of the row.</param>
         /// <param name="columnIndex">The index of the column.</param>
+        /// <returns>The element at the given row and column index.</returns>
         public double this[int rowIndex, int columnIndex]
         {
             get
@@ -367,19 +366,19 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix2d left, ref Matrix2d right, out Matrix2d result)
         {
-            double lM11 = left.Row0.X,
-                lM12 = left.Row0.Y,
-                lM21 = left.Row1.X,
-                lM22 = left.Row1.Y,
-                rM11 = right.Row0.X,
-                rM12 = right.Row0.Y,
-                rM21 = right.Row1.X,
-                rM22 = right.Row1.Y;
+            double leftM11 = left.Row0.X,
+                leftM12 = left.Row0.Y,
+                leftM21 = left.Row1.X,
+                leftM22 = left.Row1.Y,
+                rightM11 = right.Row0.X,
+                rightM12 = right.Row0.Y,
+                rightM21 = right.Row1.X,
+                rightM22 = right.Row1.Y;
 
-            result.Row0.X = (lM11 * rM11) + (lM12 * rM21);
-            result.Row0.Y = (lM11 * rM12) + (lM12 * rM22);
-            result.Row1.X = (lM21 * rM11) + (lM22 * rM21);
-            result.Row1.Y = (lM21 * rM12) + (lM22 * rM22);
+            result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21);
+            result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22);
+            result.Row1.X = (leftM21 * rightM11) + (leftM22 * rightM21);
+            result.Row1.Y = (leftM21 * rightM12) + (leftM22 * rightM22);
         }
 
         /// <summary>
@@ -402,23 +401,23 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix2d left, ref Matrix2x3d right, out Matrix2x3d result)
         {
-            double lM11 = left.Row0.X,
-                lM12 = left.Row0.Y,
-                lM21 = left.Row1.X,
-                lM22 = left.Row1.Y,
-                rM11 = right.Row0.X,
-                rM12 = right.Row0.Y,
-                rM13 = right.Row0.Z,
-                rM21 = right.Row1.X,
-                rM22 = right.Row1.Y,
-                rM23 = right.Row1.Z;
+            double leftM11 = left.Row0.X,
+                leftM12 = left.Row0.Y,
+                leftM21 = left.Row1.X,
+                leftM22 = left.Row1.Y,
+                rightM11 = right.Row0.X,
+                rightM12 = right.Row0.Y,
+                rightM13 = right.Row0.Z,
+                rightM21 = right.Row1.X,
+                rightM22 = right.Row1.Y,
+                rightM23 = right.Row1.Z;
 
-            result.Row0.X = (lM11 * rM11) + (lM12 * rM21);
-            result.Row0.Y = (lM11 * rM12) + (lM12 * rM22);
-            result.Row0.Z = (lM11 * rM13) + (lM12 * rM23);
-            result.Row1.X = (lM21 * rM11) + (lM22 * rM21);
-            result.Row1.Y = (lM21 * rM12) + (lM22 * rM22);
-            result.Row1.Z = (lM21 * rM13) + (lM22 * rM23);
+            result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21);
+            result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22);
+            result.Row0.Z = (leftM11 * rightM13) + (leftM12 * rightM23);
+            result.Row1.X = (leftM21 * rightM11) + (leftM22 * rightM21);
+            result.Row1.Y = (leftM21 * rightM12) + (leftM22 * rightM22);
+            result.Row1.Z = (leftM21 * rightM13) + (leftM22 * rightM23);
         }
 
         /// <summary>
@@ -441,27 +440,27 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix2d left, ref Matrix2x4d right, out Matrix2x4d result)
         {
-            double lM11 = left.Row0.X,
-                lM12 = left.Row0.Y,
-                lM21 = left.Row1.X,
-                lM22 = left.Row1.Y,
-                rM11 = right.Row0.X,
-                rM12 = right.Row0.Y,
-                rM13 = right.Row0.Z,
-                rM14 = right.Row0.W,
-                rM21 = right.Row1.X,
-                rM22 = right.Row1.Y,
-                rM23 = right.Row1.Z,
-                rM24 = right.Row1.W;
+            double leftM11 = left.Row0.X,
+                leftM12 = left.Row0.Y,
+                leftM21 = left.Row1.X,
+                leftM22 = left.Row1.Y,
+                rightM11 = right.Row0.X,
+                rightM12 = right.Row0.Y,
+                rightM13 = right.Row0.Z,
+                rightM14 = right.Row0.W,
+                rightM21 = right.Row1.X,
+                rightM22 = right.Row1.Y,
+                rightM23 = right.Row1.Z,
+                rightM24 = right.Row1.W;
 
-            result.Row0.X = (lM11 * rM11) + (lM12 * rM21);
-            result.Row0.Y = (lM11 * rM12) + (lM12 * rM22);
-            result.Row0.Z = (lM11 * rM13) + (lM12 * rM23);
-            result.Row0.W = (lM11 * rM14) + (lM12 * rM24);
-            result.Row1.X = (lM21 * rM11) + (lM22 * rM21);
-            result.Row1.Y = (lM21 * rM12) + (lM22 * rM22);
-            result.Row1.Z = (lM21 * rM13) + (lM22 * rM23);
-            result.Row1.W = (lM21 * rM14) + (lM22 * rM24);
+            result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21);
+            result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22);
+            result.Row0.Z = (leftM11 * rightM13) + (leftM12 * rightM23);
+            result.Row0.W = (leftM11 * rightM14) + (leftM12 * rightM24);
+            result.Row1.X = (leftM21 * rightM11) + (leftM22 * rightM21);
+            result.Row1.Y = (leftM21 * rightM12) + (leftM22 * rightM22);
+            result.Row1.Z = (leftM21 * rightM13) + (leftM22 * rightM23);
+            result.Row1.W = (leftM21 * rightM14) + (leftM22 * rightM24);
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Matrix/Matrix2x3.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix2x3.cs
@@ -21,6 +21,7 @@ SOFTWARE.
  */
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace OpenTK.Mathematics
 {
@@ -64,15 +65,10 @@ namespace OpenTK.Mathematics
         /// <param name="m10">First item of the second row of the matrix.</param>
         /// <param name="m11">Second item of the second row of the matrix.</param>
         /// <param name="m12">Third item of the second row of the matrix.</param>
-        public Matrix2x3
-        (
-            float m00,
-            float m01,
-            float m02,
-            float m10,
-            float m11,
-            float m12
-        )
+        [SuppressMessage("ReSharper", "SA1117", Justification = "For better readability of Matrix struct.")]
+        public Matrix2x3(
+            float m00, float m01, float m02,
+            float m10, float m11, float m12)
         {
             Row0 = new Vector3(m00, m01, m02);
             Row1 = new Vector3(m10, m11, m12);
@@ -194,6 +190,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="rowIndex">The index of the row.</param>
         /// <param name="columnIndex">The index of the column.</param>
+        /// <returns>The element at the given row and column index.</returns>
         public float this[int rowIndex, int columnIndex]
         {
             get
@@ -375,23 +372,23 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix2x3 left, ref Matrix3x2 right, out Matrix2 result)
         {
-            float lM11 = left.Row0.X,
-                lM12 = left.Row0.Y,
-                lM13 = left.Row0.Z,
-                lM21 = left.Row1.X,
-                lM22 = left.Row1.Y,
-                lM23 = left.Row1.Z,
-                rM11 = right.Row0.X,
-                rM12 = right.Row0.Y,
-                rM21 = right.Row1.X,
-                rM22 = right.Row1.Y,
-                rM31 = right.Row2.X,
-                rM32 = right.Row2.Y;
+            float leftM11 = left.Row0.X,
+                leftM12 = left.Row0.Y,
+                leftM13 = left.Row0.Z,
+                leftM21 = left.Row1.X,
+                leftM22 = left.Row1.Y,
+                leftM23 = left.Row1.Z,
+                rightM11 = right.Row0.X,
+                rightM12 = right.Row0.Y,
+                rightM21 = right.Row1.X,
+                rightM22 = right.Row1.Y,
+                rightM31 = right.Row2.X,
+                rightM32 = right.Row2.Y;
 
-            result.Row0.X = (lM11 * rM11) + (lM12 * rM21) + (lM13 * rM31);
-            result.Row0.Y = (lM11 * rM12) + (lM12 * rM22) + (lM13 * rM32);
-            result.Row1.X = (lM21 * rM11) + (lM22 * rM21) + (lM23 * rM31);
-            result.Row1.Y = (lM21 * rM12) + (lM22 * rM22) + (lM23 * rM32);
+            result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21) + (leftM13 * rightM31);
+            result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22) + (leftM13 * rightM32);
+            result.Row1.X = (leftM21 * rightM11) + (leftM22 * rightM21) + (leftM23 * rightM31);
+            result.Row1.Y = (leftM21 * rightM12) + (leftM22 * rightM22) + (leftM23 * rightM32);
         }
 
         /// <summary>
@@ -414,28 +411,28 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix2x3 left, ref Matrix3 right, out Matrix2x3 result)
         {
-            float lM11 = left.Row0.X,
-                lM12 = left.Row0.Y,
-                lM13 = left.Row0.Z,
-                lM21 = left.Row1.X,
-                lM22 = left.Row1.Y,
-                lM23 = left.Row1.Z,
-                rM11 = right.Row0.X,
-                rM12 = right.Row0.Y,
-                rM13 = right.Row0.Z,
-                rM21 = right.Row1.X,
-                rM22 = right.Row1.Y,
-                rM23 = right.Row1.Z,
-                rM31 = right.Row2.X,
-                rm32 = right.Row2.Y,
-                rM33 = right.Row2.Z;
+            float leftM11 = left.Row0.X,
+                leftM12 = left.Row0.Y,
+                leftM13 = left.Row0.Z,
+                leftM21 = left.Row1.X,
+                leftM22 = left.Row1.Y,
+                leftM23 = left.Row1.Z,
+                rightM11 = right.Row0.X,
+                rightM12 = right.Row0.Y,
+                rightM13 = right.Row0.Z,
+                rightM21 = right.Row1.X,
+                rightM22 = right.Row1.Y,
+                rightM23 = right.Row1.Z,
+                rightM31 = right.Row2.X,
+                rightM32 = right.Row2.Y,
+                rightM33 = right.Row2.Z;
 
-            result.Row0.X = (lM11 * rM11) + (lM12 * rM21) + (lM13 * rM31);
-            result.Row0.Y = (lM11 * rM12) + (lM12 * rM22) + (lM13 * rm32);
-            result.Row0.Z = (lM11 * rM13) + (lM12 * rM23) + (lM13 * rM33);
-            result.Row1.X = (lM21 * rM11) + (lM22 * rM21) + (lM23 * rM31);
-            result.Row1.Y = (lM21 * rM12) + (lM22 * rM22) + (lM23 * rm32);
-            result.Row1.Z = (lM21 * rM13) + (lM22 * rM23) + (lM23 * rM33);
+            result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21) + (leftM13 * rightM31);
+            result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22) + (leftM13 * rightM32);
+            result.Row0.Z = (leftM11 * rightM13) + (leftM12 * rightM23) + (leftM13 * rightM33);
+            result.Row1.X = (leftM21 * rightM11) + (leftM22 * rightM21) + (leftM23 * rightM31);
+            result.Row1.Y = (leftM21 * rightM12) + (leftM22 * rightM22) + (leftM23 * rightM32);
+            result.Row1.Z = (leftM21 * rightM13) + (leftM22 * rightM23) + (leftM23 * rightM33);
         }
 
         /// <summary>
@@ -458,33 +455,33 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix2x3 left, ref Matrix3x4 right, out Matrix2x4 result)
         {
-            float lM11 = left.Row0.X,
-                lM12 = left.Row0.Y,
-                lM13 = left.Row0.Z,
-                lM21 = left.Row1.X,
-                lM22 = left.Row1.Y,
-                lM23 = left.Row1.Z,
-                rM11 = right.Row0.X,
-                rM12 = right.Row0.Y,
-                rM13 = right.Row0.Z,
-                rM14 = right.Row0.W,
-                rM21 = right.Row1.X,
-                rM22 = right.Row1.Y,
-                rM23 = right.Row1.Z,
-                rM24 = right.Row1.W,
-                rM31 = right.Row2.X,
-                rm32 = right.Row2.Y,
-                rM33 = right.Row2.Z,
-                rM34 = right.Row2.W;
+            float leftM11 = left.Row0.X,
+                leftM12 = left.Row0.Y,
+                leftM13 = left.Row0.Z,
+                leftM21 = left.Row1.X,
+                leftM22 = left.Row1.Y,
+                leftM23 = left.Row1.Z,
+                rightM11 = right.Row0.X,
+                rightM12 = right.Row0.Y,
+                rightM13 = right.Row0.Z,
+                rightM14 = right.Row0.W,
+                rightM21 = right.Row1.X,
+                rightM22 = right.Row1.Y,
+                rightM23 = right.Row1.Z,
+                rightM24 = right.Row1.W,
+                rightM31 = right.Row2.X,
+                rightm32 = right.Row2.Y,
+                rightM33 = right.Row2.Z,
+                rightM34 = right.Row2.W;
 
-            result.Row0.X = (lM11 * rM11) + (lM12 * rM21) + (lM13 * rM31);
-            result.Row0.Y = (lM11 * rM12) + (lM12 * rM22) + (lM13 * rm32);
-            result.Row0.Z = (lM11 * rM13) + (lM12 * rM23) + (lM13 * rM33);
-            result.Row0.W = (lM11 * rM14) + (lM12 * rM24) + (lM13 * rM34);
-            result.Row1.X = (lM21 * rM11) + (lM22 * rM21) + (lM23 * rM31);
-            result.Row1.Y = (lM21 * rM12) + (lM22 * rM22) + (lM23 * rm32);
-            result.Row1.Z = (lM21 * rM13) + (lM22 * rM23) + (lM23 * rM33);
-            result.Row1.W = (lM21 * rM14) + (lM22 * rM24) + (lM23 * rM34);
+            result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21) + (leftM13 * rightM31);
+            result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22) + (leftM13 * rightm32);
+            result.Row0.Z = (leftM11 * rightM13) + (leftM12 * rightM23) + (leftM13 * rightM33);
+            result.Row0.W = (leftM11 * rightM14) + (leftM12 * rightM24) + (leftM13 * rightM34);
+            result.Row1.X = (leftM21 * rightM11) + (leftM22 * rightM21) + (leftM23 * rightM31);
+            result.Row1.Y = (leftM21 * rightM12) + (leftM22 * rightM22) + (leftM23 * rightm32);
+            result.Row1.Z = (leftM21 * rightM13) + (leftM22 * rightM23) + (leftM23 * rightM33);
+            result.Row1.W = (leftM21 * rightM14) + (leftM22 * rightM24) + (leftM23 * rightM34);
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Matrix/Matrix2x3.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix2x3.cs
@@ -66,9 +66,11 @@ namespace OpenTK.Mathematics
         /// <param name="m11">Second item of the second row of the matrix.</param>
         /// <param name="m12">Third item of the second row of the matrix.</param>
         [SuppressMessage("ReSharper", "SA1117", Justification = "For better readability of Matrix struct.")]
-        public Matrix2x3(
+        public Matrix2x3
+        (
             float m00, float m01, float m02,
-            float m10, float m11, float m12)
+            float m10, float m11, float m12
+        )
         {
             Row0 = new Vector3(m00, m01, m02);
             Row1 = new Vector3(m10, m11, m12);
@@ -372,18 +374,18 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix2x3 left, ref Matrix3x2 right, out Matrix2 result)
         {
-            float leftM11 = left.Row0.X,
-                leftM12 = left.Row0.Y,
-                leftM13 = left.Row0.Z,
-                leftM21 = left.Row1.X,
-                leftM22 = left.Row1.Y,
-                leftM23 = left.Row1.Z,
-                rightM11 = right.Row0.X,
-                rightM12 = right.Row0.Y,
-                rightM21 = right.Row1.X,
-                rightM22 = right.Row1.Y,
-                rightM31 = right.Row2.X,
-                rightM32 = right.Row2.Y;
+            float leftM11 = left.Row0.X;
+            float leftM12 = left.Row0.Y;
+            float leftM13 = left.Row0.Z;
+            float leftM21 = left.Row1.X;
+            float leftM22 = left.Row1.Y;
+            float leftM23 = left.Row1.Z;
+            float rightM11 = right.Row0.X;
+            float rightM12 = right.Row0.Y;
+            float rightM21 = right.Row1.X;
+            float rightM22 = right.Row1.Y;
+            float rightM31 = right.Row2.X;
+            float rightM32 = right.Row2.Y;
 
             result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21) + (leftM13 * rightM31);
             result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22) + (leftM13 * rightM32);
@@ -411,21 +413,21 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix2x3 left, ref Matrix3 right, out Matrix2x3 result)
         {
-            float leftM11 = left.Row0.X,
-                leftM12 = left.Row0.Y,
-                leftM13 = left.Row0.Z,
-                leftM21 = left.Row1.X,
-                leftM22 = left.Row1.Y,
-                leftM23 = left.Row1.Z,
-                rightM11 = right.Row0.X,
-                rightM12 = right.Row0.Y,
-                rightM13 = right.Row0.Z,
-                rightM21 = right.Row1.X,
-                rightM22 = right.Row1.Y,
-                rightM23 = right.Row1.Z,
-                rightM31 = right.Row2.X,
-                rightM32 = right.Row2.Y,
-                rightM33 = right.Row2.Z;
+            float leftM11 = left.Row0.X;
+            float leftM12 = left.Row0.Y;
+            float leftM13 = left.Row0.Z;
+            float leftM21 = left.Row1.X;
+            float leftM22 = left.Row1.Y;
+            float leftM23 = left.Row1.Z;
+            float rightM11 = right.Row0.X;
+            float rightM12 = right.Row0.Y;
+            float rightM13 = right.Row0.Z;
+            float rightM21 = right.Row1.X;
+            float rightM22 = right.Row1.Y;
+            float rightM23 = right.Row1.Z;
+            float rightM31 = right.Row2.X;
+            float rightM32 = right.Row2.Y;
+            float rightM33 = right.Row2.Z;
 
             result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21) + (leftM13 * rightM31);
             result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22) + (leftM13 * rightM32);
@@ -455,24 +457,24 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix2x3 left, ref Matrix3x4 right, out Matrix2x4 result)
         {
-            float leftM11 = left.Row0.X,
-                leftM12 = left.Row0.Y,
-                leftM13 = left.Row0.Z,
-                leftM21 = left.Row1.X,
-                leftM22 = left.Row1.Y,
-                leftM23 = left.Row1.Z,
-                rightM11 = right.Row0.X,
-                rightM12 = right.Row0.Y,
-                rightM13 = right.Row0.Z,
-                rightM14 = right.Row0.W,
-                rightM21 = right.Row1.X,
-                rightM22 = right.Row1.Y,
-                rightM23 = right.Row1.Z,
-                rightM24 = right.Row1.W,
-                rightM31 = right.Row2.X,
-                rightm32 = right.Row2.Y,
-                rightM33 = right.Row2.Z,
-                rightM34 = right.Row2.W;
+            float leftM11 = left.Row0.X;
+            float leftM12 = left.Row0.Y;
+            float leftM13 = left.Row0.Z;
+            float leftM21 = left.Row1.X;
+            float leftM22 = left.Row1.Y;
+            float leftM23 = left.Row1.Z;
+            float rightM11 = right.Row0.X;
+            float rightM12 = right.Row0.Y;
+            float rightM13 = right.Row0.Z;
+            float rightM14 = right.Row0.W;
+            float rightM21 = right.Row1.X;
+            float rightM22 = right.Row1.Y;
+            float rightM23 = right.Row1.Z;
+            float rightM24 = right.Row1.W;
+            float rightM31 = right.Row2.X;
+            float rightm32 = right.Row2.Y;
+            float rightM33 = right.Row2.Z;
+            float rightM34 = right.Row2.W;
 
             result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21) + (leftM13 * rightM31);
             result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22) + (leftM13 * rightm32);

--- a/src/OpenTK.Mathematics/Matrix/Matrix2x3d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix2x3d.cs
@@ -21,6 +21,7 @@ SOFTWARE.
  */
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace OpenTK.Mathematics
 {
@@ -64,15 +65,10 @@ namespace OpenTK.Mathematics
         /// <param name="m10">First item of the second row of the matrix.</param>
         /// <param name="m11">Second item of the second row of the matrix.</param>
         /// <param name="m12">Third item of the second row of the matrix.</param>
-        public Matrix2x3d
-        (
-            double m00,
-            double m01,
-            double m02,
-            double m10,
-            double m11,
-            double m12
-        )
+        [SuppressMessage("ReSharper", "SA1117", Justification = "For better readability of Matrix struct.")]
+        public Matrix2x3d(
+            double m00, double m01, double m02,
+            double m10, double m11, double m12)
         {
             Row0 = new Vector3d(m00, m01, m02);
             Row1 = new Vector3d(m10, m11, m12);
@@ -375,23 +371,23 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix2x3d left, ref Matrix3x2 right, out Matrix2d result)
         {
-            double lM11 = left.Row0.X,
-                lM12 = left.Row0.Y,
-                lM13 = left.Row0.Z,
-                lM21 = left.Row1.X,
-                lM22 = left.Row1.Y,
-                lM23 = left.Row1.Z,
-                rM11 = right.Row0.X,
-                rM12 = right.Row0.Y,
-                rM21 = right.Row1.X,
-                rM22 = right.Row1.Y,
-                rM31 = right.Row2.X,
-                rM32 = right.Row2.Y;
+            double leftM11 = left.Row0.X,
+                leftM12 = left.Row0.Y,
+                leftM13 = left.Row0.Z,
+                leftM21 = left.Row1.X,
+                leftM22 = left.Row1.Y,
+                leftM23 = left.Row1.Z,
+                rightM11 = right.Row0.X,
+                rightM12 = right.Row0.Y,
+                rightM21 = right.Row1.X,
+                rightM22 = right.Row1.Y,
+                rightM31 = right.Row2.X,
+                rightM32 = right.Row2.Y;
 
-            result.Row0.X = (lM11 * rM11) + (lM12 * rM21) + (lM13 * rM31);
-            result.Row0.Y = (lM11 * rM12) + (lM12 * rM22) + (lM13 * rM32);
-            result.Row1.X = (lM21 * rM11) + (lM22 * rM21) + (lM23 * rM31);
-            result.Row1.Y = (lM21 * rM12) + (lM22 * rM22) + (lM23 * rM32);
+            result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21) + (leftM13 * rightM31);
+            result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22) + (leftM13 * rightM32);
+            result.Row1.X = (leftM21 * rightM11) + (leftM22 * rightM21) + (leftM23 * rightM31);
+            result.Row1.Y = (leftM21 * rightM12) + (leftM22 * rightM22) + (leftM23 * rightM32);
         }
 
         /// <summary>
@@ -414,28 +410,28 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix2x3d left, ref Matrix3 right, out Matrix2x3d result)
         {
-            double lM11 = left.Row0.X,
-                lM12 = left.Row0.Y,
-                lM13 = left.Row0.Z,
-                lM21 = left.Row1.X,
-                lM22 = left.Row1.Y,
-                lM23 = left.Row1.Z,
-                rM11 = right.Row0.X,
-                rM12 = right.Row0.Y,
-                rM13 = right.Row0.Z,
-                rM21 = right.Row1.X,
-                rM22 = right.Row1.Y,
-                rM23 = right.Row1.Z,
-                rM31 = right.Row2.X,
-                rm32 = right.Row2.Y,
-                rM33 = right.Row2.Z;
+            double leftM11 = left.Row0.X,
+                leftM12 = left.Row0.Y,
+                leftM13 = left.Row0.Z,
+                leftM21 = left.Row1.X,
+                leftM22 = left.Row1.Y,
+                leftM23 = left.Row1.Z,
+                rightM11 = right.Row0.X,
+                rightM12 = right.Row0.Y,
+                rightM13 = right.Row0.Z,
+                rightM21 = right.Row1.X,
+                rightM22 = right.Row1.Y,
+                rightM23 = right.Row1.Z,
+                rightM31 = right.Row2.X,
+                rightM32 = right.Row2.Y,
+                rightM33 = right.Row2.Z;
 
-            result.Row0.X = (lM11 * rM11) + (lM12 * rM21) + (lM13 * rM31);
-            result.Row0.Y = (lM11 * rM12) + (lM12 * rM22) + (lM13 * rm32);
-            result.Row0.Z = (lM11 * rM13) + (lM12 * rM23) + (lM13 * rM33);
-            result.Row1.X = (lM21 * rM11) + (lM22 * rM21) + (lM23 * rM31);
-            result.Row1.Y = (lM21 * rM12) + (lM22 * rM22) + (lM23 * rm32);
-            result.Row1.Z = (lM21 * rM13) + (lM22 * rM23) + (lM23 * rM33);
+            result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21) + (leftM13 * rightM31);
+            result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22) + (leftM13 * rightM32);
+            result.Row0.Z = (leftM11 * rightM13) + (leftM12 * rightM23) + (leftM13 * rightM33);
+            result.Row1.X = (leftM21 * rightM11) + (leftM22 * rightM21) + (leftM23 * rightM31);
+            result.Row1.Y = (leftM21 * rightM12) + (leftM22 * rightM22) + (leftM23 * rightM32);
+            result.Row1.Z = (leftM21 * rightM13) + (leftM22 * rightM23) + (leftM23 * rightM33);
         }
 
         /// <summary>
@@ -458,33 +454,33 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix2x3d left, ref Matrix3x4 right, out Matrix2x4d result)
         {
-            double lM11 = left.Row0.X,
-                lM12 = left.Row0.Y,
-                lM13 = left.Row0.Z,
-                lM21 = left.Row1.X,
-                lM22 = left.Row1.Y,
-                lM23 = left.Row1.Z,
-                rM11 = right.Row0.X,
-                rM12 = right.Row0.Y,
-                rM13 = right.Row0.Z,
-                rM14 = right.Row0.W,
-                rM21 = right.Row1.X,
-                rM22 = right.Row1.Y,
-                rM23 = right.Row1.Z,
-                rM24 = right.Row1.W,
-                rM31 = right.Row2.X,
-                rm32 = right.Row2.Y,
-                rM33 = right.Row2.Z,
-                rM34 = right.Row2.W;
+            double leftM11 = left.Row0.X,
+                leftM12 = left.Row0.Y,
+                leftM13 = left.Row0.Z,
+                leftM21 = left.Row1.X,
+                leftM22 = left.Row1.Y,
+                leftM23 = left.Row1.Z,
+                rightM11 = right.Row0.X,
+                rightM12 = right.Row0.Y,
+                rightM13 = right.Row0.Z,
+                rightM14 = right.Row0.W,
+                rightM21 = right.Row1.X,
+                rightM22 = right.Row1.Y,
+                rightM23 = right.Row1.Z,
+                rightM24 = right.Row1.W,
+                rightM31 = right.Row2.X,
+                rightM32 = right.Row2.Y,
+                rightM33 = right.Row2.Z,
+                rightM34 = right.Row2.W;
 
-            result.Row0.X = (lM11 * rM11) + (lM12 * rM21) + (lM13 * rM31);
-            result.Row0.Y = (lM11 * rM12) + (lM12 * rM22) + (lM13 * rm32);
-            result.Row0.Z = (lM11 * rM13) + (lM12 * rM23) + (lM13 * rM33);
-            result.Row0.W = (lM11 * rM14) + (lM12 * rM24) + (lM13 * rM34);
-            result.Row1.X = (lM21 * rM11) + (lM22 * rM21) + (lM23 * rM31);
-            result.Row1.Y = (lM21 * rM12) + (lM22 * rM22) + (lM23 * rm32);
-            result.Row1.Z = (lM21 * rM13) + (lM22 * rM23) + (lM23 * rM33);
-            result.Row1.W = (lM21 * rM14) + (lM22 * rM24) + (lM23 * rM34);
+            result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21) + (leftM13 * rightM31);
+            result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22) + (leftM13 * rightM32);
+            result.Row0.Z = (leftM11 * rightM13) + (leftM12 * rightM23) + (leftM13 * rightM33);
+            result.Row0.W = (leftM11 * rightM14) + (leftM12 * rightM24) + (leftM13 * rightM34);
+            result.Row1.X = (leftM21 * rightM11) + (leftM22 * rightM21) + (leftM23 * rightM31);
+            result.Row1.Y = (leftM21 * rightM12) + (leftM22 * rightM22) + (leftM23 * rightM32);
+            result.Row1.Z = (leftM21 * rightM13) + (leftM22 * rightM23) + (leftM23 * rightM33);
+            result.Row1.W = (leftM21 * rightM14) + (leftM22 * rightM24) + (leftM23 * rightM34);
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Matrix/Matrix2x3d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix2x3d.cs
@@ -66,9 +66,11 @@ namespace OpenTK.Mathematics
         /// <param name="m11">Second item of the second row of the matrix.</param>
         /// <param name="m12">Third item of the second row of the matrix.</param>
         [SuppressMessage("ReSharper", "SA1117", Justification = "For better readability of Matrix struct.")]
-        public Matrix2x3d(
+        public Matrix2x3d
+        (
             double m00, double m01, double m02,
-            double m10, double m11, double m12)
+            double m10, double m11, double m12
+        )
         {
             Row0 = new Vector3d(m00, m01, m02);
             Row1 = new Vector3d(m10, m11, m12);
@@ -371,18 +373,18 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix2x3d left, ref Matrix3x2 right, out Matrix2d result)
         {
-            double leftM11 = left.Row0.X,
-                leftM12 = left.Row0.Y,
-                leftM13 = left.Row0.Z,
-                leftM21 = left.Row1.X,
-                leftM22 = left.Row1.Y,
-                leftM23 = left.Row1.Z,
-                rightM11 = right.Row0.X,
-                rightM12 = right.Row0.Y,
-                rightM21 = right.Row1.X,
-                rightM22 = right.Row1.Y,
-                rightM31 = right.Row2.X,
-                rightM32 = right.Row2.Y;
+            double leftM11 = left.Row0.X;
+            double leftM12 = left.Row0.Y;
+            double leftM13 = left.Row0.Z;
+            double leftM21 = left.Row1.X;
+            double leftM22 = left.Row1.Y;
+            double leftM23 = left.Row1.Z;
+            double rightM11 = right.Row0.X;
+            double rightM12 = right.Row0.Y;
+            double rightM21 = right.Row1.X;
+            double rightM22 = right.Row1.Y;
+            double rightM31 = right.Row2.X;
+            double rightM32 = right.Row2.Y;
 
             result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21) + (leftM13 * rightM31);
             result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22) + (leftM13 * rightM32);
@@ -410,21 +412,21 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix2x3d left, ref Matrix3 right, out Matrix2x3d result)
         {
-            double leftM11 = left.Row0.X,
-                leftM12 = left.Row0.Y,
-                leftM13 = left.Row0.Z,
-                leftM21 = left.Row1.X,
-                leftM22 = left.Row1.Y,
-                leftM23 = left.Row1.Z,
-                rightM11 = right.Row0.X,
-                rightM12 = right.Row0.Y,
-                rightM13 = right.Row0.Z,
-                rightM21 = right.Row1.X,
-                rightM22 = right.Row1.Y,
-                rightM23 = right.Row1.Z,
-                rightM31 = right.Row2.X,
-                rightM32 = right.Row2.Y,
-                rightM33 = right.Row2.Z;
+            double leftM11 = left.Row0.X;
+            double leftM12 = left.Row0.Y;
+            double leftM13 = left.Row0.Z;
+            double leftM21 = left.Row1.X;
+            double leftM22 = left.Row1.Y;
+            double leftM23 = left.Row1.Z;
+            double rightM11 = right.Row0.X;
+            double rightM12 = right.Row0.Y;
+            double rightM13 = right.Row0.Z;
+            double rightM21 = right.Row1.X;
+            double rightM22 = right.Row1.Y;
+            double rightM23 = right.Row1.Z;
+            double rightM31 = right.Row2.X;
+            double rightM32 = right.Row2.Y;
+            double rightM33 = right.Row2.Z;
 
             result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21) + (leftM13 * rightM31);
             result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22) + (leftM13 * rightM32);
@@ -454,24 +456,24 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix2x3d left, ref Matrix3x4 right, out Matrix2x4d result)
         {
-            double leftM11 = left.Row0.X,
-                leftM12 = left.Row0.Y,
-                leftM13 = left.Row0.Z,
-                leftM21 = left.Row1.X,
-                leftM22 = left.Row1.Y,
-                leftM23 = left.Row1.Z,
-                rightM11 = right.Row0.X,
-                rightM12 = right.Row0.Y,
-                rightM13 = right.Row0.Z,
-                rightM14 = right.Row0.W,
-                rightM21 = right.Row1.X,
-                rightM22 = right.Row1.Y,
-                rightM23 = right.Row1.Z,
-                rightM24 = right.Row1.W,
-                rightM31 = right.Row2.X,
-                rightM32 = right.Row2.Y,
-                rightM33 = right.Row2.Z,
-                rightM34 = right.Row2.W;
+            double leftM11 = left.Row0.X;
+            double leftM12 = left.Row0.Y;
+            double leftM13 = left.Row0.Z;
+            double leftM21 = left.Row1.X;
+            double leftM22 = left.Row1.Y;
+            double leftM23 = left.Row1.Z;
+            double rightM11 = right.Row0.X;
+            double rightM12 = right.Row0.Y;
+            double rightM13 = right.Row0.Z;
+            double rightM14 = right.Row0.W;
+            double rightM21 = right.Row1.X;
+            double rightM22 = right.Row1.Y;
+            double rightM23 = right.Row1.Z;
+            double rightM24 = right.Row1.W;
+            double rightM31 = right.Row2.X;
+            double rightM32 = right.Row2.Y;
+            double rightM33 = right.Row2.Z;
+            double rightM34 = right.Row2.W;
 
             result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21) + (leftM13 * rightM31);
             result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22) + (leftM13 * rightM32);

--- a/src/OpenTK.Mathematics/Matrix/Matrix2x4.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix2x4.cs
@@ -68,9 +68,11 @@ namespace OpenTK.Mathematics
         /// <param name="m12">Third item of the second row of the matrix.</param>
         /// <param name="m13">Fourth item of the second row of the matrix.</param>
         [SuppressMessage("ReSharper", "SA1117", Justification = "For better readability of Matrix struct.")]
-        public Matrix2x4(
+        public Matrix2x4
+        (
             float m00, float m01, float m02, float m03,
-            float m10, float m11, float m12, float m13)
+            float m10, float m11, float m12, float m13
+        )
         {
             Row0 = new Vector4(m00, m01, m02, m03);
             Row1 = new Vector4(m10, m11, m12, m13);
@@ -415,22 +417,22 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix2x4 left, ref Matrix4x2 right, out Matrix2 result)
         {
-            float leftM11 = left.Row0.X,
-                leftM12 = left.Row0.Y,
-                leftM13 = left.Row0.Z,
-                leftM14 = left.Row0.W,
-                leftM21 = left.Row1.X,
-                leftM22 = left.Row1.Y,
-                leftM23 = left.Row1.Z,
-                leftM24 = left.Row1.W,
-                rightM11 = right.Row0.X,
-                rightM12 = right.Row0.Y,
-                rightM21 = right.Row1.X,
-                rightM22 = right.Row1.Y,
-                rightM31 = right.Row2.X,
-                rightM32 = right.Row2.Y,
-                rightM41 = right.Row3.X,
-                rightM42 = right.Row3.Y;
+            float leftM11 = left.Row0.X;
+            float leftM12 = left.Row0.Y;
+            float leftM13 = left.Row0.Z;
+            float leftM14 = left.Row0.W;
+            float leftM21 = left.Row1.X;
+            float leftM22 = left.Row1.Y;
+            float leftM23 = left.Row1.Z;
+            float leftM24 = left.Row1.W;
+            float rightM11 = right.Row0.X;
+            float rightM12 = right.Row0.Y;
+            float rightM21 = right.Row1.X;
+            float rightM22 = right.Row1.Y;
+            float rightM31 = right.Row2.X;
+            float rightM32 = right.Row2.Y;
+            float rightM41 = right.Row3.X;
+            float rightM42 = right.Row3.Y;
 
             result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21) + (leftM13 * rightM31) + (leftM14 * rightM41);
             result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22) + (leftM13 * rightM32) + (leftM14 * rightM42);
@@ -458,26 +460,26 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix2x4 left, ref Matrix4x3 right, out Matrix2x3 result)
         {
-            float leftM11 = left.Row0.X,
-                leftM12 = left.Row0.Y,
-                leftM13 = left.Row0.Z,
-                leftM14 = left.Row0.W,
-                leftM21 = left.Row1.X,
-                leftM22 = left.Row1.Y,
-                leftM23 = left.Row1.Z,
-                leftM24 = left.Row1.W,
-                rightM11 = right.Row0.X,
-                rightM12 = right.Row0.Y,
-                rightM13 = right.Row0.Z,
-                rightM21 = right.Row1.X,
-                rightM22 = right.Row1.Y,
-                rightM23 = right.Row1.Z,
-                rightM31 = right.Row2.X,
-                rightM32 = right.Row2.Y,
-                rightM33 = right.Row2.Z,
-                rightM41 = right.Row3.X,
-                rightM42 = right.Row3.Y,
-                rightM43 = right.Row3.Z;
+            float leftM11 = left.Row0.X;
+            float leftM12 = left.Row0.Y;
+            float leftM13 = left.Row0.Z;
+            float leftM14 = left.Row0.W;
+            float leftM21 = left.Row1.X;
+            float leftM22 = left.Row1.Y;
+            float leftM23 = left.Row1.Z;
+            float leftM24 = left.Row1.W;
+            float rightM11 = right.Row0.X;
+            float rightM12 = right.Row0.Y;
+            float rightM13 = right.Row0.Z;
+            float rightM21 = right.Row1.X;
+            float rightM22 = right.Row1.Y;
+            float rightM23 = right.Row1.Z;
+            float rightM31 = right.Row2.X;
+            float rightM32 = right.Row2.Y;
+            float rightM33 = right.Row2.Z;
+            float rightM41 = right.Row3.X;
+            float rightM42 = right.Row3.Y;
+            float rightM43 = right.Row3.Z;
 
             result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21) + (leftM13 * rightM31) + (leftM14 * rightM41);
             result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22) + (leftM13 * rightM32) + (leftM14 * rightM42);
@@ -507,30 +509,30 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix2x4 left, ref Matrix4 right, out Matrix2x4 result)
         {
-            float leftM11 = left.Row0.X,
-                leftM12 = left.Row0.Y,
-                leftM13 = left.Row0.Z,
-                leftM14 = left.Row0.W,
-                leftM21 = left.Row1.X,
-                leftM22 = left.Row1.Y,
-                leftM23 = left.Row1.Z,
-                leftM24 = left.Row1.W,
-                rightM11 = right.Row0.X,
-                rightM12 = right.Row0.Y,
-                rightM13 = right.Row0.Z,
-                rightM14 = right.Row0.W,
-                rightM21 = right.Row1.X,
-                rightM22 = right.Row1.Y,
-                rightM23 = right.Row1.Z,
-                rightM24 = right.Row1.W,
-                rightM31 = right.Row2.X,
-                rightM32 = right.Row2.Y,
-                rightM33 = right.Row2.Z,
-                rightM34 = right.Row2.W,
-                rightM41 = right.Row3.X,
-                rightM42 = right.Row3.Y,
-                rightM43 = right.Row3.Z,
-                rightM44 = right.Row3.W;
+            float leftM11 = left.Row0.X;
+            float leftM12 = left.Row0.Y;
+            float leftM13 = left.Row0.Z;
+            float leftM14 = left.Row0.W;
+            float leftM21 = left.Row1.X;
+            float leftM22 = left.Row1.Y;
+            float leftM23 = left.Row1.Z;
+            float leftM24 = left.Row1.W;
+            float rightM11 = right.Row0.X;
+            float rightM12 = right.Row0.Y;
+            float rightM13 = right.Row0.Z;
+            float rightM14 = right.Row0.W;
+            float rightM21 = right.Row1.X;
+            float rightM22 = right.Row1.Y;
+            float rightM23 = right.Row1.Z;
+            float rightM24 = right.Row1.W;
+            float rightM31 = right.Row2.X;
+            float rightM32 = right.Row2.Y;
+            float rightM33 = right.Row2.Z;
+            float rightM34 = right.Row2.W;
+            float rightM41 = right.Row3.X;
+            float rightM42 = right.Row3.Y;
+            float rightM43 = right.Row3.Z;
+            float rightM44 = right.Row3.W;
 
             result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21) + (leftM13 * rightM31) + (leftM14 * rightM41);
             result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22) + (leftM13 * rightM32) + (leftM14 * rightM42);

--- a/src/OpenTK.Mathematics/Matrix/Matrix2x4.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix2x4.cs
@@ -21,6 +21,7 @@ SOFTWARE.
  */
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace OpenTK.Mathematics
 {
@@ -66,17 +67,10 @@ namespace OpenTK.Mathematics
         /// <param name="m11">Second item of the second row of the matrix.</param>
         /// <param name="m12">Third item of the second row of the matrix.</param>
         /// <param name="m13">Fourth item of the second row of the matrix.</param>
-        public Matrix2x4
-        (
-            float m00,
-            float m01,
-            float m02,
-            float m03,
-            float m10,
-            float m11,
-            float m12,
-            float m13
-        )
+        [SuppressMessage("ReSharper", "SA1117", Justification = "For better readability of Matrix struct.")]
+        public Matrix2x4(
+            float m00, float m01, float m02, float m03,
+            float m10, float m11, float m12, float m13)
         {
             Row0 = new Vector4(m00, m01, m02, m03);
             Row1 = new Vector4(m10, m11, m12, m13);
@@ -229,6 +223,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="rowIndex">The index of the row.</param>
         /// <param name="columnIndex">The index of the column.</param>
+        /// <returns>The element at the given row and column index.</returns>
         public float this[int rowIndex, int columnIndex]
         {
             get
@@ -420,27 +415,27 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix2x4 left, ref Matrix4x2 right, out Matrix2 result)
         {
-            float lM11 = left.Row0.X,
-                lM12 = left.Row0.Y,
-                lM13 = left.Row0.Z,
-                lM14 = left.Row0.W,
-                lM21 = left.Row1.X,
-                lM22 = left.Row1.Y,
-                lM23 = left.Row1.Z,
-                lM24 = left.Row1.W,
-                rM11 = right.Row0.X,
-                rM12 = right.Row0.Y,
-                rM21 = right.Row1.X,
-                rM22 = right.Row1.Y,
-                rM31 = right.Row2.X,
-                rM32 = right.Row2.Y,
-                rM41 = right.Row3.X,
-                rM42 = right.Row3.Y;
+            float leftM11 = left.Row0.X,
+                leftM12 = left.Row0.Y,
+                leftM13 = left.Row0.Z,
+                leftM14 = left.Row0.W,
+                leftM21 = left.Row1.X,
+                leftM22 = left.Row1.Y,
+                leftM23 = left.Row1.Z,
+                leftM24 = left.Row1.W,
+                rightM11 = right.Row0.X,
+                rightM12 = right.Row0.Y,
+                rightM21 = right.Row1.X,
+                rightM22 = right.Row1.Y,
+                rightM31 = right.Row2.X,
+                rightM32 = right.Row2.Y,
+                rightM41 = right.Row3.X,
+                rightM42 = right.Row3.Y;
 
-            result.Row0.X = (lM11 * rM11) + (lM12 * rM21) + (lM13 * rM31) + (lM14 * rM41);
-            result.Row0.Y = (lM11 * rM12) + (lM12 * rM22) + (lM13 * rM32) + (lM14 * rM42);
-            result.Row1.X = (lM21 * rM11) + (lM22 * rM21) + (lM23 * rM31) + (lM24 * rM41);
-            result.Row1.Y = (lM21 * rM12) + (lM22 * rM22) + (lM23 * rM32) + (lM24 * rM42);
+            result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21) + (leftM13 * rightM31) + (leftM14 * rightM41);
+            result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22) + (leftM13 * rightM32) + (leftM14 * rightM42);
+            result.Row1.X = (leftM21 * rightM11) + (leftM22 * rightM21) + (leftM23 * rightM31) + (leftM24 * rightM41);
+            result.Row1.Y = (leftM21 * rightM12) + (leftM22 * rightM22) + (leftM23 * rightM32) + (leftM24 * rightM42);
         }
 
         /// <summary>
@@ -463,33 +458,33 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix2x4 left, ref Matrix4x3 right, out Matrix2x3 result)
         {
-            float lM11 = left.Row0.X,
-                lM12 = left.Row0.Y,
-                lM13 = left.Row0.Z,
-                lM14 = left.Row0.W,
-                lM21 = left.Row1.X,
-                lM22 = left.Row1.Y,
-                lM23 = left.Row1.Z,
-                lM24 = left.Row1.W,
-                rM11 = right.Row0.X,
-                rM12 = right.Row0.Y,
-                rM13 = right.Row0.Z,
-                rM21 = right.Row1.X,
-                rM22 = right.Row1.Y,
-                rM23 = right.Row1.Z,
-                rM31 = right.Row2.X,
-                rM32 = right.Row2.Y,
-                rM33 = right.Row2.Z,
-                rM41 = right.Row3.X,
-                rM42 = right.Row3.Y,
-                rM43 = right.Row3.Z;
+            float leftM11 = left.Row0.X,
+                leftM12 = left.Row0.Y,
+                leftM13 = left.Row0.Z,
+                leftM14 = left.Row0.W,
+                leftM21 = left.Row1.X,
+                leftM22 = left.Row1.Y,
+                leftM23 = left.Row1.Z,
+                leftM24 = left.Row1.W,
+                rightM11 = right.Row0.X,
+                rightM12 = right.Row0.Y,
+                rightM13 = right.Row0.Z,
+                rightM21 = right.Row1.X,
+                rightM22 = right.Row1.Y,
+                rightM23 = right.Row1.Z,
+                rightM31 = right.Row2.X,
+                rightM32 = right.Row2.Y,
+                rightM33 = right.Row2.Z,
+                rightM41 = right.Row3.X,
+                rightM42 = right.Row3.Y,
+                rightM43 = right.Row3.Z;
 
-            result.Row0.X = (lM11 * rM11) + (lM12 * rM21) + (lM13 * rM31) + (lM14 * rM41);
-            result.Row0.Y = (lM11 * rM12) + (lM12 * rM22) + (lM13 * rM32) + (lM14 * rM42);
-            result.Row0.Z = (lM11 * rM13) + (lM12 * rM23) + (lM13 * rM33) + (lM14 * rM43);
-            result.Row1.X = (lM21 * rM11) + (lM22 * rM21) + (lM23 * rM31) + (lM24 * rM41);
-            result.Row1.Y = (lM21 * rM12) + (lM22 * rM22) + (lM23 * rM32) + (lM24 * rM42);
-            result.Row1.Z = (lM21 * rM13) + (lM22 * rM23) + (lM23 * rM33) + (lM24 * rM43);
+            result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21) + (leftM13 * rightM31) + (leftM14 * rightM41);
+            result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22) + (leftM13 * rightM32) + (leftM14 * rightM42);
+            result.Row0.Z = (leftM11 * rightM13) + (leftM12 * rightM23) + (leftM13 * rightM33) + (leftM14 * rightM43);
+            result.Row1.X = (leftM21 * rightM11) + (leftM22 * rightM21) + (leftM23 * rightM31) + (leftM24 * rightM41);
+            result.Row1.Y = (leftM21 * rightM12) + (leftM22 * rightM22) + (leftM23 * rightM32) + (leftM24 * rightM42);
+            result.Row1.Z = (leftM21 * rightM13) + (leftM22 * rightM23) + (leftM23 * rightM33) + (leftM24 * rightM43);
         }
 
         /// <summary>
@@ -512,39 +507,39 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix2x4 left, ref Matrix4 right, out Matrix2x4 result)
         {
-            float lM11 = left.Row0.X,
-                lM12 = left.Row0.Y,
-                lM13 = left.Row0.Z,
-                lM14 = left.Row0.W,
-                lM21 = left.Row1.X,
-                lM22 = left.Row1.Y,
-                lM23 = left.Row1.Z,
-                lM24 = left.Row1.W,
-                rM11 = right.Row0.X,
-                rM12 = right.Row0.Y,
-                rM13 = right.Row0.Z,
-                rM14 = right.Row0.W,
-                rM21 = right.Row1.X,
-                rM22 = right.Row1.Y,
-                rM23 = right.Row1.Z,
-                rM24 = right.Row1.W,
-                rM31 = right.Row2.X,
-                rM32 = right.Row2.Y,
-                rM33 = right.Row2.Z,
-                rM34 = right.Row2.W,
-                rM41 = right.Row3.X,
-                rM42 = right.Row3.Y,
-                rM43 = right.Row3.Z,
-                rM44 = right.Row3.W;
+            float leftM11 = left.Row0.X,
+                leftM12 = left.Row0.Y,
+                leftM13 = left.Row0.Z,
+                leftM14 = left.Row0.W,
+                leftM21 = left.Row1.X,
+                leftM22 = left.Row1.Y,
+                leftM23 = left.Row1.Z,
+                leftM24 = left.Row1.W,
+                rightM11 = right.Row0.X,
+                rightM12 = right.Row0.Y,
+                rightM13 = right.Row0.Z,
+                rightM14 = right.Row0.W,
+                rightM21 = right.Row1.X,
+                rightM22 = right.Row1.Y,
+                rightM23 = right.Row1.Z,
+                rightM24 = right.Row1.W,
+                rightM31 = right.Row2.X,
+                rightM32 = right.Row2.Y,
+                rightM33 = right.Row2.Z,
+                rightM34 = right.Row2.W,
+                rightM41 = right.Row3.X,
+                rightM42 = right.Row3.Y,
+                rightM43 = right.Row3.Z,
+                rightM44 = right.Row3.W;
 
-            result.Row0.X = (lM11 * rM11) + (lM12 * rM21) + (lM13 * rM31) + (lM14 * rM41);
-            result.Row0.Y = (lM11 * rM12) + (lM12 * rM22) + (lM13 * rM32) + (lM14 * rM42);
-            result.Row0.Z = (lM11 * rM13) + (lM12 * rM23) + (lM13 * rM33) + (lM14 * rM43);
-            result.Row0.W = (lM11 * rM14) + (lM12 * rM24) + (lM13 * rM34) + (lM14 * rM44);
-            result.Row1.X = (lM21 * rM11) + (lM22 * rM21) + (lM23 * rM31) + (lM24 * rM41);
-            result.Row1.Y = (lM21 * rM12) + (lM22 * rM22) + (lM23 * rM32) + (lM24 * rM42);
-            result.Row1.Z = (lM21 * rM13) + (lM22 * rM23) + (lM23 * rM33) + (lM24 * rM43);
-            result.Row1.W = (lM21 * rM14) + (lM22 * rM24) + (lM23 * rM34) + (lM24 * rM44);
+            result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21) + (leftM13 * rightM31) + (leftM14 * rightM41);
+            result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22) + (leftM13 * rightM32) + (leftM14 * rightM42);
+            result.Row0.Z = (leftM11 * rightM13) + (leftM12 * rightM23) + (leftM13 * rightM33) + (leftM14 * rightM43);
+            result.Row0.W = (leftM11 * rightM14) + (leftM12 * rightM24) + (leftM13 * rightM34) + (leftM14 * rightM44);
+            result.Row1.X = (leftM21 * rightM11) + (leftM22 * rightM21) + (leftM23 * rightM31) + (leftM24 * rightM41);
+            result.Row1.Y = (leftM21 * rightM12) + (leftM22 * rightM22) + (leftM23 * rightM32) + (leftM24 * rightM42);
+            result.Row1.Z = (leftM21 * rightM13) + (leftM22 * rightM23) + (leftM23 * rightM33) + (leftM24 * rightM43);
+            result.Row1.W = (leftM21 * rightM14) + (leftM22 * rightM24) + (leftM23 * rightM34) + (leftM24 * rightM44);
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Matrix/Matrix2x4d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix2x4d.cs
@@ -21,6 +21,7 @@ SOFTWARE.
  */
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace OpenTK.Mathematics
 {
@@ -66,17 +67,10 @@ namespace OpenTK.Mathematics
         /// <param name="m11">Second item of the second row of the matrix.</param>
         /// <param name="m12">Third item of the second row of the matrix.</param>
         /// <param name="m13">Fourth item of the second row of the matrix.</param>
-        public Matrix2x4d
-        (
-            double m00,
-            double m01,
-            double m02,
-            double m03,
-            double m10,
-            double m11,
-            double m12,
-            double m13
-        )
+        [SuppressMessage("ReSharper", "SA1117", Justification = "For better readability of Matrix struct.")]
+        public Matrix2x4d(
+            double m00, double m01, double m02, double m03,
+            double m10, double m11, double m12, double m13)
         {
             Row0 = new Vector4d(m00, m01, m02, m03);
             Row1 = new Vector4d(m10, m11, m12, m13);
@@ -229,6 +223,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="rowIndex">The index of the row.</param>
         /// <param name="columnIndex">The index of the column.</param>
+        /// <returns>The element at the given row and column index.</returns>
         public double this[int rowIndex, int columnIndex]
         {
             get
@@ -420,27 +415,27 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix2x4d left, ref Matrix4x2 right, out Matrix2d result)
         {
-            double lM11 = left.Row0.X,
-                lM12 = left.Row0.Y,
-                lM13 = left.Row0.Z,
-                lM14 = left.Row0.W,
-                lM21 = left.Row1.X,
-                lM22 = left.Row1.Y,
-                lM23 = left.Row1.Z,
-                lM24 = left.Row1.W,
-                rM11 = right.Row0.X,
-                rM12 = right.Row0.Y,
-                rM21 = right.Row1.X,
-                rM22 = right.Row1.Y,
-                rM31 = right.Row2.X,
-                rM32 = right.Row2.Y,
-                rM41 = right.Row3.X,
-                rM42 = right.Row3.Y;
+            double leftM11 = left.Row0.X,
+                leftM12 = left.Row0.Y,
+                leftM13 = left.Row0.Z,
+                leftM14 = left.Row0.W,
+                leftM21 = left.Row1.X,
+                leftM22 = left.Row1.Y,
+                leftM23 = left.Row1.Z,
+                leftM24 = left.Row1.W,
+                rightM11 = right.Row0.X,
+                rightM12 = right.Row0.Y,
+                rightM21 = right.Row1.X,
+                rightM22 = right.Row1.Y,
+                rightM31 = right.Row2.X,
+                rightM32 = right.Row2.Y,
+                rightM41 = right.Row3.X,
+                rightM42 = right.Row3.Y;
 
-            result.Row0.X = (lM11 * rM11) + (lM12 * rM21) + (lM13 * rM31) + (lM14 * rM41);
-            result.Row0.Y = (lM11 * rM12) + (lM12 * rM22) + (lM13 * rM32) + (lM14 * rM42);
-            result.Row1.X = (lM21 * rM11) + (lM22 * rM21) + (lM23 * rM31) + (lM24 * rM41);
-            result.Row1.Y = (lM21 * rM12) + (lM22 * rM22) + (lM23 * rM32) + (lM24 * rM42);
+            result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21) + (leftM13 * rightM31) + (leftM14 * rightM41);
+            result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22) + (leftM13 * rightM32) + (leftM14 * rightM42);
+            result.Row1.X = (leftM21 * rightM11) + (leftM22 * rightM21) + (leftM23 * rightM31) + (leftM24 * rightM41);
+            result.Row1.Y = (leftM21 * rightM12) + (leftM22 * rightM22) + (leftM23 * rightM32) + (leftM24 * rightM42);
         }
 
         /// <summary>
@@ -463,33 +458,33 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix2x4d left, ref Matrix4x3 right, out Matrix2x3d result)
         {
-            double lM11 = left.Row0.X,
-                lM12 = left.Row0.Y,
-                lM13 = left.Row0.Z,
-                lM14 = left.Row0.W,
-                lM21 = left.Row1.X,
-                lM22 = left.Row1.Y,
-                lM23 = left.Row1.Z,
-                lM24 = left.Row1.W,
-                rM11 = right.Row0.X,
-                rM12 = right.Row0.Y,
-                rM13 = right.Row0.Z,
-                rM21 = right.Row1.X,
-                rM22 = right.Row1.Y,
-                rM23 = right.Row1.Z,
-                rM31 = right.Row2.X,
-                rM32 = right.Row2.Y,
-                rM33 = right.Row2.Z,
-                rM41 = right.Row3.X,
-                rM42 = right.Row3.Y,
-                rM43 = right.Row3.Z;
+            double leftM11 = left.Row0.X,
+                leftM12 = left.Row0.Y,
+                leftM13 = left.Row0.Z,
+                leftM14 = left.Row0.W,
+                leftM21 = left.Row1.X,
+                leftM22 = left.Row1.Y,
+                leftM23 = left.Row1.Z,
+                leftM24 = left.Row1.W,
+                rightM11 = right.Row0.X,
+                rightM12 = right.Row0.Y,
+                rightM13 = right.Row0.Z,
+                rightM21 = right.Row1.X,
+                rightM22 = right.Row1.Y,
+                rightM23 = right.Row1.Z,
+                rightM31 = right.Row2.X,
+                rightM32 = right.Row2.Y,
+                rightM33 = right.Row2.Z,
+                rightM41 = right.Row3.X,
+                rightM42 = right.Row3.Y,
+                rightM43 = right.Row3.Z;
 
-            result.Row0.X = (lM11 * rM11) + (lM12 * rM21) + (lM13 * rM31) + (lM14 * rM41);
-            result.Row0.Y = (lM11 * rM12) + (lM12 * rM22) + (lM13 * rM32) + (lM14 * rM42);
-            result.Row0.Z = (lM11 * rM13) + (lM12 * rM23) + (lM13 * rM33) + (lM14 * rM43);
-            result.Row1.X = (lM21 * rM11) + (lM22 * rM21) + (lM23 * rM31) + (lM24 * rM41);
-            result.Row1.Y = (lM21 * rM12) + (lM22 * rM22) + (lM23 * rM32) + (lM24 * rM42);
-            result.Row1.Z = (lM21 * rM13) + (lM22 * rM23) + (lM23 * rM33) + (lM24 * rM43);
+            result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21) + (leftM13 * rightM31) + (leftM14 * rightM41);
+            result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22) + (leftM13 * rightM32) + (leftM14 * rightM42);
+            result.Row0.Z = (leftM11 * rightM13) + (leftM12 * rightM23) + (leftM13 * rightM33) + (leftM14 * rightM43);
+            result.Row1.X = (leftM21 * rightM11) + (leftM22 * rightM21) + (leftM23 * rightM31) + (leftM24 * rightM41);
+            result.Row1.Y = (leftM21 * rightM12) + (leftM22 * rightM22) + (leftM23 * rightM32) + (leftM24 * rightM42);
+            result.Row1.Z = (leftM21 * rightM13) + (leftM22 * rightM23) + (leftM23 * rightM33) + (leftM24 * rightM43);
         }
 
         /// <summary>
@@ -512,39 +507,39 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix2x4d left, ref Matrix4 right, out Matrix2x4d result)
         {
-            double lM11 = left.Row0.X,
-                lM12 = left.Row0.Y,
-                lM13 = left.Row0.Z,
-                lM14 = left.Row0.W,
-                lM21 = left.Row1.X,
-                lM22 = left.Row1.Y,
-                lM23 = left.Row1.Z,
-                lM24 = left.Row1.W,
-                rM11 = right.Row0.X,
-                rM12 = right.Row0.Y,
-                rM13 = right.Row0.Z,
-                rM14 = right.Row0.W,
-                rM21 = right.Row1.X,
-                rM22 = right.Row1.Y,
-                rM23 = right.Row1.Z,
-                rM24 = right.Row1.W,
-                rM31 = right.Row2.X,
-                rM32 = right.Row2.Y,
-                rM33 = right.Row2.Z,
-                rM34 = right.Row2.W,
-                rM41 = right.Row3.X,
-                rM42 = right.Row3.Y,
-                rM43 = right.Row3.Z,
-                rM44 = right.Row3.W;
+            double leftM11 = left.Row0.X,
+                leftM12 = left.Row0.Y,
+                leftM13 = left.Row0.Z,
+                leftM14 = left.Row0.W,
+                leftM21 = left.Row1.X,
+                leftM22 = left.Row1.Y,
+                leftM23 = left.Row1.Z,
+                leftM24 = left.Row1.W,
+                rightM11 = right.Row0.X,
+                rightM12 = right.Row0.Y,
+                rightM13 = right.Row0.Z,
+                rightM14 = right.Row0.W,
+                rightM21 = right.Row1.X,
+                rightM22 = right.Row1.Y,
+                rightM23 = right.Row1.Z,
+                rightM24 = right.Row1.W,
+                rightM31 = right.Row2.X,
+                rightM32 = right.Row2.Y,
+                rightM33 = right.Row2.Z,
+                rightM34 = right.Row2.W,
+                rightM41 = right.Row3.X,
+                rightM42 = right.Row3.Y,
+                rightM43 = right.Row3.Z,
+                rightM44 = right.Row3.W;
 
-            result.Row0.X = (lM11 * rM11) + (lM12 * rM21) + (lM13 * rM31) + (lM14 * rM41);
-            result.Row0.Y = (lM11 * rM12) + (lM12 * rM22) + (lM13 * rM32) + (lM14 * rM42);
-            result.Row0.Z = (lM11 * rM13) + (lM12 * rM23) + (lM13 * rM33) + (lM14 * rM43);
-            result.Row0.W = (lM11 * rM14) + (lM12 * rM24) + (lM13 * rM34) + (lM14 * rM44);
-            result.Row1.X = (lM21 * rM11) + (lM22 * rM21) + (lM23 * rM31) + (lM24 * rM41);
-            result.Row1.Y = (lM21 * rM12) + (lM22 * rM22) + (lM23 * rM32) + (lM24 * rM42);
-            result.Row1.Z = (lM21 * rM13) + (lM22 * rM23) + (lM23 * rM33) + (lM24 * rM43);
-            result.Row1.W = (lM21 * rM14) + (lM22 * rM24) + (lM23 * rM34) + (lM24 * rM44);
+            result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21) + (leftM13 * rightM31) + (leftM14 * rightM41);
+            result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22) + (leftM13 * rightM32) + (leftM14 * rightM42);
+            result.Row0.Z = (leftM11 * rightM13) + (leftM12 * rightM23) + (leftM13 * rightM33) + (leftM14 * rightM43);
+            result.Row0.W = (leftM11 * rightM14) + (leftM12 * rightM24) + (leftM13 * rightM34) + (leftM14 * rightM44);
+            result.Row1.X = (leftM21 * rightM11) + (leftM22 * rightM21) + (leftM23 * rightM31) + (leftM24 * rightM41);
+            result.Row1.Y = (leftM21 * rightM12) + (leftM22 * rightM22) + (leftM23 * rightM32) + (leftM24 * rightM42);
+            result.Row1.Z = (leftM21 * rightM13) + (leftM22 * rightM23) + (leftM23 * rightM33) + (leftM24 * rightM43);
+            result.Row1.W = (leftM21 * rightM14) + (leftM22 * rightM24) + (leftM23 * rightM34) + (leftM24 * rightM44);
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Matrix/Matrix2x4d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix2x4d.cs
@@ -68,9 +68,11 @@ namespace OpenTK.Mathematics
         /// <param name="m12">Third item of the second row of the matrix.</param>
         /// <param name="m13">Fourth item of the second row of the matrix.</param>
         [SuppressMessage("ReSharper", "SA1117", Justification = "For better readability of Matrix struct.")]
-        public Matrix2x4d(
+        public Matrix2x4d
+        (
             double m00, double m01, double m02, double m03,
-            double m10, double m11, double m12, double m13)
+            double m10, double m11, double m12, double m13
+        )
         {
             Row0 = new Vector4d(m00, m01, m02, m03);
             Row1 = new Vector4d(m10, m11, m12, m13);
@@ -415,22 +417,22 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix2x4d left, ref Matrix4x2 right, out Matrix2d result)
         {
-            double leftM11 = left.Row0.X,
-                leftM12 = left.Row0.Y,
-                leftM13 = left.Row0.Z,
-                leftM14 = left.Row0.W,
-                leftM21 = left.Row1.X,
-                leftM22 = left.Row1.Y,
-                leftM23 = left.Row1.Z,
-                leftM24 = left.Row1.W,
-                rightM11 = right.Row0.X,
-                rightM12 = right.Row0.Y,
-                rightM21 = right.Row1.X,
-                rightM22 = right.Row1.Y,
-                rightM31 = right.Row2.X,
-                rightM32 = right.Row2.Y,
-                rightM41 = right.Row3.X,
-                rightM42 = right.Row3.Y;
+            double leftM11 = left.Row0.X;
+            double leftM12 = left.Row0.Y;
+            double leftM13 = left.Row0.Z;
+            double leftM14 = left.Row0.W;
+            double leftM21 = left.Row1.X;
+            double leftM22 = left.Row1.Y;
+            double leftM23 = left.Row1.Z;
+            double leftM24 = left.Row1.W;
+            double rightM11 = right.Row0.X;
+            double rightM12 = right.Row0.Y;
+            double rightM21 = right.Row1.X;
+            double rightM22 = right.Row1.Y;
+            double rightM31 = right.Row2.X;
+            double rightM32 = right.Row2.Y;
+            double rightM41 = right.Row3.X;
+            double rightM42 = right.Row3.Y;
 
             result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21) + (leftM13 * rightM31) + (leftM14 * rightM41);
             result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22) + (leftM13 * rightM32) + (leftM14 * rightM42);
@@ -458,26 +460,26 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix2x4d left, ref Matrix4x3 right, out Matrix2x3d result)
         {
-            double leftM11 = left.Row0.X,
-                leftM12 = left.Row0.Y,
-                leftM13 = left.Row0.Z,
-                leftM14 = left.Row0.W,
-                leftM21 = left.Row1.X,
-                leftM22 = left.Row1.Y,
-                leftM23 = left.Row1.Z,
-                leftM24 = left.Row1.W,
-                rightM11 = right.Row0.X,
-                rightM12 = right.Row0.Y,
-                rightM13 = right.Row0.Z,
-                rightM21 = right.Row1.X,
-                rightM22 = right.Row1.Y,
-                rightM23 = right.Row1.Z,
-                rightM31 = right.Row2.X,
-                rightM32 = right.Row2.Y,
-                rightM33 = right.Row2.Z,
-                rightM41 = right.Row3.X,
-                rightM42 = right.Row3.Y,
-                rightM43 = right.Row3.Z;
+            double leftM11 = left.Row0.X;
+            double leftM12 = left.Row0.Y;
+            double leftM13 = left.Row0.Z;
+            double leftM14 = left.Row0.W;
+            double leftM21 = left.Row1.X;
+            double leftM22 = left.Row1.Y;
+            double leftM23 = left.Row1.Z;
+            double leftM24 = left.Row1.W;
+            double rightM11 = right.Row0.X;
+            double rightM12 = right.Row0.Y;
+            double rightM13 = right.Row0.Z;
+            double rightM21 = right.Row1.X;
+            double rightM22 = right.Row1.Y;
+            double rightM23 = right.Row1.Z;
+            double rightM31 = right.Row2.X;
+            double rightM32 = right.Row2.Y;
+            double rightM33 = right.Row2.Z;
+            double rightM41 = right.Row3.X;
+            double rightM42 = right.Row3.Y;
+            double rightM43 = right.Row3.Z;
 
             result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21) + (leftM13 * rightM31) + (leftM14 * rightM41);
             result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22) + (leftM13 * rightM32) + (leftM14 * rightM42);
@@ -507,30 +509,30 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix2x4d left, ref Matrix4 right, out Matrix2x4d result)
         {
-            double leftM11 = left.Row0.X,
-                leftM12 = left.Row0.Y,
-                leftM13 = left.Row0.Z,
-                leftM14 = left.Row0.W,
-                leftM21 = left.Row1.X,
-                leftM22 = left.Row1.Y,
-                leftM23 = left.Row1.Z,
-                leftM24 = left.Row1.W,
-                rightM11 = right.Row0.X,
-                rightM12 = right.Row0.Y,
-                rightM13 = right.Row0.Z,
-                rightM14 = right.Row0.W,
-                rightM21 = right.Row1.X,
-                rightM22 = right.Row1.Y,
-                rightM23 = right.Row1.Z,
-                rightM24 = right.Row1.W,
-                rightM31 = right.Row2.X,
-                rightM32 = right.Row2.Y,
-                rightM33 = right.Row2.Z,
-                rightM34 = right.Row2.W,
-                rightM41 = right.Row3.X,
-                rightM42 = right.Row3.Y,
-                rightM43 = right.Row3.Z,
-                rightM44 = right.Row3.W;
+            double leftM11 = left.Row0.X;
+            double leftM12 = left.Row0.Y;
+            double leftM13 = left.Row0.Z;
+            double leftM14 = left.Row0.W;
+            double leftM21 = left.Row1.X;
+            double leftM22 = left.Row1.Y;
+            double leftM23 = left.Row1.Z;
+            double leftM24 = left.Row1.W;
+            double rightM11 = right.Row0.X;
+            double rightM12 = right.Row0.Y;
+            double rightM13 = right.Row0.Z;
+            double rightM14 = right.Row0.W;
+            double rightM21 = right.Row1.X;
+            double rightM22 = right.Row1.Y;
+            double rightM23 = right.Row1.Z;
+            double rightM24 = right.Row1.W;
+            double rightM31 = right.Row2.X;
+            double rightM32 = right.Row2.Y;
+            double rightM33 = right.Row2.Z;
+            double rightM34 = right.Row2.W;
+            double rightM41 = right.Row3.X;
+            double rightM42 = right.Row3.Y;
+            double rightM43 = right.Row3.Z;
+            double rightM44 = right.Row3.W;
 
             result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21) + (leftM13 * rightM31) + (leftM14 * rightM41);
             result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22) + (leftM13 * rightM32) + (leftM14 * rightM42);

--- a/src/OpenTK.Mathematics/Matrix/Matrix3.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix3.cs
@@ -21,6 +21,7 @@ SOFTWARE.
  */
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
 namespace OpenTK.Mathematics
@@ -82,18 +83,11 @@ namespace OpenTK.Mathematics
         /// <param name="m20">First item of the third row of the matrix.</param>
         /// <param name="m21">Second item of the third row of the matrix.</param>
         /// <param name="m22">Third item of the third row of the matrix.</param>
-        public Matrix3
-        (
-            float m00,
-            float m01,
-            float m02,
-            float m10,
-            float m11,
-            float m12,
-            float m20,
-            float m21,
-            float m22
-        )
+        [SuppressMessage("ReSharper", "SA1117", Justification = "For better readability of Matrix struct.")]
+        public Matrix3(
+            float m00, float m01, float m02,
+            float m10, float m11, float m12,
+            float m20, float m21, float m22)
         {
             Row0 = new Vector3(m00, m01, m02);
             Row1 = new Vector3(m10, m11, m12);
@@ -253,6 +247,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="rowIndex">The index of the row.</param>
         /// <param name="columnIndex">The index of the column.</param>
+        /// <returns>The element at the given row and column index.</returns>
         public float this[int rowIndex, int columnIndex]
         {
             get
@@ -315,9 +310,9 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
-        /// Returns a normalised copy of this instance.
+        /// Returns a normalized copy of this instance.
         /// </summary>
-        /// <returns>The matrix.</returns>
+        /// <returns>The normalized matrix.</returns>
         public Matrix3 Normalized()
         {
             var m = this;
@@ -339,7 +334,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Returns an inverted copy of this instance.
         /// </summary>
-        /// <returns>The matrix.</returns>
+        /// <returns>The inverted matrix.</returns>
         public Matrix3 Inverted()
         {
             var m = this;
@@ -354,7 +349,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Returns a copy of this Matrix3 without scale.
         /// </summary>
-        /// <returns>The matrix.</returns>
+        /// <returns>The matrix without scaling.</returns>
         public Matrix3 ClearScale()
         {
             var m = this;
@@ -367,7 +362,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Returns a copy of this Matrix3 without rotation.
         /// </summary>
-        /// <returns>The matrix.</returns>
+        /// <returns>The matrix without rotation.</returns>
         public Matrix3 ClearRotation()
         {
             var m = this;
@@ -389,18 +384,18 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Returns the rotation component of this instance. Quite slow.
         /// </summary>
-        /// <param name="row_normalise">
-        /// Whether the method should row-normalise (i.e. remove scale from) the Matrix. Pass false if
-        /// you know it's already normalised.
+        /// <param name="rowNormalize">
+        /// Whether the method should row-normalize (i.e. remove scale from) the Matrix. Pass false if
+        /// you know it's already normalized.
         /// </param>
         /// <returns>The rotation.</returns>
-        public Quaternion ExtractRotation(bool row_normalise = true)
+        public Quaternion ExtractRotation(bool rowNormalize = true)
         {
             var row0 = Row0;
             var row1 = Row1;
             var row2 = Row2;
 
-            if (row_normalise)
+            if (rowNormalize)
             {
                 row0 = row0.Normalized();
                 row1 = row1.Normalized();
@@ -462,6 +457,7 @@ namespace OpenTK.Mathematics
         /// <param name="axis">The axis to rotate about.</param>
         /// <param name="angle">Angle in radians to rotate counter-clockwise (looking in the direction of the given axis).</param>
         /// <param name="result">A matrix instance.</param>
+        [SuppressMessage("Microsoft.StyleCop.CSharp.DocumentationRules", "SA1305", Justification = "Is not hungarian notation but abbreveation for precalculated values.")]
         public static void CreateFromAxisAngle(Vector3 axis, float angle, out Matrix3 result)
         {
             // normalize and create a local copy of the vector.
@@ -735,34 +731,34 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix3 left, ref Matrix3 right, out Matrix3 result)
         {
-            float lM11 = left.Row0.X,
-                lM12 = left.Row0.Y,
-                lM13 = left.Row0.Z,
-                lM21 = left.Row1.X,
-                lM22 = left.Row1.Y,
-                lM23 = left.Row1.Z,
-                lM31 = left.Row2.X,
-                lM32 = left.Row2.Y,
-                lM33 = left.Row2.Z,
-                rM11 = right.Row0.X,
-                rM12 = right.Row0.Y,
-                rM13 = right.Row0.Z,
-                rM21 = right.Row1.X,
-                rM22 = right.Row1.Y,
-                rM23 = right.Row1.Z,
-                rM31 = right.Row2.X,
-                rM32 = right.Row2.Y,
-                rM33 = right.Row2.Z;
+            float leftM11 = left.Row0.X,
+                leftM12 = left.Row0.Y,
+                leftM13 = left.Row0.Z,
+                leftM21 = left.Row1.X,
+                leftM22 = left.Row1.Y,
+                leftM23 = left.Row1.Z,
+                leftM31 = left.Row2.X,
+                leftM32 = left.Row2.Y,
+                leftM33 = left.Row2.Z,
+                rightM11 = right.Row0.X,
+                rightM12 = right.Row0.Y,
+                rightM13 = right.Row0.Z,
+                rightM21 = right.Row1.X,
+                rightM22 = right.Row1.Y,
+                rightM23 = right.Row1.Z,
+                rightM31 = right.Row2.X,
+                rightM32 = right.Row2.Y,
+                rightM33 = right.Row2.Z;
 
-            result.Row0.X = (lM11 * rM11) + (lM12 * rM21) + (lM13 * rM31);
-            result.Row0.Y = (lM11 * rM12) + (lM12 * rM22) + (lM13 * rM32);
-            result.Row0.Z = (lM11 * rM13) + (lM12 * rM23) + (lM13 * rM33);
-            result.Row1.X = (lM21 * rM11) + (lM22 * rM21) + (lM23 * rM31);
-            result.Row1.Y = (lM21 * rM12) + (lM22 * rM22) + (lM23 * rM32);
-            result.Row1.Z = (lM21 * rM13) + (lM22 * rM23) + (lM23 * rM33);
-            result.Row2.X = (lM31 * rM11) + (lM32 * rM21) + (lM33 * rM31);
-            result.Row2.Y = (lM31 * rM12) + (lM32 * rM22) + (lM33 * rM32);
-            result.Row2.Z = (lM31 * rM13) + (lM32 * rM23) + (lM33 * rM33);
+            result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21) + (leftM13 * rightM31);
+            result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22) + (leftM13 * rightM32);
+            result.Row0.Z = (leftM11 * rightM13) + (leftM12 * rightM23) + (leftM13 * rightM33);
+            result.Row1.X = (leftM21 * rightM11) + (leftM22 * rightM21) + (leftM23 * rightM31);
+            result.Row1.Y = (leftM21 * rightM12) + (leftM22 * rightM22) + (leftM23 * rightM32);
+            result.Row1.Z = (leftM21 * rightM13) + (leftM22 * rightM23) + (leftM23 * rightM33);
+            result.Row2.X = (leftM31 * rightM11) + (leftM32 * rightM21) + (leftM33 * rightM31);
+            result.Row2.Y = (leftM31 * rightM12) + (leftM32 * rightM22) + (leftM33 * rightM32);
+            result.Row2.Z = (leftM31 * rightM13) + (leftM32 * rightM23) + (leftM33 * rightM33);
         }
 
         /// <summary>
@@ -781,7 +777,7 @@ namespace OpenTK.Mathematics
             {
                 { mat.Row0.X, mat.Row0.Y, mat.Row0.Z },
                 { mat.Row1.X, mat.Row1.Y, mat.Row1.Z },
-                { mat.Row2.X, mat.Row2.Y, mat.Row2.Z }
+                { mat.Row2.X, mat.Row2.Y, mat.Row2.Z },
             };
 
             var icol = 0;

--- a/src/OpenTK.Mathematics/Matrix/Matrix3.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix3.cs
@@ -84,10 +84,12 @@ namespace OpenTK.Mathematics
         /// <param name="m21">Second item of the third row of the matrix.</param>
         /// <param name="m22">Third item of the third row of the matrix.</param>
         [SuppressMessage("ReSharper", "SA1117", Justification = "For better readability of Matrix struct.")]
-        public Matrix3(
+        public Matrix3
+        (
             float m00, float m01, float m02,
             float m10, float m11, float m12,
-            float m20, float m21, float m22)
+            float m20, float m21, float m22
+        )
         {
             Row0 = new Vector3(m00, m01, m02);
             Row1 = new Vector3(m10, m11, m12);
@@ -112,15 +114,15 @@ namespace OpenTK.Mathematics
         {
             get
             {
-                float m11 = Row0.X,
-                    m12 = Row0.Y,
-                    m13 = Row0.Z,
-                    m21 = Row1.X,
-                    m22 = Row1.Y,
-                    m23 = Row1.Z,
-                    m31 = Row2.X,
-                    m32 = Row2.Y,
-                    m33 = Row2.Z;
+                float m11 = Row0.X;
+                float m12 = Row0.Y;
+                float m13 = Row0.Z;
+                float m21 = Row1.X;
+                float m22 = Row1.Y;
+                float m23 = Row1.Z;
+                float m31 = Row2.X;
+                float m32 = Row2.Y;
+                float m33 = Row2.Z;
 
                 return (m11 * m22 * m33) + (m12 * m23 * m31) + (m13 * m21 * m32)
                        - (m13 * m22 * m31) - (m11 * m23 * m32) - (m12 * m21 * m33);
@@ -312,7 +314,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Returns a normalized copy of this instance.
         /// </summary>
-        /// <returns>The normalized matrix.</returns>
+        /// <returns>The normalized copy.</returns>
         public Matrix3 Normalized()
         {
             var m = this;
@@ -334,7 +336,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Returns an inverted copy of this instance.
         /// </summary>
-        /// <returns>The inverted matrix.</returns>
+        /// <returns>The inverted copy.</returns>
         public Matrix3 Inverted()
         {
             var m = this;
@@ -457,7 +459,6 @@ namespace OpenTK.Mathematics
         /// <param name="axis">The axis to rotate about.</param>
         /// <param name="angle">Angle in radians to rotate counter-clockwise (looking in the direction of the given axis).</param>
         /// <param name="result">A matrix instance.</param>
-        [SuppressMessage("Microsoft.StyleCop.CSharp.DocumentationRules", "SA1305", Justification = "Is not hungarian notation but abbreveation for precalculated values.")]
         public static void CreateFromAxisAngle(Vector3 axis, float angle, out Matrix3 result)
         {
             // normalize and create a local copy of the vector.
@@ -470,16 +471,16 @@ namespace OpenTK.Mathematics
             var t = 1.0f - cos;
 
             // do the conversion math once
-            float tXX = t * axisX * axisX,
-                tXY = t * axisX * axisY,
-                tXZ = t * axisX * axisZ,
-                tYY = t * axisY * axisY,
-                tYZ = t * axisY * axisZ,
-                tZZ = t * axisZ * axisZ;
+            float tXX = t * axisX * axisX;
+            float tXY = t * axisX * axisY;
+            float tXZ = t * axisX * axisZ;
+            float tYY = t * axisY * axisY;
+            float tYZ = t * axisY * axisZ;
+            float tZZ = t * axisZ * axisZ;
 
-            float sinX = sin * axisX,
-                sinY = sin * axisY,
-                sinZ = sin * axisZ;
+            float sinX = sin * axisX;
+            float sinY = sin * axisY;
+            float sinZ = sin * axisZ;
 
             result.Row0.X = tXX + cos;
             result.Row0.Y = tXY - sinZ;
@@ -731,24 +732,24 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix3 left, ref Matrix3 right, out Matrix3 result)
         {
-            float leftM11 = left.Row0.X,
-                leftM12 = left.Row0.Y,
-                leftM13 = left.Row0.Z,
-                leftM21 = left.Row1.X,
-                leftM22 = left.Row1.Y,
-                leftM23 = left.Row1.Z,
-                leftM31 = left.Row2.X,
-                leftM32 = left.Row2.Y,
-                leftM33 = left.Row2.Z,
-                rightM11 = right.Row0.X,
-                rightM12 = right.Row0.Y,
-                rightM13 = right.Row0.Z,
-                rightM21 = right.Row1.X,
-                rightM22 = right.Row1.Y,
-                rightM23 = right.Row1.Z,
-                rightM31 = right.Row2.X,
-                rightM32 = right.Row2.Y,
-                rightM33 = right.Row2.Z;
+            float leftM11 = left.Row0.X;
+            float leftM12 = left.Row0.Y;
+            float leftM13 = left.Row0.Z;
+            float leftM21 = left.Row1.X;
+            float leftM22 = left.Row1.Y;
+            float leftM23 = left.Row1.Z;
+            float leftM31 = left.Row2.X;
+            float leftM32 = left.Row2.Y;
+            float leftM33 = left.Row2.Z;
+            float rightM11 = right.Row0.X;
+            float rightM12 = right.Row0.Y;
+            float rightM13 = right.Row0.Z;
+            float rightM21 = right.Row1.X;
+            float rightM22 = right.Row1.Y;
+            float rightM23 = right.Row1.Z;
+            float rightM31 = right.Row2.X;
+            float rightM32 = right.Row2.Y;
+            float rightM33 = right.Row2.Z;
 
             result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21) + (leftM13 * rightM31);
             result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22) + (leftM13 * rightM32);
@@ -777,7 +778,7 @@ namespace OpenTK.Mathematics
             {
                 { mat.Row0.X, mat.Row0.Y, mat.Row0.Z },
                 { mat.Row1.X, mat.Row1.Y, mat.Row1.Z },
-                { mat.Row2.X, mat.Row2.Y, mat.Row2.Z },
+                { mat.Row2.X, mat.Row2.Y, mat.Row2.Z }
             };
 
             var icol = 0;

--- a/src/OpenTK.Mathematics/Matrix/Matrix3d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix3d.cs
@@ -79,10 +79,12 @@ namespace OpenTK.Mathematics
         /// <param name="m21">Second item of the third row of the matrix.</param>
         /// <param name="m22">Third item of the third row of the matrix.</param>
         [SuppressMessage("ReSharper", "SA1117", Justification = "For better readability of Matrix struct.")]
-        public Matrix3d(
+        public Matrix3d
+        (
             double m00, double m01, double m02,
             double m10, double m11, double m12,
-            double m20, double m21, double m22)
+            double m20, double m21, double m22
+        )
         {
             Row0 = new Vector3d(m00, m01, m02);
             Row1 = new Vector3d(m10, m11, m12);
@@ -107,15 +109,15 @@ namespace OpenTK.Mathematics
         {
             get
             {
-                double m11 = Row0.X,
-                    m12 = Row0.Y,
-                    m13 = Row0.Z,
-                    m21 = Row1.X,
-                    m22 = Row1.Y,
-                    m23 = Row1.Z,
-                    m31 = Row2.X,
-                    m32 = Row2.Y,
-                    m33 = Row2.Z;
+                double m11 = Row0.X;
+                double m12 = Row0.Y;
+                double m13 = Row0.Z;
+                double m21 = Row1.X;
+                double m22 = Row1.Y;
+                double m23 = Row1.Z;
+                double m31 = Row2.X;
+                double m32 = Row2.Y;
+                double m33 = Row2.Z;
 
                 return
                     (m11 * m22 * m33) + (m12 * m23 * m31) + (m13 * m21 * m32)
@@ -307,7 +309,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Returns a normalized copy of this instance.
         /// </summary>
-        /// <returns>The normalized vector.</returns>
+        /// <returns>The normalized copy.</returns>
         public Matrix3d Normalized()
         {
             var m = this;
@@ -329,7 +331,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Returns an inverted copy of this instance.
         /// </summary>
-        /// <returns>The inverted matrix.</returns>
+        /// <returns>The inverted copy.</returns>
         public Matrix3d Inverted()
         {
             var m = this;
@@ -452,7 +454,6 @@ namespace OpenTK.Mathematics
         /// <param name="axis">The axis to rotate about.</param>
         /// <param name="angle">Angle in radians to rotate counter-clockwise (looking in the direction of the given axis).</param>
         /// <param name="result">A matrix instance.</param>
-        [SuppressMessage("Microsoft.StyleCop.CSharp.DocumentationRules", "SA1305", Justification = "Is not hungarian notation but abbreveation for precalculated values.")]
         public static void CreateFromAxisAngle(Vector3d axis, double angle, out Matrix3d result)
         {
             // normalize and create a local copy of the vector.
@@ -465,16 +466,16 @@ namespace OpenTK.Mathematics
             var t = 1.0f - cos;
 
             // do the conversion math once
-            double tXX = t * axisX * axisX,
-                tXY = t * axisX * axisY,
-                tXZ = t * axisX * axisZ,
-                tYY = t * axisY * axisY,
-                tYZ = t * axisY * axisZ,
-                tZZ = t * axisZ * axisZ;
+            double tXX = t * axisX * axisX;
+            double tXY = t * axisX * axisY;
+            double tXZ = t * axisX * axisZ;
+            double tYY = t * axisY * axisY;
+            double tYZ = t * axisY * axisZ;
+            double tZZ = t * axisZ * axisZ;
 
-            double sinX = sin * axisX,
-                sinY = sin * axisY,
-                sinZ = sin * axisZ;
+            double sinX = sin * axisX;
+            double sinY = sin * axisY;
+            double sinZ = sin * axisZ;
 
             result.Row0.X = tXX + cos;
             result.Row0.Y = tXY - sinZ;
@@ -726,24 +727,24 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix3d left, ref Matrix3d right, out Matrix3d result)
         {
-            double leftM11 = left.Row0.X,
-                leftM12 = left.Row0.Y,
-                leftM13 = left.Row0.Z,
-                leftM21 = left.Row1.X,
-                leftM22 = left.Row1.Y,
-                leftM23 = left.Row1.Z,
-                leftM31 = left.Row2.X,
-                leftM32 = left.Row2.Y,
-                leftM33 = left.Row2.Z,
-                rightM11 = right.Row0.X,
-                rightM12 = right.Row0.Y,
-                rightM13 = right.Row0.Z,
-                rightM21 = right.Row1.X,
-                rightM22 = right.Row1.Y,
-                rightM23 = right.Row1.Z,
-                rightM31 = right.Row2.X,
-                rightM32 = right.Row2.Y,
-                rightM33 = right.Row2.Z;
+            double leftM11 = left.Row0.X;
+            double leftM12 = left.Row0.Y;
+            double leftM13 = left.Row0.Z;
+            double leftM21 = left.Row1.X;
+            double leftM22 = left.Row1.Y;
+            double leftM23 = left.Row1.Z;
+            double leftM31 = left.Row2.X;
+            double leftM32 = left.Row2.Y;
+            double leftM33 = left.Row2.Z;
+            double rightM11 = right.Row0.X;
+            double rightM12 = right.Row0.Y;
+            double rightM13 = right.Row0.Z;
+            double rightM21 = right.Row1.X;
+            double rightM22 = right.Row1.Y;
+            double rightM23 = right.Row1.Z;
+            double rightM31 = right.Row2.X;
+            double rightM32 = right.Row2.Y;
+            double rightM33 = right.Row2.Z;
 
             result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21) + (leftM13 * rightM31);
             result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22) + (leftM13 * rightM32);

--- a/src/OpenTK.Mathematics/Matrix/Matrix3d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix3d.cs
@@ -21,6 +21,7 @@ SOFTWARE.
  */
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
 namespace OpenTK.Mathematics
@@ -77,18 +78,11 @@ namespace OpenTK.Mathematics
         /// <param name="m20">First item of the third row of the matrix.</param>
         /// <param name="m21">Second item of the third row of the matrix.</param>
         /// <param name="m22">Third item of the third row of the matrix.</param>
-        public Matrix3d
-        (
-            double m00,
-            double m01,
-            double m02,
-            double m10,
-            double m11,
-            double m12,
-            double m20,
-            double m21,
-            double m22
-        )
+        [SuppressMessage("ReSharper", "SA1117", Justification = "For better readability of Matrix struct.")]
+        public Matrix3d(
+            double m00, double m01, double m02,
+            double m10, double m11, double m12,
+            double m20, double m21, double m22)
         {
             Row0 = new Vector3d(m00, m01, m02);
             Row1 = new Vector3d(m10, m11, m12);
@@ -311,7 +305,7 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
-        /// Returns a normalised copy of this instance.
+        /// Returns a normalized copy of this instance.
         /// </summary>
         /// <returns>The normalized vector.</returns>
         public Matrix3d Normalized()
@@ -350,7 +344,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Returns a copy of this Matrix3 without scale.
         /// </summary>
-        /// <returns>The matrix.</returns>
+        /// <returns>The matrix without scaling.</returns>
         public Matrix3d ClearScale()
         {
             var m = this;
@@ -363,7 +357,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Returns a copy of this Matrix3 without rotation.
         /// </summary>
-        /// <returns>The matrix.</returns>
+        /// <returns>The matrix without rotation.</returns>
         public Matrix3d ClearRotation()
         {
             var m = this;
@@ -376,7 +370,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Returns the scale component of this instance.
         /// </summary>
-        /// <returns>The matrix.</returns>
+        /// <returns>The scale components.</returns>
         public Vector3d ExtractScale()
         {
             return new Vector3d(Row0.Length, Row1.Length, Row2.Length);
@@ -385,18 +379,18 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Returns the rotation component of this instance. Quite slow.
         /// </summary>
-        /// <param name="row_normalise">
-        /// Whether the method should row-normalise (i.e. remove scale from) the Matrix. Pass false if
-        /// you know it's already normalised.
+        /// <param name="rowNormalize">
+        /// Whether the method should row-normalize (i.e. remove scale from) the Matrix. Pass false if
+        /// you know it's already normalized.
         /// </param>
         /// <returns>The rotation.</returns>
-        public Quaterniond ExtractRotation(bool row_normalise = true)
+        public Quaterniond ExtractRotation(bool rowNormalize = true)
         {
             var row0 = Row0;
             var row1 = Row1;
             var row2 = Row2;
 
-            if (row_normalise)
+            if (rowNormalize)
             {
                 row0 = row0.Normalized();
                 row1 = row1.Normalized();
@@ -458,6 +452,7 @@ namespace OpenTK.Mathematics
         /// <param name="axis">The axis to rotate about.</param>
         /// <param name="angle">Angle in radians to rotate counter-clockwise (looking in the direction of the given axis).</param>
         /// <param name="result">A matrix instance.</param>
+        [SuppressMessage("Microsoft.StyleCop.CSharp.DocumentationRules", "SA1305", Justification = "Is not hungarian notation but abbreveation for precalculated values.")]
         public static void CreateFromAxisAngle(Vector3d axis, double angle, out Matrix3d result)
         {
             // normalize and create a local copy of the vector.
@@ -731,34 +726,34 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix3d left, ref Matrix3d right, out Matrix3d result)
         {
-            double lM11 = left.Row0.X,
-                lM12 = left.Row0.Y,
-                lM13 = left.Row0.Z,
-                lM21 = left.Row1.X,
-                lM22 = left.Row1.Y,
-                lM23 = left.Row1.Z,
-                lM31 = left.Row2.X,
-                lM32 = left.Row2.Y,
-                lM33 = left.Row2.Z,
-                rM11 = right.Row0.X,
-                rM12 = right.Row0.Y,
-                rM13 = right.Row0.Z,
-                rM21 = right.Row1.X,
-                rM22 = right.Row1.Y,
-                rM23 = right.Row1.Z,
-                rM31 = right.Row2.X,
-                rM32 = right.Row2.Y,
-                rM33 = right.Row2.Z;
+            double leftM11 = left.Row0.X,
+                leftM12 = left.Row0.Y,
+                leftM13 = left.Row0.Z,
+                leftM21 = left.Row1.X,
+                leftM22 = left.Row1.Y,
+                leftM23 = left.Row1.Z,
+                leftM31 = left.Row2.X,
+                leftM32 = left.Row2.Y,
+                leftM33 = left.Row2.Z,
+                rightM11 = right.Row0.X,
+                rightM12 = right.Row0.Y,
+                rightM13 = right.Row0.Z,
+                rightM21 = right.Row1.X,
+                rightM22 = right.Row1.Y,
+                rightM23 = right.Row1.Z,
+                rightM31 = right.Row2.X,
+                rightM32 = right.Row2.Y,
+                rightM33 = right.Row2.Z;
 
-            result.Row0.X = (lM11 * rM11) + (lM12 * rM21) + (lM13 * rM31);
-            result.Row0.Y = (lM11 * rM12) + (lM12 * rM22) + (lM13 * rM32);
-            result.Row0.Z = (lM11 * rM13) + (lM12 * rM23) + (lM13 * rM33);
-            result.Row1.X = (lM21 * rM11) + (lM22 * rM21) + (lM23 * rM31);
-            result.Row1.Y = (lM21 * rM12) + (lM22 * rM22) + (lM23 * rM32);
-            result.Row1.Z = (lM21 * rM13) + (lM22 * rM23) + (lM23 * rM33);
-            result.Row2.X = (lM31 * rM11) + (lM32 * rM21) + (lM33 * rM31);
-            result.Row2.Y = (lM31 * rM12) + (lM32 * rM22) + (lM33 * rM32);
-            result.Row2.Z = (lM31 * rM13) + (lM32 * rM23) + (lM33 * rM33);
+            result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21) + (leftM13 * rightM31);
+            result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22) + (leftM13 * rightM32);
+            result.Row0.Z = (leftM11 * rightM13) + (leftM12 * rightM23) + (leftM13 * rightM33);
+            result.Row1.X = (leftM21 * rightM11) + (leftM22 * rightM21) + (leftM23 * rightM31);
+            result.Row1.Y = (leftM21 * rightM12) + (leftM22 * rightM22) + (leftM23 * rightM32);
+            result.Row1.Z = (leftM21 * rightM13) + (leftM22 * rightM23) + (leftM23 * rightM33);
+            result.Row2.X = (leftM31 * rightM11) + (leftM32 * rightM21) + (leftM33 * rightM31);
+            result.Row2.Y = (leftM31 * rightM12) + (leftM32 * rightM22) + (leftM33 * rightM32);
+            result.Row2.Z = (leftM31 * rightM13) + (leftM32 * rightM23) + (leftM33 * rightM33);
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Matrix/Matrix3x2.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix3x2.cs
@@ -73,10 +73,12 @@ namespace OpenTK.Mathematics
         /// <param name="m20">First item of the third row of the matrix.</param>
         /// <param name="m21">Second item of the third row of the matrix.</param>
         [SuppressMessage("ReSharper", "SA1117", Justification = "For better readability of Matrix struct.")]
-        public Matrix3x2(
+        public Matrix3x2
+        (
             float m00, float m01,
             float m10, float m11,
-            float m20, float m21)
+            float m20, float m21
+        )
         {
             Row0 = new Vector2(m00, m01);
             Row1 = new Vector2(m10, m11);
@@ -379,16 +381,16 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix3x2 left, ref Matrix2 right, out Matrix3x2 result)
         {
-            float leftM11 = left.Row0.X,
-                leftM12 = left.Row0.Y,
-                leftM21 = left.Row1.X,
-                leftM22 = left.Row1.Y,
-                leftM31 = left.Row2.X,
-                leftM32 = left.Row2.Y,
-                rightM11 = right.Row0.X,
-                rightM12 = right.Row0.Y,
-                rightM21 = right.Row1.X,
-                rightM22 = right.Row1.Y;
+            float leftM11 = left.Row0.X;
+            float leftM12 = left.Row0.Y;
+            float leftM21 = left.Row1.X;
+            float leftM22 = left.Row1.Y;
+            float leftM31 = left.Row2.X;
+            float leftM32 = left.Row2.Y;
+            float rightM11 = right.Row0.X;
+            float rightM12 = right.Row0.Y;
+            float rightM21 = right.Row1.X;
+            float rightM22 = right.Row1.Y;
 
             result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21);
             result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22);
@@ -418,18 +420,18 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix3x2 left, ref Matrix2x3 right, out Matrix3 result)
         {
-            float leftM11 = left.Row0.X,
-                leftM12 = left.Row0.Y,
-                leftM21 = left.Row1.X,
-                leftM22 = left.Row1.Y,
-                leftM31 = left.Row2.X,
-                leftM32 = left.Row2.Y,
-                rightM11 = right.Row0.X,
-                rightM12 = right.Row0.Y,
-                rightM13 = right.Row0.Z,
-                rightM21 = right.Row1.X,
-                rightM22 = right.Row1.Y,
-                rightM23 = right.Row1.Z;
+            float leftM11 = left.Row0.X;
+            float leftM12 = left.Row0.Y;
+            float leftM21 = left.Row1.X;
+            float leftM22 = left.Row1.Y;
+            float leftM31 = left.Row2.X;
+            float leftM32 = left.Row2.Y;
+            float rightM11 = right.Row0.X;
+            float rightM12 = right.Row0.Y;
+            float rightM13 = right.Row0.Z;
+            float rightM21 = right.Row1.X;
+            float rightM22 = right.Row1.Y;
+            float rightM23 = right.Row1.Z;
 
             result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21);
             result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22);
@@ -462,20 +464,20 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix3x2 left, ref Matrix2x4 right, out Matrix3x4 result)
         {
-            float leftM11 = left.Row0.X,
-                leftM12 = left.Row0.Y,
-                leftM21 = left.Row1.X,
-                leftM22 = left.Row1.Y,
-                leftM31 = left.Row2.X,
-                leftM32 = left.Row2.Y,
-                rightM11 = right.Row0.X,
-                rightM12 = right.Row0.Y,
-                rightM13 = right.Row0.Z,
-                rightM14 = right.Row0.W,
-                rightM21 = right.Row1.X,
-                rightM22 = right.Row1.Y,
-                rightM23 = right.Row1.Z,
-                rightM24 = right.Row1.W;
+            float leftM11 = left.Row0.X;
+            float leftM12 = left.Row0.Y;
+            float leftM21 = left.Row1.X;
+            float leftM22 = left.Row1.Y;
+            float leftM31 = left.Row2.X;
+            float leftM32 = left.Row2.Y;
+            float rightM11 = right.Row0.X;
+            float rightM12 = right.Row0.Y;
+            float rightM13 = right.Row0.Z;
+            float rightM14 = right.Row0.W;
+            float rightM21 = right.Row1.X;
+            float rightM22 = right.Row1.Y;
+            float rightM23 = right.Row1.Z;
+            float rightM24 = right.Row1.W;
 
             result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21);
             result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22);

--- a/src/OpenTK.Mathematics/Matrix/Matrix3x2.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix3x2.cs
@@ -21,6 +21,7 @@ SOFTWARE.
  */
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace OpenTK.Mathematics
 {
@@ -71,15 +72,11 @@ namespace OpenTK.Mathematics
         /// <param name="m11">Second item of the second row of the matrix.</param>
         /// <param name="m20">First item of the third row of the matrix.</param>
         /// <param name="m21">Second item of the third row of the matrix.</param>
-        public Matrix3x2
-        (
-            float m00,
-            float m01,
-            float m10,
-            float m11,
-            float m20,
-            float m21
-        )
+        [SuppressMessage("ReSharper", "SA1117", Justification = "For better readability of Matrix struct.")]
+        public Matrix3x2(
+            float m00, float m01,
+            float m10, float m11,
+            float m20, float m21)
         {
             Row0 = new Vector2(m00, m01);
             Row1 = new Vector2(m10, m11);
@@ -191,6 +188,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="rowIndex">The index of the row.</param>
         /// <param name="columnIndex">The index of the column.</param>
+        /// <returns>The element at the given row and column index.</returns>
         public float this[int rowIndex, int columnIndex]
         {
             get
@@ -381,23 +379,23 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix3x2 left, ref Matrix2 right, out Matrix3x2 result)
         {
-            float lM11 = left.Row0.X,
-                lM12 = left.Row0.Y,
-                lM21 = left.Row1.X,
-                lM22 = left.Row1.Y,
-                lM31 = left.Row2.X,
-                lM32 = left.Row2.Y,
-                rM11 = right.Row0.X,
-                rM12 = right.Row0.Y,
-                rM21 = right.Row1.X,
-                rM22 = right.Row1.Y;
+            float leftM11 = left.Row0.X,
+                leftM12 = left.Row0.Y,
+                leftM21 = left.Row1.X,
+                leftM22 = left.Row1.Y,
+                leftM31 = left.Row2.X,
+                leftM32 = left.Row2.Y,
+                rightM11 = right.Row0.X,
+                rightM12 = right.Row0.Y,
+                rightM21 = right.Row1.X,
+                rightM22 = right.Row1.Y;
 
-            result.Row0.X = (lM11 * rM11) + (lM12 * rM21);
-            result.Row0.Y = (lM11 * rM12) + (lM12 * rM22);
-            result.Row1.X = (lM21 * rM11) + (lM22 * rM21);
-            result.Row1.Y = (lM21 * rM12) + (lM22 * rM22);
-            result.Row2.X = (lM31 * rM11) + (lM32 * rM21);
-            result.Row2.Y = (lM31 * rM12) + (lM32 * rM22);
+            result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21);
+            result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22);
+            result.Row1.X = (leftM21 * rightM11) + (leftM22 * rightM21);
+            result.Row1.Y = (leftM21 * rightM12) + (leftM22 * rightM22);
+            result.Row2.X = (leftM31 * rightM11) + (leftM32 * rightM21);
+            result.Row2.Y = (leftM31 * rightM12) + (leftM32 * rightM22);
         }
 
         /// <summary>
@@ -420,28 +418,28 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix3x2 left, ref Matrix2x3 right, out Matrix3 result)
         {
-            float lM11 = left.Row0.X,
-                lM12 = left.Row0.Y,
-                lM21 = left.Row1.X,
-                lM22 = left.Row1.Y,
-                lM31 = left.Row2.X,
-                lM32 = left.Row2.Y,
-                rM11 = right.Row0.X,
-                rM12 = right.Row0.Y,
-                rM13 = right.Row0.Z,
-                rM21 = right.Row1.X,
-                rM22 = right.Row1.Y,
-                rM23 = right.Row1.Z;
+            float leftM11 = left.Row0.X,
+                leftM12 = left.Row0.Y,
+                leftM21 = left.Row1.X,
+                leftM22 = left.Row1.Y,
+                leftM31 = left.Row2.X,
+                leftM32 = left.Row2.Y,
+                rightM11 = right.Row0.X,
+                rightM12 = right.Row0.Y,
+                rightM13 = right.Row0.Z,
+                rightM21 = right.Row1.X,
+                rightM22 = right.Row1.Y,
+                rightM23 = right.Row1.Z;
 
-            result.Row0.X = (lM11 * rM11) + (lM12 * rM21);
-            result.Row0.Y = (lM11 * rM12) + (lM12 * rM22);
-            result.Row0.Z = (lM11 * rM13) + (lM12 * rM23);
-            result.Row1.X = (lM21 * rM11) + (lM22 * rM21);
-            result.Row1.Y = (lM21 * rM12) + (lM22 * rM22);
-            result.Row1.Z = (lM21 * rM13) + (lM22 * rM23);
-            result.Row2.X = (lM31 * rM11) + (lM32 * rM21);
-            result.Row2.Y = (lM31 * rM12) + (lM32 * rM22);
-            result.Row2.Z = (lM31 * rM13) + (lM32 * rM23);
+            result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21);
+            result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22);
+            result.Row0.Z = (leftM11 * rightM13) + (leftM12 * rightM23);
+            result.Row1.X = (leftM21 * rightM11) + (leftM22 * rightM21);
+            result.Row1.Y = (leftM21 * rightM12) + (leftM22 * rightM22);
+            result.Row1.Z = (leftM21 * rightM13) + (leftM22 * rightM23);
+            result.Row2.X = (leftM31 * rightM11) + (leftM32 * rightM21);
+            result.Row2.Y = (leftM31 * rightM12) + (leftM32 * rightM22);
+            result.Row2.Z = (leftM31 * rightM13) + (leftM32 * rightM23);
         }
 
         /// <summary>
@@ -464,33 +462,33 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix3x2 left, ref Matrix2x4 right, out Matrix3x4 result)
         {
-            float lM11 = left.Row0.X,
-                lM12 = left.Row0.Y,
-                lM21 = left.Row1.X,
-                lM22 = left.Row1.Y,
-                lM31 = left.Row2.X,
-                lM32 = left.Row2.Y,
-                rM11 = right.Row0.X,
-                rM12 = right.Row0.Y,
-                rM13 = right.Row0.Z,
-                rM14 = right.Row0.W,
-                rM21 = right.Row1.X,
-                rM22 = right.Row1.Y,
-                rM23 = right.Row1.Z,
-                rM24 = right.Row1.W;
+            float leftM11 = left.Row0.X,
+                leftM12 = left.Row0.Y,
+                leftM21 = left.Row1.X,
+                leftM22 = left.Row1.Y,
+                leftM31 = left.Row2.X,
+                leftM32 = left.Row2.Y,
+                rightM11 = right.Row0.X,
+                rightM12 = right.Row0.Y,
+                rightM13 = right.Row0.Z,
+                rightM14 = right.Row0.W,
+                rightM21 = right.Row1.X,
+                rightM22 = right.Row1.Y,
+                rightM23 = right.Row1.Z,
+                rightM24 = right.Row1.W;
 
-            result.Row0.X = (lM11 * rM11) + (lM12 * rM21);
-            result.Row0.Y = (lM11 * rM12) + (lM12 * rM22);
-            result.Row0.Z = (lM11 * rM13) + (lM12 * rM23);
-            result.Row0.W = (lM11 * rM14) + (lM12 * rM24);
-            result.Row1.X = (lM21 * rM11) + (lM22 * rM21);
-            result.Row1.Y = (lM21 * rM12) + (lM22 * rM22);
-            result.Row1.Z = (lM21 * rM13) + (lM22 * rM23);
-            result.Row1.W = (lM21 * rM14) + (lM22 * rM24);
-            result.Row2.X = (lM31 * rM11) + (lM32 * rM21);
-            result.Row2.Y = (lM31 * rM12) + (lM32 * rM22);
-            result.Row2.Z = (lM31 * rM13) + (lM32 * rM23);
-            result.Row2.W = (lM31 * rM14) + (lM32 * rM24);
+            result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21);
+            result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22);
+            result.Row0.Z = (leftM11 * rightM13) + (leftM12 * rightM23);
+            result.Row0.W = (leftM11 * rightM14) + (leftM12 * rightM24);
+            result.Row1.X = (leftM21 * rightM11) + (leftM22 * rightM21);
+            result.Row1.Y = (leftM21 * rightM12) + (leftM22 * rightM22);
+            result.Row1.Z = (leftM21 * rightM13) + (leftM22 * rightM23);
+            result.Row1.W = (leftM21 * rightM14) + (leftM22 * rightM24);
+            result.Row2.X = (leftM31 * rightM11) + (leftM32 * rightM21);
+            result.Row2.Y = (leftM31 * rightM12) + (leftM32 * rightM22);
+            result.Row2.Z = (leftM31 * rightM13) + (leftM32 * rightM23);
+            result.Row2.W = (leftM31 * rightM14) + (leftM32 * rightM24);
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Matrix/Matrix3x2d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix3x2d.cs
@@ -21,6 +21,7 @@ SOFTWARE.
  */
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace OpenTK.Mathematics
 {
@@ -71,15 +72,11 @@ namespace OpenTK.Mathematics
         /// <param name="m11">Second item of the second row of the matrix.</param>
         /// <param name="m20">First item of the third row of the matrix.</param>
         /// <param name="m21">Second item of the third row of the matrix.</param>
-        public Matrix3x2d
-        (
-            double m00,
-            double m01,
-            double m10,
-            double m11,
-            double m20,
-            double m21
-        )
+        [SuppressMessage("ReSharper", "SA1117", Justification = "For better readability of Matrix struct.")]
+        public Matrix3x2d(
+            double m00, double m01,
+            double m10, double m11,
+            double m20, double m21)
         {
             Row0 = new Vector2d(m00, m01);
             Row1 = new Vector2d(m10, m11);
@@ -191,6 +188,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="rowIndex">The index of the row.</param>
         /// <param name="columnIndex">The index of the column.</param>
+        /// <returns>The element at the given row and column index.</returns>
         public double this[int rowIndex, int columnIndex]
         {
             get
@@ -381,23 +379,23 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix3x2d left, ref Matrix2d right, out Matrix3x2d result)
         {
-            double lM11 = left.Row0.X,
-                lM12 = left.Row0.Y,
-                lM21 = left.Row1.X,
-                lM22 = left.Row1.Y,
-                lM31 = left.Row2.X,
-                lM32 = left.Row2.Y,
-                rM11 = right.Row0.X,
-                rM12 = right.Row0.Y,
-                rM21 = right.Row1.X,
-                rM22 = right.Row1.Y;
+            double leftM11 = left.Row0.X,
+                leftM12 = left.Row0.Y,
+                leftM21 = left.Row1.X,
+                leftM22 = left.Row1.Y,
+                leftM31 = left.Row2.X,
+                leftM32 = left.Row2.Y,
+                rightM11 = right.Row0.X,
+                rightM12 = right.Row0.Y,
+                rightM21 = right.Row1.X,
+                rightM22 = right.Row1.Y;
 
-            result.Row0.X = (lM11 * rM11) + (lM12 * rM21);
-            result.Row0.Y = (lM11 * rM12) + (lM12 * rM22);
-            result.Row1.X = (lM21 * rM11) + (lM22 * rM21);
-            result.Row1.Y = (lM21 * rM12) + (lM22 * rM22);
-            result.Row2.X = (lM31 * rM11) + (lM32 * rM21);
-            result.Row2.Y = (lM31 * rM12) + (lM32 * rM22);
+            result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21);
+            result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22);
+            result.Row1.X = (leftM21 * rightM11) + (leftM22 * rightM21);
+            result.Row1.Y = (leftM21 * rightM12) + (leftM22 * rightM22);
+            result.Row2.X = (leftM31 * rightM11) + (leftM32 * rightM21);
+            result.Row2.Y = (leftM31 * rightM12) + (leftM32 * rightM22);
         }
 
         /// <summary>
@@ -420,28 +418,28 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix3x2d left, ref Matrix2x3d right, out Matrix3d result)
         {
-            double lM11 = left.Row0.X,
-                lM12 = left.Row0.Y,
-                lM21 = left.Row1.X,
-                lM22 = left.Row1.Y,
-                lM31 = left.Row2.X,
-                lM32 = left.Row2.Y,
-                rM11 = right.Row0.X,
-                rM12 = right.Row0.Y,
-                rM13 = right.Row0.Z,
-                rM21 = right.Row1.X,
-                rM22 = right.Row1.Y,
-                rM23 = right.Row1.Z;
+            double leftM11 = left.Row0.X,
+                leftM12 = left.Row0.Y,
+                leftM21 = left.Row1.X,
+                leftM22 = left.Row1.Y,
+                leftM31 = left.Row2.X,
+                leftM32 = left.Row2.Y,
+                rightM11 = right.Row0.X,
+                rightM12 = right.Row0.Y,
+                rightM13 = right.Row0.Z,
+                rightM21 = right.Row1.X,
+                rightM22 = right.Row1.Y,
+                rightM23 = right.Row1.Z;
 
-            result.Row0.X = (lM11 * rM11) + (lM12 * rM21);
-            result.Row0.Y = (lM11 * rM12) + (lM12 * rM22);
-            result.Row0.Z = (lM11 * rM13) + (lM12 * rM23);
-            result.Row1.X = (lM21 * rM11) + (lM22 * rM21);
-            result.Row1.Y = (lM21 * rM12) + (lM22 * rM22);
-            result.Row1.Z = (lM21 * rM13) + (lM22 * rM23);
-            result.Row2.X = (lM31 * rM11) + (lM32 * rM21);
-            result.Row2.Y = (lM31 * rM12) + (lM32 * rM22);
-            result.Row2.Z = (lM31 * rM13) + (lM32 * rM23);
+            result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21);
+            result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22);
+            result.Row0.Z = (leftM11 * rightM13) + (leftM12 * rightM23);
+            result.Row1.X = (leftM21 * rightM11) + (leftM22 * rightM21);
+            result.Row1.Y = (leftM21 * rightM12) + (leftM22 * rightM22);
+            result.Row1.Z = (leftM21 * rightM13) + (leftM22 * rightM23);
+            result.Row2.X = (leftM31 * rightM11) + (leftM32 * rightM21);
+            result.Row2.Y = (leftM31 * rightM12) + (leftM32 * rightM22);
+            result.Row2.Z = (leftM31 * rightM13) + (leftM32 * rightM23);
         }
 
         /// <summary>
@@ -464,33 +462,33 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix3x2d left, ref Matrix2x4d right, out Matrix3x4d result)
         {
-            double lM11 = left.Row0.X,
-                lM12 = left.Row0.Y,
-                lM21 = left.Row1.X,
-                lM22 = left.Row1.Y,
-                lM31 = left.Row2.X,
-                lM32 = left.Row2.Y,
-                rM11 = right.Row0.X,
-                rM12 = right.Row0.Y,
-                rM13 = right.Row0.Z,
-                rM14 = right.Row0.W,
-                rM21 = right.Row1.X,
-                rM22 = right.Row1.Y,
-                rM23 = right.Row1.Z,
-                rM24 = right.Row1.W;
+            double leftM11 = left.Row0.X,
+                leftM12 = left.Row0.Y,
+                leftM21 = left.Row1.X,
+                leftM22 = left.Row1.Y,
+                leftM31 = left.Row2.X,
+                leftM32 = left.Row2.Y,
+                rightM11 = right.Row0.X,
+                rightM12 = right.Row0.Y,
+                rightM13 = right.Row0.Z,
+                rightM14 = right.Row0.W,
+                rightM21 = right.Row1.X,
+                rightM22 = right.Row1.Y,
+                rightM23 = right.Row1.Z,
+                rightM24 = right.Row1.W;
 
-            result.Row0.X = (lM11 * rM11) + (lM12 * rM21);
-            result.Row0.Y = (lM11 * rM12) + (lM12 * rM22);
-            result.Row0.Z = (lM11 * rM13) + (lM12 * rM23);
-            result.Row0.W = (lM11 * rM14) + (lM12 * rM24);
-            result.Row1.X = (lM21 * rM11) + (lM22 * rM21);
-            result.Row1.Y = (lM21 * rM12) + (lM22 * rM22);
-            result.Row1.Z = (lM21 * rM13) + (lM22 * rM23);
-            result.Row1.W = (lM21 * rM14) + (lM22 * rM24);
-            result.Row2.X = (lM31 * rM11) + (lM32 * rM21);
-            result.Row2.Y = (lM31 * rM12) + (lM32 * rM22);
-            result.Row2.Z = (lM31 * rM13) + (lM32 * rM23);
-            result.Row2.W = (lM31 * rM14) + (lM32 * rM24);
+            result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21);
+            result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22);
+            result.Row0.Z = (leftM11 * rightM13) + (leftM12 * rightM23);
+            result.Row0.W = (leftM11 * rightM14) + (leftM12 * rightM24);
+            result.Row1.X = (leftM21 * rightM11) + (leftM22 * rightM21);
+            result.Row1.Y = (leftM21 * rightM12) + (leftM22 * rightM22);
+            result.Row1.Z = (leftM21 * rightM13) + (leftM22 * rightM23);
+            result.Row1.W = (leftM21 * rightM14) + (leftM22 * rightM24);
+            result.Row2.X = (leftM31 * rightM11) + (leftM32 * rightM21);
+            result.Row2.Y = (leftM31 * rightM12) + (leftM32 * rightM22);
+            result.Row2.Z = (leftM31 * rightM13) + (leftM32 * rightM23);
+            result.Row2.W = (leftM31 * rightM14) + (leftM32 * rightM24);
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Matrix/Matrix3x2d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix3x2d.cs
@@ -73,10 +73,12 @@ namespace OpenTK.Mathematics
         /// <param name="m20">First item of the third row of the matrix.</param>
         /// <param name="m21">Second item of the third row of the matrix.</param>
         [SuppressMessage("ReSharper", "SA1117", Justification = "For better readability of Matrix struct.")]
-        public Matrix3x2d(
+        public Matrix3x2d
+        (
             double m00, double m01,
             double m10, double m11,
-            double m20, double m21)
+            double m20, double m21
+        )
         {
             Row0 = new Vector2d(m00, m01);
             Row1 = new Vector2d(m10, m11);
@@ -379,16 +381,16 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix3x2d left, ref Matrix2d right, out Matrix3x2d result)
         {
-            double leftM11 = left.Row0.X,
-                leftM12 = left.Row0.Y,
-                leftM21 = left.Row1.X,
-                leftM22 = left.Row1.Y,
-                leftM31 = left.Row2.X,
-                leftM32 = left.Row2.Y,
-                rightM11 = right.Row0.X,
-                rightM12 = right.Row0.Y,
-                rightM21 = right.Row1.X,
-                rightM22 = right.Row1.Y;
+            double leftM11 = left.Row0.X;
+            double leftM12 = left.Row0.Y;
+            double leftM21 = left.Row1.X;
+            double leftM22 = left.Row1.Y;
+            double leftM31 = left.Row2.X;
+            double leftM32 = left.Row2.Y;
+            double rightM11 = right.Row0.X;
+            double rightM12 = right.Row0.Y;
+            double rightM21 = right.Row1.X;
+            double rightM22 = right.Row1.Y;
 
             result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21);
             result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22);
@@ -418,18 +420,18 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix3x2d left, ref Matrix2x3d right, out Matrix3d result)
         {
-            double leftM11 = left.Row0.X,
-                leftM12 = left.Row0.Y,
-                leftM21 = left.Row1.X,
-                leftM22 = left.Row1.Y,
-                leftM31 = left.Row2.X,
-                leftM32 = left.Row2.Y,
-                rightM11 = right.Row0.X,
-                rightM12 = right.Row0.Y,
-                rightM13 = right.Row0.Z,
-                rightM21 = right.Row1.X,
-                rightM22 = right.Row1.Y,
-                rightM23 = right.Row1.Z;
+            double leftM11 = left.Row0.X;
+            double leftM12 = left.Row0.Y;
+            double leftM21 = left.Row1.X;
+            double leftM22 = left.Row1.Y;
+            double leftM31 = left.Row2.X;
+            double leftM32 = left.Row2.Y;
+            double rightM11 = right.Row0.X;
+            double rightM12 = right.Row0.Y;
+            double rightM13 = right.Row0.Z;
+            double rightM21 = right.Row1.X;
+            double rightM22 = right.Row1.Y;
+            double rightM23 = right.Row1.Z;
 
             result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21);
             result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22);
@@ -462,20 +464,20 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix3x2d left, ref Matrix2x4d right, out Matrix3x4d result)
         {
-            double leftM11 = left.Row0.X,
-                leftM12 = left.Row0.Y,
-                leftM21 = left.Row1.X,
-                leftM22 = left.Row1.Y,
-                leftM31 = left.Row2.X,
-                leftM32 = left.Row2.Y,
-                rightM11 = right.Row0.X,
-                rightM12 = right.Row0.Y,
-                rightM13 = right.Row0.Z,
-                rightM14 = right.Row0.W,
-                rightM21 = right.Row1.X,
-                rightM22 = right.Row1.Y,
-                rightM23 = right.Row1.Z,
-                rightM24 = right.Row1.W;
+            double leftM11 = left.Row0.X;
+            double leftM12 = left.Row0.Y;
+            double leftM21 = left.Row1.X;
+            double leftM22 = left.Row1.Y;
+            double leftM31 = left.Row2.X;
+            double leftM32 = left.Row2.Y;
+            double rightM11 = right.Row0.X;
+            double rightM12 = right.Row0.Y;
+            double rightM13 = right.Row0.Z;
+            double rightM14 = right.Row0.W;
+            double rightM21 = right.Row1.X;
+            double rightM22 = right.Row1.Y;
+            double rightM23 = right.Row1.Z;
+            double rightM24 = right.Row1.W;
 
             result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21);
             result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22);

--- a/src/OpenTK.Mathematics/Matrix/Matrix3x4.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix3x4.cs
@@ -82,10 +82,12 @@ namespace OpenTK.Mathematics
         /// <param name="m22">Third item of the third row of the matrix.</param>
         /// <param name="m23">Fourth item of the third row of the matrix.</param>
         [SuppressMessage("ReSharper", "SA1117", Justification = "For better readability of Matrix struct.")]
-        public Matrix3x4(
+        public Matrix3x4
+        (
             float m00, float m01, float m02, float m03,
             float m10, float m11, float m12, float m13,
-            float m20, float m21, float m22, float m23)
+            float m20, float m21, float m22, float m23
+        )
         {
             Row0 = new Vector4(m00, m01, m02, m03);
             Row1 = new Vector4(m10, m11, m12, m13);
@@ -304,7 +306,6 @@ namespace OpenTK.Mathematics
         /// <param name="axis">The axis to rotate about.</param>
         /// <param name="angle">Angle in radians to rotate counter-clockwise (looking in the direction of the given axis).</param>
         /// <param name="result">A matrix instance.</param>
-        [SuppressMessage("Microsoft.StyleCop.CSharp.DocumentationRules", "SA1305", Justification = "Is not hungarian notation but abbreveation for precalculated values.")]
         public static void CreateFromAxisAngle(Vector3 axis, float angle, out Matrix3x4 result)
         {
             axis.Normalize();
@@ -314,16 +315,16 @@ namespace OpenTK.Mathematics
             var sin = (float)Math.Sin(angle);
             var t = 1.0f - cos;
 
-            float tXX = t * axisX * axisX,
-                tXY = t * axisX * axisY,
-                tXZ = t * axisX * axisZ,
-                tYY = t * axisY * axisY,
-                tYZ = t * axisY * axisZ,
-                tZZ = t * axisZ * axisZ;
+            float tXX = t * axisX * axisX;
+            float tXY = t * axisX * axisY;
+            float tXZ = t * axisX * axisZ;
+            float tYY = t * axisY * axisY;
+            float tYZ = t * axisY * axisZ;
+            float tZZ = t * axisZ * axisZ;
 
-            float sinX = sin * axisX,
-                sinY = sin * axisY,
-                sinZ = sin * axisZ;
+            float sinX = sin * axisX;
+            float sinY = sin * axisY;
+            float sinZ = sin * axisZ;
 
             result.Row0.X = tXX + cos;
             result.Row0.Y = tXY - sinZ;
@@ -358,22 +359,22 @@ namespace OpenTK.Mathematics
         /// <param name="result">A matrix instance.</param>
         public static void CreateFromQuaternion(ref Quaternion q, out Matrix3x4 result)
         {
-            float x = q.X,
-                y = q.Y,
-                z = q.Z,
-                w = q.W,
-                tx = 2 * x,
-                ty = 2 * y,
-                tz = 2 * z,
-                txx = tx * x,
-                tyy = ty * y,
-                tzz = tz * z,
-                txy = tx * y,
-                txz = tx * z,
-                tyz = ty * z,
-                txw = tx * w,
-                tyw = ty * w,
-                tzw = tz * w;
+            float x = q.X;
+            float y = q.Y;
+            float z = q.Z;
+            float w = q.W;
+            float tx = 2 * x;
+            float ty = 2 * y;
+            float tz = 2 * z;
+            float txx = tx * x;
+            float tyy = ty * y;
+            float tzz = tz * z;
+            float txy = tx * y;
+            float txz = tx * z;
+            float tyz = ty * z;
+            float txw = tx * w;
+            float tyw = ty * w;
+            float tzw = tz * w;
 
             result.Row0.X = 1f - (tyy + tzz);
             result.Row0.Y = txy + tzw;
@@ -387,11 +388,6 @@ namespace OpenTK.Mathematics
             result.Row2.Y = tyz - txw;
             result.Row2.Z = 1f - (txx + tyy);
             result.Row2.W = 0f;
-
-            /*Vector3 axis;
-            float angle;
-            q.ToAxisAngle(out axis, out angle);
-            CreateFromAxisAngle(axis, angle, out result);*/
         }
 
         /// <summary>
@@ -643,30 +639,30 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix3x4 left, ref Matrix4x3 right, out Matrix3 result)
         {
-            float leftM11 = left.Row0.X,
-                leftM12 = left.Row0.Y,
-                leftM13 = left.Row0.Z,
-                leftM14 = left.Row0.W,
-                leftM21 = left.Row1.X,
-                leftM22 = left.Row1.Y,
-                leftM23 = left.Row1.Z,
-                leftM24 = left.Row1.W,
-                leftM31 = left.Row2.X,
-                leftM32 = left.Row2.Y,
-                leftM33 = left.Row2.Z,
-                leftM34 = left.Row2.W,
-                rightM11 = right.Row0.X,
-                rightM12 = right.Row0.Y,
-                rightM13 = right.Row0.Z,
-                rightM21 = right.Row1.X,
-                rightM22 = right.Row1.Y,
-                rightM23 = right.Row1.Z,
-                rightM31 = right.Row2.X,
-                rightM32 = right.Row2.Y,
-                rightM33 = right.Row2.Z,
-                rightM41 = right.Row3.X,
-                rightM42 = right.Row3.Y,
-                rightM43 = right.Row3.Z;
+            float leftM11 = left.Row0.X;
+            float leftM12 = left.Row0.Y;
+            float leftM13 = left.Row0.Z;
+            float leftM14 = left.Row0.W;
+            float leftM21 = left.Row1.X;
+            float leftM22 = left.Row1.Y;
+            float leftM23 = left.Row1.Z;
+            float leftM24 = left.Row1.W;
+            float leftM31 = left.Row2.X;
+            float leftM32 = left.Row2.Y;
+            float leftM33 = left.Row2.Z;
+            float leftM34 = left.Row2.W;
+            float rightM11 = right.Row0.X;
+            float rightM12 = right.Row0.Y;
+            float rightM13 = right.Row0.Z;
+            float rightM21 = right.Row1.X;
+            float rightM22 = right.Row1.Y;
+            float rightM23 = right.Row1.Z;
+            float rightM31 = right.Row2.X;
+            float rightM32 = right.Row2.Y;
+            float rightM33 = right.Row2.Z;
+            float rightM41 = right.Row3.X;
+            float rightM42 = right.Row3.Y;
+            float rightM43 = right.Row3.Z;
 
             result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21) + (leftM13 * rightM31) + (leftM14 * rightM41);
             result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22) + (leftM13 * rightM32) + (leftM14 * rightM42);
@@ -699,30 +695,30 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix3x4 left, ref Matrix3x4 right, out Matrix3x4 result)
         {
-            float leftM11 = left.Row0.X,
-                leftM12 = left.Row0.Y,
-                leftM13 = left.Row0.Z,
-                leftM14 = left.Row0.W,
-                leftM21 = left.Row1.X,
-                leftM22 = left.Row1.Y,
-                leftM23 = left.Row1.Z,
-                leftM24 = left.Row1.W,
-                leftM31 = left.Row2.X,
-                leftM32 = left.Row2.Y,
-                leftM33 = left.Row2.Z,
-                leftM34 = left.Row2.W,
-                rightM11 = right.Row0.X,
-                rightM12 = right.Row0.Y,
-                rightM13 = right.Row0.Z,
-                rightM14 = right.Row0.W,
-                rightM21 = right.Row1.X,
-                rightM22 = right.Row1.Y,
-                rightM23 = right.Row1.Z,
-                rightM24 = right.Row1.W,
-                rightM31 = right.Row2.X,
-                rightM32 = right.Row2.Y,
-                rightM33 = right.Row2.Z,
-                rightM34 = right.Row2.W;
+            float leftM11 = left.Row0.X;
+            float leftM12 = left.Row0.Y;
+            float leftM13 = left.Row0.Z;
+            float leftM14 = left.Row0.W;
+            float leftM21 = left.Row1.X;
+            float leftM22 = left.Row1.Y;
+            float leftM23 = left.Row1.Z;
+            float leftM24 = left.Row1.W;
+            float leftM31 = left.Row2.X;
+            float leftM32 = left.Row2.Y;
+            float leftM33 = left.Row2.Z;
+            float leftM34 = left.Row2.W;
+            float rightM11 = right.Row0.X;
+            float rightM12 = right.Row0.Y;
+            float rightM13 = right.Row0.Z;
+            float rightM14 = right.Row0.W;
+            float rightM21 = right.Row1.X;
+            float rightM22 = right.Row1.Y;
+            float rightM23 = right.Row1.Z;
+            float rightM24 = right.Row1.W;
+            float rightM31 = right.Row2.X;
+            float rightM32 = right.Row2.Y;
+            float rightM33 = right.Row2.Z;
+            float rightM34 = right.Row2.W;
 
             result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21) + (leftM13 * rightM31);
             result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22) + (leftM13 * rightM32);
@@ -736,15 +732,6 @@ namespace OpenTK.Mathematics
             result.Row2.Y = (leftM31 * rightM12) + (leftM32 * rightM22) + (leftM33 * rightM32);
             result.Row2.Z = (leftM31 * rightM13) + (leftM32 * rightM23) + (leftM33 * rightM33);
             result.Row2.W = (leftM31 * rightM14) + (leftM32 * rightM24) + (leftM33 * rightM34) + leftM34;
-
-            /*result.Row0 = (right.Row0 * leftM11 + right.Row1 * leftM12 + right.Row2 * leftM13);
-            result.Row0.W += leftM14;
-
-            result.Row1 = (right.Row0 * leftM21 + right.Row1 * leftM22 + right.Row2 * leftM23);
-            result.Row1.W += leftM24;
-
-            result.Row2 = (right.Row0 * leftM31 + right.Row1 * leftM32 + right.Row2 * leftM33);
-            result.Row2.W += leftM34;*/
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Matrix/Matrix3x4.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix3x4.cs
@@ -21,6 +21,7 @@ SOFTWARE.
  */
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
 namespace OpenTK.Mathematics
@@ -80,21 +81,11 @@ namespace OpenTK.Mathematics
         /// <param name="m21">Second item of the third row of the matrix.</param>
         /// <param name="m22">Third item of the third row of the matrix.</param>
         /// <param name="m23">Fourth item of the third row of the matrix.</param>
-        public Matrix3x4
-        (
-            float m00,
-            float m01,
-            float m02,
-            float m03,
-            float m10,
-            float m11,
-            float m12,
-            float m13,
-            float m20,
-            float m21,
-            float m22,
-            float m23
-        )
+        [SuppressMessage("ReSharper", "SA1117", Justification = "For better readability of Matrix struct.")]
+        public Matrix3x4(
+            float m00, float m01, float m02, float m03,
+            float m10, float m11, float m12, float m13,
+            float m20, float m21, float m22, float m23)
         {
             Row0 = new Vector4(m00, m01, m02, m03);
             Row1 = new Vector4(m10, m11, m12, m13);
@@ -253,6 +244,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="rowIndex">The index of the row.</param>
         /// <param name="columnIndex">The index of the column.</param>
+        /// <returns>The element at the given row and column index.</returns>
         public float this[int rowIndex, int columnIndex]
         {
             get
@@ -312,6 +304,7 @@ namespace OpenTK.Mathematics
         /// <param name="axis">The axis to rotate about.</param>
         /// <param name="angle">Angle in radians to rotate counter-clockwise (looking in the direction of the given axis).</param>
         /// <param name="result">A matrix instance.</param>
+        [SuppressMessage("Microsoft.StyleCop.CSharp.DocumentationRules", "SA1305", Justification = "Is not hungarian notation but abbreveation for precalculated values.")]
         public static void CreateFromAxisAngle(Vector3 axis, float angle, out Matrix3x4 result)
         {
             axis.Normalize();
@@ -650,40 +643,40 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix3x4 left, ref Matrix4x3 right, out Matrix3 result)
         {
-            float lM11 = left.Row0.X,
-                lM12 = left.Row0.Y,
-                lM13 = left.Row0.Z,
-                lM14 = left.Row0.W,
-                lM21 = left.Row1.X,
-                lM22 = left.Row1.Y,
-                lM23 = left.Row1.Z,
-                lM24 = left.Row1.W,
-                lM31 = left.Row2.X,
-                lM32 = left.Row2.Y,
-                lM33 = left.Row2.Z,
-                lM34 = left.Row2.W,
-                rM11 = right.Row0.X,
-                rM12 = right.Row0.Y,
-                rM13 = right.Row0.Z,
-                rM21 = right.Row1.X,
-                rM22 = right.Row1.Y,
-                rM23 = right.Row1.Z,
-                rM31 = right.Row2.X,
-                rM32 = right.Row2.Y,
-                rM33 = right.Row2.Z,
-                rM41 = right.Row3.X,
-                rM42 = right.Row3.Y,
-                rM43 = right.Row3.Z;
+            float leftM11 = left.Row0.X,
+                leftM12 = left.Row0.Y,
+                leftM13 = left.Row0.Z,
+                leftM14 = left.Row0.W,
+                leftM21 = left.Row1.X,
+                leftM22 = left.Row1.Y,
+                leftM23 = left.Row1.Z,
+                leftM24 = left.Row1.W,
+                leftM31 = left.Row2.X,
+                leftM32 = left.Row2.Y,
+                leftM33 = left.Row2.Z,
+                leftM34 = left.Row2.W,
+                rightM11 = right.Row0.X,
+                rightM12 = right.Row0.Y,
+                rightM13 = right.Row0.Z,
+                rightM21 = right.Row1.X,
+                rightM22 = right.Row1.Y,
+                rightM23 = right.Row1.Z,
+                rightM31 = right.Row2.X,
+                rightM32 = right.Row2.Y,
+                rightM33 = right.Row2.Z,
+                rightM41 = right.Row3.X,
+                rightM42 = right.Row3.Y,
+                rightM43 = right.Row3.Z;
 
-            result.Row0.X = (lM11 * rM11) + (lM12 * rM21) + (lM13 * rM31) + (lM14 * rM41);
-            result.Row0.Y = (lM11 * rM12) + (lM12 * rM22) + (lM13 * rM32) + (lM14 * rM42);
-            result.Row0.Z = (lM11 * rM13) + (lM12 * rM23) + (lM13 * rM33) + (lM14 * rM43);
-            result.Row1.X = (lM21 * rM11) + (lM22 * rM21) + (lM23 * rM31) + (lM24 * rM41);
-            result.Row1.Y = (lM21 * rM12) + (lM22 * rM22) + (lM23 * rM32) + (lM24 * rM42);
-            result.Row1.Z = (lM21 * rM13) + (lM22 * rM23) + (lM23 * rM33) + (lM24 * rM43);
-            result.Row2.X = (lM31 * rM11) + (lM32 * rM21) + (lM33 * rM31) + (lM34 * rM41);
-            result.Row2.Y = (lM31 * rM12) + (lM32 * rM22) + (lM33 * rM32) + (lM34 * rM42);
-            result.Row2.Z = (lM31 * rM13) + (lM32 * rM23) + (lM33 * rM33) + (lM34 * rM43);
+            result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21) + (leftM13 * rightM31) + (leftM14 * rightM41);
+            result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22) + (leftM13 * rightM32) + (leftM14 * rightM42);
+            result.Row0.Z = (leftM11 * rightM13) + (leftM12 * rightM23) + (leftM13 * rightM33) + (leftM14 * rightM43);
+            result.Row1.X = (leftM21 * rightM11) + (leftM22 * rightM21) + (leftM23 * rightM31) + (leftM24 * rightM41);
+            result.Row1.Y = (leftM21 * rightM12) + (leftM22 * rightM22) + (leftM23 * rightM32) + (leftM24 * rightM42);
+            result.Row1.Z = (leftM21 * rightM13) + (leftM22 * rightM23) + (leftM23 * rightM33) + (leftM24 * rightM43);
+            result.Row2.X = (leftM31 * rightM11) + (leftM32 * rightM21) + (leftM33 * rightM31) + (leftM34 * rightM41);
+            result.Row2.Y = (leftM31 * rightM12) + (leftM32 * rightM22) + (leftM33 * rightM32) + (leftM34 * rightM42);
+            result.Row2.Z = (leftM31 * rightM13) + (leftM32 * rightM23) + (leftM33 * rightM33) + (leftM34 * rightM43);
         }
 
         /// <summary>
@@ -706,52 +699,52 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix3x4 left, ref Matrix3x4 right, out Matrix3x4 result)
         {
-            float lM11 = left.Row0.X,
-                lM12 = left.Row0.Y,
-                lM13 = left.Row0.Z,
-                lM14 = left.Row0.W,
-                lM21 = left.Row1.X,
-                lM22 = left.Row1.Y,
-                lM23 = left.Row1.Z,
-                lM24 = left.Row1.W,
-                lM31 = left.Row2.X,
-                lM32 = left.Row2.Y,
-                lM33 = left.Row2.Z,
-                lM34 = left.Row2.W,
-                rM11 = right.Row0.X,
-                rM12 = right.Row0.Y,
-                rM13 = right.Row0.Z,
-                rM14 = right.Row0.W,
-                rM21 = right.Row1.X,
-                rM22 = right.Row1.Y,
-                rM23 = right.Row1.Z,
-                rM24 = right.Row1.W,
-                rM31 = right.Row2.X,
-                rM32 = right.Row2.Y,
-                rM33 = right.Row2.Z,
-                rM34 = right.Row2.W;
+            float leftM11 = left.Row0.X,
+                leftM12 = left.Row0.Y,
+                leftM13 = left.Row0.Z,
+                leftM14 = left.Row0.W,
+                leftM21 = left.Row1.X,
+                leftM22 = left.Row1.Y,
+                leftM23 = left.Row1.Z,
+                leftM24 = left.Row1.W,
+                leftM31 = left.Row2.X,
+                leftM32 = left.Row2.Y,
+                leftM33 = left.Row2.Z,
+                leftM34 = left.Row2.W,
+                rightM11 = right.Row0.X,
+                rightM12 = right.Row0.Y,
+                rightM13 = right.Row0.Z,
+                rightM14 = right.Row0.W,
+                rightM21 = right.Row1.X,
+                rightM22 = right.Row1.Y,
+                rightM23 = right.Row1.Z,
+                rightM24 = right.Row1.W,
+                rightM31 = right.Row2.X,
+                rightM32 = right.Row2.Y,
+                rightM33 = right.Row2.Z,
+                rightM34 = right.Row2.W;
 
-            result.Row0.X = (lM11 * rM11) + (lM12 * rM21) + (lM13 * rM31);
-            result.Row0.Y = (lM11 * rM12) + (lM12 * rM22) + (lM13 * rM32);
-            result.Row0.Z = (lM11 * rM13) + (lM12 * rM23) + (lM13 * rM33);
-            result.Row0.W = (lM11 * rM14) + (lM12 * rM24) + (lM13 * rM34) + lM14;
-            result.Row1.X = (lM21 * rM11) + (lM22 * rM21) + (lM23 * rM31);
-            result.Row1.Y = (lM21 * rM12) + (lM22 * rM22) + (lM23 * rM32);
-            result.Row1.Z = (lM21 * rM13) + (lM22 * rM23) + (lM23 * rM33);
-            result.Row1.W = (lM21 * rM14) + (lM22 * rM24) + (lM23 * rM34) + lM24;
-            result.Row2.X = (lM31 * rM11) + (lM32 * rM21) + (lM33 * rM31);
-            result.Row2.Y = (lM31 * rM12) + (lM32 * rM22) + (lM33 * rM32);
-            result.Row2.Z = (lM31 * rM13) + (lM32 * rM23) + (lM33 * rM33);
-            result.Row2.W = (lM31 * rM14) + (lM32 * rM24) + (lM33 * rM34) + lM34;
+            result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21) + (leftM13 * rightM31);
+            result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22) + (leftM13 * rightM32);
+            result.Row0.Z = (leftM11 * rightM13) + (leftM12 * rightM23) + (leftM13 * rightM33);
+            result.Row0.W = (leftM11 * rightM14) + (leftM12 * rightM24) + (leftM13 * rightM34) + leftM14;
+            result.Row1.X = (leftM21 * rightM11) + (leftM22 * rightM21) + (leftM23 * rightM31);
+            result.Row1.Y = (leftM21 * rightM12) + (leftM22 * rightM22) + (leftM23 * rightM32);
+            result.Row1.Z = (leftM21 * rightM13) + (leftM22 * rightM23) + (leftM23 * rightM33);
+            result.Row1.W = (leftM21 * rightM14) + (leftM22 * rightM24) + (leftM23 * rightM34) + leftM24;
+            result.Row2.X = (leftM31 * rightM11) + (leftM32 * rightM21) + (leftM33 * rightM31);
+            result.Row2.Y = (leftM31 * rightM12) + (leftM32 * rightM22) + (leftM33 * rightM32);
+            result.Row2.Z = (leftM31 * rightM13) + (leftM32 * rightM23) + (leftM33 * rightM33);
+            result.Row2.W = (leftM31 * rightM14) + (leftM32 * rightM24) + (leftM33 * rightM34) + leftM34;
 
-            /*result.Row0 = (right.Row0 * lM11 + right.Row1 * lM12 + right.Row2 * lM13);
-            result.Row0.W += lM14;
+            /*result.Row0 = (right.Row0 * leftM11 + right.Row1 * leftM12 + right.Row2 * leftM13);
+            result.Row0.W += leftM14;
 
-            result.Row1 = (right.Row0 * lM21 + right.Row1 * lM22 + right.Row2 * lM23);
-            result.Row1.W += lM24;
+            result.Row1 = (right.Row0 * leftM21 + right.Row1 * leftM22 + right.Row2 * leftM23);
+            result.Row1.W += leftM24;
 
-            result.Row2 = (right.Row0 * lM31 + right.Row1 * lM32 + right.Row2 * lM33);
-            result.Row2.W += lM34;*/
+            result.Row2 = (right.Row0 * leftM31 + right.Row1 * leftM32 + right.Row2 * leftM33);
+            result.Row2.W += leftM34;*/
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Matrix/Matrix3x4d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix3x4d.cs
@@ -21,6 +21,7 @@ SOFTWARE.
  */
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
 namespace OpenTK.Mathematics
@@ -80,21 +81,11 @@ namespace OpenTK.Mathematics
         /// <param name="m21">Second item of the third row of the matrix.</param>
         /// <param name="m22">Third item of the third row of the matrix.</param>
         /// <param name="m23">Fourth item of the third row of the matrix.</param>
-        public Matrix3x4d
-        (
-            double m00,
-            double m01,
-            double m02,
-            double m03,
-            double m10,
-            double m11,
-            double m12,
-            double m13,
-            double m20,
-            double m21,
-            double m22,
-            double m23
-        )
+        [SuppressMessage("ReSharper", "SA1117", Justification = "For better readability of Matrix struct.")]
+        public Matrix3x4d(
+            double m00, double m01, double m02, double m03,
+            double m10, double m11, double m12, double m13,
+            double m20, double m21, double m22, double m23)
         {
             Row0 = new Vector4d(m00, m01, m02, m03);
             Row1 = new Vector4d(m10, m11, m12, m13);
@@ -253,6 +244,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="rowIndex">The index of the row.</param>
         /// <param name="columnIndex">The index of the column.</param>
+        /// <returns>The element at the given row and column index.</returns>
         public double this[int rowIndex, int columnIndex]
         {
             get
@@ -312,6 +304,7 @@ namespace OpenTK.Mathematics
         /// <param name="axis">The axis to rotate about.</param>
         /// <param name="angle">Angle in radians to rotate counter-clockwise (looking in the direction of the given axis).</param>
         /// <param name="result">A matrix instance.</param>
+        [SuppressMessage("Microsoft.StyleCop.CSharp.DocumentationRules", "SA1305", Justification = "Is not hungarian notation but abbreveation for precalculated values.")]
         public static void CreateFromAxisAngle(Vector3d axis, double angle, out Matrix3x4d result)
         {
             axis.Normalize();
@@ -650,40 +643,40 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix3x4d left, ref Matrix4x3d right, out Matrix3d result)
         {
-            double lM11 = left.Row0.X,
-                lM12 = left.Row0.Y,
-                lM13 = left.Row0.Z,
-                lM14 = left.Row0.W,
-                lM21 = left.Row1.X,
-                lM22 = left.Row1.Y,
-                lM23 = left.Row1.Z,
-                lM24 = left.Row1.W,
-                lM31 = left.Row2.X,
-                lM32 = left.Row2.Y,
-                lM33 = left.Row2.Z,
-                lM34 = left.Row2.W,
-                rM11 = right.Row0.X,
-                rM12 = right.Row0.Y,
-                rM13 = right.Row0.Z,
-                rM21 = right.Row1.X,
-                rM22 = right.Row1.Y,
-                rM23 = right.Row1.Z,
-                rM31 = right.Row2.X,
-                rM32 = right.Row2.Y,
-                rM33 = right.Row2.Z,
-                rM41 = right.Row3.X,
-                rM42 = right.Row3.Y,
-                rM43 = right.Row3.Z;
+            double leftM11 = left.Row0.X,
+                leftM12 = left.Row0.Y,
+                leftM13 = left.Row0.Z,
+                leftM14 = left.Row0.W,
+                leftM21 = left.Row1.X,
+                leftM22 = left.Row1.Y,
+                leftM23 = left.Row1.Z,
+                leftM24 = left.Row1.W,
+                leftM31 = left.Row2.X,
+                leftM32 = left.Row2.Y,
+                leftM33 = left.Row2.Z,
+                leftM34 = left.Row2.W,
+                rightM11 = right.Row0.X,
+                rightM12 = right.Row0.Y,
+                rightM13 = right.Row0.Z,
+                rightM21 = right.Row1.X,
+                rightM22 = right.Row1.Y,
+                rightM23 = right.Row1.Z,
+                rightM31 = right.Row2.X,
+                rightM32 = right.Row2.Y,
+                rightM33 = right.Row2.Z,
+                rightM41 = right.Row3.X,
+                rightM42 = right.Row3.Y,
+                rightM43 = right.Row3.Z;
 
-            result.Row0.X = (lM11 * rM11) + (lM12 * rM21) + (lM13 * rM31) + (lM14 * rM41);
-            result.Row0.Y = (lM11 * rM12) + (lM12 * rM22) + (lM13 * rM32) + (lM14 * rM42);
-            result.Row0.Z = (lM11 * rM13) + (lM12 * rM23) + (lM13 * rM33) + (lM14 * rM43);
-            result.Row1.X = (lM21 * rM11) + (lM22 * rM21) + (lM23 * rM31) + (lM24 * rM41);
-            result.Row1.Y = (lM21 * rM12) + (lM22 * rM22) + (lM23 * rM32) + (lM24 * rM42);
-            result.Row1.Z = (lM21 * rM13) + (lM22 * rM23) + (lM23 * rM33) + (lM24 * rM43);
-            result.Row2.X = (lM31 * rM11) + (lM32 * rM21) + (lM33 * rM31) + (lM34 * rM41);
-            result.Row2.Y = (lM31 * rM12) + (lM32 * rM22) + (lM33 * rM32) + (lM34 * rM42);
-            result.Row2.Z = (lM31 * rM13) + (lM32 * rM23) + (lM33 * rM33) + (lM34 * rM43);
+            result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21) + (leftM13 * rightM31) + (leftM14 * rightM41);
+            result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22) + (leftM13 * rightM32) + (leftM14 * rightM42);
+            result.Row0.Z = (leftM11 * rightM13) + (leftM12 * rightM23) + (leftM13 * rightM33) + (leftM14 * rightM43);
+            result.Row1.X = (leftM21 * rightM11) + (leftM22 * rightM21) + (leftM23 * rightM31) + (leftM24 * rightM41);
+            result.Row1.Y = (leftM21 * rightM12) + (leftM22 * rightM22) + (leftM23 * rightM32) + (leftM24 * rightM42);
+            result.Row1.Z = (leftM21 * rightM13) + (leftM22 * rightM23) + (leftM23 * rightM33) + (leftM24 * rightM43);
+            result.Row2.X = (leftM31 * rightM11) + (leftM32 * rightM21) + (leftM33 * rightM31) + (leftM34 * rightM41);
+            result.Row2.Y = (leftM31 * rightM12) + (leftM32 * rightM22) + (leftM33 * rightM32) + (leftM34 * rightM42);
+            result.Row2.Z = (leftM31 * rightM13) + (leftM32 * rightM23) + (leftM33 * rightM33) + (leftM34 * rightM43);
         }
 
         /// <summary>
@@ -706,52 +699,52 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix3x4d left, ref Matrix3x4d right, out Matrix3x4d result)
         {
-            double lM11 = left.Row0.X,
-                lM12 = left.Row0.Y,
-                lM13 = left.Row0.Z,
-                lM14 = left.Row0.W,
-                lM21 = left.Row1.X,
-                lM22 = left.Row1.Y,
-                lM23 = left.Row1.Z,
-                lM24 = left.Row1.W,
-                lM31 = left.Row2.X,
-                lM32 = left.Row2.Y,
-                lM33 = left.Row2.Z,
-                lM34 = left.Row2.W,
-                rM11 = right.Row0.X,
-                rM12 = right.Row0.Y,
-                rM13 = right.Row0.Z,
-                rM14 = right.Row0.W,
-                rM21 = right.Row1.X,
-                rM22 = right.Row1.Y,
-                rM23 = right.Row1.Z,
-                rM24 = right.Row1.W,
-                rM31 = right.Row2.X,
-                rM32 = right.Row2.Y,
-                rM33 = right.Row2.Z,
-                rM34 = right.Row2.W;
+            double leftM11 = left.Row0.X,
+                leftM12 = left.Row0.Y,
+                leftM13 = left.Row0.Z,
+                leftM14 = left.Row0.W,
+                leftM21 = left.Row1.X,
+                leftM22 = left.Row1.Y,
+                leftM23 = left.Row1.Z,
+                leftM24 = left.Row1.W,
+                leftM31 = left.Row2.X,
+                leftM32 = left.Row2.Y,
+                leftM33 = left.Row2.Z,
+                leftM34 = left.Row2.W,
+                rightM11 = right.Row0.X,
+                rightM12 = right.Row0.Y,
+                rightM13 = right.Row0.Z,
+                rightM14 = right.Row0.W,
+                rightM21 = right.Row1.X,
+                rightM22 = right.Row1.Y,
+                rightM23 = right.Row1.Z,
+                rightM24 = right.Row1.W,
+                rightM31 = right.Row2.X,
+                rightM32 = right.Row2.Y,
+                rightM33 = right.Row2.Z,
+                rightM34 = right.Row2.W;
 
-            result.Row0.X = (lM11 * rM11) + (lM12 * rM21) + (lM13 * rM31);
-            result.Row0.Y = (lM11 * rM12) + (lM12 * rM22) + (lM13 * rM32);
-            result.Row0.Z = (lM11 * rM13) + (lM12 * rM23) + (lM13 * rM33);
-            result.Row0.W = (lM11 * rM14) + (lM12 * rM24) + (lM13 * rM34) + lM14;
-            result.Row1.X = (lM21 * rM11) + (lM22 * rM21) + (lM23 * rM31);
-            result.Row1.Y = (lM21 * rM12) + (lM22 * rM22) + (lM23 * rM32);
-            result.Row1.Z = (lM21 * rM13) + (lM22 * rM23) + (lM23 * rM33);
-            result.Row1.W = (lM21 * rM14) + (lM22 * rM24) + (lM23 * rM34) + lM24;
-            result.Row2.X = (lM31 * rM11) + (lM32 * rM21) + (lM33 * rM31);
-            result.Row2.Y = (lM31 * rM12) + (lM32 * rM22) + (lM33 * rM32);
-            result.Row2.Z = (lM31 * rM13) + (lM32 * rM23) + (lM33 * rM33);
-            result.Row2.W = (lM31 * rM14) + (lM32 * rM24) + (lM33 * rM34) + lM34;
+            result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21) + (leftM13 * rightM31);
+            result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22) + (leftM13 * rightM32);
+            result.Row0.Z = (leftM11 * rightM13) + (leftM12 * rightM23) + (leftM13 * rightM33);
+            result.Row0.W = (leftM11 * rightM14) + (leftM12 * rightM24) + (leftM13 * rightM34) + leftM14;
+            result.Row1.X = (leftM21 * rightM11) + (leftM22 * rightM21) + (leftM23 * rightM31);
+            result.Row1.Y = (leftM21 * rightM12) + (leftM22 * rightM22) + (leftM23 * rightM32);
+            result.Row1.Z = (leftM21 * rightM13) + (leftM22 * rightM23) + (leftM23 * rightM33);
+            result.Row1.W = (leftM21 * rightM14) + (leftM22 * rightM24) + (leftM23 * rightM34) + leftM24;
+            result.Row2.X = (leftM31 * rightM11) + (leftM32 * rightM21) + (leftM33 * rightM31);
+            result.Row2.Y = (leftM31 * rightM12) + (leftM32 * rightM22) + (leftM33 * rightM32);
+            result.Row2.Z = (leftM31 * rightM13) + (leftM32 * rightM23) + (leftM33 * rightM33);
+            result.Row2.W = (leftM31 * rightM14) + (leftM32 * rightM24) + (leftM33 * rightM34) + leftM34;
 
-            /*result.Row0 = (right.Row0 * lM11 + right.Row1 * lM12 + right.Row2 * lM13);
-            result.Row0.W += lM14;
+            /*result.Row0 = (right.Row0 * leftM11 + right.Row1 * leftM12 + right.Row2 * leftM13);
+            result.Row0.W += leftM14;
 
-            result.Row1 = (right.Row0 * lM21 + right.Row1 * lM22 + right.Row2 * lM23);
-            result.Row1.W += lM24;
+            result.Row1 = (right.Row0 * leftM21 + right.Row1 * leftM22 + right.Row2 * leftM23);
+            result.Row1.W += leftM24;
 
-            result.Row2 = (right.Row0 * lM31 + right.Row1 * lM32 + right.Row2 * lM33);
-            result.Row2.W += lM34;*/
+            result.Row2 = (right.Row0 * leftM31 + right.Row1 * leftM32 + right.Row2 * leftM33);
+            result.Row2.W += leftM34;*/
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Matrix/Matrix3x4d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix3x4d.cs
@@ -82,10 +82,12 @@ namespace OpenTK.Mathematics
         /// <param name="m22">Third item of the third row of the matrix.</param>
         /// <param name="m23">Fourth item of the third row of the matrix.</param>
         [SuppressMessage("ReSharper", "SA1117", Justification = "For better readability of Matrix struct.")]
-        public Matrix3x4d(
+        public Matrix3x4d
+        (
             double m00, double m01, double m02, double m03,
             double m10, double m11, double m12, double m13,
-            double m20, double m21, double m22, double m23)
+            double m20, double m21, double m22, double m23
+        )
         {
             Row0 = new Vector4d(m00, m01, m02, m03);
             Row1 = new Vector4d(m10, m11, m12, m13);
@@ -304,7 +306,6 @@ namespace OpenTK.Mathematics
         /// <param name="axis">The axis to rotate about.</param>
         /// <param name="angle">Angle in radians to rotate counter-clockwise (looking in the direction of the given axis).</param>
         /// <param name="result">A matrix instance.</param>
-        [SuppressMessage("Microsoft.StyleCop.CSharp.DocumentationRules", "SA1305", Justification = "Is not hungarian notation but abbreveation for precalculated values.")]
         public static void CreateFromAxisAngle(Vector3d axis, double angle, out Matrix3x4d result)
         {
             axis.Normalize();
@@ -314,16 +315,16 @@ namespace OpenTK.Mathematics
             var sin = Math.Sin(angle);
             var t = 1.0f - cos;
 
-            double tXX = t * axisX * axisX,
-                tXY = t * axisX * axisY,
-                tXZ = t * axisX * axisZ,
-                tYY = t * axisY * axisY,
-                tYZ = t * axisY * axisZ,
-                tZZ = t * axisZ * axisZ;
+            double tXX = t * axisX * axisX;
+            double tXY = t * axisX * axisY;
+            double tXZ = t * axisX * axisZ;
+            double tYY = t * axisY * axisY;
+            double tYZ = t * axisY * axisZ;
+            double tZZ = t * axisZ * axisZ;
 
-            double sinX = sin * axisX,
-                sinY = sin * axisY,
-                sinZ = sin * axisZ;
+            double sinX = sin * axisX;
+            double sinY = sin * axisY;
+            double sinZ = sin * axisZ;
 
             result.Row0.X = tXX + cos;
             result.Row0.Y = tXY - sinZ;
@@ -358,22 +359,22 @@ namespace OpenTK.Mathematics
         /// <param name="result">A matrix instance.</param>
         public static void CreateFromQuaternion(ref Quaternion q, out Matrix3x4d result)
         {
-            double x = q.X,
-                y = q.Y,
-                z = q.Z,
-                w = q.W,
-                tx = 2 * x,
-                ty = 2 * y,
-                tz = 2 * z,
-                txx = tx * x,
-                tyy = ty * y,
-                tzz = tz * z,
-                txy = tx * y,
-                txz = tx * z,
-                tyz = ty * z,
-                txw = tx * w,
-                tyw = ty * w,
-                tzw = tz * w;
+            double x = q.X;
+            double y = q.Y;
+            double z = q.Z;
+            double w = q.W;
+            double tx = 2 * x;
+            double ty = 2 * y;
+            double tz = 2 * z;
+            double txx = tx * x;
+            double tyy = ty * y;
+            double tzz = tz * z;
+            double txy = tx * y;
+            double txz = tx * z;
+            double tyz = ty * z;
+            double txw = tx * w;
+            double tyw = ty * w;
+            double tzw = tz * w;
 
             result.Row0.X = 1f - (tyy + tzz);
             result.Row0.Y = txy + tzw;
@@ -387,11 +388,6 @@ namespace OpenTK.Mathematics
             result.Row2.Y = tyz - txw;
             result.Row2.Z = 1f - (txx + tyy);
             result.Row2.W = 0f;
-
-            /*Vector3d axis;
-            double angle;
-            q.ToAxisAngle(out axis, out angle);
-            CreateFromAxisAngle(axis, angle, out result);*/
         }
 
         /// <summary>
@@ -643,30 +639,30 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix3x4d left, ref Matrix4x3d right, out Matrix3d result)
         {
-            double leftM11 = left.Row0.X,
-                leftM12 = left.Row0.Y,
-                leftM13 = left.Row0.Z,
-                leftM14 = left.Row0.W,
-                leftM21 = left.Row1.X,
-                leftM22 = left.Row1.Y,
-                leftM23 = left.Row1.Z,
-                leftM24 = left.Row1.W,
-                leftM31 = left.Row2.X,
-                leftM32 = left.Row2.Y,
-                leftM33 = left.Row2.Z,
-                leftM34 = left.Row2.W,
-                rightM11 = right.Row0.X,
-                rightM12 = right.Row0.Y,
-                rightM13 = right.Row0.Z,
-                rightM21 = right.Row1.X,
-                rightM22 = right.Row1.Y,
-                rightM23 = right.Row1.Z,
-                rightM31 = right.Row2.X,
-                rightM32 = right.Row2.Y,
-                rightM33 = right.Row2.Z,
-                rightM41 = right.Row3.X,
-                rightM42 = right.Row3.Y,
-                rightM43 = right.Row3.Z;
+            double leftM11 = left.Row0.X;
+            double leftM12 = left.Row0.Y;
+            double leftM13 = left.Row0.Z;
+            double leftM14 = left.Row0.W;
+            double leftM21 = left.Row1.X;
+            double leftM22 = left.Row1.Y;
+            double leftM23 = left.Row1.Z;
+            double leftM24 = left.Row1.W;
+            double leftM31 = left.Row2.X;
+            double leftM32 = left.Row2.Y;
+            double leftM33 = left.Row2.Z;
+            double leftM34 = left.Row2.W;
+            double rightM11 = right.Row0.X;
+            double rightM12 = right.Row0.Y;
+            double rightM13 = right.Row0.Z;
+            double rightM21 = right.Row1.X;
+            double rightM22 = right.Row1.Y;
+            double rightM23 = right.Row1.Z;
+            double rightM31 = right.Row2.X;
+            double rightM32 = right.Row2.Y;
+            double rightM33 = right.Row2.Z;
+            double rightM41 = right.Row3.X;
+            double rightM42 = right.Row3.Y;
+            double rightM43 = right.Row3.Z;
 
             result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21) + (leftM13 * rightM31) + (leftM14 * rightM41);
             result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22) + (leftM13 * rightM32) + (leftM14 * rightM42);
@@ -699,30 +695,30 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix3x4d left, ref Matrix3x4d right, out Matrix3x4d result)
         {
-            double leftM11 = left.Row0.X,
-                leftM12 = left.Row0.Y,
-                leftM13 = left.Row0.Z,
-                leftM14 = left.Row0.W,
-                leftM21 = left.Row1.X,
-                leftM22 = left.Row1.Y,
-                leftM23 = left.Row1.Z,
-                leftM24 = left.Row1.W,
-                leftM31 = left.Row2.X,
-                leftM32 = left.Row2.Y,
-                leftM33 = left.Row2.Z,
-                leftM34 = left.Row2.W,
-                rightM11 = right.Row0.X,
-                rightM12 = right.Row0.Y,
-                rightM13 = right.Row0.Z,
-                rightM14 = right.Row0.W,
-                rightM21 = right.Row1.X,
-                rightM22 = right.Row1.Y,
-                rightM23 = right.Row1.Z,
-                rightM24 = right.Row1.W,
-                rightM31 = right.Row2.X,
-                rightM32 = right.Row2.Y,
-                rightM33 = right.Row2.Z,
-                rightM34 = right.Row2.W;
+            double leftM11 = left.Row0.X;
+            double leftM12 = left.Row0.Y;
+            double leftM13 = left.Row0.Z;
+            double leftM14 = left.Row0.W;
+            double leftM21 = left.Row1.X;
+            double leftM22 = left.Row1.Y;
+            double leftM23 = left.Row1.Z;
+            double leftM24 = left.Row1.W;
+            double leftM31 = left.Row2.X;
+            double leftM32 = left.Row2.Y;
+            double leftM33 = left.Row2.Z;
+            double leftM34 = left.Row2.W;
+            double rightM11 = right.Row0.X;
+            double rightM12 = right.Row0.Y;
+            double rightM13 = right.Row0.Z;
+            double rightM14 = right.Row0.W;
+            double rightM21 = right.Row1.X;
+            double rightM22 = right.Row1.Y;
+            double rightM23 = right.Row1.Z;
+            double rightM24 = right.Row1.W;
+            double rightM31 = right.Row2.X;
+            double rightM32 = right.Row2.Y;
+            double rightM33 = right.Row2.Z;
+            double rightM34 = right.Row2.W;
 
             result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21) + (leftM13 * rightM31);
             result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22) + (leftM13 * rightM32);
@@ -736,15 +732,6 @@ namespace OpenTK.Mathematics
             result.Row2.Y = (leftM31 * rightM12) + (leftM32 * rightM22) + (leftM33 * rightM32);
             result.Row2.Z = (leftM31 * rightM13) + (leftM32 * rightM23) + (leftM33 * rightM33);
             result.Row2.W = (leftM31 * rightM14) + (leftM32 * rightM24) + (leftM33 * rightM34) + leftM34;
-
-            /*result.Row0 = (right.Row0 * leftM11 + right.Row1 * leftM12 + right.Row2 * leftM13);
-            result.Row0.W += leftM14;
-
-            result.Row1 = (right.Row0 * leftM21 + right.Row1 * leftM22 + right.Row2 * leftM23);
-            result.Row1.W += leftM24;
-
-            result.Row2 = (right.Row0 * leftM31 + right.Row1 * leftM32 + right.Row2 * leftM33);
-            result.Row2.W += leftM34;*/
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Matrix/Matrix4.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix4.cs
@@ -100,11 +100,13 @@ namespace OpenTK.Mathematics
         /// <param name="m32">Third item of the fourth row of the matrix.</param>
         /// <param name="m33">Fourth item of the fourth row of the matrix.</param>
         [SuppressMessage("ReSharper", "SA1117", Justification = "For better readability of Matrix struct.")]
-        public Matrix4(
+        public Matrix4
+        (
             float m00, float m01, float m02, float m03,
             float m10, float m11, float m12, float m13,
             float m20, float m21, float m22, float m23,
-            float m30, float m31, float m32, float m33)
+            float m30, float m31, float m32, float m33
+        )
         {
             Row0 = new Vector4(m00, m01, m02, m03);
             Row1 = new Vector4(m10, m11, m12, m13);
@@ -143,22 +145,22 @@ namespace OpenTK.Mathematics
         {
             get
             {
-                float m11 = Row0.X,
-                    m12 = Row0.Y,
-                    m13 = Row0.Z,
-                    m14 = Row0.W,
-                    m21 = Row1.X,
-                    m22 = Row1.Y,
-                    m23 = Row1.Z,
-                    m24 = Row1.W,
-                    m31 = Row2.X,
-                    m32 = Row2.Y,
-                    m33 = Row2.Z,
-                    m34 = Row2.W,
-                    m41 = Row3.X,
-                    m42 = Row3.Y,
-                    m43 = Row3.Z,
-                    m44 = Row3.W;
+                float m11 = Row0.X;
+                float m12 = Row0.Y;
+                float m13 = Row0.Z;
+                float m14 = Row0.W;
+                float m21 = Row1.X;
+                float m22 = Row1.Y;
+                float m23 = Row1.Z;
+                float m24 = Row1.W;
+                float m31 = Row2.X;
+                float m32 = Row2.Y;
+                float m33 = Row2.Z;
+                float m34 = Row2.W;
+                float m41 = Row3.X;
+                float m42 = Row3.Y;
+                float m43 = Row3.Z;
+                float m44 = Row3.W;
 
                 return
                     (m11 * m22 * m33 * m44) - (m11 * m22 * m34 * m43) + (m11 * m23 * m34 * m42) - (m11 * m23 * m32 * m44)
@@ -474,7 +476,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Returns a normalized copy of this instance.
         /// </summary>
-        /// <returns>The normalized matrix.</returns>
+        /// <returns>The normalized copy.</returns>
         public Matrix4 Normalized()
         {
             var m = this;
@@ -497,7 +499,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Returns an inverted copy of this instance.
         /// </summary>
-        /// <returns>The inverted matrix.</returns>
+        /// <returns>The inverted copy.</returns>
         public Matrix4 Inverted()
         {
             var m = this;
@@ -660,7 +662,6 @@ namespace OpenTK.Mathematics
         /// <param name="axis">The axis to rotate about.</param>
         /// <param name="angle">Angle in radians to rotate counter-clockwise (looking in the direction of the given axis).</param>
         /// <param name="result">A matrix instance.</param>
-        [SuppressMessage("Microsoft.StyleCop.CSharp.DocumentationRules", "SA1305", Justification = "Is not hungarian notation but abbreveation for precalculated values.")]
         public static void CreateFromAxisAngle(Vector3 axis, float angle, out Matrix4 result)
         {
             // normalize and create a local copy of the vector.
@@ -673,16 +674,16 @@ namespace OpenTK.Mathematics
             var t = 1.0f - cos;
 
             // do the conversion math once
-            float tXX = t * axisX * axisX,
-                tXY = t * axisX * axisY,
-                tXZ = t * axisX * axisZ,
-                tYY = t * axisY * axisY,
-                tYZ = t * axisY * axisZ,
-                tZZ = t * axisZ * axisZ;
+            float tXX = t * axisX * axisX;
+            float tXY = t * axisX * axisY;
+            float tXZ = t * axisX * axisZ;
+            float tYY = t * axisY * axisY;
+            float tYZ = t * axisY * axisZ;
+            float tZZ = t * axisZ * axisZ;
 
-            float sinX = sin * axisX,
-                sinY = sin * axisY,
-                sinZ = sin * axisZ;
+            float sinX = sin * axisX;
+            float sinY = sin * axisY;
+            float sinZ = sin * axisZ;
 
             result.Row0.X = tXX + cos;
             result.Row0.Y = tXY - sinZ;
@@ -1359,38 +1360,38 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix4 left, ref Matrix4 right, out Matrix4 result)
         {
-            float leftM11 = left.Row0.X,
-                leftM12 = left.Row0.Y,
-                leftM13 = left.Row0.Z,
-                leftM14 = left.Row0.W,
-                leftM21 = left.Row1.X,
-                leftM22 = left.Row1.Y,
-                leftM23 = left.Row1.Z,
-                leftM24 = left.Row1.W,
-                leftM31 = left.Row2.X,
-                leftM32 = left.Row2.Y,
-                leftM33 = left.Row2.Z,
-                leftM34 = left.Row2.W,
-                leftM41 = left.Row3.X,
-                leftM42 = left.Row3.Y,
-                leftM43 = left.Row3.Z,
-                leftM44 = left.Row3.W,
-                rightM11 = right.Row0.X,
-                rightM12 = right.Row0.Y,
-                rightM13 = right.Row0.Z,
-                rightM14 = right.Row0.W,
-                rightM21 = right.Row1.X,
-                rightM22 = right.Row1.Y,
-                rightM23 = right.Row1.Z,
-                rightM24 = right.Row1.W,
-                rightM31 = right.Row2.X,
-                rightM32 = right.Row2.Y,
-                rightM33 = right.Row2.Z,
-                rightM34 = right.Row2.W,
-                rightM41 = right.Row3.X,
-                rightM42 = right.Row3.Y,
-                rightM43 = right.Row3.Z,
-                rightM44 = right.Row3.W;
+            float leftM11 = left.Row0.X;
+            float leftM12 = left.Row0.Y;
+            float leftM13 = left.Row0.Z;
+            float leftM14 = left.Row0.W;
+            float leftM21 = left.Row1.X;
+            float leftM22 = left.Row1.Y;
+            float leftM23 = left.Row1.Z;
+            float leftM24 = left.Row1.W;
+            float leftM31 = left.Row2.X;
+            float leftM32 = left.Row2.Y;
+            float leftM33 = left.Row2.Z;
+            float leftM34 = left.Row2.W;
+            float leftM41 = left.Row3.X;
+            float leftM42 = left.Row3.Y;
+            float leftM43 = left.Row3.Z;
+            float leftM44 = left.Row3.W;
+            float rightM11 = right.Row0.X;
+            float rightM12 = right.Row0.Y;
+            float rightM13 = right.Row0.Z;
+            float rightM14 = right.Row0.W;
+            float rightM21 = right.Row1.X;
+            float rightM22 = right.Row1.Y;
+            float rightM23 = right.Row1.Z;
+            float rightM24 = right.Row1.W;
+            float rightM31 = right.Row2.X;
+            float rightM32 = right.Row2.Y;
+            float rightM33 = right.Row2.Z;
+            float rightM34 = right.Row2.W;
+            float rightM41 = right.Row3.X;
+            float rightM42 = right.Row3.Y;
+            float rightM43 = right.Row3.Z;
+            float rightM44 = right.Row3.W;
 
             result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21) + (leftM13 * rightM31) + (leftM14 * rightM41);
             result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22) + (leftM13 * rightM32) + (leftM14 * rightM42);
@@ -1454,7 +1455,7 @@ namespace OpenTK.Mathematics
                 { mat.Row0.X, mat.Row0.Y, mat.Row0.Z, mat.Row0.W },
                 { mat.Row1.X, mat.Row1.Y, mat.Row1.Z, mat.Row1.W },
                 { mat.Row2.X, mat.Row2.Y, mat.Row2.Z, mat.Row2.W },
-                { mat.Row3.X, mat.Row3.Y, mat.Row3.Z, mat.Row3.W },
+                { mat.Row3.X, mat.Row3.Y, mat.Row3.Z, mat.Row3.W }
             };
             var icol = 0;
             var irow = 0;

--- a/src/OpenTK.Mathematics/Matrix/Matrix4.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix4.cs
@@ -21,6 +21,7 @@ SOFTWARE.
  */
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
 namespace OpenTK.Mathematics
@@ -98,25 +99,12 @@ namespace OpenTK.Mathematics
         /// <param name="m31">Second item of the fourth row of the matrix.</param>
         /// <param name="m32">Third item of the fourth row of the matrix.</param>
         /// <param name="m33">Fourth item of the fourth row of the matrix.</param>
-        public Matrix4
-        (
-            float m00,
-            float m01,
-            float m02,
-            float m03,
-            float m10,
-            float m11,
-            float m12,
-            float m13,
-            float m20,
-            float m21,
-            float m22,
-            float m23,
-            float m30,
-            float m31,
-            float m32,
-            float m33
-        )
+        [SuppressMessage("ReSharper", "SA1117", Justification = "For better readability of Matrix struct.")]
+        public Matrix4(
+            float m00, float m01, float m02, float m03,
+            float m10, float m11, float m12, float m13,
+            float m20, float m21, float m22, float m23,
+            float m30, float m31, float m32, float m33)
         {
             Row0 = new Vector4(m00, m01, m02, m03);
             Row1 = new Vector4(m10, m11, m12, m13);
@@ -412,6 +400,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="rowIndex">The index of the row.</param>
         /// <param name="columnIndex">The index of the column.</param>
+        /// <returns>The element at the given row and column index.</returns>
         public float this[int rowIndex, int columnIndex]
         {
             get
@@ -483,9 +472,9 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
-        /// Returns a normalised copy of this instance.
+        /// Returns a normalized copy of this instance.
         /// </summary>
-        /// <returns>The matrix.</returns>
+        /// <returns>The normalized matrix.</returns>
         public Matrix4 Normalized()
         {
             var m = this;
@@ -508,7 +497,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Returns an inverted copy of this instance.
         /// </summary>
-        /// <returns>The matrix.</returns>
+        /// <returns>The inverted matrix.</returns>
         public Matrix4 Inverted()
         {
             var m = this;
@@ -523,7 +512,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Returns a copy of this Matrix4 without translation.
         /// </summary>
-        /// <returns>The matrix.</returns>
+        /// <returns>The matrix without translation.</returns>
         public Matrix4 ClearTranslation()
         {
             var m = this;
@@ -534,7 +523,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Returns a copy of this Matrix4 without scale.
         /// </summary>
-        /// <returns>The matrix.</returns>
+        /// <returns>The matrix without scaling.</returns>
         public Matrix4 ClearScale()
         {
             var m = this;
@@ -547,7 +536,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Returns a copy of this Matrix4 without rotation.
         /// </summary>
-        /// <returns>The matrix.</returns>
+        /// <returns>The matrix without rotation.</returns>
         public Matrix4 ClearRotation()
         {
             var m = this;
@@ -560,7 +549,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Returns a copy of this Matrix4 without projection.
         /// </summary>
-        /// <returns>The matrix.</returns>
+        /// <returns>The matrix without projection.</returns>
         public Matrix4 ClearProjection()
         {
             var m = this;
@@ -589,18 +578,18 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Returns the rotation component of this instance. Quite slow.
         /// </summary>
-        /// <param name="row_normalise">
-        /// Whether the method should row-normalise (i.e. remove scale from) the Matrix. Pass false if
-        /// you know it's already normalised.
+        /// <param name="rowNormalize">
+        /// Whether the method should row-normalize (i.e. remove scale from) the Matrix. Pass false if
+        /// you know it's already normalized.
         /// </param>
         /// <returns>The rotation.</returns>
-        public Quaternion ExtractRotation(bool row_normalise = true)
+        public Quaternion ExtractRotation(bool rowNormalize = true)
         {
             var row0 = Row0.Xyz;
             var row1 = Row1.Xyz;
             var row2 = Row2.Xyz;
 
-            if (row_normalise)
+            if (rowNormalize)
             {
                 row0 = row0.Normalized();
                 row1 = row1.Normalized();
@@ -671,6 +660,7 @@ namespace OpenTK.Mathematics
         /// <param name="axis">The axis to rotate about.</param>
         /// <param name="angle">Angle in radians to rotate counter-clockwise (looking in the direction of the given axis).</param>
         /// <param name="result">A matrix instance.</param>
+        [SuppressMessage("Microsoft.StyleCop.CSharp.DocumentationRules", "SA1305", Justification = "Is not hungarian notation but abbreveation for precalculated values.")]
         public static void CreateFromAxisAngle(Vector3 axis, float angle, out Matrix4 result)
         {
             // normalize and create a local copy of the vector.
@@ -960,12 +950,12 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="width">The width of the projection volume.</param>
         /// <param name="height">The height of the projection volume.</param>
-        /// <param name="zNear">The near edge of the projection volume.</param>
-        /// <param name="zFar">The far edge of the projection volume.</param>
+        /// <param name="depthNear">The near edge of the projection volume.</param>
+        /// <param name="depthFar">The far edge of the projection volume.</param>
         /// <param name="result">The resulting Matrix4 instance.</param>
-        public static void CreateOrthographic(float width, float height, float zNear, float zFar, out Matrix4 result)
+        public static void CreateOrthographic(float width, float height, float depthNear, float depthFar, out Matrix4 result)
         {
-            CreateOrthographicOffCenter(-width / 2, width / 2, -height / 2, height / 2, zNear, zFar, out result);
+            CreateOrthographicOffCenter(-width / 2, width / 2, -height / 2, height / 2, depthNear, depthFar, out result);
         }
 
         /// <summary>
@@ -973,12 +963,12 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="width">The width of the projection volume.</param>
         /// <param name="height">The height of the projection volume.</param>
-        /// <param name="zNear">The near edge of the projection volume.</param>
-        /// <param name="zFar">The far edge of the projection volume.</param>
+        /// <param name="depthNear">The near edge of the projection volume.</param>
+        /// <param name="depthFar">The far edge of the projection volume.</param>
         /// <returns>The resulting Matrix4 instance.</returns>
-        public static Matrix4 CreateOrthographic(float width, float height, float zNear, float zFar)
+        public static Matrix4 CreateOrthographic(float width, float height, float depthNear, float depthFar)
         {
-            CreateOrthographicOffCenter(-width / 2, width / 2, -height / 2, height / 2, zNear, zFar, out Matrix4 result);
+            CreateOrthographicOffCenter(-width / 2, width / 2, -height / 2, height / 2, depthNear, depthFar, out Matrix4 result);
             return result;
         }
 
@@ -989,8 +979,8 @@ namespace OpenTK.Mathematics
         /// <param name="right">The right edge of the projection volume.</param>
         /// <param name="bottom">The bottom edge of the projection volume.</param>
         /// <param name="top">The top edge of the projection volume.</param>
-        /// <param name="zNear">The near edge of the projection volume.</param>
-        /// <param name="zFar">The far edge of the projection volume.</param>
+        /// <param name="depthNear">The near edge of the projection volume.</param>
+        /// <param name="depthFar">The far edge of the projection volume.</param>
         /// <param name="result">The resulting Matrix4 instance.</param>
         public static void CreateOrthographicOffCenter
         (
@@ -998,8 +988,8 @@ namespace OpenTK.Mathematics
             float right,
             float bottom,
             float top,
-            float zNear,
-            float zFar,
+            float depthNear,
+            float depthFar,
             out Matrix4 result
         )
         {
@@ -1007,7 +997,7 @@ namespace OpenTK.Mathematics
 
             var invRL = 1.0f / (right - left);
             var invTB = 1.0f / (top - bottom);
-            var invFN = 1.0f / (zFar - zNear);
+            var invFN = 1.0f / (depthFar - depthNear);
 
             result.Row0.X = 2 * invRL;
             result.Row1.Y = 2 * invTB;
@@ -1015,7 +1005,7 @@ namespace OpenTK.Mathematics
 
             result.Row3.X = -(right + left) * invRL;
             result.Row3.Y = -(top + bottom) * invTB;
-            result.Row3.Z = -(zFar + zNear) * invFN;
+            result.Row3.Z = -(depthFar + depthNear) * invFN;
         }
 
         /// <summary>
@@ -1025,8 +1015,8 @@ namespace OpenTK.Mathematics
         /// <param name="right">The right edge of the projection volume.</param>
         /// <param name="bottom">The bottom edge of the projection volume.</param>
         /// <param name="top">The top edge of the projection volume.</param>
-        /// <param name="zNear">The near edge of the projection volume.</param>
-        /// <param name="zFar">The far edge of the projection volume.</param>
+        /// <param name="depthNear">The near edge of the projection volume.</param>
+        /// <param name="depthFar">The far edge of the projection volume.</param>
         /// <returns>The resulting Matrix4 instance.</returns>
         public static Matrix4 CreateOrthographicOffCenter
         (
@@ -1034,11 +1024,11 @@ namespace OpenTK.Mathematics
             float right,
             float bottom,
             float top,
-            float zNear,
-            float zFar
+            float depthNear,
+            float depthFar
         )
         {
-            CreateOrthographicOffCenter(left, right, bottom, top, zNear, zFar, out Matrix4 result);
+            CreateOrthographicOffCenter(left, right, bottom, top, depthNear, depthFar, out Matrix4 result);
             return result;
         }
 
@@ -1047,25 +1037,25 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="fovy">Angle of the field of view in the y direction (in radians).</param>
         /// <param name="aspect">Aspect ratio of the view (width / height).</param>
-        /// <param name="zNear">Distance to the near clip plane.</param>
-        /// <param name="zFar">Distance to the far clip plane.</param>
+        /// <param name="depthNear">Distance to the near clip plane.</param>
+        /// <param name="depthFar">Distance to the far clip plane.</param>
         /// <param name="result">A projection matrix that transforms camera space to raster space.</param>
         /// <exception cref="System.ArgumentOutOfRangeException">
         /// Thrown under the following conditions:
         ///  <list type="bullet">
         ///  <item>fovy is zero, less than zero or larger than Math.PI</item>
         ///  <item>aspect is negative or zero</item>
-        ///  <item>zNear is negative or zero</item>
-        ///  <item>zFar is negative or zero</item>
-        ///  <item>zNear is larger than zFar</item>
+        ///  <item>depthNear is negative or zero</item>
+        ///  <item>depthFar is negative or zero</item>
+        ///  <item>depthNear is larger than depthFar</item>
         ///  </list>
         /// </exception>
         public static void CreatePerspectiveFieldOfView
         (
             float fovy,
             float aspect,
-            float zNear,
-            float zFar,
+            float depthNear,
+            float depthFar,
             out Matrix4 result
         )
         {
@@ -1079,22 +1069,22 @@ namespace OpenTK.Mathematics
                 throw new ArgumentOutOfRangeException(nameof(aspect));
             }
 
-            if (zNear <= 0)
+            if (depthNear <= 0)
             {
-                throw new ArgumentOutOfRangeException(nameof(zNear));
+                throw new ArgumentOutOfRangeException(nameof(depthNear));
             }
 
-            if (zFar <= 0)
+            if (depthFar <= 0)
             {
-                throw new ArgumentOutOfRangeException(nameof(zFar));
+                throw new ArgumentOutOfRangeException(nameof(depthFar));
             }
 
-            var yMax = zNear * (float)Math.Tan(0.5f * fovy);
-            var yMin = -yMax;
-            var xMin = yMin * aspect;
-            var xMax = yMax * aspect;
+            var maxY = depthNear * (float)Math.Tan(0.5f * fovy);
+            var minY = -maxY;
+            var minX = minY * aspect;
+            var maxX = maxY * aspect;
 
-            CreatePerspectiveOffCenter(xMin, xMax, yMin, yMax, zNear, zFar, out result);
+            CreatePerspectiveOffCenter(minX, maxX, minY, maxY, depthNear, depthFar, out result);
         }
 
         /// <summary>
@@ -1102,22 +1092,22 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="fovy">Angle of the field of view in the y direction (in radians).</param>
         /// <param name="aspect">Aspect ratio of the view (width / height).</param>
-        /// <param name="zNear">Distance to the near clip plane.</param>
-        /// <param name="zFar">Distance to the far clip plane.</param>
+        /// <param name="depthNear">Distance to the near clip plane.</param>
+        /// <param name="depthFar">Distance to the far clip plane.</param>
         /// <returns>A projection matrix that transforms camera space to raster space.</returns>
         /// <exception cref="System.ArgumentOutOfRangeException">
         /// Thrown under the following conditions:
         ///  <list type="bullet">
         ///  <item>fovy is zero, less than zero or larger than Math.PI</item>
         ///  <item>aspect is negative or zero</item>
-        ///  <item>zNear is negative or zero</item>
-        ///  <item>zFar is negative or zero</item>
-        ///  <item>zNear is larger than zFar</item>
+        ///  <item>depthNear is negative or zero</item>
+        ///  <item>depthFar is negative or zero</item>
+        ///  <item>depthNear is larger than depthFar</item>
         ///  </list>
         /// </exception>
-        public static Matrix4 CreatePerspectiveFieldOfView(float fovy, float aspect, float zNear, float zFar)
+        public static Matrix4 CreatePerspectiveFieldOfView(float fovy, float aspect, float depthNear, float depthFar)
         {
-            CreatePerspectiveFieldOfView(fovy, aspect, zNear, zFar, out Matrix4 result);
+            CreatePerspectiveFieldOfView(fovy, aspect, depthNear, depthFar, out Matrix4 result);
             return result;
         }
 
@@ -1128,15 +1118,15 @@ namespace OpenTK.Mathematics
         /// <param name="right">Right edge of the view frustum.</param>
         /// <param name="bottom">Bottom edge of the view frustum.</param>
         /// <param name="top">Top edge of the view frustum.</param>
-        /// <param name="zNear">Distance to the near clip plane.</param>
-        /// <param name="zFar">Distance to the far clip plane.</param>
+        /// <param name="depthNear">Distance to the near clip plane.</param>
+        /// <param name="depthFar">Distance to the far clip plane.</param>
         /// <param name="result">A projection matrix that transforms camera space to raster space.</param>
         /// <exception cref="System.ArgumentOutOfRangeException">
         /// Thrown under the following conditions:
         ///  <list type="bullet">
-        ///  <item>zNear is negative or zero</item>
-        ///  <item>zFar is negative or zero</item>
-        ///  <item>zNear is larger than zFar</item>
+        ///  <item>depthNear is negative or zero</item>
+        ///  <item>depthFar is negative or zero</item>
+        ///  <item>depthNear is larger than depthFar</item>
         ///  </list>
         /// </exception>
         public static void CreatePerspectiveOffCenter
@@ -1145,32 +1135,32 @@ namespace OpenTK.Mathematics
             float right,
             float bottom,
             float top,
-            float zNear,
-            float zFar,
+            float depthNear,
+            float depthFar,
             out Matrix4 result
         )
         {
-            if (zNear <= 0)
+            if (depthNear <= 0)
             {
-                throw new ArgumentOutOfRangeException(nameof(zNear));
+                throw new ArgumentOutOfRangeException(nameof(depthNear));
             }
 
-            if (zFar <= 0)
+            if (depthFar <= 0)
             {
-                throw new ArgumentOutOfRangeException(nameof(zFar));
+                throw new ArgumentOutOfRangeException(nameof(depthFar));
             }
 
-            if (zNear >= zFar)
+            if (depthNear >= depthFar)
             {
-                throw new ArgumentOutOfRangeException(nameof(zNear));
+                throw new ArgumentOutOfRangeException(nameof(depthNear));
             }
 
-            var x = 2.0f * zNear / (right - left);
-            var y = 2.0f * zNear / (top - bottom);
+            var x = 2.0f * depthNear / (right - left);
+            var y = 2.0f * depthNear / (top - bottom);
             var a = (right + left) / (right - left);
             var b = (top + bottom) / (top - bottom);
-            var c = -(zFar + zNear) / (zFar - zNear);
-            var d = -(2.0f * zFar * zNear) / (zFar - zNear);
+            var c = -(depthFar + depthNear) / (depthFar - depthNear);
+            var d = -(2.0f * depthFar * depthNear) / (depthFar - depthNear);
 
             result.Row0.X = x;
             result.Row0.Y = 0;
@@ -1197,15 +1187,15 @@ namespace OpenTK.Mathematics
         /// <param name="right">Right edge of the view frustum.</param>
         /// <param name="bottom">Bottom edge of the view frustum.</param>
         /// <param name="top">Top edge of the view frustum.</param>
-        /// <param name="zNear">Distance to the near clip plane.</param>
-        /// <param name="zFar">Distance to the far clip plane.</param>
+        /// <param name="depthNear">Distance to the near clip plane.</param>
+        /// <param name="depthFar">Distance to the far clip plane.</param>
         /// <returns>A projection matrix that transforms camera space to raster space.</returns>
         /// <exception cref="System.ArgumentOutOfRangeException">
         /// Thrown under the following conditions:
         ///  <list type="bullet">
-        ///  <item>zNear is negative or zero</item>
-        ///  <item>zFar is negative or zero</item>
-        ///  <item>zNear is larger than zFar</item>
+        ///  <item>depthNear is negative or zero</item>
+        ///  <item>depthFar is negative or zero</item>
+        ///  <item>depthNear is larger than depthFar</item>
         ///  </list>
         /// </exception>
         public static Matrix4 CreatePerspectiveOffCenter
@@ -1214,11 +1204,11 @@ namespace OpenTK.Mathematics
             float right,
             float bottom,
             float top,
-            float zNear,
-            float zFar
+            float depthNear,
+            float depthFar
         )
         {
-            CreatePerspectiveOffCenter(left, right, bottom, top, zNear, zFar, out Matrix4 result);
+            CreatePerspectiveOffCenter(left, right, bottom, top, depthNear, depthFar, out Matrix4 result);
             return result;
         }
 
@@ -1227,9 +1217,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="eye">Eye (camera) position in world space.</param>
         /// <param name="target">Target position in world space.</param>
-        /// <param name="up">
-        /// Up vector in world space (should not be parallel to the camera direction, that is target - eye).
-        /// </param>
+        /// <param name="up">Up vector in world space (should not be parallel to the camera direction, that is target - eye).</param>
         /// <returns>A Matrix4 that transforms world space to camera space.</returns>
         public static Matrix4 LookAt(Vector3 eye, Vector3 target, Vector3 up)
         {
@@ -1371,55 +1359,55 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix4 left, ref Matrix4 right, out Matrix4 result)
         {
-            float lM11 = left.Row0.X,
-                lM12 = left.Row0.Y,
-                lM13 = left.Row0.Z,
-                lM14 = left.Row0.W,
-                lM21 = left.Row1.X,
-                lM22 = left.Row1.Y,
-                lM23 = left.Row1.Z,
-                lM24 = left.Row1.W,
-                lM31 = left.Row2.X,
-                lM32 = left.Row2.Y,
-                lM33 = left.Row2.Z,
-                lM34 = left.Row2.W,
-                lM41 = left.Row3.X,
-                lM42 = left.Row3.Y,
-                lM43 = left.Row3.Z,
-                lM44 = left.Row3.W,
-                rM11 = right.Row0.X,
-                rM12 = right.Row0.Y,
-                rM13 = right.Row0.Z,
-                rM14 = right.Row0.W,
-                rM21 = right.Row1.X,
-                rM22 = right.Row1.Y,
-                rM23 = right.Row1.Z,
-                rM24 = right.Row1.W,
-                rM31 = right.Row2.X,
-                rM32 = right.Row2.Y,
-                rM33 = right.Row2.Z,
-                rM34 = right.Row2.W,
-                rM41 = right.Row3.X,
-                rM42 = right.Row3.Y,
-                rM43 = right.Row3.Z,
-                rM44 = right.Row3.W;
+            float leftM11 = left.Row0.X,
+                leftM12 = left.Row0.Y,
+                leftM13 = left.Row0.Z,
+                leftM14 = left.Row0.W,
+                leftM21 = left.Row1.X,
+                leftM22 = left.Row1.Y,
+                leftM23 = left.Row1.Z,
+                leftM24 = left.Row1.W,
+                leftM31 = left.Row2.X,
+                leftM32 = left.Row2.Y,
+                leftM33 = left.Row2.Z,
+                leftM34 = left.Row2.W,
+                leftM41 = left.Row3.X,
+                leftM42 = left.Row3.Y,
+                leftM43 = left.Row3.Z,
+                leftM44 = left.Row3.W,
+                rightM11 = right.Row0.X,
+                rightM12 = right.Row0.Y,
+                rightM13 = right.Row0.Z,
+                rightM14 = right.Row0.W,
+                rightM21 = right.Row1.X,
+                rightM22 = right.Row1.Y,
+                rightM23 = right.Row1.Z,
+                rightM24 = right.Row1.W,
+                rightM31 = right.Row2.X,
+                rightM32 = right.Row2.Y,
+                rightM33 = right.Row2.Z,
+                rightM34 = right.Row2.W,
+                rightM41 = right.Row3.X,
+                rightM42 = right.Row3.Y,
+                rightM43 = right.Row3.Z,
+                rightM44 = right.Row3.W;
 
-            result.Row0.X = (lM11 * rM11) + (lM12 * rM21) + (lM13 * rM31) + (lM14 * rM41);
-            result.Row0.Y = (lM11 * rM12) + (lM12 * rM22) + (lM13 * rM32) + (lM14 * rM42);
-            result.Row0.Z = (lM11 * rM13) + (lM12 * rM23) + (lM13 * rM33) + (lM14 * rM43);
-            result.Row0.W = (lM11 * rM14) + (lM12 * rM24) + (lM13 * rM34) + (lM14 * rM44);
-            result.Row1.X = (lM21 * rM11) + (lM22 * rM21) + (lM23 * rM31) + (lM24 * rM41);
-            result.Row1.Y = (lM21 * rM12) + (lM22 * rM22) + (lM23 * rM32) + (lM24 * rM42);
-            result.Row1.Z = (lM21 * rM13) + (lM22 * rM23) + (lM23 * rM33) + (lM24 * rM43);
-            result.Row1.W = (lM21 * rM14) + (lM22 * rM24) + (lM23 * rM34) + (lM24 * rM44);
-            result.Row2.X = (lM31 * rM11) + (lM32 * rM21) + (lM33 * rM31) + (lM34 * rM41);
-            result.Row2.Y = (lM31 * rM12) + (lM32 * rM22) + (lM33 * rM32) + (lM34 * rM42);
-            result.Row2.Z = (lM31 * rM13) + (lM32 * rM23) + (lM33 * rM33) + (lM34 * rM43);
-            result.Row2.W = (lM31 * rM14) + (lM32 * rM24) + (lM33 * rM34) + (lM34 * rM44);
-            result.Row3.X = (lM41 * rM11) + (lM42 * rM21) + (lM43 * rM31) + (lM44 * rM41);
-            result.Row3.Y = (lM41 * rM12) + (lM42 * rM22) + (lM43 * rM32) + (lM44 * rM42);
-            result.Row3.Z = (lM41 * rM13) + (lM42 * rM23) + (lM43 * rM33) + (lM44 * rM43);
-            result.Row3.W = (lM41 * rM14) + (lM42 * rM24) + (lM43 * rM34) + (lM44 * rM44);
+            result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21) + (leftM13 * rightM31) + (leftM14 * rightM41);
+            result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22) + (leftM13 * rightM32) + (leftM14 * rightM42);
+            result.Row0.Z = (leftM11 * rightM13) + (leftM12 * rightM23) + (leftM13 * rightM33) + (leftM14 * rightM43);
+            result.Row0.W = (leftM11 * rightM14) + (leftM12 * rightM24) + (leftM13 * rightM34) + (leftM14 * rightM44);
+            result.Row1.X = (leftM21 * rightM11) + (leftM22 * rightM21) + (leftM23 * rightM31) + (leftM24 * rightM41);
+            result.Row1.Y = (leftM21 * rightM12) + (leftM22 * rightM22) + (leftM23 * rightM32) + (leftM24 * rightM42);
+            result.Row1.Z = (leftM21 * rightM13) + (leftM22 * rightM23) + (leftM23 * rightM33) + (leftM24 * rightM43);
+            result.Row1.W = (leftM21 * rightM14) + (leftM22 * rightM24) + (leftM23 * rightM34) + (leftM24 * rightM44);
+            result.Row2.X = (leftM31 * rightM11) + (leftM32 * rightM21) + (leftM33 * rightM31) + (leftM34 * rightM41);
+            result.Row2.Y = (leftM31 * rightM12) + (leftM32 * rightM22) + (leftM33 * rightM32) + (leftM34 * rightM42);
+            result.Row2.Z = (leftM31 * rightM13) + (leftM32 * rightM23) + (leftM33 * rightM33) + (leftM34 * rightM43);
+            result.Row2.W = (leftM31 * rightM14) + (leftM32 * rightM24) + (leftM33 * rightM34) + (leftM34 * rightM44);
+            result.Row3.X = (leftM41 * rightM11) + (leftM42 * rightM21) + (leftM43 * rightM31) + (leftM44 * rightM41);
+            result.Row3.Y = (leftM41 * rightM12) + (leftM42 * rightM22) + (leftM43 * rightM32) + (leftM44 * rightM42);
+            result.Row3.Z = (leftM41 * rightM13) + (leftM42 * rightM23) + (leftM43 * rightM33) + (leftM44 * rightM43);
+            result.Row3.W = (leftM41 * rightM14) + (leftM42 * rightM24) + (leftM43 * rightM34) + (leftM44 * rightM44);
         }
 
         /// <summary>
@@ -1466,7 +1454,7 @@ namespace OpenTK.Mathematics
                 { mat.Row0.X, mat.Row0.Y, mat.Row0.Z, mat.Row0.W },
                 { mat.Row1.X, mat.Row1.Y, mat.Row1.Z, mat.Row1.W },
                 { mat.Row2.X, mat.Row2.Y, mat.Row2.Z, mat.Row2.W },
-                { mat.Row3.X, mat.Row3.Y, mat.Row3.Z, mat.Row3.W }
+                { mat.Row3.X, mat.Row3.Y, mat.Row3.Z, mat.Row3.W },
             };
             var icol = 0;
             var irow = 0;

--- a/src/OpenTK.Mathematics/Matrix/Matrix4d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix4d.cs
@@ -475,7 +475,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Returns an inverted copy of this instance.
         /// </summary>
-        /// <returns>The inverted matrix.</returns>
+        /// <returns>The inverted copy.</returns>
         public Matrix4d Inverted()
         {
             var m = this;

--- a/src/OpenTK.Mathematics/Matrix/Matrix4d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix4d.cs
@@ -21,6 +21,7 @@ SOFTWARE.
  */
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
 namespace OpenTK.Mathematics
@@ -60,7 +61,6 @@ namespace OpenTK.Mathematics
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Matrix4d"/> struct.
-        /// Constructs a new instance.
         /// </summary>
         /// <param name="row0">Top row of the matrix.</param>
         /// <param name="row1">Second row of the matrix.</param>
@@ -93,25 +93,12 @@ namespace OpenTK.Mathematics
         /// <param name="m31">Second item of the fourth row.</param>
         /// <param name="m32">Third item of the fourth row.</param>
         /// <param name="m33">Fourth item of the fourth row.</param>
-        public Matrix4d
-        (
-            double m00,
-            double m01,
-            double m02,
-            double m03,
-            double m10,
-            double m11,
-            double m12,
-            double m13,
-            double m20,
-            double m21,
-            double m22,
-            double m23,
-            double m30,
-            double m31,
-            double m32,
-            double m33
-        )
+        [SuppressMessage("ReSharper", "SA1117", Justification = "For better readability of Matrix struct.")]
+        public Matrix4d(
+            double m00, double m01, double m02, double m03,
+            double m10, double m11, double m12, double m13,
+            double m20, double m21, double m22, double m23,
+            double m30, double m31, double m32, double m33)
         {
             Row0 = new Vector4d(m00, m01, m02, m03);
             Row1 = new Vector4d(m10, m11, m12, m13);
@@ -389,6 +376,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="rowIndex">The index of the row.</param>
         /// <param name="columnIndex">The index of the column.</param>
+        /// <returns>The element at the given row and column index.</returns>
         public double this[int rowIndex, int columnIndex]
         {
             get
@@ -460,9 +448,9 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
-        /// Returns a normalised copy of this instance.
+        /// Returns a normalized copy of this instance.
         /// </summary>
-        /// <returns>The matrix.</returns>
+        /// <returns>The normalized matrix.</returns>
         public Matrix4d Normalized()
         {
             var m = this;
@@ -485,7 +473,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Returns an inverted copy of this instance.
         /// </summary>
-        /// <returns>The matrix.</returns>
+        /// <returns>The inverted matrix.</returns>
         public Matrix4d Inverted()
         {
             var m = this;
@@ -500,7 +488,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Returns a copy of this Matrix4d without translation.
         /// </summary>
-        /// <returns>The matrix.</returns>
+        /// <returns>The matrix without translation.</returns>
         public Matrix4d ClearTranslation()
         {
             var m = this;
@@ -511,7 +499,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Returns a copy of this Matrix4d without scale.
         /// </summary>
-        /// <returns>The matrix.</returns>
+        /// <returns>The matrix without scaling.</returns>
         public Matrix4d ClearScale()
         {
             var m = this;
@@ -524,7 +512,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Returns a copy of this Matrix4d without rotation.
         /// </summary>
-        /// <returns>The matrix.</returns>
+        /// <returns>The matrix without rotation.</returns>
         public Matrix4d ClearRotation()
         {
             var m = this;
@@ -537,7 +525,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Returns a copy of this Matrix4d without projection.
         /// </summary>
-        /// <returns>The matrix.</returns>
+        /// <returns>The matrix without projection.</returns>
         public Matrix4d ClearProjection()
         {
             var m = this;
@@ -566,18 +554,18 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Returns the rotation component of this instance. Quite slow.
         /// </summary>
-        /// <param name="row_normalise">
-        /// Whether the method should row-normalise (i.e. remove scale from) the Matrix. Pass false if
-        /// you know it's already normalised.
+        /// <param name="rowNormalize">
+        /// Whether the method should row-normalize (i.e. remove scale from) the Matrix. Pass false if
+        /// you know it's already normalized.
         /// </param>
         /// <returns>The rotation.</returns>
-        public Quaterniond ExtractRotation(bool row_normalise = true)
+        public Quaterniond ExtractRotation(bool rowNormalize = true)
         {
             var row0 = Row0.Xyz;
             var row1 = Row1.Xyz;
             var row2 = Row2.Xyz;
 
-            if (row_normalise)
+            if (rowNormalize)
             {
                 row0 = row0.Normalized();
                 row1 = row1.Normalized();
@@ -648,6 +636,7 @@ namespace OpenTK.Mathematics
         /// <param name="axis">The axis to rotate about.</param>
         /// <param name="angle">Angle in radians to rotate counter-clockwise (looking in the direction of the given axis).</param>
         /// <param name="result">A matrix instance.</param>
+        [SuppressMessage("Microsoft.StyleCop.CSharp.DocumentationRules", "SA1305", Justification = "Is not hungarian notation but abbreveation for precalculated values.")]
         public static void CreateFromAxisAngle(Vector3d axis, double angle, out Matrix4d result)
         {
             // normalize and create a local copy of the vector.
@@ -832,19 +821,19 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="width">The width of the projection volume.</param>
         /// <param name="height">The height of the projection volume.</param>
-        /// <param name="zNear">The near edge of the projection volume.</param>
-        /// <param name="zFar">The far edge of the projection volume.</param>
+        /// <param name="depthNear">The near edge of the projection volume.</param>
+        /// <param name="depthFar">The far edge of the projection volume.</param>
         /// <param name="result">The resulting Matrix4d instance.</param>
         public static void CreateOrthographic
         (
             double width,
             double height,
-            double zNear,
-            double zFar,
+            double depthNear,
+            double depthFar,
             out Matrix4d result
         )
         {
-            CreateOrthographicOffCenter(-width / 2, width / 2, -height / 2, height / 2, zNear, zFar, out result);
+            CreateOrthographicOffCenter(-width / 2, width / 2, -height / 2, height / 2, depthNear, depthFar, out result);
         }
 
         /// <summary>
@@ -852,12 +841,12 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="width">The width of the projection volume.</param>
         /// <param name="height">The height of the projection volume.</param>
-        /// <param name="zNear">The near edge of the projection volume.</param>
-        /// <param name="zFar">The far edge of the projection volume.</param>
+        /// <param name="depthNear">The near edge of the projection volume.</param>
+        /// <param name="depthFar">The far edge of the projection volume.</param>
         /// <returns>The resulting Matrix4d instance.</returns>
-        public static Matrix4d CreateOrthographic(double width, double height, double zNear, double zFar)
+        public static Matrix4d CreateOrthographic(double width, double height, double depthNear, double depthFar)
         {
-            CreateOrthographicOffCenter(-width / 2, width / 2, -height / 2, height / 2, zNear, zFar, out Matrix4d result);
+            CreateOrthographicOffCenter(-width / 2, width / 2, -height / 2, height / 2, depthNear, depthFar, out Matrix4d result);
             return result;
         }
 
@@ -868,8 +857,8 @@ namespace OpenTK.Mathematics
         /// <param name="right">The right edge of the projection volume.</param>
         /// <param name="bottom">The bottom edge of the projection volume.</param>
         /// <param name="top">The top edge of the projection volume.</param>
-        /// <param name="zNear">The near edge of the projection volume.</param>
-        /// <param name="zFar">The far edge of the projection volume.</param>
+        /// <param name="depthNear">The near edge of the projection volume.</param>
+        /// <param name="depthFar">The far edge of the projection volume.</param>
         /// <param name="result">The resulting Matrix4d instance.</param>
         public static void CreateOrthographicOffCenter
         (
@@ -877,14 +866,14 @@ namespace OpenTK.Mathematics
             double right,
             double bottom,
             double top,
-            double zNear,
-            double zFar,
+            double depthNear,
+            double depthFar,
             out Matrix4d result
         )
         {
             var invRL = 1 / (right - left);
             var invTB = 1 / (top - bottom);
-            var invFN = 1 / (zFar - zNear);
+            var invFN = 1 / (depthFar - depthNear);
 
             result = new Matrix4d
             {
@@ -894,7 +883,7 @@ namespace OpenTK.Mathematics
 
                 M41 = -(right + left) * invRL,
                 M42 = -(top + bottom) * invTB,
-                M43 = -(zFar + zNear) * invFN,
+                M43 = -(depthFar + depthNear) * invFN,
                 M44 = 1
             };
         }
@@ -906,8 +895,8 @@ namespace OpenTK.Mathematics
         /// <param name="right">The right edge of the projection volume.</param>
         /// <param name="bottom">The bottom edge of the projection volume.</param>
         /// <param name="top">The top edge of the projection volume.</param>
-        /// <param name="zNear">The near edge of the projection volume.</param>
-        /// <param name="zFar">The far edge of the projection volume.</param>
+        /// <param name="depthNear">The near edge of the projection volume.</param>
+        /// <param name="depthFar">The far edge of the projection volume.</param>
         /// <returns>The resulting Matrix4d instance.</returns>
         public static Matrix4d CreateOrthographicOffCenter
         (
@@ -915,11 +904,11 @@ namespace OpenTK.Mathematics
             double right,
             double bottom,
             double top,
-            double zNear,
-            double zFar
+            double depthNear,
+            double depthFar
         )
         {
-            CreateOrthographicOffCenter(left, right, bottom, top, zNear, zFar, out Matrix4d result);
+            CreateOrthographicOffCenter(left, right, bottom, top, depthNear, depthFar, out Matrix4d result);
             return result;
         }
 
@@ -928,25 +917,25 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="fovy">Angle of the field of view in the y direction (in radians).</param>
         /// <param name="aspect">Aspect ratio of the view (width / height).</param>
-        /// <param name="zNear">Distance to the near clip plane.</param>
-        /// <param name="zFar">Distance to the far clip plane.</param>
+        /// <param name="depthNear">Distance to the near clip plane.</param>
+        /// <param name="depthFar">Distance to the far clip plane.</param>
         /// <param name="result">A projection matrix that transforms camera space to raster space.</param>
         /// <exception cref="System.ArgumentOutOfRangeException">
         /// Thrown under the following conditions:
         ///  <list type="bullet">
         ///  <item>fovy is zero, less than zero or larger than Math.PI</item>
         ///  <item>aspect is negative or zero</item>
-        ///  <item>zNear is negative or zero</item>
-        ///  <item>zFar is negative or zero</item>
-        ///  <item>zNear is larger than zFar</item>
+        ///  <item>depthNear is negative or zero</item>
+        ///  <item>depthFar is negative or zero</item>
+        ///  <item>depthNear is larger than depthFar</item>
         ///  </list>
         /// </exception>
         public static void CreatePerspectiveFieldOfView
         (
             double fovy,
             double aspect,
-            double zNear,
-            double zFar,
+            double depthNear,
+            double depthFar,
             out Matrix4d result
         )
         {
@@ -960,22 +949,22 @@ namespace OpenTK.Mathematics
                 throw new ArgumentOutOfRangeException(nameof(aspect));
             }
 
-            if (zNear <= 0)
+            if (depthNear <= 0)
             {
-                throw new ArgumentOutOfRangeException(nameof(zNear));
+                throw new ArgumentOutOfRangeException(nameof(depthNear));
             }
 
-            if (zFar <= 0)
+            if (depthFar <= 0)
             {
-                throw new ArgumentOutOfRangeException(nameof(zFar));
+                throw new ArgumentOutOfRangeException(nameof(depthFar));
             }
 
-            var yMax = zNear * Math.Tan(0.5 * fovy);
-            var yMin = -yMax;
-            var xMin = yMin * aspect;
-            var xMax = yMax * aspect;
+            var maxY = depthNear * Math.Tan(0.5 * fovy);
+            var minY = -maxY;
+            var minX = minY * aspect;
+            var maxX = maxY * aspect;
 
-            CreatePerspectiveOffCenter(xMin, xMax, yMin, yMax, zNear, zFar, out result);
+            CreatePerspectiveOffCenter(minX, maxX, minY, maxY, depthNear, depthFar, out result);
         }
 
         /// <summary>
@@ -983,22 +972,22 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="fovy">Angle of the field of view in the y direction (in radians).</param>
         /// <param name="aspect">Aspect ratio of the view (width / height).</param>
-        /// <param name="zNear">Distance to the near clip plane.</param>
-        /// <param name="zFar">Distance to the far clip plane.</param>
+        /// <param name="depthNear">Distance to the near clip plane.</param>
+        /// <param name="depthFar">Distance to the far clip plane.</param>
         /// <returns>A projection matrix that transforms camera space to raster space.</returns>
         /// <exception cref="System.ArgumentOutOfRangeException">
         /// Thrown under the following conditions:
         ///  <list type="bullet">
         ///  <item>fovy is zero, less than zero or larger than Math.PI</item>
         ///  <item>aspect is negative or zero</item>
-        ///  <item>zNear is negative or zero</item>
-        ///  <item>zFar is negative or zero</item>
-        ///  <item>zNear is larger than zFar</item>
+        ///  <item>depthNear is negative or zero</item>
+        ///  <item>depthFar is negative or zero</item>
+        ///  <item>depthNear is larger than depthFar</item>
         ///  </list>
         /// </exception>
-        public static Matrix4d CreatePerspectiveFieldOfView(double fovy, double aspect, double zNear, double zFar)
+        public static Matrix4d CreatePerspectiveFieldOfView(double fovy, double aspect, double depthNear, double depthFar)
         {
-            CreatePerspectiveFieldOfView(fovy, aspect, zNear, zFar, out Matrix4d result);
+            CreatePerspectiveFieldOfView(fovy, aspect, depthNear, depthFar, out Matrix4d result);
             return result;
         }
 
@@ -1009,15 +998,15 @@ namespace OpenTK.Mathematics
         /// <param name="right">Right edge of the view frustum.</param>
         /// <param name="bottom">Bottom edge of the view frustum.</param>
         /// <param name="top">Top edge of the view frustum.</param>
-        /// <param name="zNear">Distance to the near clip plane.</param>
-        /// <param name="zFar">Distance to the far clip plane.</param>
+        /// <param name="depthNear">Distance to the near clip plane.</param>
+        /// <param name="depthFar">Distance to the far clip plane.</param>
         /// <param name="result">A projection matrix that transforms camera space to raster space.</param>
         /// <exception cref="System.ArgumentOutOfRangeException">
         /// Thrown under the following conditions:
         ///  <list type="bullet">
-        ///  <item>zNear is negative or zero</item>
-        ///  <item>zFar is negative or zero</item>
-        ///  <item>zNear is larger than zFar</item>
+        ///  <item>depthNear is negative or zero</item>
+        ///  <item>depthFar is negative or zero</item>
+        ///  <item>depthNear is larger than depthFar</item>
         ///  </list>
         /// </exception>
         public static void CreatePerspectiveOffCenter
@@ -1026,32 +1015,32 @@ namespace OpenTK.Mathematics
             double right,
             double bottom,
             double top,
-            double zNear,
-            double zFar,
+            double depthNear,
+            double depthFar,
             out Matrix4d result
         )
         {
-            if (zNear <= 0)
+            if (depthNear <= 0)
             {
-                throw new ArgumentOutOfRangeException(nameof(zNear));
+                throw new ArgumentOutOfRangeException(nameof(depthNear));
             }
 
-            if (zFar <= 0)
+            if (depthFar <= 0)
             {
-                throw new ArgumentOutOfRangeException(nameof(zFar));
+                throw new ArgumentOutOfRangeException(nameof(depthFar));
             }
 
-            if (zNear >= zFar)
+            if (depthNear >= depthFar)
             {
-                throw new ArgumentOutOfRangeException(nameof(zNear));
+                throw new ArgumentOutOfRangeException(nameof(depthNear));
             }
 
-            var x = 2.0 * zNear / (right - left);
-            var y = 2.0 * zNear / (top - bottom);
+            var x = 2.0 * depthNear / (right - left);
+            var y = 2.0 * depthNear / (top - bottom);
             var a = (right + left) / (right - left);
             var b = (top + bottom) / (top - bottom);
-            var c = -(zFar + zNear) / (zFar - zNear);
-            var d = -(2.0 * zFar * zNear) / (zFar - zNear);
+            var c = -(depthFar + depthNear) / (depthFar - depthNear);
+            var d = -(2.0 * depthFar * depthNear) / (depthFar - depthNear);
 
 #pragma warning disable SA1117 // Parameters should be on same line or separate lines
             result = new Matrix4d
@@ -1071,15 +1060,15 @@ namespace OpenTK.Mathematics
         /// <param name="right">Right edge of the view frustum.</param>
         /// <param name="bottom">Bottom edge of the view frustum.</param>
         /// <param name="top">Top edge of the view frustum.</param>
-        /// <param name="zNear">Distance to the near clip plane.</param>
-        /// <param name="zFar">Distance to the far clip plane.</param>
+        /// <param name="depthNear">Distance to the near clip plane.</param>
+        /// <param name="depthFar">Distance to the far clip plane.</param>
         /// <returns>A projection matrix that transforms camera space to raster space.</returns>
         /// <exception cref="System.ArgumentOutOfRangeException">
         /// Thrown under the following conditions:
         ///  <list type="bullet">
-        ///  <item>zNear is negative or zero</item>
-        ///  <item>zFar is negative or zero</item>
-        ///  <item>zNear is larger than zFar</item>
+        ///  <item>depthNear is negative or zero</item>
+        ///  <item>depthFar is negative or zero</item>
+        ///  <item>depthNear is larger than depthFar</item>
         ///  </list>
         /// </exception>
         public static Matrix4d CreatePerspectiveOffCenter
@@ -1088,11 +1077,11 @@ namespace OpenTK.Mathematics
             double right,
             double bottom,
             double top,
-            double zNear,
-            double zFar
+            double depthNear,
+            double depthFar
         )
         {
-            CreatePerspectiveOffCenter(left, right, bottom, top, zNear, zFar, out Matrix4d result);
+            CreatePerspectiveOffCenter(left, right, bottom, top, depthNear, depthFar, out Matrix4d result);
             return result;
         }
 
@@ -1336,20 +1325,20 @@ namespace OpenTK.Mathematics
         /// <param name="right">Right edge of the view frustum.</param>
         /// <param name="bottom">Bottom edge of the view frustum.</param>
         /// <param name="top">Top edge of the view frustum.</param>
-        /// <param name="zNear">Distance to the near clip plane.</param>
-        /// <param name="zFar">Distance to the far clip plane.</param>
+        /// <param name="depthNear">Distance to the near clip plane.</param>
+        /// <param name="depthFar">Distance to the far clip plane.</param>
         /// <returns>A projection matrix that transforms camera space to raster space.</returns>
-        public static Matrix4d Frustum(double left, double right, double bottom, double top, double zNear, double zFar)
+        public static Matrix4d Frustum(double left, double right, double bottom, double top, double depthNear, double depthFar)
         {
             var invRL = 1.0 / (right - left);
             var invTB = 1.0 / (top - bottom);
-            var invFN = 1.0 / (zFar - zNear);
+            var invFN = 1.0 / (depthFar - depthNear);
             return new Matrix4d
             (
-                new Vector4d(2.0 * zNear * invRL, 0.0, 0.0, 0.0),
-                new Vector4d(0.0, 2.0 * zNear * invTB, 0.0, 0.0),
-                new Vector4d((right + left) * invRL, (top + bottom) * invTB, -(zFar + zNear) * invFN, -1.0),
-                new Vector4d(0.0, 0.0, -2.0 * zFar * zNear * invFN, 0.0)
+                new Vector4d(2.0 * depthNear * invRL, 0.0, 0.0, 0.0),
+                new Vector4d(0.0, 2.0 * depthNear * invTB, 0.0, 0.0),
+                new Vector4d((right + left) * invRL, (top + bottom) * invTB, -(depthFar + depthNear) * invFN, -1.0),
+                new Vector4d(0.0, 0.0, -2.0 * depthFar * depthNear * invFN, 0.0)
             );
         }
 
@@ -1358,17 +1347,18 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="fovy">Angle of the field of view in the y direction (in radians).</param>
         /// <param name="aspect">Aspect ratio of the view (width / height).</param>
-        /// <param name="zNear">Distance to the near clip plane.</param>
-        /// <param name="zFar">Distance to the far clip plane.</param>
+        /// <param name="depthNear">Distance to the near clip plane.</param>
+        /// <param name="depthFar">Distance to the far clip plane.</param>
         /// <returns>A projection matrix that transforms camera space to raster space.</returns>
-        public static Matrix4d Perspective(double fovy, double aspect, double zNear, double zFar)
+        [SuppressMessage("Microsoft.StyleCop.CSharp.DocumentationRules", "SA1305", Justification = "Is not hungarian notation but abbreveation for precalculated values.")]
+        public static Matrix4d Perspective(double fovy, double aspect, double depthNear, double depthFar)
         {
-            var yMax = zNear * Math.Tan(0.5f * fovy);
+            var yMax = depthNear * Math.Tan(0.5f * fovy);
             var yMin = -yMax;
             var xMin = yMin * aspect;
             var xMax = yMax * aspect;
 
-            return Frustum(xMin, xMax, yMin, yMax, zNear, zFar);
+            return Frustum(xMin, xMax, yMin, yMax, depthNear, depthFar);
         }
 
         /// <summary>
@@ -1443,55 +1433,55 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix4d left, ref Matrix4d right, out Matrix4d result)
         {
-            double lM11 = left.Row0.X,
-                lM12 = left.Row0.Y,
-                lM13 = left.Row0.Z,
-                lM14 = left.Row0.W,
-                lM21 = left.Row1.X,
-                lM22 = left.Row1.Y,
-                lM23 = left.Row1.Z,
-                lM24 = left.Row1.W,
-                lM31 = left.Row2.X,
-                lM32 = left.Row2.Y,
-                lM33 = left.Row2.Z,
-                lM34 = left.Row2.W,
-                lM41 = left.Row3.X,
-                lM42 = left.Row3.Y,
-                lM43 = left.Row3.Z,
-                lM44 = left.Row3.W,
-                rM11 = right.Row0.X,
-                rM12 = right.Row0.Y,
-                rM13 = right.Row0.Z,
-                rM14 = right.Row0.W,
-                rM21 = right.Row1.X,
-                rM22 = right.Row1.Y,
-                rM23 = right.Row1.Z,
-                rM24 = right.Row1.W,
-                rM31 = right.Row2.X,
-                rM32 = right.Row2.Y,
-                rM33 = right.Row2.Z,
-                rM34 = right.Row2.W,
-                rM41 = right.Row3.X,
-                rM42 = right.Row3.Y,
-                rM43 = right.Row3.Z,
-                rM44 = right.Row3.W;
+            double leftM11 = left.Row0.X,
+                leftM12 = left.Row0.Y,
+                leftM13 = left.Row0.Z,
+                leftM14 = left.Row0.W,
+                leftM21 = left.Row1.X,
+                leftM22 = left.Row1.Y,
+                leftM23 = left.Row1.Z,
+                leftM24 = left.Row1.W,
+                leftM31 = left.Row2.X,
+                leftM32 = left.Row2.Y,
+                leftM33 = left.Row2.Z,
+                leftM34 = left.Row2.W,
+                leftM41 = left.Row3.X,
+                leftM42 = left.Row3.Y,
+                leftM43 = left.Row3.Z,
+                leftM44 = left.Row3.W,
+                rightM11 = right.Row0.X,
+                rightM12 = right.Row0.Y,
+                rightM13 = right.Row0.Z,
+                rightM14 = right.Row0.W,
+                rightM21 = right.Row1.X,
+                rightM22 = right.Row1.Y,
+                rightM23 = right.Row1.Z,
+                rightM24 = right.Row1.W,
+                rightM31 = right.Row2.X,
+                rightM32 = right.Row2.Y,
+                rightM33 = right.Row2.Z,
+                rightM34 = right.Row2.W,
+                rightM41 = right.Row3.X,
+                rightM42 = right.Row3.Y,
+                rightM43 = right.Row3.Z,
+                rightM44 = right.Row3.W;
 
-            result.Row0.X = (lM11 * rM11) + (lM12 * rM21) + (lM13 * rM31) + (lM14 * rM41);
-            result.Row0.Y = (lM11 * rM12) + (lM12 * rM22) + (lM13 * rM32) + (lM14 * rM42);
-            result.Row0.Z = (lM11 * rM13) + (lM12 * rM23) + (lM13 * rM33) + (lM14 * rM43);
-            result.Row0.W = (lM11 * rM14) + (lM12 * rM24) + (lM13 * rM34) + (lM14 * rM44);
-            result.Row1.X = (lM21 * rM11) + (lM22 * rM21) + (lM23 * rM31) + (lM24 * rM41);
-            result.Row1.Y = (lM21 * rM12) + (lM22 * rM22) + (lM23 * rM32) + (lM24 * rM42);
-            result.Row1.Z = (lM21 * rM13) + (lM22 * rM23) + (lM23 * rM33) + (lM24 * rM43);
-            result.Row1.W = (lM21 * rM14) + (lM22 * rM24) + (lM23 * rM34) + (lM24 * rM44);
-            result.Row2.X = (lM31 * rM11) + (lM32 * rM21) + (lM33 * rM31) + (lM34 * rM41);
-            result.Row2.Y = (lM31 * rM12) + (lM32 * rM22) + (lM33 * rM32) + (lM34 * rM42);
-            result.Row2.Z = (lM31 * rM13) + (lM32 * rM23) + (lM33 * rM33) + (lM34 * rM43);
-            result.Row2.W = (lM31 * rM14) + (lM32 * rM24) + (lM33 * rM34) + (lM34 * rM44);
-            result.Row3.X = (lM41 * rM11) + (lM42 * rM21) + (lM43 * rM31) + (lM44 * rM41);
-            result.Row3.Y = (lM41 * rM12) + (lM42 * rM22) + (lM43 * rM32) + (lM44 * rM42);
-            result.Row3.Z = (lM41 * rM13) + (lM42 * rM23) + (lM43 * rM33) + (lM44 * rM43);
-            result.Row3.W = (lM41 * rM14) + (lM42 * rM24) + (lM43 * rM34) + (lM44 * rM44);
+            result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21) + (leftM13 * rightM31) + (leftM14 * rightM41);
+            result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22) + (leftM13 * rightM32) + (leftM14 * rightM42);
+            result.Row0.Z = (leftM11 * rightM13) + (leftM12 * rightM23) + (leftM13 * rightM33) + (leftM14 * rightM43);
+            result.Row0.W = (leftM11 * rightM14) + (leftM12 * rightM24) + (leftM13 * rightM34) + (leftM14 * rightM44);
+            result.Row1.X = (leftM21 * rightM11) + (leftM22 * rightM21) + (leftM23 * rightM31) + (leftM24 * rightM41);
+            result.Row1.Y = (leftM21 * rightM12) + (leftM22 * rightM22) + (leftM23 * rightM32) + (leftM24 * rightM42);
+            result.Row1.Z = (leftM21 * rightM13) + (leftM22 * rightM23) + (leftM23 * rightM33) + (leftM24 * rightM43);
+            result.Row1.W = (leftM21 * rightM14) + (leftM22 * rightM24) + (leftM23 * rightM34) + (leftM24 * rightM44);
+            result.Row2.X = (leftM31 * rightM11) + (leftM32 * rightM21) + (leftM33 * rightM31) + (leftM34 * rightM41);
+            result.Row2.Y = (leftM31 * rightM12) + (leftM32 * rightM22) + (leftM33 * rightM32) + (leftM34 * rightM42);
+            result.Row2.Z = (leftM31 * rightM13) + (leftM32 * rightM23) + (leftM33 * rightM33) + (leftM34 * rightM43);
+            result.Row2.W = (leftM31 * rightM14) + (leftM32 * rightM24) + (leftM33 * rightM34) + (leftM34 * rightM44);
+            result.Row3.X = (leftM41 * rightM11) + (leftM42 * rightM21) + (leftM43 * rightM31) + (leftM44 * rightM41);
+            result.Row3.Y = (leftM41 * rightM12) + (leftM42 * rightM22) + (leftM43 * rightM32) + (leftM44 * rightM42);
+            result.Row3.Z = (leftM41 * rightM13) + (leftM42 * rightM23) + (leftM43 * rightM33) + (leftM44 * rightM43);
+            result.Row3.W = (leftM41 * rightM14) + (leftM42 * rightM24) + (leftM43 * rightM34) + (leftM44 * rightM44);
         }
 
         /// <summary>
@@ -1538,7 +1528,7 @@ namespace OpenTK.Mathematics
                 { mat.Row0.X, mat.Row0.Y, mat.Row0.Z, mat.Row0.W },
                 { mat.Row1.X, mat.Row1.Y, mat.Row1.Z, mat.Row1.W },
                 { mat.Row2.X, mat.Row2.Y, mat.Row2.Z, mat.Row2.W },
-                { mat.Row3.X, mat.Row3.Y, mat.Row3.Z, mat.Row3.W }
+                { mat.Row3.X, mat.Row3.Y, mat.Row3.Z, mat.Row3.W },
             };
             var icol = 0;
             var irow = 0;

--- a/src/OpenTK.Mathematics/Matrix/Matrix4d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix4d.cs
@@ -94,11 +94,13 @@ namespace OpenTK.Mathematics
         /// <param name="m32">Third item of the fourth row.</param>
         /// <param name="m33">Fourth item of the fourth row.</param>
         [SuppressMessage("ReSharper", "SA1117", Justification = "For better readability of Matrix struct.")]
-        public Matrix4d(
+        public Matrix4d
+        (
             double m00, double m01, double m02, double m03,
             double m10, double m11, double m12, double m13,
             double m20, double m21, double m22, double m23,
-            double m30, double m31, double m32, double m33)
+            double m30, double m31, double m32, double m33
+        )
         {
             Row0 = new Vector4d(m00, m01, m02, m03);
             Row1 = new Vector4d(m10, m11, m12, m13);
@@ -450,7 +452,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Returns a normalized copy of this instance.
         /// </summary>
-        /// <returns>The normalized matrix.</returns>
+        /// <returns>The normalized copy.</returns>
         public Matrix4d Normalized()
         {
             var m = this;
@@ -636,7 +638,6 @@ namespace OpenTK.Mathematics
         /// <param name="axis">The axis to rotate about.</param>
         /// <param name="angle">Angle in radians to rotate counter-clockwise (looking in the direction of the given axis).</param>
         /// <param name="result">A matrix instance.</param>
-        [SuppressMessage("Microsoft.StyleCop.CSharp.DocumentationRules", "SA1305", Justification = "Is not hungarian notation but abbreveation for precalculated values.")]
         public static void CreateFromAxisAngle(Vector3d axis, double angle, out Matrix4d result)
         {
             // normalize and create a local copy of the vector.
@@ -649,16 +650,16 @@ namespace OpenTK.Mathematics
             var t = 1.0f - cos;
 
             // do the conversion math once
-            double tXX = t * axisX * axisX,
-                tXY = t * axisX * axisY,
-                tXZ = t * axisX * axisZ,
-                tYY = t * axisY * axisY,
-                tYZ = t * axisY * axisZ,
-                tZZ = t * axisZ * axisZ;
+            double tXX = t * axisX * axisX;
+            double tXY = t * axisX * axisY;
+            double tXZ = t * axisX * axisZ;
+            double tYY = t * axisY * axisY;
+            double tYZ = t * axisY * axisZ;
+            double tZZ = t * axisZ * axisZ;
 
-            double sinX = sin * axisX,
-                sinY = sin * axisY,
-                sinZ = sin * axisZ;
+            double sinX = sin * axisX;
+            double sinY = sin * axisY;
+            double sinZ = sin * axisZ;
 
             result.Row0.X = tXX + cos;
             result.Row0.Y = tXY - sinZ;
@@ -1350,7 +1351,6 @@ namespace OpenTK.Mathematics
         /// <param name="depthNear">Distance to the near clip plane.</param>
         /// <param name="depthFar">Distance to the far clip plane.</param>
         /// <returns>A projection matrix that transforms camera space to raster space.</returns>
-        [SuppressMessage("Microsoft.StyleCop.CSharp.DocumentationRules", "SA1305", Justification = "Is not hungarian notation but abbreveation for precalculated values.")]
         public static Matrix4d Perspective(double fovy, double aspect, double depthNear, double depthFar)
         {
             var yMax = depthNear * Math.Tan(0.5f * fovy);
@@ -1433,38 +1433,38 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix4d left, ref Matrix4d right, out Matrix4d result)
         {
-            double leftM11 = left.Row0.X,
-                leftM12 = left.Row0.Y,
-                leftM13 = left.Row0.Z,
-                leftM14 = left.Row0.W,
-                leftM21 = left.Row1.X,
-                leftM22 = left.Row1.Y,
-                leftM23 = left.Row1.Z,
-                leftM24 = left.Row1.W,
-                leftM31 = left.Row2.X,
-                leftM32 = left.Row2.Y,
-                leftM33 = left.Row2.Z,
-                leftM34 = left.Row2.W,
-                leftM41 = left.Row3.X,
-                leftM42 = left.Row3.Y,
-                leftM43 = left.Row3.Z,
-                leftM44 = left.Row3.W,
-                rightM11 = right.Row0.X,
-                rightM12 = right.Row0.Y,
-                rightM13 = right.Row0.Z,
-                rightM14 = right.Row0.W,
-                rightM21 = right.Row1.X,
-                rightM22 = right.Row1.Y,
-                rightM23 = right.Row1.Z,
-                rightM24 = right.Row1.W,
-                rightM31 = right.Row2.X,
-                rightM32 = right.Row2.Y,
-                rightM33 = right.Row2.Z,
-                rightM34 = right.Row2.W,
-                rightM41 = right.Row3.X,
-                rightM42 = right.Row3.Y,
-                rightM43 = right.Row3.Z,
-                rightM44 = right.Row3.W;
+            double leftM11 = left.Row0.X;
+            double leftM12 = left.Row0.Y;
+            double leftM13 = left.Row0.Z;
+            double leftM14 = left.Row0.W;
+            double leftM21 = left.Row1.X;
+            double leftM22 = left.Row1.Y;
+            double leftM23 = left.Row1.Z;
+            double leftM24 = left.Row1.W;
+            double leftM31 = left.Row2.X;
+            double leftM32 = left.Row2.Y;
+            double leftM33 = left.Row2.Z;
+            double leftM34 = left.Row2.W;
+            double leftM41 = left.Row3.X;
+            double leftM42 = left.Row3.Y;
+            double leftM43 = left.Row3.Z;
+            double leftM44 = left.Row3.W;
+            double rightM11 = right.Row0.X;
+            double rightM12 = right.Row0.Y;
+            double rightM13 = right.Row0.Z;
+            double rightM14 = right.Row0.W;
+            double rightM21 = right.Row1.X;
+            double rightM22 = right.Row1.Y;
+            double rightM23 = right.Row1.Z;
+            double rightM24 = right.Row1.W;
+            double rightM31 = right.Row2.X;
+            double rightM32 = right.Row2.Y;
+            double rightM33 = right.Row2.Z;
+            double rightM34 = right.Row2.W;
+            double rightM41 = right.Row3.X;
+            double rightM42 = right.Row3.Y;
+            double rightM43 = right.Row3.Z;
+            double rightM44 = right.Row3.W;
 
             result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21) + (leftM13 * rightM31) + (leftM14 * rightM41);
             result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22) + (leftM13 * rightM32) + (leftM14 * rightM42);
@@ -1528,7 +1528,7 @@ namespace OpenTK.Mathematics
                 { mat.Row0.X, mat.Row0.Y, mat.Row0.Z, mat.Row0.W },
                 { mat.Row1.X, mat.Row1.Y, mat.Row1.Z, mat.Row1.W },
                 { mat.Row2.X, mat.Row2.Y, mat.Row2.Z, mat.Row2.W },
-                { mat.Row3.X, mat.Row3.Y, mat.Row3.Z, mat.Row3.W },
+                { mat.Row3.X, mat.Row3.Y, mat.Row3.Z, mat.Row3.W }
             };
             var icol = 0;
             var irow = 0;
@@ -1582,8 +1582,6 @@ namespace OpenTK.Mathematics
                 if (pivot == 0.0)
                 {
                     throw new InvalidOperationException("Matrix is singular and cannot be inverted.");
-
-                    // return mat;
                 }
 
                 // Scale row so it has a unit diagonal

--- a/src/OpenTK.Mathematics/Matrix/Matrix4x2.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix4x2.cs
@@ -21,6 +21,7 @@ SOFTWARE.
  */
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace OpenTK.Mathematics
 {
@@ -80,17 +81,12 @@ namespace OpenTK.Mathematics
         /// <param name="m21">Second item of the third row of the matrix.</param>
         /// <param name="m30">First item of the fourth row of the matrix.</param>
         /// <param name="m31">Second item of the fourth row of the matrix.</param>
-        public Matrix4x2
-        (
-            float m00,
-            float m01,
-            float m10,
-            float m11,
-            float m20,
-            float m21,
-            float m30,
-            float m31
-        )
+        [SuppressMessage("Microsoft.StyleCop.CSharp.DocumentationRules", "SA1117", Justification = "For better readability of Matrix struct.")]
+        public Matrix4x2(
+            float m00, float m01,
+            float m10, float m11,
+            float m20, float m21,
+            float m30, float m31)
         {
             Row0 = new Vector2(m00, m01);
             Row1 = new Vector2(m10, m11);
@@ -223,6 +219,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="rowIndex">The index of the row.</param>
         /// <param name="columnIndex">The index of the column.</param>
+        /// <returns>The element at the given row and column index.</returns>
         public float this[int rowIndex, int columnIndex]
         {
             get
@@ -432,27 +429,27 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix4x2 left, ref Matrix2 right, out Matrix4x2 result)
         {
-            float lM11 = left.Row0.X,
-                lM12 = left.Row0.Y,
-                lM21 = left.Row1.X,
-                lM22 = left.Row1.Y,
-                lM31 = left.Row2.X,
-                lM32 = left.Row2.Y,
-                lM41 = left.Row3.X,
-                lM42 = left.Row3.Y,
-                rM11 = right.Row0.X,
-                rM12 = right.Row0.Y,
-                rM21 = right.Row1.X,
-                rM22 = right.Row1.Y;
+            float leftM11 = left.Row0.X,
+                leftM12 = left.Row0.Y,
+                leftM21 = left.Row1.X,
+                leftM22 = left.Row1.Y,
+                leftM31 = left.Row2.X,
+                leftM32 = left.Row2.Y,
+                leftM41 = left.Row3.X,
+                leftM42 = left.Row3.Y,
+                rightM11 = right.Row0.X,
+                rightM12 = right.Row0.Y,
+                rightM21 = right.Row1.X,
+                rightM22 = right.Row1.Y;
 
-            result.Row0.X = (lM11 * rM11) + (lM12 * rM21);
-            result.Row0.Y = (lM11 * rM12) + (lM12 * rM22);
-            result.Row1.X = (lM21 * rM11) + (lM22 * rM21);
-            result.Row1.Y = (lM21 * rM12) + (lM22 * rM22);
-            result.Row2.X = (lM31 * rM11) + (lM32 * rM21);
-            result.Row2.Y = (lM31 * rM12) + (lM32 * rM22);
-            result.Row3.X = (lM41 * rM11) + (lM42 * rM21);
-            result.Row3.Y = (lM41 * rM12) + (lM42 * rM22);
+            result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21);
+            result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22);
+            result.Row1.X = (leftM21 * rightM11) + (leftM22 * rightM21);
+            result.Row1.Y = (leftM21 * rightM12) + (leftM22 * rightM22);
+            result.Row2.X = (leftM31 * rightM11) + (leftM32 * rightM21);
+            result.Row2.Y = (leftM31 * rightM12) + (leftM32 * rightM22);
+            result.Row3.X = (leftM41 * rightM11) + (leftM42 * rightM21);
+            result.Row3.Y = (leftM41 * rightM12) + (leftM42 * rightM22);
         }
 
         /// <summary>
@@ -475,33 +472,33 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix4x2 left, ref Matrix2x3 right, out Matrix4x3 result)
         {
-            float lM11 = left.Row0.X,
-                lM12 = left.Row0.Y,
-                lM21 = left.Row1.X,
-                lM22 = left.Row1.Y,
-                lM31 = left.Row2.X,
-                lM32 = left.Row2.Y,
-                lM41 = left.Row3.X,
-                lM42 = left.Row3.Y,
-                rM11 = right.Row0.X,
-                rM12 = right.Row0.Y,
-                rM13 = right.Row0.Z,
-                rM21 = right.Row1.X,
-                rM22 = right.Row1.Y,
-                rM23 = right.Row1.Z;
+            float leftM11 = left.Row0.X,
+                leftM12 = left.Row0.Y,
+                leftM21 = left.Row1.X,
+                leftM22 = left.Row1.Y,
+                leftM31 = left.Row2.X,
+                leftM32 = left.Row2.Y,
+                leftM41 = left.Row3.X,
+                leftM42 = left.Row3.Y,
+                rightM11 = right.Row0.X,
+                rightM12 = right.Row0.Y,
+                rightM13 = right.Row0.Z,
+                rightM21 = right.Row1.X,
+                rightM22 = right.Row1.Y,
+                rightM23 = right.Row1.Z;
 
-            result.Row0.X = (lM11 * rM11) + (lM12 * rM21);
-            result.Row0.Y = (lM11 * rM12) + (lM12 * rM22);
-            result.Row0.Z = (lM11 * rM13) + (lM12 * rM23);
-            result.Row1.X = (lM21 * rM11) + (lM22 * rM21);
-            result.Row1.Y = (lM21 * rM12) + (lM22 * rM22);
-            result.Row1.Z = (lM21 * rM13) + (lM22 * rM23);
-            result.Row2.X = (lM31 * rM11) + (lM32 * rM21);
-            result.Row2.Y = (lM31 * rM12) + (lM32 * rM22);
-            result.Row2.Z = (lM31 * rM13) + (lM32 * rM23);
-            result.Row3.X = (lM41 * rM11) + (lM42 * rM21);
-            result.Row3.Y = (lM41 * rM12) + (lM42 * rM22);
-            result.Row3.Z = (lM41 * rM13) + (lM42 * rM23);
+            result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21);
+            result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22);
+            result.Row0.Z = (leftM11 * rightM13) + (leftM12 * rightM23);
+            result.Row1.X = (leftM21 * rightM11) + (leftM22 * rightM21);
+            result.Row1.Y = (leftM21 * rightM12) + (leftM22 * rightM22);
+            result.Row1.Z = (leftM21 * rightM13) + (leftM22 * rightM23);
+            result.Row2.X = (leftM31 * rightM11) + (leftM32 * rightM21);
+            result.Row2.Y = (leftM31 * rightM12) + (leftM32 * rightM22);
+            result.Row2.Z = (leftM31 * rightM13) + (leftM32 * rightM23);
+            result.Row3.X = (leftM41 * rightM11) + (leftM42 * rightM21);
+            result.Row3.Y = (leftM41 * rightM12) + (leftM42 * rightM22);
+            result.Row3.Z = (leftM41 * rightM13) + (leftM42 * rightM23);
         }
 
         /// <summary>
@@ -524,39 +521,39 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix4x2 left, ref Matrix2x4 right, out Matrix4 result)
         {
-            float lM11 = left.Row0.X,
-                lM12 = left.Row0.Y,
-                lM21 = left.Row1.X,
-                lM22 = left.Row1.Y,
-                lM31 = left.Row2.X,
-                lM32 = left.Row2.Y,
-                lM41 = left.Row3.X,
-                lM42 = left.Row3.Y,
-                rM11 = right.Row0.X,
-                rM12 = right.Row0.Y,
-                rM13 = right.Row0.Z,
-                rM14 = right.Row0.W,
-                rM21 = right.Row1.X,
-                rM22 = right.Row1.Y,
-                rM23 = right.Row1.Z,
-                rM24 = right.Row1.W;
+            float leftM11 = left.Row0.X,
+                leftM12 = left.Row0.Y,
+                leftM21 = left.Row1.X,
+                leftM22 = left.Row1.Y,
+                leftM31 = left.Row2.X,
+                leftM32 = left.Row2.Y,
+                leftM41 = left.Row3.X,
+                leftM42 = left.Row3.Y,
+                rightM11 = right.Row0.X,
+                rightM12 = right.Row0.Y,
+                rightM13 = right.Row0.Z,
+                rightM14 = right.Row0.W,
+                rightM21 = right.Row1.X,
+                rightM22 = right.Row1.Y,
+                rightM23 = right.Row1.Z,
+                rightM24 = right.Row1.W;
 
-            result.Row0.X = (lM11 * rM11) + (lM12 * rM21);
-            result.Row0.Y = (lM11 * rM12) + (lM12 * rM22);
-            result.Row0.Z = (lM11 * rM13) + (lM12 * rM23);
-            result.Row0.W = (lM11 * rM14) + (lM12 * rM24);
-            result.Row1.X = (lM21 * rM11) + (lM22 * rM21);
-            result.Row1.Y = (lM21 * rM12) + (lM22 * rM22);
-            result.Row1.Z = (lM21 * rM13) + (lM22 * rM23);
-            result.Row1.W = (lM21 * rM14) + (lM22 * rM24);
-            result.Row2.X = (lM31 * rM11) + (lM32 * rM21);
-            result.Row2.Y = (lM31 * rM12) + (lM32 * rM22);
-            result.Row2.Z = (lM31 * rM13) + (lM32 * rM23);
-            result.Row2.W = (lM31 * rM14) + (lM32 * rM24);
-            result.Row3.X = (lM41 * rM11) + (lM42 * rM21);
-            result.Row3.Y = (lM41 * rM12) + (lM42 * rM22);
-            result.Row3.Z = (lM41 * rM13) + (lM42 * rM23);
-            result.Row3.W = (lM41 * rM14) + (lM42 * rM24);
+            result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21);
+            result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22);
+            result.Row0.Z = (leftM11 * rightM13) + (leftM12 * rightM23);
+            result.Row0.W = (leftM11 * rightM14) + (leftM12 * rightM24);
+            result.Row1.X = (leftM21 * rightM11) + (leftM22 * rightM21);
+            result.Row1.Y = (leftM21 * rightM12) + (leftM22 * rightM22);
+            result.Row1.Z = (leftM21 * rightM13) + (leftM22 * rightM23);
+            result.Row1.W = (leftM21 * rightM14) + (leftM22 * rightM24);
+            result.Row2.X = (leftM31 * rightM11) + (leftM32 * rightM21);
+            result.Row2.Y = (leftM31 * rightM12) + (leftM32 * rightM22);
+            result.Row2.Z = (leftM31 * rightM13) + (leftM32 * rightM23);
+            result.Row2.W = (leftM31 * rightM14) + (leftM32 * rightM24);
+            result.Row3.X = (leftM41 * rightM11) + (leftM42 * rightM21);
+            result.Row3.Y = (leftM41 * rightM12) + (leftM42 * rightM22);
+            result.Row3.Z = (leftM41 * rightM13) + (leftM42 * rightM23);
+            result.Row3.W = (leftM41 * rightM14) + (leftM42 * rightM24);
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Matrix/Matrix4x2.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix4x2.cs
@@ -82,11 +82,13 @@ namespace OpenTK.Mathematics
         /// <param name="m30">First item of the fourth row of the matrix.</param>
         /// <param name="m31">Second item of the fourth row of the matrix.</param>
         [SuppressMessage("Microsoft.StyleCop.CSharp.DocumentationRules", "SA1117", Justification = "For better readability of Matrix struct.")]
-        public Matrix4x2(
+        public Matrix4x2
+        (
             float m00, float m01,
             float m10, float m11,
             float m20, float m21,
-            float m30, float m31)
+            float m30, float m31
+        )
         {
             Row0 = new Vector2(m00, m01);
             Row1 = new Vector2(m10, m11);
@@ -429,18 +431,18 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix4x2 left, ref Matrix2 right, out Matrix4x2 result)
         {
-            float leftM11 = left.Row0.X,
-                leftM12 = left.Row0.Y,
-                leftM21 = left.Row1.X,
-                leftM22 = left.Row1.Y,
-                leftM31 = left.Row2.X,
-                leftM32 = left.Row2.Y,
-                leftM41 = left.Row3.X,
-                leftM42 = left.Row3.Y,
-                rightM11 = right.Row0.X,
-                rightM12 = right.Row0.Y,
-                rightM21 = right.Row1.X,
-                rightM22 = right.Row1.Y;
+            float leftM11 = left.Row0.X;
+            float leftM12 = left.Row0.Y;
+            float leftM21 = left.Row1.X;
+            float leftM22 = left.Row1.Y;
+            float leftM31 = left.Row2.X;
+            float leftM32 = left.Row2.Y;
+            float leftM41 = left.Row3.X;
+            float leftM42 = left.Row3.Y;
+            float rightM11 = right.Row0.X;
+            float rightM12 = right.Row0.Y;
+            float rightM21 = right.Row1.X;
+            float rightM22 = right.Row1.Y;
 
             result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21);
             result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22);
@@ -472,20 +474,20 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix4x2 left, ref Matrix2x3 right, out Matrix4x3 result)
         {
-            float leftM11 = left.Row0.X,
-                leftM12 = left.Row0.Y,
-                leftM21 = left.Row1.X,
-                leftM22 = left.Row1.Y,
-                leftM31 = left.Row2.X,
-                leftM32 = left.Row2.Y,
-                leftM41 = left.Row3.X,
-                leftM42 = left.Row3.Y,
-                rightM11 = right.Row0.X,
-                rightM12 = right.Row0.Y,
-                rightM13 = right.Row0.Z,
-                rightM21 = right.Row1.X,
-                rightM22 = right.Row1.Y,
-                rightM23 = right.Row1.Z;
+            float leftM11 = left.Row0.X;
+            float leftM12 = left.Row0.Y;
+            float leftM21 = left.Row1.X;
+            float leftM22 = left.Row1.Y;
+            float leftM31 = left.Row2.X;
+            float leftM32 = left.Row2.Y;
+            float leftM41 = left.Row3.X;
+            float leftM42 = left.Row3.Y;
+            float rightM11 = right.Row0.X;
+            float rightM12 = right.Row0.Y;
+            float rightM13 = right.Row0.Z;
+            float rightM21 = right.Row1.X;
+            float rightM22 = right.Row1.Y;
+            float rightM23 = right.Row1.Z;
 
             result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21);
             result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22);
@@ -521,22 +523,22 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix4x2 left, ref Matrix2x4 right, out Matrix4 result)
         {
-            float leftM11 = left.Row0.X,
-                leftM12 = left.Row0.Y,
-                leftM21 = left.Row1.X,
-                leftM22 = left.Row1.Y,
-                leftM31 = left.Row2.X,
-                leftM32 = left.Row2.Y,
-                leftM41 = left.Row3.X,
-                leftM42 = left.Row3.Y,
-                rightM11 = right.Row0.X,
-                rightM12 = right.Row0.Y,
-                rightM13 = right.Row0.Z,
-                rightM14 = right.Row0.W,
-                rightM21 = right.Row1.X,
-                rightM22 = right.Row1.Y,
-                rightM23 = right.Row1.Z,
-                rightM24 = right.Row1.W;
+            float leftM11 = left.Row0.X;
+            float leftM12 = left.Row0.Y;
+            float leftM21 = left.Row1.X;
+            float leftM22 = left.Row1.Y;
+            float leftM31 = left.Row2.X;
+            float leftM32 = left.Row2.Y;
+            float leftM41 = left.Row3.X;
+            float leftM42 = left.Row3.Y;
+            float rightM11 = right.Row0.X;
+            float rightM12 = right.Row0.Y;
+            float rightM13 = right.Row0.Z;
+            float rightM14 = right.Row0.W;
+            float rightM21 = right.Row1.X;
+            float rightM22 = right.Row1.Y;
+            float rightM23 = right.Row1.Z;
+            float rightM24 = right.Row1.W;
 
             result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21);
             result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22);

--- a/src/OpenTK.Mathematics/Matrix/Matrix4x2d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix4x2d.cs
@@ -88,11 +88,13 @@ namespace OpenTK.Mathematics
         /// <param name="m30">First item of the fourth row of the matrix.</param>
         /// <param name="m31">Second item of the fourth row of the matrix.</param>
         [SuppressMessage("Microsoft.StyleCop.CSharp.DocumentationRules", "SA1117", Justification = "For better readability of Matrix struct.")]
-        public Matrix4x2d(
+        public Matrix4x2d
+        (
             double m00, double m01,
             double m10, double m11,
             double m20, double m21,
-            double m30, double m31)
+            double m30, double m31
+        )
         {
             Row0 = new Vector2d(m00, m01);
             Row1 = new Vector2d(m10, m11);
@@ -435,18 +437,18 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix4x2d left, ref Matrix2d right, out Matrix4x2d result)
         {
-            double leftM11 = left.Row0.X,
-                leftM12 = left.Row0.Y,
-                leftM21 = left.Row1.X,
-                leftM22 = left.Row1.Y,
-                leftM31 = left.Row2.X,
-                leftM32 = left.Row2.Y,
-                leftM41 = left.Row3.X,
-                leftM42 = left.Row3.Y,
-                rightM11 = right.Row0.X,
-                rightM12 = right.Row0.Y,
-                rightM21 = right.Row1.X,
-                rightM22 = right.Row1.Y;
+            double leftM11 = left.Row0.X;
+            double leftM12 = left.Row0.Y;
+            double leftM21 = left.Row1.X;
+            double leftM22 = left.Row1.Y;
+            double leftM31 = left.Row2.X;
+            double leftM32 = left.Row2.Y;
+            double leftM41 = left.Row3.X;
+            double leftM42 = left.Row3.Y;
+            double rightM11 = right.Row0.X;
+            double rightM12 = right.Row0.Y;
+            double rightM21 = right.Row1.X;
+            double rightM22 = right.Row1.Y;
 
             result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21);
             result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22);
@@ -478,20 +480,20 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix4x2d left, ref Matrix2x3d right, out Matrix4x3d result)
         {
-            double leftM11 = left.Row0.X,
-                leftM12 = left.Row0.Y,
-                leftM21 = left.Row1.X,
-                leftM22 = left.Row1.Y,
-                leftM31 = left.Row2.X,
-                leftM32 = left.Row2.Y,
-                leftM41 = left.Row3.X,
-                leftM42 = left.Row3.Y,
-                rightM11 = right.Row0.X,
-                rightM12 = right.Row0.Y,
-                rightM13 = right.Row0.Z,
-                rightM21 = right.Row1.X,
-                rightM22 = right.Row1.Y,
-                rightM23 = right.Row1.Z;
+            double leftM11 = left.Row0.X;
+            double leftM12 = left.Row0.Y;
+            double leftM21 = left.Row1.X;
+            double leftM22 = left.Row1.Y;
+            double leftM31 = left.Row2.X;
+            double leftM32 = left.Row2.Y;
+            double leftM41 = left.Row3.X;
+            double leftM42 = left.Row3.Y;
+            double rightM11 = right.Row0.X;
+            double rightM12 = right.Row0.Y;
+            double rightM13 = right.Row0.Z;
+            double rightM21 = right.Row1.X;
+            double rightM22 = right.Row1.Y;
+            double rightM23 = right.Row1.Z;
 
             result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21);
             result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22);
@@ -527,22 +529,22 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix4x2d left, ref Matrix2x4d right, out Matrix4d result)
         {
-            double leftM11 = left.Row0.X,
-                leftM12 = left.Row0.Y,
-                leftM21 = left.Row1.X,
-                leftM22 = left.Row1.Y,
-                leftM31 = left.Row2.X,
-                leftM32 = left.Row2.Y,
-                leftM41 = left.Row3.X,
-                leftM42 = left.Row3.Y,
-                rightM11 = right.Row0.X,
-                rightM12 = right.Row0.Y,
-                rightM13 = right.Row0.Z,
-                rightM14 = right.Row0.W,
-                rightM21 = right.Row1.X,
-                rightM22 = right.Row1.Y,
-                rightM23 = right.Row1.Z,
-                rightM24 = right.Row1.W;
+            double leftM11 = left.Row0.X;
+            double leftM12 = left.Row0.Y;
+            double leftM21 = left.Row1.X;
+            double leftM22 = left.Row1.Y;
+            double leftM31 = left.Row2.X;
+            double leftM32 = left.Row2.Y;
+            double leftM41 = left.Row3.X;
+            double leftM42 = left.Row3.Y;
+            double rightM11 = right.Row0.X;
+            double rightM12 = right.Row0.Y;
+            double rightM13 = right.Row0.Z;
+            double rightM14 = right.Row0.W;
+            double rightM21 = right.Row1.X;
+            double rightM22 = right.Row1.Y;
+            double rightM23 = right.Row1.Z;
+            double rightM24 = right.Row1.W;
 
             result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21);
             result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22);

--- a/src/OpenTK.Mathematics/Matrix/Matrix4x2d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix4x2d.cs
@@ -21,6 +21,7 @@ SOFTWARE.
  */
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace OpenTK.Mathematics
 {
@@ -86,17 +87,12 @@ namespace OpenTK.Mathematics
         /// <param name="m21">Second item of the third row of the matrix.</param>
         /// <param name="m30">First item of the fourth row of the matrix.</param>
         /// <param name="m31">Second item of the fourth row of the matrix.</param>
-        public Matrix4x2d
-        (
-            double m00,
-            double m01,
-            double m10,
-            double m11,
-            double m20,
-            double m21,
-            double m30,
-            double m31
-        )
+        [SuppressMessage("Microsoft.StyleCop.CSharp.DocumentationRules", "SA1117", Justification = "For better readability of Matrix struct.")]
+        public Matrix4x2d(
+            double m00, double m01,
+            double m10, double m11,
+            double m20, double m21,
+            double m30, double m31)
         {
             Row0 = new Vector2d(m00, m01);
             Row1 = new Vector2d(m10, m11);
@@ -229,6 +225,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="rowIndex">The index of the row.</param>
         /// <param name="columnIndex">The index of the column.</param>
+        /// <returns>The element at the given row and column index.</returns>
         public double this[int rowIndex, int columnIndex]
         {
             get
@@ -438,27 +435,27 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix4x2d left, ref Matrix2d right, out Matrix4x2d result)
         {
-            double lM11 = left.Row0.X,
-                lM12 = left.Row0.Y,
-                lM21 = left.Row1.X,
-                lM22 = left.Row1.Y,
-                lM31 = left.Row2.X,
-                lM32 = left.Row2.Y,
-                lM41 = left.Row3.X,
-                lM42 = left.Row3.Y,
-                rM11 = right.Row0.X,
-                rM12 = right.Row0.Y,
-                rM21 = right.Row1.X,
-                rM22 = right.Row1.Y;
+            double leftM11 = left.Row0.X,
+                leftM12 = left.Row0.Y,
+                leftM21 = left.Row1.X,
+                leftM22 = left.Row1.Y,
+                leftM31 = left.Row2.X,
+                leftM32 = left.Row2.Y,
+                leftM41 = left.Row3.X,
+                leftM42 = left.Row3.Y,
+                rightM11 = right.Row0.X,
+                rightM12 = right.Row0.Y,
+                rightM21 = right.Row1.X,
+                rightM22 = right.Row1.Y;
 
-            result.Row0.X = (lM11 * rM11) + (lM12 * rM21);
-            result.Row0.Y = (lM11 * rM12) + (lM12 * rM22);
-            result.Row1.X = (lM21 * rM11) + (lM22 * rM21);
-            result.Row1.Y = (lM21 * rM12) + (lM22 * rM22);
-            result.Row2.X = (lM31 * rM11) + (lM32 * rM21);
-            result.Row2.Y = (lM31 * rM12) + (lM32 * rM22);
-            result.Row3.X = (lM41 * rM11) + (lM42 * rM21);
-            result.Row3.Y = (lM41 * rM12) + (lM42 * rM22);
+            result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21);
+            result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22);
+            result.Row1.X = (leftM21 * rightM11) + (leftM22 * rightM21);
+            result.Row1.Y = (leftM21 * rightM12) + (leftM22 * rightM22);
+            result.Row2.X = (leftM31 * rightM11) + (leftM32 * rightM21);
+            result.Row2.Y = (leftM31 * rightM12) + (leftM32 * rightM22);
+            result.Row3.X = (leftM41 * rightM11) + (leftM42 * rightM21);
+            result.Row3.Y = (leftM41 * rightM12) + (leftM42 * rightM22);
         }
 
         /// <summary>
@@ -481,33 +478,33 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix4x2d left, ref Matrix2x3d right, out Matrix4x3d result)
         {
-            double lM11 = left.Row0.X,
-                lM12 = left.Row0.Y,
-                lM21 = left.Row1.X,
-                lM22 = left.Row1.Y,
-                lM31 = left.Row2.X,
-                lM32 = left.Row2.Y,
-                lM41 = left.Row3.X,
-                lM42 = left.Row3.Y,
-                rM11 = right.Row0.X,
-                rM12 = right.Row0.Y,
-                rM13 = right.Row0.Z,
-                rM21 = right.Row1.X,
-                rM22 = right.Row1.Y,
-                rM23 = right.Row1.Z;
+            double leftM11 = left.Row0.X,
+                leftM12 = left.Row0.Y,
+                leftM21 = left.Row1.X,
+                leftM22 = left.Row1.Y,
+                leftM31 = left.Row2.X,
+                leftM32 = left.Row2.Y,
+                leftM41 = left.Row3.X,
+                leftM42 = left.Row3.Y,
+                rightM11 = right.Row0.X,
+                rightM12 = right.Row0.Y,
+                rightM13 = right.Row0.Z,
+                rightM21 = right.Row1.X,
+                rightM22 = right.Row1.Y,
+                rightM23 = right.Row1.Z;
 
-            result.Row0.X = (lM11 * rM11) + (lM12 * rM21);
-            result.Row0.Y = (lM11 * rM12) + (lM12 * rM22);
-            result.Row0.Z = (lM11 * rM13) + (lM12 * rM23);
-            result.Row1.X = (lM21 * rM11) + (lM22 * rM21);
-            result.Row1.Y = (lM21 * rM12) + (lM22 * rM22);
-            result.Row1.Z = (lM21 * rM13) + (lM22 * rM23);
-            result.Row2.X = (lM31 * rM11) + (lM32 * rM21);
-            result.Row2.Y = (lM31 * rM12) + (lM32 * rM22);
-            result.Row2.Z = (lM31 * rM13) + (lM32 * rM23);
-            result.Row3.X = (lM41 * rM11) + (lM42 * rM21);
-            result.Row3.Y = (lM41 * rM12) + (lM42 * rM22);
-            result.Row3.Z = (lM41 * rM13) + (lM42 * rM23);
+            result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21);
+            result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22);
+            result.Row0.Z = (leftM11 * rightM13) + (leftM12 * rightM23);
+            result.Row1.X = (leftM21 * rightM11) + (leftM22 * rightM21);
+            result.Row1.Y = (leftM21 * rightM12) + (leftM22 * rightM22);
+            result.Row1.Z = (leftM21 * rightM13) + (leftM22 * rightM23);
+            result.Row2.X = (leftM31 * rightM11) + (leftM32 * rightM21);
+            result.Row2.Y = (leftM31 * rightM12) + (leftM32 * rightM22);
+            result.Row2.Z = (leftM31 * rightM13) + (leftM32 * rightM23);
+            result.Row3.X = (leftM41 * rightM11) + (leftM42 * rightM21);
+            result.Row3.Y = (leftM41 * rightM12) + (leftM42 * rightM22);
+            result.Row3.Z = (leftM41 * rightM13) + (leftM42 * rightM23);
         }
 
         /// <summary>
@@ -530,39 +527,39 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix4x2d left, ref Matrix2x4d right, out Matrix4d result)
         {
-            double lM11 = left.Row0.X,
-                lM12 = left.Row0.Y,
-                lM21 = left.Row1.X,
-                lM22 = left.Row1.Y,
-                lM31 = left.Row2.X,
-                lM32 = left.Row2.Y,
-                lM41 = left.Row3.X,
-                lM42 = left.Row3.Y,
-                rM11 = right.Row0.X,
-                rM12 = right.Row0.Y,
-                rM13 = right.Row0.Z,
-                rM14 = right.Row0.W,
-                rM21 = right.Row1.X,
-                rM22 = right.Row1.Y,
-                rM23 = right.Row1.Z,
-                rM24 = right.Row1.W;
+            double leftM11 = left.Row0.X,
+                leftM12 = left.Row0.Y,
+                leftM21 = left.Row1.X,
+                leftM22 = left.Row1.Y,
+                leftM31 = left.Row2.X,
+                leftM32 = left.Row2.Y,
+                leftM41 = left.Row3.X,
+                leftM42 = left.Row3.Y,
+                rightM11 = right.Row0.X,
+                rightM12 = right.Row0.Y,
+                rightM13 = right.Row0.Z,
+                rightM14 = right.Row0.W,
+                rightM21 = right.Row1.X,
+                rightM22 = right.Row1.Y,
+                rightM23 = right.Row1.Z,
+                rightM24 = right.Row1.W;
 
-            result.Row0.X = (lM11 * rM11) + (lM12 * rM21);
-            result.Row0.Y = (lM11 * rM12) + (lM12 * rM22);
-            result.Row0.Z = (lM11 * rM13) + (lM12 * rM23);
-            result.Row0.W = (lM11 * rM14) + (lM12 * rM24);
-            result.Row1.X = (lM21 * rM11) + (lM22 * rM21);
-            result.Row1.Y = (lM21 * rM12) + (lM22 * rM22);
-            result.Row1.Z = (lM21 * rM13) + (lM22 * rM23);
-            result.Row1.W = (lM21 * rM14) + (lM22 * rM24);
-            result.Row2.X = (lM31 * rM11) + (lM32 * rM21);
-            result.Row2.Y = (lM31 * rM12) + (lM32 * rM22);
-            result.Row2.Z = (lM31 * rM13) + (lM32 * rM23);
-            result.Row2.W = (lM31 * rM14) + (lM32 * rM24);
-            result.Row3.X = (lM41 * rM11) + (lM42 * rM21);
-            result.Row3.Y = (lM41 * rM12) + (lM42 * rM22);
-            result.Row3.Z = (lM41 * rM13) + (lM42 * rM23);
-            result.Row3.W = (lM41 * rM14) + (lM42 * rM24);
+            result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21);
+            result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22);
+            result.Row0.Z = (leftM11 * rightM13) + (leftM12 * rightM23);
+            result.Row0.W = (leftM11 * rightM14) + (leftM12 * rightM24);
+            result.Row1.X = (leftM21 * rightM11) + (leftM22 * rightM21);
+            result.Row1.Y = (leftM21 * rightM12) + (leftM22 * rightM22);
+            result.Row1.Z = (leftM21 * rightM13) + (leftM22 * rightM23);
+            result.Row1.W = (leftM21 * rightM14) + (leftM22 * rightM24);
+            result.Row2.X = (leftM31 * rightM11) + (leftM32 * rightM21);
+            result.Row2.Y = (leftM31 * rightM12) + (leftM32 * rightM22);
+            result.Row2.Z = (leftM31 * rightM13) + (leftM32 * rightM23);
+            result.Row2.W = (leftM31 * rightM14) + (leftM32 * rightM24);
+            result.Row3.X = (leftM41 * rightM11) + (leftM42 * rightM21);
+            result.Row3.Y = (leftM41 * rightM12) + (leftM42 * rightM22);
+            result.Row3.Z = (leftM41 * rightM13) + (leftM42 * rightM23);
+            result.Row3.W = (leftM41 * rightM14) + (leftM42 * rightM24);
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Matrix/Matrix4x3.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix4x3.cs
@@ -21,6 +21,7 @@ SOFTWARE.
  */
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
 namespace OpenTK.Mathematics
@@ -87,21 +88,12 @@ namespace OpenTK.Mathematics
         /// <param name="m30">First item of the fourth row of the matrix.</param>
         /// <param name="m31">Second item of the fourth row of the matrix.</param>
         /// <param name="m32">Third item of the fourth row of the matrix.</param>
-        public Matrix4x3
-        (
-            float m00,
-            float m01,
-            float m02,
-            float m10,
-            float m11,
-            float m12,
-            float m20,
-            float m21,
-            float m22,
-            float m30,
-            float m31,
-            float m32
-        )
+        [SuppressMessage("Microsoft.StyleCop.CSharp.DocumentationRules", "SA1117", Justification = "For better readability of Matrix struct.")]
+        public Matrix4x3(
+            float m00, float m01, float m02,
+            float m10, float m11, float m12,
+            float m20, float m21, float m22,
+            float m30, float m31, float m32)
         {
             Row0 = new Vector3(m00, m01, m02);
             Row1 = new Vector3(m10, m11, m12);
@@ -256,6 +248,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="rowIndex">The index of the row.</param>
         /// <param name="columnIndex">The index of the column.</param>
+        /// <returns>The element at the given row and column index.</returns>
         public float this[int rowIndex, int columnIndex]
         {
             get
@@ -324,6 +317,7 @@ namespace OpenTK.Mathematics
         /// <param name="axis">The axis to rotate about.</param>
         /// <param name="angle">Angle in radians to rotate counter-clockwise (looking in the direction of the given axis).</param>
         /// <param name="result">A matrix instance.</param>
+        [SuppressMessage("Microsoft.StyleCop.CSharp.DocumentationRules", "SA1305", Justification = "Is not hungarian notation but abbreveation for precalculated values.")]
         public static void CreateFromAxisAngle(Vector3 axis, float angle, out Matrix4x3 result)
         {
             axis.Normalize();
@@ -664,47 +658,47 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix4x3 left, ref Matrix3x4 right, out Matrix4 result)
         {
-            float lM11 = left.Row0.X,
-                lM12 = left.Row0.Y,
-                lM13 = left.Row0.Z,
-                lM21 = left.Row1.X,
-                lM22 = left.Row1.Y,
-                lM23 = left.Row1.Z,
-                lM31 = left.Row2.X,
-                lM32 = left.Row2.Y,
-                lM33 = left.Row2.Z,
-                lM41 = left.Row3.X,
-                lM42 = left.Row3.Y,
-                lM43 = left.Row3.Z,
-                rM11 = right.Row0.X,
-                rM12 = right.Row0.Y,
-                rM13 = right.Row0.Z,
-                rM14 = right.Row0.W,
-                rM21 = right.Row1.X,
-                rM22 = right.Row1.Y,
-                rM23 = right.Row1.Z,
-                rM24 = right.Row1.W,
-                rM31 = right.Row2.X,
-                rM32 = right.Row2.Y,
-                rM33 = right.Row2.Z,
-                rM34 = right.Row2.W;
+            float leftM11 = left.Row0.X,
+                leftM12 = left.Row0.Y,
+                leftM13 = left.Row0.Z,
+                leftM21 = left.Row1.X,
+                leftM22 = left.Row1.Y,
+                leftM23 = left.Row1.Z,
+                leftM31 = left.Row2.X,
+                leftM32 = left.Row2.Y,
+                leftM33 = left.Row2.Z,
+                leftM41 = left.Row3.X,
+                leftM42 = left.Row3.Y,
+                leftM43 = left.Row3.Z,
+                rightM11 = right.Row0.X,
+                rightM12 = right.Row0.Y,
+                rightM13 = right.Row0.Z,
+                rightM14 = right.Row0.W,
+                rightM21 = right.Row1.X,
+                rightM22 = right.Row1.Y,
+                rightM23 = right.Row1.Z,
+                rightM24 = right.Row1.W,
+                rightM31 = right.Row2.X,
+                rightM32 = right.Row2.Y,
+                rightM33 = right.Row2.Z,
+                rightM34 = right.Row2.W;
 
-            result.Row0.X = (lM11 * rM11) + (lM12 * rM21) + (lM13 * rM31);
-            result.Row0.Y = (lM11 * rM12) + (lM12 * rM22) + (lM13 * rM32);
-            result.Row0.Z = (lM11 * rM13) + (lM12 * rM23) + (lM13 * rM33);
-            result.Row0.W = (lM11 * rM14) + (lM12 * rM24) + (lM13 * rM34);
-            result.Row1.X = (lM21 * rM11) + (lM22 * rM21) + (lM23 * rM31);
-            result.Row1.Y = (lM21 * rM12) + (lM22 * rM22) + (lM23 * rM32);
-            result.Row1.Z = (lM21 * rM13) + (lM22 * rM23) + (lM23 * rM33);
-            result.Row1.W = (lM21 * rM14) + (lM22 * rM24) + (lM23 * rM34);
-            result.Row2.X = (lM31 * rM11) + (lM32 * rM21) + (lM33 * rM31);
-            result.Row2.Y = (lM31 * rM12) + (lM32 * rM22) + (lM33 * rM32);
-            result.Row2.Z = (lM31 * rM13) + (lM32 * rM23) + (lM33 * rM33);
-            result.Row2.W = (lM31 * rM14) + (lM32 * rM24) + (lM33 * rM34);
-            result.Row3.X = (lM41 * rM11) + (lM42 * rM21) + (lM43 * rM31);
-            result.Row3.Y = (lM41 * rM12) + (lM42 * rM22) + (lM43 * rM32);
-            result.Row3.Z = (lM41 * rM13) + (lM42 * rM23) + (lM43 * rM33);
-            result.Row3.W = (lM41 * rM14) + (lM42 * rM24) + (lM43 * rM34);
+            result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21) + (leftM13 * rightM31);
+            result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22) + (leftM13 * rightM32);
+            result.Row0.Z = (leftM11 * rightM13) + (leftM12 * rightM23) + (leftM13 * rightM33);
+            result.Row0.W = (leftM11 * rightM14) + (leftM12 * rightM24) + (leftM13 * rightM34);
+            result.Row1.X = (leftM21 * rightM11) + (leftM22 * rightM21) + (leftM23 * rightM31);
+            result.Row1.Y = (leftM21 * rightM12) + (leftM22 * rightM22) + (leftM23 * rightM32);
+            result.Row1.Z = (leftM21 * rightM13) + (leftM22 * rightM23) + (leftM23 * rightM33);
+            result.Row1.W = (leftM21 * rightM14) + (leftM22 * rightM24) + (leftM23 * rightM34);
+            result.Row2.X = (leftM31 * rightM11) + (leftM32 * rightM21) + (leftM33 * rightM31);
+            result.Row2.Y = (leftM31 * rightM12) + (leftM32 * rightM22) + (leftM33 * rightM32);
+            result.Row2.Z = (leftM31 * rightM13) + (leftM32 * rightM23) + (leftM33 * rightM33);
+            result.Row2.W = (leftM31 * rightM14) + (leftM32 * rightM24) + (leftM33 * rightM34);
+            result.Row3.X = (leftM41 * rightM11) + (leftM42 * rightM21) + (leftM43 * rightM31);
+            result.Row3.Y = (leftM41 * rightM12) + (leftM42 * rightM22) + (leftM43 * rightM32);
+            result.Row3.Z = (leftM41 * rightM13) + (leftM42 * rightM23) + (leftM43 * rightM33);
+            result.Row3.W = (leftM41 * rightM14) + (leftM42 * rightM24) + (leftM43 * rightM34);
         }
 
         /// <summary>
@@ -728,43 +722,43 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix4x3 left, ref Matrix4x3 right, out Matrix4x3 result)
         {
-            float lM11 = left.Row0.X,
-                lM12 = left.Row0.Y,
-                lM13 = left.Row0.Z,
-                lM21 = left.Row1.X,
-                lM22 = left.Row1.Y,
-                lM23 = left.Row1.Z,
-                lM31 = left.Row2.X,
-                lM32 = left.Row2.Y,
-                lM33 = left.Row2.Z,
-                lM41 = left.Row3.X,
-                lM42 = left.Row3.Y,
-                lM43 = left.Row3.Z,
-                rM11 = right.Row0.X,
-                rM12 = right.Row0.Y,
-                rM13 = right.Row0.Z,
-                rM21 = right.Row1.X,
-                rM22 = right.Row1.Y,
-                rM23 = right.Row1.Z,
-                rM31 = right.Row2.X,
-                rM32 = right.Row2.Y,
-                rM33 = right.Row2.Z,
-                rM41 = right.Row3.X,
-                rM42 = right.Row3.Y,
-                rM43 = right.Row3.Z;
+            float leftM11 = left.Row0.X,
+                leftM12 = left.Row0.Y,
+                leftM13 = left.Row0.Z,
+                leftM21 = left.Row1.X,
+                leftM22 = left.Row1.Y,
+                leftM23 = left.Row1.Z,
+                leftM31 = left.Row2.X,
+                leftM32 = left.Row2.Y,
+                leftM33 = left.Row2.Z,
+                leftM41 = left.Row3.X,
+                leftM42 = left.Row3.Y,
+                leftM43 = left.Row3.Z,
+                rightM11 = right.Row0.X,
+                rightM12 = right.Row0.Y,
+                rightM13 = right.Row0.Z,
+                rightM21 = right.Row1.X,
+                rightM22 = right.Row1.Y,
+                rightM23 = right.Row1.Z,
+                rightM31 = right.Row2.X,
+                rightM32 = right.Row2.Y,
+                rightM33 = right.Row2.Z,
+                rightM41 = right.Row3.X,
+                rightM42 = right.Row3.Y,
+                rightM43 = right.Row3.Z;
 
-            result.Row0.X = (lM11 * rM11) + (lM12 * rM21) + (lM13 * rM31) + rM41;
-            result.Row0.Y = (lM11 * rM12) + (lM12 * rM22) + (lM13 * rM32) + rM42;
-            result.Row0.Z = (lM11 * rM13) + (lM12 * rM23) + (lM13 * rM33) + rM43;
-            result.Row1.X = (lM21 * rM11) + (lM22 * rM21) + (lM23 * rM31) + rM41;
-            result.Row1.Y = (lM21 * rM12) + (lM22 * rM22) + (lM23 * rM32) + rM42;
-            result.Row1.Z = (lM21 * rM13) + (lM22 * rM23) + (lM23 * rM33) + rM43;
-            result.Row2.X = (lM31 * rM11) + (lM32 * rM21) + (lM33 * rM31) + rM41;
-            result.Row2.Y = (lM31 * rM12) + (lM32 * rM22) + (lM33 * rM32) + rM42;
-            result.Row2.Z = (lM31 * rM13) + (lM32 * rM23) + (lM33 * rM33) + rM43;
-            result.Row3.X = (lM41 * rM11) + (lM42 * rM21) + (lM43 * rM31) + rM41;
-            result.Row3.Y = (lM41 * rM12) + (lM42 * rM22) + (lM43 * rM32) + rM42;
-            result.Row3.Z = (lM41 * rM13) + (lM42 * rM23) + (lM43 * rM33) + rM43;
+            result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21) + (leftM13 * rightM31) + rightM41;
+            result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22) + (leftM13 * rightM32) + rightM42;
+            result.Row0.Z = (leftM11 * rightM13) + (leftM12 * rightM23) + (leftM13 * rightM33) + rightM43;
+            result.Row1.X = (leftM21 * rightM11) + (leftM22 * rightM21) + (leftM23 * rightM31) + rightM41;
+            result.Row1.Y = (leftM21 * rightM12) + (leftM22 * rightM22) + (leftM23 * rightM32) + rightM42;
+            result.Row1.Z = (leftM21 * rightM13) + (leftM22 * rightM23) + (leftM23 * rightM33) + rightM43;
+            result.Row2.X = (leftM31 * rightM11) + (leftM32 * rightM21) + (leftM33 * rightM31) + rightM41;
+            result.Row2.Y = (leftM31 * rightM12) + (leftM32 * rightM22) + (leftM33 * rightM32) + rightM42;
+            result.Row2.Z = (leftM31 * rightM13) + (leftM32 * rightM23) + (leftM33 * rightM33) + rightM43;
+            result.Row3.X = (leftM41 * rightM11) + (leftM42 * rightM21) + (leftM43 * rightM31) + rightM41;
+            result.Row3.Y = (leftM41 * rightM12) + (leftM42 * rightM22) + (leftM43 * rightM32) + rightM42;
+            result.Row3.Z = (leftM41 * rightM13) + (leftM42 * rightM23) + (leftM43 * rightM33) + rightM43;
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Matrix/Matrix4x3.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix4x3.cs
@@ -89,11 +89,13 @@ namespace OpenTK.Mathematics
         /// <param name="m31">Second item of the fourth row of the matrix.</param>
         /// <param name="m32">Third item of the fourth row of the matrix.</param>
         [SuppressMessage("Microsoft.StyleCop.CSharp.DocumentationRules", "SA1117", Justification = "For better readability of Matrix struct.")]
-        public Matrix4x3(
+        public Matrix4x3
+        (
             float m00, float m01, float m02,
             float m10, float m11, float m12,
             float m20, float m21, float m22,
-            float m30, float m31, float m32)
+            float m30, float m31, float m32
+        )
         {
             Row0 = new Vector3(m00, m01, m02);
             Row1 = new Vector3(m10, m11, m12);
@@ -317,7 +319,6 @@ namespace OpenTK.Mathematics
         /// <param name="axis">The axis to rotate about.</param>
         /// <param name="angle">Angle in radians to rotate counter-clockwise (looking in the direction of the given axis).</param>
         /// <param name="result">A matrix instance.</param>
-        [SuppressMessage("Microsoft.StyleCop.CSharp.DocumentationRules", "SA1305", Justification = "Is not hungarian notation but abbreveation for precalculated values.")]
         public static void CreateFromAxisAngle(Vector3 axis, float angle, out Matrix4x3 result)
         {
             axis.Normalize();
@@ -327,16 +328,16 @@ namespace OpenTK.Mathematics
             var sin = (float)Math.Sin(-angle);
             var t = 1.0f - cos;
 
-            float tXX = t * axisX * axisX,
-                tXY = t * axisX * axisY,
-                tXZ = t * axisX * axisZ,
-                tYY = t * axisY * axisY,
-                tYZ = t * axisY * axisZ,
-                tZZ = t * axisZ * axisZ;
+            float tXX = t * axisX * axisX;
+            float tXY = t * axisX * axisY;
+            float tXZ = t * axisX * axisZ;
+            float tYY = t * axisY * axisY;
+            float tYZ = t * axisY * axisZ;
+            float tZZ = t * axisZ * axisZ;
 
-            float sinX = sin * axisX,
-                sinY = sin * axisY,
-                sinZ = sin * axisZ;
+            float sinX = sin * axisX;
+            float sinY = sin * axisY;
+            float sinZ = sin * axisZ;
 
             result.Row0.X = tXX + cos;
             result.Row0.Y = tXY - sinZ;
@@ -371,22 +372,22 @@ namespace OpenTK.Mathematics
         /// <param name="result">A matrix instance.</param>
         public static void CreateFromQuaternion(ref Quaternion q, out Matrix4x3 result)
         {
-            float x = q.X,
-                y = q.Y,
-                z = q.Z,
-                w = q.W,
-                tx = 2 * x,
-                ty = 2 * y,
-                tz = 2 * z,
-                txx = tx * x,
-                tyy = ty * y,
-                tzz = tz * z,
-                txy = tx * y,
-                txz = tx * z,
-                tyz = ty * z,
-                twx = w * tx,
-                twy = w * ty,
-                twz = w * tz;
+            float x = q.X;
+            float y = q.Y;
+            float z = q.Z;
+            float w = q.W;
+            float tx = 2 * x;
+            float ty = 2 * y;
+            float tz = 2 * z;
+            float txx = tx * x;
+            float tyy = ty * y;
+            float tzz = tz * z;
+            float txy = tx * y;
+            float txz = tx * z;
+            float tyz = ty * z;
+            float twx = w * tx;
+            float twy = w * ty;
+            float twz = w * tz;
 
             result.Row0.X = 1f - tyy - tzz;
             result.Row0.Y = txy - twz;
@@ -400,11 +401,6 @@ namespace OpenTK.Mathematics
             result.Row3.X = 0;
             result.Row3.Y = 0;
             result.Row3.Z = 0;
-
-            /*Vector3 axis;
-            float angle;
-            q.ToAxisAngle(out axis, out angle);
-            CreateFromAxisAngle(axis, angle, out result);*/
         }
 
         /// <summary>
@@ -658,30 +654,30 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix4x3 left, ref Matrix3x4 right, out Matrix4 result)
         {
-            float leftM11 = left.Row0.X,
-                leftM12 = left.Row0.Y,
-                leftM13 = left.Row0.Z,
-                leftM21 = left.Row1.X,
-                leftM22 = left.Row1.Y,
-                leftM23 = left.Row1.Z,
-                leftM31 = left.Row2.X,
-                leftM32 = left.Row2.Y,
-                leftM33 = left.Row2.Z,
-                leftM41 = left.Row3.X,
-                leftM42 = left.Row3.Y,
-                leftM43 = left.Row3.Z,
-                rightM11 = right.Row0.X,
-                rightM12 = right.Row0.Y,
-                rightM13 = right.Row0.Z,
-                rightM14 = right.Row0.W,
-                rightM21 = right.Row1.X,
-                rightM22 = right.Row1.Y,
-                rightM23 = right.Row1.Z,
-                rightM24 = right.Row1.W,
-                rightM31 = right.Row2.X,
-                rightM32 = right.Row2.Y,
-                rightM33 = right.Row2.Z,
-                rightM34 = right.Row2.W;
+            float leftM11 = left.Row0.X;
+            float leftM12 = left.Row0.Y;
+            float leftM13 = left.Row0.Z;
+            float leftM21 = left.Row1.X;
+            float leftM22 = left.Row1.Y;
+            float leftM23 = left.Row1.Z;
+            float leftM31 = left.Row2.X;
+            float leftM32 = left.Row2.Y;
+            float leftM33 = left.Row2.Z;
+            float leftM41 = left.Row3.X;
+            float leftM42 = left.Row3.Y;
+            float leftM43 = left.Row3.Z;
+            float rightM11 = right.Row0.X;
+            float rightM12 = right.Row0.Y;
+            float rightM13 = right.Row0.Z;
+            float rightM14 = right.Row0.W;
+            float rightM21 = right.Row1.X;
+            float rightM22 = right.Row1.Y;
+            float rightM23 = right.Row1.Z;
+            float rightM24 = right.Row1.W;
+            float rightM31 = right.Row2.X;
+            float rightM32 = right.Row2.Y;
+            float rightM33 = right.Row2.Z;
+            float rightM34 = right.Row2.W;
 
             result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21) + (leftM13 * rightM31);
             result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22) + (leftM13 * rightM32);
@@ -722,30 +718,30 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix4x3 left, ref Matrix4x3 right, out Matrix4x3 result)
         {
-            float leftM11 = left.Row0.X,
-                leftM12 = left.Row0.Y,
-                leftM13 = left.Row0.Z,
-                leftM21 = left.Row1.X,
-                leftM22 = left.Row1.Y,
-                leftM23 = left.Row1.Z,
-                leftM31 = left.Row2.X,
-                leftM32 = left.Row2.Y,
-                leftM33 = left.Row2.Z,
-                leftM41 = left.Row3.X,
-                leftM42 = left.Row3.Y,
-                leftM43 = left.Row3.Z,
-                rightM11 = right.Row0.X,
-                rightM12 = right.Row0.Y,
-                rightM13 = right.Row0.Z,
-                rightM21 = right.Row1.X,
-                rightM22 = right.Row1.Y,
-                rightM23 = right.Row1.Z,
-                rightM31 = right.Row2.X,
-                rightM32 = right.Row2.Y,
-                rightM33 = right.Row2.Z,
-                rightM41 = right.Row3.X,
-                rightM42 = right.Row3.Y,
-                rightM43 = right.Row3.Z;
+            float leftM11 = left.Row0.X;
+            float leftM12 = left.Row0.Y;
+            float leftM13 = left.Row0.Z;
+            float leftM21 = left.Row1.X;
+            float leftM22 = left.Row1.Y;
+            float leftM23 = left.Row1.Z;
+            float leftM31 = left.Row2.X;
+            float leftM32 = left.Row2.Y;
+            float leftM33 = left.Row2.Z;
+            float leftM41 = left.Row3.X;
+            float leftM42 = left.Row3.Y;
+            float leftM43 = left.Row3.Z;
+            float rightM11 = right.Row0.X;
+            float rightM12 = right.Row0.Y;
+            float rightM13 = right.Row0.Z;
+            float rightM21 = right.Row1.X;
+            float rightM22 = right.Row1.Y;
+            float rightM23 = right.Row1.Z;
+            float rightM31 = right.Row2.X;
+            float rightM32 = right.Row2.Y;
+            float rightM33 = right.Row2.Z;
+            float rightM41 = right.Row3.X;
+            float rightM42 = right.Row3.Y;
+            float rightM43 = right.Row3.Z;
 
             result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21) + (leftM13 * rightM31) + rightM41;
             result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22) + (leftM13 * rightM32) + rightM42;

--- a/src/OpenTK.Mathematics/Matrix/Matrix4x3d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix4x3d.cs
@@ -21,6 +21,7 @@ SOFTWARE.
  */
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
 namespace OpenTK.Mathematics
@@ -87,21 +88,12 @@ namespace OpenTK.Mathematics
         /// <param name="m30">First item of the fourth row of the matrix.</param>
         /// <param name="m31">Second item of the fourth row of the matrix.</param>
         /// <param name="m32">Third item of the fourth row of the matrix.</param>
-        public Matrix4x3d
-        (
-            double m00,
-            double m01,
-            double m02,
-            double m10,
-            double m11,
-            double m12,
-            double m20,
-            double m21,
-            double m22,
-            double m30,
-            double m31,
-            double m32
-        )
+        [SuppressMessage("ReSharper", "SA1117", Justification = "For better readability of Matrix struct.")]
+        public Matrix4x3d(
+            double m00, double m01, double m02,
+            double m10, double m11, double m12,
+            double m20, double m21, double m22,
+            double m30, double m31, double m32)
         {
             Row0 = new Vector3d(m00, m01, m02);
             Row1 = new Vector3d(m10, m11, m12);
@@ -256,6 +248,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="rowIndex">The index of the row.</param>
         /// <param name="columnIndex">The index of the column.</param>
+        /// <returns>The element at the given row and column index.</returns>
         public double this[int rowIndex, int columnIndex]
         {
             get
@@ -324,6 +317,7 @@ namespace OpenTK.Mathematics
         /// <param name="axis">The axis to rotate about.</param>
         /// <param name="angle">Angle in radians to rotate counter-clockwise (looking in the direction of the given axis).</param>
         /// <param name="result">A matrix instance.</param>
+        [SuppressMessage("Microsoft.StyleCop.CSharp.DocumentationRules", "SA1305", Justification = "Is not hungarian notation but abbreveation for precalculated values.")]
         public static void CreateFromAxisAngle(Vector3d axis, double angle, out Matrix4x3d result)
         {
             axis.Normalize();
@@ -664,47 +658,47 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix4x3d left, ref Matrix3x4d right, out Matrix4d result)
         {
-            double lM11 = left.Row0.X,
-                lM12 = left.Row0.Y,
-                lM13 = left.Row0.Z,
-                lM21 = left.Row1.X,
-                lM22 = left.Row1.Y,
-                lM23 = left.Row1.Z,
-                lM31 = left.Row2.X,
-                lM32 = left.Row2.Y,
-                lM33 = left.Row2.Z,
-                lM41 = left.Row3.X,
-                lM42 = left.Row3.Y,
-                lM43 = left.Row3.Z,
-                rM11 = right.Row0.X,
-                rM12 = right.Row0.Y,
-                rM13 = right.Row0.Z,
-                rM14 = right.Row0.W,
-                rM21 = right.Row1.X,
-                rM22 = right.Row1.Y,
-                rM23 = right.Row1.Z,
-                rM24 = right.Row1.W,
-                rM31 = right.Row2.X,
-                rM32 = right.Row2.Y,
-                rM33 = right.Row2.Z,
-                rM34 = right.Row2.W;
+            double leftM11 = left.Row0.X,
+                leftM12 = left.Row0.Y,
+                leftM13 = left.Row0.Z,
+                leftM21 = left.Row1.X,
+                leftM22 = left.Row1.Y,
+                leftM23 = left.Row1.Z,
+                leftM31 = left.Row2.X,
+                leftM32 = left.Row2.Y,
+                leftM33 = left.Row2.Z,
+                leftM41 = left.Row3.X,
+                leftM42 = left.Row3.Y,
+                leftM43 = left.Row3.Z,
+                rightM11 = right.Row0.X,
+                rightM12 = right.Row0.Y,
+                rightM13 = right.Row0.Z,
+                rightM14 = right.Row0.W,
+                rightM21 = right.Row1.X,
+                rightM22 = right.Row1.Y,
+                rightM23 = right.Row1.Z,
+                rightM24 = right.Row1.W,
+                rightM31 = right.Row2.X,
+                rightM32 = right.Row2.Y,
+                rightM33 = right.Row2.Z,
+                rightM34 = right.Row2.W;
 
-            result.Row0.X = (lM11 * rM11) + (lM12 * rM21) + (lM13 * rM31);
-            result.Row0.Y = (lM11 * rM12) + (lM12 * rM22) + (lM13 * rM32);
-            result.Row0.Z = (lM11 * rM13) + (lM12 * rM23) + (lM13 * rM33);
-            result.Row0.W = (lM11 * rM14) + (lM12 * rM24) + (lM13 * rM34);
-            result.Row1.X = (lM21 * rM11) + (lM22 * rM21) + (lM23 * rM31);
-            result.Row1.Y = (lM21 * rM12) + (lM22 * rM22) + (lM23 * rM32);
-            result.Row1.Z = (lM21 * rM13) + (lM22 * rM23) + (lM23 * rM33);
-            result.Row1.W = (lM21 * rM14) + (lM22 * rM24) + (lM23 * rM34);
-            result.Row2.X = (lM31 * rM11) + (lM32 * rM21) + (lM33 * rM31);
-            result.Row2.Y = (lM31 * rM12) + (lM32 * rM22) + (lM33 * rM32);
-            result.Row2.Z = (lM31 * rM13) + (lM32 * rM23) + (lM33 * rM33);
-            result.Row2.W = (lM31 * rM14) + (lM32 * rM24) + (lM33 * rM34);
-            result.Row3.X = (lM41 * rM11) + (lM42 * rM21) + (lM43 * rM31);
-            result.Row3.Y = (lM41 * rM12) + (lM42 * rM22) + (lM43 * rM32);
-            result.Row3.Z = (lM41 * rM13) + (lM42 * rM23) + (lM43 * rM33);
-            result.Row3.W = (lM41 * rM14) + (lM42 * rM24) + (lM43 * rM34);
+            result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21) + (leftM13 * rightM31);
+            result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22) + (leftM13 * rightM32);
+            result.Row0.Z = (leftM11 * rightM13) + (leftM12 * rightM23) + (leftM13 * rightM33);
+            result.Row0.W = (leftM11 * rightM14) + (leftM12 * rightM24) + (leftM13 * rightM34);
+            result.Row1.X = (leftM21 * rightM11) + (leftM22 * rightM21) + (leftM23 * rightM31);
+            result.Row1.Y = (leftM21 * rightM12) + (leftM22 * rightM22) + (leftM23 * rightM32);
+            result.Row1.Z = (leftM21 * rightM13) + (leftM22 * rightM23) + (leftM23 * rightM33);
+            result.Row1.W = (leftM21 * rightM14) + (leftM22 * rightM24) + (leftM23 * rightM34);
+            result.Row2.X = (leftM31 * rightM11) + (leftM32 * rightM21) + (leftM33 * rightM31);
+            result.Row2.Y = (leftM31 * rightM12) + (leftM32 * rightM22) + (leftM33 * rightM32);
+            result.Row2.Z = (leftM31 * rightM13) + (leftM32 * rightM23) + (leftM33 * rightM33);
+            result.Row2.W = (leftM31 * rightM14) + (leftM32 * rightM24) + (leftM33 * rightM34);
+            result.Row3.X = (leftM41 * rightM11) + (leftM42 * rightM21) + (leftM43 * rightM31);
+            result.Row3.Y = (leftM41 * rightM12) + (leftM42 * rightM22) + (leftM43 * rightM32);
+            result.Row3.Z = (leftM41 * rightM13) + (leftM42 * rightM23) + (leftM43 * rightM33);
+            result.Row3.W = (leftM41 * rightM14) + (leftM42 * rightM24) + (leftM43 * rightM34);
         }
 
         /// <summary>
@@ -727,43 +721,43 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix4x3d left, ref Matrix4x3d right, out Matrix4x3d result)
         {
-            double lM11 = left.Row0.X,
-                lM12 = left.Row0.Y,
-                lM13 = left.Row0.Z,
-                lM21 = left.Row1.X,
-                lM22 = left.Row1.Y,
-                lM23 = left.Row1.Z,
-                lM31 = left.Row2.X,
-                lM32 = left.Row2.Y,
-                lM33 = left.Row2.Z,
-                lM41 = left.Row3.X,
-                lM42 = left.Row3.Y,
-                lM43 = left.Row3.Z,
-                rM11 = right.Row0.X,
-                rM12 = right.Row0.Y,
-                rM13 = right.Row0.Z,
-                rM21 = right.Row1.X,
-                rM22 = right.Row1.Y,
-                rM23 = right.Row1.Z,
-                rM31 = right.Row2.X,
-                rM32 = right.Row2.Y,
-                rM33 = right.Row2.Z,
-                rM41 = right.Row3.X,
-                rM42 = right.Row3.Y,
-                rM43 = right.Row3.Z;
+            double leftM11 = left.Row0.X,
+                leftM12 = left.Row0.Y,
+                leftM13 = left.Row0.Z,
+                leftM21 = left.Row1.X,
+                leftM22 = left.Row1.Y,
+                leftM23 = left.Row1.Z,
+                leftM31 = left.Row2.X,
+                leftM32 = left.Row2.Y,
+                leftM33 = left.Row2.Z,
+                leftM41 = left.Row3.X,
+                leftM42 = left.Row3.Y,
+                leftM43 = left.Row3.Z,
+                rightM11 = right.Row0.X,
+                rightM12 = right.Row0.Y,
+                rightM13 = right.Row0.Z,
+                rightM21 = right.Row1.X,
+                rightM22 = right.Row1.Y,
+                rightM23 = right.Row1.Z,
+                rightM31 = right.Row2.X,
+                rightM32 = right.Row2.Y,
+                rightM33 = right.Row2.Z,
+                rightM41 = right.Row3.X,
+                rightM42 = right.Row3.Y,
+                rightM43 = right.Row3.Z;
 
-            result.Row0.X = (lM11 * rM11) + (lM12 * rM21) + (lM13 * rM31) + rM41;
-            result.Row0.Y = (lM11 * rM12) + (lM12 * rM22) + (lM13 * rM32) + rM42;
-            result.Row0.Z = (lM11 * rM13) + (lM12 * rM23) + (lM13 * rM33) + rM43;
-            result.Row1.X = (lM21 * rM11) + (lM22 * rM21) + (lM23 * rM31) + rM41;
-            result.Row1.Y = (lM21 * rM12) + (lM22 * rM22) + (lM23 * rM32) + rM42;
-            result.Row1.Z = (lM21 * rM13) + (lM22 * rM23) + (lM23 * rM33) + rM43;
-            result.Row2.X = (lM31 * rM11) + (lM32 * rM21) + (lM33 * rM31) + rM41;
-            result.Row2.Y = (lM31 * rM12) + (lM32 * rM22) + (lM33 * rM32) + rM42;
-            result.Row2.Z = (lM31 * rM13) + (lM32 * rM23) + (lM33 * rM33) + rM43;
-            result.Row3.X = (lM41 * rM11) + (lM42 * rM21) + (lM43 * rM31) + rM41;
-            result.Row3.Y = (lM41 * rM12) + (lM42 * rM22) + (lM43 * rM32) + rM42;
-            result.Row3.Z = (lM41 * rM13) + (lM42 * rM23) + (lM43 * rM33) + rM43;
+            result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21) + (leftM13 * rightM31) + rightM41;
+            result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22) + (leftM13 * rightM32) + rightM42;
+            result.Row0.Z = (leftM11 * rightM13) + (leftM12 * rightM23) + (leftM13 * rightM33) + rightM43;
+            result.Row1.X = (leftM21 * rightM11) + (leftM22 * rightM21) + (leftM23 * rightM31) + rightM41;
+            result.Row1.Y = (leftM21 * rightM12) + (leftM22 * rightM22) + (leftM23 * rightM32) + rightM42;
+            result.Row1.Z = (leftM21 * rightM13) + (leftM22 * rightM23) + (leftM23 * rightM33) + rightM43;
+            result.Row2.X = (leftM31 * rightM11) + (leftM32 * rightM21) + (leftM33 * rightM31) + rightM41;
+            result.Row2.Y = (leftM31 * rightM12) + (leftM32 * rightM22) + (leftM33 * rightM32) + rightM42;
+            result.Row2.Z = (leftM31 * rightM13) + (leftM32 * rightM23) + (leftM33 * rightM33) + rightM43;
+            result.Row3.X = (leftM41 * rightM11) + (leftM42 * rightM21) + (leftM43 * rightM31) + rightM41;
+            result.Row3.Y = (leftM41 * rightM12) + (leftM42 * rightM22) + (leftM43 * rightM32) + rightM42;
+            result.Row3.Z = (leftM41 * rightM13) + (leftM42 * rightM23) + (leftM43 * rightM33) + rightM43;
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Matrix/Matrix4x3d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix4x3d.cs
@@ -89,11 +89,13 @@ namespace OpenTK.Mathematics
         /// <param name="m31">Second item of the fourth row of the matrix.</param>
         /// <param name="m32">Third item of the fourth row of the matrix.</param>
         [SuppressMessage("ReSharper", "SA1117", Justification = "For better readability of Matrix struct.")]
-        public Matrix4x3d(
+        public Matrix4x3d
+        (
             double m00, double m01, double m02,
             double m10, double m11, double m12,
             double m20, double m21, double m22,
-            double m30, double m31, double m32)
+            double m30, double m31, double m32
+        )
         {
             Row0 = new Vector3d(m00, m01, m02);
             Row1 = new Vector3d(m10, m11, m12);
@@ -317,7 +319,6 @@ namespace OpenTK.Mathematics
         /// <param name="axis">The axis to rotate about.</param>
         /// <param name="angle">Angle in radians to rotate counter-clockwise (looking in the direction of the given axis).</param>
         /// <param name="result">A matrix instance.</param>
-        [SuppressMessage("Microsoft.StyleCop.CSharp.DocumentationRules", "SA1305", Justification = "Is not hungarian notation but abbreveation for precalculated values.")]
         public static void CreateFromAxisAngle(Vector3d axis, double angle, out Matrix4x3d result)
         {
             axis.Normalize();
@@ -327,16 +328,16 @@ namespace OpenTK.Mathematics
             var sin = Math.Sin(-angle);
             var t = 1.0f - cos;
 
-            double tXX = t * axisX * axisX,
-                tXY = t * axisX * axisY,
-                tXZ = t * axisX * axisZ,
-                tYY = t * axisY * axisY,
-                tYZ = t * axisY * axisZ,
-                tZZ = t * axisZ * axisZ;
+            double tXX = t * axisX * axisX;
+            double tXY = t * axisX * axisY;
+            double tXZ = t * axisX * axisZ;
+            double tYY = t * axisY * axisY;
+            double tYZ = t * axisY * axisZ;
+            double tZZ = t * axisZ * axisZ;
 
-            double sinX = sin * axisX,
-                sinY = sin * axisY,
-                sinZ = sin * axisZ;
+            double sinX = sin * axisX;
+            double sinY = sin * axisY;
+            double sinZ = sin * axisZ;
 
             result.Row0.X = tXX + cos;
             result.Row0.Y = tXY - sinZ;
@@ -371,22 +372,22 @@ namespace OpenTK.Mathematics
         /// <param name="result">A matrix instance.</param>
         public static void CreateFromQuaternion(ref Quaternion q, out Matrix4x3d result)
         {
-            double x = q.X,
-                y = q.Y,
-                z = q.Z,
-                w = q.W,
-                tx = 2 * x,
-                ty = 2 * y,
-                tz = 2 * z,
-                txx = tx * x,
-                tyy = ty * y,
-                tzz = tz * z,
-                txy = tx * y,
-                txz = tx * z,
-                tyz = ty * z,
-                twx = w * tx,
-                twy = w * ty,
-                twz = w * tz;
+            double x = q.X;
+            double y = q.Y;
+            double z = q.Z;
+            double w = q.W;
+            double tx = 2 * x;
+            double ty = 2 * y;
+            double tz = 2 * z;
+            double txx = tx * x;
+            double tyy = ty * y;
+            double tzz = tz * z;
+            double txy = tx * y;
+            double txz = tx * z;
+            double tyz = ty * z;
+            double twx = w * tx;
+            double twy = w * ty;
+            double twz = w * tz;
 
             result.Row0.X = 1f - tyy - tzz;
             result.Row0.Y = txy - twz;
@@ -400,11 +401,6 @@ namespace OpenTK.Mathematics
             result.Row3.X = 0;
             result.Row3.Y = 0;
             result.Row3.Z = 0;
-
-            /*Vector3d axis;
-            double angle;
-            q.ToAxisAngle(out axis, out angle);
-            CreateFromAxisAngle(axis, angle, out result);*/
         }
 
         /// <summary>
@@ -658,30 +654,30 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix4x3d left, ref Matrix3x4d right, out Matrix4d result)
         {
-            double leftM11 = left.Row0.X,
-                leftM12 = left.Row0.Y,
-                leftM13 = left.Row0.Z,
-                leftM21 = left.Row1.X,
-                leftM22 = left.Row1.Y,
-                leftM23 = left.Row1.Z,
-                leftM31 = left.Row2.X,
-                leftM32 = left.Row2.Y,
-                leftM33 = left.Row2.Z,
-                leftM41 = left.Row3.X,
-                leftM42 = left.Row3.Y,
-                leftM43 = left.Row3.Z,
-                rightM11 = right.Row0.X,
-                rightM12 = right.Row0.Y,
-                rightM13 = right.Row0.Z,
-                rightM14 = right.Row0.W,
-                rightM21 = right.Row1.X,
-                rightM22 = right.Row1.Y,
-                rightM23 = right.Row1.Z,
-                rightM24 = right.Row1.W,
-                rightM31 = right.Row2.X,
-                rightM32 = right.Row2.Y,
-                rightM33 = right.Row2.Z,
-                rightM34 = right.Row2.W;
+            double leftM11 = left.Row0.X;
+            double leftM12 = left.Row0.Y;
+            double leftM13 = left.Row0.Z;
+            double leftM21 = left.Row1.X;
+            double leftM22 = left.Row1.Y;
+            double leftM23 = left.Row1.Z;
+            double leftM31 = left.Row2.X;
+            double leftM32 = left.Row2.Y;
+            double leftM33 = left.Row2.Z;
+            double leftM41 = left.Row3.X;
+            double leftM42 = left.Row3.Y;
+            double leftM43 = left.Row3.Z;
+            double rightM11 = right.Row0.X;
+            double rightM12 = right.Row0.Y;
+            double rightM13 = right.Row0.Z;
+            double rightM14 = right.Row0.W;
+            double rightM21 = right.Row1.X;
+            double rightM22 = right.Row1.Y;
+            double rightM23 = right.Row1.Z;
+            double rightM24 = right.Row1.W;
+            double rightM31 = right.Row2.X;
+            double rightM32 = right.Row2.Y;
+            double rightM33 = right.Row2.Z;
+            double rightM34 = right.Row2.W;
 
             result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21) + (leftM13 * rightM31);
             result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22) + (leftM13 * rightM32);
@@ -721,30 +717,30 @@ namespace OpenTK.Mathematics
         /// <param name="result">A new instance that is the result of the multiplication.</param>
         public static void Mult(ref Matrix4x3d left, ref Matrix4x3d right, out Matrix4x3d result)
         {
-            double leftM11 = left.Row0.X,
-                leftM12 = left.Row0.Y,
-                leftM13 = left.Row0.Z,
-                leftM21 = left.Row1.X,
-                leftM22 = left.Row1.Y,
-                leftM23 = left.Row1.Z,
-                leftM31 = left.Row2.X,
-                leftM32 = left.Row2.Y,
-                leftM33 = left.Row2.Z,
-                leftM41 = left.Row3.X,
-                leftM42 = left.Row3.Y,
-                leftM43 = left.Row3.Z,
-                rightM11 = right.Row0.X,
-                rightM12 = right.Row0.Y,
-                rightM13 = right.Row0.Z,
-                rightM21 = right.Row1.X,
-                rightM22 = right.Row1.Y,
-                rightM23 = right.Row1.Z,
-                rightM31 = right.Row2.X,
-                rightM32 = right.Row2.Y,
-                rightM33 = right.Row2.Z,
-                rightM41 = right.Row3.X,
-                rightM42 = right.Row3.Y,
-                rightM43 = right.Row3.Z;
+            double leftM11 = left.Row0.X;
+            double leftM12 = left.Row0.Y;
+            double leftM13 = left.Row0.Z;
+            double leftM21 = left.Row1.X;
+            double leftM22 = left.Row1.Y;
+            double leftM23 = left.Row1.Z;
+            double leftM31 = left.Row2.X;
+            double leftM32 = left.Row2.Y;
+            double leftM33 = left.Row2.Z;
+            double leftM41 = left.Row3.X;
+            double leftM42 = left.Row3.Y;
+            double leftM43 = left.Row3.Z;
+            double rightM11 = right.Row0.X;
+            double rightM12 = right.Row0.Y;
+            double rightM13 = right.Row0.Z;
+            double rightM21 = right.Row1.X;
+            double rightM22 = right.Row1.Y;
+            double rightM23 = right.Row1.Z;
+            double rightM31 = right.Row2.X;
+            double rightM32 = right.Row2.Y;
+            double rightM33 = right.Row2.Z;
+            double rightM41 = right.Row3.X;
+            double rightM42 = right.Row3.Y;
+            double rightM43 = right.Row3.Z;
 
             result.Row0.X = (leftM11 * rightM11) + (leftM12 * rightM21) + (leftM13 * rightM31) + rightM41;
             result.Row0.Y = (leftM11 * rightM12) + (leftM12 * rightM22) + (leftM13 * rightM32) + rightM42;

--- a/src/OpenTK.Mathematics/OpenTK.Mathematics.csproj
+++ b/src/OpenTK.Mathematics/OpenTK.Mathematics.csproj
@@ -9,7 +9,7 @@
     <Version>1.0.0</Version>
     <Description>Mathematical structures and algorithms, provided and used by OpenTK.</Description>
   </PropertyGroup>
-
   <Import Project="..\..\props\common.props" />
   <Import Project="..\..\props\nuget-common.props" />
+  <Import Project="..\..\props\stylecop.props" />
 </Project>

--- a/src/OpenTK.Mathematics/Vector/Vector2.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2.cs
@@ -71,7 +71,8 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Gets or sets the value at the index of the Vector.
         /// </summary>
-        /// <param name="index">The index.</param>
+        /// <param name="index">The index of the component from the Vector.</param>
+        /// <exception cref="IndexOutOfRangeException">Thrown if the index is less than 0 or greater than 1.</exception>
         public float this[int index]
         {
             get
@@ -148,7 +149,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Returns a copy of the Vector2 scaled to unit length.
         /// </summary>
-        /// <returns>The vector.</returns>
+        /// <returns>The normalized Vector2.</returns>
         public Vector2 Normalized()
         {
             var v = this;

--- a/src/OpenTK.Mathematics/Vector/Vector2.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2.cs
@@ -149,7 +149,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Returns a copy of the Vector2 scaled to unit length.
         /// </summary>
-        /// <returns>The normalized Vector2.</returns>
+        /// <returns>The normalized copy.</returns>
         public Vector2 Normalized()
         {
             var v = this;
@@ -545,7 +545,7 @@ namespace OpenTK.Mathematics
         /// Scale a vector to unit length.
         /// </summary>
         /// <param name="vec">The input vector.</param>
-        /// <returns>The normalized vector.</returns>
+        /// <returns>The normalized copy.</returns>
         public static Vector2 Normalize(Vector2 vec)
         {
             var scale = 1.0f / vec.Length;
@@ -570,7 +570,7 @@ namespace OpenTK.Mathematics
         /// Scale a vector to approximately unit length.
         /// </summary>
         /// <param name="vec">The input vector.</param>
-        /// <returns>The normalized vector.</returns>
+        /// <returns>The normalized copy.</returns>
         public static Vector2 NormalizeFast(Vector2 vec)
         {
             var scale = MathHelper.InverseSqrtFast((vec.X * vec.X) + (vec.Y * vec.Y));

--- a/src/OpenTK.Mathematics/Vector/Vector2d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2d.cs
@@ -93,7 +93,8 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Gets or sets the value at the index of the Vector.
         /// </summary>
-        /// <param name="index">The index.</param>
+        /// <param name="index">The index of the component from the Vector.</param>
+        /// <exception cref="IndexOutOfRangeException">Thrown if the index is less than 0 or greater than 1.</exception>
         public double this[int index]
         {
             get
@@ -157,7 +158,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Returns a copy of the Vector2d scaled to unit length.
         /// </summary>
-        /// <returns>The vector.</returns>
+        /// <returns>The normalized Vector2d.</returns>
         public Vector2d Normalized()
         {
             var v = this;

--- a/src/OpenTK.Mathematics/Vector/Vector2d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2d.cs
@@ -158,7 +158,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Returns a copy of the Vector2d scaled to unit length.
         /// </summary>
-        /// <returns>The normalized Vector2d.</returns>
+        /// <returns>The normalized copy.</returns>
         public Vector2d Normalized()
         {
             var v = this;
@@ -549,7 +549,7 @@ namespace OpenTK.Mathematics
         /// Scale a vector to unit length.
         /// </summary>
         /// <param name="vec">The input vector.</param>
-        /// <returns>The normalized vector.</returns>
+        /// <returns>The normalized copy.</returns>
         public static Vector2d Normalize(Vector2d vec)
         {
             var scale = 1.0 / vec.Length;
@@ -574,7 +574,7 @@ namespace OpenTK.Mathematics
         /// Scale a vector to approximately unit length.
         /// </summary>
         /// <param name="vec">The input vector.</param>
-        /// <returns>The normalized vector.</returns>
+        /// <returns>The normalized copy.</returns>
         public static Vector2d NormalizeFast(Vector2d vec)
         {
             var scale = MathHelper.InverseSqrtFast((vec.X * vec.X) + (vec.Y * vec.Y));

--- a/src/OpenTK.Mathematics/Vector/Vector3.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3.cs
@@ -189,7 +189,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Returns a copy of the Vector3 scaled to unit length.
         /// </summary>
-        /// <returns>The normalized Vector3.</returns>
+        /// <returns>The normalized copy.</returns>
         public Vector3 Normalized()
         {
             var v = this;
@@ -606,7 +606,7 @@ namespace OpenTK.Mathematics
         /// Scale a vector to unit length.
         /// </summary>
         /// <param name="vec">The input vector.</param>
-        /// <returns>The normalized vector.</returns>
+        /// <returns>The normalized copy.</returns>
         public static Vector3 Normalize(Vector3 vec)
         {
             var scale = 1.0f / vec.Length;
@@ -633,7 +633,7 @@ namespace OpenTK.Mathematics
         /// Scale a vector to approximately unit length.
         /// </summary>
         /// <param name="vec">The input vector.</param>
-        /// <returns>The normalized vector.</returns>
+        /// <returns>The normalized copy.</returns>
         public static Vector3 NormalizeFast(Vector3 vec)
         {
             var scale = MathHelper.InverseSqrtFast((vec.X * vec.X) + (vec.Y * vec.Y) + (vec.Z * vec.Z));

--- a/src/OpenTK.Mathematics/Vector/Vector3.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3.cs
@@ -112,7 +112,8 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Gets or sets the value at the index of the Vector.
         /// </summary>
-        /// <param name="index">The index.</param>
+        /// <param name="index">The index of the component from the Vector.</param>
+        /// <exception cref="IndexOutOfRangeException">Thrown if the index is less than 0 or greater than 2.</exception>
         public float this[int index]
         {
             get
@@ -188,7 +189,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Returns a copy of the Vector3 scaled to unit length.
         /// </summary>
-        /// <returns>The vector.</returns>
+        /// <returns>The normalized Vector3.</returns>
         public Vector3 Normalized()
         {
             var v = this;

--- a/src/OpenTK.Mathematics/Vector/Vector3d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3d.cs
@@ -186,7 +186,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Returns a copy of the Vector3d scaled to unit length.
         /// </summary>
-        /// <returns>The normalized vector.</returns>
+        /// <returns>The normalized copy.</returns>
         public Vector3d Normalized()
         {
             var v = this;
@@ -599,7 +599,7 @@ namespace OpenTK.Mathematics
         /// Scale a vector to unit length.
         /// </summary>
         /// <param name="vec">The input vector.</param>
-        /// <returns>The normalized vector.</returns>
+        /// <returns>The normalized copy.</returns>
         public static Vector3d Normalize(Vector3d vec)
         {
             var scale = 1.0 / vec.Length;
@@ -626,7 +626,7 @@ namespace OpenTK.Mathematics
         /// Scale a vector to approximately unit length.
         /// </summary>
         /// <param name="vec">The input vector.</param>
-        /// <returns>The normalized vector.</returns>
+        /// <returns>The normalized copy.</returns>
         public static Vector3d NormalizeFast(Vector3d vec)
         {
             var scale = MathHelper.InverseSqrtFast((vec.X * vec.X) + (vec.Y * vec.Y) + (vec.Z * vec.Z));

--- a/src/OpenTK.Mathematics/Vector/Vector3d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3d.cs
@@ -109,7 +109,8 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Gets or sets the value at the index of the Vector.
         /// </summary>
-        /// <param name="index">The index.</param>
+        /// <param name="index">The index of the component from the Vector.</param>
+        /// <exception cref="IndexOutOfRangeException">Thrown if the index is less than 0 or greater than 2.</exception>
         public double this[int index]
         {
             get
@@ -185,7 +186,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Returns a copy of the Vector3d scaled to unit length.
         /// </summary>
-        /// <returns>The vector.</returns>
+        /// <returns>The normalized vector.</returns>
         public Vector3d Normalized()
         {
             var v = this;

--- a/src/OpenTK.Mathematics/Vector/Vector4.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4.cs
@@ -260,7 +260,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Returns a copy of the Vector4 scaled to unit length.
         /// </summary>
-        /// <returns>The normalized vector.</returns>
+        /// <returns>The normalized copy.</returns>
         public Vector4 Normalized()
         {
             var v = this;
@@ -651,7 +651,7 @@ namespace OpenTK.Mathematics
         /// Scale a vector to unit length.
         /// </summary>
         /// <param name="vec">The input vector.</param>
-        /// <returns>The normalized vector.</returns>
+        /// <returns>The normalized copy.</returns>
         public static Vector4 Normalize(Vector4 vec)
         {
             var scale = 1.0f / vec.Length;
@@ -680,7 +680,7 @@ namespace OpenTK.Mathematics
         /// Scale a vector to approximately unit length.
         /// </summary>
         /// <param name="vec">The input vector.</param>
-        /// <returns>The normalized vector.</returns>
+        /// <returns>The normalized copy.</returns>
         public static Vector4 NormalizeFast(Vector4 vec)
         {
             var scale = MathHelper.InverseSqrtFast((vec.X * vec.X) + (vec.Y * vec.Y) + (vec.Z * vec.Z) + (vec.W * vec.W));
@@ -695,7 +695,7 @@ namespace OpenTK.Mathematics
         /// Scale a vector to approximately unit length.
         /// </summary>
         /// <param name="vec">The input vector.</param>
-        /// <param name="result">The normalized vector.</param>
+        /// <param name="result">The normalized copy.</param>
         public static void NormalizeFast(ref Vector4 vec, out Vector4 result)
         {
             var scale = MathHelper.InverseSqrtFast((vec.X * vec.X) + (vec.Y * vec.Y) + (vec.Z * vec.Z) + (vec.W * vec.W));

--- a/src/OpenTK.Mathematics/Vector/Vector4.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4.cs
@@ -174,7 +174,8 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Gets or sets the value at the index of the Vector.
         /// </summary>
-        /// <param name="index">The index.</param>
+        /// <param name="index">The index of the component from the Vector.</param>
+        /// <exception cref="IndexOutOfRangeException">Thrown if the index is less than 0 or greater than 3.</exception>
         public float this[int index]
         {
             get
@@ -259,7 +260,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Returns a copy of the Vector4 scaled to unit length.
         /// </summary>
-        /// <returns>The vector.</returns>
+        /// <returns>The normalized vector.</returns>
         public Vector4 Normalized()
         {
             var v = this;

--- a/src/OpenTK.Mathematics/Vector/Vector4d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4d.cs
@@ -171,7 +171,8 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Gets or sets the value at the index of the Vector.
         /// </summary>
-        /// <param name="index">The index.</param>
+        /// <param name="index">The index of the component from the Vector.</param>
+        /// <exception cref="IndexOutOfRangeException">Thrown if the index is less than 0 or greater than 3.</exception>
         public double this[int index]
         {
             get
@@ -255,7 +256,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Returns a copy of the Vector4d scaled to unit length.
         /// </summary>
-        /// <returns>The vector.</returns>
+        /// <returns>The normalized vector.</returns>
         public Vector4d Normalized()
         {
             var v = this;

--- a/src/OpenTK.Mathematics/Vector/Vector4d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4d.cs
@@ -256,7 +256,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Returns a copy of the Vector4d scaled to unit length.
         /// </summary>
-        /// <returns>The normalized vector.</returns>
+        /// <returns>The normalized copy.</returns>
         public Vector4d Normalized()
         {
             var v = this;
@@ -643,7 +643,7 @@ namespace OpenTK.Mathematics
         /// Scale a vector to unit length.
         /// </summary>
         /// <param name="vec">The input vector.</param>
-        /// <returns>The normalized vector.</returns>
+        /// <returns>The normalized copy.</returns>
         public static Vector4d Normalize(Vector4d vec)
         {
             var scale = 1.0 / vec.Length;
@@ -672,7 +672,7 @@ namespace OpenTK.Mathematics
         /// Scale a vector to approximately unit length.
         /// </summary>
         /// <param name="vec">The input vector.</param>
-        /// <returns>The normalized vector.</returns>
+        /// <returns>The normalized copy.</returns>
         public static Vector4d NormalizeFast(Vector4d vec)
         {
             var scale = MathHelper.InverseSqrtFast((vec.X * vec.X) + (vec.Y * vec.Y) + (vec.Z * vec.Z) + (vec.W * vec.W));

--- a/src/OpenTK.Mathematics/Vector/Vector4h.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4h.cs
@@ -129,7 +129,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector4h"/> struct.
         /// </summary>
-        /// <param name="v">The <see cref="Vector4"/> to convert.</param>
+        /// <param name="v">The vector.</param>
         public Vector4h(Vector4 v)
         {
             X = new Half(v.X);

--- a/src/OpenTK.Mathematics/Vector/Vector4h.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4h.cs
@@ -129,7 +129,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector4h"/> struct.
         /// </summary>
-        /// <param name="v">The vector.</param>
+        /// <param name="v">The <see cref="Vector4"/> to convert.</param>
         public Vector4h(Vector4 v)
         {
             X = new Half(v.X);

--- a/tests/OpenTK.Tests.Math/Helpers/QuaternionTestHelper.cs
+++ b/tests/OpenTK.Tests.Math/Helpers/QuaternionTestHelper.cs
@@ -14,8 +14,8 @@ namespace OpenTK.Tests.Math.Helpers
         /// false: When <paramref name="toTest" /> does contain xyz values, when it should be 0,
         /// or does not contain 0 when it should be
         /// </returns>
-        /// <param name="toTest">To test</param>
-        /// <param name="expected">Expected directions. Values getting only 0 checked</param>
+        /// <param name="toTest">To test.</param>
+        /// <param name="expected">Expected directions. Values getting only 0 checked.</param>>
         public static bool VerifyEqualSingleDirection(Vector3 toTest, Vector3 expected)
         {
             //To verify the direction of an vector, just respect the 0 values and check against these.

--- a/tests/OpenTK.Tests.Math/QuaternionTests.cs
+++ b/tests/OpenTK.Tests.Math/QuaternionTests.cs
@@ -15,8 +15,8 @@ namespace OpenTK.Tests.Math
             /// <summary>
             /// Checks if a single given value (either pitch, yaw or roll) get converted into correct x,y,z value of quaternion.
             /// </summary>
-            /// <param name="eulerValues">euler angle values</param>
-            /// <param name="expectedResult">expected xyz component of quaternion</param>
+            /// <param name="eulerValues">euler angle values.</param>
+            /// <param name="expectedResult">expected xyz component of quaternion.</param>
             [Theory]
             [MemberData(nameof(QuaternionTestDataGenerator.SingleAxisTestCases), MemberType =
                 typeof(QuaternionTestDataGenerator))]
@@ -35,8 +35,8 @@ namespace OpenTK.Tests.Math
             /// <summary>
             /// Checks if a single given value (either pitch, yaw or roll) get converted into correct x,y,z value of quaternion.
             /// </summary>
-            /// <param name="eulerValues">euler angle values</param>
-            /// <param name="expectedResult">expected xyz component of quaternion</param>
+            /// <param name="eulerValues">euler angle values.</param>
+            /// <param name="expectedResult">expected xyz component of quaternion.</param>
             [Theory]
             [MemberData(nameof(QuaternionTestDataGenerator.SingleAxisTestCases), MemberType =
                 typeof(QuaternionTestDataGenerator))]
@@ -63,8 +63,8 @@ namespace OpenTK.Tests.Math
             /// <summary>
             /// Checks if a single given value (either pitch, yaw or roll) get converted into correct x,y,z value of quaternion.
             /// </summary>
-            /// <param name="eulerValues">euler angle values</param>
-            /// <param name="expectedResult">expected xyz component of quaternion</param>
+            /// <param name="eulerValues">euler angle values.</param>
+            /// <param name="expectedResult">expected xyz component of quaternion.</param>
             [Theory]
             [MemberData(nameof(QuaternionTestDataGenerator.SingleAxisTestCases), MemberType =
                 typeof(QuaternionTestDataGenerator))]
@@ -83,8 +83,8 @@ namespace OpenTK.Tests.Math
             /// <summary>
             /// Checks if a single given value (either pitch, yaw or roll) get converted into correct x,y,z value of quaternion.
             /// </summary>
-            /// <param name="eulerValues">euler angle values</param>
-            /// <param name="expectedResult">expected xyz component of quaternion</param>
+            /// <param name="eulerValues">euler angle values.</param>
+            /// <param name="expectedResult">expected xyz component of quaternion.</param>
             [Theory]
             [MemberData(nameof(QuaternionTestDataGenerator.SingleAxisTestCases), MemberType =
                 typeof(QuaternionTestDataGenerator))]
@@ -103,8 +103,8 @@ namespace OpenTK.Tests.Math
             /// <summary>
             /// Checks if a single given value (either pitch, yaw or roll) get converted into correct x,y,z value of quaternion.
             /// </summary>
-            /// <param name="eulerValues">euler angle values</param>
-            /// <param name="expectedResult">expected xyz component of quaternion</param>
+            /// <param name="eulerValues">euler angle values.</param>
+            /// <param name="expectedResult">expected xyz component of quaternion.</param>
             [Theory]
             [MemberData(nameof(QuaternionTestDataGenerator.SingleAxisTestCases), MemberType =
                 typeof(QuaternionTestDataGenerator))]
@@ -133,7 +133,7 @@ namespace OpenTK.Tests.Math
             /// <summary>
             /// Check if a quaternion returns a a rotation about the correct coordinate axis
             /// </summary>
-            /// <param name="cut">Prepared Quaternion</param>
+            /// <param name="cut">Prepared Quaternion.</param>
             /// <param name="expectedResult">Expected result.</param>
             [Theory]
             [MemberData(nameof(QuaternionTestDataGenerator.ToAxisAngleTestCases), MemberType =


### PR DESCRIPTION
### Purpose of this PR

* stylecop.props import readded to .Math and fixed all stylecop errors
* fixed some xml comment inconsistencies
* fixed missing file documentation at top of file(in .Core/Utility/BlittableValueType{T}.cs)

### Testing status
Well it does build and it shouldn't have any major implementation changes.

### Comments
fixed some stuff of https://github.com/opentk/opentk/pull/802 and now in a feature branch. I hope the simple naming is enough.
I did not reorder static variables, because there still seems to be a discussion about that.
