### PR TITLE
Int vectors in windows

### DIFF
--- a/src/Windowing/OpenToolkit.Windowing.Common/Interfaces/INativeWindow.cs
+++ b/src/Windowing/OpenToolkit.Windowing.Common/Interfaces/INativeWindow.cs
@@ -41,7 +41,7 @@ namespace OpenToolkit.Windowing.Common
         /// <returns>
         /// The point transformed to client coordinates.
         /// </returns>
-        Vector2 PointToClient(Vector2 point);
+        Vector2i PointToClient(Vector2i point);
 
         /// <summary>
         /// Transforms the specified point from client to screen coordinates.
@@ -52,6 +52,6 @@ namespace OpenToolkit.Windowing.Common
         /// <returns>
         /// The point transformed to screen coordinates.
         /// </returns>
-        Vector2 PointToScreen(Vector2 point);
+        Vector2i PointToScreen(Vector2i point);
     }
 }

--- a/src/Windowing/OpenToolkit.Windowing.Common/Interfaces/INativeWindowProperties.cs
+++ b/src/Windowing/OpenToolkit.Windowing.Common/Interfaces/INativeWindowProperties.cs
@@ -88,12 +88,12 @@ namespace OpenToolkit.Windowing.Common
         /// Gets or sets a <see cref="OpenToolkit.Mathematics.Vector2" /> structure that contains the location of this window on the
         /// desktop.
         /// </summary>
-        Vector2 Location { get; set; }
+        Vector2i Location { get; set; }
 
         /// <summary>
         /// Gets or sets a <see cref="OpenToolkit.Mathematics.Vector2" /> structure that contains the external size of this window.
         /// </summary>
-        Vector2 Size { get; set; }
+        Vector2i Size { get; set; }
 
         /// <summary>
         /// Gets or sets the horizontal location of this window on the desktop.

--- a/src/Windowing/OpenToolkit.Windowing.Common/Interfaces/INativeWindowProperties.cs
+++ b/src/Windowing/OpenToolkit.Windowing.Common/Interfaces/INativeWindowProperties.cs
@@ -78,20 +78,20 @@ namespace OpenToolkit.Windowing.Common
         WindowBorder WindowBorder { get; set; }
 
         /// <summary>
-        /// Gets or sets a <see cref="OpenToolkit.Mathematics.Box2" /> structure the contains the external bounds of this window,
+        /// Gets or sets a <see cref="OpenToolkit.Mathematics.Box2i" /> structure the contains the external bounds of this window,
         /// in screen coordinates.
         /// External bounds include the title bar, borders and drawing area of the window.
         /// </summary>
-        Box2 Bounds { get; set; }
+        Box2i Bounds { get; set; }
 
         /// <summary>
-        /// Gets or sets a <see cref="OpenToolkit.Mathematics.Vector2" /> structure that contains the location of this window on the
+        /// Gets or sets a <see cref="OpenToolkit.Mathematics.Vector2i" /> structure that contains the location of this window on the
         /// desktop.
         /// </summary>
         Vector2i Location { get; set; }
 
         /// <summary>
-        /// Gets or sets a <see cref="OpenToolkit.Mathematics.Vector2" /> structure that contains the external size of this window.
+        /// Gets or sets a <see cref="OpenToolkit.Mathematics.Vector2i" /> structure that contains the external size of this window.
         /// </summary>
         Vector2i Size { get; set; }
 
@@ -116,16 +116,16 @@ namespace OpenToolkit.Windowing.Common
         int Height { get; set; }
 
         /// <summary>
-        /// Gets or sets a <see cref="OpenToolkit.Mathematics.Box2" /> structure that contains the internal bounds of this window,
+        /// Gets or sets a <see cref="OpenToolkit.Mathematics.Box2i" /> structure that contains the internal bounds of this window,
         /// in client coordinates.
         /// The internal bounds include the drawing area of the window, but exclude the titlebar and window borders.
         /// </summary>
-        Box2 ClientRectangle { get; set; }
+        Box2i ClientRectangle { get; set; }
 
         /// <summary>
-        /// Gets a <see cref="OpenToolkit.Mathematics.Vector2" /> structure that contains the internal size this window.
+        /// Gets a <see cref="OpenToolkit.Mathematics.Vector2i" /> structure that contains the internal size this window.
         /// </summary>
-        Vector2 ClientSize { get; }
+        Vector2i ClientSize { get; }
 
         /// <summary>
         /// Gets or sets a value indicating whether the window is fullscreen or not.

