### PR TITLE
Apply Unsafe.As optimization to all vector types

### DIFF
--- a/src/OpenTK.Mathematics/Vector/Vector3.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3.cs
@@ -22,6 +22,7 @@ SOFTWARE.
 
 using System;
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Xml.Serialization;
 
@@ -1200,7 +1201,7 @@ namespace OpenToolkit.Mathematics
         [XmlIgnore]
         public Vector2 Xy
         {
-            get => new Vector2(X, Y);
+            get => Unsafe.As<Vector3, Vector2>(ref this);
             set
             {
                 X = value.X;

--- a/src/OpenTK.Mathematics/Vector/Vector3d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3d.cs
@@ -22,6 +22,7 @@ SOFTWARE.
 
 using System;
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Xml.Serialization;
 
@@ -1049,7 +1050,7 @@ namespace OpenToolkit.Mathematics
         [XmlIgnore]
         public Vector2d Xy
         {
-            get => new Vector2d(X, Y);
+            get => Unsafe.As<Vector3d, Vector2d>(ref this);
             set
             {
                 X = value.X;

--- a/src/OpenTK.Mathematics/Vector/Vector3h.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3h.cs
@@ -24,6 +24,7 @@ using System;
 using System.Globalization;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 using System.Xml.Serialization;
 
@@ -213,7 +214,7 @@ namespace OpenToolkit.Mathematics
         [XmlIgnore]
         public Vector2h Xy
         {
-            get => new Vector2h(X, Y);
+            get => Unsafe.As<Vector3h, Vector2h>(ref this);
             set
             {
                 X = value.X;

--- a/src/OpenTK.Mathematics/Vector/Vector3h.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3h.cs
@@ -23,8 +23,8 @@ SOFTWARE.
 using System;
 using System.Globalization;
 using System.IO;
-using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Runtime.Serialization;
 using System.Xml.Serialization;
 

--- a/src/OpenTK.Mathematics/Vector/Vector4.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4.cs
@@ -899,7 +899,7 @@ namespace OpenToolkit.Mathematics
         [XmlIgnore]
         public Vector2 Xy
         {
-            get => new Vector2(X, Y);
+            get => Unsafe.As<Vector4, Vector2>(ref this);
             set
             {
                 X = value.X;
@@ -1067,7 +1067,7 @@ namespace OpenToolkit.Mathematics
         [XmlIgnore]
         public Vector3 Xyz
         {
-            get => new Vector3(X, Y, Z);
+            get => Unsafe.As<Vector4, Vector3>(ref this);
             set
             {
                 X = value.X;
@@ -2042,16 +2042,11 @@ namespace OpenToolkit.Mathematics
         /// Returns this Vector4 as a Color4. The resulting struct will have RGBA mapped to XYZW, in that order.
         /// </summary>
         /// <param name="v">The Vector4 to convert.</param>
-        /// <returns>The Vector4 converted to a Color4.</returns>
+        /// <returns>The Vector4, converted to a Color4.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static explicit operator Color4(Vector4 v)
         {
-            unsafe
-            {
-                // Because these structs are identical on the byte-level (due to the StructLayout above),
-                // we can use pointer-casting to convert this into a Color4, which lets us reinterpret the data instead of copying it to a new struct.
-                return *((Color4*)&v);
-            }
+            return Unsafe.As<Vector4, Color4>(ref v);
         }
 
         private static readonly string ListSeparator = CultureInfo.CurrentCulture.TextInfo.ListSeparator;

--- a/src/OpenTK.Mathematics/Vector/Vector4d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4d.cs
@@ -23,6 +23,7 @@ SOFTWARE.
 using System;
 using System.Globalization;
 using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
 using System.Xml.Serialization;
 
 namespace OpenToolkit.Mathematics
@@ -863,7 +864,7 @@ namespace OpenToolkit.Mathematics
         [XmlIgnore]
         public Vector2d Xy
         {
-            get => new Vector2d(X, Y);
+            get => Unsafe.As<Vector4d, Vector2d>(ref this);
             set
             {
                 X = value.X;
@@ -1031,7 +1032,7 @@ namespace OpenToolkit.Mathematics
         [XmlIgnore]
         public Vector3d Xyz
         {
-            get => new Vector3d(X, Y, Z);
+            get => Unsafe.As<Vector4d, Vector3d>(ref this);
             set
             {
                 X = value.X;

--- a/src/OpenTK.Mathematics/Vector/Vector4d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4d.cs
@@ -22,8 +22,8 @@ SOFTWARE.
 
 using System;
 using System.Globalization;
-using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Xml.Serialization;
 
 namespace OpenToolkit.Mathematics

--- a/src/OpenTK.Mathematics/Vector/Vector4h.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4h.cs
@@ -23,8 +23,8 @@ SOFTWARE.
 using System;
 using System.Globalization;
 using System.IO;
-using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Runtime.Serialization;
 using System.Xml.Serialization;
 

--- a/src/OpenTK.Mathematics/Vector/Vector4h.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4h.cs
@@ -24,6 +24,7 @@ using System;
 using System.Globalization;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 using System.Xml.Serialization;
 
@@ -232,7 +233,7 @@ namespace OpenToolkit.Mathematics
         [XmlIgnore]
         public Vector2h Xy
         {
-            get => new Vector2h(X, Y);
+            get => Unsafe.As<Vector4h, Vector2h>(ref this);
             set
             {
                 X = value.X;
@@ -400,7 +401,7 @@ namespace OpenToolkit.Mathematics
         [XmlIgnore]
         public Vector3h Xyz
         {
-            get => new Vector3h(X, Y, Z);
+            get => Unsafe.As<Vector4h, Vector3h>(ref this);
             set
             {
                 X = value.X;


### PR DESCRIPTION
### Purpose of this PR

* Applies the Unsafe.As conversion optimizations from #877 to all vector types
* Affects OpenTK.Mathematics

### Testing status

* Built it, tested it to make sure that it works, that's about it.
