### PR TITLE
[3.x] Quaternion(d) Modify instance Invert() to match static functions

### DIFF
--- a/src/OpenTK/Math/Quaternion.cs
+++ b/src/OpenTK/Math/Quaternion.cs
@@ -195,15 +195,15 @@ namespace OpenTK
         }
 
         /// <summary>
-        /// Reverses the rotation angle of this Quaterniond.
+        /// Inverts this Quaternion.
         /// </summary>
         public void Invert()
         {
-            W = -W;
+            Invert(ref this, out this);
         }
 
         /// <summary>
-        /// Returns a copy of this Quaterniond with its rotation angle reversed.
+        /// Returns the inverse of this Quaternion.
         /// </summary>
         public Quaternion Inverted()
         {

--- a/src/OpenTK/Math/Quaterniond.cs
+++ b/src/OpenTK/Math/Quaterniond.cs
@@ -192,15 +192,15 @@ namespace OpenTK
         }
 
         /// <summary>
-        /// Reverses the rotation angle of this Quaterniond.
+        /// Inverts this Quaterniond.
         /// </summary>
         public void Invert()
         {
-            W = -W;
+            Invert(ref this, out this);
         }
 
         /// <summary>
-        /// Returns a copy of this Quaterniond with its rotation angle reversed.
+        /// Returns the inverse of this Quaterniond.
         /// </summary>
         public Quaterniond Inverted()
         {


### PR DESCRIPTION
### Purpose of this PR

Math: As of current the instance methods on `Quaternion` for invert don't return an inverted quaternion, but just flip the W value. This is not a valid transformation.

This PR replaces the implementations of `Invert/Inverted()` with calls to the static functions properly implementing inversions.
