### PR TITLE
Fix binder script paths

### DIFF
--- a/update-bindings.bat
+++ b/update-bindings.bat
@@ -1,2 +1,2 @@
-dotnet run -f netcoreapp20 -p "src/generators/generator.bind/generator.bind.csproj" %*
+dotnet run -f netcoreapp20 -p "src/Generators/Generator.Bind/Generator.Bind.csproj" %*
 pause

--- a/update-specifications.bat
+++ b/update-specifications.bat
@@ -1,2 +1,2 @@
-dotnet run -f netcoreapp20 -p "src/generators/generator.converter/generator.convert.csproj" -i https://raw.githubusercontent.com/KhronosGroup/OpenGL-Registry/master/xml/gl.xml -o src/generators/generator.bind/specifications/OpenGL/signatures.xml --prefix gl
+dotnet run -f netcoreapp20 -p "src/Generators/Generator.Converter/Generator.Convert.csproj" -i https://raw.githubusercontent.com/KhronosGroup/OpenGL-Registry/master/xml/gl.xml -o src/generators/generator.bind/specifications/OpenGL/signatures.xml --prefix gl
 pause

--- a/update-specifications.bat
+++ b/update-specifications.bat
@@ -1,2 +1,2 @@
-dotnet run -f netcoreapp20 -p "src/Generators/Generator.Converter/Generator.Convert.csproj" -i https://raw.githubusercontent.com/KhronosGroup/OpenGL-Registry/master/xml/gl.xml -o src/generators/generator.bind/specifications/OpenGL/signatures.xml --prefix gl
+dotnet run -f netcoreapp20 -p "src/Generators/Generator.Converter/Generator.Convert.csproj" -i https://raw.githubusercontent.com/KhronosGroup/OpenGL-Registry/master/xml/gl.xml -o src/Generators/Generator.Bind/Specifications/OpenGL/signatures.xml --prefix gl
 pause


### PR DESCRIPTION
### Purpose of this PR

* On Linux Mint, `update-specifications.bat` and `update-bindings.bat` don't work because of the use of lowercase paths. This PR changes them to properly run.
* Affects Generators.
* No docs required.

### Testing status

* It runs.

### Comments

* No additional comments.
