### PR TITLE
Make GLFW.Image better.

### DIFF
--- a/src/Windowing/OpenToolkit.GraphicsLibraryFramework/Image.cs
+++ b/src/Windowing/OpenToolkit.GraphicsLibraryFramework/Image.cs
@@ -8,14 +8,13 @@
 //
 
 using System;
-using System.Runtime.InteropServices;
 
 namespace OpenToolkit.GraphicsLibraryFramework
 {
     /// <summary>
-    /// Opaque handle to a GLFW image.
+    ///     Contains GLFW Image data.
     /// </summary>
-    public struct Image : IDisposable
+    public readonly unsafe struct Image
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Image"/> struct.
@@ -23,11 +22,11 @@ namespace OpenToolkit.GraphicsLibraryFramework
         /// <param name="width">The width of the image in pixels.</param>
         /// <param name="height">The height of the image in pixels.</param>
         /// <param name="pixels"><see cref="IntPtr"/> pointing to the RGBA pixel data of the image.</param>
-        public Image(int width, int height, IntPtr pixels)
+        public Image(int width, int height, byte* pixels)
         {
-            this.Width = width;
-            this.Height = height;
-            this.Pixels = pixels;
+            Width = width;
+            Height = height;
+            Pixels = pixels;
         }
 
         /// <summary>
@@ -41,14 +40,8 @@ namespace OpenToolkit.GraphicsLibraryFramework
         public int Height { get; }
 
         /// <summary>
-        /// Gets a <see cref="IntPtr"/> pointing to the RGBA pixel data.
+        /// Gets a <see cref="byte"/> pointer pointing to the RGBA pixel data.
         /// </summary>
-        public IntPtr Pixels { get; }
-
-        /// <inheritdoc />
-        public void Dispose()
-        {
-            Marshal.FreeHGlobal(Pixels);
-        }
+        public byte* Pixels { get; }
     }
 }

--- a/src/Windowing/OpenToolkit.Windowing.Desktop/NativeWindow.cs
+++ b/src/Windowing/OpenToolkit.Windowing.Desktop/NativeWindow.cs
@@ -433,7 +433,7 @@ namespace OpenToolkit.Windowing.Desktop
                     {
                         fixed (byte* ptr = value.Data)
                         {
-                            var cursorImg = new GraphicsLibraryFramework.Image(value.Width, value.Height, (IntPtr)ptr);
+                            var cursorImg = new GraphicsLibraryFramework.Image(value.Width, value.Height, ptr);
                             var cursor = Glfw.CreateCursor(&cursorImg, value.X, value.Y);
                             Glfw.SetCursor(WindowPtr, cursor);
                         }


### PR DESCRIPTION
Made it use byte*.
Removed very dangerous Dispose implementation.
Made it readonly.