### PR TITLE
Add remaining GLFW Window functions

### DIFF
--- a/src/Windowing/OpenToolkit.GraphicsLibraryFramework/GLFW.cs
+++ b/src/Windowing/OpenToolkit.GraphicsLibraryFramework/GLFW.cs
@@ -1101,6 +1101,49 @@ namespace OpenToolkit.GraphicsLibraryFramework
 
         /// <summary>
         /// <para>
+        /// This function retrieves the content scale for the specified window.
+        /// </para>
+        /// <para>
+        /// The content scale is the ratio between the current DPI and the platform's default DPI.
+        /// This is especially important for text and any UI elements.
+        /// If the pixel dimensions of your UI scaled by this look appropriate on your machine then it should
+        /// appear at a reasonable size on other machines regardless of their DPI and scaling settings.
+        /// This relies on the system DPI and scaling settings being somewhat correct.
+        /// </para>
+        ///
+        /// <para>
+        /// On systems where each monitors can have its own content scale,
+        /// the window content scale will depend on which monitor the system considers the window to be on.
+        /// </para>
+        /// </summary>
+        /// <param name="window">The window to query.</param>
+        /// <param name="xScale">
+        /// Where to store the x-axis content scale, or <c>out _</c>.
+        /// </param>
+        /// <param name="yScale">
+        /// Where to store the y-axis content scale, or <c>out _</c>.
+        /// </param>
+        /// <remarks>
+        /// <para>
+        /// This function must only be called from the main thread.
+        /// </para>
+        /// <para>
+        /// Possible errors include <see cref="ErrorCode.NotInitialized"/> and <see cref="ErrorCode.PlatformError"/>.
+        /// </para>
+        /// </remarks>
+        public static unsafe void GetWindowContentScale(
+            Window* window,
+            out float xScale,
+            out float yScale)
+        {
+            float x, y;
+            glfwGetWindowContentScale(window, &x, &y);
+            xScale = x;
+            yScale = y;
+        }
+
+        /// <summary>
+        /// <para>
         /// This function returns the opacity of the window, including any decorations.
         /// </para>
         /// <para>
@@ -3479,6 +3522,53 @@ namespace OpenToolkit.GraphicsLibraryFramework
 
         /// <summary>
         /// <para>
+        /// This function sets the user-defined pointer of the specified window.
+        /// </para>
+        /// <para>
+        /// The current value is retained until the window is destroyed.
+        /// The initial value is <see cref="IntPtr.Zero"/>.
+        /// </para>
+        /// </summary>
+        /// <param name="window">The window whose pointer to set.</param>
+        /// <param name="pointer">The new value.</param>
+        /// <remarks>
+        /// <para>
+        /// This function may be called from any thread. Access is not synchronized.
+        /// </para>
+        /// <para>
+        /// Possible errors include <see cref="ErrorCode.NotInitialized"/>.
+        /// </para>
+        /// </remarks>
+        public static unsafe void SetWindowUserPointer(Window* window, void* pointer)
+        {
+            glfwSetWindowUserPointer(window, pointer);
+        }
+
+        /// <summary>
+        /// <para>
+        /// This function returns the current value of the user-defined pointer of the specified window.
+        /// </para>
+        /// <para>
+        /// The initial value is <see cref="IntPtr.Zero"/>.
+        /// </para>
+        /// </summary>
+        /// <param name="window">The window whose pointer to return.</param>
+        /// <returns>The user-defined pointer of the given <paramref name="window"/>.</returns>
+        /// <remarks>
+        /// <para>
+        /// This function may be called from any thread. Access is not synchronized.
+        /// </para>
+        /// <para>
+        /// Possible errors include <see cref="ErrorCode.NotInitialized"/>.
+        /// </para>
+        /// </remarks>
+        public static unsafe void* GetWindowUserPointer(Window* window)
+        {
+            return glfwGetWindowUserPointer(window);
+        }
+
+        /// <summary>
+        /// <para>
         /// This function retrieves the size, in screen coordinates, of the client area of the specified window.
         /// If you wish to retrieve the size of the framebuffer of the window in pixels, see <see cref="GetFramebufferSize"/>.
         /// </para>
@@ -3701,6 +3791,78 @@ namespace OpenToolkit.GraphicsLibraryFramework
         /// </para>
         /// </remarks>
         public static unsafe void MaximizeWindow(Window* window) => glfwMaximizeWindow(window);
