### PR TITLE
Windows Fixes

### DIFF
--- a/src/OpenTK/Platform/Common/Hid.cs
+++ b/src/OpenTK/Platform/Common/Hid.cs
@@ -95,7 +95,7 @@ namespace OpenTK.Platform.Common
             }
 
             Debug.Print("[Input] Unknown axis with HID page/usage {0}/{1}", page, usage);
-            return 0;
+            return -1;
         }
     }
 

--- a/src/OpenTK/Platform/Windows/WinGLContext.cs
+++ b/src/OpenTK/Platform/Windows/WinGLContext.cs
@@ -228,6 +228,7 @@ namespace OpenTK.Platform.Windows
         private static ArbCreateContext GetARBContextFlags(GraphicsContextFlags flags)
         {
             ArbCreateContext result = 0;
+            result |= (flags & GraphicsContextFlags.ForwardCompatible) != 0 ? ArbCreateContext.ForwardCompatibleBit : 0;
             result |= (flags & GraphicsContextFlags.Debug) != 0 ? ArbCreateContext.DebugBit : 0;
             return result;
         }
@@ -235,9 +236,8 @@ namespace OpenTK.Platform.Windows
         private static ArbCreateContext GetARBContextProfile(GraphicsContextFlags flags)
         {
             ArbCreateContext result = 0;
-            result |= (flags & GraphicsContextFlags.ForwardCompatible) != 0
-                ? ArbCreateContext.CoreProfileBit
-                : ArbCreateContext.CompatibilityProfileBit;
+            // Interpret the ForwardCompatible flag as wanting the core profile. (Should make a separate flag to differentiate core profile vs forward compatible one?)
+            result |= (flags & GraphicsContextFlags.ForwardCompatible) != 0 ? ArbCreateContext.CoreProfileBit : ArbCreateContext.CompatibilityProfileBit;
             return result;
         }
 

--- a/src/OpenTK/Platform/Windows/WinGLNative.cs
+++ b/src/OpenTK/Platform/Windows/WinGLNative.cs
@@ -481,7 +481,8 @@ namespace OpenTK.Platform.Windows
                 }
                 else if (points == -1)
                 {
-                    throw new System.ComponentModel.Win32Exception(lastError);
+                    // A different error occured - we still just use the mouse move position.
+                    OnMouseMove(point.X, point.Y);
                 }
                 else
                 {

--- a/src/OpenTK/Platform/Windows/WinRawJoystick.cs
+++ b/src/OpenTK/Platform/Windows/WinRawJoystick.cs
@@ -81,6 +81,8 @@ namespace OpenTK.Platform.Windows
                     if ((int)usage != 1)
                     {
                         int axis = GetAxis(collection, page, usage);
+                        // Skip axes that we couldn't map to any of our known joystick axes
+                        if (axis == -1) return;
                         State.SetAxis(axis, value);
                     }
                 }

--- a/src/OpenTK/Platform/Windows/WinRawJoystick.cs
+++ b/src/OpenTK/Platform/Windows/WinRawJoystick.cs
@@ -223,7 +223,8 @@ namespace OpenTK.Platform.Windows
 
             // Discover joystick devices
             int xinput_device_count = 0;
