### PR TITLE
Box2n and Box3n cleanup

### DIFF
--- a/src/OpenToolkit.Mathematics/Geometry/Box2.cs
+++ b/src/OpenToolkit.Mathematics/Geometry/Box2.cs
@@ -20,8 +20,9 @@ namespace OpenToolkit.Mathematics
     public struct Box2 : IEquatable<Box2>
     {
         private Vector2 _min;
+
         /// <summary>
-        /// The minimum boundary of the structure.
+        /// Gets or sets the minimum boundary of the structure.
         /// </summary>
         public Vector2 Min
         {
@@ -51,8 +52,9 @@ namespace OpenToolkit.Mathematics
         }
 
         private Vector2 _max;
+
         /// <summary>
-        /// The maximum boundary of the structure.
+        /// Gets or sets the maximum boundary of the structure.
         /// </summary>
         public Vector2 Max
         {
@@ -114,14 +116,13 @@ namespace OpenToolkit.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Box2"/> struct.
         /// </summary>
-        /// <param name="minX">The minimum X value to be enclosed</param>
-        /// <param name="minY">The maximum Y value to be enclosed</param>
-        /// <param name="maxX">The minimum X value to be enclosed</param>
-        /// <param name="maxY">The maximum Y value to be enclosed</param>
+        /// <param name="minX">The minimum X value to be enclosed.</param>
+        /// <param name="minY">The minimum Y value to be enclosed.</param>
+        /// <param name="maxX">The maximum X value to be enclosed.</param>
+        /// <param name="maxY">The maximum Y value to be enclosed.</param>
         public Box2(float minX, float minY, float maxX, float maxY)
             : this(new Vector2(minX, minY), new Vector2(maxX, maxY))
         {
-
         }
 
         /// <summary>
@@ -154,7 +155,7 @@ namespace OpenToolkit.Mathematics
         /// Returns whether the box contains the specified box (borders inclusive).
         /// </summary>
         /// <param name="other">The box to query.</param>
-        /// <returns>Whether this box contains the other box</returns>
+        /// <returns>Whether this box contains the other box.</returns>
         public bool Contains(Box2 other)
         {
             return Contains(other._max) && Contains(other._max);
@@ -212,11 +213,13 @@ namespace OpenToolkit.Mathematics
         public Box2 Scaled(Vector2 scale, Vector2 anchor)
         {
             var newDistMin = (anchor - _min) * scale;
-            var min = new Vector2(anchor.X + _min.X > anchor.X ? newDistMin.X : -newDistMin.X,
+            var min = new Vector2(
+                anchor.X + _min.X > anchor.X ? newDistMin.X : -newDistMin.X,
                 anchor.Y + _min.Y > anchor.Y ? newDistMin.Y : -newDistMin.Y);
 
             var newDistMax = (anchor - _max) * scale;
-            var max = new Vector2(anchor.X + _max.X > anchor.X ? newDistMax.X : -newDistMax.X,
+            var max = new Vector2(
+                anchor.X + _max.X > anchor.X ? newDistMax.X : -newDistMax.X,
                 anchor.Y + _max.Y > anchor.Y ? newDistMax.Y : -newDistMax.Y);
 
             return new Box2(min, max);
@@ -230,11 +233,13 @@ namespace OpenToolkit.Mathematics
         public void Scale(Vector2 scale, Vector2 anchor)
         {
             var newDistMin = (anchor - _min) * scale;
-            _min = new Vector2(anchor.X + _min.X > anchor.X ? newDistMin.X : -newDistMin.X,
+            _min = new Vector2(
+                anchor.X + _min.X > anchor.X ? newDistMin.X : -newDistMin.X,
                 anchor.Y + _min.Y > anchor.Y ? newDistMin.Y : -newDistMin.Y);
 
             var newDistMax = (anchor - _max) * scale;
-            _max = new Vector2(anchor.X + _max.X > anchor.X ? newDistMax.X : -newDistMax.X,
+            _max = new Vector2(
+                anchor.X + _max.X > anchor.X ? newDistMax.X : -newDistMax.X,
                 anchor.Y + _min.Y > anchor.Y ? newDistMax.Y : -newDistMax.Y);
         }
 
@@ -242,6 +247,7 @@ namespace OpenToolkit.Mathematics
         /// Inflate this Box2 to encapsulate a given point.
         /// </summary>
         /// <param name="point">The point to query.</param>
+        /// <returns>The inflated box.</returns>
         public Box2 Inflated(Vector2 point)
         {
             var distMin = _min - point;
@@ -308,7 +314,10 @@ namespace OpenToolkit.Mathematics
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
             return obj is Box2 other && Equals(other);
         }
 

--- a/src/OpenToolkit.Mathematics/Geometry/Box2.cs
+++ b/src/OpenToolkit.Mathematics/Geometry/Box2.cs
@@ -126,19 +126,31 @@ namespace OpenToolkit.Mathematics
         }
 
         /// <summary>
-        /// Gets a vector describing the size of the Box2 structure.
+        /// Gets or sets a vector describing the size of the Box2 structure.
         /// </summary>
-        public Vector2 Size => Max - Min;
+        public Vector2 Size
+        {
+            get => Max - Min;
+            set => Scale(Size - value, Center);
+        }
 
         /// <summary>
-        /// Gets a vector describing half the size of the box.
+        /// Gets or sets a vector describing half the size of the box.
         /// </summary>
-        public Vector2 HalfSize => Size / 2;
+        public Vector2 HalfSize
+        {   
+            get => Size / 2;
+            set => Size = value / 2;
+        }
 
         /// <summary>
-        /// Gets a vector describing the center of the box.
+        /// Gets or sets a vector describing the center of the box.
         /// </summary>
-        public Vector2 Center => _min + HalfSize;
+        public Vector2 Center
+        {
+            get => (_min + _max) * 0.5f;
+            set => Translate(Center - value);
+        }
 
         /// <summary>
         /// Returns whether the box contains the specified point (borders inclusive).
@@ -158,7 +170,8 @@ namespace OpenToolkit.Mathematics
         /// <returns>Whether this box contains the other box.</returns>
         public bool Contains(Box2 other)
         {
-            return Contains(other._max) && Contains(other._max);
+            return _max.X >= other._min.X && _min.X <= other._max.X &&
+                   _max.Y >= other._min.Y && _min.Y <= other._max.Y;
         }
 
         /// <summary>
@@ -175,26 +188,6 @@ namespace OpenToolkit.Mathematics
         }
 
         /// <summary>
-        /// Returns the distance between the center of this box and the specified point.
-        /// </summary>
-        /// <param name="point">The point to find distance for.</param>
-        /// <returns>The distance between the specified point and the center.</returns>
-        public float DistanceToCenter(Vector2 point)
-        {
-            return Vector2.Distance(point, Center);
-        }
-
-        /// <summary>
-        /// Returns a Box2 translated by the given amount.
-        /// </summary>
-        /// <param name="distance">The distance to translate the box.</param>
-        /// <returns>The translated box.</returns>
-        public Box2 Translated(Vector2 distance)
-        {
-            return new Box2(Min + distance, Max + distance);
-        }
-
-        /// <summary>
         /// Translates this Box2 by the given amount.
         /// </summary>
         /// <param name="distance">The distance to translate the box.</param>
@@ -205,24 +198,16 @@ namespace OpenToolkit.Mathematics
         }
 
         /// <summary>
-        /// Returns a Box2 scaled by a given amount from an anchor point.
+        /// Returns a Box2 translated by the given amount.
         /// </summary>
-        /// <param name="scale">The scale to scale the box.</param>
-        /// <param name="anchor">The anchor to scale the box from.</param>
-        /// <returns>The scaled box.</returns>
-        public Box2 Scaled(Vector2 scale, Vector2 anchor)
+        /// <param name="distance">The distance to translate the box.</param>
+        /// <returns>The translated box.</returns>
+        public Box2 Translated(Vector2 distance)
         {
-            var newDistMin = (anchor - _min) * scale;
-            var min = new Vector2(
-                anchor.X + _min.X > anchor.X ? newDistMin.X : -newDistMin.X,
-                anchor.Y + _min.Y > anchor.Y ? newDistMin.Y : -newDistMin.Y);
-
-            var newDistMax = (anchor - _max) * scale;
-            var max = new Vector2(
-                anchor.X + _max.X > anchor.X ? newDistMax.X : -newDistMax.X,
-                anchor.Y + _max.Y > anchor.Y ? newDistMax.Y : -newDistMax.Y);
-
-            return new Box2(min, max);
+            // create a local copy of this box
+            Box2 box = this;
+            box.Translate(distance);
+            return box;
         }
 
         /// <summary>
@@ -244,17 +229,17 @@ namespace OpenToolkit.Mathematics
         }
 
         /// <summary>
-        /// Inflate this Box2 to encapsulate a given point.
+        /// Returns a Box2 scaled by a given amount from an anchor point.
         /// </summary>
-        /// <param name="point">The point to query.</param>
-        /// <returns>The inflated box.</returns>
-        public Box2 Inflated(Vector2 point)
+        /// <param name="scale">The scale to scale the box.</param>
+        /// <param name="anchor">The anchor to scale the box from.</param>
+        /// <returns>The scaled box.</returns>
+        public Box2 Scaled(Vector2 scale, Vector2 anchor)
         {
-            var distMin = _min - point;
-            var distMax = point - _max;
-            var x = distMin.X < distMax.X;
-            var y = distMin.Y < distMax.Y;
-            return new Box2(x ? point.X : _min.X, y ? point.Y : _min.Y, x ? _max.X : point.X, y ? _max.Y : point.Y);
+            // create a local copy of this box
+            Box2 box = this;
+            box.Scale(scale, anchor);
+            return box;
         }
 
         /// <summary>
@@ -283,6 +268,19 @@ namespace OpenToolkit.Mathematics
             {
                 _max.Y = point.Y;
             }
+        }
+
+        /// <summary>
+        /// Inflate this Box2 to encapsulate a given point.
+        /// </summary>
+        /// <param name="point">The point to query.</param>
+        /// <returns>The inflated box.</returns>
+        public Box2 Inflated(Vector2 point)
+        {
+            // create a local copy of this box
+            Box2 box = this;
+            box.Inflate(point);
+            return box;
         }
 
         /// <summary>

--- a/src/OpenToolkit.Mathematics/Geometry/Box2.cs
+++ b/src/OpenToolkit.Mathematics/Geometry/Box2.cs
@@ -20,51 +20,37 @@ namespace OpenToolkit.Mathematics
     public struct Box2 : IEquatable<Box2>
     {
         /// <summary>
-        /// The left boundary of the structure.
+        /// The minimum boundary of the structure.
         /// </summary>
-        public float Left;
+        public Vector2 Min;
 
         /// <summary>
-        /// The right boundary of the structure.
+        /// The maximum boundary of the structure.
         /// </summary>
-        public float Right;
-
-        /// <summary>
-        /// The top boundary of the structure.
-        /// </summary>
-        public float Top;
-
-        /// <summary>
-        /// The bottom boundary of the structure.
-        /// </summary>
-        public float Bottom;
+        public Vector2 Max;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Box2"/> struct.
         /// </summary>
-        /// <param name="topLeft">An OpenToolkit.Vector2 describing the top-left corner of the Box2.</param>
-        /// <param name="bottomRight">An OpenToolkit.Vector2 describing the bottom-right corner of the Box2.</param>
-        public Box2(Vector2 topLeft, Vector2 bottomRight)
+        /// <param name="min">An Vector2 describing the top-left corner of the Box2.</param>
+        /// <param name="max">A Vector2 describing the bottom-right corner of the Box2.</param>
+        public Box2(Vector2 min, Vector2 max)
         {
-            Left = topLeft.X;
-            Top = topLeft.Y;
-            Right = bottomRight.X;
-            Bottom = bottomRight.Y;
+            Min = min;
+            Max = max;
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Box2"/> struct.
         /// </summary>
-        /// <param name="left">The position of the left boundary.</param>
-        /// <param name="top">The position of the top boundary.</param>
-        /// <param name="right">The position of the right boundary.</param>
-        /// <param name="bottom">The position of the bottom boundary.</param>
-        public Box2(float left, float top, float right, float bottom)
+        /// <param name="minX">The position of the left boundary.</param>
+        /// <param name="minY">The position of the top boundary.</param>
+        /// <param name="maxX">The position of the right boundary.</param>
+        /// <param name="maxY">The position of the bottom boundary.</param>
+        public Box2(float minX, float minY, float maxX, float maxY)
         {
-            Left = left;
-            Top = top;
-            Right = right;
-            Bottom = bottom;
+            Min = new Vector2(minX, minY);
+            Max = new Vector2(maxX, maxY);
         }
 
         /// <summary>
@@ -74,7 +60,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The position of the left boundary.</param>
         /// <param name="right">The position of the right boundary.</param>
         /// <param name="bottom">The position of the bottom boundary.</param>
-        /// <returns>A new OpenToolkit.Box2 with the specfied dimensions.</returns>
+        /// <returns>A new OpenToolkit.Box2 with the specified dimensions.</returns>
         public static Box2 FromTLRB(float top, float left, float right, float bottom)
         {
             return new Box2(left, top, right, bottom);
@@ -83,22 +69,22 @@ namespace OpenToolkit.Mathematics
         /// <summary>
         /// Creates a new Box2 with the specified dimensions.
         /// </summary>
-        /// <param name="left">The position of the left boundary.</param>
-        /// <param name="top">The position of the top boundary.</param>
+        /// <param name="minX">The position of the left boundary.</param>
+        /// <param name="minY">The position of the top boundary.</param>
         /// <param name="width">The width of the box.</param>
         /// <param name="height">The height of the box.</param>
-        /// <returns>A new OpenToolkit.Box2 with the specfied dimensions.</returns>
-        public static Box2 FromDimensions(float left, float top, float width, float height)
+        /// <returns>A new OpenToolkit.Box2 with the specified dimensions.</returns>
+        public static Box2 FromDimensions(float minX, float minY, float width, float height)
         {
-            return new Box2(left, top, left + width, top + height);
+            return new Box2(minX, minY, minX + width, minY + height);
         }
 
         /// <summary>
         /// Creates a new Box2 with the specified dimensions.
         /// </summary>
-        /// <param name="position">The position of the top left corner.</param>
+        /// <param name="position">The position of the top-left corner.</param>
         /// <param name="size">The size of the box.</param>
-        /// <returns>A new OpenToolkit.Box2 with the specfied dimensions.</returns>
+        /// <returns>A new OpenToolkit.Box2 with the specified dimensions.</returns>
         public static Box2 FromDimensions(Vector2 position, Vector2 size)
         {
             return FromDimensions(position.X, position.Y, size.X, size.Y);
@@ -107,12 +93,12 @@ namespace OpenToolkit.Mathematics
         /// <summary>
         /// Gets a float describing the width of the Box2 structure.
         /// </summary>
-        public float Width => Math.Abs(Right - Left);
+        public float Width => Math.Abs(Min.X - Max.X);
 
         /// <summary>
         /// Gets a float describing the height of the Box2 structure.
         /// </summary>
-        public float Height => Math.Abs(Bottom - Top);
+        public float Height => Math.Abs(Min.Y - Max.Y);
 
         /// <summary>
         /// Returns whether the box contains the specified point.
@@ -122,13 +108,13 @@ namespace OpenToolkit.Mathematics
         /// <returns>Whether this box contains the point.</returns>
         public bool Contains(Vector2 point, bool closedRegion = true)
         {
-            var containsX = closedRegion == Left <= Right
-                ? point.X >= Left != point.X > Right
-                : point.X > Left != point.X >= Right;
+            var containsX = closedRegion == Min.X <= Max.X
+                ? point.X >= Min.X != point.X > Max.X
+                : point.X > Min.X != point.X >= Max.X;
 
-            var containsY = closedRegion == Top <= Bottom
-                ? point.Y >= Top != point.Y > Bottom
-                : point.Y > Top != point.Y >= Bottom;
+            var containsY = closedRegion == Min.Y <= Max.Y
+                ? point.Y >= Min.Y != point.Y > Min.X
+                : point.Y > Min.Y != point.Y >= Max.Y;
 
             return containsX && containsY;
         }
@@ -136,23 +122,21 @@ namespace OpenToolkit.Mathematics
         /// <summary>
         /// Returns a Box2 translated by the given amount.
         /// </summary>
-        /// <param name="point">The distance to translate the box.</param>
+        /// <param name="distance">The distance to translate the box.</param>
         /// <returns>The translated box.</returns>
-        public Box2 Translated(Vector2 point)
+        public Box2 Translated(Vector2 distance)
         {
-            return new Box2(Left + point.X, Top + point.Y, Right + point.X, Bottom + point.Y);
+            return new Box2(Min + distance, Max + distance);
         }
 
         /// <summary>
         /// Translates this Box2 by the given amount.
         /// </summary>
-        /// <param name="point">The distance to translate the box.</param>
-        public void Translate(Vector2 point)
+        /// <param name="distance">The distance to translate the box.</param>
+        public void Translate(Vector2 distance)
         {
-            Left += point.X;
-            Right += point.X;
-            Top += point.Y;
-            Bottom += point.Y;
+            Min += distance;
+            Max += distance;
         }
 
         /// <summary>
@@ -162,10 +146,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="right">The right operand.</param>
         public static bool operator ==(Box2 left, Box2 right)
         {
-            return MathHelper.ApproximatelyEqualEpsilon(left.Bottom, right.Bottom, 0.0001f)
-                && MathHelper.ApproximatelyEqualEpsilon(left.Top, right.Top, 0.0001f)
-                && MathHelper.ApproximatelyEqualEpsilon(left.Left, right.Left, 0.0001f)
-                && MathHelper.ApproximatelyEqualEpsilon(left.Bottom, right.Bottom, 0.0001f);
+            return left.Min == right.Min && left.Max == right.Max;
         }
 
         /// <summary>
@@ -195,10 +176,10 @@ namespace OpenToolkit.Mathematics
         {
             unchecked
             {
-                var hashCode = Left.GetHashCode();
-                hashCode = (hashCode * 397) ^ Right.GetHashCode();
-                hashCode = (hashCode * 397) ^ Top.GetHashCode();
-                hashCode = (hashCode * 397) ^ Bottom.GetHashCode();
+                var hashCode = Min.X.GetHashCode();
+                hashCode = (hashCode * 397) ^ Min.Y.GetHashCode();
+                hashCode = (hashCode * 397) ^ Max.X.GetHashCode();
+                hashCode = (hashCode * 397) ^ Max.Y.GetHashCode();
                 return hashCode;
             }
         }
@@ -208,7 +189,7 @@ namespace OpenToolkit.Mathematics
         /// <inheritdoc/>
         public override string ToString()
         {
-            return string.Format("({0}{4} {1}) - ({2}{4} {3})", Left, Top, Right, Bottom, ListSeparator);
+            return string.Format("({0}{4} {1}) - ({2}{4} {3})", Min.X, Min.Y, Max.X, Max.Y, ListSeparator);
         }
     }
 }

--- a/src/OpenToolkit.Mathematics/Geometry/Box2.cs
+++ b/src/OpenToolkit.Mathematics/Geometry/Box2.cs
@@ -138,7 +138,7 @@ namespace OpenToolkit.Mathematics
         /// Gets or sets a vector describing half the size of the box.
         /// </summary>
         public Vector2 HalfSize
-        {   
+        {
             get => Size / 2;
             set => Size = value / 2;
         }

--- a/src/OpenToolkit.Mathematics/Geometry/Box2.cs
+++ b/src/OpenToolkit.Mathematics/Geometry/Box2.cs
@@ -160,7 +160,7 @@ namespace OpenToolkit.Mathematics
         public bool Contains(Vector2 point)
         {
             return _min.X <= point.X && point.X <= _max.X &&
-                   _min.Y <= point.X && point.Y <= _max.Y;
+                   _min.Y <= point.Y && point.Y <= _max.Y;
         }
 
         /// <summary>

--- a/src/OpenToolkit.Mathematics/Geometry/Box2.cs
+++ b/src/OpenToolkit.Mathematics/Geometry/Box2.cs
@@ -14,7 +14,7 @@ using System.Runtime.InteropServices;
 namespace OpenToolkit.Mathematics
 {
     /// <summary>
-    /// Defines a 2d box (rectangle).
+    /// Defines an axis-aligned 2d box (rectangle).
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct Box2 : IEquatable<Box2>

--- a/src/OpenToolkit.Mathematics/Geometry/Box2.cs
+++ b/src/OpenToolkit.Mathematics/Geometry/Box2.cs
@@ -46,7 +46,7 @@ namespace OpenToolkit.Mathematics
                 }
                 else
                 {
-                    _min.X = value.Y;
+                    _min.Y = value.Y;
                 }
             }
         }
@@ -78,7 +78,7 @@ namespace OpenToolkit.Mathematics
                 }
                 else
                 {
-                    _max.X = value.Y;
+                    _max.Y = value.Y;
                 }
             }
         }

--- a/src/OpenToolkit.Mathematics/Geometry/Box2d.cs
+++ b/src/OpenToolkit.Mathematics/Geometry/Box2d.cs
@@ -19,140 +19,268 @@ namespace OpenToolkit.Mathematics
     [StructLayout(LayoutKind.Sequential)]
     public struct Box2d : IEquatable<Box2d>
     {
-        /// <summary>
-        /// The left boundary of the structure.
-        /// </summary>
-        public double Left;
+        private Vector2d _min;
 
         /// <summary>
-        /// The right boundary of the structure.
+        /// Gets or sets the minimum boundary of the structure.
         /// </summary>
-        public double Right;
-
-        /// <summary>
-        /// The top boundary of the structure.
-        /// </summary>
-        public double Top;
-
-        /// <summary>
-        /// The bottom boundary of the structure.
-        /// </summary>
-        public double Bottom;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Box2d"/> struct.
-        /// </summary>
-        /// <param name="topLeft">An OpenToolkit.Vector2d describing the top-left corner of the Box2d.</param>
-        /// <param name="bottomRight">An OpenToolkit.Vector2d describing the bottom-right corner of the Box2d.</param>
-        public Box2d(Vector2d topLeft, Vector2d bottomRight)
+        public Vector2d Min
         {
-            Left = topLeft.X;
-            Top = topLeft.Y;
-            Right = bottomRight.X;
-            Bottom = bottomRight.Y;
+            get => _min;
+            set
+            {
+                if (value.X > _max.X)
+                {
+                    _min.X = _max.X;
+                    _max.X = value.X;
+                }
+                else
+                {
+                    _min.X = value.X;
+                }
+
+                if (value.Y > _max.Y)
+                {
+                    _min.Y = _max.Y;
+                    _max.Y = value.Y;
+                }
+                else
+                {
+                    _min.X = value.Y;
+                }
+            }
+        }
+
+        private Vector2d _max;
+
+        /// <summary>
+        /// Gets or sets the maximum boundary of the structure.
+        /// </summary>
+        public Vector2d Max
+        {
+            get => _min;
+            set
+            {
+                if (value.X < _min.X)
+                {
+                    _max.X = _min.X;
+                    _min.X = value.X;
+                }
+                else
+                {
+                    _max.X = value.X;
+                }
+
+                if (value.Y < _min.Y)
+                {
+                    _max.Y = _min.Y;
+                    _min.Y = value.Y;
+                }
+                else
+                {
+                    _max.X = value.Y;
+                }
+            }
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Box2d"/> struct.
         /// </summary>
-        /// <param name="left">The position of the left boundary.</param>
-        /// <param name="top">The position of the top boundary.</param>
-        /// <param name="right">The position of the right boundary.</param>
-        /// <param name="bottom">The position of the bottom boundary.</param>
-        public Box2d(double left, double top, double right, double bottom)
+        /// <param name="min">The minimum point on the XY plane this box encloses.</param>
+        /// <param name="max">The maximum point on the XY plane this box encloses.</param>
+        public Box2d(Vector2d min, Vector2d max)
         {
-            Left = left;
-            Top = top;
-            Right = right;
-            Bottom = bottom;
+            if (min.X < max.X)
+            {
+                _min.X = min.X;
+                _max.X = max.X;
+            }
+            else
+            {
+                _min.X = max.X;
+                _max.X = min.X;
+            }
+
+            if (min.Y < max.Y)
+            {
+                _min.Y = min.Y;
+                _max.Y = max.Y;
+            }
+            else
+            {
+                _min.Y = max.Y;
+                _max.Y = min.Y;
+            }
         }
 
         /// <summary>
-        /// Creates a new Box2d with the specified dimensions.
+        /// Initializes a new instance of the <see cref="Box2d"/> struct.
         /// </summary>
-        /// <param name="top">The position of the top boundary.</param>
-        /// <param name="left">The position of the left boundary.</param>
-        /// <param name="right">The position of the right boundary.</param>
-        /// <param name="bottom">The position of the bottom boundary.</param>
-        /// <returns>A new OpenToolkit.Box2d with the specfied dimensions.</returns>
-        public static Box2d FromTLRB(double top, double left, double right, double bottom)
+        /// <param name="minX">The minimum X value to be enclosed.</param>
+        /// <param name="minY">The minimum Y value to be enclosed.</param>
+        /// <param name="maxX">The maximum X value to be enclosed.</param>
+        /// <param name="maxY">The maximum Y value to be enclosed.</param>
+        public Box2d(double minX, double minY, double maxX, double maxY)
+            : this(new Vector2d(minX, minY), new Vector2d(maxX, maxY))
         {
-            return new Box2d(left, top, right, bottom);
         }
 
         /// <summary>
-        /// Creates a new Box2d with the specified dimensions.
+        /// Gets or sets a vector describing the size of the Box2 structure.
         /// </summary>
-        /// <param name="left">The position of the left boundary.</param>
-        /// <param name="top">The position of the top boundary.</param>
-        /// <param name="width">The width of the box.</param>
-        /// <param name="height">The height of the box.</param>
-        /// <returns>A new OpenToolkit.Box2d with the specfied dimensions.</returns>
-        public static Box2d FromDimensions(double left, double top, double width, double height)
+        public Vector2d Size
         {
-            return new Box2d(left, top, left + width, top + height);
+            get => Max - Min;
+            set => Scale(Size - value, Center);
         }
 
         /// <summary>
-        /// Creates a new Box2d with the specified dimensions.
+        /// Gets or sets a vector describing half the size of the box.
         /// </summary>
-        /// <param name="position">The position of the top left corner.</param>
-        /// <param name="size">The size of the box.</param>
-        /// <returns>A new OpenToolkit.Box2d with the specfied dimensions.</returns>
-        public static Box2d FromDimensions(Vector2d position, Vector2d size)
+        public Vector2d HalfSize
         {
-            return FromDimensions(position.X, position.Y, size.X, size.Y);
+            get => Size / 2;
+            set => Size = value / 2;
         }
 
         /// <summary>
-        /// Gets a double describing the width of the Box2d structure.
+        /// Gets or sets a vector describing the center of the box.
         /// </summary>
-        public double Width => Math.Abs(Right - Left);
+        public Vector2d Center
+        {
+            get => (_min + _max) * 0.5f;
+            set => Translate(Center - value);
+        }
 
         /// <summary>
-        /// Gets a double describing the height of the Box2d structure.
-        /// </summary>
-        public double Height => Math.Abs(Bottom - Top);
-
-        /// <summary>
-        /// Returns whether the box contains the specified point.
+        /// Returns whether the box contains the specified point (borders inclusive).
         /// </summary>
         /// <param name="point">The point to query.</param>
-        /// <param name="closedRegion">Whether to include the box boundary in the test region.</param>
         /// <returns>Whether this box contains the point.</returns>
-        public bool Contains(Vector2d point, bool closedRegion = true)
+        public bool Contains(Vector2d point)
         {
-            var containsX = closedRegion == Left <= Right
-                ? point.X >= Left != point.X > Right
-                : point.X > Left != point.X >= Right;
-
-            var containsY = closedRegion == Top <= Bottom
-                ? point.Y >= Top != point.Y > Bottom
-                : point.Y > Top != point.Y >= Bottom;
-
-            return containsX && containsY;
+            return _min.X <= point.X && point.X <= _max.X &&
+                   _min.Y <= point.X && point.Y <= _max.Y;
         }
 
         /// <summary>
-        /// Returns a Box2d translated by the given amount.
+        /// Returns whether the box contains the specified box (borders inclusive).
         /// </summary>
-        /// <param name="point">The distance to translate the box.</param>
+        /// <param name="other">The box to query.</param>
+        /// <returns>Whether this box contains the other box.</returns>
+        public bool Contains(Box2d other)
+        {
+            return _max.X >= other._min.X && _min.X <= other._max.X &&
+                   _max.Y >= other._min.Y && _min.Y <= other._max.Y;
+        }
+
+        /// <summary>
+        /// Returns the distance between the nearest edge and the specified point.
+        /// </summary>
+        /// <param name="point">The point to find distance for.</param>
+        /// <returns>The distance between the specified point and the nearest edge.</returns>
+        public double DistanceToNearestEdge(Vector2d point)
+        {
+            var distMin = _min - point;
+            var distMax = point - _max;
+            var dist = new Vector2d(MathHelper.Min(distMin.X, distMax.X), MathHelper.Min(distMin.Y, distMax.Y));
+            return dist.Length;
+        }
+
+        /// <summary>
+        /// Translates this Box2 by the given amount.
+        /// </summary>
+        /// <param name="distance">The distance to translate the box.</param>
+        public void Translate(Vector2d distance)
+        {
+            Min += distance;
+            Max += distance;
+        }
+
+        /// <summary>
+        /// Returns a Box2 translated by the given amount.
+        /// </summary>
+        /// <param name="distance">The distance to translate the box.</param>
         /// <returns>The translated box.</returns>
-        public Box2d Translated(Vector2d point)
+        public Box2d Translated(Vector2d distance)
         {
-            return new Box2d(Left + point.X, Top + point.Y, Right + point.X, Bottom + point.Y);
+            // create a local copy of this box
+            Box2d box = this;
+            box.Translate(distance);
+            return box;
         }
 
         /// <summary>
-        /// Translates this Box2d by the given amount.
+        /// Scales this Box2 by the given amount.
         /// </summary>
-        /// <param name="point">The distance to translate the box.</param>
-        public void Translate(Vector2d point)
+        /// <param name="scale">The scale to scale the box.</param>
+        /// <param name="anchor">The anchor to scale the box from.</param>
+        public void Scale(Vector2d scale, Vector2d anchor)
         {
-            Left += point.X;
-            Right += point.X;
-            Top += point.Y;
-            Bottom += point.Y;
+            var newDistMin = (anchor - _min) * scale;
+            _min = new Vector2d(
+                anchor.X + _min.X > anchor.X ? newDistMin.X : -newDistMin.X,
+                anchor.Y + _min.Y > anchor.Y ? newDistMin.Y : -newDistMin.Y);
+
+            var newDistMax = (anchor - _max) * scale;
+            _max = new Vector2d(
+                anchor.X + _max.X > anchor.X ? newDistMax.X : -newDistMax.X,
+                anchor.Y + _min.Y > anchor.Y ? newDistMax.Y : -newDistMax.Y);
+        }
+
+        /// <summary>
+        /// Returns a Box2 scaled by a given amount from an anchor point.
+        /// </summary>
+        /// <param name="scale">The scale to scale the box.</param>
+        /// <param name="anchor">The anchor to scale the box from.</param>
+        /// <returns>The scaled box.</returns>
+        public Box2d Scaled(Vector2d scale, Vector2d anchor)
+        {
+            // create a local copy of this box
+            Box2d box = this;
+            box.Scale(scale, anchor);
+            return box;
+        }
+
+        /// <summary>
+        /// Inflate this Box2 to encapsulate a given point.
+        /// </summary>
+        /// <param name="point">The point to query.</param>
+        public void Inflate(Vector2d point)
+        {
+            var distMin = _min - point;
+            var distMax = point - _max;
+
+            if (distMin.X < distMax.X)
+            {
+                _min.X = point.X;
+            }
+            else
+            {
+                _max.X = point.X;
+            }
+
+            if (distMin.Y < distMax.Y)
+            {
+                _min.Y = point.Y;
+            }
+            else
+            {
+                _max.Y = point.Y;
+            }
+        }
+
+        /// <summary>
+        /// Inflate this Box2 to encapsulate a given point.
+        /// </summary>
+        /// <param name="point">The point to query.</param>
+        /// <returns>The inflated box.</returns>
+        public Box2d Inflated(Vector2d point)
+        {
+            // create a local copy of this box
+            Box2d box = this;
+            box.Inflate(point);
+            return box;
         }
 
         /// <summary>
@@ -162,10 +290,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="right">The right operand.</param>
         public static bool operator ==(Box2d left, Box2d right)
         {
-            return MathHelper.ApproximatelyEqualEpsilon(left.Bottom, right.Bottom, 0.0001f)
-                   && MathHelper.ApproximatelyEqualEpsilon(left.Top, right.Top, 0.0001f)
-                   && MathHelper.ApproximatelyEqualEpsilon(left.Left, right.Left, 0.0001f)
-                   && MathHelper.ApproximatelyEqualEpsilon(left.Bottom, right.Bottom, 0.0001f);
+            return left.Min == right.Min && left.Max == right.Max;
         }
 
         /// <summary>
@@ -181,13 +306,17 @@ namespace OpenToolkit.Mathematics
         /// <inheritdoc/>
         public bool Equals(Box2d other)
         {
-            return this == other;
+            return Min.Equals(other.Min) && Max.Equals(other.Max);
         }
 
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            return obj is Box2d d && Equals(d);
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+            return obj is Box2d other && Equals(other);
         }
 
         /// <inheritdoc/>
@@ -195,11 +324,7 @@ namespace OpenToolkit.Mathematics
         {
             unchecked
             {
-                var hashCode = Left.GetHashCode();
-                hashCode = (hashCode * 397) ^ Right.GetHashCode();
-                hashCode = (hashCode * 397) ^ Top.GetHashCode();
-                hashCode = (hashCode * 397) ^ Bottom.GetHashCode();
-                return hashCode;
+                return (Min.GetHashCode() * 397) ^ Max.GetHashCode();
             }
         }
 
@@ -208,7 +333,7 @@ namespace OpenToolkit.Mathematics
         /// <inheritdoc/>
         public override string ToString()
         {
-            return string.Format("({0}{4} {1}) - ({2}{4} {3})", Left, Top, Right, Bottom, ListSeparator);
+            return $"({Min.X}{ListSeparator} {Min.Y}) - ({Max.X}{ListSeparator} {Max.Y})";
         }
     }
 }

