### PR TITLE
[Wip] System.Math and OpenToolkit.MathHelper symmetry

### DIFF
--- a/src/OpenTK.Mathematics/MathHelper.cs
+++ b/src/OpenTK.Mathematics/MathHelper.cs
@@ -68,6 +68,69 @@ namespace OpenToolkit.Mathematics
         public const float Log2E = 1.442695041f;
 
         /// <summary>
+        /// Returns the sine of the specified angle.
+        /// </summary>
+        /// <param name="a">An angle, measured in radians.</param>
+        /// <returns>Sine of the angle. If a is equal to NaN, NegativeInfinity, or PositiveInfinity, this method returns NaN.</returns>
+        public static double Sin(double a) => Math.Sin(a);
+
+        /// <summary>
+        /// Returns the hyperbolic sine of the specified angle.
+        /// </summary>
+        /// <param name="a">An angle, measured in radians.</param>
+        /// <returns>Hyperbolic sine of the specified angle. If a is equal to NaN, NegativeInfinity, or PositiveInfinity, this method returns NaN.</returns>
+        public static double HSin(double a) => Math.Sinh(a);
+
+        /// <summary>
+        /// Returns the arc sine of the specified angle.
+        /// </summary>
+        /// <param name="a">An angle, measured in radians.</param>
+        /// <returns>Arc sine of the specified angle. If a is equal to NaN, NegativeInfinity, or PositiveInfinity, this method returns NaN.</returns>
+        public static double ASin(double a) => Math.Asin(a);
+
+        /// <summary>
+        /// Returns the cosine of the specified angle.
+        /// </summary>
+        /// <param name="a">An angle, measured in radians.</param>
+        /// <returns>Cosine of the angle. If a is equal to NaN, NegativeInfinity, or PositiveInfinity, this method returns NaN.</returns>
+        public static double Cos(double a) => Math.Cos(a);
+
+        /// <summary>
+        /// Returns the hyperbolic cosine of the specified angle.
+        /// </summary>
+        /// <param name="a">An angle, measured in radians.</param>
+        /// <returns>Hyperbolic cosine of the specified angle. If a is equal to NaN, NegativeInfinity, or PositiveInfinity, this method returns NaN.</returns>
+        public static double HCos(double a) => Math.Cosh(a);
+
+        /// <summary>
+        /// Returns the arc sine of the specified angle.
+        /// </summary>
+        /// <param name="a">An angle, measured in radians.</param>
+        /// <returns>Arc sine of the specified angle. If a is equal to NaN, NegativeInfinity, or PositiveInfinity, this method returns NaN.</returns>
+        public static double ACos(double a) => Math.Acos(a);
+
+        /// <summary>
+        /// Returns the tangent of the specified angle.
+        /// </summary>
+        /// <param name="a">An angle, measured in radians.</param>
+        /// <returns>Tangent of the specified angle. If a is equal to NaN, NegativeInfinity, or PositiveInfinity, this method returns NaN.</returns>
+        public static double Tan(double a) => Math.Tan(a);
+
+        /// <summary>
+        /// Returns the hyperbolic tangent of the specified angle.
+        /// </summary>
+        /// <param name="a">An angle, measured in radians.</param>
+        /// <returns>Hyperbolic tangent of the specified angle. If a is equal to NaN, NegativeInfinity, or PositiveInfinity, this method returns NaN.</returns>
+        public static double HTan(double a) => Math.Tanh(a);
+
+        /// <summary>
+        /// Returns the arc tangent of the specified angle.
+        /// </summary>
+        /// <param name="a">An angle, measured in radians.</param>
+        /// <returns>Arc tangent of the specified angle. If a is equal to NaN, NegativeInfinity, or PositiveInfinity, this method returns NaN.</returns>
+        public static double ATan(double a) => Math.Atan(a);
+
+        /// <summary>
         /// Returns the next power of two that is greater than or equal to the specified number.
         /// </summary>
         /// <param name="n">The specified number.</param>


### PR DESCRIPTION
### Purpose of this PR
Add symmetry between the System.Math and OpenToolkit.MathHelper.

### Testing status
Tests haven't been written yet.

### Comments
This is to help users (like myself) not having to look through two libraries as none of them are complete with all the features you need. This way you would only ever have to use MathHelper to do all your math stuff