-            foreach (RawInputDeviceList dev in WinRawInput.GetDeviceList())
+            RawInputDeviceList[] deviceList = WinRawInput.GetDeviceList();
+            foreach (RawInputDeviceList dev in deviceList)
             {
                 // Skip non-joystick devices
                 if (dev.Type != RawInputDeviceType.HID)
@@ -515,138 +516,140 @@ namespace OpenTK.Platform.Windows
             Debug.Print("[{0}] Querying joystick {1}",
                 TypeName, stick.GetGuid());
 
+            bool anyInputDetected = false;
             try
             {
                 Debug.Indent();
                 HidProtocolCaps caps;
 
-                if (GetPreparsedData(stick.Handle, ref PreparsedData) &&
-                    GetDeviceCaps(stick, PreparsedData, out caps))
+                if (!GetPreparsedData(stick.Handle, ref PreparsedData) ||
+                    !GetDeviceCaps(stick, PreparsedData, out caps))
+                    return false;
+
+                if (stick.AxisCaps.Count >= JoystickState.MaxAxes ||
+                    stick.ButtonCaps.Count >= JoystickState.MaxButtons)
                 {
-                    if (stick.AxisCaps.Count >= JoystickState.MaxAxes ||
-                        stick.ButtonCaps.Count >= JoystickState.MaxButtons)
+                    Debug.Print("Device {0} has {1} and {2} buttons. This might be a touch device - skipping.",
+                        stick.Handle, stick.AxisCaps.Count, stick.ButtonCaps.Count);
+                    return false;
+                }
+
+                for (int i = 0; i < stick.AxisCaps.Count; i++)
+                {
+                    Debug.Print("Analyzing value collection {0} {1} {2}",
+                        i,
+                        stick.AxisCaps[i].IsRange ? "range" : "",
+                        stick.AxisCaps[i].IsAlias ? "alias" : "");
+
+                    if (stick.AxisCaps[i].IsRange || stick.AxisCaps[i].IsAlias)
                     {
-                        Debug.Print("Device {0} has {1} and {2} buttons. This might be a touch device - skipping.",
-                            stick.Handle, stick.AxisCaps.Count, stick.ButtonCaps.Count);
-                        return false;
+                        Debug.Print("Skipping value collection {0}", i);
+                        continue;
                     }
 
-                    for (int i = 0; i < stick.AxisCaps.Count; i++)
+                    HIDPage page = stick.AxisCaps[i].UsagePage;
+                    short collection = stick.AxisCaps[i].LinkCollection;
+                    switch (page)
                     {
-                        Debug.Print("Analyzing value collection {0} {1} {2}",
-                            i,
-                            stick.AxisCaps[i].IsRange ? "range" : "",
-                            stick.AxisCaps[i].IsAlias ? "alias" : "");
+                        case HIDPage.GenericDesktop:
+                            HIDUsageGD gd_usage = (HIDUsageGD)stick.AxisCaps[i].NotRange.Usage;
+                            switch (gd_usage)
+                            {
+                                case HIDUsageGD.X:
+                                case HIDUsageGD.Y:
+                                case HIDUsageGD.Z:
+                                case HIDUsageGD.Rx:
+                                case HIDUsageGD.Ry:
+                                case HIDUsageGD.Rz:
+                                case HIDUsageGD.Slider:
+                                case HIDUsageGD.Dial:
+                                case HIDUsageGD.Wheel:
+                                    Debug.Print("Found axis {0} ({1} / {2})",
+                                        stick.GetCapabilities().AxisCount,
+                                        page, (HIDUsageGD)stick.AxisCaps[i].NotRange.Usage);
+                                    stick.SetAxis(collection, page, stick.AxisCaps[i].NotRange.Usage, 0);
+                                    anyInputDetected = true;
+                                    break;
 
-                        if (stick.AxisCaps[i].IsRange || stick.AxisCaps[i].IsAlias)
-                        {
-                            Debug.Print("Skipping value collection {0}", i);
-                            continue;
-                        }
+                                case HIDUsageGD.Hatswitch:
+                                    Debug.Print("Found hat {0} ({1} / {2})",
+                                        JoystickHat.Hat0 + stick.GetCapabilities().HatCount,
+                                        page, (HIDUsageGD)stick.AxisCaps[i].NotRange.Usage);
+                                    stick.SetHat(collection, page, stick.AxisCaps[i].NotRange.Usage, HatPosition.Centered);
+                                    anyInputDetected = true;
+                                    break;
 
-                        HIDPage page = stick.AxisCaps[i].UsagePage;
-                        short collection = stick.AxisCaps[i].LinkCollection;
-                        switch (page)
-                        {
-                            case HIDPage.GenericDesktop:
-                                HIDUsageGD gd_usage = (HIDUsageGD)stick.AxisCaps[i].NotRange.Usage;
-                                switch (gd_usage)
-                                {
-                                    case HIDUsageGD.X:
-                                    case HIDUsageGD.Y:
-                                    case HIDUsageGD.Z:
-                                    case HIDUsageGD.Rx:
-                                    case HIDUsageGD.Ry:
-                                    case HIDUsageGD.Rz:
-                                    case HIDUsageGD.Slider:
-                                    case HIDUsageGD.Dial:
-                                    case HIDUsageGD.Wheel:
-                                        Debug.Print("Found axis {0} ({1} / {2})",
-                                            stick.GetCapabilities().AxisCount,
-                                            page, (HIDUsageGD)stick.AxisCaps[i].NotRange.Usage);
-                                        stick.SetAxis(collection, page, stick.AxisCaps[i].NotRange.Usage, 0);
-                                        break;
+                                default:
+                                    Debug.Print("Unknown usage {0} for page {1}",
+                                        gd_usage, page);
+                                    break;
+                            }
+                            break;
 
-                                    case HIDUsageGD.Hatswitch:
-                                        Debug.Print("Found hat {0} ({1} / {2})",
-                                            JoystickHat.Hat0 + stick.GetCapabilities().HatCount,
-                                            page, (HIDUsageGD)stick.AxisCaps[i].NotRange.Usage);
-                                        stick.SetHat(collection, page, stick.AxisCaps[i].NotRange.Usage, HatPosition.Centered);
-                                        break;
+                        case HIDPage.Simulation:
+                            switch ((HIDUsageSim)stick.AxisCaps[i].NotRange.Usage)
+                            {
+                                case HIDUsageSim.Rudder:
+                                case HIDUsageSim.Throttle:
+                                    Debug.Print("Found simulation axis {0} ({1} / {2})",
+                                        stick.GetCapabilities().AxisCount,
+                                        page, (HIDUsageSim)stick.AxisCaps[i].NotRange.Usage);
+                                    stick.SetAxis(collection, page, stick.AxisCaps[i].NotRange.Usage, 0);
+                                    anyInputDetected = true;
+                                    break;
+                            }
+                            break;
 
-                                    default:
-                                        Debug.Print("Unknown usage {0} for page {1}",
-                                            gd_usage, page);
-                                        break;
-                                }
-                                break;
+                        default:
+                            Debug.Print("Unknown page {0}", page);
+                            break;
+                    }
+                }
 
-                            case HIDPage.Simulation:
-                                switch ((HIDUsageSim)stick.AxisCaps[i].NotRange.Usage)
-                                {
-                                    case HIDUsageSim.Rudder:
-                                    case HIDUsageSim.Throttle:
-                                        Debug.Print("Found simulation axis {0} ({1} / {2})",
-                                            stick.GetCapabilities().AxisCount,
-                                            page, (HIDUsageSim)stick.AxisCaps[i].NotRange.Usage);
-                                        stick.SetAxis(collection, page, stick.AxisCaps[i].NotRange.Usage, 0);
-                                        break;
-                                }
-                                break;
+                for (int i = 0; i < stick.ButtonCaps.Count; i++)
+                {
+                    Debug.Print("Analyzing button collection {0} {1} {2}",
+                        i,
+                        stick.ButtonCaps[i].IsRange ? "range" : "",
+                        stick.ButtonCaps[i].IsAlias ? "alias" : "");
 
-                            default:
-                                Debug.Print("Unknown page {0}", page);
-                                break;
-                        }
+                    if (stick.ButtonCaps[i].IsAlias)
+                    {
+                        Debug.Print("Skipping button collection {0}", i);
+                        continue;
                     }
 
-                    for (int i = 0; i < stick.ButtonCaps.Count; i++)
+                    bool is_range = stick.ButtonCaps[i].IsRange;
+                    HIDPage page = stick.ButtonCaps[i].UsagePage;
+                    short collection = stick.ButtonCaps[i].LinkCollection;
+                    switch (page)
                     {
-                        Debug.Print("Analyzing button collection {0} {1} {2}",
-                            i,
-                            stick.ButtonCaps[i].IsRange ? "range" : "",
-                            stick.ButtonCaps[i].IsAlias ? "alias" : "");
-
-                        if (stick.ButtonCaps[i].IsAlias)
-                        {
-                            Debug.Print("Skipping button collection {0}", i);
-                            continue;
-                        }
-
-                        bool is_range = stick.ButtonCaps[i].IsRange;
-                        HIDPage page = stick.ButtonCaps[i].UsagePage;
-                        short collection = stick.ButtonCaps[i].LinkCollection;
-                        switch (page)
-                        {
-                            case HIDPage.Button:
-                                if (is_range)
-                                {
-                                    for (short usage = stick.ButtonCaps[i].Range.UsageMin; usage <= stick.ButtonCaps[i].Range.UsageMax; usage++)
-                                    {
-                                        Debug.Print("Found button {0} ({1} / {2})",
-                                            stick.GetCapabilities().ButtonCount,
-                                            page, usage);
-                                        stick.SetButton(collection, page, usage, false);
-                                    }
-                                }
-                                else
+                        case HIDPage.Button:
+                            if (is_range)
+                            {
+                                for (short usage = stick.ButtonCaps[i].Range.UsageMin; usage <= stick.ButtonCaps[i].Range.UsageMax; usage++)
                                 {
                                     Debug.Print("Found button {0} ({1} / {2})",
                                         stick.GetCapabilities().ButtonCount,
-                                        page, stick.ButtonCaps[i].NotRange.Usage);
-                                    stick.SetButton(collection, page, stick.ButtonCaps[i].NotRange.Usage, false);
+                                        page, usage);
+                                    stick.SetButton(collection, page, usage, false);
+                                    anyInputDetected = true;
                                 }
-                                break;
+                            }
+                            else
+                            {
+                                Debug.Print("Found button {0} ({1} / {2})",
+                                    stick.GetCapabilities().ButtonCount,
+                                    page, stick.ButtonCaps[i].NotRange.Usage);
+                                stick.SetButton(collection, page, stick.ButtonCaps[i].NotRange.Usage, false);
+                                anyInputDetected = true;
+                            }
+                            break;
 
-                            default:
-                                Debug.Print("Unknown page {0} for button.", page);
-                                break;
-                        }
+                        default:
+                            Debug.Print("Unknown page {0} for button.", page);
+                            break;
                     }
-                }
-                else
-                {
-                    return false;
                 }
             }
             finally
