### PR TITLE
[4.0] Add RootNamespace tags to projects

### DIFF
--- a/src/Generator.Bind/Specifications/csharp.tm
+++ b/src/Generator.Bind/Specifications/csharp.tm
@@ -32,8 +32,8 @@ GLboolean*,         bool*
 GLsizeiptrARB,      UIntPtr
 GLintptrARB,        IntPtr
 GLhandleARB,        uint
-GLhalfARB,          OpenToolkit.Mathematics.Half
-GLhalfNV,           OpenToolkit.Mathematics.Half
+GLhalfARB,          OpenToolkit.Math.Half
+GLhalfNV,           OpenToolkit.Math.Half
 GLcharARB,          char
 
 # 64 bit types (introduced in 2.1)

--- a/src/Generator.Bind/XML/ParsingHelpers.cs
+++ b/src/Generator.Bind/XML/ParsingHelpers.cs
@@ -163,7 +163,7 @@ namespace Bind.XML
                 var firstPointerLevelIndex = typeName.IndexOf('*');
                 var lastPointerLevelIndex = typeName.LastIndexOf('*');
 
-                pointerLevel = Math.Abs(lastPointerLevelIndex - firstPointerLevelIndex) + 1;
+                pointerLevel = System.Math.Abs(lastPointerLevelIndex - firstPointerLevelIndex) + 1;
 
                 typeName = typeName.Remove(firstPointerLevelIndex);
             }
@@ -175,7 +175,7 @@ namespace Bind.XML
                 var firstArrayIndex = typeName.IndexOf('[');
                 var lastArrayIndex = typeName.IndexOf(']');
 
-                arrayLevel = Math.Abs(firstArrayIndex - lastArrayIndex);
+                arrayLevel = System.Math.Abs(firstArrayIndex - lastArrayIndex);
 
                 typeName = typeName.Remove(firstArrayIndex);
             }

--- a/src/Generator.Bind/XML/ParsingHelpers.cs
+++ b/src/Generator.Bind/XML/ParsingHelpers.cs
@@ -163,7 +163,7 @@ namespace Bind.XML
                 var firstPointerLevelIndex = typeName.IndexOf('*');
                 var lastPointerLevelIndex = typeName.LastIndexOf('*');
 
-                pointerLevel = System.Math.Abs(lastPointerLevelIndex - firstPointerLevelIndex) + 1;
+                pointerLevel = Math.Abs(lastPointerLevelIndex - firstPointerLevelIndex) + 1;
 
                 typeName = typeName.Remove(firstPointerLevelIndex);
             }

--- a/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.Creative.EFX/EffectExtension.cs
+++ b/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.Creative.EFX/EffectExtension.cs
@@ -1,6 +1,6 @@
 using AdvancedDLSupport;
 using OpenToolkit.Core.Loader;
