### PR TITLE
Remove reference to Mathematics from GLFW bind.

### DIFF
--- a/src/Windowing/OpenToolkit.GraphicsLibraryFramework/OpenToolkit.GraphicsLibraryFramework.csproj
+++ b/src/Windowing/OpenToolkit.GraphicsLibraryFramework/OpenToolkit.GraphicsLibraryFramework.csproj
@@ -8,7 +8,6 @@
     
     <ItemGroup>
       <ProjectReference Include="..\..\OpenToolkit.Core\OpenToolkit.Core.csproj" />
-      <ProjectReference Include="..\..\OpenToolkit.Mathematics\OpenToolkit.Mathematics.csproj" />
     </ItemGroup>
     
     <ItemGroup>


### PR DESCRIPTION
It's a ~230 KiB dependency and was unused. Removing it is quite a nice improvement.
