### PR TITLE
Add tuple deconstructors and conversions to vector types.

### DIFF
--- a/src/OpenToolkit.Mathematics/Vector/Vector2.cs
+++ b/src/OpenToolkit.Mathematics/Vector/Vector2.cs
@@ -872,6 +872,18 @@ namespace OpenToolkit.Mathematics
             return !left.Equals(right);
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector2"/> struct using a tuple containing the component
+        /// values.
+        /// </summary>
+        /// <param name="values">A tuple containing the component values.</param>
+        /// <returns>A new instance of the <see cref="Vector2"/> struct with the given component values.</returns>
+        [Pure]
+        public static implicit operator Vector2((float X, float Y) values)
+        {
+            return new Vector2(values.X, values.Y);
+        }
+
         private static readonly string ListSeparator = CultureInfo.CurrentCulture.TextInfo.ListSeparator;
 
         /// <inheritdoc/>
@@ -919,6 +931,18 @@ namespace OpenToolkit.Mathematics
             return
                 X == other.X &&
                 Y == other.Y;
+        }
+
+        /// <summary>
+        /// Deconstructs the vector into it's individual components.
+        /// </summary>
+        /// <param name="x">The X component of the vector.</param>
+        /// <param name="y">The Y component of the vector.</param>
+        [Pure]
+        public void Deconstruct(out float x, out float y)
+        {
+            x = X;
+            y = Y;
         }
     }
 }

--- a/src/OpenToolkit.Mathematics/Vector/Vector2d.cs
+++ b/src/OpenToolkit.Mathematics/Vector/Vector2d.cs
@@ -858,6 +858,18 @@ namespace OpenToolkit.Mathematics
             return new Vector2((float)v2d.X, (float)v2d.Y);
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector2d"/> struct using a tuple containing the component
+        /// values.
+        /// </summary>
+        /// <param name="values">A tuple containing the component values.</param>
+        /// <returns>A new instance of the <see cref="Vector2d"/> struct with the given component values.</returns>
+        [Pure]
+        public static implicit operator Vector2d((double X, double Y) values)
+        {
+            return new Vector2d(values.X, values.Y);
+        }
+
         private static readonly string ListSeparator = CultureInfo.CurrentCulture.TextInfo.ListSeparator;
 
         /// <inheritdoc/>
@@ -905,6 +917,18 @@ namespace OpenToolkit.Mathematics
             return
                 X == other.X &&
                 Y == other.Y;
+        }
+
+        /// <summary>
+        /// Deconstructs the vector into it's individual components.
+        /// </summary>
+        /// <param name="x">The X component of the vector.</param>
+        /// <param name="y">The Y component of the vector.</param>
+        [Pure]
+        public void Deconstruct(out double x, out double y)
+        {
+            x = X;
+            y = Y;
         }
     }
 }

--- a/src/OpenToolkit.Mathematics/Vector/Vector2h.cs
+++ b/src/OpenToolkit.Mathematics/Vector/Vector2h.cs
@@ -262,6 +262,18 @@ namespace OpenToolkit.Mathematics
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="Vector2h"/> struct using a tuple containing the component
+        /// values.
+        /// </summary>
+        /// <param name="values">A tuple containing the component values.</param>
+        /// <returns>A new instance of the <see cref="Vector2h"/> struct with the given component values.</returns>
+        [Pure]
+        public static implicit operator Vector2h((Half X, Half Y) values)
+        {
+            return new Vector2h(values.X, values.Y);
+        }
+
+        /// <summary>
         /// The size in bytes for an instance of the Half2 struct is 4.
         /// </summary>
         public static readonly int SizeInBytes = 4;
@@ -355,6 +367,18 @@ namespace OpenToolkit.Mathematics
             return new Vector2h(
                 Half.FromBytes(value, startIndex),
                 Half.FromBytes(value, startIndex + 2));
+        }
+
+        /// <summary>
+        /// Deconstructs the vector into it's individual components.
+        /// </summary>
+        /// <param name="x">The X component of the vector.</param>
+        /// <param name="y">The Y component of the vector.</param>
+        [Pure]
+        public void Deconstruct(out Half x, out Half y)
+        {
+            x = X;
+            y = Y;
         }
     }
 }