-using OpenToolkit.Mathematics;
+using OpenToolkit.Math;
 
 namespace OpenToolkit.OpenAL.Extensions.Creative.EFX
 {

--- a/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.Creative.EFX/Interfaces/IEFXEffects.cs
+++ b/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.Creative.EFX/Interfaces/IEFXEffects.cs
@@ -1,5 +1,5 @@
 using AdvancedDLSupport;
-using OpenToolkit.Mathematics;
+using OpenToolkit.Math;
 
 // ReSharper disable ExplicitCallerInfoArgument
 

--- a/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.Creative.EFX/OpenTK.OpenAL.Extensions.Creative.EFX.csproj
+++ b/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.Creative.EFX/OpenTK.OpenAL.Extensions.Creative.EFX.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
+    <RootNamespace>OpenToolkit.OpenAL.Extensions.Creative.EFX</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.Creative.EFX/OpenTK.OpenAL.Extensions.Creative.EFX.csproj
+++ b/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.Creative.EFX/OpenTK.OpenAL.Extensions.Creative.EFX.csproj
@@ -5,6 +5,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <RootNamespace>OpenToolkit.OpenAL.Extensions.Creative.EFX</RootNamespace>
+    <AssemblyName>OpenToolkit.OpenAL.Extensions.Creative.EFX</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.Creative.EFX/Presets/ReverbPresets.cs
+++ b/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.Creative.EFX/Presets/ReverbPresets.cs
@@ -1,4 +1,4 @@
-﻿using OpenToolkit.Mathematics;
+﻿using OpenToolkit.Math;
 
 namespace OpenToolkit.OpenAL.Extensions.Creative.EFX
 {

--- a/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.Creative.EFX/Presets/ReverbProperties.cs
+++ b/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.Creative.EFX/Presets/ReverbProperties.cs
@@ -1,4 +1,4 @@
-﻿using OpenToolkit.Mathematics;
+﻿using OpenToolkit.Math;
 
 namespace OpenToolkit.OpenAL.Extensions.Creative.EFX
 {

--- a/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.Creative.EnumerateAll/OpenTK.OpenAL.Extensions.Creative.EnumerateAll.csproj
+++ b/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.Creative.EnumerateAll/OpenTK.OpenAL.Extensions.Creative.EnumerateAll.csproj
@@ -5,6 +5,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <RootNamespace>OpenToolkit.OpenAL.Extensions.Creative.EnumerateAll</RootNamespace>
+    <AssemblyName>OpenToolkit.OpenAL.Extensions.Creative.EnumerateAll</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.Creative.EnumerateAll/OpenTK.OpenAL.Extensions.Creative.EnumerateAll.csproj
+++ b/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.Creative.EnumerateAll/OpenTK.OpenAL.Extensions.Creative.EnumerateAll.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
+    <RootNamespace>OpenToolkit.OpenAL.Extensions.Creative.EnumerateAll</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.Creative.MultiChannelBuffers/OpenTK.OpenAL.Extensions.Creative.MultiChannelBuffers.csproj
+++ b/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.Creative.MultiChannelBuffers/OpenTK.OpenAL.Extensions.Creative.MultiChannelBuffers.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
+    <RootNamespace>OpenToolkit.OpenAL.Extensions.Creative.MultiChannelBuffers</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.Creative.MultiChannelBuffers/OpenTK.OpenAL.Extensions.Creative.MultiChannelBuffers.csproj
+++ b/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.Creative.MultiChannelBuffers/OpenTK.OpenAL.Extensions.Creative.MultiChannelBuffers.csproj
@@ -5,6 +5,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <RootNamespace>OpenToolkit.OpenAL.Extensions.Creative.MultiChannelBuffers</RootNamespace>
+    <AssemblyName>OpenToolkit.OpenAL.Extensions.Creative.MultiChannelBuffers</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.Creative.XRam/OpenTK.OpenAL.Extensions.Creative.XRam.csproj
+++ b/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.Creative.XRam/OpenTK.OpenAL.Extensions.Creative.XRam.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
+    <RootNamespace>OpenToolkit.OpenAL.Extensions.Creative.XRam</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.Creative.XRam/OpenTK.OpenAL.Extensions.Creative.XRam.csproj
+++ b/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.Creative.XRam/OpenTK.OpenAL.Extensions.Creative.XRam.csproj
@@ -5,6 +5,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <RootNamespace>OpenToolkit.OpenAL.Extensions.Creative.XRam</RootNamespace>
+    <AssemblyName>OpenToolkit.OpenAL.Extensions.Creative.XRam</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.EXT.ALAWFormat/OpenTK.OpenAL.Extensions.EXT.ALAWFormat.csproj
+++ b/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.EXT.ALAWFormat/OpenTK.OpenAL.Extensions.EXT.ALAWFormat.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
+    <RootNamespace>OpenToolkit.OpenAL.Extensions.EXT.ALAWFormat</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.EXT.ALAWFormat/OpenTK.OpenAL.Extensions.EXT.ALAWFormat.csproj
+++ b/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.EXT.ALAWFormat/OpenTK.OpenAL.Extensions.EXT.ALAWFormat.csproj
@@ -5,6 +5,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <RootNamespace>OpenToolkit.OpenAL.Extensions.EXT.ALAWFormat</RootNamespace>
+    <AssemblyName>OpenToolkit.OpenAL.Extensions.EXT.ALAWFormat</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.EXT.Capture.Enumeration/OpenTK.OpenAL.Extensions.EXT.Capture.Enumeration.csproj
+++ b/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.EXT.Capture.Enumeration/OpenTK.OpenAL.Extensions.EXT.Capture.Enumeration.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
+    <RootNamespace>OpenToolkit.OpenAL.Extensions.EXT.Capture.Enumeration</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.EXT.Capture.Enumeration/OpenTK.OpenAL.Extensions.EXT.Capture.Enumeration.csproj
+++ b/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.EXT.Capture.Enumeration/OpenTK.OpenAL.Extensions.EXT.Capture.Enumeration.csproj
@@ -5,6 +5,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <RootNamespace>OpenToolkit.OpenAL.Extensions.EXT.Capture.Enumeration</RootNamespace>
+    <AssemblyName>OpenToolkit.OpenAL.Extensions.EXT.Capture.Enumeration</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.EXT.Capture/OpenTK.OpenAL.Extensions.EXT.Capture.csproj
+++ b/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.EXT.Capture/OpenTK.OpenAL.Extensions.EXT.Capture.csproj
@@ -5,6 +5,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <RootNamespace>OpenToolkit.OpenAL.Extensions.EXT.Capture</RootNamespace>
+    <AssemblyName>OpenToolkit.OpenAL.Extensions.EXT.Capture</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.EXT.Capture/OpenTK.OpenAL.Extensions.EXT.Capture.csproj
+++ b/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.EXT.Capture/OpenTK.OpenAL.Extensions.EXT.Capture.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
+    <RootNamespace>OpenToolkit.OpenAL.Extensions.EXT.Capture</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.EXT.DoubleFormat/OpenTK.OpenAL.Extensions.EXT.DoubleFormat.csproj
+++ b/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.EXT.DoubleFormat/OpenTK.OpenAL.Extensions.EXT.DoubleFormat.csproj
@@ -5,6 +5,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <RootNamespace>OpenToolkit.OpenAL.Extensions.EXT.DoubleFormat</RootNamespace>
+    <AssemblyName>OpenToolkit.OpenAL.Extensions.EXT.DoubleFormat</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.EXT.DoubleFormat/OpenTK.OpenAL.Extensions.EXT.DoubleFormat.csproj
+++ b/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.EXT.DoubleFormat/OpenTK.OpenAL.Extensions.EXT.DoubleFormat.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
+    <RootNamespace>OpenToolkit.OpenAL.Extensions.EXT.DoubleFormat</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.EXT.FloatFormat/OpenTK.OpenAL.Extensions.EXT.FloatFormat.csproj
+++ b/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.EXT.FloatFormat/OpenTK.OpenAL.Extensions.EXT.FloatFormat.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
+    <RootNamespace>OpenToolkit.OpenAL.Extensions.EXT.FloatFormat</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.EXT.FloatFormat/OpenTK.OpenAL.Extensions.EXT.FloatFormat.csproj
+++ b/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.EXT.FloatFormat/OpenTK.OpenAL.Extensions.EXT.FloatFormat.csproj
@@ -5,6 +5,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <RootNamespace>OpenToolkit.OpenAL.Extensions.EXT.FloatFormat</RootNamespace>
+    <AssemblyName>OpenToolkit.OpenAL.Extensions.EXT.FloatFormat</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.EXT.IMA4Format/OpenTK.OpenAL.Extensions.EXT.IMA4Format.csproj
+++ b/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.EXT.IMA4Format/OpenTK.OpenAL.Extensions.EXT.IMA4Format.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
+    <RootNamespace>OpenToolkit.OpenAL.Extensions.EXT.IMA4Format</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.EXT.IMA4Format/OpenTK.OpenAL.Extensions.EXT.IMA4Format.csproj
+++ b/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.EXT.IMA4Format/OpenTK.OpenAL.Extensions.EXT.IMA4Format.csproj
@@ -5,6 +5,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <RootNamespace>OpenToolkit.OpenAL.Extensions.EXT.IMA4Format</RootNamespace>
+    <AssemblyName>OpenToolkit.OpenAL.Extensions.EXT.IMA4Format</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.EXT.MP3Format/OpenTK.OpenAL.Extensions.EXT.MP3Format.csproj
+++ b/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.EXT.MP3Format/OpenTK.OpenAL.Extensions.EXT.MP3Format.csproj
@@ -5,6 +5,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <RootNamespace>OpenToolkit.OpenAL.Extensions.EXT.MP3Format</RootNamespace>
+    <AssemblyName>OpenToolkit.OpenAL.Extensions.EXT.MP3Format</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.EXT.MP3Format/OpenTK.OpenAL.Extensions.EXT.MP3Format.csproj
+++ b/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.EXT.MP3Format/OpenTK.OpenAL.Extensions.EXT.MP3Format.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
+    <RootNamespace>OpenToolkit.OpenAL.Extensions.EXT.MP3Format</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.EXT.MULAWFormat/OpenTK.OpenAL.Extensions.EXT.MULAWFormat.csproj
+++ b/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.EXT.MULAWFormat/OpenTK.OpenAL.Extensions.EXT.MULAWFormat.csproj
@@ -5,6 +5,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <RootNamespace>OpenToolkit.OpenAL.Extensions.EXT.MULAWFormat</RootNamespace>
+    <AssemblyName>OpenToolkit.OpenAL.Extensions.EXT.MULAWFormat</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.EXT.MULAWFormat/OpenTK.OpenAL.Extensions.EXT.MULAWFormat.csproj
+++ b/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.EXT.MULAWFormat/OpenTK.OpenAL.Extensions.EXT.MULAWFormat.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
+    <RootNamespace>OpenToolkit.OpenAL.Extensions.EXT.MULAWFormat</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.EXT.VorbisFormat/OpenTK.OpenAL.Extensions.EXT.VorbisFormat.csproj
+++ b/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.EXT.VorbisFormat/OpenTK.OpenAL.Extensions.EXT.VorbisFormat.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
+    <RootNamespace>OpenToolkit.OpenAL.Extensions.EXT.VorbisFormat</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.EXT.VorbisFormat/OpenTK.OpenAL.Extensions.EXT.VorbisFormat.csproj
+++ b/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.EXT.VorbisFormat/OpenTK.OpenAL.Extensions.EXT.VorbisFormat.csproj
@@ -5,6 +5,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <RootNamespace>OpenToolkit.OpenAL.Extensions.EXT.VorbisFormat</RootNamespace>
+    <AssemblyName>OpenToolkit.OpenAL.Extensions.EXT.VorbisFormat</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.Enumeration/OpenTK.OpenAL.Extensions.Enumeration.csproj
+++ b/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.Enumeration/OpenTK.OpenAL.Extensions.Enumeration.csproj
@@ -5,6 +5,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <RootNamespace>OpenToolkit.OpenAL.Extensions.Enumeration</RootNamespace>
+    <AssemblyName>OpenToolkit.OpenAL.Extensions.Enumeration</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.Enumeration/OpenTK.OpenAL.Extensions.Enumeration.csproj
+++ b/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.Enumeration/OpenTK.OpenAL.Extensions.Enumeration.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
+    <RootNamespace>OpenToolkit.OpenAL.Extensions.Enumeration</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.Soft.DeferredUpdates/OpenTK.OpenAL.Extensions.Soft.DeferredUpdates.csproj
+++ b/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.Soft.DeferredUpdates/OpenTK.OpenAL.Extensions.Soft.DeferredUpdates.csproj
@@ -5,6 +5,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <RootNamespace>OpenToolkit.OpenAL.Extensions.Soft.DeferredUpdates</RootNamespace>
+    <AssemblyName>OpenToolkit.OpenAL.Extensions.Soft.DeferredUpdates</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.Soft.DeferredUpdates/OpenTK.OpenAL.Extensions.Soft.DeferredUpdates.csproj
+++ b/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.Soft.DeferredUpdates/OpenTK.OpenAL.Extensions.Soft.DeferredUpdates.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
+    <RootNamespace>OpenToolkit.OpenAL.Extensions.Soft.DeferredUpdates</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.Soft/OpenTK.OpenAL.Extensions.Soft.csproj
+++ b/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.Soft/OpenTK.OpenAL.Extensions.Soft.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
+    <RootNamespace>OpenToolkit.OpenAL.Extensions.Soft</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.Soft/OpenTK.OpenAL.Extensions.Soft.csproj
+++ b/src/OpenAL/Extensions/OpenTK.OpenAL.Extensions.Soft/OpenTK.OpenAL.Extensions.Soft.csproj
@@ -5,6 +5,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <RootNamespace>OpenToolkit.OpenAL.Extensions.Soft</RootNamespace>
+    <AssemblyName>OpenToolkit.OpenAL.Extensions.Soft</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenAL/OpenTK.OpenAL/AL/AL.cs
+++ b/src/OpenAL/OpenTK.OpenAL/AL/AL.cs
@@ -8,7 +8,7 @@
 using System;
 using AdvancedDLSupport;
 using OpenToolkit.Core.Loader;
-using OpenToolkit.Mathematics;
+using OpenToolkit.Math;
 using OpenToolkit.OpenAL.Attributes;
 using OpenToolkit.OpenAL.Extensions;
 using OpenToolkit.OpenAL.Interfaces;

--- a/src/OpenAL/OpenTK.OpenAL/AL/Enums/Buffers/BufferVector3.cs
+++ b/src/OpenAL/OpenTK.OpenAL/AL/Enums/Buffers/BufferVector3.cs
@@ -1,4 +1,4 @@
-using OpenToolkit.Mathematics;
+using OpenToolkit.Math;
 
 namespace OpenToolkit.OpenAL
 {

--- a/src/OpenAL/OpenTK.OpenAL/AL/Interfaces/IBuffers.cs
+++ b/src/OpenAL/OpenTK.OpenAL/AL/Interfaces/IBuffers.cs
@@ -1,5 +1,5 @@
 using AdvancedDLSupport;
-using OpenToolkit.Mathematics;
+using OpenToolkit.Math;
 
 // ReSharper disable ExplicitCallerInfoArgument
 namespace OpenToolkit.OpenAL.Interfaces

--- a/src/OpenAL/OpenTK.OpenAL/AL/Interfaces/IListener.cs
+++ b/src/OpenAL/OpenTK.OpenAL/AL/Interfaces/IListener.cs
@@ -1,5 +1,5 @@
 using AdvancedDLSupport;
-using OpenToolkit.Mathematics;
+using OpenToolkit.Math;
 
 // ReSharper disable ExplicitCallerInfoArgument
 namespace OpenToolkit.OpenAL.Interfaces

--- a/src/OpenAL/OpenTK.OpenAL/AL/Interfaces/ISources.cs
+++ b/src/OpenAL/OpenTK.OpenAL/AL/Interfaces/ISources.cs
@@ -1,5 +1,5 @@
 using AdvancedDLSupport;
-using OpenToolkit.Mathematics;
+using OpenToolkit.Math;
 
 // ReSharper disable ExplicitCallerInfoArgument
 namespace OpenToolkit.OpenAL.Interfaces

--- a/src/OpenAL/OpenTK.OpenAL/OpenTK.OpenAL.csproj
+++ b/src/OpenAL/OpenTK.OpenAL/OpenTK.OpenAL.csproj
@@ -4,6 +4,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Deterministic>true</Deterministic>
     <LangVersion>latest</LangVersion>
+    <RootNamespace>OpenToolkit.OpenAL</RootNamespace>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OpenAL/OpenTK.OpenAL/OpenTK.OpenAL.csproj
+++ b/src/OpenAL/OpenTK.OpenAL/OpenTK.OpenAL.csproj
@@ -5,6 +5,7 @@
     <Deterministic>true</Deterministic>
     <LangVersion>latest</LangVersion>
     <RootNamespace>OpenToolkit.OpenAL</RootNamespace>
+    <AssemblyName>OpenToolkit.OpenAL</AssemblyName>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OpenTK.Core/OpenTK.Core.csproj
+++ b/src/OpenTK.Core/OpenTK.Core.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <RootNamespace>OpenToolkit.Core</RootNamespace>
+    <AssemblyName>OpenToolkit.Core</AssemblyName>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OpenTK.Core/OpenTK.Core.csproj
+++ b/src/OpenTK.Core/OpenTK.Core.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <RootNamespace>OpenToolkit.Core</RootNamespace>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OpenTK.Input/OpenTK.Input.csproj
+++ b/src/OpenTK.Input/OpenTK.Input.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Deterministic>true</Deterministic>
     <RootNamespace>OpenToolkit.Input</RootNamespace>
+    <AssemblyName>OpenToolkit.Input</AssemblyName>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OpenTK.Input/OpenTK.Input.csproj
+++ b/src/OpenTK.Input/OpenTK.Input.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Deterministic>true</Deterministic>
+    <RootNamespace>OpenToolkit.Input</RootNamespace>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OpenTK.Mathematics/Data/Color4.cs
+++ b/src/OpenTK.Mathematics/Data/Color4.cs
@@ -26,7 +26,7 @@
 using System;
 using System.Drawing;
 
-namespace OpenToolkit.Mathematics
+namespace OpenToolkit.Math
 {
     /// <summary>
     /// Represents a color with 4 floating-point components (R, G, B, A).
@@ -906,7 +906,7 @@ namespace OpenToolkit.Mathematics
             }
             else
             {
-                r = (float)Math.Pow((srgb.R + 0.055f) / (1.0f + 0.055f), 2.4f);
+                r = (float)System.Math.Pow((srgb.R + 0.055f) / (1.0f + 0.055f), 2.4f);
             }
 
             if (srgb.G <= 0.04045f)
@@ -915,7 +915,7 @@ namespace OpenToolkit.Mathematics
             }
             else
             {
-                g = (float)Math.Pow((srgb.G + 0.055f) / (1.0f + 0.055f), 2.4f);
+                g = (float)System.Math.Pow((srgb.G + 0.055f) / (1.0f + 0.055f), 2.4f);
             }
 
             if (srgb.B <= 0.04045f)
@@ -924,7 +924,7 @@ namespace OpenToolkit.Mathematics
             }
             else
             {
-                b = (float)Math.Pow((srgb.B + 0.055f) / (1.0f + 0.055f), 2.4f);
+                b = (float)System.Math.Pow((srgb.B + 0.055f) / (1.0f + 0.055f), 2.4f);
             }
 
             return new Color4(r, g, b, srgb.A);
@@ -947,7 +947,7 @@ namespace OpenToolkit.Mathematics
             }
             else
             {
-                r = ((1.0f + 0.055f) * (float)Math.Pow(rgb.R, 1.0f / 2.4f)) - 0.055f;
+                r = ((1.0f + 0.055f) * (float)System.Math.Pow(rgb.R, 1.0f / 2.4f)) - 0.055f;
             }
 
             if (rgb.G <= 0.0031308)
@@ -956,7 +956,7 @@ namespace OpenToolkit.Mathematics
             }
             else
             {
-                g = ((1.0f + 0.055f) * (float)Math.Pow(rgb.G, 1.0f / 2.4f)) - 0.055f;
+                g = ((1.0f + 0.055f) * (float)System.Math.Pow(rgb.G, 1.0f / 2.4f)) - 0.055f;
             }
 
             if (rgb.B <= 0.0031308)
@@ -965,7 +965,7 @@ namespace OpenToolkit.Mathematics
             }
             else
             {
-                b = ((1.0f + 0.055f) * (float)Math.Pow(rgb.B, 1.0f / 2.4f)) - 0.055f;
+                b = ((1.0f + 0.055f) * (float)System.Math.Pow(rgb.B, 1.0f / 2.4f)) - 0.055f;
             }
 
             return new Color4(r, g, b, rgb.A);
@@ -989,10 +989,10 @@ namespace OpenToolkit.Mathematics
             var saturation = hsl.Y;
             var lightness = hsl.Z;
 
-            var c = (1.0f - Math.Abs((2.0f * lightness) - 1.0f)) * saturation;
+            var c = (1.0f - System.Math.Abs((2.0f * lightness) - 1.0f)) * saturation;
 
             var h = hue / 60.0f;
-            var x = c * (1.0f - Math.Abs((h % 2.0f) - 1.0f));
+            var x = c * (1.0f - System.Math.Abs((h % 2.0f) - 1.0f));
 
             float r, g, b;
             if (h >= 0.0f && h < 1.0f)
