### PR TITLE
Add matrix multiplication + missing operator to Vector2/Vector2d

### DIFF
--- a/src/OpenToolkit.Mathematics/Vector/Vector2.cs
+++ b/src/OpenToolkit.Mathematics/Vector/Vector2.cs
@@ -708,6 +708,32 @@ namespace OpenToolkit.Mathematics
         }
 
         /// <summary>
+        /// Transform a Vector by the given Matrix.
+        /// </summary>
+        /// <param name="vec">The vector to transform.</param>
+        /// <param name="mat">The desired transformation.</param>
+        /// <returns>The transformed vector.</returns>
+        [Pure]
+        public static Vector2 Transform(Vector2 vec, Matrix2 mat)
+        {
+            Transform(ref vec, ref mat, out Vector2 result);
+            return result;
+        }
+
+        /// <summary>
+        /// Transform a Vector by the given Matrix.
+        /// </summary>
+        /// <param name="vec">The vector to transform.</param>
+        /// <param name="mat">The desired transformation.</param>
+        /// <param name="result">The transformed vector.</param>
+        public static void Transform(ref Vector2 vec, ref Matrix2 mat, out Vector2 result)
+        {
+            result = new Vector2(
+                (vec.X * mat.Row0.X) + (vec.Y * mat.Row1.X),
+                (vec.X * mat.Row0.Y) + (vec.Y * mat.Row1.Y));
+        }
+
+        /// <summary>
         /// Transforms a vector by a quaternion rotation.
         /// </summary>
         /// <param name="vec">The vector to transform.</param>
@@ -735,6 +761,31 @@ namespace OpenToolkit.Mathematics
 
             result.X = v.X;
             result.Y = v.Y;
+        }
+
+        /// <summary>
+        /// Transform a Vector by the given Matrix using right-handed notation.
+        /// </summary>
+        /// <param name="mat">The desired transformation.</param>
+        /// <param name="vec">The vector to transform.</param>
+        /// <returns>The transformed vector.</returns>
+        [Pure]
+        public static Vector2 Transform(Matrix2 mat, Vector2 vec)
+        {
+            Transform(ref mat, ref vec, out Vector2 result);
+            return result;
+        }
+
+        /// <summary>
+        /// Transform a Vector by the given Matrix using right-handed notation.
+        /// </summary>
+        /// <param name="mat">The desired transformation.</param>
+        /// <param name="vec">The vector to transform.</param>
+        /// <param name="result">The transformed vector.</param>
+        public static void Transform(ref Matrix2 mat, ref Vector2 vec, out Vector2 result)
+        {
+            result.X = (mat.Row0.X * vec.X) + (mat.Row0.Y * vec.Y);
+            result.Y = (mat.Row1.X * vec.X) + (mat.Row1.Y * vec.Y);
         }
 
         /// <summary>
@@ -832,6 +883,45 @@ namespace OpenToolkit.Mathematics
             vec.X *= scale.X;
             vec.Y *= scale.Y;
             return vec;
+        }
+
+        /// <summary>
+        /// Transform a Vector by the given Matrix.
+        /// </summary>
+        /// <param name="vec">The vector to transform.</param>
+        /// <param name="mat">The desired transformation.</param>
+        /// <returns>The transformed vector.</returns>
+        [Pure]
+        public static Vector2 operator *(Vector2 vec, Matrix2 mat)
+        {
+            Transform(ref vec, ref mat, out Vector2 result);
+            return result;
+        }
+
+        /// <summary>
+        /// Transform a Vector by the given Matrix using right-handed notation.
+        /// </summary>
+        /// <param name="mat">The desired transformation.</param>
+        /// <param name="vec">The vector to transform.</param>
+        /// <returns>The transformed vector.</returns>
+        [Pure]
+        public static Vector2 operator *(Matrix2 mat, Vector2 vec)
+        {
+            Transform(ref mat, ref vec, out Vector2 result);
+            return result;
+        }
+
+        /// <summary>
+        /// Transforms a vector by a quaternion rotation.
+        /// </summary>
+        /// <param name="vec">The vector to transform.</param>
+        /// <param name="quat">The quaternion to rotate the vector by.</param>
+        /// <returns>The multiplied vector.</returns>
+        [Pure]
+        public static Vector2 operator *(Quaternion quat, Vector2 vec)
+        {
+            Transform(ref vec, ref quat, out Vector2 result);
+            return result;
         }
 
         /// <summary>

--- a/src/OpenToolkit.Mathematics/Vector/Vector2d.cs
+++ b/src/OpenToolkit.Mathematics/Vector/Vector2d.cs
@@ -659,6 +659,32 @@ namespace OpenToolkit.Mathematics
         }
 
         /// <summary>