--- a/src/OpenToolkit.Mathematics/Geometry/Box2d.cs
+++ b/src/OpenToolkit.Mathematics/Geometry/Box2d.cs
@@ -160,7 +160,7 @@ namespace OpenToolkit.Mathematics
         public bool Contains(Vector2d point)
         {
             return _min.X <= point.X && point.X <= _max.X &&
-                   _min.Y <= point.X && point.Y <= _max.Y;
+                   _min.Y <= point.Y && point.Y <= _max.Y;
         }
 
         /// <summary>

--- a/src/OpenToolkit.Mathematics/Geometry/Box2d.cs
+++ b/src/OpenToolkit.Mathematics/Geometry/Box2d.cs
@@ -14,7 +14,7 @@ using System.Runtime.InteropServices;
 namespace OpenToolkit.Mathematics
 {
     /// <summary>
-    /// Defines a 2d box (rectangle).
+    /// Defines an axis-aligned 2d box (rectangle).
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct Box2d : IEquatable<Box2d>

--- a/src/OpenToolkit.Mathematics/Geometry/Box2d.cs
+++ b/src/OpenToolkit.Mathematics/Geometry/Box2d.cs
@@ -46,7 +46,7 @@ namespace OpenToolkit.Mathematics
                 }
                 else
                 {
-                    _min.X = value.Y;
+                    _min.Y = value.Y;
                 }
             }
         }
