### PR TITLE
[4.0] Impliment Vectord * Quaterniond

### DIFF
--- a/src/OpenTK.Mathematics/Vector/Vector2d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2d.cs
@@ -814,6 +814,18 @@ namespace OpenToolkit.Mathematics
         }
 
         /// <summary>
+        /// Transforms a vector by a quaternion rotation.
+        /// </summary>
+        /// <param name="quat">The quaternion to rotate the vector by.</param>
+        /// <param name="vec">The vector to transform.</param>
+        /// <returns>The transformed vector.</returns>
+        public static Vector2d operator *(Quaterniond quat, Vector2d vec)
+        {
+            Transform(ref vec, ref quat, out Vector2d result);
+            return result;
+        }
+
+        /// <summary>
         /// Divides an instance by a scalar.
         /// </summary>
         /// <param name="vec">The instance.</param>

--- a/src/OpenTK.Mathematics/Vector/Vector3d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3d.cs
@@ -1286,6 +1286,18 @@ namespace OpenToolkit.Mathematics
         }
 
         /// <summary>
+        /// Transforms a vector by a quaternion rotation.
+        /// </summary>
+        /// <param name="quat">The quaternion to rotate the vector by.</param>
+        /// <param name="vec">The vector to transform.</param>
+        /// <returns>The transformed vector.</returns>
+        public static Vector3d operator *(Quaterniond quat, Vector3d vec)
+        {
+            Transform(ref vec, ref quat, out Vector3d result);
+            return result;
+        }
+
+        /// <summary>
         /// Divides an instance by a scalar.
         /// </summary>
         /// <param name="vec">The instance.</param>

--- a/src/OpenTK.Mathematics/Vector/Vector4d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4d.cs
@@ -1907,6 +1907,18 @@ namespace OpenToolkit.Mathematics
         }
 
         /// <summary>
+        /// Transforms a vector by a quaternion rotation.
+        /// </summary>
+        /// <param name="quat">The quaternion to rotate the vector by.</param>
+        /// <param name="vec">The vector to transform.</param>
+        /// <returns>The transformed vector.</returns>
+        public static Vector4d operator *(Quaterniond quat, Vector4d vec)
+        {
+            Transform(ref vec, ref quat, out Vector4d result);
+            return result;
+        }
+
+        /// <summary>
         /// Divides an instance by a scalar.
         /// </summary>
         /// <param name="vec">The instance.</param>


### PR DESCRIPTION
Vector4 and Quaternion can be multiplied, but the double-precision equivalents can't. This just impliments the * operator for Vector4d and Quaterniond. Closes #678.