+        /// Transform a Vector by the given Matrix.
+        /// </summary>
+        /// <param name="vec">The vector to transform.</param>
+        /// <param name="mat">The desired transformation.</param>
+        /// <returns>The transformed vector.</returns>
+        [Pure]
+        public static Vector2d Transform(Vector2d vec, Matrix2d mat)
+        {
+            Transform(ref vec, ref mat, out Vector2d result);
+            return result;
+        }
+
+        /// <summary>
+        /// Transform a Vector by the given Matrix.
+        /// </summary>
+        /// <param name="vec">The vector to transform.</param>
+        /// <param name="mat">The desired transformation.</param>
+        /// <param name="result">The transformed vector.</param>
+        public static void Transform(ref Vector2d vec, ref Matrix2d mat, out Vector2d result)
+        {
+            result = new Vector2d(
+                (vec.X * mat.Row0.X) + (vec.Y * mat.Row1.X),
+                (vec.X * mat.Row0.Y) + (vec.Y * mat.Row1.Y));
+        }
+
+        /// <summary>
         /// Transforms a vector by a quaternion rotation.
         /// </summary>
         /// <param name="vec">The vector to transform.</param>
@@ -686,6 +712,31 @@ namespace OpenToolkit.Mathematics
 
             result.X = v.X;
             result.Y = v.Y;
+        }
+
+        /// <summary>
+        /// Transform a Vector by the given Matrix using right-handed notation.
+        /// </summary>
+        /// <param name="mat">The desired transformation.</param>
+        /// <param name="vec">The vector to transform.</param>
+        /// <returns>The transformed vector.</returns>
+        [Pure]
+        public static Vector2d Transform(Matrix2d mat, Vector2d vec)
+        {
+            Transform(ref mat, ref vec, out Vector2d result);
+            return result;
+        }
+
+        /// <summary>
+        /// Transform a Vector by the given Matrix using right-handed notation.
+        /// </summary>
+        /// <param name="mat">The desired transformation.</param>
+        /// <param name="vec">The vector to transform.</param>
+        /// <param name="result">The transformed vector.</param>
+        public static void Transform(ref Matrix2d mat, ref Vector2d vec, out Vector2d result)
+        {
+            result.X = (mat.Row0.X * vec.X) + (mat.Row0.Y * vec.Y);
+            result.Y = (mat.Row1.X * vec.X) + (mat.Row1.Y * vec.Y);
         }
 
         /// <summary>
@@ -783,6 +834,32 @@ namespace OpenToolkit.Mathematics
             vec.X *= scale.X;
             vec.Y *= scale.Y;
             return vec;
+        }
+
+        /// <summary>
+        /// Transform a Vector by the given Matrix.
+        /// </summary>
+        /// <param name="vec">The vector to transform.</param>
+        /// <param name="mat">The desired transformation.</param>
+        /// <returns>The transformed vector.</returns>
+        [Pure]
+        public static Vector2d operator *(Vector2d vec, Matrix2d mat)
+        {
+            Transform(ref vec, ref mat, out Vector2d result);
+            return result;
+        }
+
+        /// <summary>
+        /// Transform a Vector by the given Matrix using right-handed notation.
+        /// </summary>
+        /// <param name="mat">The desired transformation.</param>
+        /// <param name="vec">The vector to transform.</param>
+        /// <returns>The transformed vector.</returns>
+        [Pure]
+        public static Vector2d operator *(Matrix2d mat, Vector2d vec)
+        {
+            Transform(ref mat, ref vec, out Vector2d result);
+            return result;
         }
 
         /// <summary>

--- a/tests/OpenToolkit.Tests/Vector2Tests.fs
+++ b/tests/OpenToolkit.Tests/Vector2Tests.fs
@@ -248,9 +248,9 @@ module Vector2 =
 
         [<Property>]
         let ``Vector2-Matrix2 multiplication using left-handed notation is consistent across overloads`` (a : Matrix2, b : Vector2) =
-            let r1 = a * b;
-            let r2 = Vector2.Transform(a, b);
-            let r3 = Vector2.Transform(ref a, ref b);
+            let r1 = b * a;
+            let r2 = Vector2.Transform(b, a);
+            let r3 = Vector2.Transform(ref b, ref a);
 
             Assert.Equal(r1, r2)
             Assert.Equal(r2, r3)

--- a/tests/OpenToolkit.Tests/Vector2Tests.fs
+++ b/tests/OpenToolkit.Tests/Vector2Tests.fs
@@ -217,7 +217,7 @@ module Vector2 =
 
         [<Property>]
         let ``Vector2-Matrix2 multiplication using right-handed notation is the same as vector/row multiplication and summation`` (a : Matrix2, b : Vector2) =
