### PR TITLE
Build and stencil fixes

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -130,7 +130,7 @@ Target "AssemblyInfo" (fun _ ->
         ]
 
     let getProjectDetails projectPath =
-        let projectName = System.IO.Path.GetFileNameWithoutExtension(projectPath)
+        let projectName = System.IO.Path.GetFileNameWithoutExtension(projectPath: string)
         ( projectPath,
           projectName,
           System.IO.Path.GetDirectoryName(projectPath),

--- a/src/OpenTK/Platform/X11/X11GraphicsMode.cs
+++ b/src/OpenTK/Platform/X11/X11GraphicsMode.cs
@@ -126,10 +126,10 @@ namespace OpenTK.Platform.X11
                 visualAttributes.Add(1);
             }
 
-            if (mode.Stereo)
+            if (mode.Stencil > 0)
             {
                 visualAttributes.Add((int)GLXAttribute.STENCIL_SIZE);
-                visualAttributes.Add(mode.Stereo ? 1 : 0);
+                visualAttributes.Add(mode.Stencil);
             }
 
             if (mode.AccumulatorFormat.BitsPerPixel > 0)


### PR DESCRIPTION
### Purpose of this PR

Two fixes:

* Fix compiling on mono 6.8 by being explicit in a F# (FAKE) function. See: https://github.com/mono/mono/issues/8310
* Correctly pass stencil information when building a window using X11 (Only when it's searching framebuffer modes)

As an aside:  I still can't get stencil working in SDL2. I'll keep digging a bit more, but wanted to get what I had in.

### Testing status

* Create a new context in X11 mode on linux.  Observe `this.Context.GraphisMode` with no stencil, after change, can correctly set stencil (eg. `8`)

### Comments

* Any other comments to help understand the change.