@@ -78,7 +78,7 @@ namespace OpenToolkit.Mathematics
                 }
                 else
                 {
-                    _max.X = value.Y;
+                    _max.Y = value.Y;
                 }
             }
         }

--- a/src/OpenToolkit.Mathematics/Geometry/Box2i.cs
+++ b/src/OpenToolkit.Mathematics/Geometry/Box2i.cs
@@ -14,7 +14,7 @@ using System.Runtime.InteropServices;
 namespace OpenToolkit.Mathematics
 {
     /// <summary>
-    /// Defines a 2d box (rectangle).
+    /// Defines an axis-aligned 2d box (rectangle).
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct Box2i : IEquatable<Box2i>

--- a/src/OpenToolkit.Mathematics/Geometry/Box2i.cs
+++ b/src/OpenToolkit.Mathematics/Geometry/Box2i.cs
@@ -160,7 +160,7 @@ namespace OpenToolkit.Mathematics
         public bool Contains(Vector2i point)
         {
             return _min.X <= point.X && point.X <= _max.X &&
-                   _min.Y <= point.X && point.Y <= _max.Y;
+                   _min.Y <= point.Y && point.Y <= _max.Y;
         }
 
         /// <summary>

--- a/src/OpenToolkit.Mathematics/Geometry/Box2i.cs
+++ b/src/OpenToolkit.Mathematics/Geometry/Box2i.cs
@@ -19,140 +19,268 @@ namespace OpenToolkit.Mathematics
     [StructLayout(LayoutKind.Sequential)]
     public struct Box2i : IEquatable<Box2i>
     {
-        /// <summary>
-        /// The left boundary of the structure.
-        /// </summary>
-        public int Left;
+        private Vector2i _min;
 
         /// <summary>
-        /// The right boundary of the structure.
+        /// Gets or sets the minimum boundary of the structure.
         /// </summary>
-        public int Right;
-
-        /// <summary>
-        /// The top boundary of the structure.
-        /// </summary>
-        public int Top;
-
-        /// <summary>
-        /// The bottom boundary of the structure.
-        /// </summary>
-        public int Bottom;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Box2i"/> struct.
-        /// </summary>
-        /// <param name="topLeft">An OpenToolkit.Vector2 describing the top-left corner of the Box2.</param>
-        /// <param name="bottomRight">An OpenToolkit.Vector2 describing the bottom-right corner of the Box2.</param>
-        public Box2i(Vector2i topLeft, Vector2i bottomRight)
+        public Vector2i Min
         {
-            Left = topLeft.X;
-            Top = topLeft.Y;
-            Right = bottomRight.X;
-            Bottom = bottomRight.Y;
+            get => _min;
+            set
+            {
+                if (value.X > _max.X)
+                {
+                    _min.X = _max.X;
+                    _max.X = value.X;
+                }
+                else
+                {
+                    _min.X = value.X;
+                }
+
+                if (value.Y > _max.Y)
+                {
+                    _min.Y = _max.Y;
+                    _max.Y = value.Y;
+                }
+                else
+                {
+                    _min.X = value.Y;
+                }
+            }
+        }
+
+        private Vector2i _max;
+
+        /// <summary>
+        /// Gets or sets the maximum boundary of the structure.
+        /// </summary>
+        public Vector2i Max
+        {
+            get => _min;
+            set
+            {
+                if (value.X < _min.X)
+                {
+                    _max.X = _min.X;
+                    _min.X = value.X;
+                }
+                else
+                {
+                    _max.X = value.X;
+                }
+
+                if (value.Y < _min.Y)
+                {
+                    _max.Y = _min.Y;
+                    _min.Y = value.Y;
+                }
+                else
+                {
+                    _max.X = value.Y;
+                }
+            }
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Box2i"/> struct.
         /// </summary>
-        /// <param name="left">The position of the left boundary.</param>
-        /// <param name="top">The position of the top boundary.</param>
-        /// <param name="right">The position of the right boundary.</param>
-        /// <param name="bottom">The position of the bottom boundary.</param>
-        public Box2i(int left, int top, int right, int bottom)
+        /// <param name="min">The minimum point on the XY plane this box encloses.</param>
+        /// <param name="max">The maximum point on the XY plane this box encloses.</param>
+        public Box2i(Vector2i min, Vector2i max)
         {
-            Left = left;
-            Top = top;
-            Right = right;
-            Bottom = bottom;
+            if (min.X < max.X)
+            {
+                _min.X = min.X;
+                _max.X = max.X;
+            }
+            else
+            {
+                _min.X = max.X;
+                _max.X = min.X;
+            }
+
+            if (min.Y < max.Y)
+            {
+                _min.Y = min.Y;
+                _max.Y = max.Y;
+            }
+            else
+            {
+                _min.Y = max.Y;
+                _max.Y = min.Y;
+            }
         }
 
         /// <summary>
-        /// Creates a new <see cref="Box2i"/> with the specified dimensions.
+        /// Initializes a new instance of the <see cref="Box2i"/> struct.
         /// </summary>
-        /// <param name="top">The position of the top boundary.</param>
-        /// <param name="left">The position of the left boundary.</param>
-        /// <param name="right">The position of the right boundary.</param>
-        /// <param name="bottom">The position of the bottom boundary.</param>
-        /// <returns>A new OpenToolkit.Box2 with the specfied dimensions.</returns>
-        public static Box2i FromTLRB(int top, int left, int right, int bottom)
+        /// <param name="minX">The minimum X value to be enclosed.</param>
+        /// <param name="minY">The minimum Y value to be enclosed.</param>
+        /// <param name="maxX">The maximum X value to be enclosed.</param>
+        /// <param name="maxY">The maximum Y value to be enclosed.</param>
+        public Box2i(int minX, int minY, int maxX, int maxY)
+            : this(new Vector2i(minX, minY), new Vector2i(maxX, maxY))
         {
-            return new Box2i(left, top, right, bottom);
         }
 
         /// <summary>
-        /// Creates a new <see cref="Box2i"/> with the specified dimensions.
+        /// Gets or sets a vector describing the size of the Box2 structure.
         /// </summary>
-        /// <param name="left">The position of the left boundary.</param>
-        /// <param name="top">The position of the top boundary.</param>
-        /// <param name="width">The width of the box.</param>
-        /// <param name="height">The height of the box.</param>
-        /// <returns>A new OpenToolkit.Box2 with the specfied dimensions.</returns>
-        public static Box2i FromDimensions(int left, int top, int width, int height)
+        public Vector2i Size
         {
-            return new Box2i(left, top, left + width, top + height);
+            get => Max - Min;
+            set => Scale(Size - value, new Vector2i((int)Center.X, (int)Center.Y));
         }
 
         /// <summary>
-        /// Creates a new <see cref="Box2i"/> with the specified dimensions.
+        /// Gets or sets a vector describing half the size of the box.
         /// </summary>
-        /// <param name="position">The position of the top left corner.</param>
-        /// <param name="size">The size of the box.</param>
-        /// <returns>A new OpenToolkit.Box2 with the specfied dimensions.</returns>
-        public static Box2i FromDimensions(Vector2i position, Vector2i size)
+        public Vector2i HalfSize
         {
-            return FromDimensions(position.X, position.Y, size.X, size.Y);
+            get => Size / 2;
+            set => Size = value / 2;
         }
 
         /// <summary>
-        /// Gets a float describing the width of the <see cref="Box2i"/> structure.
+        /// Gets a vector describing the center of the box.
         /// </summary>
-        public int Width => MathHelper.Abs(Right - Left);
+        /// to avoid annoying off-by-one errors in box placement, no setter is provided for this property
+        public Vector2 Center
+        {
+            get => (_min + _max).ToVector2() * 0.5f;
+        }
 
         /// <summary>
-        /// Gets a float describing the height of the <see cref="Box2i"/> structure.
-        /// </summary>
-        public int Height => MathHelper.Abs(Bottom - Top);
-
-        /// <summary>
-        /// Returns whether the <see cref="Box2i"/> contains the specified point.
+        /// Returns whether the box contains the specified point (borders inclusive).
         /// </summary>
         /// <param name="point">The point to query.</param>
-        /// <param name="closedRegion">Whether to include the box boundary in the test region.</param>
         /// <returns>Whether this box contains the point.</returns>
-        public bool Contains(Vector2i point, bool closedRegion = true)
+        public bool Contains(Vector2i point)
         {
-            var containsX = closedRegion == Left <= Right
-                ? point.X >= Left != point.X > Right
-                : point.X > Left != point.X >= Right;
-
-            var containsY = closedRegion == Top <= Bottom
-                ? point.Y >= Top != point.Y > Bottom
-                : point.Y > Top != point.Y >= Bottom;
-
-            return containsX && containsY;
+            return _min.X <= point.X && point.X <= _max.X &&
+                   _min.Y <= point.X && point.Y <= _max.Y;
         }
 
         /// <summary>
-        /// Returns a <see cref="Box2i"/> translated by the given amount.
+        /// Returns whether the box contains the specified box (borders inclusive).
         /// </summary>
-        /// <param name="point">The distance to translate the box.</param>
+        /// <param name="other">The box to query.</param>
+        /// <returns>Whether this box contains the other box.</returns>
+        public bool Contains(Box2i other)
+        {
+            return _max.X >= other._min.X && _min.X <= other._max.X &&
+                   _max.Y >= other._min.Y && _min.Y <= other._max.Y;
+        }
+
+        /// <summary>
+        /// Returns the distance between the nearest edge and the specified point.
+        /// </summary>
+        /// <param name="point">The point to find distance for.</param>
+        /// <returns>The distance between the specified point and the nearest edge.</returns>
+        public float DistanceToNearestEdge(Vector2i point)
+        {
+            var distMin = _min - point;
+            var distMax = point - _max;
+            var dist = new Vector2(MathHelper.Min(distMin.X, distMax.X), MathHelper.Min(distMin.Y, distMax.Y));
+            return dist.Length;
+        }
+
+        /// <summary>
+        /// Translates this Box2 by the given amount.
+        /// </summary>
+        /// <param name="distance">The distance to translate the box.</param>
+        public void Translate(Vector2i distance)
+        {
+            Min += distance;
+            Max += distance;
+        }
+
+        /// <summary>
+        /// Returns a Box2 translated by the given amount.
+        /// </summary>
+        /// <param name="distance">The distance to translate the box.</param>
         /// <returns>The translated box.</returns>
-        public Box2 Translated(Vector2i point)
+        public Box2i Translated(Vector2i distance)
         {
-            return new Box2(Left + point.X, Top + point.Y, Right + point.X, Bottom + point.Y);
+            // create a local copy of this box
+            Box2i box = this;
+            box.Translate(distance);
+            return box;
         }
 
         /// <summary>
-        /// Translates this <see cref="Box2i"/> by the given amount.
+        /// Scales this Box2 by the given amount.
         /// </summary>
-        /// <param name="point">The distance to translate the box.</param>
-        public void Translate(Vector2i point)
+        /// <param name="scale">The scale to scale the box.</param>
+        /// <param name="anchor">The anchor to scale the box from.</param>
+        public void Scale(Vector2i scale, Vector2i anchor)
         {
-            Left += point.X;
-            Right += point.X;
-            Top += point.Y;
-            Bottom += point.Y;
+            var newDistMin = (anchor - _min) * scale;
+            _min = new Vector2i(
+                anchor.X + _min.X > anchor.X ? newDistMin.X : -newDistMin.X,
+                anchor.Y + _min.Y > anchor.Y ? newDistMin.Y : -newDistMin.Y);
+
+            var newDistMax = (anchor - _max) * scale;
+            _max = new Vector2i(
+                anchor.X + _max.X > anchor.X ? newDistMax.X : -newDistMax.X,
+                anchor.Y + _min.Y > anchor.Y ? newDistMax.Y : -newDistMax.Y);
+        }
+
+        /// <summary>
+        /// Returns a Box2 scaled by a given amount from an anchor point.
+        /// </summary>
+        /// <param name="scale">The scale to scale the box.</param>
+        /// <param name="anchor">The anchor to scale the box from.</param>
+        /// <returns>The scaled box.</returns>
+        public Box2i Scaled(Vector2i scale, Vector2i anchor)
+        {
+            // create a local copy of this box
+            Box2i box = this;
+            box.Scale(scale, anchor);
+            return box;
+        }
+
+        /// <summary>
+        /// Inflate this Box2 to encapsulate a given point.
+        /// </summary>
+        /// <param name="point">The point to query.</param>
+        public void Inflate(Vector2i point)
+        {
+            var distMin = _min - point;
+            var distMax = point - _max;
+
+            if (distMin.X < distMax.X)
+            {
+                _min.X = point.X;
+            }
+            else
+            {
+                _max.X = point.X;
+            }
+
+            if (distMin.Y < distMax.Y)
+            {
+                _min.Y = point.Y;
+            }
+            else
+            {
+                _max.Y = point.Y;
+            }
+        }
+
+        /// <summary>
+        /// Inflate this Box2 to encapsulate a given point.
+        /// </summary>
+        /// <param name="point">The point to query.</param>
+        /// <returns>The inflated box.</returns>
+        public Box2i Inflated(Vector2i point)
+        {
+            // create a local copy of this box
+            Box2i box = this;
+            box.Inflate(point);
+            return box;
         }
 
         /// <summary>
@@ -162,8 +290,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="right">The right operand.</param>
         public static bool operator ==(Box2i left, Box2i right)
         {
-            return left.Bottom == right.Bottom && left.Top == right.Top &&
-                   left.Left == right.Left && left.Right == right.Right;
+            return left.Min == right.Min && left.Max == right.Max;
         }
 
         /// <summary>
@@ -179,13 +306,17 @@ namespace OpenToolkit.Mathematics
         /// <inheritdoc/>
         public bool Equals(Box2i other)
         {
-            return this == other;
+            return Min.Equals(other.Min) && Max.Equals(other.Max);
         }
 
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            return obj is Box2i box && Equals(box);
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+            return obj is Box2i other && Equals(other);
         }
 
         /// <inheritdoc/>
@@ -193,11 +324,7 @@ namespace OpenToolkit.Mathematics
         {
             unchecked
             {
-                var hashCode = Left.GetHashCode();
-                hashCode = (hashCode * 397) ^ Right.GetHashCode();
-                hashCode = (hashCode * 397) ^ Top.GetHashCode();
-                hashCode = (hashCode * 397) ^ Bottom.GetHashCode();
-                return hashCode;
+                return (Min.GetHashCode() * 397) ^ Max.GetHashCode();
             }
         }
 
@@ -206,7 +333,7 @@ namespace OpenToolkit.Mathematics
         /// <inheritdoc/>
         public override string ToString()
         {
-            return string.Format("({0}{4} {1}) - ({2}{4} {3})", Left, Top, Right, Bottom, ListSeparator);
+            return $"({Min.X}{ListSeparator} {Min.Y}) - ({Max.X}{ListSeparator} {Max.Y})";
         }
     }
 }

