### PR TITLE
Move GLFWProvider to Windowing.Desktop.

### DIFF
--- a/src/Windowing/OpenToolkit.GraphicsLibraryFramework/GLFW.cs
+++ b/src/Windowing/OpenToolkit.GraphicsLibraryFramework/GLFW.cs
@@ -28,14 +28,6 @@ namespace OpenToolkit.GraphicsLibraryFramework
         }
 
         /// <summary>
-        /// Gets the default callback which gets called when a GLFW-Error occurs.
-        /// </summary>
-        /// <seealso cref="SetErrorCallback"/>
-        /// TODO: pretty sure this callback should not be settable, because if we exchange values it will still call the old value,
-        /// TODO: we would need to set the new callback with SetErrorCallback-function
-        public static GLFWCallbacks.ErrorCallback ErrorCallback { get; } = (errorCode, description) => throw new GLFWException(description) { ErrorCode = errorCode };
-
-        /// <summary>
         /// Gets an integer equal to GLFW_DONT_CARE. This can be used for several window hints to use the platform default.
         /// </summary>
         public const int DontCare = -1;

--- a/src/Windowing/OpenToolkit.GraphicsLibraryFramework/GLFWException.cs
+++ b/src/Windowing/OpenToolkit.GraphicsLibraryFramework/GLFWException.cs
@@ -19,9 +19,9 @@ namespace OpenToolkit.GraphicsLibraryFramework
     public class GLFWException : Exception
     {
         /// <summary>
-        /// Gets or sets the underlying GLFW-error code.
+        /// Gets the underlying GLFW-error code.
         /// </summary>
-        public ErrorCode ErrorCode { get; set; }
+        public ErrorCode ErrorCode { get; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="GLFWException"/> class.
@@ -37,6 +37,18 @@ namespace OpenToolkit.GraphicsLibraryFramework
         public GLFWException(string message)
             : base(message)
         {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GLFWException"/> class
+        /// with the specified detailed description and GLFW error code.
+        /// </summary>
+        /// <param name="message">A detailed description of the error.</param>
+        /// <param name="errorCode">The GLFW error code causing the exception.</param>
+        public GLFWException(string message, ErrorCode errorCode)
+            : base(message)
+        {
+            ErrorCode = errorCode;
         }
 
         /// <summary>


### PR DESCRIPTION
This is a "higher level" binding to the GLFW API,
that should not be part of the low level GLFW bind.