@@ -654,8 +657,9 @@ namespace OpenTK.Platform.Windows
                 Debug.Unindent();
             }
 
-            return true;
+            return anyInputDetected;
         }
+
 
         private static bool GetDeviceCaps(Device stick, byte[] preparsed_data, out HidProtocolCaps caps)
         {


### PR DESCRIPTION
### Purpose of this PR
Several fixes as proposed in the discussion in the following PR:
https://github.com/opentk/opentk/pull/883

* Ignore the MouseMoveEx errors. ( https://github.com/opentk/opentk/pull/883 )
* Detect joysticks which declare no valid controls & ignore (Cherry-picked from https://github.com/opentk/opentk/issues/819 )
* Fix where an invalid joystick axis overwrites the first joystick axis. (Cherry-picked from https://github.com/opentk/opentk/issues/819 )
* Makes the ArbCreateContext return valid settings ( https://github.com/opentk/opentk/issues/754 )

### Others discussed / mentioned:
* SDL joystick DB update (Part of https://github.com/opentk/opentk/issues/819 )- Already merged.
* Use a dictionary to map joystick axis, so that when an axis is declared multiple times we can handle better (Part of https://github.com/opentk/opentk/issues/819 )- I think needs a separate PR, as this mucks about with some of the fundamentals rather than a simple fix.


### Testing status

These are all simple and logical changes, and only affect the Windows Raw input backend :)
The openGL context creates correctly.
I don't however have joystick hardware samples exhibiting these specific issues, so I cannot physically confirm that the issues have been fixed. However @ilexp did so in the original issue.