### PR TITLE
Fix ToHSV and ToHsl functions generating nan when they shouldn't

### DIFF
--- a/src/OpenToolkit.Mathematics/Data/Color4.cs
+++ b/src/OpenToolkit.Mathematics/Data/Color4.cs
@@ -1063,6 +1063,10 @@ namespace OpenToolkit.Mathematics
             }
 
             var m = lightness - (c / 2.0f);
+            if (m < 0)
+            {
+                m = 0;
+            }
             return new Color4(r + m, g + m, b + m, hsl.W);
         }
 
@@ -1090,7 +1094,11 @@ namespace OpenToolkit.Mathematics
             }
             else if (max == rgb.R)
             {
-                h = (rgb.G - rgb.B) / diff;
+                h = ((rgb.G - rgb.B) / diff) % 6;
+                if (h < 0)
+                {
+                    h += 6;
+                }
             }
             else if (max == rgb.G)
             {
@@ -1110,9 +1118,12 @@ namespace OpenToolkit.Mathematics
             var lightness = (max + min) / 2.0f;
 
             var saturation = 0.0f;
-            if (lightness != 0.0f && lightness != 1.0f)
+            if ((1.0f - Math.Abs((2.0f * lightness) - 1.0f)) != 0)
             {
                 saturation = diff / (1.0f - Math.Abs((2.0f * lightness) - 1.0f));
+                if (saturation < 0)
+                {
+                }
             }
 
             return new Vector4(hue, saturation, lightness, rgb.A);
@@ -1215,6 +1226,10 @@ namespace OpenToolkit.Mathematics
             else if (max == rgb.R)
             {
                 h = ((rgb.G - rgb.B) / diff) % 6.0f;
+                if (h < 0)
+                {
+                    h += 6f;
+                }
             }
             else if (max == rgb.G)
             {

--- a/src/OpenToolkit.Mathematics/Data/Color4.cs
+++ b/src/OpenToolkit.Mathematics/Data/Color4.cs
@@ -1084,6 +1084,10 @@ namespace OpenToolkit.Mathematics
             var diff = max - min;
 
             var h = 0.0f;
+            if (diff == 0)
+            {
+                h = 0.0f;
+            }
             if (max == rgb.R)
             {
                 h = (rgb.G - rgb.B) / diff;
@@ -1204,6 +1208,10 @@ namespace OpenToolkit.Mathematics
             var diff = max - min;
 
             var h = 0.0f;
+            if (diff == 0)
+            {
+                h = 0.0f;
+            }
             if (max == rgb.R)
             {
                 h = ((rgb.G - rgb.B) / diff) % 6.0f;

--- a/src/OpenToolkit.Mathematics/Data/Color4.cs
+++ b/src/OpenToolkit.Mathematics/Data/Color4.cs
@@ -1121,9 +1121,6 @@ namespace OpenToolkit.Mathematics
             if ((1.0f - Math.Abs((2.0f * lightness) - 1.0f)) != 0)
             {
                 saturation = diff / (1.0f - Math.Abs((2.0f * lightness) - 1.0f));
-                if (saturation < 0)
-                {
-                }
             }
 
             return new Vector4(hue, saturation, lightness, rgb.A);

--- a/src/OpenToolkit.Mathematics/Data/Color4.cs
+++ b/src/OpenToolkit.Mathematics/Data/Color4.cs
@@ -1088,7 +1088,7 @@ namespace OpenToolkit.Mathematics
             {
                 h = 0.0f;
             }
-            if (max == rgb.R)
+            else if (max == rgb.R)
             {
                 h = (rgb.G - rgb.B) / diff;
             }
@@ -1212,7 +1212,7 @@ namespace OpenToolkit.Mathematics
             {
                 h = 0.0f;
             }
-            if (max == rgb.R)
+            else if (max == rgb.R)
             {
                 h = ((rgb.G - rgb.B) / diff) % 6.0f;
             }

--- a/tests/OpenToolkit.Tests/Assertions.fs
+++ b/tests/OpenToolkit.Tests/Assertions.fs
@@ -16,6 +16,7 @@ module private AssertHelpers =
     let private EquivalenceTolerance = 0.00005f
 
     let approxEq a b = MathHelper.ApproximatelyEquivalent(a, b, EquivalenceTolerance)
+    let approxEqEpsilon a b eps = MathHelper.ApproximatelyEquivalent(a, b, float32(eps))
 
     let approxEqDelta a b = MathHelper.ApproximatelyEqual(a, b, BitAccuracy)
 
@@ -49,6 +50,9 @@ type internal Assert =
     static member ApproximatelyEquivalent(a : float32,b : float32) =
         if not <| approxEq a b then raise <| new Xunit.Sdk.EqualException(a,b)
 
+    static member ApproximatelyEquivalent(a : Color4, b : Color4, epsilon:float32) =
+        if not <| approxEqEpsilon a.R b.R epsilon && approxEqEpsilon a.G b.G epsilon && approxEqEpsilon a.B b.B epsilon && approxEqEpsilon a.A b.A epsilon then
+            raise <| new Xunit.Sdk.EqualException(a,b)
 
     static member ApproximatelyEqualEpsilon(a : Vector2, b : Vector2, epsilon:float32) =
         if neqEpsilon a.X b.X epsilon || neqEpsilon a.Y b.Y epsilon then
@@ -60,10 +64,6 @@ type internal Assert =
 
     static member ApproximatelyEqualEpsilon(a : Vector4, b : Vector4, epsilon:float32) =
         if neqEpsilon a.X b.X epsilon || neqEpsilon a.Y b.Y epsilon || neqEpsilon a.Z b.Z epsilon || neqEpsilon a.W b.W epsilon then
-            raise <| new Xunit.Sdk.EqualException(a,b)
-
-    static member ApproximatelyEqualEpsilon(a : Color4, b : Color4, epsilon:float32) =
-        if neqEpsilon a.R b.R epsilon || neqEpsilon a.G b.G epsilon || neqEpsilon a.B b.B epsilon || neqEpsilon a.A b.A epsilon then
             raise <| new Xunit.Sdk.EqualException(a,b)
 
     static member ApproximatelyEqualEpsilon(a : float32, b : float32) =

--- a/tests/OpenToolkit.Tests/Assertions.fs
+++ b/tests/OpenToolkit.Tests/Assertions.fs
@@ -62,6 +62,10 @@ type internal Assert =
         if neqEpsilon a.X b.X epsilon || neqEpsilon a.Y b.Y epsilon || neqEpsilon a.Z b.Z epsilon || neqEpsilon a.W b.W epsilon then
             raise <| new Xunit.Sdk.EqualException(a,b)
 
+    static member ApproximatelyEqualEpsilon(a : Color4, b : Color4, epsilon:float32) =
+        if neqEpsilon a.R b.R epsilon || neqEpsilon a.G b.G epsilon || neqEpsilon a.B b.B epsilon || neqEpsilon a.A b.A epsilon then
+            raise <| new Xunit.Sdk.EqualException(a,b)
+
     static member ApproximatelyEqualEpsilon(a : float32, b : float32) =
         if not <| approxEqSingleEpsilon a b then raise <| new Xunit.Sdk.EqualException(a,b)
 

--- a/tests/OpenToolkit.Tests/Color4Tests.fs
+++ b/tests/OpenToolkit.Tests/Color4Tests.fs
@@ -1,0 +1,55 @@
+﻿namespace OpenToolkit.Tests
+
+open Xunit
+open FsCheck
+open FsCheck.Xunit
+open System
+open System.Runtime.InteropServices
+open OpenToolkit
+open OpenToolkit.Mathematics
+
+module Color4 =
+    [<Literal>]
+    let private epsilon:float32 = 1e-6f
+
+    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
+    module Covertions =
+        [<Property>]
+        let ``RGB to sRGB to RGB roundtrip`` (c : Color4) =
+            let srgb = Color4.ToSrgb c
+            let rgb = Color4.FromSrgb srgb
+            Assert.ApproximatelyEqualEpsilon(c, rgb, epsilon)
+
+        [<Property>]
+        let ``RGB to HSL to RGB roundtrip`` (Color4LDR c) =
+            let hsl = Color4.ToHsl c
+            let rgb = Color4.FromHsl hsl
+            Assert.ApproximatelyEqualEpsilon(c, rgb, epsilon)
+
+        [<Property>]
+        let ``RGB to HSV to RGB roundtrip`` (c : Color4) =
+            let hsv = Color4.ToHsv c
+            let rgb = Color4.FromHsv hsv
+            Assert.ApproximatelyEqualEpsilon(c, rgb, epsilon)
+
+        [<Property>]
+        let ``RGB to XYZ to RGB roundtrip`` (Color4LDR c) =
+            let xyz = Color4.ToXyz c
+            let rgb = Color4.FromXyz xyz
+            Assert.ApproximatelyEqualEpsilon(c, rgb, epsilon)
+        
+        [<Property>]
+        let ``RGB to YCbCr to RGB roundtrip`` (c : Color4) =
+            let ycbcr = Color4.ToYcbcr c
+            let rgb = Color4.FromYcbcr ycbcr
+            Assert.ApproximatelyEqualEpsilon(c, rgb, epsilon)
+
+        [<Property>]
+        let ``RGB to HCY to RGB roundtrip`` (Color4LDR c) =
+            let hcy = Color4.ToHcy c
+            let rgb = Color4.FromHcy hcy
+            Assert.ApproximatelyEqualEpsilon(c, rgb, epsilon)
+
+            
+
+

--- a/tests/OpenToolkit.Tests/Color4Tests.fs
+++ b/tests/OpenToolkit.Tests/Color4Tests.fs
@@ -10,45 +10,46 @@ open OpenToolkit.Mathematics
 
 module Color4 =
     [<Literal>]
-    let private epsilon:float32 = 1e-4f
+    let private epsilon:float32 = 1e-6f
+    let private epsilonXYZ:float32 = 1e-4f
 
     [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Covertions =
-        [<Property(MaxTest = 1000)>]
+        [<Property>]
         let ``RGB to sRGB to RGB roundtrip`` (c : Color4) =
             let srgb = Color4.ToSrgb c
             let rgb = Color4.FromSrgb srgb
-            Assert.ApproximatelyEqualEpsilon(c, rgb, epsilon)
+            Assert.ApproximatelyEquivalent(c, rgb, epsilon)
 
-        [<Property(MaxTest = 1000)>]
+        [<Property>]
         let ``RGB to HSL to RGB roundtrip`` (Color4LDR c) =
             let hsl = Color4.ToHsl c
             let rgb = Color4.FromHsl hsl
-            Assert.ApproximatelyEqualEpsilon(c, rgb, epsilon)
+            Assert.ApproximatelyEquivalent(c, rgb, epsilon)
 
-        [<Property(MaxTest = 1000)>]
+        [<Property>]
         let ``RGB to HSV to RGB roundtrip`` (c : Color4) =
             let hsv = Color4.ToHsv c
             let rgb = Color4.FromHsv hsv
-            Assert.ApproximatelyEqualEpsilon(c, rgb, epsilon)
+            Assert.ApproximatelyEquivalent(c, rgb, epsilon)
 
-        [<Property(MaxTest = 1000)>]
+        [<Property>]
         let ``RGB to XYZ to RGB roundtrip`` (Color4LDR c) =
             let xyz = Color4.ToXyz c
             let rgb = Color4.FromXyz xyz
-            Assert.ApproximatelyEqualEpsilon(c, rgb, epsilon)
+            Assert.ApproximatelyEquivalent(c, rgb, epsilonXYZ)
         
-        [<Property(MaxTest = 1000)>]
-        let ``RGB to YCbCr to RGB roundtrip`` (c : Color4) =
+        [<Property>]
+        let ``RGB to YCbCr to RGB roundtrip`` (Color4LDR c) =
             let ycbcr = Color4.ToYcbcr c
             let rgb = Color4.FromYcbcr ycbcr
-            Assert.ApproximatelyEqualEpsilon(c, rgb, epsilon)
+            Assert.ApproximatelyEquivalent(c, rgb, epsilon)
 
-        [<Property(MaxTest = 1000)>]
+        [<Property>]
         let ``RGB to HCY to RGB roundtrip`` (Color4LDR c) =
             let hcy = Color4.ToHcy c
             let rgb = Color4.FromHcy hcy
-            Assert.ApproximatelyEqualEpsilon(c, rgb, epsilon)
+            Assert.ApproximatelyEquivalent(c, rgb, epsilon)
 
             
 

--- a/tests/OpenToolkit.Tests/Color4Tests.fs
+++ b/tests/OpenToolkit.Tests/Color4Tests.fs
@@ -10,41 +10,41 @@ open OpenToolkit.Mathematics
 
 module Color4 =
     [<Literal>]
-    let private epsilon:float32 = 1e-6f
+    let private epsilon:float32 = 1e-4f
 
     [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Covertions =
-        [<Property>]
+        [<Property(MaxTest = 1000)>]
         let ``RGB to sRGB to RGB roundtrip`` (c : Color4) =
             let srgb = Color4.ToSrgb c
             let rgb = Color4.FromSrgb srgb
             Assert.ApproximatelyEqualEpsilon(c, rgb, epsilon)
 
-        [<Property>]
+        [<Property(MaxTest = 1000)>]
         let ``RGB to HSL to RGB roundtrip`` (Color4LDR c) =
             let hsl = Color4.ToHsl c
             let rgb = Color4.FromHsl hsl
             Assert.ApproximatelyEqualEpsilon(c, rgb, epsilon)
 
-        [<Property>]
+        [<Property(MaxTest = 1000)>]
         let ``RGB to HSV to RGB roundtrip`` (c : Color4) =
             let hsv = Color4.ToHsv c
             let rgb = Color4.FromHsv hsv
             Assert.ApproximatelyEqualEpsilon(c, rgb, epsilon)
 
-        [<Property>]
+        [<Property(MaxTest = 1000)>]
         let ``RGB to XYZ to RGB roundtrip`` (Color4LDR c) =
             let xyz = Color4.ToXyz c
             let rgb = Color4.FromXyz xyz
             Assert.ApproximatelyEqualEpsilon(c, rgb, epsilon)
         
-        [<Property>]
+        [<Property(MaxTest = 1000)>]
         let ``RGB to YCbCr to RGB roundtrip`` (c : Color4) =
             let ycbcr = Color4.ToYcbcr c
             let rgb = Color4.FromYcbcr ycbcr
             Assert.ApproximatelyEqualEpsilon(c, rgb, epsilon)
 
-        [<Property>]
+        [<Property(MaxTest = 1000)>]
         let ``RGB to HCY to RGB roundtrip`` (Color4LDR c) =
             let hcy = Color4.ToHcy c
             let rgb = Color4.FromHcy hcy

--- a/tests/OpenToolkit.Tests/Generators.fs
+++ b/tests/OpenToolkit.Tests/Generators.fs
@@ -7,6 +7,9 @@ open System
 open OpenToolkit
 open OpenToolkit.Mathematics
 
+[<Struct>]
+type Color4LDR = Color4LDR of Color4
+
 [<AutoOpen>]
 module private Generators =
     let private isValidFloat f = not (Single.IsNaN f || Single.IsInfinity f || Single.IsInfinity (f * f) || f = Single.MinValue || f = Single.MaxValue )
@@ -81,6 +84,20 @@ module private Generators =
         |> Gen.map Box3
         |> Arb.fromGen
 
+    let color4HDR =
+        singleArb
+        |> Gen.filter (fun x -> x >= 0.0f)
+        |> Gen.four
+        |> Gen.map Color4
+        |> Arb.fromGen
+
+    let color4LDR =
+        singleArb
+        |> Gen.filter (fun x -> (x >= 0.0f && x <= 1.0f))
+        |> Gen.four
+        |> Gen.map Color4
+        |> Arb.fromGen
+   
 type OpenTKGen =
     static member Single() = single
     static member float32() = single
@@ -95,3 +112,5 @@ type OpenTKGen =
     static member Matrix4() = mat4
     static member Box2() = box2
     static member Box3() = box3
+    static member Color4LDR() = color4LDR
+    static member Color4() = color4HDR

--- a/tests/OpenToolkit.Tests/OpenToolkit.Tests.fsproj
+++ b/tests/OpenToolkit.Tests/OpenToolkit.Tests.fsproj
@@ -22,6 +22,7 @@
     <Compile Include="BezierCurveTest.fs" />
     <Compile Include="Box3Tests.fs" />
     <Compile Include="Box2Tests.fs" />
+    <Compile Include="Color4Tests.fs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Purpose of this PR

Fix a bug in the ToHSV and ToHSL functions that cause them to return Nan.
`Color4.ToHSV(Color4.White)` will return a vector `(Nan, 0, 1, 1)` when it should return `(0, 0, 1, 1)`.
This PR fixes this behavior.