--- a/src/Windowing/OpenToolkit.Windowing.Common/WindowState.cs
+++ b/src/Windowing/OpenToolkit.Windowing.Common/WindowState.cs
@@ -32,6 +32,6 @@ namespace OpenToolkit.Windowing.Common
         /// <summary>
         /// The window covers the whole screen, including all taskbars and/or panels.
         /// </summary>
-        Fullscreen
+        Fullscreen,
     }
 }

--- a/src/Windowing/OpenToolkit.Windowing.Desktop/NativeWindow.cs
+++ b/src/Windowing/OpenToolkit.Windowing.Desktop/NativeWindow.cs
@@ -124,10 +124,10 @@ namespace OpenToolkit.Windowing.Desktop
                 Glfw.SetWindowMonitor(
                     WindowPtr,
                     monitor,
-                    (int)_location.X,
-                    (int)_location.Y,
-                    (int)_size.X,
-                    (int)_size.Y,
+                    _location.X,
+                    _location.Y,
+                    _size.X,
+                    _size.Y,
                     mode->RefreshRate);
             }
         }
@@ -278,95 +278,95 @@ namespace OpenToolkit.Windowing.Desktop
         }
 
         /// <inheritdoc />
-        public unsafe Box2 Bounds
+        public unsafe Box2i Bounds
         {
-            get => Box2.FromDimensions(Location, Size);
+            get => Box2i.FromDimensions(Location, Size);
             set
             {
-                Glfw.SetWindowSize(WindowPtr, (int)value.Width, (int)value.Height);
-                Glfw.SetWindowPos(WindowPtr, (int)value.Left, (int)value.Top);
+                Glfw.SetWindowSize(WindowPtr, value.Width, value.Height);
+                Glfw.SetWindowPos(WindowPtr, value.Left, value.Top);
             }
         }
 
-        private Vector2 _location;
+        private Vector2i _location;
 
         /// <inheritdoc />
-        public unsafe Vector2 Location
+        public unsafe Vector2i Location
         {
             get => _location;
-            set => Glfw.SetWindowPos(WindowPtr, (int)value.X, (int)value.Y);
+            set => Glfw.SetWindowPos(WindowPtr, value.X, value.Y);
         }
 
-        private Vector2 _size;
+        private Vector2i _size;
 
         /// <inheritdoc />
-        public unsafe Vector2 Size
+        public unsafe Vector2i Size
         {
             get => _size;
-            set => Glfw.SetWindowSize(WindowPtr, (int)value.X, (int)value.Y);
+            set => Glfw.SetWindowSize(WindowPtr, value.X, value.Y);
         }
 
         /// <inheritdoc />
         public unsafe int X
         {
-            get => (int)Location.X;
+            get => Location.X;
             set
             {
                 _location.X = value;
 
-                Glfw.SetWindowPos(WindowPtr, value, (int)_location.Y);
+                Glfw.SetWindowPos(WindowPtr, value, _location.Y);
             }
         }
 
         /// <inheritdoc />
         public unsafe int Y
         {
-            get => (int)Location.Y;
+            get => Location.Y;
             set
             {
                 _location.Y = value;
 
-                Glfw.SetWindowPos(WindowPtr, (int)_location.X, value);
+                Glfw.SetWindowPos(WindowPtr, _location.X, value);
             }
         }
 
         /// <inheritdoc />
         public unsafe int Width
         {
-            get => (int)Size.X;
+            get => Size.X;
             set
             {
                 _size.X = value;
 
-                Glfw.SetWindowSize(WindowPtr, value, (int)_size.Y);
+                Glfw.SetWindowSize(WindowPtr, value, _size.Y);
             }
         }
 
         /// <inheritdoc />
         public unsafe int Height
         {
-            get => (int)Size.Y;
+            get => Size.Y;
             set
             {
                 _size.Y = value;
 
-                Glfw.SetWindowSize(WindowPtr, (int)_size.Y, value);
+                Glfw.SetWindowSize(WindowPtr, _size.Y, value);
             }
         }
 
         /// <inheritdoc />
-        public Box2 ClientRectangle
+        public Box2i ClientRectangle
         {
-            get => Box2.FromDimensions(Location, Size);
+            get => Box2i.FromDimensions(Location, Size);
             set
             {
-                Location = new Vector2(value.Right, value.Top);
-                Size = new Vector2(value.Width, value.Height);
+                Location = new Vector2i(value.Right, value.Top);
+                Size = new Vector2i(value.Width, value.Height);
             }
         }
 
         /// <inheritdoc />
-        public Vector2 ClientSize { get; }
+        public Vector2i ClientSize { get; }
 
         private MouseCursor _cursor;
 