@@ -1054,8 +1054,8 @@ namespace OpenToolkit.Mathematics
         /// <param name="rgb">Color value to convert.</param>
         public static Vector4 ToHsl(Color4 rgb)
         {
-            var max = Math.Max(rgb.R, Math.Max(rgb.G, rgb.B));
-            var min = Math.Min(rgb.R, Math.Min(rgb.G, rgb.B));
+            var max = System.Math.Max(rgb.R, System.Math.Max(rgb.G, rgb.B));
+            var min = System.Math.Min(rgb.R, System.Math.Min(rgb.G, rgb.B));
             var diff = max - min;
 
             var h = 0.0f;
@@ -1083,7 +1083,7 @@ namespace OpenToolkit.Mathematics
             var saturation = 0.0f;
             if (lightness != 0.0f && lightness != 1.0f)
             {
-                saturation = diff / (1.0f - Math.Abs((2.0f * lightness) - 1.0f));
+                saturation = diff / (1.0f - System.Math.Abs((2.0f * lightness) - 1.0f));
             }
 
             return new Vector4(hue, saturation, lightness, rgb.A);
@@ -1110,7 +1110,7 @@ namespace OpenToolkit.Mathematics
             var c = value * saturation;
 
             var h = hue / 60.0f;
-            var x = c * (1.0f - Math.Abs((h % 2.0f) - 1.0f));
+            var x = c * (1.0f - System.Math.Abs((h % 2.0f) - 1.0f));
 
             float r, g, b;
             if (h >= 0.0f && h < 1.0f)
@@ -1172,8 +1172,8 @@ namespace OpenToolkit.Mathematics
         /// <param name="rgb">Color value to convert.</param>
         public static Vector4 ToHsv(Color4 rgb)
         {
-            var max = Math.Max(rgb.R, Math.Max(rgb.G, rgb.B));
-            var min = Math.Min(rgb.R, Math.Min(rgb.G, rgb.B));
+            var max = System.Math.Max(rgb.R, System.Math.Max(rgb.G, rgb.B));
+            var min = System.Math.Min(rgb.R, System.Math.Min(rgb.G, rgb.B));
             var diff = max - min;
 
             var h = 0.0f;
@@ -1299,7 +1299,7 @@ namespace OpenToolkit.Mathematics
             var luminance = hcy.Z;
 
             var h = hue / 60.0f;
-            var x = y * (1.0f - Math.Abs((h % 2.0f) - 1.0f));
+            var x = y * (1.0f - System.Math.Abs((h % 2.0f) - 1.0f));
 
             float r, g, b;
             if (h >= 0.0f && h < 1.0f)
@@ -1361,8 +1361,8 @@ namespace OpenToolkit.Mathematics
         /// <param name="rgb">Color value to convert.</param>
         public static Vector4 ToHcy(Color4 rgb)
         {
-            var max = Math.Max(rgb.R, Math.Max(rgb.G, rgb.B));
-            var min = Math.Min(rgb.R, Math.Min(rgb.G, rgb.B));
+            var max = System.Math.Max(rgb.R, System.Math.Max(rgb.G, rgb.B));
+            var min = System.Math.Min(rgb.R, System.Math.Min(rgb.G, rgb.B));
             var diff = max - min;
 
             var h = 0.0f;

--- a/src/OpenTK.Mathematics/Data/Half.cs
+++ b/src/OpenTK.Mathematics/Data/Half.cs
@@ -60,7 +60,7 @@ using System.IO;
 using System.Runtime.InteropServices;
 using System.Runtime.Serialization;
 
-namespace OpenToolkit.Mathematics
+namespace OpenToolkit.Math
 {
     /// <summary>
     /// The name Half is derived from half-precision floating-point number.
@@ -462,7 +462,7 @@ namespace OpenToolkit.Mathematics
                 l = (short)(0x8000 - l);
             }
 
-            var intDiff = Math.Abs((short)(k - l));
+            var intDiff = System.Math.Abs((short)(k - l));
 
             if (intDiff <= maxUlps)
             {

--- a/src/OpenTK.Mathematics/Data/Quaternion.cs
+++ b/src/OpenTK.Mathematics/Data/Quaternion.cs
@@ -24,7 +24,7 @@ using System;
 using System.Runtime.InteropServices;
 using System.Xml.Serialization;
 
-namespace OpenToolkit.Mathematics
+namespace OpenToolkit.Math
 {
     /// <summary>
     /// Represents a Quaternion.
@@ -79,12 +79,12 @@ namespace OpenToolkit.Mathematics
             rotationY *= 0.5f;
             rotationZ *= 0.5f;
 
-            var c1 = (float)Math.Cos(rotationX);
-            var c2 = (float)Math.Cos(rotationY);
-            var c3 = (float)Math.Cos(rotationZ);
-            var s1 = (float)Math.Sin(rotationX);
-            var s2 = (float)Math.Sin(rotationY);
-            var s3 = (float)Math.Sin(rotationZ);
+            var c1 = (float)System.Math.Cos(rotationX);
+            var c2 = (float)System.Math.Cos(rotationY);
+            var c3 = (float)System.Math.Cos(rotationZ);
+            var s1 = (float)System.Math.Sin(rotationX);
+            var s2 = (float)System.Math.Sin(rotationY);
+            var s3 = (float)System.Math.Sin(rotationZ);
 
             W = (c1 * c2 * c3) - (s1 * s2 * s3);
             Xyz.X = (s1 * c2 * c3) + (c1 * s2 * s3);
@@ -152,17 +152,17 @@ namespace OpenToolkit.Mathematics
         public Vector4 ToAxisAngle()
         {
             var q = this;
-            if (Math.Abs(q.W) > 1.0f)
+            if (System.Math.Abs(q.W) > 1.0f)
             {
                 q.Normalize();
             }
 
             var result = new Vector4
             {
-                W = 2.0f * (float)Math.Acos(q.W) // angle
+                W = 2.0f * (float)System.Math.Acos(q.W) // angle
             };
 
-            var den = (float)Math.Sqrt(1.0 - (q.W * q.W));
+            var den = (float)System.Math.Sqrt(1.0 - (q.W * q.W));
             if (den > 0.0001f)
             {
                 result.Xyz = q.Xyz / den;
@@ -181,7 +181,7 @@ namespace OpenToolkit.Mathematics
         /// Gets the length (magnitude) of the quaternion.
         /// </summary>
         /// <seealso cref="LengthSquared"/>
-        public float Length => (float)Math.Sqrt((W * W) + Xyz.LengthSquared);
+        public float Length => (float)System.Math.Sqrt((W * W) + Xyz.LengthSquared);
 
         /// <summary>
         /// Gets the square of the quaternion length (magnitude).
@@ -441,8 +441,8 @@ namespace OpenToolkit.Mathematics
 
             angle *= 0.5f;
             axis.Normalize();
-            result.Xyz = axis * (float)Math.Sin(angle);
-            result.W = (float)Math.Cos(angle);
+            result.Xyz = axis * (float)System.Math.Sin(angle);
+            result.W = (float)System.Math.Cos(angle);
 
             return Normalize(result);
         }
@@ -482,12 +482,12 @@ namespace OpenToolkit.Mathematics
         /// <param name="result">The equivalent Quaternion.</param>
         public static void FromEulerAngles(ref Vector3 eulerAngles, out Quaternion result)
         {
-            var c1 = (float)Math.Cos(eulerAngles.X * 0.5f);
-            var c2 = (float)Math.Cos(eulerAngles.Y * 0.5f);
-            var c3 = (float)Math.Cos(eulerAngles.Z * 0.5f);
-            var s1 = (float)Math.Sin(eulerAngles.X * 0.5f);
-            var s2 = (float)Math.Sin(eulerAngles.Y * 0.5f);
-            var s3 = (float)Math.Sin(eulerAngles.Z * 0.5f);
+            var c1 = (float)System.Math.Cos(eulerAngles.X * 0.5f);
+            var c2 = (float)System.Math.Cos(eulerAngles.Y * 0.5f);
+            var c3 = (float)System.Math.Cos(eulerAngles.Z * 0.5f);
+            var s1 = (float)System.Math.Sin(eulerAngles.X * 0.5f);
+            var s2 = (float)System.Math.Sin(eulerAngles.Y * 0.5f);
+            var s3 = (float)System.Math.Sin(eulerAngles.Z * 0.5f);
 
             result.W = (c1 * c2 * c3) - (s1 * s2 * s3);
             result.Xyz.X = (s1 * c2 * c3) + (c1 * s2 * s3);
@@ -517,7 +517,7 @@ namespace OpenToolkit.Mathematics
 
             if (trace > 0)
             {
-                var s = (float)Math.Sqrt(trace + 1) * 2;
+                var s = (float)System.Math.Sqrt(trace + 1) * 2;
                 var invS = 1f / s;
 
                 result.W = s * 0.25f;
@@ -531,7 +531,7 @@ namespace OpenToolkit.Mathematics
 
                 if (m00 > m11 && m00 > m22)
                 {
-                    var s = (float)Math.Sqrt(1 + m00 - m11 - m22) * 2;
+                    var s = (float)System.Math.Sqrt(1 + m00 - m11 - m22) * 2;
                     var invS = 1f / s;
 
                     result.W = (matrix.Row2.Y - matrix.Row1.Z) * invS;
@@ -541,7 +541,7 @@ namespace OpenToolkit.Mathematics
                 }
                 else if (m11 > m22)
                 {
-                    var s = (float)Math.Sqrt(1 + m11 - m00 - m22) * 2;
+                    var s = (float)System.Math.Sqrt(1 + m11 - m00 - m22) * 2;
                     var invS = 1f / s;
 
                     result.W = (matrix.Row0.Z - matrix.Row2.X) * invS;
@@ -551,7 +551,7 @@ namespace OpenToolkit.Mathematics
                 }
                 else
                 {
-                    var s = (float)Math.Sqrt(1 + m22 - m00 - m11) * 2;
+                    var s = (float)System.Math.Sqrt(1 + m22 - m00 - m11) * 2;
                     var invS = 1f / s;
 
                     result.W = (matrix.Row1.X - matrix.Row0.Y) * invS;
@@ -607,11 +607,11 @@ namespace OpenToolkit.Mathematics
             if (cosHalfAngle < 0.99f)
             {
                 // do proper slerp for big angles
-                var halfAngle = (float)Math.Acos(cosHalfAngle);
-                var sinHalfAngle = (float)Math.Sin(halfAngle);
+                var halfAngle = (float)System.Math.Acos(cosHalfAngle);
+                var sinHalfAngle = (float)System.Math.Sin(halfAngle);
                 var oneOverSinHalfAngle = 1.0f / sinHalfAngle;
-                blendA = (float)Math.Sin(halfAngle * (1.0f - blend)) * oneOverSinHalfAngle;
-                blendB = (float)Math.Sin(halfAngle * blend) * oneOverSinHalfAngle;
+                blendA = (float)System.Math.Sin(halfAngle * (1.0f - blend)) * oneOverSinHalfAngle;
+                blendB = (float)System.Math.Sin(halfAngle * blend) * oneOverSinHalfAngle;
             }
             else
             {

--- a/src/OpenTK.Mathematics/Data/Quaterniond.cs
+++ b/src/OpenTK.Mathematics/Data/Quaterniond.cs
@@ -24,7 +24,7 @@ using System;
 using System.Runtime.InteropServices;
 using System.Xml.Serialization;
 
-namespace OpenToolkit.Mathematics
+namespace OpenToolkit.Math
 {
     /// <summary>
     /// Represents a double-precision Quaternion.
@@ -77,12 +77,12 @@ namespace OpenToolkit.Mathematics
             pitch *= 0.5;
             roll *= 0.5;
 
-            var c1 = Math.Cos(yaw);
-            var c2 = Math.Cos(pitch);
-            var c3 = Math.Cos(roll);
-            var s1 = Math.Sin(yaw);
-            var s2 = Math.Sin(pitch);
-            var s3 = Math.Sin(roll);
+            var c1 = System.Math.Cos(yaw);
+            var c2 = System.Math.Cos(pitch);
+            var c3 = System.Math.Cos(roll);
+            var s1 = System.Math.Sin(yaw);
+            var s2 = System.Math.Sin(pitch);
+            var s3 = System.Math.Sin(roll);
 
             W = (c1 * c2 * c3) - (s1 * s2 * s3);
             Xyz.X = (s1 * s2 * c3) + (c1 * c2 * s3);
@@ -148,17 +148,17 @@ namespace OpenToolkit.Mathematics
         public Vector4d ToAxisAngle()
         {
             var q = this;
-            if (Math.Abs(q.W) > 1.0f)
+            if (System.Math.Abs(q.W) > 1.0f)
             {
                 q.Normalize();
             }
 
             var result = new Vector4d
             {
-                W = 2.0f * (float)Math.Acos(q.W) // angle
+                W = 2.0f * (float)System.Math.Acos(q.W) // angle
             };
 
-            var den = (float)Math.Sqrt(1.0 - (q.W * q.W));
+            var den = (float)System.Math.Sqrt(1.0 - (q.W * q.W));
             if (den > 0.0001f)
             {
                 result.Xyz = q.Xyz / den;
@@ -177,7 +177,7 @@ namespace OpenToolkit.Mathematics
         /// Gets the length (magnitude) of the Quaterniond.
         /// </summary>
         /// <seealso cref="LengthSquared"/>
-        public double Length => Math.Sqrt((W * W) + Xyz.LengthSquared);
+        public double Length => System.Math.Sqrt((W * W) + Xyz.LengthSquared);
 
         /// <summary>
         /// Gets the square of the Quaterniond length (magnitude).
@@ -437,8 +437,8 @@ namespace OpenToolkit.Mathematics
 
             angle *= 0.5f;
             axis.Normalize();
-            result.Xyz = axis * Math.Sin(angle);
-            result.W = Math.Cos(angle);
+            result.Xyz = axis * System.Math.Sin(angle);
+            result.W = System.Math.Cos(angle);
 
             return Normalize(result);
         }
@@ -472,12 +472,12 @@ namespace OpenToolkit.Mathematics
         /// <param name="result">The equivalent Quaterniond.</param>
         public static void FromEulerAngles(ref Vector3d eulerAngles, out Quaterniond result)
         {
-            var c1 = Math.Cos(eulerAngles.Y * 0.5);
-            var c2 = Math.Cos(eulerAngles.X * 0.5);
-            var c3 = Math.Cos(eulerAngles.Z * 0.5);
-            var s1 = Math.Sin(eulerAngles.Y * 0.5);
-            var s2 = Math.Sin(eulerAngles.X * 0.5);
-            var s3 = Math.Sin(eulerAngles.Z * 0.5);
+            var c1 = System.Math.Cos(eulerAngles.Y * 0.5);
+            var c2 = System.Math.Cos(eulerAngles.X * 0.5);
+            var c3 = System.Math.Cos(eulerAngles.Z * 0.5);
+            var s1 = System.Math.Sin(eulerAngles.Y * 0.5);
+            var s2 = System.Math.Sin(eulerAngles.X * 0.5);
+            var s3 = System.Math.Sin(eulerAngles.Z * 0.5);
 
             result.W = (c1 * c2 * c3) - (s1 * s2 * s3);
             result.Xyz.X = (s1 * s2 * c3) + (c1 * c2 * s3);
@@ -507,7 +507,7 @@ namespace OpenToolkit.Mathematics
 
             if (trace > 0)
             {
-                var s = Math.Sqrt(trace + 1) * 2;
+                var s = System.Math.Sqrt(trace + 1) * 2;
                 var invS = 1.0 / s;
 
                 result.W = s * 0.25;
@@ -521,7 +521,7 @@ namespace OpenToolkit.Mathematics
 
                 if (m00 > m11 && m00 > m22)
                 {
-                    var s = Math.Sqrt(1 + m00 - m11 - m22) * 2;
+                    var s = System.Math.Sqrt(1 + m00 - m11 - m22) * 2;
                     var invS = 1.0 / s;
 
                     result.W = (matrix.Row2.Y - matrix.Row1.Z) * invS;
@@ -531,7 +531,7 @@ namespace OpenToolkit.Mathematics
                 }
                 else if (m11 > m22)
                 {
-                    var s = Math.Sqrt(1 + m11 - m00 - m22) * 2;
+                    var s = System.Math.Sqrt(1 + m11 - m00 - m22) * 2;
                     var invS = 1.0 / s;
 
                     result.W = (matrix.Row0.Z - matrix.Row2.X) * invS;
@@ -541,7 +541,7 @@ namespace OpenToolkit.Mathematics
                 }
                 else
                 {
-                    var s = Math.Sqrt(1 + m22 - m00 - m11) * 2;
+                    var s = System.Math.Sqrt(1 + m22 - m00 - m11) * 2;
                     var invS = 1.0 / s;
 
                     result.W = (matrix.Row1.X - matrix.Row0.Y) * invS;
@@ -597,11 +597,11 @@ namespace OpenToolkit.Mathematics
             if (cosHalfAngle < 0.99f)
             {
                 // do proper slerp for big angles
-                var halfAngle = Math.Acos(cosHalfAngle);
-                var sinHalfAngle = Math.Sin(halfAngle);
+                var halfAngle = System.Math.Acos(cosHalfAngle);
+                var sinHalfAngle = System.Math.Sin(halfAngle);
                 var oneOverSinHalfAngle = 1.0f / sinHalfAngle;
-                blendA = Math.Sin(halfAngle * (1.0f - blend)) * oneOverSinHalfAngle;
-                blendB = Math.Sin(halfAngle * blend) * oneOverSinHalfAngle;
+                blendA = System.Math.Sin(halfAngle * (1.0f - blend)) * oneOverSinHalfAngle;
+                blendB = System.Math.Sin(halfAngle * blend) * oneOverSinHalfAngle;
             }
             else
             {

--- a/src/OpenTK.Mathematics/Geometry/BezierCurve.cs
+++ b/src/OpenTK.Mathematics/Geometry/BezierCurve.cs
@@ -9,7 +9,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace OpenToolkit.Mathematics
+namespace OpenToolkit.Math
 {
     /// <summary>
     /// Represents a bezier curve with as many points as you want.
@@ -205,7 +205,7 @@ namespace OpenToolkit.Mathematics
             {
                 temp = MathHelper.BinomialCoefficient
                 (
-                    points.Count - 1, i) * (float)(Math.Pow(t, i) * Math.Pow(c, points.Count - 1 - i)
+                    points.Count - 1, i) * (float)(System.Math.Pow(t, i) * System.Math.Pow(c, points.Count - 1 - i)
                 );
 
                 r.X += temp * pt.X;
@@ -249,7 +249,7 @@ namespace OpenToolkit.Mathematics
             {
                 temp = MathHelper.BinomialCoefficient
                 (
-                    points.Count - 2, i) * (float)(Math.Pow(t, i) * Math.Pow(c, points.Count - 2 - i)
+                    points.Count - 2, i) * (float)(System.Math.Pow(t, i) * System.Math.Pow(c, points.Count - 2 - i)
                 );
 
                 r.X += temp * pt.X;

--- a/src/OpenTK.Mathematics/Geometry/BezierCurveCubic.cs
+++ b/src/OpenTK.Mathematics/Geometry/BezierCurveCubic.cs
@@ -8,7 +8,7 @@
 
 using System;
 
-namespace OpenToolkit.Mathematics
+namespace OpenToolkit.Math
 {
     /// <summary>
     /// Represents a cubic bezier curve with two anchor and two control points.

--- a/src/OpenTK.Mathematics/Geometry/BezierCurveQuadric.cs
+++ b/src/OpenTK.Mathematics/Geometry/BezierCurveQuadric.cs
@@ -8,7 +8,7 @@
 
 using System;
 
-namespace OpenToolkit.Mathematics
+namespace OpenToolkit.Math
 {
     /// <summary>
     /// Represents a quadric bezier curve with two anchor and one control point.

--- a/src/OpenTK.Mathematics/Geometry/Box2.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box2.cs
@@ -6,7 +6,7 @@ using System;
 using System.Globalization;
 using System.Runtime.InteropServices;
 
-namespace OpenToolkit.Mathematics
+namespace OpenToolkit.Math
 {
     /// <summary>
     /// Defines a 2d box (rectangle).
@@ -102,12 +102,12 @@ namespace OpenToolkit.Mathematics
         /// <summary>
         /// Gets a float describing the width of the Box2 structure.
         /// </summary>
-        public float Width => Math.Abs(Right - Left);
+        public float Width => System.Math.Abs(Right - Left);
 
         /// <summary>
         /// Gets a float describing the height of the Box2 structure.
         /// </summary>
-        public float Height => Math.Abs(Bottom - Top);
+        public float Height => System.Math.Abs(Bottom - Top);
 
         /// <summary>
         /// Returns whether the box contains the specified point on the closed region described by this Box2.

--- a/src/OpenTK.Mathematics/Geometry/Box2d.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box2d.cs
@@ -6,7 +6,7 @@ using System;
 using System.Globalization;
 using System.Runtime.InteropServices;
 
-namespace OpenToolkit.Mathematics
+namespace OpenToolkit.Math
 {
     /// <summary>
     /// Defines a 2d box (rectangle).
@@ -102,12 +102,12 @@ namespace OpenToolkit.Mathematics
         /// <summary>
         /// Gets a double describing the width of the Box2d structure.
         /// </summary>
-        public double Width => Math.Abs(Right - Left);
+        public double Width => System.Math.Abs(Right - Left);
 
         /// <summary>
         /// Gets a double describing the height of the Box2d structure.
         /// </summary>
-        public double Height => Math.Abs(Bottom - Top);
+        public double Height => System.Math.Abs(Bottom - Top);
 
         /// <summary>
         /// Returns whether the box contains the specified point on the closed region described by this Box2.

--- a/src/OpenTK.Mathematics/MathHelper.cs
+++ b/src/OpenTK.Mathematics/MathHelper.cs
@@ -9,7 +9,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace OpenToolkit.Mathematics
+namespace OpenToolkit.Math
 {
     /// <summary>
     /// Contains common mathematical functions and constants.
@@ -79,7 +79,7 @@ namespace OpenToolkit.Mathematics
                 throw new ArgumentOutOfRangeException(nameof(n), "Must be positive.");
             }
 
-            return (long)Math.Pow(2, Math.Ceiling(Math.Log(n, 2)));
+            return (long)System.Math.Pow(2, System.Math.Ceiling(System.Math.Log(n, 2)));
         }
 
         /// <summary>
@@ -94,7 +94,7 @@ namespace OpenToolkit.Mathematics
                 throw new ArgumentOutOfRangeException(nameof(n), "Must be positive.");
             }
 
-            return (int)Math.Pow(2, Math.Ceiling(Math.Log(n, 2)));
+            return (int)System.Math.Pow(2, System.Math.Ceiling(System.Math.Log(n, 2)));
         }
 
         /// <summary>
@@ -109,7 +109,7 @@ namespace OpenToolkit.Mathematics
                 throw new ArgumentOutOfRangeException(nameof(n), "Must be positive.");
             }
 
-            return (float)Math.Pow(2, Math.Ceiling(Math.Log(n, 2)));
+            return (float)System.Math.Pow(2, System.Math.Ceiling(System.Math.Log(n, 2)));
         }
 
         /// <summary>
@@ -124,7 +124,7 @@ namespace OpenToolkit.Mathematics
                 throw new ArgumentOutOfRangeException(nameof(n), "Must be positive.");
             }
 
-            return Math.Pow(2, Math.Ceiling(Math.Log(n, 2)));
+            return System.Math.Pow(2, System.Math.Ceiling(System.Math.Log(n, 2)));
         }
 
         /// <summary>
@@ -212,7 +212,7 @@ namespace OpenToolkit.Mathematics
         /// <returns>The angle expressed in radians.</returns>
         public static float DegreesToRadians(float degrees)
         {
-            const float degToRad = (float)Math.PI / 180.0f;
+            const float degToRad = (float)System.Math.PI / 180.0f;
             return degrees * degToRad;
         }
 
@@ -223,7 +223,7 @@ namespace OpenToolkit.Mathematics
         /// <returns>The angle expressed in degrees.</returns>
         public static float RadiansToDegrees(float radians)
         {
-            const float radToDeg = 180.0f / (float)Math.PI;
+            const float radToDeg = 180.0f / (float)System.Math.PI;
             return radians * radToDeg;
         }
 
@@ -234,7 +234,7 @@ namespace OpenToolkit.Mathematics
         /// <returns>The angle expressed in radians.</returns>
         public static double DegreesToRadians(double degrees)
         {
-            const double degToRad = Math.PI / 180.0;
+            const double degToRad = System.Math.PI / 180.0;
             return degrees * degToRad;
         }
 
@@ -245,7 +245,7 @@ namespace OpenToolkit.Mathematics
         /// <returns>The angle expressed in degrees.</returns>
         public static double RadiansToDegrees(double radians)
         {
-            const double radToDeg = 180.0 / Math.PI;
+            const double radToDeg = 180.0 / System.Math.PI;
             return radians * radToDeg;
         }
 
@@ -282,7 +282,7 @@ namespace OpenToolkit.Mathematics
         /// <returns>min, if n is lower than min; max, if n is higher than max; n otherwise.</returns>
         public static int Clamp(int n, int min, int max)
         {
-            return Math.Max(Math.Min(n, max), min);
+            return System.Math.Max(System.Math.Min(n, max), min);
         }
 
         /// <summary>
@@ -294,7 +294,7 @@ namespace OpenToolkit.Mathematics
         /// <returns>min, if n is lower than min; max, if n is higher than max; n otherwise.</returns>
         public static float Clamp(float n, float min, float max)
         {
-            return Math.Max(Math.Min(n, max), min);
+            return System.Math.Max(System.Math.Min(n, max), min);
         }
 
         /// <summary>
@@ -306,7 +306,7 @@ namespace OpenToolkit.Mathematics
         /// <returns>min, if n is lower than min; max, if n is higher than max; n otherwise.</returns>
         public static double Clamp(double n, double min, double max)
         {
-            return Math.Max(Math.Min(n, max), min);
+            return System.Math.Max(System.Math.Min(n, max), min);
         }
 
         private static unsafe int FloatToInt32Bits(float f)
@@ -369,7 +369,7 @@ namespace OpenToolkit.Mathematics
                 l = int.MinValue - l;
             }
 
-            var intDiff = Math.Abs(k - l);
+            var intDiff = System.Math.Abs(k - l);
             return intDiff <= 1 << maxDeltaBits;
         }
 
@@ -388,9 +388,9 @@ namespace OpenToolkit.Mathematics
         public static bool ApproximatelyEqualEpsilon(double a, double b, double epsilon)
         {
             const double doubleNormal = (1L << 52) * double.Epsilon;
-            var absA = Math.Abs(a);
-            var absB = Math.Abs(b);
-            var diff = Math.Abs(a - b);
+            var absA = System.Math.Abs(a);
+            var absB = System.Math.Abs(b);
+            var diff = System.Math.Abs(a - b);
 
             if (a == b)
             {
@@ -406,7 +406,7 @@ namespace OpenToolkit.Mathematics
             }
 
             // use relative error
-            return diff / Math.Min(absA + absB, double.MaxValue) < epsilon;
+            return diff / System.Math.Min(absA + absB, double.MaxValue) < epsilon;
         }
 
         /// <summary>
@@ -424,9 +424,9 @@ namespace OpenToolkit.Mathematics
         public static bool ApproximatelyEqualEpsilon(float a, float b, float epsilon)
         {
             const float floatNormal = (1 << 23) * float.Epsilon;
-            var absA = Math.Abs(a);
-            var absB = Math.Abs(b);
-            var diff = Math.Abs(a - b);
+            var absA = System.Math.Abs(a);
+            var absB = System.Math.Abs(b);
+            var diff = System.Math.Abs(a - b);
 
             if (a == b)
             {
@@ -442,7 +442,7 @@ namespace OpenToolkit.Mathematics
             }
 
             // use relative error
-            var relativeError = diff / Math.Min(absA + absB, float.MaxValue);
+            var relativeError = diff / System.Math.Min(absA + absB, float.MaxValue);
             return relativeError < epsilon;
         }
 
@@ -465,7 +465,7 @@ namespace OpenToolkit.Mathematics
                 return true;
             }
 
-            var diff = Math.Abs(a - b);
+            var diff = System.Math.Abs(a - b);
             return diff <= tolerance;
         }
 
@@ -488,7 +488,7 @@ namespace OpenToolkit.Mathematics
                 return true;
             }
 
-            var diff = Math.Abs(a - b);
+            var diff = System.Math.Abs(a - b);
             return diff <= tolerance;
         }
     }

--- a/src/OpenTK.Mathematics/Matrix/Matrix2.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix2.cs
@@ -23,7 +23,7 @@ SOFTWARE.
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace OpenToolkit.Mathematics
+namespace OpenToolkit.Math
 {
     /// <summary>
     /// Represents a 2x2 matrix.
@@ -240,8 +240,8 @@ namespace OpenToolkit.Mathematics
         /// <param name="result">The resulting Matrix2 instance.</param>
         public static void CreateRotation(float angle, out Matrix2 result)
         {
-            var cos = (float)Math.Cos(angle);
-            var sin = (float)Math.Sin(angle);
+            var cos = (float)System.Math.Cos(angle);
+            var sin = (float)System.Math.Sin(angle);
 
             result.Row0.X = cos;
             result.Row0.Y = sin;

--- a/src/OpenTK.Mathematics/Matrix/Matrix2d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix2d.cs
@@ -23,7 +23,7 @@ SOFTWARE.
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace OpenToolkit.Mathematics
+namespace OpenToolkit.Math
 {
     /// <summary>
     /// Represents a 2x2 matrix.
@@ -240,8 +240,8 @@ namespace OpenToolkit.Mathematics
         /// <param name="result">The resulting Matrix2d instance.</param>
         public static void CreateRotation(double angle, out Matrix2d result)
         {
-            var cos = Math.Cos(angle);
-            var sin = Math.Sin(angle);
+            var cos = System.Math.Cos(angle);
+            var sin = System.Math.Sin(angle);
 
             result.Row0.X = cos;
             result.Row0.Y = sin;

--- a/src/OpenTK.Mathematics/Matrix/Matrix2x3.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix2x3.cs
@@ -23,7 +23,7 @@ SOFTWARE.
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace OpenToolkit.Mathematics
+namespace OpenToolkit.Math
 {
     /// <summary>
     /// Represents a 2x3 matrix.
@@ -236,8 +236,8 @@ namespace OpenToolkit.Mathematics
         /// <param name="result">The resulting Matrix2x3 instance.</param>
         public static void CreateRotation(float angle, out Matrix2x3 result)
         {
-            var cos = (float)Math.Cos(angle);
-            var sin = (float)Math.Sin(angle);
+            var cos = (float)System.Math.Cos(angle);
+            var sin = (float)System.Math.Sin(angle);
 
             result.Row0.X = cos;
             result.Row0.Y = sin;

--- a/src/OpenTK.Mathematics/Matrix/Matrix2x3d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix2x3d.cs
@@ -23,7 +23,7 @@ SOFTWARE.
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace OpenToolkit.Mathematics
+namespace OpenToolkit.Math
 {
     /// <summary>
     /// Represents a 2x3 matrix.
@@ -235,8 +235,8 @@ namespace OpenToolkit.Mathematics
         /// <param name="result">The resulting Matrix2x3d instance.</param>
         public static void CreateRotation(double angle, out Matrix2x3d result)
         {
-            var cos = Math.Cos(angle);
-            var sin = Math.Sin(angle);
+            var cos = System.Math.Cos(angle);
+            var sin = System.Math.Sin(angle);
 
             result.Row0.X = cos;
             result.Row0.Y = sin;

--- a/src/OpenTK.Mathematics/Matrix/Matrix2x4.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix2x4.cs
@@ -23,7 +23,7 @@ SOFTWARE.
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace OpenToolkit.Mathematics
+namespace OpenToolkit.Math
 {
     /// <summary>
     /// Represents a 2x4 matrix.
@@ -269,8 +269,8 @@ namespace OpenToolkit.Mathematics
         /// <param name="result">The resulting Matrix2x4 instance.</param>
         public static void CreateRotation(float angle, out Matrix2x4 result)
         {
-            var cos = (float)Math.Cos(angle);
-            var sin = (float)Math.Sin(angle);
+            var cos = (float)System.Math.Cos(angle);
+            var sin = (float)System.Math.Sin(angle);
 
             result.Row0.X = cos;
             result.Row0.Y = sin;

--- a/src/OpenTK.Mathematics/Matrix/Matrix2x4d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix2x4d.cs
@@ -23,7 +23,7 @@ SOFTWARE.
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace OpenToolkit.Mathematics
+namespace OpenToolkit.Math
 {
     /// <summary>
     /// Represents a 2x4 matrix.
@@ -269,8 +269,8 @@ namespace OpenToolkit.Mathematics
         /// <param name="result">The resulting Matrix2x4d instance.</param>
         public static void CreateRotation(double angle, out Matrix2x4d result)
         {
-            var cos = Math.Cos(angle);
-            var sin = Math.Sin(angle);
+            var cos = System.Math.Cos(angle);
+            var sin = System.Math.Sin(angle);
 
             result.Row0.X = cos;
             result.Row0.Y = sin;

--- a/src/OpenTK.Mathematics/Matrix/Matrix3.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix3.cs
@@ -24,7 +24,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
-namespace OpenToolkit.Mathematics
+namespace OpenToolkit.Math
 {
     /// <summary>
     /// Represents a 3x3 matrix containing 3D rotation and scale.
@@ -410,7 +410,7 @@ namespace OpenToolkit.Mathematics
 
             if (trace > 0)
             {
-                var sq = Math.Sqrt(trace);
+                var sq = System.Math.Sqrt(trace);
 
                 q.W = (float)sq;
                 sq = 1.0 / (4.0 * sq);
@@ -420,7 +420,7 @@ namespace OpenToolkit.Mathematics
             }
             else if (row0[0] > row1[1] && row0[0] > row2[2])
             {
-                var sq = 2.0 * Math.Sqrt(1.0 + row0[0] - row1[1] - row2[2]);
+                var sq = 2.0 * System.Math.Sqrt(1.0 + row0[0] - row1[1] - row2[2]);
 
                 q.X = (float)(0.25 * sq);
                 sq = 1.0 / sq;
@@ -430,7 +430,7 @@ namespace OpenToolkit.Mathematics
             }
             else if (row1[1] > row2[2])
             {
-                var sq = 2.0 * Math.Sqrt(1.0 + row1[1] - row0[0] - row2[2]);
+                var sq = 2.0 * System.Math.Sqrt(1.0 + row1[1] - row0[0] - row2[2]);
 
                 q.Y = (float)(0.25 * sq);
                 sq = 1.0 / sq;
@@ -440,7 +440,7 @@ namespace OpenToolkit.Mathematics
             }
             else
             {
-                var sq = 2.0 * Math.Sqrt(1.0 + row2[2] - row0[0] - row1[1]);
+                var sq = 2.0 * System.Math.Sqrt(1.0 + row2[2] - row0[0] - row1[1]);
 
                 q.Z = (float)(0.25 * sq);
                 sq = 1.0 / sq;
@@ -466,8 +466,8 @@ namespace OpenToolkit.Mathematics
             float axisX = axis.X, axisY = axis.Y, axisZ = axis.Z;
 
             // calculate angles
-            var cos = (float)Math.Cos(-angle);
-            var sin = (float)Math.Sin(-angle);
+            var cos = (float)System.Math.Cos(-angle);
+            var sin = (float)System.Math.Sin(-angle);
             var t = 1.0f - cos;
 
             // do the conversion math once
@@ -534,8 +534,8 @@ namespace OpenToolkit.Mathematics
         /// <param name="result">The resulting Matrix3 instance.</param>
         public static void CreateRotationX(float angle, out Matrix3 result)
         {
-            var cos = (float)Math.Cos(angle);
-            var sin = (float)Math.Sin(angle);
+            var cos = (float)System.Math.Cos(angle);
+            var sin = (float)System.Math.Sin(angle);
 
             result = Identity;
             result.Row1.Y = cos;
@@ -562,8 +562,8 @@ namespace OpenToolkit.Mathematics
         /// <param name="result">The resulting Matrix3 instance.</param>
         public static void CreateRotationY(float angle, out Matrix3 result)
         {
-            var cos = (float)Math.Cos(angle);
-            var sin = (float)Math.Sin(angle);
+            var cos = (float)System.Math.Cos(angle);
+            var sin = (float)System.Math.Sin(angle);
 
             result = Identity;
             result.Row0.X = cos;
@@ -590,8 +590,8 @@ namespace OpenToolkit.Mathematics
         /// <param name="result">The resulting Matrix3 instance.</param>
         public static void CreateRotationZ(float angle, out Matrix3 result)
         {
-            var cos = (float)Math.Cos(angle);
-            var sin = (float)Math.Sin(angle);
+            var cos = (float)System.Math.Cos(angle);
+            var sin = (float)System.Math.Sin(angle);
 
             result = Identity;
             result.Row0.X = cos;
@@ -794,7 +794,7 @@ namespace OpenToolkit.Mathematics
                         {
                             if (pivotIdx[k] == -1)
                             {
-                                var absVal = Math.Abs(inverse[j, k]);
+                                var absVal = System.Math.Abs(inverse[j, k]);
                                 if (absVal > maxPivot)
                                 {
                                     maxPivot = absVal;

--- a/src/OpenTK.Mathematics/Matrix/Matrix3d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix3d.cs
@@ -24,7 +24,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
-namespace OpenToolkit.Mathematics
+namespace OpenToolkit.Math
 {
     /// <summary>
     /// Represents a 3x3 matrix containing 3D rotation and scale with double-precision components.
@@ -405,7 +405,7 @@ namespace OpenToolkit.Mathematics
 
             if (trace > 0)
             {
-                var sq = Math.Sqrt(trace);
+                var sq = System.Math.Sqrt(trace);
 
                 q.W = sq;
                 sq = 1.0 / (4.0 * sq);
@@ -415,7 +415,7 @@ namespace OpenToolkit.Mathematics
             }
             else if (row0[0] > row1[1] && row0[0] > row2[2])
             {
-                var sq = 2.0 * Math.Sqrt(1.0 + row0[0] - row1[1] - row2[2]);
+                var sq = 2.0 * System.Math.Sqrt(1.0 + row0[0] - row1[1] - row2[2]);
 
                 q.X = 0.25 * sq;
                 sq = 1.0 / sq;
@@ -425,7 +425,7 @@ namespace OpenToolkit.Mathematics
             }
             else if (row1[1] > row2[2])
             {
-                var sq = 2.0 * Math.Sqrt(1.0 + row1[1] - row0[0] - row2[2]);
+                var sq = 2.0 * System.Math.Sqrt(1.0 + row1[1] - row0[0] - row2[2]);
 
                 q.Y = 0.25 * sq;
                 sq = 1.0 / sq;
@@ -435,7 +435,7 @@ namespace OpenToolkit.Mathematics
             }
             else
             {
-                var sq = 2.0 * Math.Sqrt(1.0 + row2[2] - row0[0] - row1[1]);
+                var sq = 2.0 * System.Math.Sqrt(1.0 + row2[2] - row0[0] - row1[1]);
 
                 q.Z = 0.25 * sq;
                 sq = 1.0 / sq;
@@ -461,8 +461,8 @@ namespace OpenToolkit.Mathematics
             double axisX = axis.X, axisY = axis.Y, axisZ = axis.Z;
 
             // calculate angles
-            var cos = Math.Cos(-angle);
-            var sin = Math.Sin(-angle);
+            var cos = System.Math.Cos(-angle);
+            var sin = System.Math.Sin(-angle);
             var t = 1.0f - cos;
 
             // do the conversion math once
@@ -529,8 +529,8 @@ namespace OpenToolkit.Mathematics
         /// <param name="result">The resulting Matrix3d instance.</param>
         public static void CreateRotationX(double angle, out Matrix3d result)
         {
-            var cos = Math.Cos(angle);
-            var sin = Math.Sin(angle);
+            var cos = System.Math.Cos(angle);
+            var sin = System.Math.Sin(angle);
 
             result = Identity;
             result.Row1.Y = cos;
@@ -557,8 +557,8 @@ namespace OpenToolkit.Mathematics
         /// <param name="result">The resulting Matrix3d instance.</param>
         public static void CreateRotationY(double angle, out Matrix3d result)
         {
-            var cos = Math.Cos(angle);
-            var sin = Math.Sin(angle);
+            var cos = System.Math.Cos(angle);
+            var sin = System.Math.Sin(angle);
 
             result = Identity;
             result.Row0.X = cos;
@@ -585,8 +585,8 @@ namespace OpenToolkit.Mathematics
         /// <param name="result">The resulting Matrix3d instance.</param>
         public static void CreateRotationZ(double angle, out Matrix3d result)
         {
-            var cos = Math.Cos(angle);
-            var sin = Math.Sin(angle);
+            var cos = System.Math.Cos(angle);
+            var sin = System.Math.Sin(angle);
 
             result = Identity;
             result.Row0.X = cos;
@@ -789,7 +789,7 @@ namespace OpenToolkit.Mathematics
                         {
                             if (pivotIdx[k] == -1)
                             {
-                                var absVal = Math.Abs(inverse[j, k]);
+                                var absVal = System.Math.Abs(inverse[j, k]);
                                 if (absVal > maxPivot)
                                 {
                                     maxPivot = absVal;

--- a/src/OpenTK.Mathematics/Matrix/Matrix3x2.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix3x2.cs
@@ -23,7 +23,7 @@ SOFTWARE.
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace OpenToolkit.Mathematics
+namespace OpenToolkit.Math
 {
     /// <summary>
     /// Represents a 3x2 matrix.
@@ -243,8 +243,8 @@ namespace OpenToolkit.Mathematics
         /// <param name="result">The resulting Matrix3x2 instance.</param>
         public static void CreateRotation(float angle, out Matrix3x2 result)
         {
-            var cos = (float)Math.Cos(angle);
-            var sin = (float)Math.Sin(angle);
+            var cos = (float)System.Math.Cos(angle);
+            var sin = (float)System.Math.Sin(angle);
 
             result.Row0.X = cos;
             result.Row0.Y = sin;

--- a/src/OpenTK.Mathematics/Matrix/Matrix3x2d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix3x2d.cs
@@ -23,7 +23,7 @@ SOFTWARE.
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace OpenToolkit.Mathematics
+namespace OpenToolkit.Math
 {
     /// <summary>
     /// Represents a 3x2 matrix.
@@ -243,8 +243,8 @@ namespace OpenToolkit.Mathematics
         /// <param name="result">The resulting Matrix3x2d instance.</param>
         public static void CreateRotation(double angle, out Matrix3x2d result)
         {
-            var cos = Math.Cos(angle);
-            var sin = Math.Sin(angle);
+            var cos = System.Math.Cos(angle);
+            var sin = System.Math.Sin(angle);
 
             result.Row0.X = cos;
             result.Row0.Y = sin;

--- a/src/OpenTK.Mathematics/Matrix/Matrix3x4.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix3x4.cs
@@ -24,7 +24,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
-namespace OpenToolkit.Mathematics
+namespace OpenToolkit.Math
 {
     /// <summary>
     /// Represents a 3x4 Matrix.
@@ -311,8 +311,8 @@ namespace OpenToolkit.Mathematics
             axis.Normalize();
             float axisX = axis.X, axisY = axis.Y, axisZ = axis.Z;
 
-            var cos = (float)Math.Cos(angle);
-            var sin = (float)Math.Sin(angle);
+            var cos = (float)System.Math.Cos(angle);
+            var sin = (float)System.Math.Sin(angle);
             var t = 1.0f - cos;
 
             float tXX = t * axisX * axisX;
@@ -408,8 +408,8 @@ namespace OpenToolkit.Mathematics
         /// <param name="result">The resulting Matrix4 instance.</param>
         public static void CreateRotationX(float angle, out Matrix3x4 result)
         {
-            var cos = (float)Math.Cos(angle);
-            var sin = (float)Math.Sin(angle);
+            var cos = (float)System.Math.Cos(angle);
+            var sin = (float)System.Math.Sin(angle);
 
             result.Row0.X = 1;
             result.Row0.Y = 0;
@@ -443,8 +443,8 @@ namespace OpenToolkit.Mathematics
         /// <param name="result">The resulting Matrix4 instance.</param>
         public static void CreateRotationY(float angle, out Matrix3x4 result)
         {
-            var cos = (float)Math.Cos(angle);
-            var sin = (float)Math.Sin(angle);
+            var cos = (float)System.Math.Cos(angle);
+            var sin = (float)System.Math.Sin(angle);
 
             result.Row0.X = cos;
             result.Row0.Y = 0;
@@ -478,8 +478,8 @@ namespace OpenToolkit.Mathematics
         /// <param name="result">The resulting Matrix4 instance.</param>
         public static void CreateRotationZ(float angle, out Matrix3x4 result)
         {
-            var cos = (float)Math.Cos(angle);
-            var sin = (float)Math.Sin(angle);
+            var cos = (float)System.Math.Cos(angle);
+            var sin = (float)System.Math.Sin(angle);
 
             result.Row0.X = cos;
             result.Row0.Y = sin;

--- a/src/OpenTK.Mathematics/Matrix/Matrix3x4d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix3x4d.cs
@@ -24,7 +24,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
-namespace OpenToolkit.Mathematics
+namespace OpenToolkit.Math
 {
     /// <summary>
     /// Represents a 3x4 Matrix.
@@ -311,8 +311,8 @@ namespace OpenToolkit.Mathematics
             axis.Normalize();
             double axisX = axis.X, axisY = axis.Y, axisZ = axis.Z;
 
-            var cos = Math.Cos(angle);
-            var sin = Math.Sin(angle);
+            var cos = System.Math.Cos(angle);
+            var sin = System.Math.Sin(angle);
             var t = 1.0f - cos;
 
             double tXX = t * axisX * axisX;
@@ -408,8 +408,8 @@ namespace OpenToolkit.Mathematics
         /// <param name="result">The resulting Matrix4 instance.</param>
         public static void CreateRotationX(double angle, out Matrix3x4d result)
         {
-            var cos = Math.Cos(angle);
-            var sin = Math.Sin(angle);
+            var cos = System.Math.Cos(angle);
+            var sin = System.Math.Sin(angle);
 
             result.Row0.X = 1;
             result.Row0.Y = 0;
@@ -443,8 +443,8 @@ namespace OpenToolkit.Mathematics
         /// <param name="result">The resulting Matrix4 instance.</param>
         public static void CreateRotationY(double angle, out Matrix3x4d result)
         {
-            var cos = Math.Cos(angle);
-            var sin = Math.Sin(angle);
+            var cos = System.Math.Cos(angle);
+            var sin = System.Math.Sin(angle);
 
             result.Row0.X = cos;
             result.Row0.Y = 0;
@@ -478,8 +478,8 @@ namespace OpenToolkit.Mathematics
         /// <param name="result">The resulting Matrix4 instance.</param>
         public static void CreateRotationZ(double angle, out Matrix3x4d result)
         {
-            var cos = Math.Cos(angle);
-            var sin = Math.Sin(angle);
+            var cos = System.Math.Cos(angle);
+            var sin = System.Math.Sin(angle);
 
             result.Row0.X = cos;
             result.Row0.Y = sin;

--- a/src/OpenTK.Mathematics/Matrix/Matrix4.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix4.cs
@@ -24,7 +24,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
-namespace OpenToolkit.Mathematics
+namespace OpenToolkit.Math
 {
     /// <summary>
     /// Represents a 4x4 matrix containing 3D rotation, scale, transform, and projection.
@@ -604,7 +604,7 @@ namespace OpenToolkit.Mathematics
 
             if (trace > 0)
             {
-                var sq = Math.Sqrt(trace);
+                var sq = System.Math.Sqrt(trace);
 
                 q.W = (float)sq;
                 sq = 1.0 / (4.0 * sq);
@@ -614,7 +614,7 @@ namespace OpenToolkit.Mathematics
             }
             else if (row0[0] > row1[1] && row0[0] > row2[2])
             {
-                var sq = 2.0 * Math.Sqrt(1.0 + row0[0] - row1[1] - row2[2]);
+                var sq = 2.0 * System.Math.Sqrt(1.0 + row0[0] - row1[1] - row2[2]);
 
                 q.X = (float)(0.25 * sq);
                 sq = 1.0 / sq;
@@ -624,7 +624,7 @@ namespace OpenToolkit.Mathematics
             }
             else if (row1[1] > row2[2])
             {
-                var sq = 2.0 * Math.Sqrt(1.0 + row1[1] - row0[0] - row2[2]);
+                var sq = 2.0 * System.Math.Sqrt(1.0 + row1[1] - row0[0] - row2[2]);
 
                 q.Y = (float)(0.25 * sq);
                 sq = 1.0 / sq;
@@ -634,7 +634,7 @@ namespace OpenToolkit.Mathematics
             }
             else
             {
-                var sq = 2.0 * Math.Sqrt(1.0 + row2[2] - row0[0] - row1[1]);
+                var sq = 2.0 * System.Math.Sqrt(1.0 + row2[2] - row0[0] - row1[1]);
 
                 q.Z = (float)(0.25 * sq);
                 sq = 1.0 / sq;
@@ -669,8 +669,8 @@ namespace OpenToolkit.Mathematics
             float axisX = axis.X, axisY = axis.Y, axisZ = axis.Z;
 
             // calculate angles
-            var cos = (float)Math.Cos(-angle);
-            var sin = (float)Math.Sin(-angle);
+            var cos = (float)System.Math.Cos(-angle);
+            var sin = (float)System.Math.Sin(-angle);
             var t = 1.0f - cos;
 
             // do the conversion math once
@@ -741,8 +741,8 @@ namespace OpenToolkit.Mathematics
         /// <param name="result">The resulting Matrix4 instance.</param>
         public static void CreateRotationX(float angle, out Matrix4 result)
         {
-            var cos = (float)Math.Cos(angle);
-            var sin = (float)Math.Sin(angle);
+            var cos = (float)System.Math.Cos(angle);
+            var sin = (float)System.Math.Sin(angle);
 
             result = Identity;
             result.Row1.Y = cos;
@@ -769,8 +769,8 @@ namespace OpenToolkit.Mathematics
         /// <param name="result">The resulting Matrix4 instance.</param>
         public static void CreateRotationY(float angle, out Matrix4 result)
         {
-            var cos = (float)Math.Cos(angle);
-            var sin = (float)Math.Sin(angle);
+            var cos = (float)System.Math.Cos(angle);
+            var sin = (float)System.Math.Sin(angle);
 
             result = Identity;
             result.Row0.X = cos;
@@ -797,8 +797,8 @@ namespace OpenToolkit.Mathematics
         /// <param name="result">The resulting Matrix4 instance.</param>
         public static void CreateRotationZ(float angle, out Matrix4 result)
         {
-            var cos = (float)Math.Cos(angle);
-            var sin = (float)Math.Sin(angle);
+            var cos = (float)System.Math.Cos(angle);
+            var sin = (float)System.Math.Sin(angle);
 
             result = Identity;
             result.Row0.X = cos;
@@ -1044,7 +1044,7 @@ namespace OpenToolkit.Mathematics
         /// <exception cref="System.ArgumentOutOfRangeException">
         /// Thrown under the following conditions:
         ///  <list type="bullet">
-        ///  <item>fovy is zero, less than zero or larger than Math.PI</item>
+        ///  <item>fovy is zero, less than zero or larger than System.Math.PI</item>
         ///  <item>aspect is negative or zero</item>
         ///  <item>depthNear is negative or zero</item>
         ///  <item>depthFar is negative or zero</item>
@@ -1060,7 +1060,7 @@ namespace OpenToolkit.Mathematics
             out Matrix4 result
         )
         {
-            if (fovy <= 0 || fovy > Math.PI)
+            if (fovy <= 0 || fovy > System.Math.PI)
             {
                 throw new ArgumentOutOfRangeException(nameof(fovy));
             }
@@ -1080,7 +1080,7 @@ namespace OpenToolkit.Mathematics
                 throw new ArgumentOutOfRangeException(nameof(depthFar));
             }
 
-            var maxY = depthNear * (float)Math.Tan(0.5f * fovy);
+            var maxY = depthNear * (float)System.Math.Tan(0.5f * fovy);
             var minY = -maxY;
             var minX = minY * aspect;
             var maxX = maxY * aspect;
@@ -1099,7 +1099,7 @@ namespace OpenToolkit.Mathematics
         /// <exception cref="System.ArgumentOutOfRangeException">
         /// Thrown under the following conditions:
         ///  <list type="bullet">
-        ///  <item>fovy is zero, less than zero or larger than Math.PI</item>
+        ///  <item>fovy is zero, less than zero or larger than System.Math.PI</item>
         ///  <item>aspect is negative or zero</item>
         ///  <item>depthNear is negative or zero</item>
         ///  <item>depthFar is negative or zero</item>
@@ -1471,7 +1471,7 @@ namespace OpenToolkit.Mathematics
                         {
                             if (pivotIdx[k] == -1)
                             {
-                                var absVal = Math.Abs(inverse[j, k]);
+                                var absVal = System.Math.Abs(inverse[j, k]);
                                 if (absVal > maxPivot)
                                 {
                                     maxPivot = absVal;

--- a/src/OpenTK.Mathematics/Matrix/Matrix4d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix4d.cs
@@ -24,7 +24,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
-namespace OpenToolkit.Mathematics
+namespace OpenToolkit.Math
 {
     /// <summary>
     /// Represents a 4x4 matrix containing 3D rotation, scale, transform, and projection with double-precision components.
@@ -580,7 +580,7 @@ namespace OpenToolkit.Mathematics
 
             if (trace > 0)
             {
-                var sq = Math.Sqrt(trace);
+                var sq = System.Math.Sqrt(trace);
 
                 q.W = sq;
                 sq = 1.0 / (4.0 * sq);
@@ -590,7 +590,7 @@ namespace OpenToolkit.Mathematics
             }
             else if (row0[0] > row1[1] && row0[0] > row2[2])
             {
-                var sq = 2.0 * Math.Sqrt(1.0 + row0[0] - row1[1] - row2[2]);
+                var sq = 2.0 * System.Math.Sqrt(1.0 + row0[0] - row1[1] - row2[2]);
 
                 q.X = 0.25 * sq;
                 sq = 1.0 / sq;
@@ -600,7 +600,7 @@ namespace OpenToolkit.Mathematics
             }
             else if (row1[1] > row2[2])
             {
-                var sq = 2.0 * Math.Sqrt(1.0 + row1[1] - row0[0] - row2[2]);
+                var sq = 2.0 * System.Math.Sqrt(1.0 + row1[1] - row0[0] - row2[2]);
 
                 q.Y = 0.25 * sq;
                 sq = 1.0 / sq;
@@ -610,7 +610,7 @@ namespace OpenToolkit.Mathematics
             }
             else
             {
-                var sq = 2.0 * Math.Sqrt(1.0 + row2[2] - row0[0] - row1[1]);
+                var sq = 2.0 * System.Math.Sqrt(1.0 + row2[2] - row0[0] - row1[1]);
 
                 q.Z = 0.25 * sq;
                 sq = 1.0 / sq;
@@ -645,8 +645,8 @@ namespace OpenToolkit.Mathematics
             double axisX = axis.X, axisY = axis.Y, axisZ = axis.Z;
 
             // calculate angles
-            var cos = Math.Cos(-angle);
-            var sin = Math.Sin(-angle);
+            var cos = System.Math.Cos(-angle);
+            var sin = System.Math.Sin(-angle);
             var t = 1.0f - cos;
 
             // do the conversion math once
@@ -695,8 +695,8 @@ namespace OpenToolkit.Mathematics
         /// <param name="result">The resulting Matrix4d instance.</param>
         public static void CreateRotationX(double angle, out Matrix4d result)
         {
-            var cos = Math.Cos(angle);
-            var sin = Math.Sin(angle);
+            var cos = System.Math.Cos(angle);
+            var sin = System.Math.Sin(angle);
 
             result.Row0 = Vector4d.UnitX;
             result.Row1 = new Vector4d(0, cos, sin, 0);
@@ -722,8 +722,8 @@ namespace OpenToolkit.Mathematics
         /// <param name="result">The resulting Matrix4d instance.</param>
         public static void CreateRotationY(double angle, out Matrix4d result)
         {
-            var cos = Math.Cos(angle);
-            var sin = Math.Sin(angle);
+            var cos = System.Math.Cos(angle);
+            var sin = System.Math.Sin(angle);
 
             result.Row0 = new Vector4d(cos, 0, -sin, 0);
             result.Row1 = Vector4d.UnitY;
@@ -749,8 +749,8 @@ namespace OpenToolkit.Mathematics
         /// <param name="result">The resulting Matrix4d instance.</param>
         public static void CreateRotationZ(double angle, out Matrix4d result)
         {
-            var cos = Math.Cos(angle);
-            var sin = Math.Sin(angle);
+            var cos = System.Math.Cos(angle);
+            var sin = System.Math.Sin(angle);
 
             result.Row0 = new Vector4d(cos, sin, 0, 0);
             result.Row1 = new Vector4d(-sin, cos, 0, 0);
@@ -924,7 +924,7 @@ namespace OpenToolkit.Mathematics
         /// <exception cref="System.ArgumentOutOfRangeException">
         /// Thrown under the following conditions:
         ///  <list type="bullet">
-        ///  <item>fovy is zero, less than zero or larger than Math.PI</item>
+        ///  <item>fovy is zero, less than zero or larger than System.Math.PI</item>
         ///  <item>aspect is negative or zero</item>
         ///  <item>depthNear is negative or zero</item>
         ///  <item>depthFar is negative or zero</item>
@@ -940,7 +940,7 @@ namespace OpenToolkit.Mathematics
             out Matrix4d result
         )
         {
-            if (fovy <= 0 || fovy > Math.PI)
+            if (fovy <= 0 || fovy > System.Math.PI)
             {
                 throw new ArgumentOutOfRangeException(nameof(fovy));
             }
@@ -960,7 +960,7 @@ namespace OpenToolkit.Mathematics
                 throw new ArgumentOutOfRangeException(nameof(depthFar));
             }
 
-            var maxY = depthNear * Math.Tan(0.5 * fovy);
+            var maxY = depthNear * System.Math.Tan(0.5 * fovy);
             var minY = -maxY;
             var minX = minY * aspect;
             var maxX = maxY * aspect;
@@ -979,7 +979,7 @@ namespace OpenToolkit.Mathematics
         /// <exception cref="System.ArgumentOutOfRangeException">
         /// Thrown under the following conditions:
         ///  <list type="bullet">
-        ///  <item>fovy is zero, less than zero or larger than Math.PI</item>
+        ///  <item>fovy is zero, less than zero or larger than System.Math.PI</item>
         ///  <item>aspect is negative or zero</item>
         ///  <item>depthNear is negative or zero</item>
         ///  <item>depthFar is negative or zero</item>
@@ -1152,8 +1152,8 @@ namespace OpenToolkit.Mathematics
         /// <returns>A rotation matrix.</returns>
         public static Matrix4d RotateX(double angle)
         {
-            var cos = Math.Cos(angle);
-            var sin = Math.Sin(angle);
+            var cos = System.Math.Cos(angle);
+            var sin = System.Math.Sin(angle);
 
             Matrix4d result;
             result.Row0 = Vector4d.UnitX;
@@ -1170,8 +1170,8 @@ namespace OpenToolkit.Mathematics
         /// <returns>A rotation matrix.</returns>
         public static Matrix4d RotateY(double angle)
         {
-            var cos = Math.Cos(angle);
-            var sin = Math.Sin(angle);
+            var cos = System.Math.Cos(angle);
+            var sin = System.Math.Sin(angle);
 
             Matrix4d result;
             result.Row0 = new Vector4d(cos, 0.0, -sin, 0.0);
@@ -1188,8 +1188,8 @@ namespace OpenToolkit.Mathematics
         /// <returns>A rotation matrix.</returns>
         public static Matrix4d RotateZ(double angle)
         {
-            var cos = Math.Cos(angle);
-            var sin = Math.Sin(angle);
+            var cos = System.Math.Cos(angle);
+            var sin = System.Math.Sin(angle);
 
             Matrix4d result;
             result.Row0 = new Vector4d(cos, sin, 0.0, 0.0);
@@ -1209,8 +1209,8 @@ namespace OpenToolkit.Mathematics
         /// <returns>A rotation matrix.</returns>
         public static Matrix4d Rotate(Vector3d axis, double angle)
         {
-            var cos = Math.Cos(-angle);
-            var sin = Math.Sin(-angle);
+            var cos = System.Math.Cos(-angle);
+            var sin = System.Math.Sin(-angle);
             var t = 1.0 - cos;
 
             axis.Normalize();
@@ -1353,7 +1353,7 @@ namespace OpenToolkit.Mathematics
         /// <returns>A projection matrix that transforms camera space to raster space.</returns>
         public static Matrix4d Perspective(double fovy, double aspect, double depthNear, double depthFar)
         {
-            var yMax = depthNear * Math.Tan(0.5f * fovy);
+            var yMax = depthNear * System.Math.Tan(0.5f * fovy);
             var yMin = -yMax;
             var xMin = yMin * aspect;
             var xMax = yMax * aspect;
@@ -1544,7 +1544,7 @@ namespace OpenToolkit.Mathematics
                         {
                             if (pivotIdx[k] == -1)
                             {
-                                var absVal = Math.Abs(inverse[j, k]);
+                                var absVal = System.Math.Abs(inverse[j, k]);
                                 if (absVal > maxPivot)
                                 {
                                     maxPivot = absVal;

--- a/src/OpenTK.Mathematics/Matrix/Matrix4x2.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix4x2.cs
@@ -23,7 +23,7 @@ SOFTWARE.
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace OpenToolkit.Mathematics
+namespace OpenToolkit.Math
 {
     /// <summary>
     /// Represents a 4x2 matrix.
@@ -283,8 +283,8 @@ namespace OpenToolkit.Mathematics
         /// <param name="result">The resulting Matrix3x2 instance.</param>
         public static void CreateRotation(float angle, out Matrix4x2 result)
         {
-            var cos = (float)Math.Cos(angle);
-            var sin = (float)Math.Sin(angle);
+            var cos = (float)System.Math.Cos(angle);
+            var sin = (float)System.Math.Sin(angle);
 
             result.Row0.X = cos;
             result.Row0.Y = sin;

--- a/src/OpenTK.Mathematics/Matrix/Matrix4x2d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix4x2d.cs
@@ -23,7 +23,7 @@ SOFTWARE.
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace OpenToolkit.Mathematics
+namespace OpenToolkit.Math
 {
     /// <summary>
     /// Represents a 4x2 matrix.
@@ -289,8 +289,8 @@ namespace OpenToolkit.Mathematics
         /// <param name="result">The resulting Matrix3x2 instance.</param>
         public static void CreateRotation(double angle, out Matrix4x2d result)
         {
-            var cos = Math.Cos(angle);
-            var sin = Math.Sin(angle);
+            var cos = System.Math.Cos(angle);
+            var sin = System.Math.Sin(angle);
 
             result.Row0.X = cos;
             result.Row0.Y = sin;

--- a/src/OpenTK.Mathematics/Matrix/Matrix4x3.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix4x3.cs
@@ -24,7 +24,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
-namespace OpenToolkit.Mathematics
+namespace OpenToolkit.Math
 {
     /// <summary>
     /// Represents a 3x4 matrix.
@@ -324,8 +324,8 @@ namespace OpenToolkit.Mathematics
             axis.Normalize();
             float axisX = axis.X, axisY = axis.Y, axisZ = axis.Z;
 
-            var cos = (float)Math.Cos(-angle);
-            var sin = (float)Math.Sin(-angle);
+            var cos = (float)System.Math.Cos(-angle);
+            var sin = (float)System.Math.Sin(-angle);
             var t = 1.0f - cos;
 
             float tXX = t * axisX * axisX;
@@ -421,8 +421,8 @@ namespace OpenToolkit.Mathematics
         /// <param name="result">The resulting Matrix4 instance.</param>
         public static void CreateRotationX(float angle, out Matrix4x3 result)
         {
-            var cos = (float)Math.Cos(angle);
-            var sin = (float)Math.Sin(angle);
+            var cos = (float)System.Math.Cos(angle);
+            var sin = (float)System.Math.Sin(angle);
 
             result.Row0.X = 1;
             result.Row0.Y = 0;
@@ -456,8 +456,8 @@ namespace OpenToolkit.Mathematics
         /// <param name="result">The resulting Matrix4 instance.</param>
         public static void CreateRotationY(float angle, out Matrix4x3 result)
         {
-            var cos = (float)Math.Cos(angle);
-            var sin = (float)Math.Sin(angle);
+            var cos = (float)System.Math.Cos(angle);
+            var sin = (float)System.Math.Sin(angle);
 
             result.Row0.X = cos;
             result.Row0.Y = 0;
@@ -491,8 +491,8 @@ namespace OpenToolkit.Mathematics
         /// <param name="result">The resulting Matrix4 instance.</param>
         public static void CreateRotationZ(float angle, out Matrix4x3 result)
         {
-            var cos = (float)Math.Cos(angle);
-            var sin = (float)Math.Sin(angle);
+            var cos = (float)System.Math.Cos(angle);
+            var sin = (float)System.Math.Sin(angle);
 
             result.Row0.X = cos;
             result.Row0.Y = sin;

--- a/src/OpenTK.Mathematics/Matrix/Matrix4x3d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix4x3d.cs
@@ -24,7 +24,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
-namespace OpenToolkit.Mathematics
+namespace OpenToolkit.Math
 {
     /// <summary>
     /// Represents a 3x4 matrix.
@@ -324,8 +324,8 @@ namespace OpenToolkit.Mathematics
             axis.Normalize();
             double axisX = axis.X, axisY = axis.Y, axisZ = axis.Z;
 
-            var cos = Math.Cos(-angle);
-            var sin = Math.Sin(-angle);
+            var cos = System.Math.Cos(-angle);
+            var sin = System.Math.Sin(-angle);
             var t = 1.0f - cos;
 
             double tXX = t * axisX * axisX;
@@ -421,8 +421,8 @@ namespace OpenToolkit.Mathematics
         /// <param name="result">The resulting Matrix4dinstance.</param>
         public static void CreateRotationX(double angle, out Matrix4x3d result)
         {
-            var cos = Math.Cos(angle);
-            var sin = Math.Sin(angle);
+            var cos = System.Math.Cos(angle);
+            var sin = System.Math.Sin(angle);
 
             result.Row0.X = 1;
             result.Row0.Y = 0;
@@ -456,8 +456,8 @@ namespace OpenToolkit.Mathematics
         /// <param name="result">The resulting Matrix4dinstance.</param>
         public static void CreateRotationY(double angle, out Matrix4x3d result)
         {
-            var cos = Math.Cos(angle);
-            var sin = Math.Sin(angle);
+            var cos = System.Math.Cos(angle);
+            var sin = System.Math.Sin(angle);
 
             result.Row0.X = cos;
             result.Row0.Y = 0;
@@ -491,8 +491,8 @@ namespace OpenToolkit.Mathematics
         /// <param name="result">The resulting Matrix4dinstance.</param>
         public static void CreateRotationZ(double angle, out Matrix4x3d result)
         {
-            var cos = Math.Cos(angle);
-            var sin = Math.Sin(angle);
+            var cos = System.Math.Cos(angle);
+            var sin = System.Math.Sin(angle);
 
             result.Row0.X = cos;
             result.Row0.Y = sin;

--- a/src/OpenTK.Mathematics/OpenTK.Mathematics.csproj
+++ b/src/OpenTK.Mathematics/OpenTK.Mathematics.csproj
@@ -3,7 +3,8 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Deterministic>true</Deterministic>
-    <RootNamespace>OpenToolkit.Mathematics</RootNamespace>
+    <RootNamespace>OpenToolkit.Math</RootNamespace>
+    <AssemblyName>OpenToolkit.Math</AssemblyName>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OpenTK.Mathematics/OpenTK.Mathematics.csproj
+++ b/src/OpenTK.Mathematics/OpenTK.Mathematics.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Deterministic>true</Deterministic>
+    <RootNamespace>OpenToolkit.Mathematics</RootNamespace>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OpenTK.Mathematics/Vector/Vector2.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2.cs
@@ -25,7 +25,7 @@ using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Xml.Serialization;
 
-namespace OpenToolkit.Mathematics
+namespace OpenToolkit.Math
 {
     /// <summary>
     /// Represents a 2D vector using two single-precision floating-point numbers.
@@ -112,7 +112,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <see cref="LengthFast"/>
         /// <seealso cref="LengthSquared"/>
-        public float Length => (float)Math.Sqrt((X * X) + (Y * Y));
+        public float Length => (float)System.Math.Sqrt((X * X) + (Y * Y));
 
         /// <summary>
         /// Gets an approximation of the vector length (magnitude).
@@ -515,7 +515,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="result">The distance.</param>
         public static void Distance(ref Vector2 vec1, ref Vector2 vec2, out float result)
         {
-            result = (float)Math.Sqrt(((vec2.X - vec1.X) * (vec2.X - vec1.X)) + ((vec2.Y - vec1.Y) * (vec2.Y - vec1.Y)));
+            result = (float)System.Math.Sqrt(((vec2.X - vec1.X) * (vec2.X - vec1.X)) + ((vec2.Y - vec1.Y) * (vec2.Y - vec1.Y)));
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Vector/Vector2d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2d.cs
@@ -25,7 +25,7 @@ using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Xml.Serialization;
 
-namespace OpenToolkit.Mathematics
+namespace OpenToolkit.Math
 {
     /// <summary>
     /// Represents a 2D vector using two double-precision floating-point numbers.
@@ -133,7 +133,7 @@ namespace OpenToolkit.Mathematics
         /// Gets the length (magnitude) of the vector.
         /// </summary>
         /// <seealso cref="LengthSquared"/>
-        public double Length => Math.Sqrt((X * X) + (Y * Y));
+        public double Length => System.Math.Sqrt((X * X) + (Y * Y));
 
         /// <summary>
         /// Gets the square of the vector length (magnitude).
@@ -519,7 +519,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="result">The distance.</param>
         public static void Distance(ref Vector2d vec1, ref Vector2d vec2, out double result)
         {
-            result = Math.Sqrt(((vec2.X - vec1.X) * (vec2.X - vec1.X)) + ((vec2.Y - vec1.Y) * (vec2.Y - vec1.Y)));
+            result = System.Math.Sqrt(((vec2.X - vec1.X) * (vec2.X - vec1.X)) + ((vec2.Y - vec1.Y) * (vec2.Y - vec1.Y)));
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Vector/Vector2h.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2h.cs
@@ -27,7 +27,7 @@ using System.Runtime.InteropServices;
 using System.Runtime.Serialization;
 using System.Xml.Serialization;
 
-namespace OpenToolkit.Mathematics
+namespace OpenToolkit.Math
 {
     /// <summary>
     /// 2-component Vector of the Half type. Occupies 4 Byte total.

--- a/src/OpenTK.Mathematics/Vector/Vector3.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3.cs
@@ -25,7 +25,7 @@ using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Xml.Serialization;
 
-namespace OpenToolkit.Mathematics
+namespace OpenToolkit.Math
 {
     /// <summary>
     /// Represents a 3D vector using three single-precision floating-point numbers.
@@ -162,7 +162,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <see cref="LengthFast"/>
         /// <seealso cref="LengthSquared"/>
-        public float Length => (float)Math.Sqrt((X * X) + (Y * Y) + (Z * Z));
+        public float Length => (float)System.Math.Sqrt((X * X) + (Y * Y) + (Z * Z));
 
         /// <summary>
         /// Gets an approximation of the vector length (magnitude).
@@ -574,7 +574,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="result">The distance.</param>
         public static void Distance(ref Vector3 vec1, ref Vector3 vec2, out float result)
         {
-            result = (float)Math.Sqrt(((vec2.X - vec1.X) * (vec2.X - vec1.X)) + ((vec2.Y - vec1.Y) * (vec2.Y - vec1.Y)) +
+            result = (float)System.Math.Sqrt(((vec2.X - vec1.X) * (vec2.X - vec1.X)) + ((vec2.Y - vec1.Y) * (vec2.Y - vec1.Y)) +
                                       ((vec2.Z - vec1.Z) * (vec2.Z - vec1.Z)));
         }
 
@@ -1065,7 +1065,7 @@ namespace OpenToolkit.Mathematics
         public static void CalculateAngle(ref Vector3 first, ref Vector3 second, out float result)
         {
             Dot(ref first, ref second, out float temp);
-            result = (float)Math.Acos(MathHelper.Clamp(temp / (first.Length * second.Length), -1.0, 1.0));
+            result = (float)System.Math.Acos(MathHelper.Clamp(temp / (first.Length * second.Length), -1.0, 1.0));
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Vector/Vector3d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3d.cs
@@ -25,7 +25,7 @@ using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Xml.Serialization;
 
-namespace OpenToolkit.Mathematics
+namespace OpenToolkit.Math
 {
     /// <summary>
     /// Represents a 3D vector using three double-precision floating-point numbers.
@@ -159,7 +159,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <see cref="LengthFast"/>
         /// <seealso cref="LengthSquared"/>
-        public double Length => Math.Sqrt((X * X) + (Y * Y) + (Z * Z));
+        public double Length => System.Math.Sqrt((X * X) + (Y * Y) + (Z * Z));
 
         /// <summary>
         /// Gets an approximation of the vector length (magnitude).
@@ -567,7 +567,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="result">The distance.</param>
         public static void Distance(ref Vector3d vec1, ref Vector3d vec2, out double result)
         {
-            result = Math.Sqrt(((vec2.X - vec1.X) * (vec2.X - vec1.X)) + ((vec2.Y - vec1.Y) * (vec2.Y - vec1.Y)) +
+            result = System.Math.Sqrt(((vec2.X - vec1.X) * (vec2.X - vec1.X)) + ((vec2.Y - vec1.Y) * (vec2.Y - vec1.Y)) +
                                ((vec2.Z - vec1.Z) * (vec2.Z - vec1.Z)));
         }
 
@@ -1040,7 +1040,7 @@ namespace OpenToolkit.Mathematics
         public static void CalculateAngle(ref Vector3d first, ref Vector3d second, out double result)
         {
             Dot(ref first, ref second, out double temp);
-            result = Math.Acos(MathHelper.Clamp(temp / (first.Length * second.Length), -1.0, 1.0));
+            result = System.Math.Acos(MathHelper.Clamp(temp / (first.Length * second.Length), -1.0, 1.0));
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Vector/Vector3h.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3h.cs
@@ -27,7 +27,7 @@ using System.Runtime.InteropServices;
 using System.Runtime.Serialization;
 using System.Xml.Serialization;
 
-namespace OpenToolkit.Mathematics
+namespace OpenToolkit.Math
 {
     /// <summary>
     /// 3-component Vector of the Half type. Occupies 6 Byte total.

--- a/src/OpenTK.Mathematics/Vector/Vector4.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4.cs
@@ -25,7 +25,7 @@ using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Xml.Serialization;
 
-namespace OpenToolkit.Mathematics
+namespace OpenToolkit.Math
 {
     /// <summary>
     /// Represents a 4D vector using four single-precision floating-point numbers.
@@ -233,7 +233,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <see cref="LengthFast"/>
         /// <seealso cref="LengthSquared"/>
-        public float Length => (float)Math.Sqrt((X * X) + (Y * Y) + (Z * Z) + (W * W));
+        public float Length => (float)System.Math.Sqrt((X * X) + (Y * Y) + (Z * Z) + (W * W));
 
         /// <summary>
         /// Gets an approximation of the vector length (magnitude).

--- a/src/OpenTK.Mathematics/Vector/Vector4d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4d.cs
@@ -25,7 +25,7 @@ using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Xml.Serialization;
 
-namespace OpenToolkit.Mathematics
+namespace OpenToolkit.Math
 {
     /// <summary>
     /// Represents a 4D vector using four double-precision floating-point numbers.
@@ -230,7 +230,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <see cref="LengthFast"/>
         /// <seealso cref="LengthSquared"/>
-        public double Length => Math.Sqrt((X * X) + (Y * Y) + (Z * Z) + (W * W));
+        public double Length => System.Math.Sqrt((X * X) + (Y * Y) + (Z * Z) + (W * W));
 
         /// <summary>
         /// Gets an approximation of the vector length (magnitude).

--- a/src/OpenTK.Mathematics/Vector/Vector4h.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4h.cs
@@ -27,7 +27,7 @@ using System.Runtime.InteropServices;
 using System.Runtime.Serialization;
 using System.Xml.Serialization;
 
-namespace OpenToolkit.Mathematics
+namespace OpenToolkit.Math
 {
     /// <summary>
     /// 4-component Vector of the Half type. Occupies 8 Byte total.

--- a/src/OpenTK.NT/OpenTK.NT.csproj
+++ b/src/OpenTK.NT/OpenTK.NT.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Deterministic>true</Deterministic>
+    <RootNamespace>OpenToolkit.NT</RootNamespace>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OpenTK.NT/OpenTK.NT.csproj
+++ b/src/OpenTK.NT/OpenTK.NT.csproj
@@ -4,6 +4,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Deterministic>true</Deterministic>
     <RootNamespace>OpenToolkit.NT</RootNamespace>
+    <AssemblyName>OpenToolkit.NT</AssemblyName>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
### Purpose of this PR

Adds the RootNamespace tags to the projects, to stop ReSharper from complaining about bad namespaces.

### Testing status

Not required

### Comments

Next steps: Changing project filenames, but we don't really have to do that anytime soon as it's just a cosmetic thing at this point.