### PR TITLE
Optimize Vector4/Color4 conversions with Unsafe.As

### DIFF
--- a/src/OpenTK.Mathematics/Data/Color4.cs
+++ b/src/OpenTK.Mathematics/Data/Color4.cs
@@ -156,16 +156,11 @@ namespace OpenToolkit.Mathematics
         /// Returns this Color4 as a Vector4. The resulting struct will have XYZW mapped to RGBA, in that order.
         /// </summary>
         /// <param name="c">The Color4 to convert.</param>
-        /// <returns>The Color4 to convert into a Vector4.</returns>
+        /// <returns>The Color4, converted into a Vector4.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static explicit operator Vector4(Color4 c)
         {
-            unsafe
-            {
-                // Because these structs are identical on the byte-level (due to the StructLayout above),
-                // we can use pointer-casting to convert this into a Vector4, which lets us reinterpret the data instead of copying it to a new struct.
-                return *((Vector4*)&c);
-            }
+            return Unsafe.As<Color4, Vector4>(ref c);
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/OpenTK.Mathematics.csproj
+++ b/src/OpenTK.Mathematics/OpenTK.Mathematics.csproj
@@ -9,6 +9,10 @@
     <Version>1.0.0</Version>
     <Description>Mathematical structures and algorithms, provided and used by OpenTK.</Description>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.2" />
+  </ItemGroup>
   <Import Project="..\..\props\common.props" />
   <Import Project="..\..\props\nuget-common.props" />
   <Import Project="..\..\props\stylecop.props" />

--- a/src/OpenTK.Mathematics/Vector/Vector4.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4.cs
@@ -2042,16 +2042,11 @@ namespace OpenToolkit.Mathematics
         /// Returns this Vector4 as a Color4. The resulting struct will have RGBA mapped to XYZW, in that order.
         /// </summary>
         /// <param name="v">The Vector4 to convert.</param>
-        /// <returns>The Vector4 converted to a Color4.</returns>
+        /// <returns>The Vector4, converted to a Color4.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static explicit operator Color4(Vector4 v)
         {
-            unsafe
-            {
-                // Because these structs are identical on the byte-level (due to the StructLayout above),
-                // we can use pointer-casting to convert this into a Color4, which lets us reinterpret the data instead of copying it to a new struct.
-                return *((Color4*)&v);
-            }
+            return Unsafe.As<Vector4, Color4>(ref v);
         }
 
         private static readonly string ListSeparator = CultureInfo.CurrentCulture.TextInfo.ListSeparator;


### PR DESCRIPTION
### Purpose of this PR

* Optimize Vector4/Color4 conversions using the Unsafe.As function.
* Affects OpenTK.Mathematics.

### Testing status

* Compiled it, checked results, that's basically it.

### Comments

Benchmark results, via BenchmarkDotNet:

```
               Method |      Mean |     Error |    StdDev |
--------------------- |----------:|----------:|----------:|
 ToVector4PointerCast | 11.336 ns | 0.2555 ns | 0.2840 ns |
         ToVector4New |  7.740 ns | 0.0446 ns | 0.0396 ns |
    ToVector4UnsafeAs |  2.442 ns | 0.0397 ns | 0.0331 ns |
```

PointerCast is what we were using before (`*((Color4*)&v);`), New is `new Vector4(r, g, b, a)`, and UnsafeAs is the new implementation.