### PR TITLE
[4.0] Add explicit operators for Color4/Vector4 conversions

### DIFF
--- a/src/OpenTK.Mathematics/Data/Color4.cs
+++ b/src/OpenTK.Mathematics/Data/Color4.cs
@@ -153,7 +153,7 @@ namespace OpenToolkit.Mathematics
         }
 
         /// <summary>
-        /// Returns this Color4 as a Vector4.
+        /// Returns this Color4 as a Vector4. The resulting struct will have XYZW mapped to RGBA, in that order.
         /// </summary>
         /// <param name="c">The Color4 to convert.</param>
         /// <returns>The Color4 to convert into a Vector4.</returns>
@@ -162,31 +162,9 @@ namespace OpenToolkit.Mathematics
         {
             unsafe
             {
+                // Because these structs are identical on the byte-level (due to the StructLayout above),
+                // we can use pointer-casting to convert this into a Vector4, which lets us reinterpret the data instead of copying it to a new struct.
                 return *((Vector4*)&c);
-            }
-        }
-
-        /// <summary>
-        /// Returns a new Vector4.
-        /// </summary>
-        /// <returns>f.</returns>
-        public Vector4 AsVector4()
-        {
-            return new Vector4(R, G, B, A);
-        }
-
-        /// <summary>
-        /// this is a bad idea.
-        /// </summary>
-        /// <returns>why is this necessary for simple operations.</returns>
-        public Vector4 AsVector4Unsafe()
-        {
-            unsafe
-            {
-                fixed (Color4* ptr = &this)
-                {
-                    return *((Vector4*)ptr);
-                }
             }
         }
 

--- a/src/OpenTK.Mathematics/Data/Color4.cs
+++ b/src/OpenTK.Mathematics/Data/Color4.cs
@@ -25,6 +25,8 @@
 
 using System;
 using System.Drawing;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace OpenToolkit.Mathematics
 {
@@ -32,6 +34,7 @@ namespace OpenToolkit.Mathematics
     /// Represents a color with 4 floating-point components (R, G, B, A).
     /// </summary>
     [Serializable]
+    [StructLayout(LayoutKind.Sequential)]
     public struct Color4 : IEquatable<Color4>
     {
         /// <summary>
@@ -147,6 +150,44 @@ namespace OpenToolkit.Mathematics
                 (int)(color.R * byte.MaxValue),
                 (int)(color.G * byte.MaxValue),
                 (int)(color.B * byte.MaxValue));
+        }
+
+        /// <summary>
+        /// Returns this Color4 as a Vector4.
+        /// </summary>
+        /// <param name="c">The Color4 to convert.</param>
+        /// <returns>The Color4 to convert into a Vector4.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Vector4(Color4 c)
+        {
+            unsafe
+            {
+                return *((Vector4*)&c);
+            }
+        }
+
+        /// <summary>
+        /// Returns a new Vector4.
+        /// </summary>
+        /// <returns>f.</returns>
+        public Vector4 AsVector4()
+        {
+            return new Vector4(R, G, B, A);
+        }
+
+        /// <summary>
+        /// this is a bad idea.
+        /// </summary>
+        /// <returns>why is this necessary for simple operations.</returns>
+        public Vector4 AsVector4Unsafe()
+        {
+            unsafe
+            {
+                fixed (Color4* ptr = &this)
+                {
+                    return *((Vector4*)ptr);
+                }
+            }
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Vector/Vector4.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4.cs
@@ -2039,7 +2039,7 @@ namespace OpenToolkit.Mathematics
         }
 
         /// <summary>
-        /// Returns this Vector4 as a Color4.
+        /// Returns this Vector4 as a Color4. The resulting struct will have RGBA mapped to XYZW, in that order.
         /// </summary>
         /// <param name="v">The Vector4 to convert.</param>
         /// <returns>The Vector4 converted to a Color4.</returns>
@@ -2048,6 +2048,8 @@ namespace OpenToolkit.Mathematics
         {
             unsafe
             {
+                // Because these structs are identical on the byte-level (due to the StructLayout above),
+                // we can use pointer-casting to convert this into a Color4, which lets us reinterpret the data instead of copying it to a new struct.
                 return *((Color4*)&v);
             }
         }

--- a/src/OpenTK.Mathematics/Vector/Vector4.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4.cs
@@ -22,6 +22,7 @@ SOFTWARE.
 
 using System;
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Xml.Serialization;
 
@@ -2034,6 +2035,20 @@ namespace OpenToolkit.Mathematics
             unsafe
             {
                 return (IntPtr)(&v.X);
+            }
+        }
+
+        /// <summary>
+        /// Returns this Vector4 as a Color4.
+        /// </summary>
+        /// <param name="v">The Vector4 to convert.</param>
+        /// <returns>The Vector4 converted to a Color4.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Color4(Vector4 v)
+        {
+            unsafe
+            {
+                return *((Color4*)&v);
             }
         }
 


### PR DESCRIPTION
### Purpose of this PR

* Adds operators to convert between Color4 and Vector4.
* Affects OpenTK.Mathematics
* No extra documentation needed.

### Testing status

* Code has been benchmarked to ensure this is the fastest way to do it. Results are in #833 
* Builds with no errors, works in both Debug and Release.

### Comments

* Operation is only unsafe in a technical context, which is why it's wrapped in a big `unsafe` block.
* LayoutType is added to Color4 just for consistancy's sake with other types.
* Closes #833.
