### PR TITLE
Fix PlatformLibraryNameContainerBase on macOS.

### DIFF
--- a/src/OpenToolkit.Core/Loader/PlatformLibraryNameContainerBase.cs
+++ b/src/OpenToolkit.Core/Loader/PlatformLibraryNameContainerBase.cs
@@ -41,7 +41,7 @@ namespace OpenToolkit.Core.Loader
                 return Windows;
             }
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Create("IOS")))
                 {


### PR DESCRIPTION
It erroneously checked for Linux to return the macOS platform.
