### PR TITLE
Quaternion(d): Modify instance Invert() to match static functions

### DIFF
--- a/src/OpenToolkit.Mathematics/Data/Quaternion.cs
+++ b/src/OpenToolkit.Mathematics/Data/Quaternion.cs
@@ -258,15 +258,15 @@ namespace OpenToolkit.Mathematics
         }
 
         /// <summary>
-        /// Reverses the rotation angle of this Quaterniond.
+        /// Inverts this Quaternion.
         /// </summary>
         public void Invert()
         {
-            W = -W;
+            Invert(ref this, out this);
         }
 
         /// <summary>
-        /// Returns a copy of this Quaterniond with its rotation angle reversed.
+        /// Returns the inverse of this Quaternion.
         /// </summary>
         /// <returns>The inverted copy.</returns>
         public Quaternion Inverted()

--- a/src/OpenToolkit.Mathematics/Data/Quaterniond.cs
+++ b/src/OpenToolkit.Mathematics/Data/Quaterniond.cs
@@ -254,15 +254,15 @@ namespace OpenToolkit.Mathematics
         }
 
         /// <summary>
-        /// Reverses the rotation angle of this Quaterniond.
+        /// Inverts this Quaterniond.
         /// </summary>
         public void Invert()
         {
-            W = -W;
+            Invert(ref this, out this);
         }
 
         /// <summary>
-        /// Returns a copy of this Quaterniond with its rotation angle reversed.
+        /// Returns the inverse of this Quaterniond.
         /// </summary>
         /// <returns>The inverted copy.</returns>
         public Quaterniond Inverted()


### PR DESCRIPTION
### Purpose of this PR
(Implements #973 on master branch)

Math: As of current the instance methods on Quaternion for invert don't return an inverted quaternion, but just flip the W value. This is not a valid transformation.

This PR replaces the implementations of `Invert/Inverted()` with calls to the static functions properly implementing inversions.
