### PR TITLE
[4.0] Update SDL2 version check

### DIFF
--- a/src/OpenTK/Configuration.cs
+++ b/src/OpenTK/Configuration.cs
@@ -154,7 +154,7 @@ namespace OpenTK
 
             // Detect whether SDL2 is supported
             // We require:
-            // - SDL2 version 2.0.0 or higher (previous beta
+            // - SDL2 version 2.0.4 or higher (previous beta
             //   versions are not ABI-compatible)
             // - Successful SDL2 initialization (sometimes the
             //   binary exists but fails to initialize correctly)
@@ -162,7 +162,7 @@ namespace OpenTK
             try
             {
                 version = SDL.Version;
-                if (version.Number >= 2000)
+                if (version.Number >= 2040)
                 {
                     if (SDL.WasInit(0))
                     {


### PR DESCRIPTION
The code in Configuration.cs claims that SDL 2.0.0 and higher are supported, but OpenTK uses entry points that are exclusive to 2.0.4 and higher. This just updates the version check to be sure it checks for a proper version. Closes #834 