### PR TITLE
Fix Quaternion(euler angle order -> roundtrip tests)

### DIFF
--- a/src/OpenToolkit.Mathematics/Data/Quaternion.cs
+++ b/src/OpenToolkit.Mathematics/Data/Quaternion.cs
@@ -195,40 +195,41 @@ namespace OpenToolkit.Mathematics
         {
             /*
             reference
-            http://en.wikipedia.org/wiki/Conversion_between_qernions_and_Euler_angles
-            http://www.euclideanspace.com/maths/geometry/rotations/conversions/qernionToEuler/
+            http://en.wikipedia.org/wiki/Conversion_between_quaternions_and_Euler_angles
+            http://www.euclideanspace.com/maths/geometry/rotations/conversions/quaternionToEuler/
             */
 
             var q = this;
 
-            q.Normalize();
-
-            float singularityTest = (q.X * q.Y) - (q.W * q.Z);
-            float yawY = 2f * ((q.W * q.X) + (q.Y * q.Z));
-            float yawX = 1f - (2f * ((q.Z * q.Z) + (q.X * q.X)));
+            Vector3 eulerAngles;
 
             // Threshold for the singularities found at the north/south poles.
             const float SINGULARITY_THRESHOLD = 0.4999995f;
 
-            Vector3 eulerAngles;
+            var sqw = q.W * q.W;
+            var sqx = q.X * q.X;
+            var sqy = q.Y * q.Y;
+            var sqz = q.Z * q.Z;
+            var unit = sqx + sqy + sqz + sqw; // if normalised is one, otherwise is correction factor
+            var singularityTest = (q.X * q.Z) + (q.W * q.Y);
 
-            if (singularityTest < -SINGULARITY_THRESHOLD)
+            if (singularityTest > SINGULARITY_THRESHOLD * unit)
             {
-                eulerAngles.Z = -MathHelper.PiOver2; // -90 degrees
-                eulerAngles.Y = (float)Math.Atan2(yawY, yawX);
-                eulerAngles.X = MathHelper.NormalizeRadians(-eulerAngles.Y - (2f * (float)Math.Atan2(q.Y, q.W)));
+                eulerAngles.Z = (float)(2 * Math.Atan2(q.X, q.W));
+                eulerAngles.Y = MathHelper.PiOver2;
+                eulerAngles.X = 0;
             }
-            else if (singularityTest > SINGULARITY_THRESHOLD)
+            else if (singularityTest < -SINGULARITY_THRESHOLD * unit)
             {
-                eulerAngles.Z = MathHelper.PiOver2; // 90 degrees
-                eulerAngles.Y = (float)Math.Atan2(yawY, yawX);
-                eulerAngles.X = MathHelper.NormalizeRadians(eulerAngles.Y - (2f * (float)Math.Atan2(q.Y, q.W)));
+                eulerAngles.Z = (float)(-2 * Math.Atan2(q.X, q.W));
+                eulerAngles.Y = -MathHelper.PiOver2;
+                eulerAngles.X = 0;
             }
             else
             {
-                eulerAngles.Z = (float)Math.Asin(2f * singularityTest);
-                eulerAngles.X = (float)Math.Atan2(yawY, yawX);
-                eulerAngles.Y = (float)Math.Atan2(-2f * ((q.W * q.Y) + (q.Z * q.X)), 1f - (2f * ((q.Y * q.Y) + (q.Z * q.Z))));
+                eulerAngles.Z = (float)Math.Atan2(2 * ((q.W * q.Z) - (q.X * q.Y)), sqw + sqx - sqy - sqz);
+                eulerAngles.Y = (float)Math.Asin(2 * singularityTest / unit);
+                eulerAngles.X = (float)Math.Atan2(2 * ((q.W * q.X) - (q.Y * q.Z)), sqw - sqx - sqy + sqz);
             }
 
             return eulerAngles;

--- a/tests/OpenToolkit.Tests/QuaternionTests.fs
+++ b/tests/OpenToolkit.Tests/QuaternionTests.fs
@@ -51,7 +51,10 @@ module Quaternion =
             let v2 = Quaternion.ToEulerAngles(&q1)
             let q2 = Quaternion.FromEulerAngles(v2)
 
-            Assert.ApproximatelyEqual(0.0f, (q1 * q2.Inverted()).Xyz.LengthSquared)
+            Assert.ApproximatelyEqual(q1.X, q2.X);
+            Assert.ApproximatelyEqual(q1.Y, q2.Y);
+            Assert.ApproximatelyEqual(q1.Z, q2.Z);
+            Assert.ApproximatelyEqual(q1.W, q2.W);
             
     [<Fact>]
     let ``Single axis as euler angles is converted to correct quaternion components``() =


### PR DESCRIPTION
* Use xyz order for quaternion to euler angles conversion(Same as currently used in euler to quaternion)
* Quaternion roundtrip test: compare components seperately for less precision loss

PR to fix the quaternion roundtrip test.
Before mixed standard for euler angles where used. Which results in roundtrip not working.
Now uses same euler angles as the quaternion ctor.(xyz order)