### PR TITLE
Backport fix for profile mask/context flag mixup

### DIFF
--- a/src/OpenTK/Platform/Windows/WinGLContext.cs
+++ b/src/OpenTK/Platform/Windows/WinGLContext.cs
@@ -228,15 +228,16 @@ namespace OpenTK.Platform.Windows
         private static ArbCreateContext GetARBContextFlags(GraphicsContextFlags flags)
         {
             ArbCreateContext result = 0;
-            result |= (flags & GraphicsContextFlags.ForwardCompatible) != 0 ?
-                ArbCreateContext.CoreProfileBit : ArbCreateContext.CompatibilityProfileBit;
+            result |= (flags & GraphicsContextFlags.Debug) != 0 ? ArbCreateContext.DebugBit : 0;
             return result;
         }
 
         private static ArbCreateContext GetARBContextProfile(GraphicsContextFlags flags)
         {
             ArbCreateContext result = 0;
-            result |= (flags & GraphicsContextFlags.Debug) != 0 ? ArbCreateContext.DebugBit : 0;
+            result |= (flags & GraphicsContextFlags.ForwardCompatible) != 0
+                ? ArbCreateContext.CoreProfileBit
+                : ArbCreateContext.CompatibilityProfileBit;
             return result;
         }
 


### PR DESCRIPTION
OpenTK 3.0.1 contains a bug wherein the methods for retrieving profile mask and context flags in Windows are backwards (see [WinGLContext.cs](https://github.com/opentk/opentk/blob/c8d58738af4d8d6599a0de5f3069ad9a6da74e23/src/OpenTK/Platform/Windows/WinGLContext.cs#L231
)).

A fix was proposed by @ilexp in pull request #789 back in 2018 on the then-current develop branch, but PRs weren't being accepted for anything but 4.0 at the time. Their subsequent pull request #790 was merged instead, and the 3.0 branch never saw this fix.

The desire for CreateContextAttribs, and in turn RenderDoc, to work properly in Windows led me to fork the project for my own use, but @Perksey gave me a not-undeserved rap on the knuckles [via Twitter](https://twitter.com/Dylan_Perks/status/1128424227693113345) (I tried to convince myself not to publish a package, but eventually I was seduced by the lure of faster CI builds of my project) and informed me I'd be welcome to instead offer a PR based on 3.0, so here I am.

I've cherry picked commit f401397 to provide the fix in question; it seemed like the sensible thing to do, but please correct me if I'm wrong.