--- a/src/OpenToolkit.Mathematics/Geometry/Box2i.cs
+++ b/src/OpenToolkit.Mathematics/Geometry/Box2i.cs
@@ -46,7 +46,7 @@ namespace OpenToolkit.Mathematics
                 }
                 else
                 {
-                    _min.X = value.Y;
+                    _min.Y = value.Y;
                 }
             }
         }
@@ -78,7 +78,7 @@ namespace OpenToolkit.Mathematics
                 }
                 else
                 {
-                    _max.X = value.Y;
+                    _max.Y = value.Y;
                 }
             }
         }

--- a/src/OpenToolkit.Mathematics/Geometry/Box3.cs
+++ b/src/OpenToolkit.Mathematics/Geometry/Box3.cs
@@ -14,161 +14,310 @@ using System.Runtime.InteropServices;
 namespace OpenToolkit.Mathematics
 {
     /// <summary>
-    /// Defines a 3d box.
+    /// Defines a 2d box (rectangle).
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct Box3 : IEquatable<Box3>
     {
-        /// <summary>
-        /// The left boundary of the structure.
-        /// </summary>
-        public float Left;
+        private Vector3 _min;
 
         /// <summary>
-        /// The right boundary of the structure
+        /// Gets or sets the minimum boundary of the structure.
         /// </summary>
-        public float Right;
-
-        /// <summary>
-        /// The top boundary of the structure
-        /// </summary>
-        public float Top;
-
-        /// <summary>
-        /// The bottom boundary of the structure
-        /// </summary>
-        public float Bottom;
-
-        /// <summary>
-        /// The back boundary of the structure
-        /// </summary>
-        public float Back;
-
-        /// <summary>
-        /// The front boundary of the structure
-        /// </summary>
-        public float Front;
-
-        /// <summary>
-        /// Creates a new instance of <see cref="Box3"/> struct.
-        /// </summary>
-        /// <param name="left">The position of the left boundary.</param>
-        /// <param name="top">The position of the top boundary.</param>
-        /// <param name="front">The position of the front boundary.</param>
-        /// <param name="right">The position of the right boundary.</param>
-        /// <param name="bottom">The position of the bottom boundary.</param>
-        /// <param name="back">The position of the back boundary.</param>
-        public Box3(float left, float top, float front, float right, float bottom, float back)
+        public Vector3 Min
         {
-            Left = left;
-            Top = top;
-            Front = front;
-            Right = right;
-            Bottom = bottom;
-            Back = back;
+            get => _min;
+            set
+            {
+                if (value.X > _max.X)
+                {
+                    _min.X = _max.X;
+                    _max.X = value.X;
+                }
+                else
+                {
+                    _min.X = value.X;
+                }
+
+                if (value.Y > _max.Y)
+                {
+                    _min.Y = _max.Y;
+                    _max.Y = value.Y;
+                }
+                else
+                {
+                    _min.Y = value.Y;
+                }
+
+                if (value.Z > _max.Z)
+                {
+                    _min.Z = _max.Z;
+                    _max.Z = value.Z;
+                }
+                else
+                {
+                    _min.Z = value.Z;
+                }
+            }
+        }
+
+        private Vector3 _max;
+
+        /// <summary>
+        /// Gets or sets the maximum boundary of the structure.
+        /// </summary>
+        public Vector3 Max
+        {
+            get => _min;
+            set
+            {
+                if (value.X < _min.X)
+                {
+                    _max.X = _min.X;
+                    _min.X = value.X;
+                }
+                else
+                {
+                    _max.X = value.X;
+                }
+
+                if (value.Y < _min.Y)
+                {
+                    _max.Y = _min.Y;
+                    _min.Y = value.Y;
+                }
+                else
+                {
+                    _max.Y = value.Y;
+                }
+
+                if (value.Z < _min.Z)
+                {
+                    _max.Z = _min.Z;
+                    _min.Z = value.Z;
+                }
+                else
+                {
+                    _max.Z = value.Z;
+                }
+            }
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Box3"/> struct.
         /// </summary>
-        /// <param name="frontTopLeft">An OpenToolkit.Vector3 describing the front-top-left corner of the Box3.</param>
-        /// <param name="backBottomRight">An OpenToolkit.Vector3 describing the back-bottom-right corner of the Box3.</param>
-        public Box3(Vector3 frontTopLeft, Vector3 backBottomRight)
+        /// <param name="min">The minimum point on the XY plane this box encloses.</param>
+        /// <param name="max">The maximum point on the XY plane this box encloses.</param>
+        public Box3(Vector3 min, Vector3 max)
         {
-            Left = frontTopLeft.X;
-            Top = frontTopLeft.Y;
-            Front = frontTopLeft.Z;
-            Right = backBottomRight.X;
-            Bottom = backBottomRight.Y;
-            Back = backBottomRight.Z;
+            if (min.X < max.X)
+            {
+                _min.X = min.X;
+                _max.X = max.X;
+            }
+            else
+            {
+                _min.X = max.X;
+                _max.X = min.X;
+            }
+
+            if (min.Y < max.Y)
+            {
+                _min.Y = min.Y;
+                _max.Y = max.Y;
+            }
+            else
+            {
+                _min.Y = max.Y;
+                _max.Y = min.Y;
+            }
+
+            if (min.Z < max.Z)
+            {
+                _min.Z = min.Z;
+                _max.Z = max.Z;
+            }
+            else
+            {
+                _min.Z = max.Z;
+                _max.Z = min.Z;
+            }
         }
 
         /// <summary>
-        /// Creates a new Box3 with the specified dimensions.
+        /// Initializes a new instance of the <see cref="Box3"/> struct.
         /// </summary>
-        /// <param name="left">The position of the left boundary.</param>
-        /// <param name="top">The position of the top boundary.</param>
-        /// <param name="front">The position of the front boundary.</param>
-        /// <param name="width">The width of the box.</param>
-        /// <param name="height">The height of the box.</param>
-        /// <param name="depth">The depth of the box.</param>
-        /// <returns>A new OpenToolkit.Box3 with the specified dimensions.</returns>
-        public static Box3 FromDimensions(float left, float top, float front, float width, float height, float depth)
+        /// <param name="minX">The minimum X value to be enclosed.</param>
+        /// <param name="minY">The minimum Y value to be enclosed.</param>
+        /// <param name="minZ">The minimum Z value to be enclosed.</param>
+        /// <param name="maxX">The maximum X value to be enclosed.</param>
+        /// <param name="maxY">The maximum Y value to be enclosed.</param>
+        /// <param name="maxZ">The maximum Z value to be enclosed.</param>
+        public Box3(float minX, float minY, float minZ, float maxX, float maxY, float maxZ)
+            : this(new Vector3(minX, minY, minZ), new Vector3(maxX, maxY, maxZ))
         {
-            return new Box3(left, top, front, left + width, top + height, front + depth);
         }
 
         /// <summary>
-        /// Creates a new box3 with the specified dimensions.
+        /// Gets or sets a vector describing the size of the Box2 structure.
         /// </summary>
-        /// <param name="position">The position of the front top left corner.</param>
-        /// <param name="size">The size of the box.</param>
-        /// <returns>A new OpenToolkit.Box3 with the specified dimensions</returns>
-        public static Box3 FromDimensions(Vector3 position, Vector3 size)
+        public Vector3 Size
         {
-            return FromDimensions(position.X, position.Y, position.Z, size.X, size.Y, size.Z);
+            get => Max - Min;
+            set => Scale(Size - value, Center);
         }
 
         /// <summary>
-        /// Gets a float describing the width of the Box3 structure.
+        /// Gets or sets a vector describing half the size of the box.
         /// </summary>
-        public float Width => Math.Abs(Right - Left);
+        public Vector3 HalfSize
+        {
+            get => Size / 2;
+            set => Size = value / 2;
+        }
 
         /// <summary>
-        /// Gets a float describing the height of the Box3 structure.
+        /// Gets or sets a vector describing the center of the box.
         /// </summary>
-        public float Height => Math.Abs(Bottom - Top);
+        public Vector3 Center
+        {
+            get => (_min + _max) * 0.5f;
+            set => Translate(Center - value);
+        }
 
         /// <summary>
-        /// Gets a float describing the depth of the box3 structure.
-        /// </summary>
-        public float Depth => Math.Abs(Back - Front);
-        
-        /// <summary>
-        /// Returns whether the box contains the specified point.
+        /// Returns whether the box contains the specified point (borders inclusive).
         /// </summary>
         /// <param name="point">The point to query.</param>
-        /// <param name="closedRegion">Whether to include the box boundary in the test region.</param>
         /// <returns>Whether this box contains the point.</returns>
-        public bool Contains(Vector3 point, bool closedRegion = true)
+        public bool Contains(Vector3 point)
         {
-            var containsX = closedRegion == Left <= Right
-                ? point.X >= Left != point.X > Right
-                : point.X > Left != point.X >= Right;
-
-            var containsY = closedRegion == Top <= Bottom
-                ? point.Y >= Top != point.Y > Bottom
-                : point.Y > Top != point.Y >= Bottom;
-
-            var containsZ = closedRegion == Front <= Back
-                ? point.Z >= Front != point.Z > Back
-                : point.Z > Front != point.Z >= Back;
-
-            return containsX && containsY && containsZ;
+            return _min.X <= point.X && point.X <= _max.X &&
+                   _min.Y <= point.Z && point.Y <= _max.Y &&
+                   _min.Z <= point.Z && point.Z <= _max.Z;
         }
 
         /// <summary>
-        /// Returns a Box3 translated by the given amount.
+        /// Returns whether the box contains the specified box (borders inclusive).
         /// </summary>
-        /// <param name="point">The distance to translate the box.</param>
+        /// <param name="other">The box to query.</param>
+        /// <returns>Whether this box contains the other box.</returns>
+        public bool Contains(Box3 other)
+        {
+            return _max.X >= other._min.X && _min.X <= other._max.X &&
+                   _max.Y >= other._min.Y && _min.Y <= other._max.Y &&
+                   _max.Z >= other._min.Z && _min.Z <= other._max.Z;
+        }
+
+        /// <summary>
+        /// Returns the distance between the nearest edge and the specified point.
+        /// </summary>
+        /// <param name="point">The point to find distance for.</param>
+        /// <returns>The distance between the specified point and the nearest edge.</returns>
+        public float DistanceToNearestEdge(Vector3 point)
+        {
+            var distMin = _min - point;
+            var distMax = point - _max;
+            var dist = new Vector2(MathHelper.Min(distMin.X, distMax.X), MathHelper.Min(distMin.Y, distMax.Y));
+            return dist.Length;
+        }
+
+        /// <summary>
+        /// Translates this Box2 by the given amount.
+        /// </summary>
+        /// <param name="distance">The distance to translate the box.</param>
+        public void Translate(Vector3 distance)
+        {
+            Min += distance;
+            Max += distance;
+        }
+
+        /// <summary>
+        /// Returns a Box2 translated by the given amount.
+        /// </summary>
+        /// <param name="distance">The distance to translate the box.</param>
         /// <returns>The translated box.</returns>
-        public Box3 Translated(Vector3 point)
+        public Box3 Translated(Vector3 distance)
         {
-            return new Box3(Left + point.X, Top + point.Y,Front + point.Z , Right + point.X, Bottom + point.Y, Front + point.Z);
+            // create a local copy of this box
+            Box3 box = this;
+            box.Translate(distance);
+            return box;
         }
 
         /// <summary>
-        /// Translates this Box3 by the given amount.
+        /// Scales this Box2 by the given amount.
         /// </summary>
-        /// <param name="point">The distance to translate the box.</param>
-        public void Translate(Vector3 point)
+        /// <param name="scale">The scale to scale the box.</param>
+        /// <param name="anchor">The anchor to scale the box from.</param>
+        public void Scale(Vector3 scale, Vector3 anchor)
         {
-            Left += point.X;
-            Right += point.X;
-            Top += point.Y;
-            Bottom += point.Y;
-            Front += point.Z;
-            Back += point.Z;
+            var newDistMin = (anchor - _min) * scale;
+            _min = new Vector3(
+                anchor.X + _min.X > anchor.X ? newDistMin.X : -newDistMin.X,
+                anchor.Y + _min.Y > anchor.Y ? newDistMin.Y : -newDistMin.Y,
+                anchor.Z + _min.Z > anchor.Z ? newDistMin.Z : -newDistMin.Z);
+
+            var newDistMax = (anchor - _max) * scale;
+            _max = new Vector3(
+                anchor.X + _max.X > anchor.X ? newDistMax.X : -newDistMax.X,
+                anchor.Y + _min.Y > anchor.Y ? newDistMax.Y : -newDistMax.Y,
+                anchor.Z + _min.Z > anchor.Z ? newDistMax.Z : -newDistMax.Z);
+        }
+
+        /// <summary>
+        /// Returns a Box2 scaled by a given amount from an anchor point.
+        /// </summary>
+        /// <param name="scale">The scale to scale the box.</param>
+        /// <param name="anchor">The anchor to scale the box from.</param>
+        /// <returns>The scaled box.</returns>
+        public Box3 Scaled(Vector3 scale, Vector3 anchor)
+        {
+            // create a local copy of this box
+            Box3 box = this;
+            box.Scale(scale, anchor);
+            return box;
+        }
+
+        /// <summary>
+        /// Inflate this Box2 to encapsulate a given point.
+        /// </summary>
+        /// <param name="point">The point to query.</param>
+        public void Inflate(Vector3 point)
+        {
+            var distMin = _min - point;
+            var distMax = point - _max;
+
+            if (distMin.X < distMax.X)
+            {
+                _min.X = point.X;
+            }
+            else
+            {
+                _max.X = point.X;
+            }
+
+            if (distMin.Y < distMax.Y)
+            {
+                _min.Y = point.Y;
+            }
+            else
+            {
+                _max.Y = point.Y;
+            }
+        }
+
+        /// <summary>
+        /// Inflate this Box2 to encapsulate a given point.
+        /// </summary>
+        /// <param name="point">The point to query.</param>
+        /// <returns>The inflated box.</returns>
+        public Box3 Inflated(Vector3 point)
+        {
+            // create a local copy of this box
+            Box3 box = this;
+            box.Inflate(point);
+            return box;
         }
 
         /// <summary>
@@ -178,12 +327,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="right">The right operand.</param>
         public static bool operator ==(Box3 left, Box3 right)
         {
-            return MathHelper.ApproximatelyEqualEpsilon(left.Bottom, right.Bottom, 0.0001f)
-                   && MathHelper.ApproximatelyEqualEpsilon(left.Top, right.Top, 0.0001f)
-                   && MathHelper.ApproximatelyEqualEpsilon(left.Left, right.Left, 0.0001f)
-                   && MathHelper.ApproximatelyEqualEpsilon(left.Right, right.Right, 0.0001f)
-                   && MathHelper.ApproximatelyEqualEpsilon(left.Front, right.Front, 0.0001f)
-                   && MathHelper.ApproximatelyEqualEpsilon(left.Back, right.Back, 0.0001f);
+            return left.Min == right.Min && left.Max == right.Max;
         }
 
         /// <summary>
@@ -199,27 +343,25 @@ namespace OpenToolkit.Mathematics
         /// <inheritdoc/>
         public bool Equals(Box3 other)
         {
-            return this == other;
+            return Min.Equals(other.Min) && Max.Equals(other.Max);
         }
 
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            return obj is Box3 && Equals(obj);
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+            return obj is Box3 other && Equals(other);
         }
-        
+
         /// <inheritdoc/>
         public override int GetHashCode()
         {
             unchecked
             {
-                var hashCode = Left.GetHashCode();
-                hashCode = (hashCode * 397) ^ Right.GetHashCode();
-                hashCode = (hashCode * 397) ^ Top.GetHashCode();
-                hashCode = (hashCode * 397) ^ Bottom.GetHashCode();
-                hashCode = (hashCode * 397) ^ Front.GetHashCode();
-                hashCode = (hashCode * 397) ^ Back.GetHashCode();
-                return hashCode;
+                return (Min.GetHashCode() * 397) ^ Max.GetHashCode();
             }
         }
 
@@ -228,7 +370,7 @@ namespace OpenToolkit.Mathematics
         /// <inheritdoc/>
         public override string ToString()
         {
-            return string.Format("({0}{6} {1}{6} {2}) - ({3}{6} {4}{6} {5})", Left, Top, Front, Right, Bottom, Back, ListSeparator);
+            return $"({Min.X}{ListSeparator} {Min.Y}) - ({Max.X}{ListSeparator} {Max.Y})";
         }
     }
 }

