### PR TITLE
[WIP] Ignoring MouseMoveEx errors and fall back to passed point.

### DIFF
--- a/src/OpenTK/Platform/Windows/WinGLNative.cs
+++ b/src/OpenTK/Platform/Windows/WinGLNative.cs
@@ -877,7 +877,8 @@ namespace OpenTK.Platform.Windows
                 }
                 else if (points == -1)
                 {
-                    throw new Win32Exception(lastError);
+                    // A different error occured - we still just use the mouse move position.
+                    OnMouseMove(point.X, point.Y);
                 }
                 else
                 {


### PR DESCRIPTION
GetMouseMovePointsEx can return e.g. an "access denied" error, in this case it is sensible to return to fall back to the old mouse move handling.
Fixes issues like #820

### Purpose of this PR

Description: GetMouseMovePointsEx was introduced in [095d3f2](https://github.com/opentk/opentk/commit/095d3f26c00499f336ab8d26bfa114e560208eea) and added Win32Exceptions that were thrown on all errors except "ERROR_POINT_NOT_FOUND". Other errors can be returned from GetMouseMovePointsEx such as "Access denied" (see: #820) 
Affects: WinGl

### Testing status

A custom version of OpenTK with the error ignored and previous point handling being used was installed for affected users, the error did not occur again over the span of a few weeks. Rolling back to the base version did reintroduce the error.

### Comments

I am still uncertain about the root cause of the error. Microsoft's documentation does not mention why the error would be returned and since the error was not reproducible on most machines (including all of mine) it was hard to guess a root cause. Some users did mention this occurred mostly after leaving the program idle for a few minutes, some reported it to occur after awaking the computer from a screensaver state. The users that did see the error had mostly older hardware.

Since GetMouseMovePointsEx is only used for smoothing out mouse movements I feel it is acceptable to ignore this error, the only thing "going wrong" in this case is the missing smooth, which already is done in case of the ERROR_POINT_NOT_FOUND error.
