### PR TITLE
[dotnetcore] Fix loading of glfw3.dll on windows, Unit-Testing of glfw3 functional…

### DIFF
--- a/src/Windowing/OpenToolkit.GraphicsLibraryFramework/GLFWNative.cs
+++ b/src/Windowing/OpenToolkit.GraphicsLibraryFramework/GLFWNative.cs
@@ -17,7 +17,7 @@ namespace OpenToolkit.GraphicsLibraryFramework
             // On net472, we rely on Mono's DllMap for this. See the .dll.config file.
             NativeLibrary.SetDllImportResolver(typeof(GLFWNative).Assembly, (name, assembly, path) =>
             {
-                if (name != "glfw3.dll")
+                if (name != LibraryName)
                 {
                     return IntPtr.Zero;
                 }
@@ -30,6 +30,16 @@ namespace OpenToolkit.GraphicsLibraryFramework
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                 {
                     return NativeLibrary.Load("libglfw.3.dylib", assembly, path);
+                }
+
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    if (IntPtr.Size == 8)
+                    {
+                        return NativeLibrary.Load("glfw3-x64.dll", assembly, path);
+                    }
+
+                    return NativeLibrary.Load("glfw3-x86.dll", assembly, path);
                 }
 
                 return IntPtr.Zero;


### PR DESCRIPTION
### Purpose of this PR

After a fresh clone of opentk, it was impossible to just run `./build.cmd`. It would compile and build, but unit-tests would fail, because nativeloader was not able to locate the proper glfw dll.

* Description of feature/change.

Unit-Tests were unable to locate glfw3.dll.

* Which part of OpenTK does this affect (Math, OpenGL, Platform, Input, etc).

Platform (glfw3.dll loading in particular)

* Links to screenshots, design docs, user docs, etc.

N/A

### Testing status

- Fresh clone of opentk/opentk/master
- ran `build.cmd`
  => build successful
  => unit-tests threw error glfw3.dll not found
- Implemented fix
- ran `build.cmd`
  => build successful
  => unit-tests successful