--- a/src/OpenToolkit.Mathematics/Vector/Vector2i.cs
+++ b/src/OpenToolkit.Mathematics/Vector/Vector2i.cs
@@ -515,6 +515,18 @@ namespace OpenToolkit.Mathematics
             return !left.Equals(right);
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector2i"/> struct using a tuple containing the component
+        /// values.
+        /// </summary>
+        /// <param name="values">A tuple containing the component values.</param>
+        /// <returns>A new instance of the <see cref="Vector2i"/> struct with the given component values.</returns>
+        [Pure]
+        public static implicit operator Vector2i((int X, int Y) values)
+        {
+            return new Vector2i(values.X, values.Y);
+        }
+
         private static readonly string ListSeparator = CultureInfo.CurrentCulture.TextInfo.ListSeparator;
 
         /// <inheritdoc/>
@@ -560,6 +572,18 @@ namespace OpenToolkit.Mathematics
         public bool Equals(Vector2i other)
         {
             return X == other.X && Y == other.Y;
+        }
+
+        /// <summary>
+        /// Deconstructs the vector into it's individual components.
+        /// </summary>
+        /// <param name="x">The X component of the vector.</param>
+        /// <param name="y">The Y component of the vector.</param>
+        [Pure]
+        public void Deconstruct(out int x, out int y)
+        {
+            x = X;
+            y = Y;
         }
     }
 }

--- a/src/OpenToolkit.Mathematics/Vector/Vector3.cs
+++ b/src/OpenToolkit.Mathematics/Vector/Vector3.cs
@@ -1529,6 +1529,18 @@ namespace OpenToolkit.Mathematics
             return !left.Equals(right);
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector3"/> struct using a tuple containing the component
+        /// values.
+        /// </summary>
+        /// <param name="values">A tuple containing the component values.</param>
+        /// <returns>A new instance of the <see cref="Vector3"/> struct with the given component values.</returns>
+        [Pure]
+        public static implicit operator Vector3((float X, float Y, float Z) values)
+        {
+            return new Vector3(values.X, values.Y, values.Z);
+        }
+
         private static readonly string ListSeparator = CultureInfo.CurrentCulture.TextInfo.ListSeparator;
 
         /// <inheritdoc />
@@ -1580,6 +1592,20 @@ namespace OpenToolkit.Mathematics
                 X == other.X &&
                 Y == other.Y &&
                 Z == other.Z;
+        }
+
+        /// <summary>
+        /// Deconstructs the vector into it's individual components.
+        /// </summary>
+        /// <param name="x">The X component of the vector.</param>
+        /// <param name="y">The Y component of the vector.</param>
+        /// <param name="z">The Z component of the vector.</param>
+        [Pure]
+        public void Deconstruct(out float x, out float y, out float z)
+        {
+            x = X;
+            y = Y;
+            z = Z;
         }
     }
 }

--- a/src/OpenToolkit.Mathematics/Vector/Vector3d.cs
+++ b/src/OpenToolkit.Mathematics/Vector/Vector3d.cs
@@ -1371,6 +1371,18 @@ namespace OpenToolkit.Mathematics
             return new Vector3((float)v3d.X, (float)v3d.Y, (float)v3d.Z);
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector3d"/> struct using a tuple containing the component
+        /// values.
+        /// </summary>
+        /// <param name="values">A tuple containing the component values.</param>
+        /// <returns>A new instance of the <see cref="Vector3d"/> struct with the given component values.</returns>
+        [Pure]
+        public static implicit operator Vector3d((double X, double Y, double Z) values)
+        {
+            return new Vector3d(values.X, values.Y, values.Z);
+        }
+
         private static readonly string ListSeparator = CultureInfo.CurrentCulture.TextInfo.ListSeparator;
 
         /// <inheritdoc />
@@ -1422,6 +1434,20 @@ namespace OpenToolkit.Mathematics
                 X == other.X &&
                 Y == other.Y &&
                 Z == other.Z;
+        }
+
+        /// <summary>
+        /// Deconstructs the vector into it's individual components.
+        /// </summary>
+        /// <param name="x">The X component of the vector.</param>
+        /// <param name="y">The Y component of the vector.</param>
+        /// <param name="z">The Z component of the vector.</param>
+        [Pure]
+        public void Deconstruct(out double x, out double y, out double z)
+        {
+            x = X;
+            y = Y;
+            z = Z;
         }
     }
 }

--- a/src/OpenToolkit.Mathematics/Vector/Vector3h.cs
+++ b/src/OpenToolkit.Mathematics/Vector/Vector3h.cs
@@ -437,6 +437,18 @@ namespace OpenToolkit.Mathematics
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="Vector3h"/> struct using a tuple containing the component
+        /// values.
+        /// </summary>
+        /// <param name="values">A tuple containing the component values.</param>
+        /// <returns>A new instance of the <see cref="Vector3h"/> struct with the given component values.</returns>
+        [Pure]
+        public static implicit operator Vector3h((Half X, Half Y, Half Z) values)
+        {
+            return new Vector3h(values.X, values.Y, values.Z);
+        }
+
+        /// <summary>
         /// The size in bytes for an instance of the Half3 struct is 6.
         /// </summary>
         public static readonly int SizeInBytes = 6;
