### PR TITLE
[OpenTK.NT] Remove type aliases

### DIFF
--- a/src/OpenTK.NT/Native/Gdi32/Enums/PixelFormatDescriptorFlags.cs
+++ b/src/OpenTK.NT/Native/Gdi32/Enums/PixelFormatDescriptorFlags.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 
-using DWORD = System.UInt32;
-
 namespace OpenToolkit.NT.Native
 {
     /// <summary>
@@ -9,7 +7,7 @@ namespace OpenToolkit.NT.Native
     /// not mutually exclusive; you can set any combination of bit flags, with the exceptions noted.
     /// </summary>
     [Flags]
-    public enum PixelFormatDescriptorFlags : DWORD
+    public enum PixelFormatDescriptorFlags : uint
     {
         /// <summary>
         /// The buffer is double-buffered. This flag and <see cref="SupportGdi"/> are mutually exclusive

--- a/src/OpenTK.NT/Native/Gdi32/Enums/PixelFormatDescriptorLayerTypes.cs
+++ b/src/OpenTK.NT/Native/Gdi32/Enums/PixelFormatDescriptorLayerTypes.cs
@@ -1,12 +1,10 @@
-﻿using BYTE = System.Byte;
-
-namespace OpenToolkit.NT.Native
+﻿namespace OpenToolkit.NT.Native
 {
     /// <summary>
     /// Specifies a layer type for a <see cref="PixelFormatDescriptor"/>.<para/>
     /// This official documentation states that this type is ignored by OpenGL, so use with care.
     /// </summary>
-    public enum PixelFormatDescriptorLayerTypes : BYTE
+    public enum PixelFormatDescriptorLayerTypes : byte
     {
         /// <summary>
         /// Undocumented member.
@@ -21,6 +19,6 @@ namespace OpenToolkit.NT.Native
         /// <summary>
         /// Undocumented member.
         /// </summary>
-        UnderlayPlane = unchecked((BYTE)(-1))
+        UnderlayPlane = unchecked((byte)(-1))
     }
 }

--- a/src/OpenTK.NT/Native/Gdi32/Enums/PixelFormatDescriptorPixelTypes.cs
+++ b/src/OpenTK.NT/Native/Gdi32/Enums/PixelFormatDescriptorPixelTypes.cs
@@ -1,11 +1,9 @@
-﻿using BYTE = System.Byte;
-
-namespace OpenToolkit.NT.Native
+﻿namespace OpenToolkit.NT.Native
 {
     /// <summary>
     /// Specifies the type of pixel data.
     /// </summary>
-    public enum PixelFormatDescriptorPixelTypes : BYTE
+    public enum PixelFormatDescriptorPixelTypes : byte
     {
         /// <summary>
         /// RGBA pixels. Each pixel has four components in this order: red, green, blue, and alpha.

--- a/src/OpenTK.NT/Native/Gdi32/Gdi32.cs
+++ b/src/OpenTK.NT/Native/Gdi32/Gdi32.cs
@@ -1,10 +1,6 @@
-﻿using System.Runtime.InteropServices;
+﻿using System;
+using System.Runtime.InteropServices;
 using System.Security;
-
-using BOOL = System.Boolean;
-using HDC = System.IntPtr;
-using HGDIOBJ = System.IntPtr;
-using UINT = System.UInt32;
 
 namespace OpenToolkit.NT.Native
 {
@@ -36,7 +32,7 @@ namespace OpenToolkit.NT.Native
         /// call <see cref="Marshal.GetLastWin32Error"/>.
         /// </returns>
         [DllImport(Library, SetLastError = true)]
-        public static extern int ChoosePixelFormat(HDC hdc, ref PixelFormatDescriptor ppfd);
+        public static extern int ChoosePixelFormat(IntPtr hdc, ref PixelFormatDescriptor ppfd);
 
         /// <summary>
         /// Obtains information about the pixel format identified by <paramref name="pixelFormatIndex"/> of the device
@@ -51,7 +47,7 @@ namespace OpenToolkit.NT.Native
         /// </param>
         /// <param name="descriptorSize">
         /// The size, in bytes, of the structure pointed to by <paramref name="ppfd"/>. The
-        /// <see cref="DescribePixelFormat(HDC, int, UINT, ref PixelFormatDescriptor)"/> function stores no more than
+        /// <see cref="DescribePixelFormat(IntPtr, int, uint, ref PixelFormatDescriptor)"/> function stores no more than
         /// <paramref name="descriptorSize"/> bytes of data to that structure.
         /// Set this value to <see cref="PixelFormatDescriptor.SizeInBytes"/>.
         /// </param>
@@ -72,9 +68,9 @@ namespace OpenToolkit.NT.Native
         [DllImport(Library, SetLastError = true)]
         public static extern int DescribePixelFormat
         (
-            HDC hdc,
+            IntPtr hdc,
             int pixelFormatIndex,
-            UINT descriptorSize,
+            uint descriptorSize,
             ref PixelFormatDescriptor ppfd
         );
 
@@ -91,7 +87,7 @@ namespace OpenToolkit.NT.Native
         /// Pointer to a <see cref="PixelFormatDescriptor"/> structure that contains the logical pixel format
         /// specification. The system's metafile component uses this structure to record the logical pixel
         /// format specification. The structure has no other effect upon the behavior of the
-        /// <see cref="SetPixelFormat(HDC, int, ref PixelFormatDescriptor)"/> function.
+        /// <see cref="SetPixelFormat(IntPtr, int, ref PixelFormatDescriptor)"/> function.
         /// </param>
         /// <returns>
         /// If the function succeeds, the return value is true.<para/>
@@ -100,9 +96,9 @@ namespace OpenToolkit.NT.Native
         /// </returns>
         [DllImport(Library, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
-        public static extern BOOL SetPixelFormat
+        public static extern bool SetPixelFormat
         (
-            HDC hdc,
+            IntPtr hdc,
             int pixelFormatIndex,
             ref PixelFormatDescriptor ppfd
         );
@@ -120,7 +116,7 @@ namespace OpenToolkit.NT.Native
         [SuppressUnmanagedCodeSecurity]
         [DllImport(Library, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
-        public static extern BOOL SwapBuffers(HDC hdc);
+        public static extern bool SwapBuffers(IntPtr hdc);
 
         /// <summary>
         /// Retrieves device-specific information for the specified device.
@@ -133,7 +129,7 @@ namespace OpenToolkit.NT.Native
         /// has 15bpp or 16bpp, the return value is 16.
         /// </returns>
         [DllImport(Library)]
-        public static extern int GetDeviceCaps([In] HDC hdc, [In] GetDeviceCapsIndex capIndex);
+        public static extern int GetDeviceCaps([In] IntPtr hdc, [In] GetDeviceCapsIndex capIndex);
 
         /// <summary>
         /// Retrieves a handle to one of the stock pens, brushes, fonts, or palettes.
@@ -144,7 +140,7 @@ namespace OpenToolkit.NT.Native
         /// If the function fails, the return value is null.
         /// </returns>
         [DllImport(Library)]
-        public static extern HGDIOBJ GetStockObject(GetStockObjectType objectType);
+        public static extern IntPtr GetStockObject(GetStockObjectType objectType);
 
         /// <summary>
         /// Deletes a logical pen, brush, font, bitmap, region, or palette, freeing all system resources associated
@@ -162,6 +158,6 @@ namespace OpenToolkit.NT.Native
         /// </remarks>
         [DllImport(Library)]
         [return: MarshalAs(UnmanagedType.Bool)]
-        public static extern BOOL DeleteObject([In] HGDIOBJ obj);
+        public static extern bool DeleteObject([In] IntPtr obj);
     }
 }

--- a/src/OpenTK.NT/Native/Gdi32/Structs/PixelFormatDescriptor.cs
+++ b/src/OpenTK.NT/Native/Gdi32/Structs/PixelFormatDescriptor.cs
@@ -1,9 +1,5 @@
 ﻿using System.Runtime.InteropServices;
 
-using BYTE = System.Byte;
-using DWORD= System.UInt32;
-using WORD = System.UInt16;
-
 namespace OpenToolkit.NT.Native
 {
     /// <summary>
@@ -20,12 +16,12 @@ namespace OpenToolkit.NT.Native
         /// <summary>
         /// Specifies the size of this data structure. This value should be set to <see cref="SizeInBytes"/>.
         /// </summary>
-        public WORD Size;
+        public ushort Size;
 
         /// <summary>
         /// Specifies the version of this data structure. This value should be set to 1.
         /// </summary>
-        public WORD Version;
+        public ushort Version;
 
         /// <summary>
         /// A set of bit flags that specify properties of the pixel buffer. The properties are generally
@@ -45,87 +41,87 @@ namespace OpenToolkit.NT.Native
         /// color buffer, excluding the alpha bitplanes.
         /// For color-index pixels, it is the size of the color-index buffer.
         /// </summary>
-        public BYTE ColorBits;
+        public byte ColorBits;
 
         /// <summary>
         /// Specifies the number of red bitplanes in each RGBA color buffer.
         /// </summary>
-        public BYTE RedBits;
+        public byte RedBits;
 
         /// <summary>
         /// Specifies the shift count for red bitplanes in each RGBA color buffer.
         /// </summary>
-        public BYTE RedShift;
+        public byte RedShift;
 
         /// <summary>
         /// Specifies the number of green bitplanes in each RGBA color buffer.
         /// </summary>
-        public BYTE GreenBits;
+        public byte GreenBits;
 
         /// <summary>
         /// Specifies the shift count for green bitplanes in each RGBA color buffer.
         /// </summary>
-        public BYTE GreenShift;
+        public byte GreenShift;
 
         /// <summary>
         /// Specifies the number of blue bitplanes in each RGBA color buffer.
         /// </summary>
-        public BYTE BlueBits;
+        public byte BlueBits;
 
         /// <summary>
         /// Specifies the shift count for blue bitplanes in each RGBA color buffer.
         /// </summary>
-        public BYTE BlueShift;
+        public byte BlueShift;
 
         /// <summary>
         /// Specifies the number of alpha bitplanes in each RGBA color buffer. Alpha bitplanes are not supported.
         /// </summary>
-        public BYTE AlphaBits;
+        public byte AlphaBits;
 
         /// <summary>
         /// Specifies the shift count for alpha bitplanes in each RGBA color buffer. Alpha bitplanes are not supported.
         /// </summary>
-        public BYTE AlphaShift;
+        public byte AlphaShift;
 
         /// <summary>
         /// Specifies the total number of bitplanes in the accumulation buffer.
         /// </summary>
-        public BYTE AccumBits;
+        public byte AccumBits;
 
         /// <summary>
         /// Specifies the number of red bitplanes in the accumulation buffer.
         /// </summary>
-        public BYTE AccumRedBits;
+        public byte AccumRedBits;
 
         /// <summary>
         /// Specifies the number of green bitplanes in the accumulation buffer.
         /// </summary>
-        public BYTE AccumGreenBits;
+        public byte AccumGreenBits;
 
         /// <summary>
         /// Specifies the number of blue bitplanes in the accumulation buffer.
         /// </summary>
-        public BYTE AccumBlueBits;
+        public byte AccumBlueBits;
 
         /// <summary>
         /// Specifies the number of alpha bitplanes in the accumulation buffer.
         /// </summary>
-        public BYTE AccumAlphaBits;
+        public byte AccumAlphaBits;
 
         /// <summary>
         /// Specifies the depth of the depth (z-axis) buffer.
         /// </summary>
-        public BYTE DepthBits;
+        public byte DepthBits;
 
         /// <summary>
         /// Specifies the depth of the stencil buffer.
         /// </summary>
-        public BYTE StencilBits;
+        public byte StencilBits;
 
         /// <summary>
         /// Specifies the number of auxiliary buffers. Auxiliary buffers are not supported.
         /// </summary>
-        public BYTE AuxBuffers;
+        public byte AuxBuffers;
 
         /// <summary>
         /// Ignored. Earlier implementations of OpenGL used this member, but it is no longer used.
@@ -136,24 +132,24 @@ namespace OpenToolkit.NT.Native
         /// Specifies the number of overlay and underlay planes. Bits 0 through 3 specify up to 15 overlay planes
         /// and bits 4 through 7 specify up to 15 underlay planes.
         /// </summary>
-        public BYTE Reserved;
+        public byte Reserved;
 
         /// <summary>
         /// Ignored. Earlier implementations of OpenGL used this member, but it is no longer used.
         /// </summary>
-        public DWORD LayerMask;
+        public uint LayerMask;
 
         /// <summary>
         /// Specifies the transparent color or index of an underlay plane. When the pixel type is RGBA,
         /// <see cref="VisibleMask"/> is a transparent RGB color value. When the pixel type is color index,
         /// it is a transparent index value.
         /// </summary>
-        public DWORD VisibleMask;
+        public uint VisibleMask;
 
         /// <summary>
         /// Ignored. Earlier implementations of OpenGL used this member, but it is no longer used.
         /// </summary>
-        public DWORD DamageMask;
+        public uint DamageMask;
 
         /// <summary>
         /// The size of this structure in bytes.

--- a/src/OpenTK.NT/Native/Kernel32/Kernel32.cs
+++ b/src/OpenTK.NT/Native/Kernel32/Kernel32.cs
@@ -2,14 +2,6 @@
 using System.Runtime.InteropServices;
 using System.Security;
 
-using BOOL = System.Boolean;
-using DWORD = System.UInt32;
-using FARPROC = System.IntPtr;
-using HMODULE = System.IntPtr;
-using LARGE_INTEGER = System.Int64;
-using LPCSTR = System.String;
-using LPCTSTR = System.String;
-
 namespace OpenToolkit.NT.Native
 {
     /// <summary>
@@ -41,7 +33,7 @@ namespace OpenToolkit.NT.Native
         [SuppressUnmanagedCodeSecurity]
         [DllImport(Library, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
-        public static extern BOOL QueryPerformanceFrequency([Out] out LARGE_INTEGER frequency);
+        public static extern bool QueryPerformanceFrequency([Out] out long frequency);
 
         /// <summary>
         /// Retrieves the current value of the performance counter, which is a high resolution (&lt;1us) time stamp
@@ -59,7 +51,7 @@ namespace OpenToolkit.NT.Native
         [SuppressUnmanagedCodeSecurity]
         [DllImport(Library, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
-        public static extern BOOL QueryPerformanceCounter([Out] out LARGE_INTEGER performanceCount);
+        public static extern bool QueryPerformanceCounter([Out] out long performanceCount);
 
         /// <summary>
         /// Retrieves the address of an exported function or variable from the specified dynamic-link library (DLL).
@@ -75,14 +67,14 @@ namespace OpenToolkit.NT.Native
         /// To get extended error information, call <see cref="Marshal.GetLastWin32Error"/>.
         /// </returns>
         [DllImport(Library, SetLastError = true, CharSet = CharSet.Unicode)]
-        public static extern FARPROC GetProcAddress([In] HMODULE module, [In] LPCSTR procName);
+        public static extern IntPtr GetProcAddress([In] IntPtr module, [In] string procName);
 
         /// <summary>
         /// Retrieves the address of an exported function or variable from the specified dynamic-link library (DLL).
         /// </summary>
         /// <param name="module">
-        /// A handle to the DLL module that contains the function or variable. The <see cref="LoadLibrary(LPCSTR)"/>,
-        /// LoadLibraryEx, LoadPackagedLibrary, or <see cref="GetModuleHandle(LPCSTR)"/> functions return this handle.
+        /// A handle to the DLL module that contains the function or variable. The <see cref="LoadLibrary(string)"/>,
+        /// LoadLibraryEx, LoadPackagedLibrary, or <see cref="GetModuleHandle(string)"/> functions return this handle.
         /// </param>
         /// <param name="procName">
         /// The function's ordinal value. It must be in the low-order word; the high-order word must be zero.
@@ -93,14 +85,14 @@ namespace OpenToolkit.NT.Native
         /// To get extended error information, call <see cref="Marshal.GetLastWin32Error"/>.
         /// </returns>
         [DllImport(Library, SetLastError = true, CharSet = CharSet.Unicode)]
-        public static extern FARPROC GetProcAddress([In] HMODULE module, [In] IntPtr procName);
+        public static extern IntPtr GetProcAddress([In] IntPtr module, [In] IntPtr procName);
 
         /// <summary>
         /// Sets the last-error code for the calling thread.
         /// </summary>
         /// <param name="errorCode">The last-error code for the thread.</param>
         [DllImport(Library)]
-        public static extern void SetLastError(DWORD errorCode);
+        public static extern void SetLastError(uint errorCode);
 
         /// <summary>
         /// Retrieves a module handle for the specified module.
@@ -113,7 +105,7 @@ namespace OpenToolkit.NT.Native
         /// specifying a path, be sure to use backslashes (\), not forward slashes (/). The name is compared (case
         /// independently) to the names of modules currently mapped into the address space of the calling process.
         /// <para/>
-        /// If this parameter is null, <see cref="GetModuleHandle(LPCSTR)"/> returns a handle to the file used to
+        /// If this parameter is null, <see cref="GetModuleHandle(string)"/> returns a handle to the file used to
         /// create the calling process (.exe file).
         /// </param>
         /// <returns>
@@ -122,7 +114,7 @@ namespace OpenToolkit.NT.Native
         /// To get extended error information, call <see cref="Marshal.GetLastWin32Error"/>.
         /// </returns>
         [DllImport(Library, SetLastError = true)]
-        public static extern HMODULE GetModuleHandle([In] [Optional] LPCTSTR moduleName);
+        public static extern IntPtr GetModuleHandle([In] [Optional] string moduleName);
 
         /// <summary>
         /// Loads the specified module into the address space of the calling process.
@@ -147,7 +139,7 @@ namespace OpenToolkit.NT.Native
         /// To get extended error information, call <see cref="Marshal.GetLastWin32Error"/>.
         /// </returns>
         [DllImport(Library, SetLastError = true)]
-        public static extern HMODULE LoadLibrary([In] LPCTSTR fileName);
+        public static extern IntPtr LoadLibrary([In] string fileName);
 
         /// <summary>
         /// Frees the loaded dynamic-link library (DLL) module and, if necessary, decrements its reference count.
@@ -155,8 +147,8 @@ namespace OpenToolkit.NT.Native
         /// process and the handle is no longer valid.
         /// </summary>
         /// <param name="module">
-        /// A handle to the loaded library module. The <see cref="LoadLibrary(LPCSTR)"/>, LoadLibraryEx,
-        /// <see cref="GetModuleHandle(LPCSTR)"/>, or GetModuleHandleEx functions return this handle.
+        /// A handle to the loaded library module. The <see cref="LoadLibrary(string)"/>, LoadLibraryEx,
+        /// <see cref="GetModuleHandle(string)"/>, or GetModuleHandleEx functions return this handle.
         /// </param>
         /// <returns>
         /// If the function succeeds, the return value is true.<para/>
@@ -165,6 +157,6 @@ namespace OpenToolkit.NT.Native
         /// </returns>
         [DllImport(Library)]
         [return: MarshalAs(UnmanagedType.Bool)]
-        public static extern BOOL FreeLibrary([In] HMODULE module);
+        public static extern bool FreeLibrary([In] IntPtr module);
     }
 }

--- a/src/OpenTK.NT/Native/Shell32/Enums/FileAttributeFlags.cs
+++ b/src/OpenTK.NT/Native/Shell32/Enums/FileAttributeFlags.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 
-using DWORD = System.UInt32;
-
 namespace OpenToolkit.NT.Native
 {
     /// <summary>
@@ -9,7 +7,7 @@ namespace OpenToolkit.NT.Native
     /// via various file I/O APIs.
     /// </summary>
     [Flags]
-    public enum FileAttributeFlags : DWORD
+    public enum FileAttributeFlags : uint
     {
         /// <summary>
         /// A file that is read-only. Applications can read the file, but cannot write to it or delete it.

--- a/src/OpenTK.NT/Native/Shell32/Enums/ShGetFileInfoFlags.cs
+++ b/src/OpenTK.NT/Native/Shell32/Enums/ShGetFileInfoFlags.cs
@@ -1,16 +1,14 @@
 ﻿using System;
 
-using UINT = System.UInt32;
-
 namespace OpenToolkit.NT.Native
 {
     /// <summary>
     /// Used in
-    /// <see cref="Shell32.SHGetFileInfo(string, FileAttributeFlags, ref SHFileInfo, UINT, ShGetFileInfoFlags)"/> to
+    /// <see cref="Shell32.SHGetFileInfo(string, FileAttributeFlags, ref SHFileInfo, uint, ShGetFileInfoFlags)"/> to
     /// specify the type of file information to retrieve.
     /// </summary>
     [Flags]
-    public enum ShGetFileInfoFlags : UINT
+    public enum ShGetFileInfoFlags : uint
     {
         /// <summary>
         /// Modify <see cref="Icon"/>, causing the function to retrieve the file's large icon.

--- a/src/OpenTK.NT/Native/Shell32/Shell32.cs
+++ b/src/OpenTK.NT/Native/Shell32/Shell32.cs
@@ -1,13 +1,6 @@
-﻿using System.Runtime.InteropServices;
-
-using BOOL = System.Boolean;
-using DWORD = System.UInt32;
-using DWORD_PTR = System.IntPtr;
-using HDROP = System.IntPtr;
-using HWND = System.IntPtr;
-using LPCTSTR = System.String;
-using LPTSTR = System.Text.StringBuilder;
-using UINT = System.UInt32;
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Text;
 
 namespace OpenToolkit.NT.Native
 {
@@ -37,7 +30,7 @@ namespace OpenToolkit.NT.Native
         /// files. This value is true to accept dropped files or false to discontinue accepting dropped files.
         /// </param>
         [DllImport(Library)]
-        public static extern void DragAcceptFiles(HWND window, BOOL accept);
+        public static extern void DragAcceptFiles(IntPtr window, bool accept);
 
         /// <summary>
         /// Retrieves the names of dropped files that result from a successful drag-and-drop operation.
@@ -45,15 +38,15 @@ namespace OpenToolkit.NT.Native
         /// <param name="drop">Identifier of the structure that contains the file names of the dropped files.</param>
         /// <param name="fileIndex">
         /// Index of the file to query. If the value of this parameter is 0xFFFFFFFF,
-        /// <see cref="DragQueryFile(DWORD_PTR, DWORD, LPTSTR, DWORD)"/> returns a count of the files dropped.
+        /// <see cref="DragQueryFile(IntPtr, uint, StringBuilder, uint)"/> returns a count of the files dropped.
         /// If the value of this parameter is between zero and the total number of files dropped,
-        /// <see cref="DragQueryFile(DWORD_PTR, DWORD, LPTSTR, DWORD)"/> copies the file name with the corresponding
+        /// <see cref="DragQueryFile(IntPtr, uint, StringBuilder, uint)"/> copies the file name with the corresponding
         /// value to the buffer pointed to by the <paramref name="lpszFile"/> parameter.
         /// </param>
         /// <param name="lpszFile">
         /// The address of a buffer that receives the file name of a dropped file when the function returns. This
         /// file name is a null-terminated string. If this parameter is null,
-        /// <see cref="DragQueryFile(DWORD_PTR, DWORD, LPTSTR, DWORD)"/> returns the required size, in characters,
+        /// <see cref="DragQueryFile(IntPtr, uint, StringBuilder, uint)"/> returns the required size, in characters,
         /// of this buffer.
         /// </param>
         /// <param name="cch">The size, in characters, of the <paramref name="lpszFile"/> buffer.</param>
@@ -68,12 +61,12 @@ namespace OpenToolkit.NT.Native
         /// null character.
         /// </returns>
         [DllImport(Library, CharSet = CharSet.Unicode)]
-        public static extern UINT DragQueryFile
+        public static extern uint DragQueryFile
         (
-            [In] HDROP drop,
-            [In] UINT fileIndex,
-            [Out] LPTSTR lpszFile,
-            UINT cch
+            [In] IntPtr drop,
+            [In] uint fileIndex,
+            [Out] StringBuilder lpszFile,
+            uint cch
         );
 
         /// <summary>
@@ -84,7 +77,7 @@ namespace OpenToolkit.NT.Native
         /// parameter of the <see cref="WindowMessage.DropFiles"/> message.
         /// </param>
         [DllImport(Library)]
-        public static extern void DragFinish(HDROP drop);
+        public static extern void DragFinish(IntPtr drop);
 
         /// <summary>
         /// Retrieves information about an object in the file system, such as a file, folder, directory, or drive root.
@@ -115,12 +108,12 @@ namespace OpenToolkit.NT.Native
         /// specifies the type of the executable file. Check the windows API documentation for more information.
         /// </returns>
         [DllImport(Library)]
-        public static extern DWORD_PTR SHGetFileInfo
+        public static extern IntPtr SHGetFileInfo
         (
-            [In] LPCTSTR pszPath,
+            [In] string pszPath,
             FileAttributeFlags fileAttributes,
             [In] [Out] ref SHFileInfo psfi,
-            UINT fileInfo,
+            uint fileInfo,
             ShGetFileInfoFlags flags
         );
     }

--- a/src/OpenTK.NT/Native/Shell32/Structs/SHFileInfo.cs
+++ b/src/OpenTK.NT/Native/Shell32/Structs/SHFileInfo.cs
@@ -1,8 +1,5 @@
-﻿using System.Runtime.InteropServices;
-
-using DWORD = System.UInt32;
-using HICON = System.IntPtr;
-using TCHAR = System.String;
+﻿using System;
+using System.Runtime.InteropServices;
 
 namespace OpenToolkit.NT.Native
 {
@@ -14,9 +11,9 @@ namespace OpenToolkit.NT.Native
     {
         /// <summary>
         /// A handle to the icon that represents the file. You are responsible for destroying this handle with
-        /// <see cref="User32.Icon.DestroyIcon(HICON)"/> when you no longer need it.
+        /// <see cref="User32.Icon.DestroyIcon(IntPtr)"/> when you no longer need it.
         /// </summary>
-        public HICON Icon;
+        public IntPtr Icon;
 
         /// <summary>
         /// The index of the icon image within the system image list.
@@ -27,20 +24,20 @@ namespace OpenToolkit.NT.Native
         /// An array of values that indicates the attributes of the file object. For information about these values,
         /// see the IShellFolder::GetAttributesOf method.
         /// </summary>
-        public DWORD Attributes;
+        public uint Attributes;
 
         /// <summary>
         /// A string that contains the name of the file as it appears in the Windows Shell, or the path and file
         /// name of the file that contains the icon representing the file.
         /// </summary>
         [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 260)]
-        public TCHAR DisplayName;
+        public string DisplayName;
 
         /// <summary>
         /// A string that describes the type of file.
         /// </summary>
         [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 80)]
-        public TCHAR TypeName;
+        public string TypeName;
 
         /// <summary>
         /// The size of this structure in bytes.

--- a/src/OpenTK.NT/Native/User32/Cursor.cs
+++ b/src/OpenTK.NT/Native/User32/Cursor.cs
@@ -2,10 +2,6 @@
 using System.Runtime.InteropServices;
 using System.Security;
 
-using BOOL = System.Boolean;
-using HCURSOR = System.IntPtr;
-using HINSTANCE = System.IntPtr;
-
 namespace OpenToolkit.NT.Native
 {
     public static partial class User32
@@ -25,7 +21,7 @@ namespace OpenToolkit.NT.Native
             /// If the function fails, the return value is <see cref="IntPtr.Zero"/>.
             /// To get extended error information, call <see cref="Marshal.GetLastWin32Error"/>.
             /// </returns>
-            public static HCURSOR LoadCursor(CursorName cursorName)
+            public static IntPtr LoadCursor(CursorName cursorName)
                 => LoadCursor(IntPtr.Zero, (int)cursorName);
 
             /// <summary>
@@ -42,9 +38,9 @@ namespace OpenToolkit.NT.Native
             /// To get extended error information, call <see cref="Marshal.GetLastWin32Error"/>.
             /// </returns>
             [DllImport(Library, SetLastError = true, CharSet = CharSet.Unicode)]
-            public static extern HCURSOR LoadCursor
+            public static extern IntPtr LoadCursor
             (
-                [In] HINSTANCE moduleInstance,
+                [In] IntPtr moduleInstance,
                 [In] string cursorName
             );
 
@@ -61,9 +57,9 @@ namespace OpenToolkit.NT.Native
             /// To get extended error information, call <see cref="Marshal.GetLastWin32Error"/>.
             /// </returns>
             [DllImport(Library, SetLastError = true)]
-            private static extern HCURSOR LoadCursor
+            private static extern IntPtr LoadCursor
             (
-                [In] [Optional] HINSTANCE moduleInstance,
+                [In] [Optional] IntPtr moduleInstance,
                 [In] int cursorIdentifier
             );
 
@@ -84,7 +80,7 @@ namespace OpenToolkit.NT.Native
             /// </returns>
             [DllImport(Library, SetLastError = true)]
             [return: MarshalAs(UnmanagedType.Bool)]
-            public static extern BOOL ClipCursor([In] [Optional] ref Rect rect);
+            public static extern bool ClipCursor([In] [Optional] ref Rect rect);
 
             /// <summary>
             /// Confines the cursor to a rectangular area on the screen. If a subsequent cursor position
@@ -103,7 +99,7 @@ namespace OpenToolkit.NT.Native
             /// </returns>
             [DllImport(Library, SetLastError = true)]
             [return: MarshalAs(UnmanagedType.Bool)]
-            public static extern BOOL ClipCursor([In] [Optional] IntPtr rect);
+            public static extern bool ClipCursor([In] [Optional] IntPtr rect);
 
             /// <summary>
             /// Displays or hides the cursor.
@@ -113,7 +109,7 @@ namespace OpenToolkit.NT.Native
             /// </param>
             /// <returns>The return value specifies the new display counter.</returns>
             [DllImport(Library)]
-            public static extern int ShowCursor([In] BOOL show);
+            public static extern int ShowCursor([In] bool show);
 
             /// <summary>
             /// Retrieves the cursor's position, in screen coordinates.
@@ -128,7 +124,7 @@ namespace OpenToolkit.NT.Native
             [DllImport(Library, SetLastError = true)]
             [SuppressUnmanagedCodeSecurity]
             [return: MarshalAs(UnmanagedType.Bool)]
-            public static extern BOOL GetCursorPos([Out] out Point point);
+            public static extern bool GetCursorPos([Out] out Point point);
 
             /// <summary>
             /// Moves the cursor to the specified screen coordinates. If the new coordinates are not within the
@@ -143,7 +139,7 @@ namespace OpenToolkit.NT.Native
             /// </returns>
             [DllImport(Library, SetLastError = true)]
             [return: MarshalAs(UnmanagedType.Bool)]
-            public static extern BOOL SetCursorPos([In] int x, [In] int y);
+            public static extern bool SetCursorPos([In] int x, [In] int y);
 
             /// <summary>
             /// Retrieves a handle to the current cursor.
@@ -153,14 +149,14 @@ namespace OpenToolkit.NT.Native
             /// no cursor, the return value is null.
             /// </returns>
             [DllImport(Library)]
-            public static extern HCURSOR GetCursor();
+            public static extern IntPtr GetCursor();
 
             /// <summary>
             /// Sets the cursor shape.
             /// </summary>
             /// <param name="cursor">
             /// A handle to the cursor. The cursor must have been created by the CreateCursor function or loaded by
-            /// the <see cref="LoadCursor(HCURSOR, string)"/> or LoadImage function. If this parameter is null,
+            /// the <see cref="LoadCursor(IntPtr, string)"/> or LoadImage function. If this parameter is null,
             /// the cursor is removed from the screen.
             /// </param>
             /// <returns>
@@ -168,7 +164,7 @@ namespace OpenToolkit.NT.Native
             /// If there was no previous cursor, the return value is null.
             /// </returns>
             [DllImport(Library)]
-            public static extern HCURSOR SetCursor([In] [Optional] HCURSOR cursor);
+            public static extern IntPtr SetCursor([In] [Optional] IntPtr cursor);
         }
     }
 }

--- a/src/OpenTK.NT/Native/User32/Delegates/TimerProc.cs
+++ b/src/OpenTK.NT/Native/User32/Delegates/TimerProc.cs
@@ -1,8 +1,5 @@
-﻿using System.Runtime.InteropServices;
-
-using DWORD = System.UInt32;
-using HWND = System.IntPtr;
-using UINT_PTR = System.UIntPtr;
+﻿using System;
+using System.Runtime.InteropServices;
 
 namespace OpenToolkit.NT.Native
 {
@@ -20,9 +17,9 @@ namespace OpenToolkit.NT.Native
     [UnmanagedFunctionPointer(CallingConvention.Winapi)]
     public delegate void TimerProc
     (
-        [In] HWND hwnd,
+        [In] IntPtr hwnd,
         [In] WindowMessage msg,
-        [In] UINT_PTR timerID,
-        [In] DWORD elapsedTime
+        [In] UIntPtr timerID,
+        [In] uint elapsedTime
     );
 }

--- a/src/OpenTK.NT/Native/User32/Delegates/WindowProc.cs
+++ b/src/OpenTK.NT/Native/User32/Delegates/WindowProc.cs
@@ -1,10 +1,6 @@
-﻿using System.Runtime.InteropServices;
+﻿using System;
+using System.Runtime.InteropServices;
 using System.Security;
-
-using HWND = System.IntPtr;
-using LPARAM = System.IntPtr;
-using LRESULT = System.IntPtr;
-using WPARAM = System.IntPtr;
 
 namespace OpenToolkit.NT.Native
 {
@@ -25,11 +21,11 @@ namespace OpenToolkit.NT.Native
     /// <returns>The return value is the result of the message processing and depends on the message sent.</returns>
     [SuppressUnmanagedCodeSecurity]
     [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-    public delegate LRESULT WindowProc
+    public delegate IntPtr WindowProc
     (
-        [In] HWND hwnd,
+        [In] IntPtr hwnd,
         [In] WindowMessage msg,
-        [In] WPARAM wparam,
-        [In] LPARAM lparam
+        [In] IntPtr wparam,
+        [In] IntPtr lparam
     );
 }

--- a/src/OpenTK.NT/Native/User32/Device.cs
+++ b/src/OpenTK.NT/Native/User32/Device.cs
@@ -1,11 +1,6 @@
 ﻿using System;
 using System.Runtime.InteropServices;
 
-using BOOL = System.Boolean;
-using HANDLE = System.IntPtr;
-using HDEVNOTIFY = System.IntPtr;
-using LPVOID = System.IntPtr;
-
 namespace OpenToolkit.NT.Native
 {
     public static partial class User32
@@ -22,7 +17,7 @@ namespace OpenToolkit.NT.Native
             /// <param name="recipient">
             /// A handle to the window or service that will receive device events for the devices specified in the
             /// <paramref name="notificationFilter"/> parameter. The same window handle can be used in multiple calls
-            /// to <see cref="RegisterDeviceNotification(HANDLE, HANDLE, DeviceNotificationEnum)"/>.<para/>
+            /// to <see cref="RegisterDeviceNotification(IntPtr, IntPtr, DeviceNotificationEnum)"/>.<para/>
             /// Services can specify either a window handle or service status handle.
             /// </param>
             /// <param name="notificationFilter">
@@ -39,10 +34,10 @@ namespace OpenToolkit.NT.Native
             /// To get extended error information, call <see cref="Marshal.GetLastWin32Error"/>.
             /// </returns>
             [DllImport(Library, SetLastError = true)]
-            public static extern HDEVNOTIFY RegisterDeviceNotification
+            public static extern IntPtr RegisterDeviceNotification
             (
-                [In] HANDLE recipient,
-                [In] LPVOID notificationFilter,
+                [In] IntPtr recipient,
+                [In] IntPtr notificationFilter,
                 [In] DeviceNotificationEnum flags
             );
 
@@ -51,7 +46,7 @@ namespace OpenToolkit.NT.Native
             /// </summary>
             /// <param name="handle">
             /// Device notification handle returned by the
-            /// <see cref="RegisterDeviceNotification(HANDLE, HANDLE, DeviceNotificationEnum)"/> function.
+            /// <see cref="RegisterDeviceNotification(IntPtr, IntPtr, DeviceNotificationEnum)"/> function.
             /// </param>
             /// <returns>
             /// If the function succeeds, the return value is true.
@@ -60,7 +55,7 @@ namespace OpenToolkit.NT.Native
             /// </returns>
             [DllImport(Library, SetLastError = true)]
             [return: MarshalAs(UnmanagedType.Bool)]
-            public static extern BOOL UnregisterDeviceNotification([In] HDEVNOTIFY handle);
+            public static extern bool UnregisterDeviceNotification([In] IntPtr handle);
         }
     }
 }

--- a/src/OpenTK.NT/Native/User32/DeviceContext.cs
+++ b/src/OpenTK.NT/Native/User32/DeviceContext.cs
@@ -1,13 +1,6 @@
 ﻿using System;
 using System.Runtime.InteropServices;
 
-using BOOL = System.Boolean;
-using DEVMODE = System.IntPtr;
-using DWORD = System.UInt32;
-using HDC = System.IntPtr;
-using HWND = System.IntPtr;
-using LPVOID = System.IntPtr;
-
 namespace OpenToolkit.NT.Native
 {
     public static partial class User32
@@ -32,7 +25,7 @@ namespace OpenToolkit.NT.Native
             /// If the function fails, the return value is <see cref="IntPtr.Zero"/>.
             /// </returns>
             [DllImport(Library)]
-            public static extern HDC GetDC([In] [Optional] HWND window);
+            public static extern IntPtr GetDC([In] [Optional] IntPtr window);
 
             /// <summary>
             /// Releases a device context (DC), freeing it for use by other applications. The effect of this function
@@ -48,12 +41,12 @@ namespace OpenToolkit.NT.Native
             /// </returns>
             [DllImport(Library)]
             [return: MarshalAs(UnmanagedType.Bool)]
-            public static extern BOOL ReleaseDC([In] HWND window, [In] HDC dc);
+            public static extern bool ReleaseDC([In] IntPtr window, [In] IntPtr dc);
 
             /// <summary>
             /// Changes the settings of the default display device to the specified graphics mode.<para/>
             /// To change the settings of a specified display device, use the
-            /// <see cref="ChangeDisplaySettingsEx(string, DEVMODE, DEVMODE, DisplaySettingsChanges, DEVMODE)"/>
+            /// <see cref="ChangeDisplaySettingsEx(string, IntPtr, IntPtr, DisplaySettingsChanges, IntPtr)"/>
             /// function.
             /// </summary>
             /// <param name="deviceMode">
@@ -80,7 +73,7 @@ namespace OpenToolkit.NT.Native
             /// <param name="deviceName">
             /// A string that specifies the display device whose graphics mode will change.<para/>
             /// Only display device names as returned by
-            /// <see cref="EnumDisplayDevices(string, DWORD, out DisplayDevice, DWORD)"/> are valid.
+            /// <see cref="EnumDisplayDevices(string, uint, out DisplayDevice, uint)"/> are valid.
             /// </param>
             /// <param name="deviceMode">
             /// A <see cref="DeviceMode"/> structure that describes the new graphics mode. If
@@ -103,10 +96,10 @@ namespace OpenToolkit.NT.Native
             public static extern ChangeDisplaySettingsResult ChangeDisplaySettingsEx
             (
                 [In] [Optional] string deviceName,
-                [In] [Optional] DEVMODE deviceMode,
-                [Optional] HWND window,
+                [In] [Optional] IntPtr deviceMode,
+                [Optional] IntPtr window,
                 [In] DisplaySettingsChanges changeFlags,
-                [In] LPVOID changeParams
+                [In] IntPtr changeParams
             );
 
             /// <summary>
@@ -117,7 +110,7 @@ namespace OpenToolkit.NT.Native
             /// A string that specifies the display device about whose graphics mode the function
             /// will obtain information.<para/>
             /// This parameter is either null or a <see cref="DisplayDevice.DeviceName"/> returned from
-            /// <see cref="EnumDisplayDevices(string, DWORD, out DisplayDevice, DWORD)"/>. A null value specifies the
+            /// <see cref="EnumDisplayDevices(string, uint, out DisplayDevice, uint)"/>. A null value specifies the
             /// current display device on the computer on which the calling thread is running.
             /// </param>
             /// <param name="modeSetting">Specifies the type of information to be retrieved.</param>
@@ -135,7 +128,7 @@ namespace OpenToolkit.NT.Native
             /// </returns>
             [DllImport(Library, CharSet = CharSet.Unicode)]
             [return: MarshalAs(UnmanagedType.Bool)]
-            public static extern BOOL EnumDisplaySettings
+            public static extern bool EnumDisplaySettings
             (
                 [In] string deviceName,
                 [In] DisplayModeSetting modeSetting,
@@ -150,7 +143,7 @@ namespace OpenToolkit.NT.Native
             /// A string that specifies the display device about whose graphics mode the function
             /// will obtain information.<para/>
             /// This parameter is either null or a <see cref="DisplayDevice.DeviceName"/> returned from
-            /// <see cref="EnumDisplayDevices(string, DWORD, out DisplayDevice, DWORD)"/>. A null value specifies the
+            /// <see cref="EnumDisplayDevices(string, uint, out DisplayDevice, uint)"/>. A null value specifies the
             /// current display device on the computer on which the calling thread is running.
             /// </param>
             /// <param name="modeSetting">Specifies the type of information to be retrieved.</param>
@@ -171,7 +164,7 @@ namespace OpenToolkit.NT.Native
             /// </returns>
             [DllImport(Library, CharSet = CharSet.Unicode)]
             [return: MarshalAs(UnmanagedType.Bool)]
-            public static extern BOOL EnumDisplaySettingsEx
+            public static extern bool EnumDisplaySettingsEx
             (
                 [In] string deviceName,
                 [In] DisplayModeSetting modeSetting,
@@ -190,7 +183,7 @@ namespace OpenToolkit.NT.Native
             /// <param name="displayDevice">
             /// A <see cref="DisplayDevice"/> structure that receives information about the display device
             /// specified by <paramref name="deviceIndex"/>.<para/>
-            /// Before calling <see cref="EnumDisplayDevices(string, DWORD, out DisplayDevice, DWORD)"/>, you must
+            /// Before calling <see cref="EnumDisplayDevices(string, uint, out DisplayDevice, uint)"/>, you must
             /// initialize the <see cref="DisplayDevice.Size"/> member of <see cref="DisplayDevice"/>
             /// to <see cref="DisplayDevice.SizeInBytes"/>.
             /// </param>
@@ -208,12 +201,12 @@ namespace OpenToolkit.NT.Native
             /// </returns>
             [DllImport(Library, CharSet = CharSet.Unicode)]
             [return: MarshalAs(UnmanagedType.Bool)]
-            public static extern BOOL EnumDisplayDevices
+            public static extern bool EnumDisplayDevices
             (
                 [In] [Optional] string deviceName,
-                [In] DWORD deviceIndex,
+                [In] uint deviceIndex,
                 [Out] out DisplayDevice displayDevice,
-                [In] DWORD flags
+                [In] uint flags
             );
         }
     }

--- a/src/OpenTK.NT/Native/User32/Enums/ChangeDisplaySettingsResult.cs
+++ b/src/OpenTK.NT/Native/User32/Enums/ChangeDisplaySettingsResult.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 
-using LONG = System.Int32;
-
 namespace OpenToolkit.NT.Native
 {
     /// <summary>
@@ -9,7 +7,7 @@ namespace OpenToolkit.NT.Native
     /// and <see cref="User32.DeviceContext.ChangeDisplaySettingsEx(string, IntPtr, IntPtr, DisplaySettingsChanges,
     /// IntPtr)"/> to indicate the result of the function call.
     /// </summary>
-    public enum ChangeDisplaySettingsResult : LONG
+    public enum ChangeDisplaySettingsResult : int
     {
         /// <summary>
         /// The settings change was successful.

--- a/src/OpenTK.NT/Native/User32/Enums/DeviceBroadcastType.cs
+++ b/src/OpenTK.NT/Native/User32/Enums/DeviceBroadcastType.cs
@@ -1,11 +1,9 @@
-﻿using DWORD = System.UInt32;
-
-namespace OpenToolkit.NT.Native
+﻿namespace OpenToolkit.NT.Native
 {
     /// <summary>
     /// Used in the <see cref="BroadcastDeviceInterface"/>.
     /// </summary>
-    public enum DeviceBroadcastType : DWORD
+    public enum DeviceBroadcastType : uint
     {
         /// <summary>
         /// This member is not officially documented. Use with care.

--- a/src/OpenTK.NT/Native/User32/Enums/DeviceModeFieldFlags.cs
+++ b/src/OpenTK.NT/Native/User32/Enums/DeviceModeFieldFlags.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 
-using DWORD = System.UInt32;
-
 namespace OpenToolkit.NT.Native
 {
     /// <summary>
@@ -12,7 +10,7 @@ namespace OpenToolkit.NT.Native
     /// printer or display technology.
     /// </summary>
     [Flags]
-    public enum DeviceModeFieldFlags : DWORD
+    public enum DeviceModeFieldFlags : uint
     {
         /// <summary>
         /// Specifies whether the <see cref="DeviceMode.PrinterDeviceOptions.Orientation"/> field is set.

--- a/src/OpenTK.NT/Native/User32/Enums/DisplayDeviceStateFlags.cs
+++ b/src/OpenTK.NT/Native/User32/Enums/DisplayDeviceStateFlags.cs
@@ -1,14 +1,12 @@
 ﻿using System;
 
-using DWORD = System.UInt32;
-
 namespace OpenToolkit.NT.Native
 {
     /// <summary>
     /// Used in <see cref="DisplayDevice"/> to represent the device state.
     /// </summary>
     [Flags]
-    public enum DisplayDeviceStateFlags : DWORD
+    public enum DisplayDeviceStateFlags : uint
     {
         /// <summary>
         /// This member is not officially documented. Use with care.

--- a/src/OpenTK.NT/Native/User32/Enums/DisplayFixedOutputType.cs
+++ b/src/OpenTK.NT/Native/User32/Enums/DisplayFixedOutputType.cs
@@ -1,12 +1,10 @@
-﻿using DWORD = System.UInt32;
-
-namespace OpenToolkit.NT.Native
+﻿namespace OpenToolkit.NT.Native
 {
     /// <summary>
     /// For fixed-resolution displays, specifies how the device can present a lower-resolution
     /// mode on a higher-resolution display.
     /// </summary>
-    public enum DisplayFixedOutputType : DWORD
+    public enum DisplayFixedOutputType : uint
     {
         /// <summary>
         /// The display device presents a lower-resolution mode image by stretching it to fill the larger screen space.

--- a/src/OpenTK.NT/Native/User32/Enums/DisplayFlags.cs
+++ b/src/OpenTK.NT/Native/User32/Enums/DisplayFlags.cs
@@ -1,14 +1,12 @@
 ﻿using System;
 
-using DWORD = System.UInt32;
-
 namespace OpenToolkit.NT.Native
 {
     /// <summary>
     /// Specifies the device's display mode.
     /// </summary>
     [Flags]
-    public enum DisplayFlags : DWORD
+    public enum DisplayFlags : uint
     {
         /// <summary>
         /// Specifies that the display is a noncolor device. If this flag is not set, color is assumed.

--- a/src/OpenTK.NT/Native/User32/Enums/DisplayModeSetting.cs
+++ b/src/OpenTK.NT/Native/User32/Enums/DisplayModeSetting.cs
@@ -1,22 +1,20 @@
-﻿using DWORD = System.UInt32;
-
-namespace OpenToolkit.NT.Native
+﻿namespace OpenToolkit.NT.Native
 {
     /// <summary>
     /// Used in <see cref="User32.DeviceContext.EnumDisplaySettings(string, DisplayModeSetting, out DeviceMode)"/> and
     /// <see cref="User32.DeviceContext.EnumDisplaySettingsEx(string, DisplayModeSetting, out DeviceMode,
     /// EnumDisplayModes)"/> to specify which information should be retrieved.
     /// </summary>
-    public enum DisplayModeSetting : DWORD
+    public enum DisplayModeSetting : uint
     {
         /// <summary>
         /// Retrieve the current settings for the display device.
         /// </summary>
-        CurrentSettings = unchecked((DWORD)(-1)),
+        CurrentSettings = unchecked((uint)(-1)),
 
         /// <summary>
         /// Retrieve the settings for the display device that are currently stored in the registry.
         /// </summary>
-        RegistrySettings = unchecked((DWORD)(-2))
+        RegistrySettings = unchecked((uint)(-2))
     }
 }

--- a/src/OpenTK.NT/Native/User32/Enums/DisplayOrientation.cs
+++ b/src/OpenTK.NT/Native/User32/Enums/DisplayOrientation.cs
@@ -1,11 +1,9 @@
-﻿using DWORD = System.UInt32;
-
-namespace OpenToolkit.NT.Native
+﻿namespace OpenToolkit.NT.Native
 {
     /// <summary>
     /// Defines possible display orientations.
     /// </summary>
-    public enum DisplayOrientation : DWORD
+    public enum DisplayOrientation : uint
     {
         /// <summary>
         /// The current mode's display device orientation is the natural orientation of the device,

--- a/src/OpenTK.NT/Native/User32/Enums/DisplaySettingsChanges.cs
+++ b/src/OpenTK.NT/Native/User32/Enums/DisplaySettingsChanges.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 
-using DWORD = System.UInt32;
-
 namespace OpenToolkit.NT.Native
 {
     /// <summary>
@@ -10,7 +8,7 @@ namespace OpenToolkit.NT.Native
     /// IntPtr)"/> to indicate how the graphics mode should be changed.
     /// </summary>
     [Flags]
-    public enum DisplaySettingsChanges : DWORD
+    public enum DisplaySettingsChanges : uint
     {
         /// <summary>
         /// The graphics mode for the current screen will be changed dynamically.

--- a/src/OpenTK.NT/Native/User32/Enums/ExtendedWindowStyles.cs
+++ b/src/OpenTK.NT/Native/User32/Enums/ExtendedWindowStyles.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 
-using DWORD = System.UInt32;
-
 namespace OpenToolkit.NT.Native
 {
     /// <summary>
@@ -10,7 +8,7 @@ namespace OpenToolkit.NT.Native
     /// ExtendedWindowStyles, string, string, WindowStyles, int, int, int, int, IntPtr, IntPtr, IntPtr, IntPtr)"/>.
     /// </summary>
     [Flags]
-    public enum ExtendedWindowStyles : DWORD
+    public enum ExtendedWindowStyles : uint
     {
         /// <summary>
         /// The window has a double border; the window can, optionally, be created with a title bar

--- a/src/OpenTK.NT/Native/User32/Enums/GetMouseMovePointsResolution.cs
+++ b/src/OpenTK.NT/Native/User32/Enums/GetMouseMovePointsResolution.cs
@@ -1,12 +1,10 @@
-﻿using DWORD = System.UInt32;
-
-namespace OpenToolkit.NT.Native
+﻿namespace OpenToolkit.NT.Native
 {
     /// <summary>
-    /// Specifies the resolution desired by <see cref="User32.Mouse.GetMouseMovePointsEx(DWORD, ref MouseMovePoint,
+    /// Specifies the resolution desired by <see cref="User32.Mouse.GetMouseMovePointsEx(uint, ref MouseMovePoint,
     /// MouseMovePoint*, int, GetMouseMovePointsResolution)"/>.
     /// </summary>
-    public enum GetMouseMovePointsResolution : DWORD
+    public enum GetMouseMovePointsResolution : uint
     {
         /// <summary>
         /// Retrieves the points using the display resolution.

--- a/src/OpenTK.NT/Native/User32/Enums/GetRawInputDataCommand.cs
+++ b/src/OpenTK.NT/Native/User32/Enums/GetRawInputDataCommand.cs
@@ -1,12 +1,10 @@
-﻿using UINT = System.UInt32;
-
-namespace OpenToolkit.NT.Native
+﻿namespace OpenToolkit.NT.Native
 {
     /// <summary>
     /// Specifies which type of raw input data to get in a <see cref="User32.RawInput.GetRawInputData(System.IntPtr,
-    /// GetRawInputDataCommand, System.IntPtr, ref UINT, UINT)"/> function call.
+    /// GetRawInputDataCommand, System.IntPtr, ref uint, uint)"/> function call.
     /// </summary>
-    public enum GetRawInputDataCommand : UINT
+    public enum GetRawInputDataCommand : uint
     {
         /// <summary>
         /// Get the raw data from the <see cref="RawInput"/> structure.

--- a/src/OpenTK.NT/Native/User32/Enums/GetRawInputDeviceInfoEnum.cs
+++ b/src/OpenTK.NT/Native/User32/Enums/GetRawInputDeviceInfoEnum.cs
@@ -1,12 +1,10 @@
-﻿using UINT = System.UInt32;
-
-namespace OpenToolkit.NT.Native
+﻿namespace OpenToolkit.NT.Native
 {
     /// <summary>
     /// Used in <see cref="User32.RawInput.GetRawInputDeviceInfo(System.IntPtr,
-    /// GetRawInputDeviceInfoEnum, byte[], ref UINT)"/> to specify what data to return in the data parameter.
+    /// GetRawInputDeviceInfoEnum, byte[], ref uint)"/> to specify what data to return in the data parameter.
     /// </summary>
-    public enum GetRawInputDeviceInfoEnum : UINT
+    public enum GetRawInputDeviceInfoEnum : uint
     {
         /// <summary>
         /// data points to the previously parsed data.

--- a/src/OpenTK.NT/Native/User32/Enums/MapVirtualKeyType.cs
+++ b/src/OpenTK.NT/Native/User32/Enums/MapVirtualKeyType.cs
@@ -1,11 +1,9 @@
-﻿using UINT = System.UInt32;
-
-namespace OpenToolkit.NT.Native
+﻿namespace OpenToolkit.NT.Native
 {
     /// <summary>
     /// Used in <see cref="MapVirtualKeyType"/> to specify the translation to be performed.
     /// </summary>
-    public enum MapVirtualKeyType : UINT
+    public enum MapVirtualKeyType : uint
     {
         /// <summary>
         /// uCode is a virtual-key code and is translated into a scan code. If it is a virtual-key code that does not

--- a/src/OpenTK.NT/Native/User32/Enums/MonitorFromDefaultValue.cs
+++ b/src/OpenTK.NT/Native/User32/Enums/MonitorFromDefaultValue.cs
@@ -1,6 +1,4 @@
-﻿using DWORD = System.UInt32;
-
-namespace OpenToolkit.NT.Native
+﻿namespace OpenToolkit.NT.Native
 {
     /// <summary>
     /// Specifies what values to return if
@@ -8,7 +6,7 @@ namespace OpenToolkit.NT.Native
     /// <see cref="User32.Monitor.MonitorFromWindow(System.IntPtr, MonitorFromDefaultValue)"/>
     /// fail to find a monitor for the given arguments.
     /// </summary>
-    public enum MonitorFromDefaultValue : DWORD
+    public enum MonitorFromDefaultValue : uint
     {
         /// <summary>
         /// Returns null.

--- a/src/OpenTK.NT/Native/User32/Enums/PeekMessageActions.cs
+++ b/src/OpenTK.NT/Native/User32/Enums/PeekMessageActions.cs
@@ -1,15 +1,13 @@
 ﻿using System;
 
-using UINT = System.UInt32;
-
 namespace OpenToolkit.NT.Native
 {
     /// <summary>
-    /// Used in <see cref="User32.Message.PeekMessage(out Msg, IntPtr, UINT, UINT, PeekMessageActions)"/>
+    /// Used in <see cref="User32.Message.PeekMessage(out Msg, IntPtr, uint, uint, PeekMessageActions)"/>
     /// to define what actions to take for retrieved messages.
     /// </summary>
     [Flags]
-    public enum PeekMessageActions : UINT
+    public enum PeekMessageActions : uint
     {
         /// <summary>
         /// Messages are not removed from the queue after processing by <see cref="User32.Message.PeekMessage"/>.

--- a/src/OpenTK.NT/Native/User32/Enums/PrinterDitherType.cs
+++ b/src/OpenTK.NT/Native/User32/Enums/PrinterDitherType.cs
@@ -1,11 +1,9 @@
-﻿using DWORD = System.UInt32;
-
-namespace OpenToolkit.NT.Native
+﻿namespace OpenToolkit.NT.Native
 {
     /// <summary>
     /// For printers, specifies types of dithering.
     /// </summary>
-    public enum PrinterDitherType : DWORD
+    public enum PrinterDitherType : uint
     {
         /// <summary>
         /// No dithering.

--- a/src/OpenTK.NT/Native/User32/Enums/PrinterIcmIntent.cs
+++ b/src/OpenTK.NT/Native/User32/Enums/PrinterIcmIntent.cs
@@ -1,11 +1,9 @@
-﻿using DWORD = System.UInt32;
-
-namespace OpenToolkit.NT.Native
+﻿namespace OpenToolkit.NT.Native
 {
     /// <summary>
     /// Specifies which color matching method, or intent, is used by default.
     /// </summary>
-    public enum PrinterIcmIntent : DWORD
+    public enum PrinterIcmIntent : uint
     {
         /// <summary>
         /// Optimize for color saturation.<para/>

--- a/src/OpenTK.NT/Native/User32/Enums/PrinterIcmMethod.cs
+++ b/src/OpenTK.NT/Native/User32/Enums/PrinterIcmMethod.cs
@@ -1,11 +1,9 @@
-﻿using DWORD = System.UInt32;
-
-namespace OpenToolkit.NT.Native
+﻿namespace OpenToolkit.NT.Native
 {
     /// <summary>
     /// Specifies how Image Color Management (ICM) is handled.
     /// </summary>
-    public enum PrinterIcmMethod : DWORD
+    public enum PrinterIcmMethod : uint
     {
         /// <summary>
         /// Specifies that ICM is disabled.

--- a/src/OpenTK.NT/Native/User32/Enums/PrinterMediaType.cs
+++ b/src/OpenTK.NT/Native/User32/Enums/PrinterMediaType.cs
@@ -1,11 +1,9 @@
-﻿using DWORD = System.UInt32;
-
-namespace OpenToolkit.NT.Native
+﻿namespace OpenToolkit.NT.Native
 {
     /// <summary>
     /// Specifies the type of media being printed on.
     /// </summary>
-    public enum PrinterMediaType : DWORD
+    public enum PrinterMediaType : uint
     {
         /// <summary>
         /// Plain paper.

--- a/src/OpenTK.NT/Native/User32/Enums/PrinterNupHandling.cs
+++ b/src/OpenTK.NT/Native/User32/Enums/PrinterNupHandling.cs
@@ -1,11 +1,9 @@
-﻿using DWORD = System.UInt32;
-
-namespace OpenToolkit.NT.Native
+﻿namespace OpenToolkit.NT.Native
 {
     /// <summary>
     /// Specifies the responsibility for performing page layout for N-up printing.
     /// </summary>
-    public enum PrinterNupHandling : DWORD
+    public enum PrinterNupHandling : uint
     {
         /// <summary>
         /// The print server does the page layout.

--- a/src/OpenTK.NT/Native/User32/Enums/QueueMessageTypes.cs
+++ b/src/OpenTK.NT/Native/User32/Enums/QueueMessageTypes.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 
-using DWORD = System.UInt32;
-
 namespace OpenToolkit.NT.Native
 {
     /// <summary>
@@ -9,7 +7,7 @@ namespace OpenToolkit.NT.Native
     /// to specify the types of messages to check for.
     /// </summary>
     [Flags]
-    public enum QueueMessageTypes : DWORD
+    public enum QueueMessageTypes : uint
     {
         /// <summary>
         /// A <see cref="WindowMessage.KeyUp"/>, <see cref="WindowMessage.KeyDown"/>,

--- a/src/OpenTK.NT/Native/User32/Enums/RawInputDeviceType.cs
+++ b/src/OpenTK.NT/Native/User32/Enums/RawInputDeviceType.cs
@@ -1,11 +1,9 @@
-﻿using DWORD = System.UInt32;
-
-namespace OpenToolkit.NT.Native
+﻿namespace OpenToolkit.NT.Native
 {
     /// <summary>
     /// Specifies the type of raw input device.
     /// </summary>
-    public enum RawInputDeviceType : DWORD
+    public enum RawInputDeviceType : uint
     {
         /// <summary>
         /// Data comes from a mouse.

--- a/src/OpenTK.NT/Native/User32/Enums/RawMouseButtonFlags.cs
+++ b/src/OpenTK.NT/Native/User32/Enums/RawMouseButtonFlags.cs
@@ -1,14 +1,12 @@
 ﻿using System;
 
-using USHORT = System.UInt16;
-
 namespace OpenToolkit.NT.Native
 {
     /// <summary>
     /// Specifies the transition state of the mouse buttons.
     /// </summary>
     [Flags]
-    public enum RawMouseButtonFlags : USHORT
+    public enum RawMouseButtonFlags : ushort
     {
         /// <summary>
         /// Left Button changed to down.

--- a/src/OpenTK.NT/Native/User32/Enums/RawMouseFlags.cs
+++ b/src/OpenTK.NT/Native/User32/Enums/RawMouseFlags.cs
@@ -1,14 +1,12 @@
 ﻿using System;
 
-using USHORT = System.UInt16;
-
 namespace OpenToolkit.NT.Native
 {
     /// <summary>
     /// Mouse indicator flags (found in winuser.h).
     /// </summary>
     [Flags]
-    public enum RawMouseFlags : USHORT
+    public enum RawMouseFlags : ushort
     {
         /// <summary>
         /// LastX/Y indicate relative motion.

--- a/src/OpenTK.NT/Native/User32/Enums/SetWindowPosFlags.cs
+++ b/src/OpenTK.NT/Native/User32/Enums/SetWindowPosFlags.cs
@@ -1,14 +1,12 @@
 ﻿using System;
 
-using UINT = System.UInt32;
-
 namespace OpenToolkit.NT.Native
 {
     /// <summary>
     /// Window sizing and positioning flags.
     /// </summary>
     [Flags]
-    public enum SetWindowPosFlags : UINT
+    public enum SetWindowPosFlags : uint
     {
         /// <summary>
         /// Retains the current size (ignores the cx and cy parameters).

--- a/src/OpenTK.NT/Native/User32/Enums/TrackMouseEvents.cs
+++ b/src/OpenTK.NT/Native/User32/Enums/TrackMouseEvents.cs
@@ -1,14 +1,12 @@
 ﻿using System;
 
-using DWORD = System.UInt32;
-
 namespace OpenToolkit.NT.Native
 {
     /// <summary>
     /// Used in <see cref="TrackMouseEvent"/> to request specific services.
     /// </summary>
     [Flags]
-    public enum TrackMouseEvents : DWORD
+    public enum TrackMouseEvents : uint
     {
         /// <summary>
         /// The caller wants hover notification. Notification is delivered as a <see cref="WindowMessage.MouseHover"/>

--- a/src/OpenTK.NT/Native/User32/Enums/WindowClassStyles.cs
+++ b/src/OpenTK.NT/Native/User32/Enums/WindowClassStyles.cs
@@ -1,14 +1,12 @@
 ﻿using System;
 
-using UINT = System.UInt32;
-
 namespace OpenToolkit.NT.Native
 {
     /// <summary>
     /// Defines additional elements of the window class.
     /// </summary>
     [Flags]
-    public enum WindowClassStyles : UINT
+    public enum WindowClassStyles : uint
     {
         /// <summary>
         /// Redraws the entire window if a movement or size adjustment changes the height of the client area.

--- a/src/OpenTK.NT/Native/User32/Enums/WindowMessage.cs
+++ b/src/OpenTK.NT/Native/User32/Enums/WindowMessage.cs
@@ -1,13 +1,11 @@
 ﻿using System;
 
-using UINT = System.UInt32;
-
 namespace OpenToolkit.NT.Native
 {
     /// <summary>
     /// Specifies the different types of window messages.
     /// </summary>
-    public enum WindowMessage : UINT
+    public enum WindowMessage : uint
     {
         /// <summary>
         /// Performs no operation. An application sends the <see cref="Null"/> message if it wants to
@@ -93,8 +91,8 @@ namespace OpenToolkit.NT.Native
         /// The message is sent when the UpdateWindow or RedrawWindow function is called, or by the
         /// <see cref="User32.Message.DispatchMessage(ref Msg)"/> function when the application obtains a
         /// <see cref="WindowMessage.Paint"/> message by using the
-        /// <see cref="User32.Message.GetMessage(out Msg, IntPtr, UINT, UINT)"/> or
-        /// <see cref="User32.Message.PeekMessage(out Msg, IntPtr, UINT, UINT, PeekMessageActions)"/> function.
+        /// <see cref="User32.Message.GetMessage(out Msg, IntPtr, uint, uint)"/> or
+        /// <see cref="User32.Message.PeekMessage(out Msg, IntPtr, uint, uint, PeekMessageActions)"/> function.
         /// </summary>
         Paint = 0x000F,
 
@@ -113,7 +111,7 @@ namespace OpenToolkit.NT.Native
         /// <summary>
         /// Indicates a request to terminate an application, and is generated when the application calls the
         /// <see cref="User32.Message.PostQuitMessage(int)"/> function. This message causes the
-        /// <see cref="User32.Message.GetMessage(out Msg, IntPtr, UINT, UINT)"/> function to return zero.
+        /// <see cref="User32.Message.GetMessage(out Msg, IntPtr, uint, uint)"/> function to return zero.
         /// </summary>
         Quit = 0x0012,
 
@@ -720,8 +718,8 @@ namespace OpenToolkit.NT.Native
 
         /// <summary>
         /// Posted to the installing thread's message queue when a timer expires.
-        /// The message is posted by the <see cref="User32.Message.GetMessage(out Msg, IntPtr, UINT, UINT)"/> or
-        /// <see cref="User32.Message.PeekMessage(out Msg, IntPtr, UINT, UINT, PeekMessageActions)"/> function.
+        /// The message is posted by the <see cref="User32.Message.GetMessage(out Msg, IntPtr, uint, uint)"/> or
+        /// <see cref="User32.Message.PeekMessage(out Msg, IntPtr, uint, uint, PeekMessageActions)"/> function.
         /// </summary>
         Timer = 0x0113,
 
@@ -883,7 +881,7 @@ namespace OpenToolkit.NT.Native
 
         /// <summary>
         /// Use to specify the first mouse message. Use the
-        /// <see cref="User32.Message.PeekMessage(out Msg, IntPtr, UINT, UINT, PeekMessageActions)"/> function.
+        /// <see cref="User32.Message.PeekMessage(out Msg, IntPtr, uint, uint, PeekMessageActions)"/> function.
         /// </summary>
         MouseFirst = 0x0200,
 

--- a/src/OpenTK.NT/Native/User32/Enums/WindowStyles.cs
+++ b/src/OpenTK.NT/Native/User32/Enums/WindowStyles.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 
-using DWORD = System.UInt32;
-
 namespace OpenToolkit.NT.Native
 {
     /// <summary>
@@ -11,7 +9,7 @@ namespace OpenToolkit.NT.Native
     /// <see cref="User32.Window.SetWindowLong(IntPtr, int, int)"/> function.
     /// </summary>
     [Flags]
-    public enum WindowStyles : DWORD
+    public enum WindowStyles : uint
     {
         /// <summary>
         /// The window is an overlapped window. An overlapped window has a title bar and a border.

--- a/src/OpenTK.NT/Native/User32/Icon.cs
+++ b/src/OpenTK.NT/Native/User32/Icon.cs
@@ -1,10 +1,6 @@
 ﻿using System;
 using System.Runtime.InteropServices;
 
-using BOOL = System.Boolean;
-using HICON = System.IntPtr;
-using HINSTANCE = System.IntPtr;
-
 namespace OpenToolkit.NT.Native
 {
     public static partial class User32
@@ -27,7 +23,7 @@ namespace OpenToolkit.NT.Native
             /// To get extended error information, call <see cref="Marshal.GetLastWin32Error"/>.
             /// </returns>
             [DllImport(Library, SetLastError = true)]
-            public static extern HICON CreateIconIndirect([In] ref IconInfo iconInfo);
+            public static extern IntPtr CreateIconIndirect([In] ref IconInfo iconInfo);
 
             /// <summary>
             /// Destroys an icon and frees any memory the icon occupied.
@@ -40,7 +36,7 @@ namespace OpenToolkit.NT.Native
             /// </returns>
             [DllImport(Library, SetLastError = true)]
             [return: MarshalAs(UnmanagedType.Bool)]
-            public static extern BOOL DestroyIcon([In] HICON icon);
+            public static extern bool DestroyIcon([In] IntPtr icon);
 
             /// <summary>
             /// Retrieves information about the specified icon or cursor.
@@ -57,7 +53,7 @@ namespace OpenToolkit.NT.Native
             /// </returns>
             [DllImport(Library, SetLastError = true)]
             [return: MarshalAs(UnmanagedType.Bool)]
-            public static extern BOOL GetIconInfo([In] HICON icon, [Out] out IconInfo iconInfo);
+            public static extern bool GetIconInfo([In] IntPtr icon, [Out] out IconInfo iconInfo);
 
             /// <summary>
             /// Retrieves information about the specified pre-defined cursor.
@@ -72,9 +68,9 @@ namespace OpenToolkit.NT.Native
             /// If the function fails, the return value is false.
             /// To get extended error information, call <see cref="Marshal.GetLastWin32Error"/>.
             /// </returns>
-            public static BOOL GetIconInfo(CursorName cursorName, out IconInfo iconInfo)
+            public static bool GetIconInfo(CursorName cursorName, out IconInfo iconInfo)
             {
-                return GetIconInfo(new HICON((int)cursorName), out iconInfo);
+                return GetIconInfo(new IntPtr((int)cursorName), out iconInfo);
             }
 
             /// <summary>
@@ -90,9 +86,9 @@ namespace OpenToolkit.NT.Native
             /// If the function fails, the return value is false.
             /// To get extended error information, call <see cref="Marshal.GetLastWin32Error"/>.
             /// </returns>
-            public static BOOL GetIconInfo(IconName iconName, out IconInfo iconInfo)
+            public static bool GetIconInfo(IconName iconName, out IconInfo iconInfo)
             {
-                return GetIconInfo(new HICON((int)iconName), out iconInfo);
+                return GetIconInfo(new IntPtr((int)iconName), out iconInfo);
             }
 
             /// <summary>
@@ -110,7 +106,7 @@ namespace OpenToolkit.NT.Native
             /// To get extended error information, call <see cref="Marshal.GetLastWin32Error"/>.
             /// </returns>
             [DllImport(Library, SetLastError = true, CharSet = CharSet.Unicode)]
-            public static extern HICON LoadIcon([In] [Optional] HINSTANCE moduleInstance, [In] string iconName);
+            public static extern IntPtr LoadIcon([In] [Optional] IntPtr moduleInstance, [In] string iconName);
 
             /// <summary>
             /// Loads the specified icon resource from the executable (.exe)
@@ -127,7 +123,7 @@ namespace OpenToolkit.NT.Native
             /// To get extended error information, call <see cref="Marshal.GetLastWin32Error"/>.
             /// </returns>
             [DllImport(Library, SetLastError = true, CharSet = CharSet.Unicode)]
-            public static extern HICON LoadIcon([In] [Optional] HINSTANCE moduleInstance, [In] IntPtr iconName);
+            public static extern IntPtr LoadIcon([In] [Optional] IntPtr moduleInstance, [In] IntPtr iconName);
 
             /// <summary>
             /// Loads the specified icon resource from the executable (.exe)
@@ -139,7 +135,7 @@ namespace OpenToolkit.NT.Native
             /// If the function fails, the return value is <see cref="IntPtr.Zero"/>.
             /// To get extended error information, call <see cref="Marshal.GetLastWin32Error"/>.
             /// </returns>
-            public static HICON LoadIcon(CursorName cursorName)
+            public static IntPtr LoadIcon(CursorName cursorName)
             {
                 return LoadIcon(IntPtr.Zero, new IntPtr((int)cursorName));
             }
@@ -154,7 +150,7 @@ namespace OpenToolkit.NT.Native
             /// If the function fails, the return value is <see cref="IntPtr.Zero"/>.
             /// To get extended error information, call <see cref="Marshal.GetLastWin32Error"/>.
             /// </returns>
-            public static HICON LoadIcon(IconName iconName)
+            public static IntPtr LoadIcon(IconName iconName)
             {
                 return LoadIcon(IntPtr.Zero, new IntPtr((int)iconName));
             }

--- a/src/OpenTK.NT/Native/User32/Keyboard.cs
+++ b/src/OpenTK.NT/Native/User32/Keyboard.cs
@@ -2,10 +2,6 @@
 using System.Runtime.InteropServices;
 using System.Security;
 
-using HWND = System.IntPtr;
-using SHORT = System.Int16;
-using UINT = System.UInt32;
-
 namespace OpenToolkit.NT.Native
 {
     public static partial class User32
@@ -30,7 +26,7 @@ namespace OpenToolkit.NT.Native
             /// </returns>
             [SuppressUnmanagedCodeSecurity]
             [DllImport(Library, SetLastError = true)]
-            public static extern SHORT GetKeyState([In] VirtualKey key);
+            public static extern short GetKeyState([In] VirtualKey key);
 
             /// <summary>
             /// Determines whether a key is up or down at the time the function is called,
@@ -46,7 +42,7 @@ namespace OpenToolkit.NT.Native
             /// </returns>
             [SuppressUnmanagedCodeSecurity]
             [DllImport(Library, SetLastError = true)]
-            public static extern SHORT GetAsyncKeyState([In] VirtualKey key);
+            public static extern short GetAsyncKeyState([In] VirtualKey key);
 
             /// <summary>
             /// Retrieves the handle to the window that has the keyboard focus,
@@ -58,7 +54,7 @@ namespace OpenToolkit.NT.Native
             /// the return value is <see cref="IntPtr.Zero"/>.
             /// </returns>
             [DllImport(Library)]
-            public static extern HWND GetFocus();
+            public static extern IntPtr GetFocus();
 
             /// <summary>
             /// Sets the keyboard focus to the specified window.
@@ -73,7 +69,7 @@ namespace OpenToolkit.NT.Native
             /// To get extended error information, call <see cref="Marshal.GetLastWin32Error"/>.
             /// </returns>
             [DllImport(Library, SetLastError = true)]
-            public static extern HWND SetFocus([In] [Optional] HWND window);
+            public static extern IntPtr SetFocus([In] [Optional] IntPtr window);
 
             /// <summary>
             /// Translates (maps) a virtual-key code into a scan code or character value,
@@ -91,7 +87,7 @@ namespace OpenToolkit.NT.Native
             /// </returns>
             [SuppressUnmanagedCodeSecurity]
             [DllImport(Library, SetLastError = true)]
-            public static extern UINT MapVirtualKey([In] VirtualKey vkey, [In] MapVirtualKeyType mapType);
+            public static extern uint MapVirtualKey([In] VirtualKey vkey, [In] MapVirtualKeyType mapType);
         }
     }
 }

--- a/src/OpenTK.NT/Native/User32/Message.cs
+++ b/src/OpenTK.NT/Native/User32/Message.cs
@@ -2,14 +2,6 @@
 using System.Runtime.InteropServices;
 using System.Security;
 
-using BOOL = System.Boolean;
-using DWORD = System.UInt32;
-using HWND = System.IntPtr;
-using LONG = System.Int32;
-using LPARAM = System.IntPtr;
-using LRESULT = System.IntPtr;
-using WPARAM = System.IntPtr;
-
 namespace OpenToolkit.NT.Native
 {
     public static partial class User32
@@ -25,7 +17,7 @@ namespace OpenToolkit.NT.Native
             /// disabled or invisible unowned windows, overlapped windows, and pop-up windows;
             /// but not to child windows.
             /// </summary>
-            public static readonly HWND BroadcastHandle = new HWND(0xFFFF);
+            public static readonly IntPtr BroadcastHandle = new IntPtr(0xFFFF);
 
             /// <summary>
             /// Dispatches incoming sent messages, checks the thread message queue for a posted message,
@@ -36,15 +28,15 @@ namespace OpenToolkit.NT.Native
             /// A handle to the window whose messages are to be retrieved.
             /// The window must belong to the current thread.<para/>
             /// If <paramref name="window"/> is <see cref="IntPtr.Zero"/>,
-            /// <see cref="PeekMessage(out Msg, HWND, uint, uint, PeekMessageActions)"/> retrieves messages for any
+            /// <see cref="PeekMessage(out Msg, IntPtr, uint, uint, PeekMessageActions)"/> retrieves messages for any
             /// window that belongs to the current thread, and any messages on the current thread's message queue whose
             /// <paramref name="window"/> value is <see cref="IntPtr.Zero"/> (see the <see cref="Msg"/> structure).
             /// Therefore if <paramref name="window"/> is <see cref="IntPtr.Zero"/>, both window messages
             /// and thread messages are processed.<para/>
             /// If <paramref name="window"/> is -1,
-            /// <see cref="PeekMessage(out Msg, HWND, uint, uint, PeekMessageActions)"/> retrieves only messages on the
+            /// <see cref="PeekMessage(out Msg, IntPtr, uint, uint, PeekMessageActions)"/> retrieves only messages on the
             /// current thread's message queue whose <paramref name="window"/> value is <see cref="IntPtr.Zero"/>,
-            /// that is, thread messages as posted by <see cref="PostMessage(HWND, WindowMessage, HWND, HWND)"/>
+            /// that is, thread messages as posted by <see cref="PostMessage(IntPtr, WindowMessage, IntPtr, IntPtr)"/>
             /// (when the window parameter is <see cref="IntPtr.Zero"/>) or PostThreadMessage.
             /// </param>
             /// <param name="messageFilterMin">
@@ -52,7 +44,7 @@ namespace OpenToolkit.NT.Native
             /// Use <see cref="WindowMessage.KeyFirst"/> to specify the first keyboard message or
             /// <see cref="WindowMessage.MouseFirst"/> to specify the first mouse message.<para/>
             /// If <paramref name="messageFilterMin"/> and <paramref name="messageFilterMax"/> are both zero,
-            /// <see cref="PeekMessage(out Msg, HWND, uint, uint, PeekMessageActions)"/> returns all available messages
+            /// <see cref="PeekMessage(out Msg, IntPtr, uint, uint, PeekMessageActions)"/> returns all available messages
             /// (that is, no range filtering is performed).
             /// </param>
             /// <param name="messageFilterMax">
@@ -60,7 +52,7 @@ namespace OpenToolkit.NT.Native
             /// <see cref="WindowMessage.KeyLast"/> to specify the last keyboard message or
             /// <see cref="WindowMessage.MouseLast"/> to specify the last mouse message.<para/>
             /// If <paramref name="messageFilterMin"/> and <paramref name="messageFilterMax"/> are both zero,
-            /// <see cref="PeekMessage(out Msg, HWND, uint, uint, PeekMessageActions)"/> returns all available messages
+            /// <see cref="PeekMessage(out Msg, IntPtr, uint, uint, PeekMessageActions)"/> returns all available messages
             /// (that is, no range filtering is performed).
             /// </param>
             /// <param name="messageActions">Specifies how messages are to be handled.</param>
@@ -71,10 +63,10 @@ namespace OpenToolkit.NT.Native
             [SuppressUnmanagedCodeSecurity]
             [DllImport(Library)]
             [return: MarshalAs(UnmanagedType.Bool)]
-            public static extern BOOL PeekMessage
+            public static extern bool PeekMessage
             (
                 [Out] out Msg msg,
-                [In] [Optional] HWND window,
+                [In] [Optional] IntPtr window,
                 [In] uint messageFilterMin,
                 [In] uint messageFilterMax,
                 [In] PeekMessageActions messageActions
@@ -83,8 +75,8 @@ namespace OpenToolkit.NT.Native
             /// <summary>
             /// Retrieves a message from the calling thread's message queue. The function dispatches
             /// incoming sent messages until a posted message is available for retrieval.<para/>
-            /// Unlike <see cref="GetMessage(out Msg, HWND, uint, uint)"/>, the
-            /// <see cref="PeekMessage(out Msg, HWND, uint, uint, PeekMessageActions)"/> function does not wait
+            /// Unlike <see cref="GetMessage(out Msg, IntPtr, uint, uint)"/>, the
+            /// <see cref="PeekMessage(out Msg, IntPtr, uint, uint, PeekMessageActions)"/> function does not wait
             /// for a message to be posted before returning.
             /// </summary>
             /// <param name="msg">
@@ -94,15 +86,15 @@ namespace OpenToolkit.NT.Native
             /// A handle to the window whose messages are to be retrieved.
             /// The window must belong to the current thread.<para/>
             /// If <paramref name="window"/> is <see cref="IntPtr.Zero"/>,
-            /// <see cref="PeekMessage(out Msg, HWND, uint, uint, PeekMessageActions)"/> retrieves messages for any
+            /// <see cref="PeekMessage(out Msg, IntPtr, uint, uint, PeekMessageActions)"/> retrieves messages for any
             /// window that belongs to the current thread, and any messages on the current thread's message queue whose
             /// <paramref name="window"/> value is <see cref="IntPtr.Zero"/> (see the <see cref="Msg"/> structure).
             /// Therefore if <paramref name="window"/> is <see cref="IntPtr.Zero"/>, both window messages
             /// and thread messages are processed.<para/>
             /// If <paramref name="window"/> is -1,
-            /// <see cref="PeekMessage(out Msg, HWND, uint, uint, PeekMessageActions)"/> retrieves only messages on the
+            /// <see cref="PeekMessage(out Msg, IntPtr, uint, uint, PeekMessageActions)"/> retrieves only messages on the
             /// current thread's message queue whose <paramref name="window"/> value is <see cref="IntPtr.Zero"/>,
-            /// that is, thread messages as posted by <see cref="PostMessage(HWND, WindowMessage, HWND, HWND)"/>
+            /// that is, thread messages as posted by <see cref="PostMessage(IntPtr, WindowMessage, IntPtr, IntPtr)"/>
             /// (when the window parameter is <see cref="IntPtr.Zero"/>) or PostThreadMessage.
             /// </param>
             /// <param name="messageFilterMin">
@@ -112,7 +104,7 @@ namespace OpenToolkit.NT.Native
             /// Use <see cref="WindowMessage.Input"/> here and in <paramref name="messageFilterMax"/> to specify only
             /// the <see cref="WindowMessage.Input"/> messages.<para/>
             /// If <paramref name="messageFilterMin"/> and <paramref name="messageFilterMax"/> are both zero,
-            /// <see cref="PeekMessage(out Msg, HWND, uint, uint, PeekMessageActions)"/> returns all available messages
+            /// <see cref="PeekMessage(out Msg, IntPtr, uint, uint, PeekMessageActions)"/> returns all available messages
             /// (that is, no range filtering is performed).
             /// </param>
             /// <param name="messageFilterMax">
@@ -122,7 +114,7 @@ namespace OpenToolkit.NT.Native
             /// Use <see cref="WindowMessage.Input"/> here and in <paramref name="messageFilterMin"/> to specify only
             /// the <see cref="WindowMessage.Input"/> messages.<para/>
             /// If <paramref name="messageFilterMin"/> and <paramref name="messageFilterMax"/> are both zero,
-            /// <see cref="PeekMessage(out Msg, HWND, uint, uint, PeekMessageActions)"/> returns all available messages
+            /// <see cref="PeekMessage(out Msg, IntPtr, uint, uint, PeekMessageActions)"/> returns all available messages
             /// (that is, no range filtering is performed).
             /// </param>
             /// <returns>
@@ -139,24 +131,24 @@ namespace OpenToolkit.NT.Native
             public static extern int GetMessage
             (
                 [Out] out Msg msg,
-                [In] [Optional] HWND window,
+                [In] [Optional] IntPtr window,
                 [In] uint messageFilterMin,
                 [In] uint messageFilterMax
             );
 
             /// <summary>
             /// Retrieves the message time for the last message retrieved by the
-            /// <see cref="GetMessage(out Msg, HWND, uint, uint)"/> function. The time is a long integer that
+            /// <see cref="GetMessage(out Msg, IntPtr, uint, uint)"/> function. The time is a long integer that
             /// specifies the elapsed time, in milliseconds, from the time the system was started to the time the
             /// message was created (that is, placed in the thread's message queue).
             /// </summary>
             /// <returns>The return value specifies the message time.</returns>
             [DllImport(Library)]
-            public static extern LONG GetMessageTime();
+            public static extern int GetMessageTime();
 
             /// <summary>
             /// Sends the specified message to a window or windows. The
-            /// <see cref="SendMessage(HWND, WindowMessage, HWND, HWND)"/> function calls the window procedure for the
+            /// <see cref="SendMessage(IntPtr, WindowMessage, IntPtr, IntPtr)"/> function calls the window procedure for the
             /// specified window and does not return until the window procedure has processed the message.
             /// </summary>
             /// <param name="window">
@@ -171,12 +163,12 @@ namespace OpenToolkit.NT.Native
             /// The return value specifies the result of the message processing; it depends on the message sent.
             /// </returns>
             [DllImport(Library, SetLastError = true)]
-            public static extern LRESULT SendMessage
+            public static extern IntPtr SendMessage
             (
-                [In] HWND window,
+                [In] IntPtr window,
                 [In] WindowMessage msg,
-                [In] WPARAM wparam,
-                [In] LPARAM lparam
+                [In] IntPtr wparam,
+                [In] IntPtr lparam
             );
 
             /// <summary>
@@ -192,7 +184,7 @@ namespace OpenToolkit.NT.Native
             /// <remarks>
             /// This method uses the constant <see cref="BroadcastHandle"/> for this special behavior.
             /// </remarks>
-            public static LRESULT SendMessageAsBroadcast(WindowMessage msg, WPARAM wparam, LPARAM lparam)
+            public static IntPtr SendMessageAsBroadcast(WindowMessage msg, IntPtr wparam, IntPtr lparam)
             {
                 return SendMessage(BroadcastHandle, msg, wparam, lparam);
             }
@@ -219,12 +211,12 @@ namespace OpenToolkit.NT.Native
             [SuppressUnmanagedCodeSecurity]
             [DllImport(Library, SetLastError = true)]
             [return: MarshalAs(UnmanagedType.Bool)]
-            public static extern BOOL PostMessage
+            public static extern bool PostMessage
             (
-                [In] [Optional] HWND window,
+                [In] [Optional] IntPtr window,
                 [In] WindowMessage msg,
-                [In] WPARAM wparam,
-                [In] LPARAM lparam
+                [In] IntPtr wparam,
+                [In] IntPtr lparam
             );
 
             /// <summary>
@@ -242,7 +234,7 @@ namespace OpenToolkit.NT.Native
             /// <remarks>
             /// This method uses the constant <see cref="BroadcastHandle"/> for this special behavior.
             /// </remarks>
-            public static BOOL PostMessageAsBroadcast(WindowMessage msg, WPARAM wparam, LPARAM lparam)
+            public static bool PostMessageAsBroadcast(WindowMessage msg, IntPtr wparam, IntPtr lparam)
             {
                 return PostMessage(BroadcastHandle, msg, wparam, lparam);
             }
@@ -260,7 +252,7 @@ namespace OpenToolkit.NT.Native
 
             /// <summary>
             /// Dispatches a message to a window procedure. It is typically used to
-            /// dispatch a message retrieved by the <see cref="GetMessage(out Msg, HWND, uint, uint)"/> function.
+            /// dispatch a message retrieved by the <see cref="GetMessage(out Msg, IntPtr, uint, uint)"/> function.
             /// </summary>
             /// <param name="msg">A structure that contains the message.</param>
             /// <returns>
@@ -269,18 +261,18 @@ namespace OpenToolkit.NT.Native
             /// </returns>
             [SuppressUnmanagedCodeSecurity]
             [DllImport(Library)]
-            public static extern LRESULT DispatchMessage([In] ref Msg msg);
+            public static extern IntPtr DispatchMessage([In] ref Msg msg);
 
             /// <summary>
             /// Translates virtual-key messages into character messages. The character messages are posted to the
             /// calling thread's message queue, to be read the next time the thread calls the
-            /// <see cref="GetMessage(out Msg, HWND, uint, uint)"/> or
-            /// <see cref="PeekMessage(out Msg, HWND, uint, uint, PeekMessageActions)"/> function.
+            /// <see cref="GetMessage(out Msg, IntPtr, uint, uint)"/> or
+            /// <see cref="PeekMessage(out Msg, IntPtr, uint, uint, PeekMessageActions)"/> function.
             /// </summary>
             /// <param name="msg">
             /// An <see cref="Msg"/> structure that contains message information retrieved from the
-            /// calling thread's message queue by using the <see cref="GetMessage(out Msg, HWND, uint, uint)"/> or
-            /// <see cref="PeekMessage(out Msg, HWND, uint, uint, PeekMessageActions)"/> function.
+            /// calling thread's message queue by using the <see cref="GetMessage(out Msg, IntPtr, uint, uint)"/> or
+            /// <see cref="PeekMessage(out Msg, IntPtr, uint, uint, PeekMessageActions)"/> function.
             /// </param>
             /// <returns>
             /// If the message is translated (that is, a character message is posted to the thread's message queue),
@@ -294,7 +286,7 @@ namespace OpenToolkit.NT.Native
             [SuppressUnmanagedCodeSecurity]
             [DllImport(Library)]
             [return: MarshalAs(UnmanagedType.Bool)]
-            public static extern BOOL TranslateMessage([In] ref Msg msg);
+            public static extern bool TranslateMessage([In] ref Msg msg);
 
             /// <summary>
             /// Retrieves the type of messages found in the calling thread's message queue.
@@ -304,12 +296,12 @@ namespace OpenToolkit.NT.Native
             /// The high-order word of the return value indicates the types of messages currently in the queue.
             /// The low-order word indicates the types of messages that have been added to the queue and that are
             /// still in the queue since the last call to the <see cref="GetQueueStatus(QueueMessageTypes)"/>,
-            /// <see cref="GetMessage(out Msg, HWND, DWORD, DWORD)"/>, or
-            /// <see cref="PeekMessage(out Msg, HWND, DWORD, DWORD, PeekMessageActions)"/> function.
+            /// <see cref="GetMessage(out Msg, IntPtr, uint, uint)"/>, or
+            /// <see cref="PeekMessage(out Msg, IntPtr, uint, uint, PeekMessageActions)"/> function.
             /// </returns>
             [SuppressUnmanagedCodeSecurity]
             [DllImport(Library)]
-            public static extern DWORD GetQueueStatus([In] QueueMessageTypes flags);
+            public static extern uint GetQueueStatus([In] QueueMessageTypes flags);
         }
     }
 }

--- a/src/OpenTK.NT/Native/User32/Monitor.cs
+++ b/src/OpenTK.NT/Native/User32/Monitor.cs
@@ -1,8 +1,5 @@
-﻿using System.Runtime.InteropServices;
-
-using BOOL = System.Boolean;
-using HMONITOR = System.IntPtr;
-using HWND = System.IntPtr;
+﻿using System;
+using System.Runtime.InteropServices;
 
 namespace OpenToolkit.NT.Native
 {
@@ -22,7 +19,7 @@ namespace OpenToolkit.NT.Native
             /// A pointer to a <see cref="MonitorInfo"/> or MONITORINFOEX structure
             /// that receives information about the specified display monitor.<para/>
             /// You must set the Size member of the structure to the respective structure's size in bytes
-            /// before calling the <see cref="GetMonitorInfo(HMONITOR, out MonitorInfo)"/> function. Doing so
+            /// before calling the <see cref="GetMonitorInfo(IntPtr, out MonitorInfo)"/> function. Doing so
             /// lets the function determine the type of structure you are passing to it.
             /// </param>
             /// <returns>
@@ -31,7 +28,7 @@ namespace OpenToolkit.NT.Native
             /// </returns>
             [DllImport(Library)]
             [return: MarshalAs(UnmanagedType.Bool)]
-            public static extern BOOL GetMonitorInfo([In] HMONITOR monitor, [Out] out MonitorInfo monitorInfo);
+            public static extern bool GetMonitorInfo([In] IntPtr monitor, [Out] out MonitorInfo monitorInfo);
 
             /// <summary>
             /// Retrieves a handle to the display monitor that contains a specified point.
@@ -44,12 +41,12 @@ namespace OpenToolkit.NT.Native
             /// </param>
             /// <returns>
             /// If the point is contained by a display monitor,
-            /// the return value is an <see cref="HMONITOR"/> handle to that display monitor.<para/>
+            /// the return value is an <see cref="IntPtr"/> handle to that display monitor.<para/>
             /// If the point is not contained by a display monitor,
             /// the return value depends on the value of <paramref name="defaultTo"/>.
             /// </returns>
             [DllImport(Library)]
-            public static extern HMONITOR MonitorFromPoint([In] Point pt, [In] MonitorFromDefaultValue defaultTo);
+            public static extern IntPtr MonitorFromPoint([In] Point pt, [In] MonitorFromDefaultValue defaultTo);
 
             /// <summary>
             /// Retrieves a handle to the display monitor that has the largest area of intersection
@@ -61,13 +58,13 @@ namespace OpenToolkit.NT.Native
             /// </param>
             /// <returns>
             /// If the window intersects one or more display monitor rectangles, the return value is an
-            /// <see cref="HMONITOR"/> handle to the display monitor that
+            /// <see cref="IntPtr"/> handle to the display monitor that
             /// has the largest area of intersection with the window.<para/>
             /// If the window does not intersect a display monitor,
             /// the return value depends on the value of <paramref name="defaultTo"/>.
             /// </returns>
             [DllImport(Library)]
-            public static extern HMONITOR MonitorFromWindow([In] HWND window, [In] MonitorFromDefaultValue defaultTo);
+            public static extern IntPtr MonitorFromWindow([In] IntPtr window, [In] MonitorFromDefaultValue defaultTo);
         }
     }
 }

--- a/src/OpenTK.NT/Native/User32/Mouse.cs
+++ b/src/OpenTK.NT/Native/User32/Mouse.cs
@@ -1,9 +1,6 @@
 ﻿using System;
 using System.Runtime.InteropServices;
 
-using BOOL = System.Boolean;
-using HWND = System.IntPtr;
-
 namespace OpenToolkit.NT.Native
 {
     public static partial class User32
@@ -23,11 +20,11 @@ namespace OpenToolkit.NT.Native
             /// If no window in the thread has captured the mouse, the return value is <see cref="IntPtr.Zero"/>.
             /// </returns>
             [DllImport(Library)]
-            public static extern HWND GetCapture();
+            public static extern IntPtr GetCapture();
 
             /// <summary>
             /// Sets the mouse capture to the specified window belonging to the current thread.
-            /// <see cref="SetCapture(HWND)"/> captures mouse input either when the mouse is over the capturing window,
+            /// <see cref="SetCapture(IntPtr)"/> captures mouse input either when the mouse is over the capturing window,
             /// or when the mouse button was pressed while the mouse was over the capturing window and the button is
             /// still down. Only one window at a time can capture the mouse.<para/>
             /// If the mouse cursor is over a window created by another thread,
@@ -41,7 +38,7 @@ namespace OpenToolkit.NT.Native
             /// If there is no such window, the return value is <see cref="IntPtr.Zero"/>.
             /// </returns>
             [DllImport(Library)]
-            public static extern HWND SetCapture(HWND window);
+            public static extern IntPtr SetCapture(IntPtr window);
 
             /// <summary>
             /// Releases the mouse capture from a window in the current thread and restores normal mouse input
@@ -56,7 +53,7 @@ namespace OpenToolkit.NT.Native
             /// </returns>
             [DllImport(Library, SetLastError = true)]
             [return: MarshalAs(UnmanagedType.Bool)]
-            public static extern BOOL ReleaseCapture();
+            public static extern bool ReleaseCapture();
 
             /// <summary>
             /// Posts messages when the mouse pointer leaves a window or hovers
@@ -72,7 +69,7 @@ namespace OpenToolkit.NT.Native
             /// </returns>
             [DllImport(Library, SetLastError = true)]
             [return: MarshalAs(UnmanagedType.Bool)]
-            public static extern BOOL TrackMouseEvent([In] [Out] ref TrackMouseEvent trackMouseEvent);
+            public static extern bool TrackMouseEvent([In] [Out] ref TrackMouseEvent trackMouseEvent);
 
             /// <summary>
             /// Retrieves a history of up to 64 previous coordinates of the mouse or pen.

--- a/src/OpenTK.NT/Native/User32/RawInput.cs
+++ b/src/OpenTK.NT/Native/User32/RawInput.cs
@@ -2,14 +2,6 @@
 using System.Runtime.InteropServices;
 using System.Security;
 
-using BOOL = System.Boolean;
-using HANDLE = System.IntPtr;
-using HRAWINPUT = System.IntPtr;
-using INT = System.Int32;
-using LPVOID = System.IntPtr;
-using LRESULT = System.IntPtr;
-using UINT = System.UInt32;
-
 namespace OpenToolkit.NT.Native
 {
     public static partial class User32
@@ -37,11 +29,11 @@ namespace OpenToolkit.NT.Native
             /// </returns>
             [SuppressUnmanagedCodeSecurity]
             [DllImport(Library)]
-            public static extern LRESULT DefRawInputProc
+            public static extern IntPtr DefRawInputProc
             (
                 [In] Native.RawInput[] rawInputArrayOut,
-                [In] INT rawInputAmount,
-                [In] UINT headerSize
+                [In] int rawInputAmount,
+                [In] uint headerSize
             );
 
             /// <summary>
@@ -63,11 +55,11 @@ namespace OpenToolkit.NT.Native
             /// </returns>
             [SuppressUnmanagedCodeSecurity]
             [DllImport(Library)]
-            public static unsafe extern LRESULT DefRawInputProc
+            public static unsafe extern IntPtr DefRawInputProc
             (
                 [In] Native.RawInput* rawInputArrayOut,
-                [In] INT rawInputAmount,
-                [In] UINT headerSize
+                [In] int rawInputAmount,
+                [In] uint headerSize
             );
 
             /// <summary>
@@ -87,11 +79,11 @@ namespace OpenToolkit.NT.Native
             /// </returns>
             [DllImport(Library, SetLastError = true)]
             [return: MarshalAs(UnmanagedType.Bool)]
-            public static extern BOOL RegisterRawInputDevices
+            public static extern bool RegisterRawInputDevices
             (
                 [In] RawInputDevice[] rawInputDevices,
-                [In] UINT deviceAmount,
-                [In] UINT size
+                [In] uint deviceAmount,
+                [In] uint size
             );
 
             /// <summary>
@@ -113,11 +105,11 @@ namespace OpenToolkit.NT.Native
             /// For more details, call <see cref="Marshal.GetLastWin32Error"/>.
             /// </returns>
             [DllImport(Library, SetLastError = true)]
-            public static extern UINT GetRegisteredRawInputDevices
+            public static extern uint GetRegisteredRawInputDevices
             (
                 [Out] [Optional] RawInputDevice[] rawInputDevicesOut,
-                [In] [Out] ref UINT deviceAmount,
-                [In] UINT size
+                [In] [Out] ref uint deviceAmount,
+                [In] uint size
             );
 
             /// <summary>
@@ -138,11 +130,11 @@ namespace OpenToolkit.NT.Native
             /// </returns>
             [SuppressUnmanagedCodeSecurity]
             [DllImport(Library, SetLastError = true)]
-            public static extern UINT GetRawInputBuffer
+            public static extern uint GetRawInputBuffer
             (
                 [Out] [Optional] Native.RawInput[] data,
-                [In] [Out] ref UINT rawInputSize,
-                [In] UINT headerSize
+                [In] [Out] ref uint rawInputSize,
+                [In] uint headerSize
             );
 
             /// <summary>
@@ -158,16 +150,16 @@ namespace OpenToolkit.NT.Native
             /// If <paramref name="data"/> is null and the function is successful, the return value is zero.
             /// If <paramref name="data"/> is not null and the function is successful, the return value is the
             /// number of <see cref="RawInput"/> structures written to <paramref name="data"/>.<para/>
-            /// If an error occurs, the return value is (UINT)-1.
+            /// If an error occurs, the return value is (uint)-1.
             /// Call <see cref="Marshal.GetLastWin32Error"/> for the error code.
             /// </returns>
             [SuppressUnmanagedCodeSecurity]
             [DllImport(Library, SetLastError = true)]
-            public static unsafe extern UINT GetRawInputBuffer
+            public static unsafe extern uint GetRawInputBuffer
             (
                 [Out] [Optional] Native.RawInput* data,
-                [In] [Out] ref UINT rawInputSize,
-                [In] UINT headerSize
+                [In] [Out] ref uint rawInputSize,
+                [In] uint headerSize
             );
 
             /// <summary>
@@ -191,15 +183,15 @@ namespace OpenToolkit.NT.Native
             /// <returns>
             /// If the function is successful, the return value is the number of devices stored in the buffer
             /// pointed to by <paramref name="deviceListArrayOut"/>.<para/>
-            /// On any other error, the function returns (UINT)-1 and
+            /// On any other error, the function returns (uint)-1 and
             /// <see cref="Marshal.GetLastWin32Error"/> returns the error indication.
             /// </returns>
             [DllImport(Library, SetLastError = true)]
-            public static extern UINT GetRawInputDeviceList
+            public static extern uint GetRawInputDeviceList
             (
                 [Out] [Optional] RawInputDeviceList[] deviceListArrayOut,
-                [In] [Out] ref UINT deviceListAmount,
-                [In] UINT deviceListSize
+                [In] [Out] ref uint deviceListAmount,
+                [In] uint deviceListSize
             );
 
             /// <summary>
@@ -223,15 +215,15 @@ namespace OpenToolkit.NT.Native
             /// <returns>
             /// If the function is successful, the return value is the number of devices stored in the buffer
             /// pointed to by <paramref name="deviceListArrayOut"/>.<para/>
-            /// On any other error, the function returns (UINT)-1 and
+            /// On any other error, the function returns (uint)-1 and
             /// <see cref="Marshal.GetLastWin32Error"/> returns the error indication.
             /// </returns>
             [DllImport(Library, SetLastError = true)]
-            public static unsafe extern UINT GetRawInputDeviceList
+            public static unsafe extern uint GetRawInputDeviceList
             (
                 [Out] [Optional] RawInputDeviceList* deviceListArrayOut,
-                [In] [Out] ref UINT deviceListAmount,
-                [In] UINT deviceListSize
+                [In] [Out] ref uint deviceListAmount,
+                [In] uint deviceListSize
             );
 
             /// <summary>
@@ -239,14 +231,14 @@ namespace OpenToolkit.NT.Native
             /// </summary>
             /// <param name="device">
             /// A handle to the raw input device. This comes from the <see cref="RawInputHeader.Device"/> or
-            /// from <see cref="GetRawInputDeviceList(RawInputDeviceList[], ref UINT, UINT)"/>.
+            /// from <see cref="GetRawInputDeviceList(RawInputDeviceList[], ref uint, uint)"/>.
             /// </param>
             /// <param name="command">Specifies what data will be returned in <paramref name="data"/>.</param>
             /// <param name="data">
             /// A buffer that contains the information specified by <paramref name="command"/>.
             /// If <paramref name="command"/> is <see cref="GetRawInputDeviceInfoEnum.DeviceInfo"/>, set the
             /// <see cref="RawInputDeviceInfo.Size"/> to <see cref="RawInputDeviceInfo.SizeInBytes"/> before calling
-            /// <see cref="GetRawInputDeviceInfo(HANDLE, GetRawInputDeviceInfoEnum, HANDLE, ref UINT)"/>.
+            /// <see cref="GetRawInputDeviceInfo(IntPtr, GetRawInputDeviceInfoEnum, IntPtr, ref uint)"/>.
             /// </param>
             /// <param name="dataSize">The size, in bytes, of the data in <paramref name="data"/>.</param>
             /// <returns>
@@ -260,9 +252,9 @@ namespace OpenToolkit.NT.Native
             /// </returns>
             [SuppressUnmanagedCodeSecurity]
             [DllImport(Library, SetLastError = true)]
-            public static extern UINT GetRawInputDeviceInfo
+            public static extern uint GetRawInputDeviceInfo
             (
-                [In] [Optional] HANDLE device,
+                [In] [Optional] IntPtr device,
                 [In] GetRawInputDeviceInfoEnum command,
                 [In] [Out] [Optional] byte[] data,
                 [In] [Out] ref uint dataSize
@@ -273,14 +265,14 @@ namespace OpenToolkit.NT.Native
             /// </summary>
             /// <param name="device">
             /// A handle to the raw input device. This comes from the <see cref="RawInputHeader.Device"/> or
-            /// from <see cref="GetRawInputDeviceList(RawInputDeviceList[], ref UINT, UINT)"/>.
+            /// from <see cref="GetRawInputDeviceList(RawInputDeviceList[], ref uint, uint)"/>.
             /// </param>
             /// <param name="command">Specifies what data will be returned in <paramref name="data"/>.</param>
             /// <param name="data">
             /// A pointer to a buffer that contains the information specified by <paramref name="command"/>.
             /// If <paramref name="command"/> is <see cref="GetRawInputDeviceInfoEnum.DeviceInfo"/>, set the
             /// <see cref="RawInputDeviceInfo.Size"/> to <see cref="RawInputDeviceInfo.SizeInBytes"/> before calling
-            /// <see cref="GetRawInputDeviceInfo(HANDLE, GetRawInputDeviceInfoEnum, LPVOID, ref UINT)"/>.
+            /// <see cref="GetRawInputDeviceInfo(IntPtr, GetRawInputDeviceInfoEnum, IntPtr, ref uint)"/>.
             /// </param>
             /// <param name="dataSize">The size, in bytes, of the data in <paramref name="data"/>.</param>
             /// <returns>
@@ -294,12 +286,12 @@ namespace OpenToolkit.NT.Native
             /// </returns>
             [SuppressUnmanagedCodeSecurity]
             [DllImport(Library, SetLastError = true)]
-            public static unsafe extern UINT GetRawInputDeviceInfo
+            public static unsafe extern uint GetRawInputDeviceInfo
             (
-                [In] [Optional] HANDLE device,
+                [In] [Optional] IntPtr device,
                 [In] GetRawInputDeviceInfoEnum command,
-                [In] [Out] [Optional] LPVOID data,
-                [In] [Out] ref UINT dataSize
+                [In] [Out] [Optional] IntPtr data,
+                [In] [Out] ref uint dataSize
             );
 
             /// <summary>
@@ -307,7 +299,7 @@ namespace OpenToolkit.NT.Native
             /// </summary>
             /// <param name="device">
             /// A handle to the raw input device. This comes from <see cref="RawInputHeader.Device"/> or from
-            /// <see cref="GetRawInputDeviceList(RawInputDeviceList[], ref UINT, UINT)"/>.
+            /// <see cref="GetRawInputDeviceList(RawInputDeviceList[], ref uint, uint)"/>.
             /// </param>
             /// <param name="command">Specifies what data will be returned in <paramref name="data"/>.</param>
             /// <param name="data">
@@ -330,7 +322,7 @@ namespace OpenToolkit.NT.Native
             [DllImport(Library, SetLastError = true)]
             public static extern uint GetRawInputDeviceInfo
             (
-                [In] [Optional] HANDLE device,
+                [In] [Optional] IntPtr device,
                 [In] GetRawInputDeviceInfoEnum command,
                 [In] [Out] [Optional] ref RawInputDeviceInfo data,
                 [In] [Out] ref uint size
@@ -347,9 +339,9 @@ namespace OpenToolkit.NT.Native
             /// <returns>
             /// If the function is successful, the return value is the number of bytes copied into
             /// <paramref name="header"/>.<para/>
-            /// If there is an error, the return value is (UINT)-1 [== <see cref="uint.MaxValue"/>].
+            /// If there is an error, the return value is (uint)-1 [== <see cref="uint.MaxValue"/>].
             /// </returns>
-            public static unsafe UINT GetRawInputData(HRAWINPUT rawInput, out RawInputHeader header)
+            public static unsafe uint GetRawInputData(IntPtr rawInput, out RawInputHeader header)
             {
                 uint size = RawInputHeader.SizeInBytes;
                 fixed (RawInputHeader* headerPtr = &header)
@@ -376,9 +368,9 @@ namespace OpenToolkit.NT.Native
             /// <returns>
             /// If the function is successful, the return value is the number of bytes copied into
             /// <paramref name="data"/>.<para/>
-            /// If there is an error, the return value is (UINT)-1 [== <see cref="uint.MaxValue"/>].
+            /// If there is an error, the return value is (uint)-1 [== <see cref="uint.MaxValue"/>].
             /// </returns>
-            public static unsafe UINT GetRawInputData(HRAWINPUT rawInput, out Native.RawInput data)
+            public static unsafe uint GetRawInputData(IntPtr rawInput, out Native.RawInput data)
             {
                 uint size = Native.RawInput.SizeInBytes;
                 fixed (Native.RawInput* dataPtr = &data)
@@ -414,17 +406,17 @@ namespace OpenToolkit.NT.Native
             /// If <paramref name="data"/> is <see cref="IntPtr.Zero"/> and the function is successful, the return
             /// value is 0. If <paramref name="data"/> is not <see cref="IntPtr.Zero"/> and the function is successful,
             /// the return value is the number of bytes copied into <paramref name="data"/>.<para/>
-            /// If there is an error, the return value is (UINT)-1 [== <see cref="uint.MaxValue"/>].
+            /// If there is an error, the return value is (uint)-1 [== <see cref="uint.MaxValue"/>].
             /// </returns>
             [SuppressUnmanagedCodeSecurity]
             [DllImport(Library, SetLastError = true)]
-            public static extern UINT GetRawInputData
+            public static extern uint GetRawInputData
             (
-                [In] HRAWINPUT rawInput,
+                [In] IntPtr rawInput,
                 [In] GetRawInputDataCommand command,
-                [Out] [Optional] LPVOID data,
-                [In] [Out] ref UINT size,
-                [In] UINT headerSize
+                [Out] [Optional] IntPtr data,
+                [In] [Out] ref uint size,
+                [In] uint headerSize
             );
         }
     }

--- a/src/OpenTK.NT/Native/User32/Structs/BroadcastDeviceInterface.cs
+++ b/src/OpenTK.NT/Native/User32/Structs/BroadcastDeviceInterface.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Runtime.InteropServices;
-using DWORD = System.UInt32;
 
 namespace OpenToolkit.NT.Native
 {
@@ -14,7 +13,7 @@ namespace OpenToolkit.NT.Native
         /// <see cref="Name"/> string (the null character is accounted for by the declaration of <see cref="Name"/>
         /// as a one-character array).
         /// </summary>
-        public DWORD Size;
+        public uint Size;
 
         /// <summary>
         /// Official documentation states "Set to <see cref="DeviceBroadcastType.DeviceInterface"/>".<para/>
@@ -25,7 +24,7 @@ namespace OpenToolkit.NT.Native
         /// <summary>
         /// Reserved; do not use.
         /// </summary>
-        public DWORD Reserved;
+        public uint Reserved;
 
         /// <summary>
         /// The GUID for the interface device class.

--- a/src/OpenTK.NT/Native/User32/Structs/CreateStruct.cs
+++ b/src/OpenTK.NT/Native/User32/Structs/CreateStruct.cs
@@ -1,20 +1,13 @@
 ﻿using System;
 using System.Runtime.InteropServices;
 
-using HINSTANCE = System.IntPtr;
-using HMENU = System.IntPtr;
-using HWND = System.IntPtr;
-using LPCTSTR = System.String;
-using LPVOID = System.IntPtr;
-using SHORT = System.Int16;
-
 namespace OpenToolkit.NT.Native
 {
     /// <summary>
     /// Defines the initialization parameters passed to the window procedure of an application. These members are
     /// identical to the parameters of the
-    /// <see cref="User32.Window.CreateWindowEx(ExtendedWindowStyles, HINSTANCE, string,
-    /// WindowStyles, int, int, int, int, HINSTANCE, HINSTANCE, HINSTANCE, HINSTANCE)"/> function.
+    /// <see cref="User32.Window.CreateWindowEx(ExtendedWindowStyles, IntPtr, string,
+    /// WindowStyles, int, int, int, int, IntPtr, IntPtr, IntPtr, IntPtr)"/> function.
     /// </summary>
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
     public struct CreateStruct
@@ -22,34 +15,34 @@ namespace OpenToolkit.NT.Native
         /// <summary>
         /// Contains additional data which may be used to create the window. If the window is being created as a
         /// result of a call to the CreateWindow or
-        /// <see cref="User32.Window.CreateWindowEx(ExtendedWindowStyles, HINSTANCE, string,
-        /// WindowStyles, int, int, int, int, HINSTANCE, HINSTANCE, HINSTANCE, HINSTANCE)"/>
+        /// <see cref="User32.Window.CreateWindowEx(ExtendedWindowStyles, IntPtr, string,
+        /// WindowStyles, int, int, int, int, IntPtr, IntPtr, IntPtr, IntPtr)"/>
         /// function, this member contains the value of the lpParam parameter specified in the function call.<para/>
         /// If the window being created is a MDI client window, this member contains a pointer to a CLIENTCREATESTRUCT
         /// structure. If the window being created is a MDI child window, this member contains a pointer to an
         /// MDICREATESTRUCT structure.<para/>
-        /// If the window is being created from a dialog template, this member is the address of a <see cref="SHORT"/>
+        /// If the window is being created from a dialog template, this member is the address of a <see cref="short"/>
         /// value that specifies the size, in bytes, of the window creation data. The value is immediately followed
         /// by the creation data.
         /// </summary>
-        public LPVOID CreateParams;
+        public IntPtr CreateParams;
 
         /// <summary>
         /// Handle to the module that owns the new window.
         /// </summary>
-        public HINSTANCE Instance;
+        public IntPtr Instance;
 
         /// <summary>
         /// Handle to the menu to be used by the new window.
         /// </summary>
-        public HMENU Menu;
+        public IntPtr Menu;
 
         /// <summary>
         /// Handle to the parent window, if the window is a child window.
         /// If the window is owned, this member identifies the owner window.
         /// If the window is not a child or owned window, this member is null.
         /// </summary>
-        public HWND Parent;
+        public IntPtr Parent;
 
         /// <summary>
         /// Specifies the height of the new window, in pixels.
@@ -83,7 +76,7 @@ namespace OpenToolkit.NT.Native
         /// <summary>
         /// Pointer to a null-terminated string that specifies the name of the new window.
         /// </summary>
-        public LPCTSTR Name;
+        public string Name;
 
         /// <summary>
         /// Either a pointer to a null-terminated string or an atom that specifies the class name

--- a/src/OpenTK.NT/Native/User32/Structs/DeviceMode.cs
+++ b/src/OpenTK.NT/Native/User32/Structs/DeviceMode.cs
@@ -1,9 +1,6 @@
 ﻿using System;
 using System.Runtime.InteropServices;
 
-using DWORD = System.UInt32;
-using WORD = System.UInt16;
-
 namespace OpenToolkit.NT.Native
 {
     /// <summary>
@@ -27,7 +24,7 @@ namespace OpenToolkit.NT.Native
         /// Default value for <see cref="SpecVersion"/> and <see cref="DriverVersion"/> (see the documentation of those
         /// fields for more information).
         /// </summary>
-        public const WORD DefaultSpecVersion = 800;
+        public const ushort DefaultSpecVersion = 800;
 
         /// <summary>
         /// A zero-terminated character array that specifies the "friendly" name of the printer or display.
@@ -41,14 +38,14 @@ namespace OpenToolkit.NT.Native
         /// The current version number is identified by <see cref="DefaultSpecVersion"/>.
         /// </summary>
         [FieldOffset(64)]
-        public WORD SpecVersion;
+        public ushort SpecVersion;
 
         /// <summary>
         /// For a printer, specifies the printer driver version number assigned by the printer driver developer.<para/>
         /// Display drivers can set this member to <see cref="DefaultSpecVersion"/>.
         /// </summary>
         [FieldOffset(66)]
-        public WORD DriverVersion;
+        public ushort DriverVersion;
 
         /// <summary>
         /// Specifies the size in bytes of the public DEVMODEW structure, not including any private,
@@ -56,14 +53,14 @@ namespace OpenToolkit.NT.Native
         /// Set this to <see cref="SizeInBytes"/>.
         /// </summary>
         [FieldOffset(68)]
-        public WORD Size;
+        public ushort Size;
 
         /// <summary>
         /// Specifies the number of bytes of private driver data that follow the public structure members.
         /// If a device driver does not provide private members, this member should be set to zero.
         /// </summary>
         [FieldOffset(70)]
-        public WORD DriverExtra;
+        public ushort DriverExtra;
 
         /// <summary>
         /// Specifies bit flags identifying which of the following members are in use.
@@ -146,25 +143,25 @@ namespace OpenToolkit.NT.Native
         /// to the ulLogPixels member of the GDIINFO structure.
         /// </summary>
         [FieldOffset(166)]
-        public WORD LogPixels;
+        public ushort LogPixels;
 
         /// <summary>
         /// For displays, specifies the color resolution, in bits per pixel, of a display device.
         /// </summary>
         [FieldOffset(168)]
-        public DWORD BitsPerPixel;
+        public uint BitsPerPixel;
 
         /// <summary>
         /// For displays, specifies the width, in pixels, of the visible device surface.
         /// </summary>
         [FieldOffset(172)]
-        public DWORD WidthInPixels;
+        public uint WidthInPixels;
 
         /// <summary>
         /// For displays, specifies the height, in pixels, of the visible device surface.
         /// </summary>
         [FieldOffset(176)]
-        public DWORD HeightInPixels;
+        public uint HeightInPixels;
 
         /// <summary>
         /// For displays, specifies a display device's display mode.
@@ -177,13 +174,13 @@ namespace OpenToolkit.NT.Native
         /// (playing multiple EMF logical pages onto a single physical page).
         /// </summary>
         [FieldOffset(180)]
-        public DWORD Nup;
+        public uint Nup;
 
         /// <summary>
         /// For displays, specifies the frequency, in hertz, of a display device in its current mode.
         /// </summary>
         [FieldOffset(184)]
-        public DWORD DisplayFrequency;
+        public uint DisplayFrequency;
 
         /// <summary>
         /// For printers, specifies how Image Color Management (ICM) is handled. For a non-ICM application, this field
@@ -224,25 +221,25 @@ namespace OpenToolkit.NT.Native
         /// Is reserved for system use and must be zero.
         /// </summary>
         [FieldOffset(204)]
-        public DWORD Reserved1;
+        public uint Reserved1;
 
         /// <summary>
         /// Is reserved for system use and must be zero.
         /// </summary>
         [FieldOffset(208)]
-        public DWORD Reserved2;
+        public uint Reserved2;
 
         /// <summary>
         /// Must be zero.
         /// </summary>
         [FieldOffset(212)]
-        public DWORD PanningWidth;
+        public uint PanningWidth;
 
         /// <summary>
         /// Must be zero.
         /// </summary>
         [FieldOffset(216)]
-        public DWORD PanningHeight;
+        public uint PanningHeight;
 
         /// <summary>
         /// The size of the structure in bytes.

--- a/src/OpenTK.NT/Native/User32/Structs/DisplayDevice.cs
+++ b/src/OpenTK.NT/Native/User32/Structs/DisplayDevice.cs
@@ -1,22 +1,20 @@
 ﻿using System.Runtime.InteropServices;
 
-using DWORD = System.UInt32;
-
 namespace OpenToolkit.NT.Native
 {
     /// <summary>
     /// Receives information about the display device specified by the iDevNum parameter of the
-    /// <see cref="User32.DeviceContext.EnumDisplayDevices(string, DWORD, out DisplayDevice, DWORD)"/> function.
+    /// <see cref="User32.DeviceContext.EnumDisplayDevices(string, uint, out DisplayDevice, uint)"/> function.
     /// </summary>
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
     public struct DisplayDevice
     {
         /// <summary>
         /// Size, in bytes, of the structure. This must be initialized prior to calling
-        /// <see cref="User32.DeviceContext.EnumDisplayDevices(string, DWORD, out DisplayDevice, DWORD)"/>.
+        /// <see cref="User32.DeviceContext.EnumDisplayDevices(string, uint, out DisplayDevice, uint)"/>.
         /// </summary>
         /// <seealso cref="SizeInBytes"/>
-        public DWORD Size;
+        public uint Size;
 
         /// <summary>
         /// An array of characters identifying the device name.

--- a/src/OpenTK.NT/Native/User32/Structs/ExtendedWindowClass.cs
+++ b/src/OpenTK.NT/Native/User32/Structs/ExtendedWindowClass.cs
@@ -1,18 +1,12 @@
 ﻿using System;
 using System.Runtime.InteropServices;
 
-using HBRUSH = System.IntPtr;
-using HCURSOR = System.IntPtr;
-using HICON = System.IntPtr;
-using HINSTANCE = System.IntPtr;
-using UINT = System.UInt32;
-
 namespace OpenToolkit.NT.Native
 {
     /// <summary>
     /// Contains window class information. It is used with the
     /// <see cref="User32.WindowClass.RegisterClassEx(ref ExtendedWindowClass)"/> and
-    /// <see cref="User32.WindowClass.GetClassInfoEx(HBRUSH, string, out ExtendedWindowClass)"/> functions.<para/>
+    /// <see cref="User32.WindowClass.GetClassInfoEx(IntPtr, string, out ExtendedWindowClass)"/> functions.<para/>
     /// The <see cref="ExtendedWindowClass"/> structure is similar to the <see cref="WindowClass"/> structure.
     /// There are two differences. <see cref="ExtendedWindowClass"/> includes the <see cref="Size"/> member, which
     /// specifies the size of the structure, and the <see cref="IconSmall"/> member, which contains a handle
@@ -24,9 +18,9 @@ namespace OpenToolkit.NT.Native
         /// <summary>
         /// The size, in bytes, of this structure. Set this member to <see cref="SizeInBytes"/>.<para/>
         /// Be sure to set this member before calling the
-        /// <see cref="User32.WindowClass.GetClassInfoEx(HBRUSH, HBRUSH, out ExtendedWindowClass)"/> function.
+        /// <see cref="User32.WindowClass.GetClassInfoEx(IntPtr, IntPtr, out ExtendedWindowClass)"/> function.
         /// </summary>
-        public UINT Size;
+        public uint Size;
 
         /// <summary>
         /// The class style(s). This member can be any combination of <see cref="WindowClassStyles"/>.
@@ -54,27 +48,27 @@ namespace OpenToolkit.NT.Native
         /// <summary>
         /// A handle to the instance that contains the window procedure for the class.
         /// </summary>
-        public HINSTANCE Instance;
+        public IntPtr Instance;
 
         /// <summary>
         /// A handle to the class icon. This member must be a handle to an icon resource.
         /// If this member is <see cref="IntPtr.Zero"/>, the system provides a default icon.
         /// </summary>
-        public HICON Icon;
+        public IntPtr Icon;
 
         /// <summary>
         /// A handle to the class cursor. This member must be a handle to a cursor resource.
         /// If this member is <see cref="IntPtr.Zero"/>, an application must explicitly set the cursor shape
         /// whenever the mouse moves into the application's window.
         /// </summary>
-        public HCURSOR Cursor;
+        public IntPtr Cursor;
 
         /// <summary>
         /// A handle to the class background brush. This member can be a handle to the brush to be used for
         /// painting the background, or it can be a color value.<para/>
         /// For more information on setting this to a color value, check the official documentation.
         /// </summary>
-        public HBRUSH Background;
+        public IntPtr Background;
 
         /// <summary>
         /// Pointer to a string that specifies the resource name of the class menu, as the name appears in the
@@ -94,7 +88,7 @@ namespace OpenToolkit.NT.Native
         /// <see cref="IntPtr.Zero"/>, the system searches the icon resource specified by the hIcon member for an icon
         /// of the appropriate size to use as the small icon.
         /// </summary>
-        public HICON IconSmall;
+        public IntPtr IconSmall;
 
         /// <summary>
         /// The size of this structure in bytes.

--- a/src/OpenTK.NT/Native/User32/Structs/IconInfo.cs
+++ b/src/OpenTK.NT/Native/User32/Structs/IconInfo.cs
@@ -1,6 +1,4 @@
-﻿using BOOL = System.Boolean;
-using DWORD = System.UInt32;
-using HBITMAP = System.IntPtr;
+﻿using System;
 
 namespace OpenToolkit.NT.Native
 {
@@ -13,21 +11,21 @@ namespace OpenToolkit.NT.Native
         /// Specifies whether this structure defines an icon or a cursor. A
         /// value of true specifies an icon; false specifies a cursor.
         /// </summary>
-        public BOOL Icon;
+        public bool Icon;
 
         /// <summary>
         /// The x-coordinate of a cursor's hot spot. If this structure defines
         /// an icon, the hot spot is always in the center of the icon, and
         /// this member is ignored.
         /// </summary>
-        public DWORD XHotspot;
+        public uint XHotspot;
 
         /// <summary>
         /// The y-coordinate of a cursor's hot spot. If this structure defines
         /// an icon, the hot spot is always in the center of the icon, and
         /// this member is ignored.
         /// </summary>
-        public DWORD YHotspot;
+        public uint YHotspot;
 
         /// <summary>
         /// The icon bitmask bitmap. If this structure defines a black and
@@ -37,7 +35,7 @@ namespace OpenToolkit.NT.Native
         /// two. If this structure defines a color icon, this mask only
         /// defines the AND bitmask of the icon.
         /// </summary>
-        public HBITMAP BitmapMask;
+        public IntPtr BitmapMask;
 
         /// <summary>
         /// A handle to the icon color bitmap. This member can be optional if
@@ -46,6 +44,6 @@ namespace OpenToolkit.NT.Native
         /// subsequently, the color bitmap is applied (using XOR) to the
         /// destination by using the SRCINVERT flag.
         /// </summary>
-        public HBITMAP BitmapColor;
+        public IntPtr BitmapColor;
     }
 }

--- a/src/OpenTK.NT/Native/User32/Structs/MonitorInfo.cs
+++ b/src/OpenTK.NT/Native/User32/Structs/MonitorInfo.cs
@@ -1,7 +1,5 @@
 ﻿using System.Runtime.InteropServices;
 
-using DWORD = System.UInt32;
-
 namespace OpenToolkit.NT.Native
 {
     /// <summary>
@@ -13,7 +11,7 @@ namespace OpenToolkit.NT.Native
         /// The size of the structure, in bytes. Set this member to <see cref="SizeInBytes"/> before calling the
         /// <see cref="User32.Monitor.GetMonitorInfo(System.IntPtr, out MonitorInfo)"/> function.
         /// </summary>
-        public DWORD Size;
+        public uint Size;
 
         /// <summary>
         /// A <see cref="Rect"/> structure that specifies the display monitor rectangle, expressed in virtual-screen
@@ -34,7 +32,7 @@ namespace OpenToolkit.NT.Native
         /// The (currently only) defined flag is "Primary" with a value of 1, so a value of 1 means the display is
         /// primary while a value of 0 means that it is not.
         /// </summary>
-        public DWORD Flags;
+        public uint Flags;
 
         /// <summary>
         /// The size of this structure in bytes.

--- a/src/OpenTK.NT/Native/User32/Structs/MouseMovePoint.cs
+++ b/src/OpenTK.NT/Native/User32/Structs/MouseMovePoint.cs
@@ -1,7 +1,5 @@
-﻿using System.Runtime.InteropServices;
-
-using DWORD = System.UInt32;
-using ULONG_PTR = System.IntPtr;
+﻿using System;
+using System.Runtime.InteropServices;
 
 namespace OpenToolkit.NT.Native
 {
@@ -23,12 +21,12 @@ namespace OpenToolkit.NT.Native
         /// <summary>
         /// The time stamp of the mouse coordinate.
         /// </summary>
-        public DWORD Time;
+        public uint Time;
 
         /// <summary>
         /// Additional information associated with this coordinate.
         /// </summary>
-        public ULONG_PTR ExtraInfo;
+        public IntPtr ExtraInfo;
 
         /// <summary>
         /// The size of this structure in bytes.

--- a/src/OpenTK.NT/Native/User32/Structs/Msg.cs
+++ b/src/OpenTK.NT/Native/User32/Structs/Msg.cs
@@ -1,7 +1,4 @@
-﻿using DWORD = System.UInt32;
-using HWND = System.IntPtr;
-using LPARAM = System.IntPtr;
-using WPARAM = System.IntPtr;
+﻿using System;
 
 namespace OpenToolkit.NT.Native
 {
@@ -14,7 +11,7 @@ namespace OpenToolkit.NT.Native
         /// A handle to the window whose window procedure receives the message. This member is
         /// <see cref="System.IntPtr.Zero"/> when the message is a thread message.
         /// </summary>
-        public HWND HWnd;
+        public IntPtr HWnd;
 
         /// <summary>
         /// The message identifier. Applications can only use the low word; the high word is reserved by the system.
@@ -25,18 +22,18 @@ namespace OpenToolkit.NT.Native
         /// Additional information about the message.The exact meaning depends on the value of the
         /// <see cref="Message"/> member.
         /// </summary>
-        public WPARAM WParam;
+        public IntPtr WParam;
 
         /// <summary>
         /// Additional information about the message.The exact meaning depends on the value of the
         /// <see cref="Message"/> member.
         /// </summary>
-        public LPARAM LParam;
+        public IntPtr LParam;
 
         /// <summary>
         /// The time at which the message was posted.
         /// </summary>
-        public DWORD Time;
+        public uint Time;
 
         /// <summary>
         /// The cursor position, in screen coordinates, when the message was posted.

--- a/src/OpenTK.NT/Native/User32/Structs/RawHid.cs
+++ b/src/OpenTK.NT/Native/User32/Structs/RawHid.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 
-using DWORD = System.UInt32;
-
 namespace OpenToolkit.NT.Native
 {
     /// <summary>
@@ -16,12 +14,12 @@ namespace OpenToolkit.NT.Native
         /// <summary>
         /// Size, in bytes, of each HID input in bRawData.
         /// </summary>
-        public DWORD SizeHid;
+        public uint SizeHid;
 
         /// <summary>
         /// Number of HID inputs in bRawData.
         /// </summary>
-        public DWORD Count;
+        public uint Count;
 
         /// <summary>
         /// The first byte of the raw input data.

--- a/src/OpenTK.NT/Native/User32/Structs/RawInputDevice.cs
+++ b/src/OpenTK.NT/Native/User32/Structs/RawInputDevice.cs
@@ -1,8 +1,6 @@
-﻿using System.Runtime.InteropServices;
+﻿using System;
+using System.Runtime.InteropServices;
 using OpenToolkit.Input.Hid;
-
-using HWND = System.IntPtr;
-using USHORT = System.UInt16;
 
 namespace OpenToolkit.NT.Native
 {
@@ -19,7 +17,7 @@ namespace OpenToolkit.NT.Native
         /// <summary>
         /// Top level collection Usage for the raw input device.
         /// </summary>
-        public USHORT Usage;
+        public ushort Usage;
 
         /// <summary>
         /// Mode flag that specifies how to interpret the information provided by UsagePage and Usage.
@@ -31,7 +29,7 @@ namespace OpenToolkit.NT.Native
         /// <summary>
         /// Handle to the target window. If NULL it follows the keyboard focus.
         /// </summary>
-        public HWND Target;
+        public IntPtr Target;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RawInputDevice"/> struct for generic desktop usage.
@@ -39,7 +37,7 @@ namespace OpenToolkit.NT.Native
         /// <param name="usage">HID usage for the Generic Desktop page.</param>
         /// <param name="flags">Specifies how to interpret the raw input data.</param>
         /// <param name="target">Handle to the target window.</param>
-        public RawInputDevice(HidGenericDesktopUsage usage, RawInputDeviceFlags flags, HWND target)
+        public RawInputDevice(HidGenericDesktopUsage usage, RawInputDeviceFlags flags, IntPtr target)
             : this((ushort)usage, flags, target, HidPage.GenericDesktop)
         {
         }
@@ -50,7 +48,7 @@ namespace OpenToolkit.NT.Native
         /// <param name="usage">HID usage for the Consumer page.</param>
         /// <param name="flags">Specifies how to interpret the raw input data.</param>
         /// <param name="target">Handle to the target window.</param>
-        public RawInputDevice(HidConsumerUsage usage, RawInputDeviceFlags flags, HWND target)
+        public RawInputDevice(HidConsumerUsage usage, RawInputDeviceFlags flags, IntPtr target)
             : this((ushort)usage, flags, target, HidPage.Consumer)
         {
         }
@@ -61,12 +59,12 @@ namespace OpenToolkit.NT.Native
         /// <param name="usage">HID usage for the Simulation page.</param>
         /// <param name="flags">Specifies how to interpret the raw input data.</param>
         /// <param name="target">Handle to the target window.</param>
-        public RawInputDevice(HidSimulationUsage usage, RawInputDeviceFlags flags, HWND target)
+        public RawInputDevice(HidSimulationUsage usage, RawInputDeviceFlags flags, IntPtr target)
             : this((ushort)usage, flags, target, HidPage.Simulation)
         {
         }
 
-        private RawInputDevice(ushort usage, RawInputDeviceFlags flags, HWND target, HidPage usagePage)
+        private RawInputDevice(ushort usage, RawInputDeviceFlags flags, IntPtr target, HidPage usagePage)
         {
             Usage = usage;
             Flags = flags;

--- a/src/OpenTK.NT/Native/User32/Structs/RawInputDeviceInfo.cs
+++ b/src/OpenTK.NT/Native/User32/Structs/RawInputDeviceInfo.cs
@@ -1,7 +1,5 @@
 ﻿using System.Runtime.InteropServices;
 
-using DWORD = System.UInt32;
-
 namespace OpenToolkit.NT.Native
 {
     /// <summary>
@@ -14,7 +12,7 @@ namespace OpenToolkit.NT.Native
         /// Size, in bytes, of the <see cref="RawInputDeviceInfo"/> structure.
         /// </summary>
         [FieldOffset(0)]
-        public DWORD Size;
+        public uint Size;
 
         /// <summary>
         /// Type of raw input data.

--- a/src/OpenTK.NT/Native/User32/Structs/RawInputDeviceInfoHid.cs
+++ b/src/OpenTK.NT/Native/User32/Structs/RawInputDeviceInfoHid.cs
@@ -1,7 +1,4 @@
-﻿using DWORD = System.UInt32;
-using USHORT = System.UInt16;
-
-namespace OpenToolkit.NT.Native
+﻿namespace OpenToolkit.NT.Native
 {
     /// <summary>
     /// Defines the raw input data coming from the specified Human Interface Device (HID).
@@ -11,26 +8,26 @@ namespace OpenToolkit.NT.Native
         /// <summary>
         /// Vendor ID for the HID.
         /// </summary>
-        public DWORD VendorId;
+        public uint VendorId;
 
         /// <summary>
         /// Product ID for the HID.
         /// </summary>
-        public DWORD ProductId;
+        public uint ProductId;
 
         /// <summary>
         /// Version number for the HID.
         /// </summary>
-        public DWORD VersionNumber;
+        public uint VersionNumber;
 
         /// <summary>
         /// Top-level collection Usage Page for the device.
         /// </summary>
-        public USHORT UsagePage;
+        public ushort UsagePage;
 
         /// <summary>
         /// Top-level collection Usage for the device.
         /// </summary>
-        public USHORT Usage;
+        public ushort Usage;
     }
 }

--- a/src/OpenTK.NT/Native/User32/Structs/RawInputDeviceInfoKeyboard.cs
+++ b/src/OpenTK.NT/Native/User32/Structs/RawInputDeviceInfoKeyboard.cs
@@ -1,6 +1,4 @@
-﻿using DWORD = System.UInt32;
-
-namespace OpenToolkit.NT.Native
+﻿namespace OpenToolkit.NT.Native
 {
     /// <summary>
     /// Defines the raw input data coming from the specified keyboard.
@@ -13,31 +11,31 @@ namespace OpenToolkit.NT.Native
         /// <summary>
         /// Type of the keyboard.
         /// </summary>
-        public DWORD Type;
+        public uint Type;
 
         /// <summary>
         /// Subtype of the keyboard.
         /// </summary>
-        public DWORD SubType;
+        public uint SubType;
 
         /// <summary>
         /// Scan code mode.
         /// </summary>
-        public DWORD KeyboardMode;
+        public uint KeyboardMode;
 
         /// <summary>
         /// Number of function keys on the keyboard.
         /// </summary>
-        public DWORD NumberOfFunctionKeys;
+        public uint NumberOfFunctionKeys;
 
         /// <summary>
         /// Number of LED indicators on the keyboard.
         /// </summary>
-        public DWORD NumberOfIndicators;
+        public uint NumberOfIndicators;
 
         /// <summary>
         /// Total number of keys on the keyboard.
         /// </summary>
-        public DWORD NumberOfKeysTotal;
+        public uint NumberOfKeysTotal;
     }
 }

--- a/src/OpenTK.NT/Native/User32/Structs/RawInputDeviceInfoMouse.cs
+++ b/src/OpenTK.NT/Native/User32/Structs/RawInputDeviceInfoMouse.cs
@@ -1,7 +1,4 @@
-﻿using BOOL = System.Boolean;
-using DWORD = System.UInt32;
-
-namespace OpenToolkit.NT.Native
+﻿namespace OpenToolkit.NT.Native
 {
     /// <summary>
     /// Defines the raw input data coming from the specified mouse.
@@ -14,17 +11,17 @@ namespace OpenToolkit.NT.Native
         /// <summary>
         /// ID for the mouse device.
         /// </summary>
-        public DWORD Id;
+        public uint Id;
 
         /// <summary>
         /// Number of buttons for the mouse.
         /// </summary>
-        public DWORD NumberOfButtons;
+        public uint NumberOfButtons;
 
         /// <summary>
         /// Number of data points per second. This information may not be applicable for every mouse device.
         /// </summary>
-        public DWORD SampleRate;
+        public uint SampleRate;
 
         /// <summary>
         /// TRUE if the mouse has a wheel for horizontal scrolling; otherwise, FALSE.
@@ -32,6 +29,6 @@ namespace OpenToolkit.NT.Native
         /// <remarks>
         /// This member is only supported under Microsoft Windows Vista and later versions.
         /// </remarks>
-        public BOOL HasHorizontalWheel;
+        public bool HasHorizontalWheel;
     }
 }

--- a/src/OpenTK.NT/Native/User32/Structs/RawInputDeviceList.cs
+++ b/src/OpenTK.NT/Native/User32/Structs/RawInputDeviceList.cs
@@ -1,6 +1,5 @@
-﻿using System.Runtime.InteropServices;
-
-using HANDLE = System.IntPtr;
+﻿using System;
+using System.Runtime.InteropServices;
 
 namespace OpenToolkit.NT.Native
 {
@@ -12,7 +11,7 @@ namespace OpenToolkit.NT.Native
         /// <summary>
         /// Handle to the raw input device.
         /// </summary>
-        public HANDLE Device;
+        public IntPtr Device;
 
         /// <summary>
         /// Type of device.

--- a/src/OpenTK.NT/Native/User32/Structs/RawInputHeader.cs
+++ b/src/OpenTK.NT/Native/User32/Structs/RawInputHeader.cs
@@ -1,8 +1,5 @@
-﻿using System.Runtime.InteropServices;
-
-using DWORD = System.UInt32;
-using HANDLE = System.IntPtr;
-using WPARAM = System.IntPtr;
+﻿using System;
+using System.Runtime.InteropServices;
 
 namespace OpenToolkit.NT.Native
 {
@@ -20,17 +17,17 @@ namespace OpenToolkit.NT.Native
         /// The size, in bytes, of the entire input packet of data. This includes <see cref="RawInput"/> plus
         /// possible extra input reports in the <see cref="RawHid"/> variable length array.
         /// </summary>
-        public DWORD Size;
+        public uint Size;
 
         /// <summary>
         /// Handle to the device generating the raw input data.
         /// </summary>
-        public HANDLE Device;
+        public IntPtr Device;
 
         /// <summary>
         /// Value passed in the wParam parameter of the <see cref="WindowMessage.Input"/> message.
         /// </summary>
-        public WPARAM Param;
+        public IntPtr Param;
 
         /// <summary>
         /// The size of this structure in bytes.

--- a/src/OpenTK.NT/Native/User32/Structs/RawKeyboard.cs
+++ b/src/OpenTK.NT/Native/User32/Structs/RawKeyboard.cs
@@ -1,8 +1,4 @@
-﻿using UINT = System.UInt32;
-using ULONG = System.UInt32;
-using USHORT = System.UInt16;
-
-namespace OpenToolkit.NT.Native
+﻿namespace OpenToolkit.NT.Native
 {
     /// <summary>
     /// Contains information about the state of the keyboard.
@@ -12,7 +8,7 @@ namespace OpenToolkit.NT.Native
         /// <summary>
         /// Scan code from the key depression. The scan code for keyboard overrun is KEYBOARD_OVERRUN_MAKE_CODE.
         /// </summary>
-        public USHORT MakeCode;
+        public ushort MakeCode;
 
         /// <summary>
         /// Flags for scan code information.
@@ -22,7 +18,7 @@ namespace OpenToolkit.NT.Native
         /// <summary>
         /// Reserved; must be zero.
         /// </summary>
-        public USHORT Reserved;
+        public ushort Reserved;
 
         /// <summary>
         /// Microsoft Windows message compatible virtual-key code. For more information, see Virtual-Key Codes.
@@ -33,11 +29,11 @@ namespace OpenToolkit.NT.Native
         /// Corresponding window message, for example <see cref="WindowMessage.KeyDown"/>,
         /// <see cref="WindowMessage.SystemKeyDown"/>, and so forth.
         /// </summary>
-        public UINT Message;
+        public uint Message;
 
         /// <summary>
         /// Device-specific additional information for the event.
         /// </summary>
-        public ULONG ExtraInformation;
+        public uint ExtraInformation;
     }
 }

--- a/src/OpenTK.NT/Native/User32/Structs/RawMouse.cs
+++ b/src/OpenTK.NT/Native/User32/Structs/RawMouse.cs
@@ -1,9 +1,5 @@
 ﻿using System.Runtime.InteropServices;
 
-using LONG = System.Int32;
-using ULONG = System.UInt32;
-using USHORT = System.UInt16;
-
 namespace OpenToolkit.NT.Native
 {
     /// <summary>
@@ -22,7 +18,7 @@ namespace OpenToolkit.NT.Native
         /// Reserved. Use <see cref="ButtonFlags"/> instead.
         /// </summary>
         [FieldOffset(4)]
-        public ULONG Buttons;
+        public uint Buttons;
 
         /// <summary>
         /// The transition state of the mouse buttons.
@@ -35,33 +31,33 @@ namespace OpenToolkit.NT.Native
         /// this member is a signed value that specifies the wheel delta.
         /// </summary>
         [FieldOffset(6)]
-        public USHORT ButtonData;
+        public ushort ButtonData;
 
         /// <summary>
         /// Raw state of the mouse buttons.
         /// </summary>
         [FieldOffset(8)]
-        public ULONG RawButtons;
+        public uint RawButtons;
 
         /// <summary>
         /// Motion in the X direction. This is signed relative motion or absolute motion,
         /// depending on the value of <see cref="Flags"/>.
         /// </summary>
         [FieldOffset(12)]
-        public LONG LastX;
+        public int LastX;
 
         /// <summary>
         /// Motion in the Y direction. This is signed relative motion or absolute motion,
         /// depending on the value of <see cref="Flags"/>.
         /// </summary>
         [FieldOffset(16)]
-        public LONG LastY;
+        public int LastY;
 
         /// <summary>
         /// Device-specific additional information for the event.
         /// </summary>
         [FieldOffset(20)]
-        public ULONG ExtraInformation;
+        public uint ExtraInformation;
 
         /// <summary>
         /// The size of this structure in bytes.

--- a/src/OpenTK.NT/Native/User32/Structs/Rect.cs
+++ b/src/OpenTK.NT/Native/User32/Structs/Rect.cs
@@ -1,7 +1,5 @@
 ﻿using System.Drawing;
 
-using LONG = System.Int32;
-
 namespace OpenToolkit.NT.Native
 {
     /// <summary>
@@ -18,32 +16,32 @@ namespace OpenToolkit.NT.Native
         /// <summary>
         /// Specifies the x-coordinate of the upper-left corner of the rectangle.
         /// </summary>
-        public LONG Left;
+        public int Left;
 
         /// <summary>
         /// Specifies the y-coordinate of the upper-left corner of the rectangle.
         /// </summary>
-        public LONG Top;
+        public int Top;
 
         /// <summary>
         /// Specifies the x-coordinate of the lower-right corner of the rectangle.
         /// </summary>
-        public LONG Right;
+        public int Right;
 
         /// <summary>
         /// Specifies the y-coordinate of the lower-right corner of the rectangle.
         /// </summary>
-        public LONG Bottom;
+        public int Bottom;
 
         /// <summary>
         /// Gets the width of the rectangle.
         /// </summary>
-        public LONG Width => Right - Left;
+        public int Width => Right - Left;
 
         /// <summary>
         /// Gets the height of the rectangle.
         /// </summary>
-        public LONG Height => Bottom - Top;
+        public int Height => Bottom - Top;
 
         /// <inheritdoc/>
         public override string ToString() => $"{{X={Left},Y={Top},Width={Width},Height={Height}}}";

--- a/src/OpenTK.NT/Native/User32/Structs/StyleStruct.cs
+++ b/src/OpenTK.NT/Native/User32/Structs/StyleStruct.cs
@@ -1,6 +1,4 @@
-﻿using DWORD = System.UInt32;
-
-namespace OpenToolkit.NT.Native
+﻿namespace OpenToolkit.NT.Native
 {
     /// <summary>
     /// Contains the styles for a window.<para/>
@@ -11,11 +9,11 @@ namespace OpenToolkit.NT.Native
         /// <summary>
         /// The previous styles for a window.
         /// </summary>
-        public DWORD StyleOld;
+        public uint StyleOld;
 
         /// <summary>
         /// The new styles for a window.
         /// </summary>
-        public DWORD StyleNew;
+        public uint StyleNew;
     }
 }

--- a/src/OpenTK.NT/Native/User32/Structs/TrackMouseEvent.cs
+++ b/src/OpenTK.NT/Native/User32/Structs/TrackMouseEvent.cs
@@ -1,7 +1,5 @@
-﻿using System.Runtime.InteropServices;
-
-using DWORD = System.UInt32;
-using HWND = System.IntPtr;
+﻿using System;
+using System.Runtime.InteropServices;
 
 namespace OpenToolkit.NT.Native
 {
@@ -14,13 +12,13 @@ namespace OpenToolkit.NT.Native
         /// <summary>
         /// Set <see cref="HoverTime"/> to this value to use the system default hover time-out.
         /// </summary>
-        public const DWORD DefaultHoverTime = 0xFFFFFFFF;
+        public const uint DefaultHoverTime = 0xFFFFFFFF;
 
         /// <summary>
         /// The size of the <see cref="TrackMouseEvent"/> structure, in bytes.<para/>
         /// Set this to <see cref="SizeInBytes"/>.
         /// </summary>
-        public DWORD Size;
+        public uint Size;
 
         /// <summary>
         /// The services requested.
@@ -30,13 +28,13 @@ namespace OpenToolkit.NT.Native
         /// <summary>
         /// A handle to the window to track.
         /// </summary>
-        public HWND TrackWindowHandle;
+        public IntPtr TrackWindowHandle;
 
         /// <summary>
         /// The hover time-out (if <see cref="TrackMouseEvents.Hover"/> was specified in <see cref="Flags"/>), in
         /// milliseconds. Can be <see cref="DefaultHoverTime"/>, which means to use the system default hover time-out.
         /// </summary>
-        public DWORD HoverTime;
+        public uint HoverTime;
 
         /// <summary>
         /// The size of this structure in bytes.

--- a/src/OpenTK.NT/Native/User32/Structs/WindowClass.cs
+++ b/src/OpenTK.NT/Native/User32/Structs/WindowClass.cs
@@ -1,11 +1,6 @@
 ﻿using System;
 using System.Runtime.InteropServices;
 
-using HBRUSH = System.IntPtr;
-using HCURSOR = System.IntPtr;
-using HICON = System.IntPtr;
-using HINSTANCE = System.IntPtr;
-
 namespace OpenToolkit.NT.Native
 {
     /// <summary>
@@ -40,27 +35,27 @@ namespace OpenToolkit.NT.Native
         /// <summary>
         /// A handle to the instance that contains the window procedure for the class.
         /// </summary>
-        public HINSTANCE Instance;
+        public IntPtr Instance;
 
         /// <summary>
         /// A handle to the class icon. This member must be a handle to an icon resource.
         /// If this member is <see cref="IntPtr.Zero"/>, the system provides a default icon.
         /// </summary>
-        public HICON Icon;
+        public IntPtr Icon;
 
         /// <summary>
         /// A handle to the class cursor. This member must be a handle to a cursor resource.
         /// If this member is <see cref="IntPtr.Zero"/>, an application must explicitly set the cursor shape
         /// whenever the mouse moves into the application's window.
         /// </summary>
-        public HCURSOR Cursor;
+        public IntPtr Cursor;
 
         /// <summary>
         /// A handle to the class background brush. This member can be a handle to the brush to be used for
         /// painting the background, or it can be a color value.<para/>
         /// For more information on setting this to a color value, check the official documentation.
         /// </summary>
-        public HBRUSH Background;
+        public IntPtr Background;
 
         /// <summary>
         /// Pointer to a string that specifies the resource name of the class menu, as the name appears in the

--- a/src/OpenTK.NT/Native/User32/Structs/WindowInfo.cs
+++ b/src/OpenTK.NT/Native/User32/Structs/WindowInfo.cs
@@ -1,10 +1,5 @@
 ﻿using System.Runtime.InteropServices;
 
-using ATOM = System.UInt16;
-using DWORD = System.UInt32;
-using UINT = System.UInt32;
-using WORD = System.UInt16;
-
 namespace OpenToolkit.NT.Native
 {
     /// <summary>
@@ -15,7 +10,7 @@ namespace OpenToolkit.NT.Native
         /// <summary>
         /// The size of the structure, in bytes.
         /// </summary>
-        public DWORD Size;
+        public uint Size;
 
         /// <summary>
         /// Pointer to a RECT structure that specifies the coordinates of the window.
@@ -41,27 +36,27 @@ namespace OpenToolkit.NT.Native
         /// The window status. If this member is WS_ACTIVECAPTION, the window is active.
         /// Otherwise, this member is zero.
         /// </summary>
-        public DWORD WindowStatus;
+        public uint WindowStatus;
 
         /// <summary>
         /// The width of the window border, in pixels.
         /// </summary>
-        public UINT WindowBordersX;
+        public uint WindowBordersX;
 
         /// <summary>
         /// The height of the window border, in pixels.
         /// </summary>
-        public UINT WindowBordersY;
+        public uint WindowBordersY;
 
         /// <summary>
         /// The window class atom (see RegisterClass).
         /// </summary>
-        public ATOM WindowType;
+        public ushort WindowType;
 
         /// <summary>
         /// The Microsoft Windows version of the application that created the window.
         /// </summary>
-        public WORD CreatorVersion;
+        public ushort CreatorVersion;
 
         /// <summary>
         /// The size of this structure in bytes.

--- a/src/OpenTK.NT/Native/User32/Structs/WindowPosition.cs
+++ b/src/OpenTK.NT/Native/User32/Structs/WindowPosition.cs
@@ -1,6 +1,5 @@
-﻿using System.Runtime.InteropServices;
-
-using HWND = System.IntPtr;
+﻿using System;
+using System.Runtime.InteropServices;
 
 namespace OpenToolkit.NT.Native
 {
@@ -13,14 +12,14 @@ namespace OpenToolkit.NT.Native
         /// <summary>
         /// Handle to the window.
         /// </summary>
-        public HWND HWnd;
+        public IntPtr HWnd;
 
         /// <summary>
         /// Specifies the position of the window in Z order (front-to-back position).
         /// This member can be a handle to the window behind which this window is placed,
         /// or can be one of the special values listed with the SetWindowPos function.
         /// </summary>
-        public HWND HWndInsertAfter;
+        public IntPtr HWndInsertAfter;
 
         /// <summary>
         /// Specifies the position of the left edge of the window.

--- a/src/OpenTK.NT/Native/User32/Timer.cs
+++ b/src/OpenTK.NT/Native/User32/Timer.cs
@@ -1,11 +1,6 @@
 ﻿using System;
 using System.Runtime.InteropServices;
 
-using BOOL = System.Boolean;
-using HWND = System.IntPtr;
-using TIMERPROC = OpenToolkit.NT.Native.TimerProc;
-using UINT_PTR = System.UIntPtr;
-
 namespace OpenToolkit.NT.Native
 {
     public static partial class User32
@@ -32,7 +27,7 @@ namespace OpenToolkit.NT.Native
             /// If the <paramref name="window"/> parameter is not <see cref="IntPtr.Zero"/>
             /// and the window specified by <paramref name="window"/> already has a timer with the value
             /// <paramref name="timerID"/>, then the existing timer is replaced by the new timer. When
-            /// <see cref="SetTimer(HWND, UINT_PTR, uint, TIMERPROC)"/> replaces a timer, the timer is reset.
+            /// <see cref="SetTimer(IntPtr, UIntPtr, uint, TimerProc)"/> replaces a timer, the timer is reset.
             /// Therefore, a message will be sent after the current time-out value elapses, but the previously set
             /// time-out value is ignored.<para/>
             /// If the call is not intended to replace an existing timer,
@@ -41,7 +36,7 @@ namespace OpenToolkit.NT.Native
             /// <param name="elapse">The time-out value, in milliseconds.</param>
             /// <param name="timerFunc">
             /// A pointer to the function to be notified when the time-out value elapses. For more information about
-            /// the function, see <see cref="TIMERPROC"/>. If <paramref name="timerFunc"/> is null, the system posts
+            /// the function, see <see cref="TimerProc"/>. If <paramref name="timerFunc"/> is null, the system posts
             /// a <see cref="WindowMessage.Timer"/> message to the application queue. The <see cref="Msg.HWnd"/>
             /// member of the message's <see cref="Msg"/> structure contains
             /// the value of the <paramref name="window"/> parameter.
@@ -49,15 +44,15 @@ namespace OpenToolkit.NT.Native
             /// <returns>
             /// If the function succeeds and the <paramref name="window"/> parameter is <see cref="IntPtr.Zero"/>,
             /// the return value is an integer identifying the new timer. An application can pass this value to the
-            /// <see cref="KillTimer(HWND, UINT_PTR)"/> function to destroy the timer.
+            /// <see cref="KillTimer(IntPtr, UIntPtr)"/> function to destroy the timer.
             /// </returns>
             [DllImport(Library, SetLastError = true)]
-            public static extern UINT_PTR SetTimer
+            public static extern UIntPtr SetTimer
             (
-                [In] [Optional] HWND window,
-                [In] UINT_PTR timerID,
+                [In] [Optional] IntPtr window,
+                [In] UIntPtr timerID,
                 [In] uint elapse,
-                [In] [Optional] TIMERPROC timerFunc
+                [In] [Optional] TimerProc timerFunc
             );
 
             /// <summary>
@@ -65,16 +60,16 @@ namespace OpenToolkit.NT.Native
             /// </summary>
             /// <param name="window">
             /// A handle to the window associated with the specified timer. This value must be the same as the window
-            /// value passed to the <see cref="SetTimer(HWND, UINT_PTR, uint, TIMERPROC)"/>
+            /// value passed to the <see cref="SetTimer(IntPtr, UIntPtr, uint, TimerProc)"/>
             /// function that created the timer.
             /// </param>
             /// <param name="timerID">
             /// The timer to be destroyed. If the window handle passed to
-            /// <see cref="SetTimer(HWND, UINT_PTR, uint, TIMERPROC)"/> is valid, this parameter must be the same as
-            /// the timerID value passed to <see cref="SetTimer(HWND, UINT_PTR, uint, TIMERPROC)"/>. If the application
-            /// calls <see cref="SetTimer(HWND, UINT_PTR, uint, TIMERPROC)"/> with window set to
+            /// <see cref="SetTimer(IntPtr, UIntPtr, uint, TimerProc)"/> is valid, this parameter must be the same as
+            /// the timerID value passed to <see cref="SetTimer(IntPtr, UIntPtr, uint, TimerProc)"/>. If the application
+            /// calls <see cref="SetTimer(IntPtr, UIntPtr, uint, TimerProc)"/> with window set to
             /// <see cref="IntPtr.Zero"/>, this parameter must be the timer identifier returned by
-            /// <see cref="SetTimer(HWND, UINT_PTR, uint, TIMERPROC)"/>.
+            /// <see cref="SetTimer(IntPtr, UIntPtr, uint, TimerProc)"/>.
             /// </param>
             /// <returns>
             /// If the function succeeds, the return value is true.<para/>
@@ -83,10 +78,10 @@ namespace OpenToolkit.NT.Native
             /// </returns>
             [DllImport(Library, SetLastError = true)]
             [return: MarshalAs(UnmanagedType.Bool)]
-            public static extern BOOL KillTimer
+            public static extern bool KillTimer
             (
-                [In] [Optional] HWND window,
-                [In] UINT_PTR timerID
+                [In] [Optional] IntPtr window,
+                [In] UIntPtr timerID
             );
         }
     }

--- a/src/OpenTK.NT/Native/User32/Window.cs
+++ b/src/OpenTK.NT/Native/User32/Window.cs
@@ -2,19 +2,7 @@
 using System.ComponentModel;
 using System.Runtime.InteropServices;
 using System.Security;
-
-using BOOL = System.Boolean;
-using HINSTANCE = System.IntPtr;
-using HMENU = System.IntPtr;
-using HWND = System.IntPtr;
-using LONG = System.Int32;
-using LONG_PTR = System.IntPtr;
-using LPARAM = System.IntPtr;
-using LPTSTR = System.Text.StringBuilder;
-using LPVOID = System.IntPtr;
-using LRESULT = System.IntPtr;
-using WNDPROC = System.IntPtr;
-using WPARAM = System.IntPtr;
+using System.Text;
 
 namespace OpenToolkit.NT.Native
 {
@@ -50,18 +38,17 @@ namespace OpenToolkit.NT.Native
             [SuppressUnmanagedCodeSecurity]
             [DllImport(Library, SetLastError = true)]
             [return: MarshalAs(UnmanagedType.Bool)]
-            public static extern BOOL AdjustWindowRect
+            public static extern bool AdjustWindowRect
             (
                 [In] [Out] ref Rect rect,
                 [In] WindowStyles style,
-                [In] BOOL hasMenu
+                [In] bool hasMenu
             );
 
             /// <summary>
             /// Calculates the required size of the window rectangle, based on the desired client-rectangle size.
             /// The window rectangle can then be passed to the
-            /// <see cref="CreateWindowEx(ExtendedWindowStyles, string, string, WindowStyles, LONG, LONG, LONG,
-            /// LONG, HINSTANCE, HINSTANCE, HINSTANCE, HINSTANCE)"/>
+            /// <see cref="CreateWindowEx(ExtendedWindowStyles, string, string, WindowStyles, int, int, int, int, IntPtr, IntPtr, IntPtr, IntPtr)"/>
             /// function to create a window whose client area is the desired size.
             /// </summary>
             /// <param name="rect">
@@ -86,11 +73,11 @@ namespace OpenToolkit.NT.Native
             [SuppressUnmanagedCodeSecurity]
             [DllImport(Library, SetLastError = true)]
             [return: MarshalAs(UnmanagedType.Bool)]
-            public static extern BOOL AdjustWindowRectEx
+            public static extern bool AdjustWindowRectEx
             (
                 [In] [Out] ref Rect rect,
                 [In] WindowStyles style,
-                [In] BOOL hasMenu,
+                [In] bool hasMenu,
                 [In] ExtendedWindowStyles extendedStyle
             );
 
@@ -130,9 +117,9 @@ namespace OpenToolkit.NT.Native
             /// If an overlapped window is created with the <see cref="WindowStyles.Visible"/> style bit set and
             /// the x parameter is set to <see cref="int.MinValue"/>, then the y parameter determines how the window
             /// is shown. If the y parameter is <see cref="int.MinValue"/>, then the window manager calls
-            /// <see cref="ShowWindow(HINSTANCE, ShowWindowCommand)"/> with the <see cref="ShowWindowCommand.Show"/>
+            /// <see cref="ShowWindow(IntPtr, ShowWindowCommand)"/> with the <see cref="ShowWindowCommand.Show"/>
             /// flag after the window has been created. If the y parameter is some other value, then the window manager
-            /// calls <see cref="ShowWindow(HINSTANCE, ShowWindowCommand)"/> with that value as the nCmdShow parameter.
+            /// calls <see cref="ShowWindow(IntPtr, ShowWindowCommand)"/> with that value as the nCmdShow parameter.
             /// </param>
             /// <param name="width">
             /// The width, in device units, of the window. For overlapped windows, nWidth is the window's width, in
@@ -177,7 +164,7 @@ namespace OpenToolkit.NT.Native
             /// To get extended error information, call <see cref="Marshal.GetLastWin32Error"/>.
             /// </returns>
             [DllImport(Library, SetLastError = true, CharSet = CharSet.Unicode)]
-            public static extern HWND CreateWindowEx
+            public static extern IntPtr CreateWindowEx
             (
                 [In] ExtendedWindowStyles extendedStyle,
                 [In] [Optional] string className,
@@ -187,10 +174,10 @@ namespace OpenToolkit.NT.Native
                 [In] int y,
                 [In] int width,
                 [In] int height,
-                [In] [Optional] HWND parentWindow,
-                [In] [Optional] HMENU menu,
-                [In] [Optional] HINSTANCE moduleInstance,
-                [In] [Optional] LPVOID createParam
+                [In] [Optional] IntPtr parentWindow,
+                [In] [Optional] IntPtr menu,
+                [In] [Optional] IntPtr moduleInstance,
+                [In] [Optional] IntPtr createParam
             );
 
             /// <summary>
@@ -223,9 +210,9 @@ namespace OpenToolkit.NT.Native
             /// If an overlapped window is created with the <see cref="WindowStyles.Visible"/> style bit set and
             /// the x parameter is set to <see cref="int.MinValue"/>, then the y parameter determines how the window
             /// is shown. If the y parameter is <see cref="int.MinValue"/>, then the window manager calls
-            /// <see cref="ShowWindow(HINSTANCE, ShowWindowCommand)"/> with the <see cref="ShowWindowCommand.Show"/>
+            /// <see cref="ShowWindow(IntPtr, ShowWindowCommand)"/> with the <see cref="ShowWindowCommand.Show"/>
             /// flag after the window has been created. If the y parameter is some other value, then the window manager
-            /// calls <see cref="ShowWindow(HINSTANCE, ShowWindowCommand)"/> with that value as the nCmdShow parameter.
+            /// calls <see cref="ShowWindow(IntPtr, ShowWindowCommand)"/> with that value as the nCmdShow parameter.
             /// </param>
             /// <param name="width">
             /// The width, in device units, of the window. For overlapped windows, nWidth is the window's width, in
@@ -270,7 +257,7 @@ namespace OpenToolkit.NT.Native
             /// To get extended error information, call <see cref="Marshal.GetLastWin32Error"/>.
             /// </returns>
             [DllImport(Library, SetLastError = true, CharSet = CharSet.Unicode)]
-            public static extern HWND CreateWindowEx
+            public static extern IntPtr CreateWindowEx
             (
                 [In] ExtendedWindowStyles extendedStyle,
                 [In] [Optional] IntPtr className,
@@ -280,10 +267,10 @@ namespace OpenToolkit.NT.Native
                 [In] int y,
                 [In] int width,
                 [In] int height,
-                [In] [Optional] HWND parentWindow,
-                [In] [Optional] HMENU menu,
-                [In] [Optional] HINSTANCE moduleInstance,
-                [In] [Optional] LPVOID createParam
+                [In] [Optional] IntPtr parentWindow,
+                [In] [Optional] IntPtr menu,
+                [In] [Optional] IntPtr moduleInstance,
+                [In] [Optional] IntPtr createParam
             );
 
             /// <summary>
@@ -319,9 +306,9 @@ namespace OpenToolkit.NT.Native
             /// If an overlapped window is created with the <see cref="WindowStyles.Visible"/> style bit set and
             /// the x parameter is set to <see cref="int.MinValue"/>, then the y parameter determines how the window
             /// is shown. If the y parameter is <see cref="int.MinValue"/>, then the window manager calls
-            /// <see cref="ShowWindow(HINSTANCE, ShowWindowCommand)"/> with the <see cref="ShowWindowCommand.Show"/>
+            /// <see cref="ShowWindow(IntPtr, ShowWindowCommand)"/> with the <see cref="ShowWindowCommand.Show"/>
             /// flag after the window has been created. If the y parameter is some other value, then the window manager
-            /// calls <see cref="ShowWindow(HINSTANCE, ShowWindowCommand)"/> with that value as the nCmdShow parameter.
+            /// calls <see cref="ShowWindow(IntPtr, ShowWindowCommand)"/> with that value as the nCmdShow parameter.
             /// </param>
             /// <param name="width">
             /// The width, in device units, of the window. For overlapped windows, nWidth is the window's width, in
@@ -365,7 +352,7 @@ namespace OpenToolkit.NT.Native
             /// If the function fails, the return value is <see cref="IntPtr.Zero"/>.
             /// To get extended error information, call <see cref="Marshal.GetLastWin32Error"/>.
             /// </returns>
-            public static HWND CreateWindowEx
+            public static IntPtr CreateWindowEx
             (
                 [In] ExtendedWindowStyles extendedStyle,
                 [In] [Optional] ushort classAtom,
@@ -375,10 +362,10 @@ namespace OpenToolkit.NT.Native
                 [In] int y,
                 [In] int width,
                 [In] int height,
-                [In] [Optional] HWND parentWindow,
-                [In] [Optional] HMENU menu,
-                [In] [Optional] HINSTANCE moduleInstance,
-                [In] [Optional] LPVOID createParam
+                [In] [Optional] IntPtr parentWindow,
+                [In] [Optional] IntPtr menu,
+                [In] [Optional] IntPtr moduleInstance,
+                [In] [Optional] IntPtr createParam
             )
             {
                 return CreateWindowEx
@@ -404,7 +391,7 @@ namespace OpenToolkit.NT.Native
             /// keyboard focus from it. The function also destroys the window's menu, flushes the thread message queue,
             /// destroys timers, removes clipboard ownership, and breaks the clipboard viewer chain
             /// (if the window is at the top of the viewer chain).<para/>
-            /// If the specified window is a parent or owner window, <see cref="DestroyWindow(HWND)"/> automatically
+            /// If the specified window is a parent or owner window, <see cref="DestroyWindow(IntPtr)"/> automatically
             /// destroys the associated child or owned windows when it destroys the parent or owner window. The
             /// function first destroys child or owned windows, and then it destroys the parent or owner window.
             /// </summary>
@@ -416,17 +403,17 @@ namespace OpenToolkit.NT.Native
             /// </returns>
             [DllImport(Library, SetLastError = true)]
             [return: MarshalAs(UnmanagedType.Bool)]
-            public static extern BOOL DestroyWindow([In] HWND window);
+            public static extern bool DestroyWindow([In] IntPtr window);
 
             /// <summary>
             /// Passes message information to the specified window procedure.
             /// </summary>
             /// <param name="previousWindowFunc">
             /// The previous window procedure. If this value is obtained by calling the
-            /// <see cref="GetWindowLong(HINSTANCE, GetWindowLongIndex)"/> function with the index parameter set to
+            /// <see cref="GetWindowLong(IntPtr, GetWindowLongIndex)"/> function with the index parameter set to
             /// <see cref="GetWindowLongIndex.WindowProcedure"/> or DWL_DLGPROC, it is actually either the address of
             /// a window or dialog box procedure, or a special internal value meaningful only to
-            /// <see cref="CallWindowProc(HINSTANCE, HINSTANCE, WindowMessage, HINSTANCE, HINSTANCE)"/>.
+            /// <see cref="CallWindowProc(IntPtr, IntPtr, WindowMessage, IntPtr, IntPtr)"/>.
             /// </param>
             /// <param name="window">A handle to the window procedure to receive the message.</param>
             /// <param name="msg">The message.</param>
@@ -443,13 +430,13 @@ namespace OpenToolkit.NT.Native
             /// </returns>
             [SuppressUnmanagedCodeSecurity]
             [DllImport(Library, SetLastError = true)]
-            public static extern LRESULT CallWindowProc
+            public static extern IntPtr CallWindowProc
             (
-                [In] WNDPROC previousWindowFunc,
-                [In] HWND window,
+                [In] IntPtr previousWindowFunc,
+                [In] IntPtr window,
                 [In] WindowMessage msg,
-                [In] WPARAM wparam,
-                [In] LPARAM lparam
+                [In] IntPtr wparam,
+                [In] IntPtr lparam
             );
 
             /// <summary>
@@ -464,7 +451,7 @@ namespace OpenToolkit.NT.Native
             /// </returns>
             [DllImport(Library)]
             [return: MarshalAs(UnmanagedType.Bool)]
-            public static extern BOOL SetProcessDPIAware();
+            public static extern bool SetProcessDPIAware();
 
             /// <summary>
             /// Changes the window procedure of the specified window.
@@ -479,7 +466,7 @@ namespace OpenToolkit.NT.Native
             /// If the function fails, the return value is zero.
             /// To get extended error information, call <see cref="Marshal.GetLastWin32Error"/>.
             /// </returns>
-            public static LONG_PTR SetWindowLong(HWND window, WindowProc newProc)
+            public static IntPtr SetWindowLong(IntPtr window, WindowProc newProc)
             {
                 return SetWindowLong
                 (
@@ -506,7 +493,7 @@ namespace OpenToolkit.NT.Native
             /// If the function fails, the return value is zero.
             /// To get extended error information, call <see cref="Marshal.GetLastWin32Error"/>.
             /// </returns>
-            public static LONG_PTR SetWindowLong(HWND window, GetWindowLongIndex index, LONG_PTR newLong)
+            public static IntPtr SetWindowLong(IntPtr window, GetWindowLongIndex index, IntPtr newLong)
             {
                 return SetWindowLong(window, (int)index, newLong);
             }
@@ -538,7 +525,7 @@ namespace OpenToolkit.NT.Native
             /// that indicates failure.
             /// </remarks>
             /// <exception cref="Win32Exception">An error occurs in the native function call.</exception>
-            public static LONG_PTR SetWindowLong(HWND window, int index, LONG_PTR newLong)
+            public static IntPtr SetWindowLong(IntPtr window, int index, IntPtr newLong)
             {
                 Kernel32.SetLastError(0);
 
@@ -565,18 +552,18 @@ namespace OpenToolkit.NT.Native
             [DllImport(Library, SetLastError = true)]
             private static extern int SetWindowLong
             (
-                [In] HWND window,
+                [In] IntPtr window,
                 [In] int index,
-                [In] LONG newLong
+                [In] int newLong
             );
 
             [SuppressUnmanagedCodeSecurity]
             [DllImport(Library, SetLastError = true)]
-            private static extern LONG_PTR SetWindowLongPtr
+            private static extern IntPtr SetWindowLongPtr
             (
-                [In] HWND window,
+                [In] IntPtr window,
                 [In] int index,
-                [In] LONG_PTR newLong
+                [In] IntPtr newLong
             );
 
             /// <summary>
@@ -602,7 +589,7 @@ namespace OpenToolkit.NT.Native
             /// This method will always call the "correct" function for this machine,
             /// and return the value wrapped in an <see cref="IntPtr"/>.
             /// </remarks>
-            public static LONG_PTR GetWindowLong(HWND window, GetWindowLongIndex index)
+            public static IntPtr GetWindowLong(IntPtr window, GetWindowLongIndex index)
             {
                 return GetWindowLong(window, (int)index);
             }
@@ -631,7 +618,7 @@ namespace OpenToolkit.NT.Native
             /// This method will always call the "correct" function for this machine,
             /// and return the value wrapped in an <see cref="IntPtr"/>.
             /// </remarks>
-            public static LONG_PTR GetWindowLong(HWND window, int index)
+            public static IntPtr GetWindowLong(IntPtr window, int index)
             {
                 if (IntPtr.Size == 8)
                 {
@@ -645,11 +632,11 @@ namespace OpenToolkit.NT.Native
 
             [SuppressUnmanagedCodeSecurity]
             [DllImport(Library, SetLastError = true)]
-            private static extern LONG GetWindowLongPrivate([In] HWND window, [In] int index);
+            private static extern int GetWindowLongPrivate([In] IntPtr window, [In] int index);
 
             [SuppressUnmanagedCodeSecurity]
             [DllImport(Library, SetLastError = true)]
-            private static extern LONG_PTR GetWindowLongPtr([In] HWND window, [In] int index);
+            private static extern IntPtr GetWindowLongPtr([In] IntPtr window, [In] int index);
 
             /// <summary>
             /// Calls the default window procedure to provide default processing for any window messages that an
@@ -667,12 +654,12 @@ namespace OpenToolkit.NT.Native
             /// </param>
             /// <returns>The return value is the result of the message processing and depends on the message.</returns>
             [DllImport(Library, CharSet = CharSet.Unicode)]
-            public static extern LRESULT DefWindowProc
+            public static extern IntPtr DefWindowProc
             (
-                [In] HWND window,
+                [In] IntPtr window,
                 [In] WindowMessage msg,
-                [In] WPARAM wparam,
-                [In] LPARAM lparam
+                [In] IntPtr wparam,
+                [In] IntPtr lparam
             );
 
             /// <summary>
@@ -684,12 +671,12 @@ namespace OpenToolkit.NT.Native
             [DllImport(Library, SetLastError = true)]
             [SuppressUnmanagedCodeSecurity]
             [return: MarshalAs(UnmanagedType.Bool)]
-            public static extern BOOL ShowWindow([In] HWND window, [In] ShowWindowCommand showCommand);
+            public static extern bool ShowWindow([In] IntPtr window, [In] ShowWindowCommand showCommand);
 
             /// <summary>
             /// Copies the text of the specified window's title bar (if it has one) into a buffer. If the specified
             /// window is a control, the text of the control is copied. However,
-            /// <see cref="GetWindowText(HINSTANCE, LPTSTR, LONG)"/> cannot retrieve the text of a control in another
+            /// <see cref="GetWindowText(IntPtr, StringBuilder, int)"/> cannot retrieve the text of a control in another
             /// application.
             /// </summary>
             /// <param name="window">A handle to the window or control containing the text.</param>
@@ -710,14 +697,14 @@ namespace OpenToolkit.NT.Native
             [DllImport(Library, SetLastError = true, CharSet = CharSet.Unicode)]
             public static extern int GetWindowText
             (
-                [In] HWND window,
-                [In] [Out] LPTSTR windowText,
+                [In] IntPtr window,
+                [In] [Out] StringBuilder windowText,
                 [In] int maxCharCount
             );
 
             /// <summary>
             /// Changes the text of the specified window's title bar (if it has one). If the specified window is a
-            /// control, the text of the control is changed. However, <see cref="SetWindowText(HINSTANCE, string)"/>
+            /// control, the text of the control is changed. However, <see cref="SetWindowText(IntPtr, string)"/>
             /// cannot change the text of a control in another application.
             /// </summary>
             /// <param name="window">A handle to the window or control whose text is to be changed.</param>
@@ -729,9 +716,9 @@ namespace OpenToolkit.NT.Native
             /// </returns>
             [DllImport(Library, SetLastError = true, CharSet = CharSet.Unicode)]
             [return: MarshalAs(UnmanagedType.Bool)]
-            public static extern BOOL SetWindowText
+            public static extern bool SetWindowText
             (
-                [In] HWND window,
+                [In] IntPtr window,
                 [In] [Optional] string newText
             );
 
@@ -757,10 +744,10 @@ namespace OpenToolkit.NT.Native
             /// </returns>
             [DllImport(Library)]
             [return: MarshalAs(UnmanagedType.Bool)]
-            public static extern BOOL SetWindowPos
+            public static extern bool SetWindowPos
             (
-                [In] HWND window,
-                [In] [Optional] HWND windowInsertAfter,
+                [In] IntPtr window,
+                [In] [Optional] IntPtr windowInsertAfter,
                 [In] int x,
                 [In] int y,
                 [In] int cx,
@@ -790,9 +777,9 @@ namespace OpenToolkit.NT.Native
             /// </returns>
             [DllImport(Library)]
             [return: MarshalAs(UnmanagedType.Bool)]
-            public static extern BOOL SetWindowPos
+            public static extern bool SetWindowPos
             (
-                [In] HWND window,
+                [In] IntPtr window,
                 [In] [Optional] SetWindowPosHwndEnum windowInsertAfter,
                 [In] int x,
                 [In] int y,
@@ -816,7 +803,7 @@ namespace OpenToolkit.NT.Native
             /// </returns>
             [DllImport(Library)]
             [return: MarshalAs(UnmanagedType.Bool)]
-            public static extern BOOL SetForegroundWindow([In] HWND window);
+            public static extern bool SetForegroundWindow([In] IntPtr window);
 
             /// <summary>
             /// Brings the specified window to the top of the Z order. If the window is a top-level window, it is
@@ -831,7 +818,7 @@ namespace OpenToolkit.NT.Native
             /// </returns>
             [DllImport(Library, SetLastError = true)]
             [return: MarshalAs(UnmanagedType.Bool)]
-            public static extern BOOL BringWindowToTop([In] HWND window);
+            public static extern bool BringWindowToTop([In] IntPtr window);
 
             /// <summary>
             /// Changes the parent window of the specified child window.
@@ -847,10 +834,10 @@ namespace OpenToolkit.NT.Native
             /// To get extended error information, call <see cref="Marshal.GetLastWin32Error"/>.
             /// </returns>
             [DllImport(Library, SetLastError = true)]
-            public static extern HWND SetParent
+            public static extern IntPtr SetParent
             (
-                [In] HWND childWindow,
-                [In] [Optional] HWND newParent
+                [In] IntPtr childWindow,
+                [In] [Optional] IntPtr newParent
             );
 
             /// <summary>
@@ -870,7 +857,7 @@ namespace OpenToolkit.NT.Native
             [SuppressUnmanagedCodeSecurity]
             [DllImport(Library, SetLastError = true)]
             [return: MarshalAs(UnmanagedType.Bool)]
-            public static extern BOOL GetWindowInfo([In] HWND hwnd, [In] [Out] ref WindowInfo wi);
+            public static extern bool GetWindowInfo([In] IntPtr hwnd, [In] [Out] ref WindowInfo wi);
 
             /// <summary>
             /// Determines the visibility state of the specified window.
@@ -885,7 +872,7 @@ namespace OpenToolkit.NT.Native
             /// </returns>
             [DllImport(Library)]
             [return: MarshalAs(UnmanagedType.Bool)]
-            public static extern BOOL IsWindowVisible([In] HWND window);
+            public static extern bool IsWindowVisible([In] IntPtr window);
 
             /// <summary>
             /// Retrieves the dimensions of the bounding rectangle of the specified window. The dimensions are given
@@ -904,7 +891,7 @@ namespace OpenToolkit.NT.Native
             [SuppressUnmanagedCodeSecurity]
             [DllImport(Library, SetLastError = true)]
             [return: MarshalAs(UnmanagedType.Bool)]
-            public static extern BOOL GetWindowRect([In] HWND windowHandle, [Out] out Rect windowRectangle);
+            public static extern bool GetWindowRect([In] IntPtr windowHandle, [Out] out Rect windowRectangle);
 
             /// <summary>
             /// Retrieves the coordinates of a window's client area. The client coordinates specify the upper-left
@@ -925,7 +912,7 @@ namespace OpenToolkit.NT.Native
             [SuppressUnmanagedCodeSecurity]
             [DllImport(Library, SetLastError = true)]
             [return: MarshalAs(UnmanagedType.Bool)]
-            public static extern BOOL GetClientRect([In] HWND windowHandle, [Out] out Rect clientRectangle);
+            public static extern bool GetClientRect([In] IntPtr windowHandle, [Out] out Rect clientRectangle);
 
             /// <summary>
             /// Converts the screen coordinates of a specified point on the screen to client-area coordinates.
@@ -941,7 +928,7 @@ namespace OpenToolkit.NT.Native
             [SuppressUnmanagedCodeSecurity]
             [DllImport(Library, SetLastError = true)]
             [return: MarshalAs(UnmanagedType.Bool)]
-            public static extern BOOL ScreenToClient([In] HWND window, ref Point point);
+            public static extern bool ScreenToClient([In] IntPtr window, ref Point point);
 
             /// <summary>
             /// Converts the client-area coordinates of a specified point to screen coordinates.
@@ -958,7 +945,7 @@ namespace OpenToolkit.NT.Native
             [SuppressUnmanagedCodeSecurity]
             [DllImport(Library, SetLastError = true)]
             [return: MarshalAs(UnmanagedType.Bool)]
-            public static extern BOOL ClientToScreen([In] HWND window, [In] [Out] ref Point point);
+            public static extern bool ClientToScreen([In] IntPtr window, [In] [Out] ref Point point);
         }
     }
 }

--- a/src/OpenTK.NT/Native/User32/WindowClass.cs
+++ b/src/OpenTK.NT/Native/User32/WindowClass.cs
@@ -1,9 +1,6 @@
 ﻿using System;
 using System.Runtime.InteropServices;
 
-using BOOL = System.Boolean;
-using HINSTANCE = System.IntPtr;
-
 namespace OpenToolkit.NT.Native
 {
     public static partial class User32
@@ -40,9 +37,9 @@ namespace OpenToolkit.NT.Native
             /// </returns>
             [DllImport(Library, SetLastError = true, CharSet = CharSet.Unicode)]
             [return: MarshalAs(UnmanagedType.Bool)]
-            public static extern BOOL GetClassInfoEx
+            public static extern bool GetClassInfoEx
             (
-                [In] [Optional] HINSTANCE instance,
+                [In] [Optional] IntPtr instance,
                 [In] string className,
                 [Out] out ExtendedWindowClass extendedWindowClass
             );
@@ -73,9 +70,9 @@ namespace OpenToolkit.NT.Native
             /// </returns>
             [DllImport(Library, SetLastError = true)]
             [return: MarshalAs(UnmanagedType.Bool)]
-            public static extern BOOL GetClassInfoEx
+            public static extern bool GetClassInfoEx
             (
-                [In] HINSTANCE instance,
+                [In] IntPtr instance,
                 [In] IntPtr className,
                 [Out] out ExtendedWindowClass extendedWindowClass
             );
@@ -103,9 +100,9 @@ namespace OpenToolkit.NT.Native
             /// If the function does not find a matching class and successfully copy the data, the return value is
             /// false. To get extended error information, call <see cref="Marshal.GetLastWin32Error"/>.
             /// </returns>
-            public static BOOL GetClassInfoEx
+            public static bool GetClassInfoEx
             (
-                [In] HINSTANCE instance,
+                [In] IntPtr instance,
                 [In] ushort classAtom,
                 [Out] out ExtendedWindowClass extendedWindowStyle
             )
@@ -115,8 +112,8 @@ namespace OpenToolkit.NT.Native
 
             /// <summary>
             /// Registers a window class for subsequent use in calls to the CreateWindow or
-            /// <see cref="Window.CreateWindowEx(ExtendedWindowStyles, HINSTANCE, string,
-            /// WindowStyles, int, int, int, int, HINSTANCE, HINSTANCE, HINSTANCE, HINSTANCE)"/> function.
+            /// <see cref="Window.CreateWindowEx(ExtendedWindowStyles, IntPtr, string,
+            /// WindowStyles, int, int, int, int, IntPtr, IntPtr, IntPtr, IntPtr)"/> function.
             /// </summary>
             /// <param name="extendedWindowClass">
             /// A pointer to a <see cref="ExtendedWindowClass"/> structure. You must fill the structure with the
@@ -125,10 +122,10 @@ namespace OpenToolkit.NT.Native
             /// <returns>
             /// If the function succeeds, the return value is a class atom that uniquely identifies the class being
             /// registered. This atom can only be used by the CreateWindow,
-            /// <see cref="Window.CreateWindowEx(ExtendedWindowStyles, HINSTANCE, string,
-            /// WindowStyles, int, int, int, int, HINSTANCE, HINSTANCE, HINSTANCE, HINSTANCE)"/>,
-            /// GetClassInfo, <see cref="GetClassInfoEx(HINSTANCE, HINSTANCE, out ExtendedWindowClass)"/>, FindWindow,
-            /// FindWindowEx, and <see cref="UnregisterClass(string, HINSTANCE)"/> functions
+            /// <see cref="Window.CreateWindowEx(ExtendedWindowStyles, IntPtr, string,
+            /// WindowStyles, int, int, int, int, IntPtr, IntPtr, IntPtr, IntPtr)"/>,
+            /// GetClassInfo, <see cref="GetClassInfoEx(IntPtr, IntPtr, out ExtendedWindowClass)"/>, FindWindow,
+            /// FindWindowEx, and <see cref="UnregisterClass(string, IntPtr)"/> functions
             /// and the IActiveIMMap::FilterClientWindows method.<para/>
             /// If the function fails, the return value is zero.
             /// To get extended error information, call <see cref="Marshal.GetLastWin32Error"/>.
@@ -157,7 +154,7 @@ namespace OpenToolkit.NT.Native
             /// </remarks>
             [DllImport(Library, SetLastError = true, CharSet = CharSet.Unicode)]
             [return: MarshalAs(UnmanagedType.Bool)]
-            public static extern BOOL UnregisterClass([In] string className, [In] [Optional] HINSTANCE moduleInstance);
+            public static extern bool UnregisterClass([In] string className, [In] [Optional] IntPtr moduleInstance);
 
             /// <summary>
             /// Unregisters a window class, freeing the memory required for the class.
@@ -180,10 +177,10 @@ namespace OpenToolkit.NT.Native
             /// </remarks>
             [DllImport(Library, SetLastError = true)]
             [return: MarshalAs(UnmanagedType.Bool)]
-            public static extern BOOL UnregisterClass
+            public static extern bool UnregisterClass
             (
                 [In] IntPtr className,
-                [In] [Optional] HINSTANCE moduleInstance
+                [In] [Optional] IntPtr moduleInstance
             );
 
             /// <summary>
@@ -204,7 +201,7 @@ namespace OpenToolkit.NT.Native
             /// specified class.<para/>
             /// All window classes that an application registers are unregistered when it terminates.
             /// </remarks>
-            public static BOOL UnregisterClass([In] ushort classAtom, [In] [Optional] HINSTANCE moduleInstance)
+            public static bool UnregisterClass([In] ushort classAtom, [In] [Optional] IntPtr moduleInstance)
             {
                 return UnregisterClass(new IntPtr(classAtom), moduleInstance);
             }


### PR DESCRIPTION
One part of #838.

I hope I didn't miss anything, but a regex search for `using .+ = .+;` doesn't yield any results in OpenTK.NT, so it should be fine.