@@ -497,7 +497,7 @@ namespace OpenToolkit.Windowing.Desktop
                 Location = settings.Location;
 
                 Glfw.GetFramebufferSize(WindowPtr, out var width, out var height);
-                ClientSize = new Vector2(width, height);
+                ClientSize = new Vector2i(width, height);
             }
 
             Interlocked.Increment(ref _numberOfUsers);
@@ -682,13 +682,13 @@ namespace OpenToolkit.Windowing.Desktop
         }
 
         /// <inheritdoc />
-        public Vector2 PointToClient(Vector2 point)
+        public Vector2i PointToClient(Vector2i point)
         {
             return point - Location;
         }
 
         /// <inheritdoc />
-        public Vector2 PointToScreen(Vector2 point)
+        public Vector2i PointToScreen(Vector2i point)
         {
             return point + Location;
         }

--- a/src/Windowing/OpenToolkit.Windowing.Desktop/NativeWindowSettings.cs
+++ b/src/Windowing/OpenToolkit.Windowing.Desktop/NativeWindowSettings.cs
@@ -98,19 +98,19 @@ namespace OpenToolkit.Windowing.Desktop
             }
         }
 
-        private Vector2 _location;
+        private Vector2i _location;
 
         /// <inheritdoc />
-        public Vector2 Location
+        public Vector2i Location
         {
             get => _location;
             set => _location = value;
         }
 
-        private Vector2 _size;
+        private Vector2i _size;
 
         /// <inheritdoc />
-        public Vector2 Size
+        public Vector2i Size
         {
             get => _size;
             set => _size = value;
@@ -119,28 +119,28 @@ namespace OpenToolkit.Windowing.Desktop
         /// <inheritdoc />
         public int X
         {
-            get => (int)Location.X;
+            get => Location.X;
             set => _location.X = value;
         }
 
         /// <inheritdoc />
         public int Y
         {
-            get => (int)Location.Y;
+            get => Location.Y;
             set => _location.Y = value;
         }
 
         /// <inheritdoc />
         public int Width
         {
-            get => (int)Size.X;
+            get => Size.X;
             set => _size.X = value;
         }
 
         /// <inheritdoc />
         public int Height
         {
-            get => (int)Size.Y;
+            get => Size.Y;
             set => _size.Y = value;
         }
 
@@ -151,8 +151,8 @@ namespace OpenToolkit.Windowing.Desktop
 
             set
             {
-                Location = new Vector2(value.Right, value.Top);
-                Size = new Vector2(value.Width, value.Height);
+                Location = new Vector2i(value.Right, value.Top);
+                Size = new Vector2i(value.Width, value.Height);
             }
         }
 

--- a/src/Windowing/OpenToolkit.Windowing.Desktop/NativeWindowSettings.cs
+++ b/src/Windowing/OpenToolkit.Windowing.Desktop/NativeWindowSettings.cs
@@ -88,13 +88,13 @@ namespace OpenToolkit.Windowing.Desktop
         public WindowBorder WindowBorder { get; set; }
 
         /// <inheritdoc />
-        public Box2 Bounds
+        public Box2i Bounds
         {
-            get => Box2.FromDimensions(Location, Size);
+            get => Box2i.FromDimensions(Location, Size);
             set
             {
-                _location = new Vector2(value.Left, value.Left);
-                _size = new Vector2(value.Width, value.Height);
+                _location = new Vector2i(value.Left, value.Left);
+                _size = new Vector2i(value.Width, value.Height);
             }
         }
 
@@ -145,9 +145,9 @@ namespace OpenToolkit.Windowing.Desktop
         }
 
         /// <inheritdoc />
-        public Box2 ClientRectangle
+        public Box2i ClientRectangle
         {
-            get => Box2.FromDimensions(Location, Size);
+            get => Box2i.FromDimensions(Location, Size);
 
             set
             {
@@ -157,7 +157,7 @@ namespace OpenToolkit.Windowing.Desktop
         }
 
         /// <inheritdoc />
-        public Vector2 ClientSize { get; }
+        public Vector2i ClientSize { get; }
 
         /// <inheritdoc />
         public bool IsFullscreen { get; set; }


### PR DESCRIPTION
### Purpose of this PR

* At the time of the GLFW PR, there weren't any int vectors, so the windows had to use float vectors that were cast to ints when passed to GLFW. Now that int vectors are in master, this makes the windows use them instead.
* Affects Windowing.
* No additional documentation necessary.

### Testing status

* It builds.

### Comments

* No other comments.