@@ -539,6 +551,20 @@ namespace OpenToolkit.Mathematics
                 Half.FromBytes(value, startIndex),
                 Half.FromBytes(value, startIndex + 2),
                 Half.FromBytes(value, startIndex + 4));
+        }
+
+        /// <summary>
+        /// Deconstructs the vector into it's individual components.
+        /// </summary>
+        /// <param name="x">The X component of the vector.</param>
+        /// <param name="y">The Y component of the vector.</param>
+        /// <param name="z">The Z component of the vector.</param>
+        [Pure]
+        public void Deconstruct(out Half x, out Half y, out Half z)
+        {
+            x = X;
+            y = Y;
+            z = Z;
         }
     }
 }

--- a/src/OpenToolkit.Mathematics/Vector/Vector3i.cs
+++ b/src/OpenToolkit.Mathematics/Vector/Vector3i.cs
@@ -694,6 +694,18 @@ namespace OpenToolkit.Mathematics
             return !left.Equals(right);
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector3i"/> struct using a tuple containing the component
+        /// values.
+        /// </summary>
+        /// <param name="values">A tuple containing the component values.</param>
+        /// <returns>A new instance of the <see cref="Vector3i"/> struct with the given component values.</returns>
+        [Pure]
+        public static implicit operator Vector3i((int X, int Y, int Z) values)
+        {
+            return new Vector3i(values.X, values.Y, values.Z);
+        }
+
         private static readonly string ListSeparator = CultureInfo.CurrentCulture.TextInfo.ListSeparator;
 
         /// <inheritdoc />
@@ -745,6 +757,20 @@ namespace OpenToolkit.Mathematics
                 X == other.X &&
                 Y == other.Y &&
                 Z == other.Z;
+        }
+
+        /// <summary>
+        /// Deconstructs the vector into it's individual components.
+        /// </summary>
+        /// <param name="x">The X component of the vector.</param>
+        /// <param name="y">The Y component of the vector.</param>
+        /// <param name="z">The Z component of the vector.</param>
+        [Pure]
+        public void Deconstruct(out int x, out int y, out int z)
+        {
+            x = X;
+            y = Y;
+            z = Z;
         }
     }
 }

--- a/src/OpenToolkit.Mathematics/Vector/Vector4.cs
+++ b/src/OpenToolkit.Mathematics/Vector/Vector4.cs
@@ -2022,6 +2022,18 @@ namespace OpenToolkit.Mathematics
             return Unsafe.As<Vector4, Color4>(ref v);
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector4"/> struct using a tuple containing the component
+        /// values.
+        /// </summary>
+        /// <param name="values">A tuple containing the component values.</param>
+        /// <returns>A new instance of the <see cref="Vector4"/> struct with the given component values.</returns>
+        [Pure]
+        public static implicit operator Vector4((float X, float Y, float Z, float W) values)
+        {
+            return new Vector4(values.X, values.Y, values.Z, values.W);
+        }
+
         private static readonly string ListSeparator = CultureInfo.CurrentCulture.TextInfo.ListSeparator;
 
         /// <inheritdoc />
@@ -2075,6 +2087,22 @@ namespace OpenToolkit.Mathematics
                 Y == other.Y &&
                 Z == other.Z &&
                 W == other.W;
+        }
+
+        /// <summary>
+        /// Deconstructs the vector into it's individual components.
+        /// </summary>
+        /// <param name="x">The X component of the vector.</param>
+        /// <param name="y">The Y component of the vector.</param>
+        /// <param name="z">The Z component of the vector.</param>
+        /// <param name="w">The W component of the vector.</param>
+        [Pure]
+        public void Deconstruct(out float x, out float y, out float z, out float w)
+        {
+            x = X;
+            y = Y;
+            z = Z;
+            w = W;
         }
     }
 }

--- a/src/OpenToolkit.Mathematics/Vector/Vector4d.cs
+++ b/src/OpenToolkit.Mathematics/Vector/Vector4d.cs
@@ -1970,6 +1970,18 @@ namespace OpenToolkit.Mathematics
             return new Vector4((float)v4d.X, (float)v4d.Y, (float)v4d.Z, (float)v4d.W);
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector4d"/> struct using a tuple containing the component
+        /// values.
+        /// </summary>
+        /// <param name="values">A tuple containing the component values.</param>
+        /// <returns>A new instance of the <see cref="Vector4d"/> struct with the given component values.</returns>
+        [Pure]
+        public static implicit operator Vector4d((double X, double Y, double Z, double W) values)
+        {
+            return new Vector4d(values.X, values.Y, values.Z, values.W);
+        }
+
         private static readonly string ListSeparator = CultureInfo.CurrentCulture.TextInfo.ListSeparator;
 
         /// <inheritdoc />