+
+        /// <summary>
+        /// <para>
+        /// This function sets the maximization callback of the specified window,
+        /// which is called when the window is maximized or restored.
+        /// </para>
+        /// </summary>
+        /// <param name="window">The window whose callback to set.</param>
+        /// <param name="callback">The new callback, or <c>null</c> to remove the currently set callback.</param>
+        /// <remarks>
+        /// <para>
+        /// This function may only be called from the main thread.
+        /// </para>
+        /// <para>
+        /// Possible errors include <see cref="ErrorCode.NotInitialized"/>.
+        /// </para>
+        /// </remarks>
+        /// <seealso cref="MaximizeWindow"/>
+        public static unsafe IntPtr SetWindowMaximizeCallback(
+            Window* window,
+            GLFWCallbacks.WindowMaximizeCallback callback)
+        {
+            return glfwSetWindowMaximizeCallback(window, Marshal.GetFunctionPointerForDelegate(callback));
+        }
+
+        /// <summary>
+        /// <para>
+        /// This function sets the framebuffer resize callback of the specified window,
+        /// which is called when the framebuffer of the specified window is resized.
+        /// </para>
+        /// </summary>
+        /// <param name="window">The window whose content scale changed.</param>
+        /// <param name="callback">The new callback, or <c>null</c> to remove the currently set callback.</param>
+        /// <remarks>
+        /// <para>
+        /// This function must only be called from the main thread.
+        /// </para>
+        /// <para>
+        /// Possible errors include <see cref="ErrorCode.NotInitialized"/>.
+        /// </para>
+        /// </remarks>
+        /// <seealso cref="GetFramebufferSize"/>
+        public static unsafe IntPtr SetFramebufferSizeCallback(
+            Window* window,
+            GLFWCallbacks.FramebufferSizeCallback callback)
+        {
+            return glfwSetFramebufferSizeCallback(window, Marshal.GetFunctionPointerForDelegate(callback));
+        }
+
+        /// <summary>
+        /// <para>
+        /// This function sets the window content scale callback of the specified window,
+        /// which is called when the content scale of the specified window changes.
+        /// </para>
+        /// </summary>
+        /// <param name="window">The window whose content scale changed.</param>
+        /// <param name="callback">The new callback, or <c>null</c> to remove the currently set callback.</param>
+        /// <remarks>
+        /// <para>
+        /// This function must only be called from the main thread.
+        /// </para>
+        /// <para>
+        /// Possible errors include <see cref="ErrorCode.NotInitialized"/>.
+        /// </para>
+        /// </remarks>
+        /// <seealso cref="GetWindowContentScale"/>
+        public static unsafe IntPtr SetWindowContentScaleCallback(
+            Window* window,
+            GLFWCallbacks.WindowContentScaleCallback callback)
+        {
+            return glfwSetWindowContentScaleCallback(window, Marshal.GetFunctionPointerForDelegate(callback));
+        }
 
         /// <summary>
         /// <para>

--- a/src/Windowing/OpenToolkit.GraphicsLibraryFramework/GLFW.cs
+++ b/src/Windowing/OpenToolkit.GraphicsLibraryFramework/GLFW.cs
@@ -1117,12 +1117,8 @@ namespace OpenToolkit.GraphicsLibraryFramework
         /// </para>
         /// </summary>
         /// <param name="window">The window to query.</param>
-        /// <param name="xScale">
-        /// Where to store the x-axis content scale, or <c>out _</c>.
-        /// </param>
-        /// <param name="yScale">
-        /// Where to store the y-axis content scale, or <c>out _</c>.
-        /// </param>
+        /// <param name="xScale">Where to store the x-axis content scale, or <c>out _</c>.</param>
+        /// <param name="yScale">Where to store the y-axis content scale, or <c>out _</c>.</param>
         /// <remarks>
         /// <para>
         /// This function must only be called from the main thread.
@@ -3800,6 +3796,9 @@ namespace OpenToolkit.GraphicsLibraryFramework
         /// </summary>
         /// <param name="window">The window whose callback to set.</param>
         /// <param name="callback">The new callback, or <c>null</c> to remove the currently set callback.</param>
+        /// <returns>
+        /// The previously set callback, or <c>null</c> if no callback was set or the library had not been initialized.
+        /// </returns>
         /// <remarks>
         /// <para>
         /// This function may only be called from the main thread.
@@ -3824,6 +3823,9 @@ namespace OpenToolkit.GraphicsLibraryFramework
         /// </summary>
         /// <param name="window">The window whose content scale changed.</param>
         /// <param name="callback">The new callback, or <c>null</c> to remove the currently set callback.</param>
+        /// <returns>
+        /// The previously set callback, or <c>null</c> if no callback was set or the library had not been initialized.
+        /// </returns>
         /// <remarks>
         /// <para>
         /// This function must only be called from the main thread.
@@ -3848,6 +3850,9 @@ namespace OpenToolkit.GraphicsLibraryFramework
         /// </summary>
         /// <param name="window">The window whose content scale changed.</param>
         /// <param name="callback">The new callback, or <c>null</c> to remove the currently set callback.</param>
