### PR TITLE
[4.0] Add StructLayout to Color4

### DIFF
--- a/src/OpenTK.Mathematics/Data/Color4.cs
+++ b/src/OpenTK.Mathematics/Data/Color4.cs
@@ -25,6 +25,7 @@
 
 using System;
 using System.Drawing;
+using System.Runtime.InteropServices;
 
 namespace OpenTK.Mathematics
 {
@@ -32,6 +33,7 @@ namespace OpenTK.Mathematics
     /// Represents a color with 4 floating-point components (R, G, B, A).
     /// </summary>
     [Serializable]
+    [StructLayout(LayoutKind.Sequential)]
     public struct Color4 : IEquatable<Color4>
     {
         /// <summary>


### PR DESCRIPTION
Add StructLayout to Color4, as mentioned in #833. This should make the class safe to pass to native functions.