### PR TITLE
[4.0] Minor edits to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ OpenTK uses and encourages [Early Pull Requests](https://medium.com/practical-bl
 Requirements
 ============
 
-- Windows (XP/Vista/7/8,10), Linux, Mac OS X, *BSD, SteamOS, Android or iOS
+- Windows (7/8,10), Linux, Mac OS X, *BSD, SteamOS, Android or iOS
 - For graphics, OpenGL drivers or a suitable emulator, such as [ANGLE](https://github.com/opentk/opentk/tree/develop/Dependencies/Readme.txt)
 - For audio, OpenAL drivers or OpenAL Soft
 - To develop desktop applications: Visual Studio, Rider, or the command line tools.

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Requirements
 
 - Windows (XP/Vista/7/8,10), Linux, Mac OS X, *BSD, SteamOS, Android or iOS
 - For graphics, OpenGL drivers or a suitable emulator, such as [ANGLE](https://github.com/opentk/opentk/tree/develop/Dependencies/Readme.txt)
-- For audio, OpenAL drivers or [OpenAL Soft](https://github.com/opentk/opentk/tree/develop/Dependencies/Readme.txt)
+- For audio, OpenAL drivers or OpenAL Soft
 - To develop desktop applications: Visual Studio, Rider, or the command line tools.
 - To develop Android applications: Visual Studio and Xamarin
 - To develop iOS applications: Visual Studio, Xamarin and XCode


### PR DESCRIPTION
The link on the words "OpenAL Soft" link to a file that no longer exist in this repository. This just removes the link.