+        /// <returns>
+        /// The previously set callback, or <c>null</c> if no callback was set or the library had not been initialized.
+        /// </returns>
         /// <remarks>
         /// <para>
         /// This function must only be called from the main thread.

--- a/src/Windowing/OpenToolkit.GraphicsLibraryFramework/GLFWCallbacks.cs
+++ b/src/Windowing/OpenToolkit.GraphicsLibraryFramework/GLFWCallbacks.cs
@@ -134,6 +134,32 @@ namespace OpenToolkit.GraphicsLibraryFramework
         public delegate void WindowIconifyCallback(Window* window, bool iconified);
 
         /// <summary>
+        /// The function signature for window maximize/restore callback functions.
+        /// </summary>
+        /// <param name="window">The window that was maximized or restored.</param>
+        /// <param name="maximized"><c>true</c> if the window was maximized, or <c>false</c> if it was restored.</param>
+        /// <seealso cref="GLFW.SetWindowMaximizeCallback"/>
+        public delegate void WindowMaximizeCallback(Window* window, bool maximized);
+
+        /// <summary>
+        /// The function signature for framebuffer size callback functions.
+        /// </summary>
+        /// <param name="window">The window whose framebuffer was resized.</param>
+        /// <param name="width">The new width, in pixels, of the framebuffer.</param>
+        /// <param name="height">The new height, in pixels, of the framebuffer.</param>
+        /// <seealso cref="GLFW.SetFramebufferSizeCallback"/>
+        public delegate void FramebufferSizeCallback(Window* window, int width, int height);
+
+        /// <summary>
+        /// This is the function pointer type for window content scale callbacks.
+        /// </summary>
+        /// <param name="window">The window whose content scale changed. </param>
+        /// <param name="xscale">The new x-axis content scale of the window. </param>
+        /// <param name="yscale">The new y-axis content scale of the window.</param>
+        /// <seealso cref="GLFW.SetWindowContentScaleCallback"/>
+        public delegate void WindowContentScaleCallback(Window* window, float xscale, float yscale);
+
+        /// <summary>
         /// The function signature for window position callback functions.
         /// </summary>
         /// <param name="window">The window that was moved.</param>

--- a/src/Windowing/OpenToolkit.GraphicsLibraryFramework/GLFWNative.cs
+++ b/src/Windowing/OpenToolkit.GraphicsLibraryFramework/GLFWNative.cs
@@ -104,6 +104,9 @@ namespace OpenToolkit.GraphicsLibraryFramework
         public static extern void glfwGetWindowFrameSize(Window* window, int* left, int* top, int* right, int* bottom);
 
         [DllImport(LibraryName)]
+        public static extern void glfwGetWindowContentScale(Window* window, float* xscale, float* yscale);
+
+        [DllImport(LibraryName)]
         public static extern float glfwGetWindowOpacity(Window* window);
 
         [DllImport(LibraryName)]
@@ -290,6 +293,12 @@ namespace OpenToolkit.GraphicsLibraryFramework
         public static extern int glfwWindowShouldClose(Window* window);
 
         [DllImport(LibraryName)]
+        public static extern void glfwSetWindowUserPointer(Window* window, void* pointer);
+
+        [DllImport(LibraryName)]
+        public static extern void* glfwGetWindowUserPointer(Window* window);
+
+        [DllImport(LibraryName)]
         public static extern IntPtr glfwSetCharCallback(Window* window, IntPtr callback);
 
         [DllImport(LibraryName)]
@@ -339,6 +348,15 @@ namespace OpenToolkit.GraphicsLibraryFramework
 
         [DllImport(LibraryName)]
         public static extern IntPtr glfwSetWindowIconifyCallback(Window* window, IntPtr callback);
+
+        [DllImport(LibraryName)]
+        public static extern IntPtr glfwSetWindowMaximizeCallback(Window* window, IntPtr callback);
+
+        [DllImport(LibraryName)]
+        public static extern IntPtr glfwSetFramebufferSizeCallback(Window* window, IntPtr callback);
+
+        [DllImport(LibraryName)]
+        public static extern IntPtr glfwSetWindowContentScaleCallback(Window* window, IntPtr callback);
 
         [DllImport(LibraryName)]
         public static extern void glfwSetWindowTitle(Window* window, byte* title);


### PR DESCRIPTION
### Purpose of this PR

Implement the rest of the GLFW Window functions.

- glfwGetWindowContentScale
- glfwSetWindowUserPointer
- glfwGetWindowUserPointer
- glfwSetWindowMaximizeCallback
- glfwSetFramebufferSizeCallback
- glfwSetWindowContentScaleCallback