-            let res = a*b
+            let res = a * b
 
             let c1 = b.X * a.M11 + b.Y * a.M12
             let c2 = b.X * a.M21 + b.Y * a.M22
@@ -237,7 +237,7 @@ module Vector2 =
 
         [<Property>]
         let ``Vector2-Matrix2 multiplication using left-handed notation is the same as vector/column multiplication and summation`` (a : Matrix2, b : Vector2) =
-            let res = b*a
+            let res = b * a
 
             let c1 = b.X * a.M11 + b.Y * a.M21
             let c2 = b.X * a.M12 + b.Y * a.M22

--- a/tests/OpenToolkit.Tests/Vector2Tests.fs
+++ b/tests/OpenToolkit.Tests/Vector2Tests.fs
@@ -216,6 +216,46 @@ module Vector2 =
             Assert.Equal(a.Y * f,r.Y)
 
         [<Property>]
+        let ``Vector2-Matrix2 multiplication using right-handed notation is the same as vector/row multiplication and summation`` (a : Matrix2, b : Vector2) =
+            let res = a*b
+
+            let c1 = b.X * a.M11 + b.Y * a.M12
+            let c2 = b.X * a.M21 + b.Y * a.M22
+
+            let exp = Vector2(c1, c2)
+
+            Assert.Equal(exp, res)
+
+        [<Property>]
+        let ``Vector2-Matrix2 multiplication using right-handed notation is consistent across overloads`` (a : Matrix2, b : Vector2) =
+            let r1 = a * b;
+            let r2 = Vector2.Transform(a, b);
+            let r3 = Vector2.Transform(ref a, ref b);
+
+            Assert.Equal(r1, r2)
+            Assert.Equal(r2, r3)
+
+        [<Property>]
+        let ``Vector2-Matrix2 multiplication using left-handed notation is the same as vector/column multiplication and summation`` (a : Matrix2, b : Vector2) =
+            let res = b*a
+
+            let c1 = b.X * a.M11 + b.Y * a.M21
+            let c2 = b.X * a.M12 + b.Y * a.M22
+
+            let exp = Vector2(c1, c2)
+
+            Assert.Equal(exp, res)
+
+        [<Property>]
+        let ``Vector2-Matrix2 multiplication using left-handed notation is consistent across overloads`` (a : Matrix2, b : Vector2) =
+            let r1 = a * b;
+            let r2 = Vector2.Transform(a, b);
+            let r3 = Vector2.Transform(ref a, ref b);
+
+            Assert.Equal(r1, r2)
+            Assert.Equal(r2, r3)
+
+        [<Property>]
         let ``Static Vector2 multiplication method is the same as component multiplication`` (a : Vector2, b : Vector2) =
 
             let v1 = Vector2(a.X * b.X, a.Y * b.Y)
@@ -602,6 +642,16 @@ module Vector2 =
             let transformedVector = Vector2(transformedQuat.X, transformedQuat.Y)
 
             Assert.ApproximatelyEquivalent(transformedVector, Vector2.Transform(ref v, ref q))
+
+        [<Property>]
+        let ``Transformation by quaternion by multiplication using right-handed notation is the same as multiplication by quaternion and its conjugate`` (v : Vector2, q : Quaternion) =
+            let vectorQuat = Quaternion(v.X, v.Y, 0.0f, 0.0f)
+            let inverse = Quaternion.Invert(q)
+
+            let transformedQuat = q * vectorQuat * inverse
+            let transformedVector = Vector2(transformedQuat.X, transformedQuat.Y)
+
+            Assert.ApproximatelyEquivalent(transformedVector, q * v)
 
     [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Serialization =


### PR DESCRIPTION
### Purpose of this PR

This pull request adds missing matrix multiplication to `Vector2` and `Vector2d`. I've tried to maintain the code order from `Vector3`.

* Description of feature/change.

Added `Transform(Matrix2, Vector2)` and `Transform(Vector2, Matrix)` to 
`Vector2`.
Added `Transform(Matrix2d, Vector2d)` and `Transform(Vector2d, Matrix2d)` to `Vector2d`.
Added corresponding multiplication operators to the above.
Added missing `Quaternion` multiplication operator to `Vector2`.

* Which part of OpenTK does this affect (Math, OpenGL, Platform, Input, etc).

Math.

* Links to screenshots, design docs, user docs, etc.

N/A

### Testing status

The code is copied verbatim from `Vector3` with missing components/rows removed. It has not been tested beyond "It compiles" under the assumption that the original math holds.

### Comments

* These methods/operators were found to be missing in comparison to `Vector3`/`Vector4`. This PR adds them for consistency.