--- a/src/OpenToolkit.Mathematics/Geometry/Box3.cs
+++ b/src/OpenToolkit.Mathematics/Geometry/Box3.cs
@@ -14,7 +14,7 @@ using System.Runtime.InteropServices;
 namespace OpenToolkit.Mathematics
 {
     /// <summary>
-    /// Defines a 2d box (rectangle).
+    /// Defines an axis-aligned 2d box (rectangle).
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct Box3 : IEquatable<Box3>

--- a/src/OpenToolkit.Mathematics/Geometry/Box3d.cs
+++ b/src/OpenToolkit.Mathematics/Geometry/Box3d.cs
@@ -14,161 +14,310 @@ using System.Runtime.InteropServices;
 namespace OpenToolkit.Mathematics
 {
     /// <summary>
-    /// Defines a 3d box.
+    /// Defines a 2d box (rectangle).
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct Box3d : IEquatable<Box3d>
     {
-        /// <summary>
-        /// The left boundary of the structure.
-        /// </summary>
-        public double Left;
+        private Vector3d _min;
 
         /// <summary>
-        /// The right boundary of the structure
+        /// Gets or sets the minimum boundary of the structure.
         /// </summary>
-        public double Right;
-
-        /// <summary>
-        /// The top boundary of the structure
-        /// </summary>
-        public double Top;
-
-        /// <summary>
-        /// The bottom boundary of the structure
-        /// </summary>
-        public double Bottom;
-
-        /// <summary>
-        /// The back boundary of the structure
-        /// </summary>
-        public double Back;
-
-        /// <summary>
-        /// The front boundary of the structure
-        /// </summary>
-        public double Front;
-
-        /// <summary>
-        /// Creates a new instance of <see cref="Box3d"/> struct.
-        /// </summary>
-        /// <param name="left">The position of the left boundary.</param>
-        /// <param name="top">The position of the top boundary.</param>
-        /// <param name="front">The position of the front boundary.</param>
-        /// <param name="right">The position of the right boundary.</param>
-        /// <param name="bottom">The position of the bottom boundary.</param>
-        /// <param name="back">The position of the back boundary.</param>
-        public Box3d(double left, double top, double front, double right, double bottom, double back)
+        public Vector3d Min
         {
-            Left = left;
-            Top = top;
-            Front = front;
-            Right = right;
-            Bottom = bottom;
-            Back = back;
+            get => _min;
+            set
+            {
+                if (value.X > _max.X)
+                {
+                    _min.X = _max.X;
+                    _max.X = value.X;
+                }
+                else
+                {
+                    _min.X = value.X;
+                }
+
+                if (value.Y > _max.Y)
+                {
+                    _min.Y = _max.Y;
+                    _max.Y = value.Y;
+                }
+                else
+                {
+                    _min.Y = value.Y;
+                }
+
+                if (value.Z > _max.Z)
+                {
+                    _min.Z = _max.Z;
+                    _max.Z = value.Z;
+                }
+                else
+                {
+                    _min.Z = value.Z;
+                }
+            }
+        }
+
+        private Vector3d _max;
+
+        /// <summary>
+        /// Gets or sets the maximum boundary of the structure.
+        /// </summary>
+        public Vector3d Max
+        {
+            get => _min;
+            set
+            {
+                if (value.X < _min.X)
+                {
+                    _max.X = _min.X;
+                    _min.X = value.X;
+                }
+                else
+                {
+                    _max.X = value.X;
+                }
+
+                if (value.Y < _min.Y)
+                {
+                    _max.Y = _min.Y;
+                    _min.Y = value.Y;
+                }
+                else
+                {
+                    _max.Y = value.Y;
+                }
+
+                if (value.Z < _min.Z)
+                {
+                    _max.Z = _min.Z;
+                    _min.Z = value.Z;
+                }
+                else
+                {
+                    _max.Z = value.Z;
+                }
+            }
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Box3d"/> struct.
         /// </summary>
-        /// <param name="frontTopLeft">An OpenToolkit.Vector3d describing the front-top-left corner of the Box3d.</param>
-        /// <param name="backBottomRight">An OpenToolkit.Vector3d describing the back-bottom-right corner of the Box3d.</param>
-        public Box3d(Vector3d frontTopLeft, Vector3d backBottomRight)
+        /// <param name="min">The minimum point on the XY plane this box encloses.</param>
+        /// <param name="max">The maximum point on the XY plane this box encloses.</param>
+        public Box3d(Vector3d min, Vector3d max)
         {
-            Left = frontTopLeft.X;
-            Top = frontTopLeft.Y;
-            Front = frontTopLeft.Z;
-            Right = backBottomRight.X;
-            Bottom = backBottomRight.Y;
-            Back = backBottomRight.Z;
+            if (min.X < max.X)
+            {
+                _min.X = min.X;
+                _max.X = max.X;
+            }
+            else
+            {
+                _min.X = max.X;
+                _max.X = min.X;
+            }
+
+            if (min.Y < max.Y)
+            {
+                _min.Y = min.Y;
+                _max.Y = max.Y;
+            }
+            else
+            {
+                _min.Y = max.Y;
+                _max.Y = min.Y;
+            }
+
+            if (min.Z < max.Z)
+            {
+                _min.Z = min.Z;
+                _max.Z = max.Z;
+            }
+            else
+            {
+                _min.Z = max.Z;
+                _max.Z = min.Z;
+            }
         }
 
         /// <summary>
-        /// Creates a new Box3d with the specified dimensions.
+        /// Initializes a new instance of the <see cref="Box3d"/> struct.
         /// </summary>
-        /// <param name="left">The position of the left boundary.</param>
-        /// <param name="top">The position of the top boundary.</param>
-        /// <param name="front">The position of the front boundary.</param>
-        /// <param name="width">The width of the box.</param>
-        /// <param name="height">The height of the box.</param>
-        /// <param name="depth">The depth of the box.</param>
-        /// <returns>A new OpenToolkit.Box3d with the specified dimensions.</returns>
-        public static Box3d FromDimensions(double left, double top, double front, double width, double height, double depth)
+        /// <param name="minX">The minimum X value to be enclosed.</param>
+        /// <param name="minY">The minimum Y value to be enclosed.</param>
+        /// <param name="minZ">The minimum Z value to be enclosed.</param>
+        /// <param name="maxX">The maximum X value to be enclosed.</param>
+        /// <param name="maxY">The maximum Y value to be enclosed.</param>
+        /// <param name="maxZ">The maximum Z value to be enclosed.</param>
+        public Box3d(double minX, double minY, double minZ, double maxX, double maxY, double maxZ)
+            : this(new Vector3d(minX, minY, minZ), new Vector3d(maxX, maxY, maxZ))
         {
-            return new Box3d(left, top, front, left + width, top + height, front + depth);
         }
 
         /// <summary>
-        /// Creates a new Box3d with the specified dimensions.
+        /// Gets or sets a vector describing the size of the Box2 structure.
         /// </summary>
-        /// <param name="position">The position of the front top left corner.</param>
-        /// <param name="size">The size of the box.</param>
-        /// <returns>A new OpenToolkit.Box3d with the specified dimensions</returns>
-        public static Box3d FromDimensions(Vector3d position, Vector3d size)
+        public Vector3d Size
         {
-            return FromDimensions(position.X, position.Y, position.Z, size.X, size.Y, size.Z);
+            get => Max - Min;
+            set => Scale(Size - value, Center);
         }
 
         /// <summary>
-        /// Gets a double describing the width of the Box3d structure.
+        /// Gets or sets a vector describing half the size of the box.
         /// </summary>
-        public double Width => Math.Abs(Right - Left);
+        public Vector3d HalfSize
+        {
+            get => Size / 2;
+            set => Size = value / 2;
+        }
 
         /// <summary>
-        /// Gets a double describing the height of the Box3d structure.
+        /// Gets or sets a vector describing the center of the box.
         /// </summary>
-        public double Height => Math.Abs(Bottom - Top);
+        public Vector3d Center
+        {
+            get => (_min + _max) * 0.5f;
+            set => Translate(Center - value);
+        }
 
         /// <summary>
-        /// Gets a double describing the depth of the box3d structure.
-        /// </summary>
-        public double Depth => Math.Abs(Back - Front);
-        
-        /// <summary>
-        /// Returns whether the box contains the specified point.
+        /// Returns whether the box contains the specified point (borders inclusive).
         /// </summary>
         /// <param name="point">The point to query.</param>
-        /// <param name="closedRegion">Whether to include the box boundary in the test region.</param>
         /// <returns>Whether this box contains the point.</returns>
-        public bool Contains(Vector3d point, bool closedRegion = true)
+        public bool Contains(Vector3d point)
         {
-            var containsX = closedRegion == Left <= Right
-                ? point.X >= Left != point.X > Right
-                : point.X > Left != point.X >= Right;
-
-            var containsY = closedRegion == Top <= Bottom
-                ? point.Y >= Top != point.Y > Bottom
-                : point.Y > Top != point.Y >= Bottom;
-
-            var containsZ = closedRegion == Front <= Back
-                ? point.Z >= Front != point.Z > Back
-                : point.Z > Front != point.Z >= Back;
-
-            return containsX && containsY && containsZ;
+            return _min.X <= point.X && point.X <= _max.X &&
+                   _min.Y <= point.Z && point.Y <= _max.Y &&
+                   _min.Z <= point.Z && point.Z <= _max.Z;
         }
 
         /// <summary>
-        /// Returns a Box3d translated by the given amount.
+        /// Returns whether the box contains the specified box (borders inclusive).
         /// </summary>
-        /// <param name="point">The distance to translate the box.</param>
+        /// <param name="other">The box to query.</param>
+        /// <returns>Whether this box contains the other box.</returns>
+        public bool Contains(Box3d other)
+        {
+            return _max.X >= other._min.X && _min.X <= other._max.X &&
+                   _max.Y >= other._min.Y && _min.Y <= other._max.Y &&
+                   _max.Z >= other._min.Z && _min.Z <= other._max.Z;
+        }
+
+        /// <summary>
+        /// Returns the distance between the nearest edge and the specified point.
+        /// </summary>
+        /// <param name="point">The point to find distance for.</param>
+        /// <returns>The distance between the specified point and the nearest edge.</returns>
+        public double DistanceToNearestEdge(Vector3d point)
+        {
+            var distMin = _min - point;
+            var distMax = point - _max;
+            var dist = new Vector2d(MathHelper.Min(distMin.X, distMax.X), MathHelper.Min(distMin.Y, distMax.Y));
+            return dist.Length;
+        }
+
+        /// <summary>
+        /// Translates this Box2 by the given amount.
+        /// </summary>
+        /// <param name="distance">The distance to translate the box.</param>
+        public void Translate(Vector3d distance)
+        {
+            Min += distance;
+            Max += distance;
+        }
+
+        /// <summary>
+        /// Returns a Box2 translated by the given amount.
+        /// </summary>
+        /// <param name="distance">The distance to translate the box.</param>
         /// <returns>The translated box.</returns>
-        public Box3d Translated(Vector3d point)
+        public Box3d Translated(Vector3d distance)
         {
-            return new Box3d(Left + point.X, Top + point.Y,Front + point.Z , Right + point.X, Bottom + point.Y, Front + point.Z);
+            // create a local copy of this box
+            Box3d box = this;
+            box.Translate(distance);
+            return box;
         }
 
         /// <summary>
-        /// Translates this Box3d by the given amount.
+        /// Scales this Box2 by the given amount.
         /// </summary>
-        /// <param name="point">The distance to translate the box.</param>
-        public void Translate(Vector3d point)
+        /// <param name="scale">The scale to scale the box.</param>
+        /// <param name="anchor">The anchor to scale the box from.</param>
+        public void Scale(Vector3d scale, Vector3d anchor)
         {
-            Left += point.X;
-            Right += point.X;
-            Top += point.Y;
-            Bottom += point.Y;
-            Front += point.Z;
-            Back += point.Z;
+            var newDistMin = (anchor - _min) * scale;
+            _min = new Vector3d(
+                anchor.X + _min.X > anchor.X ? newDistMin.X : -newDistMin.X,
+                anchor.Y + _min.Y > anchor.Y ? newDistMin.Y : -newDistMin.Y,
+                anchor.Z + _min.Z > anchor.Z ? newDistMin.Z : -newDistMin.Z);
+
+            var newDistMax = (anchor - _max) * scale;
+            _max = new Vector3d(
+                anchor.X + _max.X > anchor.X ? newDistMax.X : -newDistMax.X,
+                anchor.Y + _min.Y > anchor.Y ? newDistMax.Y : -newDistMax.Y,
+                anchor.Z + _min.Z > anchor.Z ? newDistMax.Z : -newDistMax.Z);
+        }
+
+        /// <summary>
+        /// Returns a Box2 scaled by a given amount from an anchor point.
+        /// </summary>
+        /// <param name="scale">The scale to scale the box.</param>
+        /// <param name="anchor">The anchor to scale the box from.</param>
+        /// <returns>The scaled box.</returns>
+        public Box3d Scaled(Vector3d scale, Vector3d anchor)
+        {
+            // create a local copy of this box
+            Box3d box = this;
+            box.Scale(scale, anchor);
+            return box;
+        }
+
+        /// <summary>
+        /// Inflate this Box2 to encapsulate a given point.
+        /// </summary>
+        /// <param name="point">The point to query.</param>
+        public void Inflate(Vector3d point)
+        {
+            var distMin = _min - point;
+            var distMax = point - _max;
+
+            if (distMin.X < distMax.X)
+            {
+                _min.X = point.X;
+            }
+            else
+            {
+                _max.X = point.X;
+            }
+
+            if (distMin.Y < distMax.Y)
+            {
+                _min.Y = point.Y;
+            }
+            else
+            {
+                _max.Y = point.Y;
+            }
+        }
+
+        /// <summary>
+        /// Inflate this Box2 to encapsulate a given point.
+        /// </summary>
+        /// <param name="point">The point to query.</param>
+        /// <returns>The inflated box.</returns>
+        public Box3d Inflated(Vector3d point)
+        {
+            // create a local copy of this box
+            Box3d box = this;
+            box.Inflate(point);
+            return box;
         }
 
         /// <summary>
@@ -178,12 +327,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="right">The right operand.</param>
         public static bool operator ==(Box3d left, Box3d right)
         {
-            return MathHelper.ApproximatelyEqualEpsilon(left.Bottom, right.Bottom, 0.0001f)
-                   && MathHelper.ApproximatelyEqualEpsilon(left.Top, right.Top, 0.0001f)
-                   && MathHelper.ApproximatelyEqualEpsilon(left.Left, right.Left, 0.0001f)
-                   && MathHelper.ApproximatelyEqualEpsilon(left.Right, right.Right, 0.0001f)
-                   && MathHelper.ApproximatelyEqualEpsilon(left.Front, right.Front, 0.0001f)
-                   && MathHelper.ApproximatelyEqualEpsilon(left.Back, right.Back, 0.0001f);
+            return left.Min == right.Min && left.Max == right.Max;
         }
 
         /// <summary>
@@ -199,27 +343,25 @@ namespace OpenToolkit.Mathematics
         /// <inheritdoc/>
         public bool Equals(Box3d other)
         {
-            return this == other;
+            return Min.Equals(other.Min) && Max.Equals(other.Max);
         }
 
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            return obj is Box3d && Equals(obj);
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+            return obj is Box3d other && Equals(other);
         }
-        
+
         /// <inheritdoc/>
         public override int GetHashCode()
         {
             unchecked
             {
-                var hashCode = Left.GetHashCode();
-                hashCode = (hashCode * 397) ^ Right.GetHashCode();
-                hashCode = (hashCode * 397) ^ Top.GetHashCode();
-                hashCode = (hashCode * 397) ^ Bottom.GetHashCode();
-                hashCode = (hashCode * 397) ^ Front.GetHashCode();
-                hashCode = (hashCode * 397) ^ Back.GetHashCode();
-                return hashCode;
+                return (Min.GetHashCode() * 397) ^ Max.GetHashCode();
             }
         }
 
@@ -228,7 +370,7 @@ namespace OpenToolkit.Mathematics
         /// <inheritdoc/>
         public override string ToString()
         {
-            return string.Format("({0}{6} {1}{6} {2}) - ({3}{6} {4}{6} {5})", Left, Top, Front, Right, Bottom, Back, ListSeparator);
+            return $"({Min.X}{ListSeparator} {Min.Y}) - ({Max.X}{ListSeparator} {Max.Y})";
         }
     }
 }

--- a/src/OpenToolkit.Mathematics/Geometry/Box3d.cs
+++ b/src/OpenToolkit.Mathematics/Geometry/Box3d.cs
@@ -14,7 +14,7 @@ using System.Runtime.InteropServices;
 namespace OpenToolkit.Mathematics
 {
     /// <summary>
-    /// Defines a 2d box (rectangle).
+    /// Defines an axis-aligned 2d box (rectangle).
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct Box3d : IEquatable<Box3d>

--- a/src/OpenToolkit.Mathematics/Geometry/Box3d.cs
+++ b/src/OpenToolkit.Mathematics/Geometry/Box3d.cs
@@ -71,9 +71,9 @@ namespace OpenToolkit.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Box3d"/> struct.
         /// </summary>
-        /// <param name="frontTopLeft">An OpenToolkit.Vector3 describing the front-top-left corner of the Box3d.</param>
-        /// <param name="backBottomRight">An OpenToolkit.Vector3 describing the back-bottom-right corner of the Box3d.</param>
-        public Box3d(Vector3 frontTopLeft, Vector3 backBottomRight)
+        /// <param name="frontTopLeft">An OpenToolkit.Vector3d describing the front-top-left corner of the Box3d.</param>
+        /// <param name="backBottomRight">An OpenToolkit.Vector3d describing the back-bottom-right corner of the Box3d.</param>
+        public Box3d(Vector3d frontTopLeft, Vector3d backBottomRight)
         {
             Left = frontTopLeft.X;
             Top = frontTopLeft.Y;
@@ -104,7 +104,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="position">The position of the front top left corner.</param>
         /// <param name="size">The size of the box.</param>
         /// <returns>A new OpenToolkit.Box3d with the specified dimensions</returns>
-        public static Box3d FromDimensions(Vector3 position, Vector3 size)
+        public static Box3d FromDimensions(Vector3d position, Vector3d size)
         {
             return FromDimensions(position.X, position.Y, position.Z, size.X, size.Y, size.Z);
         }
@@ -120,7 +120,7 @@ namespace OpenToolkit.Mathematics
         public double Height => Math.Abs(Bottom - Top);
 
         /// <summary>
-        /// Gets a double describing the depth of the box3 structure.
+        /// Gets a double describing the depth of the box3d structure.
         /// </summary>
         public double Depth => Math.Abs(Back - Front);
         
@@ -130,7 +130,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="point">The point to query.</param>
         /// <param name="closedRegion">Whether to include the box boundary in the test region.</param>
         /// <returns>Whether this box contains the point.</returns>
-        public bool Contains(Vector3 point, bool closedRegion = true)
+        public bool Contains(Vector3d point, bool closedRegion = true)
         {
             var containsX = closedRegion == Left <= Right
                 ? point.X >= Left != point.X > Right
@@ -152,7 +152,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="point">The distance to translate the box.</param>
         /// <returns>The translated box.</returns>
-        public Box3d Translated(Vector3 point)
+        public Box3d Translated(Vector3d point)
         {
             return new Box3d(Left + point.X, Top + point.Y,Front + point.Z , Right + point.X, Bottom + point.Y, Front + point.Z);
         }
@@ -161,7 +161,7 @@ namespace OpenToolkit.Mathematics
         /// Translates this Box3d by the given amount.
         /// </summary>
         /// <param name="point">The distance to translate the box.</param>
-        public void Translate(Vector3 point)
+        public void Translate(Vector3d point)
         {
             Left += point.X;
             Right += point.X;

--- a/src/OpenToolkit.Mathematics/Geometry/Box3i.cs
+++ b/src/OpenToolkit.Mathematics/Geometry/Box3i.cs
@@ -14,7 +14,7 @@ using System.Runtime.InteropServices;
 namespace OpenToolkit.Mathematics
 {
     /// <summary>
-    /// Defines a 2d box (rectangle).
+    /// Defines an axis-aligned 2d box (rectangle).
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct Box3i : IEquatable<Box3i>

--- a/src/OpenToolkit.Mathematics/Geometry/Box3i.cs
+++ b/src/OpenToolkit.Mathematics/Geometry/Box3i.cs
@@ -14,161 +14,310 @@ using System.Runtime.InteropServices;
 namespace OpenToolkit.Mathematics
 {
     /// <summary>
-    /// Defines a 3d box.
+    /// Defines a 2d box (rectangle).
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct Box3i : IEquatable<Box3i>
     {
-        /// <summary>
-        /// The left boundary of the structure.
-        /// </summary>
-        public int Left;
+        private Vector3i _min;
 
         /// <summary>
-        /// The right boundary of the structure
+        /// Gets or sets the minimum boundary of the structure.
         /// </summary>
-        public int Right;
-
-        /// <summary>
-        /// The top boundary of the structure
-        /// </summary>
-        public int Top;
-
-        /// <summary>
-        /// The bottom boundary of the structure
-        /// </summary>
-        public int Bottom;
-
-        /// <summary>
-        /// The back boundary of the structure
-        /// </summary>
-        public int Back;
-
-        /// <summary>
-        /// The front boundary of the structure
-        /// </summary>
-        public int Front;
-
-        /// <summary>
-        /// Creates a new instance of <see cref="Box3i"/> struct.
-        /// </summary>
-        /// <param name="left">The position of the left boundary.</param>
-        /// <param name="top">The position of the top boundary.</param>
-        /// <param name="front">The position of the front boundary.</param>
-        /// <param name="right">The position of the right boundary.</param>
-        /// <param name="bottom">The position of the bottom boundary.</param>
-        /// <param name="back">The position of the back boundary.</param>
-        public Box3i(int left, int top, int front, int right, int bottom, int back)
+        public Vector3i Min
         {
-            Left = left;
-            Top = top;
-            Front = front;
-            Right = right;
-            Bottom = bottom;
-            Back = back;
+            get => _min;
+            set
+            {
+                if (value.X > _max.X)
+                {
+                    _min.X = _max.X;
+                    _max.X = value.X;
+                }
+                else
+                {
+                    _min.X = value.X;
+                }
+
+                if (value.Y > _max.Y)
+                {
+                    _min.Y = _max.Y;
+                    _max.Y = value.Y;
+                }
+                else
+                {
+                    _min.Y = value.Y;
+                }
+
+                if (value.Z > _max.Z)
+                {
+                    _min.Z = _max.Z;
+                    _max.Z = value.Z;
+                }
+                else
+                {
+                    _min.Z = value.Z;
+                }
+            }
+        }
+
+        private Vector3i _max;
+
+        /// <summary>
+        /// Gets or sets the maximum boundary of the structure.
+        /// </summary>
+        public Vector3i Max
+        {
+            get => _min;
+            set
+            {
+                if (value.X < _min.X)
+                {
+                    _max.X = _min.X;
+                    _min.X = value.X;
+                }
+                else
+                {
+                    _max.X = value.X;
+                }
+
+                if (value.Y < _min.Y)
+                {
+                    _max.Y = _min.Y;
+                    _min.Y = value.Y;
+                }
+                else
+                {
+                    _max.Y = value.Y;
+                }
+
+                if (value.Z < _min.Z)
+                {
+                    _max.Z = _min.Z;
+                    _min.Z = value.Z;
+                }
+                else
+                {
+                    _max.Z = value.Z;
+                }
+            }
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Box3i"/> struct.
         /// </summary>
-        /// <param name="frontTopLeft">An OpenToolkit.Vector3i describing the front-top-left corner of the Box3i.</param>
-        /// <param name="backBottomRight">An OpenToolkit.Vector3i describing the back-bottom-right corner of the Box3i.</param>
-        public Box3i(Vector3i frontTopLeft, Vector3i backBottomRight)
+        /// <param name="min">The minimum point on the XY plane this box encloses.</param>
+        /// <param name="max">The maximum point on the XY plane this box encloses.</param>
+        public Box3i(Vector3i min, Vector3i max)
         {
-            Left = frontTopLeft.X;
-            Top = frontTopLeft.Y;
-            Front = frontTopLeft.Z;
-            Right = backBottomRight.X;
-            Bottom = backBottomRight.Y;
-            Back = backBottomRight.Z;
+            if (min.X < max.X)
+            {
+                _min.X = min.X;
+                _max.X = max.X;
+            }
+            else
+            {
+                _min.X = max.X;
+                _max.X = min.X;
+            }
+
+            if (min.Y < max.Y)
+            {
+                _min.Y = min.Y;
+                _max.Y = max.Y;
+            }
+            else
+            {
+                _min.Y = max.Y;
+                _max.Y = min.Y;
+            }
+
+            if (min.Z < max.Z)
+            {
+                _min.Z = min.Z;
+                _max.Z = max.Z;
+            }
+            else
+            {
+                _min.Z = max.Z;
+                _max.Z = min.Z;
+            }
         }
 
         /// <summary>
-        /// Creates a new Box3i with the specified dimensions.
+        /// Initializes a new instance of the <see cref="Box3i"/> struct.
         /// </summary>
-        /// <param name="left">The position of the left boundary.</param>
-        /// <param name="top">The position of the top boundary.</param>
-        /// <param name="front">The position of the front boundary.</param>
-        /// <param name="width">The width of the box.</param>
-        /// <param name="height">The height of the box.</param>
-        /// <param name="depth">The depth of the box.</param>
-        /// <returns>A new OpenToolkit.Box3i with the specified dimensions.</returns>
-        public static Box3i FromDimensions(int left, int top, int front, int width, int height, int depth)
+        /// <param name="minX">The minimum X value to be enclosed.</param>
+        /// <param name="minY">The minimum Y value to be enclosed.</param>
+        /// <param name="minZ">The minimum Z value to be enclosed.</param>
+        /// <param name="maxX">The maximum X value to be enclosed.</param>
+        /// <param name="maxY">The maximum Y value to be enclosed.</param>
+        /// <param name="maxZ">The maximum Z value to be enclosed.</param>
+        public Box3i(int minX, int minY, int minZ, int maxX, int maxY, int maxZ)
+            : this(new Vector3i(minX, minY, minZ), new Vector3i(maxX, maxY, maxZ))
         {
-            return new Box3i(left, top, front, left + width, top + height, front + depth);
         }
 
         /// <summary>
-        /// Creates a new Box3d with the specified dimensions.
+        /// Gets or sets a vector describing the size of the Box2 structure.
         /// </summary>
-        /// <param name="position">The position of the front top left corner.</param>
-        /// <param name="size">The size of the box.</param>
-        /// <returns>A new OpenToolkit.Box3d with the specified dimensions</returns>
-        public static Box3i FromDimensions(Vector3i position, Vector3i size)
+        public Vector3i Size
         {
-            return FromDimensions(position.X, position.Y, position.Z, size.X, size.Y, size.Z);
+            get => Max - Min;
+            set => Scale(Size - value, new Vector3i((int)Center.X, (int)Center.Y, (int)Center.Z));
         }
 
         /// <summary>
-        /// Gets a int describing the width of the Box3i structure.
+        /// Gets or sets a vector describing half the size of the box.
         /// </summary>
-        public int Width => Math.Abs(Right - Left);
+        public Vector3i HalfSize
+        {
+            get => Size / 2;
+            set => Size = value / 2;
+        }
 
         /// <summary>
-        /// Gets a int describing the height of the Box3i structure.
+        /// Gets a vector describing the center of the box.
         /// </summary>
-        public int Height => Math.Abs(Bottom - Top);
+        /// to avoid annoying off-by-one errors in box placement, no setter is provided for this property
+        public Vector3 Center
+        {
+            get => (_min + _max).ToVector3() * 0.5f;
+        }
 
         /// <summary>
-        /// Gets a int describing the depth of the Box3i structure.
-        /// </summary>
-        public int Depth => Math.Abs(Back - Front);
-        
-        /// <summary>
-        /// Returns whether the box contains the specified point.
+        /// Returns whether the box contains the specified point (borders inclusive).
         /// </summary>
         /// <param name="point">The point to query.</param>
-        /// <param name="closedRegion">Whether to include the box boundary in the test region.</param>
         /// <returns>Whether this box contains the point.</returns>
-        public bool Contains(Vector3i point, bool closedRegion = true)
+        public bool Contains(Vector3i point)
         {
-            var containsX = closedRegion == Left <= Right
-                ? point.X >= Left != point.X > Right
-                : point.X > Left != point.X >= Right;
-
-            var containsY = closedRegion == Top <= Bottom
-                ? point.Y >= Top != point.Y > Bottom
-                : point.Y > Top != point.Y >= Bottom;
-
-            var containsZ = closedRegion == Front <= Back
-                ? point.Z >= Front != point.Z > Back
-                : point.Z > Front != point.Z >= Back;
-
-            return containsX && containsY && containsZ;
+            return _min.X <= point.X && point.X <= _max.X &&
+                   _min.Y <= point.Z && point.Y <= _max.Y &&
+                   _min.Z <= point.Z && point.Z <= _max.Z;
         }
 
         /// <summary>
-        /// Returns a Box3i translated by the given amount.
+        /// Returns whether the box contains the specified box (borders inclusive).
         /// </summary>
-        /// <param name="point">The distance to translate the box.</param>
+        /// <param name="other">The box to query.</param>
+        /// <returns>Whether this box contains the other box.</returns>
+        public bool Contains(Box3i other)
+        {
+            return _max.X >= other._min.X && _min.X <= other._max.X &&
+                   _max.Y >= other._min.Y && _min.Y <= other._max.Y &&
+                   _max.Z >= other._min.Z && _min.Z <= other._max.Z;
+        }
+
+        /// <summary>
+        /// Returns the distance between the nearest edge and the specified point.
+        /// </summary>
+        /// <param name="point">The point to find distance for.</param>
+        /// <returns>The distance between the specified point and the nearest edge.</returns>
+        public float DistanceToNearestEdge(Vector3i point)
+        {
+            var distMin = _min - point;
+            var distMax = point - _max;
+            var dist = new Vector2(MathHelper.Min(distMin.X, distMax.X), MathHelper.Min(distMin.Y, distMax.Y));
+            return dist.Length;
+        }
+
+        /// <summary>
+        /// Translates this Box2 by the given amount.
+        /// </summary>
+        /// <param name="distance">The distance to translate the box.</param>
+        public void Translate(Vector3i distance)
+        {
+            Min += distance;
+            Max += distance;
+        }
+
+        /// <summary>
+        /// Returns a Box2 translated by the given amount.
+        /// </summary>
+        /// <param name="distance">The distance to translate the box.</param>
         /// <returns>The translated box.</returns>
-        public Box3i Translated(Vector3i point)
+        public Box3i Translated(Vector3i distance)
         {
-            return new Box3i(Left + point.X, Top + point.Y,Front + point.Z , Right + point.X, Bottom + point.Y, Front + point.Z);
+            // create a local copy of this box
+            Box3i box = this;
+            box.Translate(distance);
+            return box;
         }
 
         /// <summary>
-        /// Translates this Box3d by the given amount.
+        /// Scales this Box2 by the given amount.
         /// </summary>
-        /// <param name="point">The distance to translate the box.</param>
-        public void Translate(Vector3i point)
+        /// <param name="scale">The scale to scale the box.</param>
+        /// <param name="anchor">The anchor to scale the box from.</param>
+        public void Scale(Vector3i scale, Vector3i anchor)
         {
-            Left += point.X;
-            Right += point.X;
-            Top += point.Y;
-            Bottom += point.Y;
-            Front += point.Z;
-            Back += point.Z;
+            var newDistMin = (anchor - _min) * scale;
+            _min = new Vector3i(
+                anchor.X + _min.X > anchor.X ? newDistMin.X : -newDistMin.X,
+                anchor.Y + _min.Y > anchor.Y ? newDistMin.Y : -newDistMin.Y,
+                anchor.Z + _min.Z > anchor.Z ? newDistMin.Z : -newDistMin.Z);
+
+            var newDistMax = (anchor - _max) * scale;
+            _max = new Vector3i(
+                anchor.X + _max.X > anchor.X ? newDistMax.X : -newDistMax.X,
+                anchor.Y + _min.Y > anchor.Y ? newDistMax.Y : -newDistMax.Y,
+                anchor.Z + _min.Z > anchor.Z ? newDistMax.Z : -newDistMax.Z);
+        }
+
+        /// <summary>
+        /// Returns a Box2 scaled by a given amount from an anchor point.
+        /// </summary>
+        /// <param name="scale">The scale to scale the box.</param>
+        /// <param name="anchor">The anchor to scale the box from.</param>
+        /// <returns>The scaled box.</returns>
+        public Box3i Scaled(Vector3i scale, Vector3i anchor)
+        {
+            // create a local copy of this box
+            Box3i box = this;
+            box.Scale(scale, anchor);
+            return box;
+        }
+
+        /// <summary>
+        /// Inflate this Box2 to encapsulate a given point.
+        /// </summary>
+        /// <param name="point">The point to query.</param>
+        public void Inflate(Vector3i point)
+        {
+            var distMin = _min - point;
+            var distMax = point - _max;
+
+            if (distMin.X < distMax.X)
+            {
+                _min.X = point.X;
+            }
+            else
+            {
+                _max.X = point.X;
+            }
+
+            if (distMin.Y < distMax.Y)
+            {
+                _min.Y = point.Y;
+            }
+            else
+            {
+                _max.Y = point.Y;
+            }
+        }
+
+        /// <summary>
+        /// Inflate this Box2 to encapsulate a given point.
+        /// </summary>
+        /// <param name="point">The point to query.</param>
+        /// <returns>The inflated box.</returns>
+        public Box3i Inflated(Vector3i point)
+        {
+            // create a local copy of this box
+            Box3i box = this;
+            box.Inflate(point);
+            return box;
         }
 
         /// <summary>
@@ -178,9 +327,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="right">The right operand.</param>
         public static bool operator ==(Box3i left, Box3i right)
         {
-            return left.Bottom == right.Bottom && left.Top == right.Top &&
-                   left.Left == right.Left && left.Right == right.Right &&
-                   left.Front == right.Front && left.Back == right.Back;
+            return left.Min == right.Min && left.Max == right.Max;
         }
 
         /// <summary>
@@ -196,27 +343,25 @@ namespace OpenToolkit.Mathematics
         /// <inheritdoc/>
         public bool Equals(Box3i other)
         {
-            return this == other;
+            return Min.Equals(other.Min) && Max.Equals(other.Max);
         }
 
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            return obj is Box3i && Equals(obj);
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+            return obj is Box3i other && Equals(other);
         }
-        
+
         /// <inheritdoc/>
         public override int GetHashCode()
         {
             unchecked
             {
-                var hashCode = Left.GetHashCode();
-                hashCode = (hashCode * 397) ^ Right.GetHashCode();
-                hashCode = (hashCode * 397) ^ Top.GetHashCode();
-                hashCode = (hashCode * 397) ^ Bottom.GetHashCode();
-                hashCode = (hashCode * 397) ^ Front.GetHashCode();
-                hashCode = (hashCode * 397) ^ Back.GetHashCode();
-                return hashCode;
+                return (Min.GetHashCode() * 397) ^ Max.GetHashCode();
             }
         }
 
@@ -225,7 +370,7 @@ namespace OpenToolkit.Mathematics
         /// <inheritdoc/>
         public override string ToString()
         {
-            return string.Format("({0}{6} {1}{6} {2}) - ({3}{6} {4}{6} {5})", Left, Top, Front, Right, Bottom, Back, ListSeparator);
+            return $"({Min.X}{ListSeparator} {Min.Y}) - ({Max.X}{ListSeparator} {Max.Y})";
         }
     }
 }

--- a/src/OpenToolkit.Mathematics/MathHelper.cs
+++ b/src/OpenToolkit.Mathematics/MathHelper.cs
@@ -450,6 +450,14 @@ namespace OpenToolkit.Mathematics
         public static float Min(float a, float b) => Math.Min(a, b);
 
         /// <summary>
+        /// Returns the smaller of two floats.
+        /// </summary>
+        /// <param name="a">The first of two floats to compare.</param>
+        /// <param name="b">The second of two floats to compare.</param>
+        /// <returns>Parameter a or b, whichever is smaller.</returns>
+        public static double Min(double a, double b) => Math.Min(a, b);
+
+        /// <summary>
         /// Returns the smaller of two longs.
         /// </summary>
         /// <param name="a">The first of two longs to compare.</param>

--- a/src/Windowing/OpenToolkit.Windowing.Desktop/NativeWindow.cs
+++ b/src/Windowing/OpenToolkit.Windowing.Desktop/NativeWindow.cs
@@ -280,11 +280,11 @@ namespace OpenToolkit.Windowing.Desktop
         /// <inheritdoc />
         public unsafe Box2 Bounds
         {
-            get => Box2.FromDimensions(Location, Size);
+            get => new Box2(Location, Location + Size);
             set
             {
-                Glfw.SetWindowSize(WindowPtr, (int)value.Width, (int)value.Height);
-                Glfw.SetWindowPos(WindowPtr, (int)value.Left, (int)value.Top);
+                Glfw.SetWindowSize(WindowPtr, (int)value.Size.X, (int)value.Size.Y);
+                Glfw.SetWindowPos(WindowPtr, (int)value.Min.X, (int)value.Min.Y);
             }
         }
 
@@ -357,11 +357,11 @@ namespace OpenToolkit.Windowing.Desktop
         /// <inheritdoc />
         public Box2 ClientRectangle
         {
-            get => Box2.FromDimensions(Location, Size);
+            get => new Box2(Location, Location + Size);
             set
             {
-                Location = new Vector2(value.Right, value.Top);
-                Size = new Vector2(value.Width, value.Height);
+                Location = value.Min;
+                Size = value.Size;
             }
         }
 

--- a/src/Windowing/OpenToolkit.Windowing.Desktop/NativeWindowSettings.cs
+++ b/src/Windowing/OpenToolkit.Windowing.Desktop/NativeWindowSettings.cs
@@ -90,11 +90,11 @@ namespace OpenToolkit.Windowing.Desktop
         /// <inheritdoc />
         public Box2 Bounds
         {
-            get => Box2.FromDimensions(Location, Size);
+            get => new Box2(Location, Location + Size);
             set
             {
-                _location = new Vector2(value.Left, value.Left);
-                _size = new Vector2(value.Width, value.Height);
+                _location = value.Min;
+                _size = value.Size;
             }
         }
 
@@ -147,12 +147,11 @@ namespace OpenToolkit.Windowing.Desktop
         /// <inheritdoc />
         public Box2 ClientRectangle
         {
-            get => Box2.FromDimensions(Location, Size);
-
+            get => new Box2(Location, Location + Size);
             set
             {
-                Location = new Vector2(value.Right, value.Top);
-                Size = new Vector2(value.Width, value.Height);
+                Location = value.Min;
+                Size = value.Size;
             }
         }
 


### PR DESCRIPTION
### Purpose of this PR

* Cleanup of the box geometries and re-implementing them so they are now bi-vector based instead.
* Targets OTK.Math

### Testing status

* Tests will be written in a sub PR as this PR is currently blocking as #919 was not stylecop compliant (woops)

### Comments

* For discussions, it would be handy to move them over to discord.
* Also this is a continuation of #919 
* I have been using a design document with pseudocode code to get a better list of what functions are needed and what functions are not needed, link: https://gist.github.com/frederikja163/b320f9de6e51fb0063996dc545b22fb8