### PR TITLE
OpenGL_Bindings.csproj: Call bash instead of sh

### DIFF
--- a/src/OpenGL/OpenGL_Bindings.csproj
+++ b/src/OpenGL/OpenGL_Bindings.csproj
@@ -18,7 +18,7 @@
 </Target>
 
 <Target Name="PreBuild" BeforeTargets="PreBuildEvent" Condition="'$(OS)' != 'Windows_NT' ">
-  <Exec Command="sh build.sh -t UpdateBindings" WorkingDirectory="../../" />
+  <Exec Command="bash build.sh -t UpdateBindings" WorkingDirectory="../../" />
 </Target>
 
 


### PR DESCRIPTION
### Purpose of this PR

Update the invocation of build.sh to be done with `bash` specifically instead of `sh`. Stops errors on Ubuntu 19.04 where sh is not symlinked to bash (as build.sh is not POSIX compliant)

### Testing status

* Builds won't fail when `sh` is not symlinked to `bash`