### PR TITLE
Fix <LangVersion> getting applied to F# projects.

### DIFF
--- a/props/common.props
+++ b/props/common.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <HasCommonProperties>true</HasCommonProperties>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion Condition="$(MSBuildProjectExtension.EndsWith('.csproj'))">7.3</LangVersion>
     <Copyright>Copyright (c) 2006 - 2018 Stefanos Apostolopoulos (stapostol@gmail.com) for the Open Toolkit library.</Copyright>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
This caused a compile failure because 7.3 isn't a valid F# version.