@@ -2023,6 +2035,22 @@ namespace OpenToolkit.Mathematics
                 Y == other.Y &&
                 Z == other.Z &&
                 W == other.W;
+        }
+
+        /// <summary>
+        /// Deconstructs the vector into it's individual components.
+        /// </summary>
+        /// <param name="x">The X component of the vector.</param>
+        /// <param name="y">The Y component of the vector.</param>
+        /// <param name="z">The Z component of the vector.</param>
+        /// <param name="w">The W component of the vector.</param>
+        [Pure]
+        public void Deconstruct(out double x, out double y, out double z, out double w)
+        {
+            x = X;
+            y = Y;
+            z = Z;
+            w = W;
         }
     }
 }

--- a/src/OpenToolkit.Mathematics/Vector/Vector4h.cs
+++ b/src/OpenToolkit.Mathematics/Vector/Vector4h.cs
@@ -1259,6 +1259,18 @@ namespace OpenToolkit.Mathematics
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="Vector4h"/> struct using a tuple containing the component
+        /// values.
+        /// </summary>
+        /// <param name="values">A tuple containing the component values.</param>
+        /// <returns>A new instance of the <see cref="Vector4h"/> struct with the given component values.</returns>
+        [Pure]
+        public static implicit operator Vector4h((Half X, Half Y, Half Z, Half W) values)
+        {
+            return new Vector4h(values.X, values.Y, values.Z, values.W);
+        }
+
+        /// <summary>
         /// The size in bytes for an instance of the Half4 struct is 8.
         /// </summary>
         public static readonly int SizeInBytes = 8;
@@ -1376,6 +1388,22 @@ namespace OpenToolkit.Mathematics
                 Half.FromBytes(value, startIndex + 2),
                 Half.FromBytes(value, startIndex + 4),
                 Half.FromBytes(value, startIndex + 6));
+        }
+
+        /// <summary>
+        /// Deconstructs the vector into it's individual components.
+        /// </summary>
+        /// <param name="x">The X component of the vector.</param>
+        /// <param name="y">The Y component of the vector.</param>
+        /// <param name="z">The Z component of the vector.</param>
+        /// <param name="w">The W component of the vector.</param>
+        [Pure]
+        public void Deconstruct(out Half x, out Half y, out Half z, out Half w)
+        {
+            x = X;
+            y = Y;
+            z = Z;
+            w = W;
         }
     }
 }

--- a/src/OpenToolkit.Mathematics/Vector/Vector4i.cs
+++ b/src/OpenToolkit.Mathematics/Vector/Vector4i.cs
@@ -1598,6 +1598,18 @@ namespace OpenToolkit.Mathematics
             }
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector4i"/> struct using a tuple containing the component
+        /// values.
+        /// </summary>
+        /// <param name="values">A tuple containing the component values.</param>
+        /// <returns>A new instance of the <see cref="Vector4i"/> struct with the given component values.</returns>
+        [Pure]
+        public static implicit operator Vector4i((int X, int Y, int Z, int W) values)
+        {
+            return new Vector4i(values.X, values.Y, values.Z, values.W);
+        }
+
         private static readonly string ListSeparator = CultureInfo.CurrentCulture.TextInfo.ListSeparator;
 
         /// <inheritdoc />
@@ -1651,6 +1663,22 @@ namespace OpenToolkit.Mathematics
                 Y == other.Y &&
                 Z == other.Z &&
                 W == other.W;
+        }
+
+        /// <summary>
+        /// Deconstructs the vector into it's individual components.
+        /// </summary>
+        /// <param name="x">The X component of the vector.</param>
+        /// <param name="y">The Y component of the vector.</param>
+        /// <param name="z">The Z component of the vector.</param>
+        /// <param name="w">The W component of the vector.</param>
+        [Pure]
+        public void Deconstruct(out int x, out int y, out int z, out int w)
+        {
+            x = X;
+            y = Y;
+            z = Z;
+            w = W;
         }
     }
 }


### PR DESCRIPTION
This PR adds tuple deconstructors (Vector to tuple) and implicit casts (tuple to Vector) to all vector types in `OpenToolkit.Mathematics`

This will allow for syntax such as:

```cs
Vector2 position = (20.0f, 10.0f);
(float x, float y) = position;
```