### PR TITLE
[speculative] Use in parameters instead of ref

### DIFF
--- a/src/OpenToolkit.Mathematics/Data/Quaternion.cs
+++ b/src/OpenToolkit.Mathematics/Data/Quaternion.cs
@@ -262,7 +262,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         public void Invert()
         {
-            Invert(ref this, out this);
+            Invert(in this, out this);
         }
 
         /// <summary>
@@ -319,7 +319,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The first operand.</param>
         /// <param name="right">The second operand.</param>
         /// <param name="result">The result of the addition.</param>
-        public static void Add(ref Quaternion left, ref Quaternion right, out Quaternion result)
+        public static void Add(in Quaternion left, in Quaternion right, out Quaternion result)
         {
             result = new Quaternion(
                 left.Xyz + right.Xyz,
@@ -346,7 +346,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left instance.</param>
         /// <param name="right">The right instance.</param>
         /// <param name="result">The result of the operation.</param>
-        public static void Sub(ref Quaternion left, ref Quaternion right, out Quaternion result)
+        public static void Sub(in Quaternion left, in Quaternion right, out Quaternion result)
         {
             result = new Quaternion(
                 left.Xyz - right.Xyz,
@@ -362,7 +362,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Quaternion Multiply(Quaternion left, Quaternion right)
         {
-            Multiply(ref left, ref right, out Quaternion result);
+            Multiply(in left, in right, out Quaternion result);
             return result;
         }
 
@@ -372,7 +372,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The first instance.</param>
         /// <param name="right">The second instance.</param>
         /// <param name="result">A new instance containing the result of the calculation.</param>
-        public static void Multiply(ref Quaternion left, ref Quaternion right, out Quaternion result)
+        public static void Multiply(in Quaternion left, in Quaternion right, out Quaternion result)
         {
             result = new Quaternion(
                 (right.W * left.Xyz) + (left.W * right.Xyz) + Vector3.Cross(left.Xyz, right.Xyz),
@@ -385,7 +385,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="quaternion">The instance.</param>
         /// <param name="scale">The scalar.</param>
         /// <param name="result">A new instance containing the result of the calculation.</param>
-        public static void Multiply(ref Quaternion quaternion, float scale, out Quaternion result)
+        public static void Multiply(in Quaternion quaternion, float scale, out Quaternion result)
         {
             result = new Quaternion
             (
@@ -430,7 +430,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="q">The quaternion.</param>
         /// <param name="result">The conjugate of the given quaternion.</param>
-        public static void Conjugate(ref Quaternion q, out Quaternion result)
+        public static void Conjugate(in Quaternion q, out Quaternion result)
         {
             result = new Quaternion(-q.Xyz, q.W);
         }
@@ -443,7 +443,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Quaternion Invert(Quaternion q)
         {
-            Invert(ref q, out Quaternion result);
+            Invert(in q, out Quaternion result);
             return result;
         }
 
@@ -452,7 +452,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="q">The quaternion to invert.</param>
         /// <param name="result">The inverse of the given quaternion.</param>
-        public static void Invert(ref Quaternion q, out Quaternion result)
+        public static void Invert(in Quaternion q, out Quaternion result)
         {
             var lengthSq = q.LengthSquared;
             if (lengthSq != 0.0)
@@ -474,7 +474,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Quaternion Normalize(Quaternion q)
         {
-            Normalize(ref q, out Quaternion result);
+            Normalize(in q, out Quaternion result);
             return result;
         }
 
@@ -483,7 +483,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="q">The quaternion to normalize.</param>
         /// <param name="result">The normalized quaternion.</param>
-        public static void Normalize(ref Quaternion q, out Quaternion result)
+        public static void Normalize(in Quaternion q, out Quaternion result)
         {
             var scale = 1.0f / q.Length;
             result = new Quaternion(q.Xyz * scale, q.W * scale);
@@ -548,7 +548,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="eulerAngles">The counterclockwise euler angles a vector.</param>
         /// <param name="result">The equivalent Quaternion.</param>
-        public static void FromEulerAngles(ref Vector3 eulerAngles, out Quaternion result)
+        public static void FromEulerAngles(in Vector3 eulerAngles, out Quaternion result)
         {
             var c1 = (float)Math.Cos(eulerAngles.X * 0.5f);
             var c2 = (float)Math.Cos(eulerAngles.Y * 0.5f);
@@ -581,7 +581,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Quaternion FromMatrix(Matrix3 matrix)
         {
-            FromMatrix(ref matrix, out Quaternion result);
+            FromMatrix(in matrix, out Quaternion result);
             return result;
         }
 
@@ -590,7 +590,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="matrix">A rotation matrix.</param>
         /// <param name="result">The equivalent quaternion.</param>
-        public static void FromMatrix(ref Matrix3 matrix, out Quaternion result)
+        public static void FromMatrix(in Matrix3 matrix, out Quaternion result)
         {
             var trace = matrix.Trace;
 
@@ -746,7 +746,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Quaternion operator *(Quaternion left, Quaternion right)
         {
-            Multiply(ref left, ref right, out left);
+            Multiply(in left, in right, out left);
             return left;
         }
 
@@ -759,7 +759,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Quaternion operator *(Quaternion quaternion, float scale)
         {
-            Multiply(ref quaternion, scale, out quaternion);
+            Multiply(in quaternion, scale, out quaternion);
             return quaternion;
         }
 

--- a/src/OpenToolkit.Mathematics/Data/Quaterniond.cs
+++ b/src/OpenToolkit.Mathematics/Data/Quaterniond.cs
@@ -258,7 +258,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         public void Invert()
         {
-            Invert(ref this, out this);
+            Invert(in this, out this);
         }
 
         /// <summary>
@@ -315,7 +315,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The first operand.</param>
         /// <param name="right">The second operand.</param>
         /// <param name="result">The result of the addition.</param>
-        public static void Add(ref Quaterniond left, ref Quaterniond right, out Quaterniond result)
+        public static void Add(in Quaterniond left, in Quaterniond right, out Quaterniond result)
         {
             result = new Quaterniond(
                 left.Xyz + right.Xyz,
@@ -342,7 +342,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left instance.</param>
         /// <param name="right">The right instance.</param>
         /// <param name="result">The result of the operation.</param>
-        public static void Sub(ref Quaterniond left, ref Quaterniond right, out Quaterniond result)
+        public static void Sub(in Quaterniond left, in Quaterniond right, out Quaterniond result)
         {
             result = new Quaterniond(
                 left.Xyz - right.Xyz,
@@ -358,7 +358,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Quaterniond Multiply(Quaterniond left, Quaterniond right)
         {
-            Multiply(ref left, ref right, out Quaterniond result);
+            Multiply(in left, in right, out Quaterniond result);
             return result;
         }
 
@@ -368,7 +368,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The first instance.</param>
         /// <param name="right">The second instance.</param>
         /// <param name="result">A new instance containing the result of the calculation.</param>
-        public static void Multiply(ref Quaterniond left, ref Quaterniond right, out Quaterniond result)
+        public static void Multiply(in Quaterniond left, in Quaterniond right, out Quaterniond result)
         {
             result = new Quaterniond(
                 (right.W * left.Xyz) + (left.W * right.Xyz) + Vector3d.Cross(left.Xyz, right.Xyz),
@@ -381,7 +381,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="quaternion">The instance.</param>
         /// <param name="scale">The scalar.</param>
         /// <param name="result">A new instance containing the result of the calculation.</param>
-        public static void Multiply(ref Quaterniond quaternion, double scale, out Quaterniond result)
+        public static void Multiply(in Quaterniond quaternion, double scale, out Quaterniond result)
         {
             result = new Quaterniond
             (
@@ -426,7 +426,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="q">The Quaterniond.</param>
         /// <param name="result">The conjugate of the given Quaterniond.</param>
-        public static void Conjugate(ref Quaterniond q, out Quaterniond result)
+        public static void Conjugate(in Quaterniond q, out Quaterniond result)
         {
             result = new Quaterniond(-q.Xyz, q.W);
         }
@@ -439,7 +439,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Quaterniond Invert(Quaterniond q)
         {
-            Invert(ref q, out Quaterniond result);
+            Invert(in q, out Quaterniond result);
             return result;
         }
 
@@ -448,7 +448,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="q">The Quaterniond to invert.</param>
         /// <param name="result">The inverse of the given Quaterniond.</param>
-        public static void Invert(ref Quaterniond q, out Quaterniond result)
+        public static void Invert(in Quaterniond q, out Quaterniond result)
         {
             var lengthSq = q.LengthSquared;
             if (lengthSq != 0.0)
@@ -470,7 +470,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Quaterniond Normalize(Quaterniond q)
         {
-            Normalize(ref q, out Quaterniond result);
+            Normalize(in q, out Quaterniond result);
             return result;
         }
 
@@ -479,7 +479,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="q">The Quaterniond to normalize.</param>
         /// <param name="result">The normalized Quaterniond.</param>
-        public static void Normalize(ref Quaterniond q, out Quaterniond result)
+        public static void Normalize(in Quaterniond q, out Quaterniond result)
         {
             var scale = 1.0d / q.Length;
             result = new Quaterniond(q.Xyz * scale, q.W * scale);
@@ -538,7 +538,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="eulerAngles">The euler angles as a vector.</param>
         /// <param name="result">The equivalent Quaterniond.</param>
-        public static void FromEulerAngles(ref Vector3d eulerAngles, out Quaterniond result)
+        public static void FromEulerAngles(in Vector3d eulerAngles, out Quaterniond result)
         {
             var c1 = Math.Cos(eulerAngles.Y * 0.5);
             var c2 = Math.Cos(eulerAngles.X * 0.5);
@@ -571,7 +571,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Quaterniond FromMatrix(Matrix3d matrix)
         {
-            FromMatrix(ref matrix, out Quaterniond result);
+            FromMatrix(in matrix, out Quaterniond result);
             return result;
         }
 
@@ -580,7 +580,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="matrix">A rotation matrix.</param>
         /// <param name="result">The equivalent quaternion.</param>
-        public static void FromMatrix(ref Matrix3d matrix, out Quaterniond result)
+        public static void FromMatrix(in Matrix3d matrix, out Quaterniond result)
         {
             var trace = matrix.Trace;
 
@@ -736,7 +736,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Quaterniond operator *(Quaterniond left, Quaterniond right)
         {
-            Multiply(ref left, ref right, out left);
+            Multiply(in left, in right, out left);
             return left;
         }
 
@@ -749,7 +749,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Quaterniond operator *(Quaterniond quaternion, double scale)
         {
-            Multiply(ref quaternion, scale, out quaternion);
+            Multiply(in quaternion, scale, out quaternion);
             return quaternion;
         }
 

--- a/src/OpenToolkit.Mathematics/Matrix/Matrix2.cs
+++ b/src/OpenToolkit.Mathematics/Matrix/Matrix2.cs
@@ -345,7 +345,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the multiplication.</param>
         /// <param name="right">The right operand of the multiplication.</param>
         /// <param name="result">A new instance that is the result of the multiplication.</param>
-        public static void Mult(ref Matrix2 left, float right, out Matrix2 result)
+        public static void Mult(in Matrix2 left, float right, out Matrix2 result)
         {
             result.Row0.X = left.Row0.X * right;
             result.Row0.Y = left.Row0.Y * right;
@@ -362,7 +362,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix2 Mult(Matrix2 left, float right)
         {
-            Mult(ref left, right, out Matrix2 result);
+            Mult(in left, right, out Matrix2 result);
             return result;
         }
 
@@ -372,7 +372,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the multiplication.</param>
         /// <param name="right">The right operand of the multiplication.</param>
         /// <param name="result">A new instance that is the result of the multiplication.</param>
-        public static void Mult(ref Matrix2 left, ref Matrix2 right, out Matrix2 result)
+        public static void Mult(in Matrix2 left, in Matrix2 right, out Matrix2 result)
         {
             float leftM11 = left.Row0.X;
             float leftM12 = left.Row0.Y;
@@ -398,7 +398,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix2 Mult(Matrix2 left, Matrix2 right)
         {
-            Mult(ref left, ref right, out Matrix2 result);
+            Mult(in left, in right, out Matrix2 result);
             return result;
         }
 
@@ -408,7 +408,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the multiplication.</param>
         /// <param name="right">The right operand of the multiplication.</param>
         /// <param name="result">A new instance that is the result of the multiplication.</param>
-        public static void Mult(ref Matrix2 left, ref Matrix2x3 right, out Matrix2x3 result)
+        public static void Mult(in Matrix2 left, in Matrix2x3 right, out Matrix2x3 result)
         {
             float leftM11 = left.Row0.X;
             float leftM12 = left.Row0.Y;
@@ -438,7 +438,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix2x3 Mult(Matrix2 left, Matrix2x3 right)
         {
-            Mult(ref left, ref right, out Matrix2x3 result);
+            Mult(in left, in right, out Matrix2x3 result);
             return result;
         }
 
@@ -448,7 +448,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the multiplication.</param>
         /// <param name="right">The right operand of the multiplication.</param>
         /// <param name="result">A new instance that is the result of the multiplication.</param>
-        public static void Mult(ref Matrix2 left, ref Matrix2x4 right, out Matrix2x4 result)
+        public static void Mult(in Matrix2 left, in Matrix2x4 right, out Matrix2x4 result)
         {
             float leftM11 = left.Row0.X;
             float leftM12 = left.Row0.Y;
@@ -482,7 +482,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix2x4 Mult(Matrix2 left, Matrix2x4 right)
         {
-            Mult(ref left, ref right, out Matrix2x4 result);
+            Mult(in left, in right, out Matrix2x4 result);
             return result;
         }
 
@@ -492,7 +492,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the addition.</param>
         /// <param name="right">The right operand of the addition.</param>
         /// <param name="result">A new instance that is the result of the addition.</param>
-        public static void Add(ref Matrix2 left, ref Matrix2 right, out Matrix2 result)
+        public static void Add(in Matrix2 left, in Matrix2 right, out Matrix2 result)
         {
             result.Row0.X = left.Row0.X + right.Row0.X;
             result.Row0.Y = left.Row0.Y + right.Row0.Y;
@@ -509,7 +509,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix2 Add(Matrix2 left, Matrix2 right)
         {
-            Add(ref left, ref right, out Matrix2 result);
+            Add(in left, in right, out Matrix2 result);
             return result;
         }
 
@@ -519,7 +519,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the subtraction.</param>
         /// <param name="right">The right operand of the subtraction.</param>
         /// <param name="result">A new instance that is the result of the subtraction.</param>
-        public static void Subtract(ref Matrix2 left, ref Matrix2 right, out Matrix2 result)
+        public static void Subtract(in Matrix2 left, in Matrix2 right, out Matrix2 result)
         {
             result.Row0.X = left.Row0.X - right.Row0.X;
             result.Row0.Y = left.Row0.Y - right.Row0.Y;
@@ -536,7 +536,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix2 Subtract(Matrix2 left, Matrix2 right)
         {
-            Subtract(ref left, ref right, out Matrix2 result);
+            Subtract(in left, in right, out Matrix2 result);
             return result;
         }
 
@@ -546,7 +546,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="mat">The matrix to invert.</param>
         /// <param name="result">The inverse of the given matrix.</param>
         /// <exception cref="InvalidOperationException">Thrown if the Matrix2 is singular.</exception>
-        public static void Invert(ref Matrix2 mat, out Matrix2 result)
+        public static void Invert(in Matrix2 mat, out Matrix2 result)
         {
             var det = mat.Determinant;
 
@@ -573,7 +573,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix2 Invert(Matrix2 mat)
         {
-            Invert(ref mat, out Matrix2 result);
+            Invert(in mat, out Matrix2 result);
             return result;
         }
 
@@ -582,7 +582,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="mat">The matrix to transpose.</param>
         /// <param name="result">The transpose of the given matrix.</param>
-        public static void Transpose(ref Matrix2 mat, out Matrix2 result)
+        public static void Transpose(in Matrix2 mat, out Matrix2 result)
         {
             result.Row0.X = mat.Row0.X;
             result.Row0.Y = mat.Row1.X;
@@ -598,7 +598,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix2 Transpose(Matrix2 mat)
         {
-            Transpose(ref mat, out Matrix2 result);
+            Transpose(in mat, out Matrix2 result);
             return result;
         }
 

--- a/src/OpenToolkit.Mathematics/Matrix/Matrix2d.cs
+++ b/src/OpenToolkit.Mathematics/Matrix/Matrix2d.cs
@@ -345,7 +345,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the multiplication.</param>
         /// <param name="right">The right operand of the multiplication.</param>
         /// <param name="result">A new instance that is the result of the multiplication.</param>
-        public static void Mult(ref Matrix2d left, double right, out Matrix2d result)
+        public static void Mult(in Matrix2d left, double right, out Matrix2d result)
         {
             result.Row0.X = left.Row0.X * right;
             result.Row0.Y = left.Row0.Y * right;
@@ -362,7 +362,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix2d Mult(Matrix2d left, double right)
         {
-            Mult(ref left, right, out Matrix2d result);
+            Mult(in left, right, out Matrix2d result);
             return result;
         }
 
@@ -372,7 +372,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the multiplication.</param>
         /// <param name="right">The right operand of the multiplication.</param>
         /// <param name="result">A new instance that is the result of the multiplication.</param>
-        public static void Mult(ref Matrix2d left, ref Matrix2d right, out Matrix2d result)
+        public static void Mult(in Matrix2d left, in Matrix2d right, out Matrix2d result)
         {
             double leftM11 = left.Row0.X;
             double leftM12 = left.Row0.Y;
@@ -398,7 +398,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix2d Mult(Matrix2d left, Matrix2d right)
         {
-            Mult(ref left, ref right, out Matrix2d result);
+            Mult(in left, in right, out Matrix2d result);
             return result;
         }
 
@@ -408,7 +408,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the multiplication.</param>
         /// <param name="right">The right operand of the multiplication.</param>
         /// <param name="result">A new instance that is the result of the multiplication.</param>
-        public static void Mult(ref Matrix2d left, ref Matrix2x3d right, out Matrix2x3d result)
+        public static void Mult(in Matrix2d left, in Matrix2x3d right, out Matrix2x3d result)
         {
             double leftM11 = left.Row0.X;
             double leftM12 = left.Row0.Y;
@@ -438,7 +438,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix2x3d Mult(Matrix2d left, Matrix2x3d right)
         {
-            Mult(ref left, ref right, out Matrix2x3d result);
+            Mult(in left, in right, out Matrix2x3d result);
             return result;
         }
 
@@ -448,7 +448,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the multiplication.</param>
         /// <param name="right">The right operand of the multiplication.</param>
         /// <param name="result">A new instance that is the result of the multiplication.</param>
-        public static void Mult(ref Matrix2d left, ref Matrix2x4d right, out Matrix2x4d result)
+        public static void Mult(in Matrix2d left, in Matrix2x4d right, out Matrix2x4d result)
         {
             double leftM11 = left.Row0.X;
             double leftM12 = left.Row0.Y;
@@ -482,7 +482,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix2x4d Mult(Matrix2d left, Matrix2x4d right)
         {
-            Mult(ref left, ref right, out Matrix2x4d result);
+            Mult(in left, in right, out Matrix2x4d result);
             return result;
         }
 
@@ -492,7 +492,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the addition.</param>
         /// <param name="right">The right operand of the addition.</param>
         /// <param name="result">A new instance that is the result of the addition.</param>
-        public static void Add(ref Matrix2d left, ref Matrix2d right, out Matrix2d result)
+        public static void Add(in Matrix2d left, in Matrix2d right, out Matrix2d result)
         {
             result.Row0.X = left.Row0.X + right.Row0.X;
             result.Row0.Y = left.Row0.Y + right.Row0.Y;
@@ -509,7 +509,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix2d Add(Matrix2d left, Matrix2d right)
         {
-            Add(ref left, ref right, out Matrix2d result);
+            Add(in left, in right, out Matrix2d result);
             return result;
         }
 
@@ -519,7 +519,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the subtraction.</param>
         /// <param name="right">The right operand of the subtraction.</param>
         /// <param name="result">A new instance that is the result of the subtraction.</param>
-        public static void Subtract(ref Matrix2d left, ref Matrix2d right, out Matrix2d result)
+        public static void Subtract(in Matrix2d left, in Matrix2d right, out Matrix2d result)
         {
             result.Row0.X = left.Row0.X - right.Row0.X;
             result.Row0.Y = left.Row0.Y - right.Row0.Y;
@@ -536,7 +536,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix2d Subtract(Matrix2d left, Matrix2d right)
         {
-            Subtract(ref left, ref right, out Matrix2d result);
+            Subtract(in left, in right, out Matrix2d result);
             return result;
         }
 
@@ -546,7 +546,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="mat">The matrix to invert.</param>
         /// <param name="result">The inverse of the given matrix if it has one, or the input if it is singular.</param>
         /// <exception cref="InvalidOperationException">Thrown if the Matrix2d is singular.</exception>
-        public static void Invert(ref Matrix2d mat, out Matrix2d result)
+        public static void Invert(in Matrix2d mat, out Matrix2d result)
         {
             var det = mat.Determinant;
 
@@ -573,7 +573,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix2d Invert(Matrix2d mat)
         {
-            Invert(ref mat, out Matrix2d result);
+            Invert(in mat, out Matrix2d result);
             return result;
         }
 
@@ -582,7 +582,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="mat">The matrix to transpose.</param>
         /// <param name="result">The transpose of the given matrix.</param>
-        public static void Transpose(ref Matrix2d mat, out Matrix2d result)
+        public static void Transpose(in Matrix2d mat, out Matrix2d result)
         {
             result.Row0.X = mat.Row0.X;
             result.Row0.Y = mat.Row1.X;
@@ -598,7 +598,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix2d Transpose(Matrix2d mat)
         {
-            Transpose(ref mat, out Matrix2d result);
+            Transpose(in mat, out Matrix2d result);
             return result;
         }
 

--- a/src/OpenToolkit.Mathematics/Matrix/Matrix2x3.cs
+++ b/src/OpenToolkit.Mathematics/Matrix/Matrix2x3.cs
@@ -349,7 +349,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the multiplication.</param>
         /// <param name="right">The right operand of the multiplication.</param>
         /// <param name="result">A new instance that is the result of the multiplication.</param>
-        public static void Mult(ref Matrix2x3 left, float right, out Matrix2x3 result)
+        public static void Mult(in Matrix2x3 left, float right, out Matrix2x3 result)
         {
             result.Row0.X = left.Row0.X * right;
             result.Row0.Y = left.Row0.Y * right;
@@ -368,7 +368,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix2x3 Mult(Matrix2x3 left, float right)
         {
-            Mult(ref left, right, out Matrix2x3 result);
+            Mult(in left, right, out Matrix2x3 result);
             return result;
         }
 
@@ -378,7 +378,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the multiplication.</param>
         /// <param name="right">The right operand of the multiplication.</param>
         /// <param name="result">A new instance that is the result of the multiplication.</param>
-        public static void Mult(ref Matrix2x3 left, ref Matrix3x2 right, out Matrix2 result)
+        public static void Mult(in Matrix2x3 left, in Matrix3x2 right, out Matrix2 result)
         {
             float leftM11 = left.Row0.X;
             float leftM12 = left.Row0.Y;
@@ -408,7 +408,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix2 Mult(Matrix2x3 left, Matrix3x2 right)
         {
-            Mult(ref left, ref right, out Matrix2 result);
+            Mult(in left, in right, out Matrix2 result);
             return result;
         }
 
@@ -418,7 +418,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the multiplication.</param>
         /// <param name="right">The right operand of the multiplication.</param>
         /// <param name="result">A new instance that is the result of the multiplication.</param>
-        public static void Mult(ref Matrix2x3 left, ref Matrix3 right, out Matrix2x3 result)
+        public static void Mult(in Matrix2x3 left, in Matrix3 right, out Matrix2x3 result)
         {
             float leftM11 = left.Row0.X;
             float leftM12 = left.Row0.Y;
@@ -453,7 +453,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix2x3 Mult(Matrix2x3 left, Matrix3 right)
         {
-            Mult(ref left, ref right, out Matrix2x3 result);
+            Mult(in left, in right, out Matrix2x3 result);
             return result;
         }
 
@@ -463,7 +463,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the multiplication.</param>
         /// <param name="right">The right operand of the multiplication.</param>
         /// <param name="result">A new instance that is the result of the multiplication.</param>
-        public static void Mult(ref Matrix2x3 left, ref Matrix3x4 right, out Matrix2x4 result)
+        public static void Mult(in Matrix2x3 left, in Matrix3x4 right, out Matrix2x4 result)
         {
             float leftM11 = left.Row0.X;
             float leftM12 = left.Row0.Y;
@@ -502,7 +502,7 @@ namespace OpenToolkit.Mathematics
         /// <returns>A new instance that is the result of the multiplication.</returns>
         public static Matrix2x4 Mult(Matrix2x3 left, Matrix3x4 right)
         {
-            Mult(ref left, ref right, out Matrix2x4 result);
+            Mult(in left, in right, out Matrix2x4 result);
             return result;
         }
 
@@ -512,7 +512,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the addition.</param>
         /// <param name="right">The right operand of the addition.</param>
         /// <param name="result">A new instance that is the result of the addition.</param>
-        public static void Add(ref Matrix2x3 left, ref Matrix2x3 right, out Matrix2x3 result)
+        public static void Add(in Matrix2x3 left, in Matrix2x3 right, out Matrix2x3 result)
         {
             result.Row0.X = left.Row0.X + right.Row0.X;
             result.Row0.Y = left.Row0.Y + right.Row0.Y;
@@ -531,7 +531,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix2x3 Add(Matrix2x3 left, Matrix2x3 right)
         {
-            Add(ref left, ref right, out Matrix2x3 result);
+            Add(in left, in right, out Matrix2x3 result);
             return result;
         }
 
@@ -541,7 +541,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the subtraction.</param>
         /// <param name="right">The right operand of the subtraction.</param>
         /// <param name="result">A new instance that is the result of the subtraction.</param>
-        public static void Subtract(ref Matrix2x3 left, ref Matrix2x3 right, out Matrix2x3 result)
+        public static void Subtract(in Matrix2x3 left, in Matrix2x3 right, out Matrix2x3 result)
         {
             result.Row0.X = left.Row0.X - right.Row0.X;
             result.Row0.Y = left.Row0.Y - right.Row0.Y;
@@ -560,7 +560,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix2x3 Subtract(Matrix2x3 left, Matrix2x3 right)
         {
-            Subtract(ref left, ref right, out Matrix2x3 result);
+            Subtract(in left, in right, out Matrix2x3 result);
             return result;
         }
 
@@ -569,7 +569,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="mat">The matrix to transpose.</param>
         /// <param name="result">The transpose of the given matrix.</param>
-        public static void Transpose(ref Matrix2x3 mat, out Matrix3x2 result)
+        public static void Transpose(in Matrix2x3 mat, out Matrix3x2 result)
         {
             result.Row0.X = mat.Row0.X;
             result.Row0.Y = mat.Row1.X;
@@ -587,7 +587,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix3x2 Transpose(Matrix2x3 mat)
         {
-            Transpose(ref mat, out Matrix3x2 result);
+            Transpose(in mat, out Matrix3x2 result);
             return result;
         }
 

--- a/src/OpenToolkit.Mathematics/Matrix/Matrix2x3d.cs
+++ b/src/OpenToolkit.Mathematics/Matrix/Matrix2x3d.cs
@@ -348,7 +348,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the multiplication.</param>
         /// <param name="right">The right operand of the multiplication.</param>
         /// <param name="result">A new instance that is the result of the multiplication.</param>
-        public static void Mult(ref Matrix2x3d left, double right, out Matrix2x3d result)
+        public static void Mult(in Matrix2x3d left, double right, out Matrix2x3d result)
         {
             result.Row0.X = left.Row0.X * right;
             result.Row0.Y = left.Row0.Y * right;
@@ -367,7 +367,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix2x3d Mult(Matrix2x3d left, double right)
         {
-            Mult(ref left, right, out Matrix2x3d result);
+            Mult(in left, right, out Matrix2x3d result);
             return result;
         }
 
@@ -377,7 +377,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the multiplication.</param>
         /// <param name="right">The right operand of the multiplication.</param>
         /// <param name="result">A new instance that is the result of the multiplication.</param>
-        public static void Mult(ref Matrix2x3d left, ref Matrix3x2 right, out Matrix2d result)
+        public static void Mult(in Matrix2x3d left, in Matrix3x2 right, out Matrix2d result)
         {
             double leftM11 = left.Row0.X;
             double leftM12 = left.Row0.Y;
@@ -407,7 +407,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix2d Mult(Matrix2x3d left, Matrix3x2 right)
         {
-            Mult(ref left, ref right, out Matrix2d result);
+            Mult(in left, in right, out Matrix2d result);
             return result;
         }
 
@@ -417,7 +417,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the multiplication.</param>
         /// <param name="right">The right operand of the multiplication.</param>
         /// <param name="result">A new instance that is the result of the multiplication.</param>
-        public static void Mult(ref Matrix2x3d left, ref Matrix3 right, out Matrix2x3d result)
+        public static void Mult(in Matrix2x3d left, in Matrix3 right, out Matrix2x3d result)
         {
             double leftM11 = left.Row0.X;
             double leftM12 = left.Row0.Y;
@@ -452,7 +452,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix2x3d Mult(Matrix2x3d left, Matrix3 right)
         {
-            Mult(ref left, ref right, out Matrix2x3d result);
+            Mult(in left, in right, out Matrix2x3d result);
             return result;
         }
 
@@ -462,7 +462,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the multiplication.</param>
         /// <param name="right">The right operand of the multiplication.</param>
         /// <param name="result">A new instance that is the result of the multiplication.</param>
-        public static void Mult(ref Matrix2x3d left, ref Matrix3x4 right, out Matrix2x4d result)
+        public static void Mult(in Matrix2x3d left, in Matrix3x4 right, out Matrix2x4d result)
         {
             double leftM11 = left.Row0.X;
             double leftM12 = left.Row0.Y;
@@ -502,7 +502,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix2x4d Mult(Matrix2x3d left, Matrix3x4 right)
         {
-            Mult(ref left, ref right, out Matrix2x4d result);
+            Mult(in left, in right, out Matrix2x4d result);
             return result;
         }
 
@@ -512,7 +512,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the addition.</param>
         /// <param name="right">The right operand of the addition.</param>
         /// <param name="result">A new instance that is the result of the addition.</param>
-        public static void Add(ref Matrix2x3d left, ref Matrix2x3d right, out Matrix2x3d result)
+        public static void Add(in Matrix2x3d left, in Matrix2x3d right, out Matrix2x3d result)
         {
             result.Row0.X = left.Row0.X + right.Row0.X;
             result.Row0.Y = left.Row0.Y + right.Row0.Y;
@@ -531,7 +531,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix2x3d Add(Matrix2x3d left, Matrix2x3d right)
         {
-            Add(ref left, ref right, out Matrix2x3d result);
+            Add(in left, in right, out Matrix2x3d result);
             return result;
         }
 
@@ -541,7 +541,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the subtraction.</param>
         /// <param name="right">The right operand of the subtraction.</param>
         /// <param name="result">A new instance that is the result of the subtraction.</param>
-        public static void Subtract(ref Matrix2x3d left, ref Matrix2x3d right, out Matrix2x3d result)
+        public static void Subtract(in Matrix2x3d left, in Matrix2x3d right, out Matrix2x3d result)
         {
             result.Row0.X = left.Row0.X - right.Row0.X;
             result.Row0.Y = left.Row0.Y - right.Row0.Y;
@@ -560,7 +560,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix2x3d Subtract(Matrix2x3d left, Matrix2x3d right)
         {
-            Subtract(ref left, ref right, out Matrix2x3d result);
+            Subtract(in left, in right, out Matrix2x3d result);
             return result;
         }
 
@@ -569,7 +569,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="mat">The matrix to transpose.</param>
         /// <param name="result">The transpose of the given matrix.</param>
-        public static void Transpose(ref Matrix2x3d mat, out Matrix3x2d result)
+        public static void Transpose(in Matrix2x3d mat, out Matrix3x2d result)
         {
             result.Row0.X = mat.Row0.X;
             result.Row0.Y = mat.Row1.X;
@@ -587,7 +587,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix3x2d Transpose(Matrix2x3d mat)
         {
-            Transpose(ref mat, out Matrix3x2d result);
+            Transpose(in mat, out Matrix3x2d result);
             return result;
         }
 

--- a/src/OpenToolkit.Mathematics/Matrix/Matrix2x4.cs
+++ b/src/OpenToolkit.Mathematics/Matrix/Matrix2x4.cs
@@ -390,7 +390,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the multiplication.</param>
         /// <param name="right">The right operand of the multiplication.</param>
         /// <param name="result">A new instance that is the result of the multiplication.</param>
-        public static void Mult(ref Matrix2x4 left, float right, out Matrix2x4 result)
+        public static void Mult(in Matrix2x4 left, float right, out Matrix2x4 result)
         {
             result.Row0.X = left.Row0.X * right;
             result.Row0.Y = left.Row0.Y * right;
@@ -411,7 +411,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix2x4 Mult(Matrix2x4 left, float right)
         {
-            Mult(ref left, right, out Matrix2x4 result);
+            Mult(in left, right, out Matrix2x4 result);
             return result;
         }
 
@@ -421,7 +421,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the multiplication.</param>
         /// <param name="right">The right operand of the multiplication.</param>
         /// <param name="result">A new instance that is the result of the multiplication.</param>
-        public static void Mult(ref Matrix2x4 left, ref Matrix4x2 right, out Matrix2 result)
+        public static void Mult(in Matrix2x4 left, in Matrix4x2 right, out Matrix2 result)
         {
             float leftM11 = left.Row0.X;
             float leftM12 = left.Row0.Y;
@@ -455,7 +455,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix2 Mult(Matrix2x4 left, Matrix4x2 right)
         {
-            Mult(ref left, ref right, out Matrix2 result);
+            Mult(in left, in right, out Matrix2 result);
             return result;
         }
 
@@ -465,7 +465,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the multiplication.</param>
         /// <param name="right">The right operand of the multiplication.</param>
         /// <param name="result">A new instance that is the result of the multiplication.</param>
-        public static void Mult(ref Matrix2x4 left, ref Matrix4x3 right, out Matrix2x3 result)
+        public static void Mult(in Matrix2x4 left, in Matrix4x3 right, out Matrix2x3 result)
         {
             float leftM11 = left.Row0.X;
             float leftM12 = left.Row0.Y;
@@ -505,7 +505,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix2x3 Mult(Matrix2x4 left, Matrix4x3 right)
         {
-            Mult(ref left, ref right, out Matrix2x3 result);
+            Mult(in left, in right, out Matrix2x3 result);
             return result;
         }
 
@@ -515,7 +515,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the multiplication.</param>
         /// <param name="right">The right operand of the multiplication.</param>
         /// <param name="result">A new instance that is the result of the multiplication.</param>
-        public static void Mult(ref Matrix2x4 left, ref Matrix4 right, out Matrix2x4 result)
+        public static void Mult(in Matrix2x4 left, in Matrix4 right, out Matrix2x4 result)
         {
             float leftM11 = left.Row0.X;
             float leftM12 = left.Row0.Y;
@@ -561,7 +561,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix2x4 Mult(Matrix2x4 left, Matrix4 right)
         {
-            Mult(ref left, ref right, out Matrix2x4 result);
+            Mult(in left, in right, out Matrix2x4 result);
             return result;
         }
 
@@ -571,7 +571,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the addition.</param>
         /// <param name="right">The right operand of the addition.</param>
         /// <param name="result">A new instance that is the result of the addition.</param>
-        public static void Add(ref Matrix2x4 left, ref Matrix2x4 right, out Matrix2x4 result)
+        public static void Add(in Matrix2x4 left, in Matrix2x4 right, out Matrix2x4 result)
         {
             result.Row0.X = left.Row0.X + right.Row0.X;
             result.Row0.Y = left.Row0.Y + right.Row0.Y;
@@ -592,7 +592,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix2x4 Add(Matrix2x4 left, Matrix2x4 right)
         {
-            Add(ref left, ref right, out Matrix2x4 result);
+            Add(in left, in right, out Matrix2x4 result);
             return result;
         }
 
@@ -602,7 +602,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the subtraction.</param>
         /// <param name="right">The right operand of the subtraction.</param>
         /// <param name="result">A new instance that is the result of the subtraction.</param>
-        public static void Subtract(ref Matrix2x4 left, ref Matrix2x4 right, out Matrix2x4 result)
+        public static void Subtract(in Matrix2x4 left, in Matrix2x4 right, out Matrix2x4 result)
         {
             result.Row0.X = left.Row0.X - right.Row0.X;
             result.Row0.Y = left.Row0.Y - right.Row0.Y;
@@ -623,7 +623,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix2x4 Subtract(Matrix2x4 left, Matrix2x4 right)
         {
-            Subtract(ref left, ref right, out Matrix2x4 result);
+            Subtract(in left, in right, out Matrix2x4 result);
             return result;
         }
 
@@ -632,7 +632,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="mat">The matrix to transpose.</param>
         /// <param name="result">The transpose of the given matrix.</param>
-        public static void Transpose(ref Matrix2x4 mat, out Matrix4x2 result)
+        public static void Transpose(in Matrix2x4 mat, out Matrix4x2 result)
         {
             result.Row0.X = mat.Row0.X;
             result.Row0.Y = mat.Row1.X;
@@ -652,7 +652,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix4x2 Transpose(Matrix2x4 mat)
         {
-            Transpose(ref mat, out Matrix4x2 result);
+            Transpose(in mat, out Matrix4x2 result);
             return result;
         }
 

--- a/src/OpenToolkit.Mathematics/Matrix/Matrix2x4d.cs
+++ b/src/OpenToolkit.Mathematics/Matrix/Matrix2x4d.cs
@@ -390,7 +390,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the multiplication.</param>
         /// <param name="right">The right operand of the multiplication.</param>
         /// <param name="result">A new instance that is the result of the multiplication.</param>
-        public static void Mult(ref Matrix2x4d left, double right, out Matrix2x4d result)
+        public static void Mult(in Matrix2x4d left, double right, out Matrix2x4d result)
         {
             result.Row0.X = left.Row0.X * right;
             result.Row0.Y = left.Row0.Y * right;
@@ -411,7 +411,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix2x4d Mult(Matrix2x4d left, double right)
         {
-            Mult(ref left, right, out Matrix2x4d result);
+            Mult(in left, right, out Matrix2x4d result);
             return result;
         }
 
@@ -421,7 +421,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the multiplication.</param>
         /// <param name="right">The right operand of the multiplication.</param>
         /// <param name="result">A new instance that is the result of the multiplication.</param>
-        public static void Mult(ref Matrix2x4d left, ref Matrix4x2 right, out Matrix2d result)
+        public static void Mult(in Matrix2x4d left, in Matrix4x2 right, out Matrix2d result)
         {
             double leftM11 = left.Row0.X;
             double leftM12 = left.Row0.Y;
@@ -455,7 +455,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix2d Mult(Matrix2x4d left, Matrix4x2 right)
         {
-            Mult(ref left, ref right, out Matrix2d result);
+            Mult(in left, in right, out Matrix2d result);
             return result;
         }
 
@@ -465,7 +465,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the multiplication.</param>
         /// <param name="right">The right operand of the multiplication.</param>
         /// <param name="result">A new instance that is the result of the multiplication.</param>
-        public static void Mult(ref Matrix2x4d left, ref Matrix4x3 right, out Matrix2x3d result)
+        public static void Mult(in Matrix2x4d left, in Matrix4x3 right, out Matrix2x3d result)
         {
             double leftM11 = left.Row0.X;
             double leftM12 = left.Row0.Y;
@@ -505,7 +505,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix2x3d Mult(Matrix2x4d left, Matrix4x3 right)
         {
-            Mult(ref left, ref right, out Matrix2x3d result);
+            Mult(in left, in right, out Matrix2x3d result);
             return result;
         }
 
@@ -515,7 +515,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the multiplication.</param>
         /// <param name="right">The right operand of the multiplication.</param>
         /// <param name="result">A new instance that is the result of the multiplication.</param>
-        public static void Mult(ref Matrix2x4d left, ref Matrix4 right, out Matrix2x4d result)
+        public static void Mult(in Matrix2x4d left, in Matrix4 right, out Matrix2x4d result)
         {
             double leftM11 = left.Row0.X;
             double leftM12 = left.Row0.Y;
@@ -561,7 +561,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix2x4d Mult(Matrix2x4d left, Matrix4 right)
         {
-            Mult(ref left, ref right, out Matrix2x4d result);
+            Mult(in left, in right, out Matrix2x4d result);
             return result;
         }
 
@@ -571,7 +571,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the addition.</param>
         /// <param name="right">The right operand of the addition.</param>
         /// <param name="result">A new instance that is the result of the addition.</param>
-        public static void Add(ref Matrix2x4d left, ref Matrix2x4d right, out Matrix2x4d result)
+        public static void Add(in Matrix2x4d left, in Matrix2x4d right, out Matrix2x4d result)
         {
             result.Row0.X = left.Row0.X + right.Row0.X;
             result.Row0.Y = left.Row0.Y + right.Row0.Y;
@@ -592,7 +592,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix2x4d Add(Matrix2x4d left, Matrix2x4d right)
         {
-            Add(ref left, ref right, out Matrix2x4d result);
+            Add(in left, in right, out Matrix2x4d result);
             return result;
         }
 
@@ -602,7 +602,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the subtraction.</param>
         /// <param name="right">The right operand of the subtraction.</param>
         /// <param name="result">A new instance that is the result of the subtraction.</param>
-        public static void Subtract(ref Matrix2x4d left, ref Matrix2x4d right, out Matrix2x4d result)
+        public static void Subtract(in Matrix2x4d left, in Matrix2x4d right, out Matrix2x4d result)
         {
             result.Row0.X = left.Row0.X - right.Row0.X;
             result.Row0.Y = left.Row0.Y - right.Row0.Y;
@@ -623,7 +623,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix2x4d Subtract(Matrix2x4d left, Matrix2x4d right)
         {
-            Subtract(ref left, ref right, out Matrix2x4d result);
+            Subtract(in left, in right, out Matrix2x4d result);
             return result;
         }
 
@@ -632,7 +632,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="mat">The matrix to transpose.</param>
         /// <param name="result">The transpose of the given matrix.</param>
-        public static void Transpose(ref Matrix2x4d mat, out Matrix4x2d result)
+        public static void Transpose(in Matrix2x4d mat, out Matrix4x2d result)
         {
             result.Row0.X = mat.Row0.X;
             result.Row0.Y = mat.Row1.X;
@@ -652,7 +652,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix4x2d Transpose(Matrix2x4d mat)
         {
-            Transpose(ref mat, out Matrix4x2d result);
+            Transpose(in mat, out Matrix4x2d result);
             return result;
         }
 

--- a/src/OpenToolkit.Mathematics/Matrix/Matrix3.cs
+++ b/src/OpenToolkit.Mathematics/Matrix/Matrix3.cs
@@ -512,7 +512,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="q">Quaternion to translate.</param>
         /// <param name="result">Matrix result.</param>
-        public static void CreateFromQuaternion(ref Quaternion q, out Matrix3 result)
+        public static void CreateFromQuaternion(in Quaternion q, out Matrix3 result)
         {
             q.ToAxisAngle(out Vector3 axis, out float angle);
             CreateFromAxisAngle(axis, angle, out result);
@@ -526,7 +526,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix3 CreateFromQuaternion(Quaternion q)
         {
-            CreateFromQuaternion(ref q, out Matrix3 result);
+            CreateFromQuaternion(in q, out Matrix3 result);
             return result;
         }
 
@@ -637,7 +637,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix3 CreateScale(Vector3 scale)
         {
-            CreateScale(ref scale, out Matrix3 result);
+            CreateScale(in scale, out Matrix3 result);
             return result;
         }
 
@@ -673,7 +673,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="scale">Scale factors for the x, y, and z axes.</param>
         /// <param name="result">A scale matrix.</param>
-        public static void CreateScale(ref Vector3 scale, out Matrix3 result)
+        public static void CreateScale(in Vector3 scale, out Matrix3 result)
         {
             result = Identity;
             result.Row0.X = scale.X;
@@ -705,7 +705,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix3 Add(Matrix3 left, Matrix3 right)
         {
-            Add(ref left, ref right, out Matrix3 result);
+            Add(in left, in right, out Matrix3 result);
             return result;
         }
 
@@ -715,11 +715,11 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the addition.</param>
         /// <param name="right">The right operand of the addition.</param>
         /// <param name="result">A new instance that is the result of the addition.</param>
-        public static void Add(ref Matrix3 left, ref Matrix3 right, out Matrix3 result)
+        public static void Add(in Matrix3 left, in Matrix3 right, out Matrix3 result)
         {
-            Vector3.Add(ref left.Row0, ref right.Row0, out result.Row0);
-            Vector3.Add(ref left.Row1, ref right.Row1, out result.Row1);
-            Vector3.Add(ref left.Row2, ref right.Row2, out result.Row2);
+            Vector3.Add(in left.Row0, in right.Row0, out result.Row0);
+            Vector3.Add(in left.Row1, in right.Row1, out result.Row1);
+            Vector3.Add(in left.Row2, in right.Row2, out result.Row2);
         }
 
         /// <summary>
@@ -731,7 +731,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix3 Mult(Matrix3 left, Matrix3 right)
         {
-            Mult(ref left, ref right, out Matrix3 result);
+            Mult(in left, in right, out Matrix3 result);
             return result;
         }
 
@@ -741,7 +741,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the multiplication.</param>
         /// <param name="right">The right operand of the multiplication.</param>
         /// <param name="result">A new instance that is the result of the multiplication.</param>
-        public static void Mult(ref Matrix3 left, ref Matrix3 right, out Matrix3 result)
+        public static void Mult(in Matrix3 left, in Matrix3 right, out Matrix3 result)
         {
             float leftM11 = left.Row0.X;
             float leftM12 = left.Row0.Y;
@@ -779,7 +779,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="mat">The matrix to invert.</param>
         /// <param name="result">The inverse of the given matrix if it has one, or the input if it is singular.</param>
         /// <exception cref="InvalidOperationException">Thrown if the Matrix3 is singular.</exception>
-        public static void Invert(ref Matrix3 mat, out Matrix3 result)
+        public static void Invert(in Matrix3 mat, out Matrix3 result)
         {
             int[] colIdx = { 0, 0, 0 };
             int[] rowIdx = { 0, 0, 0 };
@@ -897,7 +897,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix3 Invert(Matrix3 mat)
         {
-            Invert(ref mat, out Matrix3 result);
+            Invert(in mat, out Matrix3 result);
             return result;
         }
 
@@ -917,7 +917,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="mat">The matrix to transpose.</param>
         /// <param name="result">The result of the calculation.</param>
-        public static void Transpose(ref Matrix3 mat, out Matrix3 result)
+        public static void Transpose(in Matrix3 mat, out Matrix3 result)
         {
             result.Row0.X = mat.Row0.X;
             result.Row0.Y = mat.Row1.X;

--- a/src/OpenToolkit.Mathematics/Matrix/Matrix3d.cs
+++ b/src/OpenToolkit.Mathematics/Matrix/Matrix3d.cs
@@ -508,7 +508,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="q">Quaternion to translate.</param>
         /// <param name="result">Matrix result.</param>
-        public static void CreateFromQuaternion(ref Quaterniond q, out Matrix3d result)
+        public static void CreateFromQuaternion(in Quaterniond q, out Matrix3d result)
         {
             q.ToAxisAngle(out Vector3d axis, out double angle);
             CreateFromAxisAngle(axis, angle, out result);
@@ -522,7 +522,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix3d CreateFromQuaternion(Quaterniond q)
         {
-            CreateFromQuaternion(ref q, out Matrix3d result);
+            CreateFromQuaternion(in q, out Matrix3d result);
             return result;
         }
 
@@ -633,7 +633,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix3d CreateScale(Vector3d scale)
         {
-            CreateScale(ref scale, out Matrix3d result);
+            CreateScale(in scale, out Matrix3d result);
             return result;
         }
 
@@ -669,7 +669,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="scale">Scale factors for the x, y, and z axes.</param>
         /// <param name="result">A scale matrix.</param>
-        public static void CreateScale(ref Vector3d scale, out Matrix3d result)
+        public static void CreateScale(in Vector3d scale, out Matrix3d result)
         {
             result = Identity;
             result.Row0.X = scale.X;
@@ -701,7 +701,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix3d Add(Matrix3d left, Matrix3d right)
         {
-            Add(ref left, ref right, out Matrix3d result);
+            Add(in left, in right, out Matrix3d result);
             return result;
         }
 
@@ -711,11 +711,11 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the addition.</param>
         /// <param name="right">The right operand of the addition.</param>
         /// <param name="result">A new instance that is the result of the addition.</param>
-        public static void Add(ref Matrix3d left, ref Matrix3d right, out Matrix3d result)
+        public static void Add(in Matrix3d left, in Matrix3d right, out Matrix3d result)
         {
-            Vector3d.Add(ref left.Row0, ref right.Row0, out result.Row0);
-            Vector3d.Add(ref left.Row1, ref right.Row1, out result.Row1);
-            Vector3d.Add(ref left.Row2, ref right.Row2, out result.Row2);
+            Vector3d.Add(in left.Row0, in right.Row0, out result.Row0);
+            Vector3d.Add(in left.Row1, in right.Row1, out result.Row1);
+            Vector3d.Add(in left.Row2, in right.Row2, out result.Row2);
         }
 
         /// <summary>
@@ -727,7 +727,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix3d Mult(Matrix3d left, Matrix3d right)
         {
-            Mult(ref left, ref right, out Matrix3d result);
+            Mult(in left, in right, out Matrix3d result);
             return result;
         }
 
@@ -737,7 +737,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the multiplication.</param>
         /// <param name="right">The right operand of the multiplication.</param>
         /// <param name="result">A new instance that is the result of the multiplication.</param>
-        public static void Mult(ref Matrix3d left, ref Matrix3d right, out Matrix3d result)
+        public static void Mult(in Matrix3d left, in Matrix3d right, out Matrix3d result)
         {
             double leftM11 = left.Row0.X;
             double leftM12 = left.Row0.Y;
@@ -775,7 +775,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="mat">The matrix to invert.</param>
         /// <param name="result">The inverse of the given matrix if it has one, or the input if it is singular.</param>
         /// <exception cref="InvalidOperationException">Thrown if the Matrix3d is singular.</exception>
-        public static void Invert(ref Matrix3d mat, out Matrix3d result)
+        public static void Invert(in Matrix3d mat, out Matrix3d result)
         {
             int[] colIdx = { 0, 0, 0 };
             int[] rowIdx = { 0, 0, 0 };
@@ -893,7 +893,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix3d Invert(Matrix3d mat)
         {
-            Invert(ref mat, out Matrix3d result);
+            Invert(in mat, out Matrix3d result);
             return result;
         }
 
@@ -913,7 +913,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="mat">The matrix to transpose.</param>
         /// <param name="result">The result of the calculation.</param>
-        public static void Transpose(ref Matrix3d mat, out Matrix3d result)
+        public static void Transpose(in Matrix3d mat, out Matrix3d result)
         {
             result.Row0 = mat.Column0;
             result.Row1 = mat.Column1;

--- a/src/OpenToolkit.Mathematics/Matrix/Matrix3x2.cs
+++ b/src/OpenToolkit.Mathematics/Matrix/Matrix3x2.cs
@@ -356,7 +356,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the multiplication.</param>
         /// <param name="right">The right operand of the multiplication.</param>
         /// <param name="result">A new instance that is the result of the multiplication.</param>
-        public static void Mult(ref Matrix3x2 left, float right, out Matrix3x2 result)
+        public static void Mult(in Matrix3x2 left, float right, out Matrix3x2 result)
         {
             result.Row0.X = left.Row0.X * right;
             result.Row0.Y = left.Row0.Y * right;
@@ -375,7 +375,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix3x2 Mult(Matrix3x2 left, float right)
         {
-            Mult(ref left, right, out Matrix3x2 result);
+            Mult(in left, right, out Matrix3x2 result);
             return result;
         }
 
@@ -385,7 +385,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the multiplication.</param>
         /// <param name="right">The right operand of the multiplication.</param>
         /// <param name="result">A new instance that is the result of the multiplication.</param>
-        public static void Mult(ref Matrix3x2 left, ref Matrix2 right, out Matrix3x2 result)
+        public static void Mult(in Matrix3x2 left, in Matrix2 right, out Matrix3x2 result)
         {
             float leftM11 = left.Row0.X;
             float leftM12 = left.Row0.Y;
@@ -415,7 +415,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix3x2 Mult(Matrix3x2 left, Matrix2 right)
         {
-            Mult(ref left, ref right, out Matrix3x2 result);
+            Mult(in left, in right, out Matrix3x2 result);
             return result;
         }
 
@@ -425,7 +425,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the multiplication.</param>
         /// <param name="right">The right operand of the multiplication.</param>
         /// <param name="result">A new instance that is the result of the multiplication.</param>
-        public static void Mult(ref Matrix3x2 left, ref Matrix2x3 right, out Matrix3 result)
+        public static void Mult(in Matrix3x2 left, in Matrix2x3 right, out Matrix3 result)
         {
             float leftM11 = left.Row0.X;
             float leftM12 = left.Row0.Y;
@@ -460,7 +460,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix3 Mult(Matrix3x2 left, Matrix2x3 right)
         {
-            Mult(ref left, ref right, out Matrix3 result);
+            Mult(in left, in right, out Matrix3 result);
             return result;
         }
 
@@ -470,7 +470,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the multiplication.</param>
         /// <param name="right">The right operand of the multiplication.</param>
         /// <param name="result">A new instance that is the result of the multiplication.</param>
-        public static void Mult(ref Matrix3x2 left, ref Matrix2x4 right, out Matrix3x4 result)
+        public static void Mult(in Matrix3x2 left, in Matrix2x4 right, out Matrix3x4 result)
         {
             float leftM11 = left.Row0.X;
             float leftM12 = left.Row0.Y;
@@ -510,7 +510,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix3x4 Mult(Matrix3x2 left, Matrix2x4 right)
         {
-            Mult(ref left, ref right, out Matrix3x4 result);
+            Mult(in left, in right, out Matrix3x4 result);
             return result;
         }
 
@@ -520,7 +520,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the addition.</param>
         /// <param name="right">The right operand of the addition.</param>
         /// <param name="result">A new instance that is the result of the addition.</param>
-        public static void Add(ref Matrix3x2 left, ref Matrix3x2 right, out Matrix3x2 result)
+        public static void Add(in Matrix3x2 left, in Matrix3x2 right, out Matrix3x2 result)
         {
             result.Row0.X = left.Row0.X + right.Row0.X;
             result.Row0.Y = left.Row0.Y + right.Row0.Y;
@@ -539,7 +539,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix3x2 Add(Matrix3x2 left, Matrix3x2 right)
         {
-            Add(ref left, ref right, out Matrix3x2 result);
+            Add(in left, in right, out Matrix3x2 result);
             return result;
         }
 
@@ -549,7 +549,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the subtraction.</param>
         /// <param name="right">The right operand of the subtraction.</param>
         /// <param name="result">A new instance that is the result of the subtraction.</param>
-        public static void Subtract(ref Matrix3x2 left, ref Matrix3x2 right, out Matrix3x2 result)
+        public static void Subtract(in Matrix3x2 left, in Matrix3x2 right, out Matrix3x2 result)
         {
             result.Row0.X = left.Row0.X - right.Row0.X;
             result.Row0.Y = left.Row0.Y - right.Row0.Y;
@@ -568,7 +568,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix3x2 Subtract(Matrix3x2 left, Matrix3x2 right)
         {
-            Subtract(ref left, ref right, out Matrix3x2 result);
+            Subtract(in left, in right, out Matrix3x2 result);
             return result;
         }
 
@@ -577,7 +577,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="mat">The matrix to transpose.</param>
         /// <param name="result">The transpose of the given matrix.</param>
-        public static void Transpose(ref Matrix3x2 mat, out Matrix2x3 result)
+        public static void Transpose(in Matrix3x2 mat, out Matrix2x3 result)
         {
             result.Row0.X = mat.Row0.X;
             result.Row0.Y = mat.Row1.X;
@@ -595,7 +595,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix2x3 Transpose(Matrix3x2 mat)
         {
-            Transpose(ref mat, out Matrix2x3 result);
+            Transpose(in mat, out Matrix2x3 result);
             return result;
         }
 

--- a/src/OpenToolkit.Mathematics/Matrix/Matrix3x2d.cs
+++ b/src/OpenToolkit.Mathematics/Matrix/Matrix3x2d.cs
@@ -356,7 +356,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the multiplication.</param>
         /// <param name="right">The right operand of the multiplication.</param>
         /// <param name="result">A new instance that is the result of the multiplication.</param>
-        public static void Mult(ref Matrix3x2d left, double right, out Matrix3x2d result)
+        public static void Mult(in Matrix3x2d left, double right, out Matrix3x2d result)
         {
             result.Row0.X = left.Row0.X * right;
             result.Row0.Y = left.Row0.Y * right;
@@ -375,7 +375,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix3x2d Mult(Matrix3x2d left, double right)
         {
-            Mult(ref left, right, out Matrix3x2d result);
+            Mult(in left, right, out Matrix3x2d result);
             return result;
         }
 
@@ -385,7 +385,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the multiplication.</param>
         /// <param name="right">The right operand of the multiplication.</param>
         /// <param name="result">A new instance that is the result of the multiplication.</param>
-        public static void Mult(ref Matrix3x2d left, ref Matrix2d right, out Matrix3x2d result)
+        public static void Mult(in Matrix3x2d left, in Matrix2d right, out Matrix3x2d result)
         {
             double leftM11 = left.Row0.X;
             double leftM12 = left.Row0.Y;
@@ -415,7 +415,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix3x2d Mult(Matrix3x2d left, Matrix2d right)
         {
-            Mult(ref left, ref right, out Matrix3x2d result);
+            Mult(in left, in right, out Matrix3x2d result);
             return result;
         }
 
@@ -425,7 +425,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the multiplication.</param>
         /// <param name="right">The right operand of the multiplication.</param>
         /// <param name="result">A new instance that is the result of the multiplication.</param>
-        public static void Mult(ref Matrix3x2d left, ref Matrix2x3d right, out Matrix3d result)
+        public static void Mult(in Matrix3x2d left, in Matrix2x3d right, out Matrix3d result)
         {
             double leftM11 = left.Row0.X;
             double leftM12 = left.Row0.Y;
@@ -460,7 +460,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix3d Mult(Matrix3x2d left, Matrix2x3d right)
         {
-            Mult(ref left, ref right, out Matrix3d result);
+            Mult(in left, in right, out Matrix3d result);
             return result;
         }
 
@@ -470,7 +470,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the multiplication.</param>
         /// <param name="right">The right operand of the multiplication.</param>
         /// <param name="result">A new instance that is the result of the multiplication.</param>
-        public static void Mult(ref Matrix3x2d left, ref Matrix2x4d right, out Matrix3x4d result)
+        public static void Mult(in Matrix3x2d left, in Matrix2x4d right, out Matrix3x4d result)
         {
             double leftM11 = left.Row0.X;
             double leftM12 = left.Row0.Y;
@@ -510,7 +510,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix3x4d Mult(Matrix3x2d left, Matrix2x4d right)
         {
-            Mult(ref left, ref right, out Matrix3x4d result);
+            Mult(in left, in right, out Matrix3x4d result);
             return result;
         }
 
@@ -520,7 +520,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the addition.</param>
         /// <param name="right">The right operand of the addition.</param>
         /// <param name="result">A new instance that is the result of the addition.</param>
-        public static void Add(ref Matrix3x2d left, ref Matrix3x2d right, out Matrix3x2d result)
+        public static void Add(in Matrix3x2d left, in Matrix3x2d right, out Matrix3x2d result)
         {
             result.Row0.X = left.Row0.X + right.Row0.X;
             result.Row0.Y = left.Row0.Y + right.Row0.Y;
@@ -539,7 +539,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix3x2d Add(Matrix3x2d left, Matrix3x2d right)
         {
-            Add(ref left, ref right, out Matrix3x2d result);
+            Add(in left, in right, out Matrix3x2d result);
             return result;
         }
 
@@ -549,7 +549,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the subtraction.</param>
         /// <param name="right">The right operand of the subtraction.</param>
         /// <param name="result">A new instance that is the result of the subtraction.</param>
-        public static void Subtract(ref Matrix3x2d left, ref Matrix3x2d right, out Matrix3x2d result)
+        public static void Subtract(in Matrix3x2d left, in Matrix3x2d right, out Matrix3x2d result)
         {
             result.Row0.X = left.Row0.X - right.Row0.X;
             result.Row0.Y = left.Row0.Y - right.Row0.Y;
@@ -568,7 +568,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix3x2d Subtract(Matrix3x2d left, Matrix3x2d right)
         {
-            Subtract(ref left, ref right, out Matrix3x2d result);
+            Subtract(in left, in right, out Matrix3x2d result);
             return result;
         }
 
@@ -577,7 +577,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="mat">The matrix to transpose.</param>
         /// <param name="result">The transpose of the given matrix.</param>
-        public static void Transpose(ref Matrix3x2d mat, out Matrix2x3d result)
+        public static void Transpose(in Matrix3x2d mat, out Matrix2x3d result)
         {
             result.Row0.X = mat.Row0.X;
             result.Row0.Y = mat.Row1.X;
@@ -595,7 +595,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix2x3d Transpose(Matrix3x2d mat)
         {
-            Transpose(ref mat, out Matrix2x3d result);
+            Transpose(in mat, out Matrix2x3d result);
             return result;
         }
 

--- a/src/OpenToolkit.Mathematics/Matrix/Matrix3x4.cs
+++ b/src/OpenToolkit.Mathematics/Matrix/Matrix3x4.cs
@@ -359,7 +359,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="q">The quaternion to rotate by.</param>
         /// <param name="result">A matrix instance.</param>
-        public static void CreateFromQuaternion(ref Quaternion q, out Matrix3x4 result)
+        public static void CreateFromQuaternion(in Quaternion q, out Matrix3x4 result)
         {
             float x = q.X;
             float y = q.Y;
@@ -400,7 +400,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix3x4 CreateFromQuaternion(Quaternion q)
         {
-            CreateFromQuaternion(ref q, out Matrix3x4 result);
+            CreateFromQuaternion(in q, out Matrix3x4 result);
             return result;
         }
 
@@ -540,7 +540,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="vector">The translation vector.</param>
         /// <param name="result">The resulting Matrix4 instance.</param>
-        public static void CreateTranslation(ref Vector3 vector, out Matrix3x4 result)
+        public static void CreateTranslation(in Vector3 vector, out Matrix3x4 result)
         {
             result.Row0.X = 1;
             result.Row0.Y = 0;
@@ -639,7 +639,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix3 Mult(Matrix3x4 left, Matrix4x3 right)
         {
-            Mult(ref left, ref right, out Matrix3 result);
+            Mult(in left, in right, out Matrix3 result);
             return result;
         }
 
@@ -649,7 +649,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the multiplication.</param>
         /// <param name="right">The right operand of the multiplication.</param>
         /// <param name="result">A new instance that is the result of the multiplication.</param>
-        public static void Mult(ref Matrix3x4 left, ref Matrix4x3 right, out Matrix3 result)
+        public static void Mult(in Matrix3x4 left, in Matrix4x3 right, out Matrix3 result)
         {
             float leftM11 = left.Row0.X;
             float leftM12 = left.Row0.Y;
@@ -696,7 +696,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix3x4 Mult(Matrix3x4 left, Matrix3x4 right)
         {
-            Mult(ref left, ref right, out Matrix3x4 result);
+            Mult(in left, in right, out Matrix3x4 result);
             return result;
         }
 
@@ -706,7 +706,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the multiplication.</param>
         /// <param name="right">The right operand of the multiplication.</param>
         /// <param name="result">A new instance that is the result of the multiplication.</param>
-        public static void Mult(ref Matrix3x4 left, ref Matrix3x4 right, out Matrix3x4 result)
+        public static void Mult(in Matrix3x4 left, in Matrix3x4 right, out Matrix3x4 result)
         {
             float leftM11 = left.Row0.X;
             float leftM12 = left.Row0.Y;
@@ -756,7 +756,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix3x4 Mult(Matrix3x4 left, float right)
         {
-            Mult(ref left, right, out Matrix3x4 result);
+            Mult(in left, right, out Matrix3x4 result);
             return result;
         }
 
@@ -766,7 +766,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the multiplication.</param>
         /// <param name="right">The right operand of the multiplication.</param>
         /// <param name="result">A new instance that is the result of the multiplication.</param>
-        public static void Mult(ref Matrix3x4 left, float right, out Matrix3x4 result)
+        public static void Mult(in Matrix3x4 left, float right, out Matrix3x4 result)
         {
             result.Row0 = left.Row0 * right;
             result.Row1 = left.Row1 * right;
@@ -782,7 +782,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix3x4 Add(Matrix3x4 left, Matrix3x4 right)
         {
-            Add(ref left, ref right, out Matrix3x4 result);
+            Add(in left, in right, out Matrix3x4 result);
             return result;
         }
 
@@ -792,7 +792,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the addition.</param>
         /// <param name="right">The right operand of the addition.</param>
         /// <param name="result">A new instance that is the result of the addition.</param>
-        public static void Add(ref Matrix3x4 left, ref Matrix3x4 right, out Matrix3x4 result)
+        public static void Add(in Matrix3x4 left, in Matrix3x4 right, out Matrix3x4 result)
         {
             result.Row0 = left.Row0 + right.Row0;
             result.Row1 = left.Row1 + right.Row1;
@@ -808,7 +808,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix3x4 Subtract(Matrix3x4 left, Matrix3x4 right)
         {
-            Subtract(ref left, ref right, out Matrix3x4 result);
+            Subtract(in left, in right, out Matrix3x4 result);
             return result;
         }
 
@@ -818,7 +818,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the subraction.</param>
         /// <param name="right">The right operand of the subraction.</param>
         /// <param name="result">A new instance that is the result of the subraction.</param>
-        public static void Subtract(ref Matrix3x4 left, ref Matrix3x4 right, out Matrix3x4 result)
+        public static void Subtract(in Matrix3x4 left, in Matrix3x4 right, out Matrix3x4 result)
         {
             result.Row0 = left.Row0 - right.Row0;
             result.Row1 = left.Row1 - right.Row1;
@@ -834,7 +834,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix3x4 Invert(Matrix3x4 mat)
         {
-            Invert(ref mat, out Matrix3x4 result);
+            Invert(in mat, out Matrix3x4 result);
             return result;
         }
 
@@ -844,7 +844,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="mat">The matrix to invert.</param>
         /// <param name="result">The inverse of the given matrix if it has one, or the input if it is singular.</param>
         /// <exception cref="InvalidOperationException">Thrown if the Matrix4 is singular.</exception>
-        public static void Invert(ref Matrix3x4 mat, out Matrix3x4 result)
+        public static void Invert(in Matrix3x4 mat, out Matrix3x4 result)
         {
             var inverseRotation = new Matrix3(mat.Column0, mat.Column1, mat.Column2);
             inverseRotation.Row0 /= inverseRotation.Row0.LengthSquared;
@@ -874,7 +874,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="mat">The matrix to transpose.</param>
         /// <param name="result">The result of the calculation.</param>
-        public static void Transpose(ref Matrix3x4 mat, out Matrix4x3 result)
+        public static void Transpose(in Matrix3x4 mat, out Matrix4x3 result)
         {
             result.Row0 = mat.Column0;
             result.Row1 = mat.Column1;

--- a/src/OpenToolkit.Mathematics/Matrix/Matrix3x4d.cs
+++ b/src/OpenToolkit.Mathematics/Matrix/Matrix3x4d.cs
@@ -359,7 +359,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="q">The quaternion to rotate by.</param>
         /// <param name="result">A matrix instance.</param>
-        public static void CreateFromQuaternion(ref Quaternion q, out Matrix3x4d result)
+        public static void CreateFromQuaternion(in Quaternion q, out Matrix3x4d result)
         {
             double x = q.X;
             double y = q.Y;
@@ -400,7 +400,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix3x4d CreateFromQuaternion(Quaternion q)
         {
-            CreateFromQuaternion(ref q, out Matrix3x4d result);
+            CreateFromQuaternion(in q, out Matrix3x4d result);
             return result;
         }
 
@@ -540,7 +540,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="vector">The translation vector.</param>
         /// <param name="result">The resulting Matrix4 instance.</param>
-        public static void CreateTranslation(ref Vector3d vector, out Matrix3x4d result)
+        public static void CreateTranslation(in Vector3d vector, out Matrix3x4d result)
         {
             result.Row0.X = 1;
             result.Row0.Y = 0;
@@ -639,7 +639,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix3d Mult(Matrix3x4d left, Matrix4x3d right)
         {
-            Mult(ref left, ref right, out Matrix3d result);
+            Mult(in left, in right, out Matrix3d result);
             return result;
         }
 
@@ -649,7 +649,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the multiplication.</param>
         /// <param name="right">The right operand of the multiplication.</param>
         /// <param name="result">A new instance that is the result of the multiplication.</param>
-        public static void Mult(ref Matrix3x4d left, ref Matrix4x3d right, out Matrix3d result)
+        public static void Mult(in Matrix3x4d left, in Matrix4x3d right, out Matrix3d result)
         {
             double leftM11 = left.Row0.X;
             double leftM12 = left.Row0.Y;
@@ -696,7 +696,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix3x4d Mult(Matrix3x4d left, Matrix3x4d right)
         {
-            Mult(ref left, ref right, out Matrix3x4d result);
+            Mult(in left, in right, out Matrix3x4d result);
             return result;
         }
 
@@ -706,7 +706,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the multiplication.</param>
         /// <param name="right">The right operand of the multiplication.</param>
         /// <param name="result">A new instance that is the result of the multiplication.</param>
-        public static void Mult(ref Matrix3x4d left, ref Matrix3x4d right, out Matrix3x4d result)
+        public static void Mult(in Matrix3x4d left, in Matrix3x4d right, out Matrix3x4d result)
         {
             double leftM11 = left.Row0.X;
             double leftM12 = left.Row0.Y;
@@ -756,7 +756,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix3x4d Mult(Matrix3x4d left, double right)
         {
-            Mult(ref left, right, out Matrix3x4d result);
+            Mult(in left, right, out Matrix3x4d result);
             return result;
         }
 
@@ -766,7 +766,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the multiplication.</param>
         /// <param name="right">The right operand of the multiplication.</param>
         /// <param name="result">A new instance that is the result of the multiplication.</param>
-        public static void Mult(ref Matrix3x4d left, double right, out Matrix3x4d result)
+        public static void Mult(in Matrix3x4d left, double right, out Matrix3x4d result)
         {
             result.Row0 = left.Row0 * right;
             result.Row1 = left.Row1 * right;
@@ -782,7 +782,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix3x4d Add(Matrix3x4d left, Matrix3x4d right)
         {
-            Add(ref left, ref right, out Matrix3x4d result);
+            Add(in left, in right, out Matrix3x4d result);
             return result;
         }
 
@@ -792,7 +792,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the addition.</param>
         /// <param name="right">The right operand of the addition.</param>
         /// <param name="result">A new instance that is the result of the addition.</param>
-        public static void Add(ref Matrix3x4d left, ref Matrix3x4d right, out Matrix3x4d result)
+        public static void Add(in Matrix3x4d left, in Matrix3x4d right, out Matrix3x4d result)
         {
             result.Row0 = left.Row0 + right.Row0;
             result.Row1 = left.Row1 + right.Row1;
@@ -808,7 +808,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix3x4d Subtract(Matrix3x4d left, Matrix3x4d right)
         {
-            Subtract(ref left, ref right, out Matrix3x4d result);
+            Subtract(in left, in right, out Matrix3x4d result);
             return result;
         }
 
@@ -818,7 +818,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the subraction.</param>
         /// <param name="right">The right operand of the subraction.</param>
         /// <param name="result">A new instance that is the result of the subraction.</param>
-        public static void Subtract(ref Matrix3x4d left, ref Matrix3x4d right, out Matrix3x4d result)
+        public static void Subtract(in Matrix3x4d left, in Matrix3x4d right, out Matrix3x4d result)
         {
             result.Row0 = left.Row0 - right.Row0;
             result.Row1 = left.Row1 - right.Row1;
@@ -834,7 +834,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix3x4d Invert(Matrix3x4d mat)
         {
-            Invert(ref mat, out Matrix3x4d result);
+            Invert(in mat, out Matrix3x4d result);
             return result;
         }
 
@@ -844,7 +844,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="mat">The matrix to invert.</param>
         /// <param name="result">The inverse of the given matrix if it has one, or the input if it is singular.</param>
         /// <exception cref="InvalidOperationException">Thrown if the Matrix4 is singular.</exception>
-        public static void Invert(ref Matrix3x4d mat, out Matrix3x4d result)
+        public static void Invert(in Matrix3x4d mat, out Matrix3x4d result)
         {
             var inverseRotation = new Matrix3d(mat.Column0, mat.Column1, mat.Column2);
             inverseRotation.Row0 /= inverseRotation.Row0.LengthSquared;
@@ -874,7 +874,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="mat">The matrix to transpose.</param>
         /// <param name="result">The result of the calculation.</param>
-        public static void Transpose(ref Matrix3x4d mat, out Matrix4x3d result)
+        public static void Transpose(in Matrix3x4d mat, out Matrix4x3d result)
         {
             result.Row0 = mat.Column0;
             result.Row1 = mat.Column1;

--- a/src/OpenToolkit.Mathematics/Matrix/Matrix4.cs
+++ b/src/OpenToolkit.Mathematics/Matrix/Matrix4.cs
@@ -720,7 +720,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="q">The quaternion to rotate by.</param>
         /// <param name="result">A matrix instance.</param>
-        public static void CreateFromQuaternion(ref Quaternion q, out Matrix4 result)
+        public static void CreateFromQuaternion(in Quaternion q, out Matrix4 result)
         {
             q.ToAxisAngle(out Vector3 axis, out float angle);
             CreateFromAxisAngle(axis, angle, out result);
@@ -734,7 +734,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix4 CreateFromQuaternion(Quaternion q)
         {
-            CreateFromQuaternion(ref q, out Matrix4 result);
+            CreateFromQuaternion(in q, out Matrix4 result);
             return result;
         }
 
@@ -845,7 +845,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="vector">The translation vector.</param>
         /// <param name="result">The resulting Matrix4 instance.</param>
-        public static void CreateTranslation(ref Vector3 vector, out Matrix4 result)
+        public static void CreateTranslation(in Vector3 vector, out Matrix4 result)
         {
             result = Identity;
             result.Row3.X = vector.X;
@@ -899,7 +899,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix4 CreateScale(Vector3 scale)
         {
-            CreateScale(ref scale, out Matrix4 result);
+            CreateScale(in scale, out Matrix4 result);
             return result;
         }
 
@@ -935,7 +935,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="scale">Scale factors for the x, y, and z axes.</param>
         /// <param name="result">A scale matrix.</param>
-        public static void CreateScale(ref Vector3 scale, out Matrix4 result)
+        public static void CreateScale(in Vector3 scale, out Matrix4 result)
         {
             result = Identity;
             result.Row0.X = scale.X;
@@ -1315,7 +1315,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix4 Add(Matrix4 left, Matrix4 right)
         {
-            Add(ref left, ref right, out Matrix4 result);
+            Add(in left, in right, out Matrix4 result);
             return result;
         }
 
@@ -1325,7 +1325,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the addition.</param>
         /// <param name="right">The right operand of the addition.</param>
         /// <param name="result">A new instance that is the result of the addition.</param>
-        public static void Add(ref Matrix4 left, ref Matrix4 right, out Matrix4 result)
+        public static void Add(in Matrix4 left, in Matrix4 right, out Matrix4 result)
         {
             result.Row0 = left.Row0 + right.Row0;
             result.Row1 = left.Row1 + right.Row1;
@@ -1342,7 +1342,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix4 Subtract(Matrix4 left, Matrix4 right)
         {
-            Subtract(ref left, ref right, out Matrix4 result);
+            Subtract(in left, in right, out Matrix4 result);
             return result;
         }
 
@@ -1352,7 +1352,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the subraction.</param>
         /// <param name="right">The right operand of the subraction.</param>
         /// <param name="result">A new instance that is the result of the subraction.</param>
-        public static void Subtract(ref Matrix4 left, ref Matrix4 right, out Matrix4 result)
+        public static void Subtract(in Matrix4 left, in Matrix4 right, out Matrix4 result)
         {
             result.Row0 = left.Row0 - right.Row0;
             result.Row1 = left.Row1 - right.Row1;
@@ -1369,7 +1369,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix4 Mult(Matrix4 left, Matrix4 right)
         {
-            Mult(ref left, ref right, out Matrix4 result);
+            Mult(in left, in right, out Matrix4 result);
             return result;
         }
 
@@ -1379,7 +1379,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the multiplication.</param>
         /// <param name="right">The right operand of the multiplication.</param>
         /// <param name="result">A new instance that is the result of the multiplication.</param>
-        public static void Mult(ref Matrix4 left, ref Matrix4 right, out Matrix4 result)
+        public static void Mult(in Matrix4 left, in Matrix4 right, out Matrix4 result)
         {
             float leftM11 = left.Row0.X;
             float leftM12 = left.Row0.Y;
@@ -1441,7 +1441,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix4 Mult(Matrix4 left, float right)
         {
-            Mult(ref left, right, out Matrix4 result);
+            Mult(in left, right, out Matrix4 result);
             return result;
         }
 
@@ -1451,7 +1451,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the multiplication.</param>
         /// <param name="right">The right operand of the multiplication.</param>
         /// <param name="result">A new instance that is the result of the multiplication.</param>
-        public static void Mult(ref Matrix4 left, float right, out Matrix4 result)
+        public static void Mult(in Matrix4 left, float right, out Matrix4 result)
         {
             result.Row0 = left.Row0 * right;
             result.Row1 = left.Row1 * right;
@@ -1465,7 +1465,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="mat">The matrix to invert.</param>
         /// <param name="result">The inverse of the given matrix if it has one, or the input if it is singular.</param>
         /// <exception cref="InvalidOperationException">Thrown if the Matrix4 is singular.</exception>
-        public static void Invert(ref Matrix4 mat, out Matrix4 result)
+        public static void Invert(in Matrix4 mat, out Matrix4 result)
         {
             int[] colIdx = { 0, 0, 0, 0 };
             int[] rowIdx = { 0, 0, 0, 0 };
@@ -1597,7 +1597,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix4 Invert(Matrix4 mat)
         {
-            Invert(ref mat, out Matrix4 result);
+            Invert(in mat, out Matrix4 result);
             return result;
         }
 
@@ -1617,7 +1617,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="mat">The matrix to transpose.</param>
         /// <param name="result">The result of the calculation.</param>
-        public static void Transpose(ref Matrix4 mat, out Matrix4 result)
+        public static void Transpose(in Matrix4 mat, out Matrix4 result)
         {
             result.Row0 = mat.Column0;
             result.Row1 = mat.Column1;

--- a/src/OpenToolkit.Mathematics/Matrix/Matrix4d.cs
+++ b/src/OpenToolkit.Mathematics/Matrix/Matrix4d.cs
@@ -793,7 +793,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="vector">The translation vector.</param>
         /// <param name="result">The resulting Matrix4d instance.</param>
-        public static void CreateTranslation(ref Vector3d vector, out Matrix4d result)
+        public static void CreateTranslation(in Vector3d vector, out Matrix4d result)
         {
             result = Identity;
             result.Row3 = new Vector4d(vector.X, vector.Y, vector.Z, 1);
@@ -1103,7 +1103,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="q">Quaternion to translate.</param>
         /// <param name="result">Matrix result.</param>
-        public static void CreateFromQuaternion(ref Quaterniond q, out Matrix4d result)
+        public static void CreateFromQuaternion(in Quaterniond q, out Matrix4d result)
         {
             q.ToAxisAngle(out Vector3d axis, out double angle);
             CreateFromAxisAngle(axis, angle, out result);
@@ -1117,7 +1117,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix4d CreateFromQuaternion(Quaterniond q)
         {
-            CreateFromQuaternion(ref q, out Matrix4d result);
+            CreateFromQuaternion(in q, out Matrix4d result);
             return result;
         }
 
@@ -1395,7 +1395,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix4d Add(Matrix4d left, Matrix4d right)
         {
-            Add(ref left, ref right, out Matrix4d result);
+            Add(in left, in right, out Matrix4d result);
             return result;
         }
 
@@ -1405,7 +1405,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the addition.</param>
         /// <param name="right">The right operand of the addition.</param>
         /// <param name="result">A new instance that is the result of the addition.</param>
-        public static void Add(ref Matrix4d left, ref Matrix4d right, out Matrix4d result)
+        public static void Add(in Matrix4d left, in Matrix4d right, out Matrix4d result)
         {
             result.Row0 = left.Row0 + right.Row0;
             result.Row1 = left.Row1 + right.Row1;
@@ -1422,7 +1422,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix4d Subtract(Matrix4d left, Matrix4d right)
         {
-            Subtract(ref left, ref right, out Matrix4d result);
+            Subtract(in left, in right, out Matrix4d result);
             return result;
         }
 
@@ -1432,7 +1432,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the subraction.</param>
         /// <param name="right">The right operand of the subraction.</param>
         /// <param name="result">A new instance that is the result of the subraction.</param>
-        public static void Subtract(ref Matrix4d left, ref Matrix4d right, out Matrix4d result)
+        public static void Subtract(in Matrix4d left, in Matrix4d right, out Matrix4d result)
         {
             result.Row0 = left.Row0 - right.Row0;
             result.Row1 = left.Row1 - right.Row1;
@@ -1449,7 +1449,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix4d Mult(Matrix4d left, Matrix4d right)
         {
-            Mult(ref left, ref right, out Matrix4d result);
+            Mult(in left, in right, out Matrix4d result);
             return result;
         }
 
@@ -1459,7 +1459,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the multiplication.</param>
         /// <param name="right">The right operand of the multiplication.</param>
         /// <param name="result">A new instance that is the result of the multiplication.</param>
-        public static void Mult(ref Matrix4d left, ref Matrix4d right, out Matrix4d result)
+        public static void Mult(in Matrix4d left, in Matrix4d right, out Matrix4d result)
         {
             double leftM11 = left.Row0.X;
             double leftM12 = left.Row0.Y;
@@ -1521,7 +1521,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix4d Mult(Matrix4d left, double right)
         {
-            Mult(ref left, right, out Matrix4d result);
+            Mult(in left, right, out Matrix4d result);
             return result;
         }
 
@@ -1531,7 +1531,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the multiplication.</param>
         /// <param name="right">The right operand of the multiplication.</param>
         /// <param name="result">A new instance that is the result of the multiplication.</param>
-        public static void Mult(ref Matrix4d left, double right, out Matrix4d result)
+        public static void Mult(in Matrix4d left, double right, out Matrix4d result)
         {
             result.Row0 = left.Row0 * right;
             result.Row1 = left.Row1 * right;
@@ -1673,7 +1673,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="mat">The matrix to transpose.</param>
         /// <param name="result">The result of the calculation.</param>
-        public static void Transpose(ref Matrix4d mat, out Matrix4d result)
+        public static void Transpose(in Matrix4d mat, out Matrix4d result)
         {
             result.Row0 = mat.Column0;
             result.Row1 = mat.Column1;

--- a/src/OpenToolkit.Mathematics/Matrix/Matrix4x2.cs
+++ b/src/OpenToolkit.Mathematics/Matrix/Matrix4x2.cs
@@ -404,7 +404,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the multiplication.</param>
         /// <param name="right">The right operand of the multiplication.</param>
         /// <param name="result">A new instance that is the result of the multiplication.</param>
-        public static void Mult(ref Matrix4x2 left, float right, out Matrix4x2 result)
+        public static void Mult(in Matrix4x2 left, float right, out Matrix4x2 result)
         {
             result.Row0.X = left.Row0.X * right;
             result.Row0.Y = left.Row0.Y * right;
@@ -425,7 +425,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix4x2 Mult(Matrix4x2 left, float right)
         {
-            Mult(ref left, right, out Matrix4x2 result);
+            Mult(in left, right, out Matrix4x2 result);
             return result;
         }
 
@@ -435,7 +435,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the multiplication.</param>
         /// <param name="right">The right operand of the multiplication.</param>
         /// <param name="result">A new instance that is the result of the multiplication.</param>
-        public static void Mult(ref Matrix4x2 left, ref Matrix2 right, out Matrix4x2 result)
+        public static void Mult(in Matrix4x2 left, in Matrix2 right, out Matrix4x2 result)
         {
             float leftM11 = left.Row0.X;
             float leftM12 = left.Row0.Y;
@@ -469,7 +469,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix4x2 Mult(Matrix4x2 left, Matrix2 right)
         {
-            Mult(ref left, ref right, out Matrix4x2 result);
+            Mult(in left, in right, out Matrix4x2 result);
             return result;
         }
 
@@ -479,7 +479,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the multiplication.</param>
         /// <param name="right">The right operand of the multiplication.</param>
         /// <param name="result">A new instance that is the result of the multiplication.</param>
-        public static void Mult(ref Matrix4x2 left, ref Matrix2x3 right, out Matrix4x3 result)
+        public static void Mult(in Matrix4x2 left, in Matrix2x3 right, out Matrix4x3 result)
         {
             float leftM11 = left.Row0.X;
             float leftM12 = left.Row0.Y;
@@ -519,7 +519,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix4x3 Mult(Matrix4x2 left, Matrix2x3 right)
         {
-            Mult(ref left, ref right, out Matrix4x3 result);
+            Mult(in left, in right, out Matrix4x3 result);
             return result;
         }
 
@@ -529,7 +529,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the multiplication.</param>
         /// <param name="right">The right operand of the multiplication.</param>
         /// <param name="result">A new instance that is the result of the multiplication.</param>
-        public static void Mult(ref Matrix4x2 left, ref Matrix2x4 right, out Matrix4 result)
+        public static void Mult(in Matrix4x2 left, in Matrix2x4 right, out Matrix4 result)
         {
             float leftM11 = left.Row0.X;
             float leftM12 = left.Row0.Y;
@@ -575,7 +575,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix4 Mult(Matrix4x2 left, Matrix2x4 right)
         {
-            Mult(ref left, ref right, out Matrix4 result);
+            Mult(in left, in right, out Matrix4 result);
             return result;
         }
 
@@ -585,7 +585,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the addition.</param>
         /// <param name="right">The right operand of the addition.</param>
         /// <param name="result">A new instance that is the result of the addition.</param>
-        public static void Add(ref Matrix4x2 left, ref Matrix4x2 right, out Matrix4x2 result)
+        public static void Add(in Matrix4x2 left, in Matrix4x2 right, out Matrix4x2 result)
         {
             result.Row0.X = left.Row0.X + right.Row0.X;
             result.Row0.Y = left.Row0.Y + right.Row0.Y;
@@ -606,7 +606,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix4x2 Add(Matrix4x2 left, Matrix4x2 right)
         {
-            Add(ref left, ref right, out Matrix4x2 result);
+            Add(in left, in right, out Matrix4x2 result);
             return result;
         }
 
@@ -616,7 +616,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the subtraction.</param>
         /// <param name="right">The right operand of the subtraction.</param>
         /// <param name="result">A new instance that is the result of the subtraction.</param>
-        public static void Subtract(ref Matrix4x2 left, ref Matrix4x2 right, out Matrix4x2 result)
+        public static void Subtract(in Matrix4x2 left, in Matrix4x2 right, out Matrix4x2 result)
         {
             result.Row0.X = left.Row0.X - right.Row0.X;
             result.Row0.Y = left.Row0.Y - right.Row0.Y;
@@ -637,7 +637,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix4x2 Subtract(Matrix4x2 left, Matrix4x2 right)
         {
-            Subtract(ref left, ref right, out Matrix4x2 result);
+            Subtract(in left, in right, out Matrix4x2 result);
             return result;
         }
 
@@ -646,7 +646,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="mat">The matrix to transpose.</param>
         /// <param name="result">The transpose of the given matrix.</param>
-        public static void Transpose(ref Matrix4x2 mat, out Matrix2x4 result)
+        public static void Transpose(in Matrix4x2 mat, out Matrix2x4 result)
         {
             result.Row0.X = mat.Row0.X;
             result.Row0.Y = mat.Row1.X;
@@ -666,7 +666,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix2x4 Transpose(Matrix4x2 mat)
         {
-            Transpose(ref mat, out Matrix2x4 result);
+            Transpose(in mat, out Matrix2x4 result);
             return result;
         }
 

--- a/src/OpenToolkit.Mathematics/Matrix/Matrix4x2d.cs
+++ b/src/OpenToolkit.Mathematics/Matrix/Matrix4x2d.cs
@@ -410,7 +410,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the multiplication.</param>
         /// <param name="right">The right operand of the multiplication.</param>
         /// <param name="result">A new instance that is the result of the multiplication.</param>
-        public static void Mult(ref Matrix4x2d left, double right, out Matrix4x2d result)
+        public static void Mult(in Matrix4x2d left, double right, out Matrix4x2d result)
         {
             result.Row0.X = left.Row0.X * right;
             result.Row0.Y = left.Row0.Y * right;
@@ -431,7 +431,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix4x2d Mult(Matrix4x2d left, double right)
         {
-            Mult(ref left, right, out Matrix4x2d result);
+            Mult(in left, right, out Matrix4x2d result);
             return result;
         }
 
@@ -441,7 +441,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the multiplication.</param>
         /// <param name="right">The right operand of the multiplication.</param>
         /// <param name="result">A new instance that is the result of the multiplication.</param>
-        public static void Mult(ref Matrix4x2d left, ref Matrix2d right, out Matrix4x2d result)
+        public static void Mult(in Matrix4x2d left, in Matrix2d right, out Matrix4x2d result)
         {
             double leftM11 = left.Row0.X;
             double leftM12 = left.Row0.Y;
@@ -475,7 +475,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix4x2d Mult(Matrix4x2d left, Matrix2d right)
         {
-            Mult(ref left, ref right, out Matrix4x2d result);
+            Mult(in left, in right, out Matrix4x2d result);
             return result;
         }
 
@@ -485,7 +485,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the multiplication.</param>
         /// <param name="right">The right operand of the multiplication.</param>
         /// <param name="result">A new instance that is the result of the multiplication.</param>
-        public static void Mult(ref Matrix4x2d left, ref Matrix2x3d right, out Matrix4x3d result)
+        public static void Mult(in Matrix4x2d left, in Matrix2x3d right, out Matrix4x3d result)
         {
             double leftM11 = left.Row0.X;
             double leftM12 = left.Row0.Y;
@@ -525,7 +525,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix4x3d Mult(Matrix4x2d left, Matrix2x3d right)
         {
-            Mult(ref left, ref right, out Matrix4x3d result);
+            Mult(in left, in right, out Matrix4x3d result);
             return result;
         }
 
@@ -535,7 +535,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the multiplication.</param>
         /// <param name="right">The right operand of the multiplication.</param>
         /// <param name="result">A new instance that is the result of the multiplication.</param>
-        public static void Mult(ref Matrix4x2d left, ref Matrix2x4d right, out Matrix4d result)
+        public static void Mult(in Matrix4x2d left, in Matrix2x4d right, out Matrix4d result)
         {
             double leftM11 = left.Row0.X;
             double leftM12 = left.Row0.Y;
@@ -581,7 +581,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix4d Mult(Matrix4x2d left, Matrix2x4d right)
         {
-            Mult(ref left, ref right, out Matrix4d result);
+            Mult(in left, in right, out Matrix4d result);
             return result;
         }
 
@@ -591,7 +591,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the addition.</param>
         /// <param name="right">The right operand of the addition.</param>
         /// <param name="result">A new instance that is the result of the addition.</param>
-        public static void Add(ref Matrix4x2d left, ref Matrix4x2d right, out Matrix4x2d result)
+        public static void Add(in Matrix4x2d left, in Matrix4x2d right, out Matrix4x2d result)
         {
             result.Row0.X = left.Row0.X + right.Row0.X;
             result.Row0.Y = left.Row0.Y + right.Row0.Y;
@@ -612,7 +612,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix4x2d Add(Matrix4x2d left, Matrix4x2d right)
         {
-            Add(ref left, ref right, out Matrix4x2d result);
+            Add(in left, in right, out Matrix4x2d result);
             return result;
         }
 
@@ -622,7 +622,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the subtraction.</param>
         /// <param name="right">The right operand of the subtraction.</param>
         /// <param name="result">A new instance that is the result of the subtraction.</param>
-        public static void Subtract(ref Matrix4x2d left, ref Matrix4x2d right, out Matrix4x2d result)
+        public static void Subtract(in Matrix4x2d left, in Matrix4x2d right, out Matrix4x2d result)
         {
             result.Row0.X = left.Row0.X - right.Row0.X;
             result.Row0.Y = left.Row0.Y - right.Row0.Y;
@@ -643,7 +643,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix4x2d Subtract(Matrix4x2d left, Matrix4x2d right)
         {
-            Subtract(ref left, ref right, out Matrix4x2d result);
+            Subtract(in left, in right, out Matrix4x2d result);
             return result;
         }
 
@@ -652,7 +652,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="mat">The matrix to transpose.</param>
         /// <param name="result">The transpose of the given matrix.</param>
-        public static void Transpose(ref Matrix4x2d mat, out Matrix2x4d result)
+        public static void Transpose(in Matrix4x2d mat, out Matrix2x4d result)
         {
             result.Row0.X = mat.Row0.X;
             result.Row0.Y = mat.Row1.X;
@@ -672,7 +672,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix2x4d Transpose(Matrix4x2d mat)
         {
-            Transpose(ref mat, out Matrix2x4d result);
+            Transpose(in mat, out Matrix2x4d result);
             return result;
         }
 

--- a/src/OpenToolkit.Mathematics/Matrix/Matrix4x3.cs
+++ b/src/OpenToolkit.Mathematics/Matrix/Matrix4x3.cs
@@ -372,7 +372,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="q">The quaternion to rotate by.</param>
         /// <param name="result">A matrix instance.</param>
-        public static void CreateFromQuaternion(ref Quaternion q, out Matrix4x3 result)
+        public static void CreateFromQuaternion(in Quaternion q, out Matrix4x3 result)
         {
             float x = q.X;
             float y = q.Y;
@@ -413,7 +413,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix4x3 CreateFromQuaternion(Quaternion q)
         {
-            CreateFromQuaternion(ref q, out Matrix4x3 result);
+            CreateFromQuaternion(in q, out Matrix4x3 result);
             return result;
         }
 
@@ -553,7 +553,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="vector">The translation vector.</param>
         /// <param name="result">The resulting Matrix4 instance.</param>
-        public static void CreateTranslation(ref Vector3 vector, out Matrix4x3 result)
+        public static void CreateTranslation(in Vector3 vector, out Matrix4x3 result)
         {
             result.Row0.X = 1;
             result.Row0.Y = 0;
@@ -653,7 +653,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix4 Mult(Matrix4x3 left, Matrix3x4 right)
         {
-            Mult(ref left, ref right, out Matrix4 result);
+            Mult(in left, in right, out Matrix4 result);
             return result;
         }
 
@@ -664,7 +664,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the multiplication.</param>
         /// <param name="right">The right operand of the multiplication.</param>
         /// <param name="result">A new instance that is the result of the multiplication.</param>
-        public static void Mult(ref Matrix4x3 left, ref Matrix3x4 right, out Matrix4 result)
+        public static void Mult(in Matrix4x3 left, in Matrix3x4 right, out Matrix4 result)
         {
             float leftM11 = left.Row0.X;
             float leftM12 = left.Row0.Y;
@@ -718,7 +718,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix4x3 Mult(Matrix4x3 left, Matrix4x3 right)
         {
-            Mult(ref left, ref right, out Matrix4x3 result);
+            Mult(in left, in right, out Matrix4x3 result);
             return result;
         }
 
@@ -729,7 +729,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the multiplication.</param>
         /// <param name="right">The right operand of the multiplication.</param>
         /// <param name="result">A new instance that is the result of the multiplication.</param>
-        public static void Mult(ref Matrix4x3 left, ref Matrix4x3 right, out Matrix4x3 result)
+        public static void Mult(in Matrix4x3 left, in Matrix4x3 right, out Matrix4x3 result)
         {
             float leftM11 = left.Row0.X;
             float leftM12 = left.Row0.Y;
@@ -779,7 +779,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix4x3 Mult(Matrix4x3 left, float right)
         {
-            Mult(ref left, right, out Matrix4x3 result);
+            Mult(in left, right, out Matrix4x3 result);
             return result;
         }
 
@@ -789,7 +789,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the multiplication.</param>
         /// <param name="right">The right operand of the multiplication.</param>
         /// <param name="result">A new instance that is the result of the multiplication.</param>
-        public static void Mult(ref Matrix4x3 left, float right, out Matrix4x3 result)
+        public static void Mult(in Matrix4x3 left, float right, out Matrix4x3 result)
         {
             result.Row0 = left.Row0 * right;
             result.Row1 = left.Row1 * right;
@@ -806,7 +806,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix4x3 Add(Matrix4x3 left, Matrix4x3 right)
         {
-            Add(ref left, ref right, out Matrix4x3 result);
+            Add(in left, in right, out Matrix4x3 result);
             return result;
         }
 
@@ -816,7 +816,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the addition.</param>
         /// <param name="right">The right operand of the addition.</param>
         /// <param name="result">A new instance that is the result of the addition.</param>
-        public static void Add(ref Matrix4x3 left, ref Matrix4x3 right, out Matrix4x3 result)
+        public static void Add(in Matrix4x3 left, in Matrix4x3 right, out Matrix4x3 result)
         {
             result.Row0 = left.Row0 + right.Row0;
             result.Row1 = left.Row1 + right.Row1;
@@ -833,7 +833,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix4x3 Subtract(Matrix4x3 left, Matrix4x3 right)
         {
-            Subtract(ref left, ref right, out Matrix4x3 result);
+            Subtract(in left, in right, out Matrix4x3 result);
             return result;
         }
 
@@ -843,7 +843,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the subraction.</param>
         /// <param name="right">The right operand of the subraction.</param>
         /// <param name="result">A new instance that is the result of the subraction.</param>
-        public static void Subtract(ref Matrix4x3 left, ref Matrix4x3 right, out Matrix4x3 result)
+        public static void Subtract(in Matrix4x3 left, in Matrix4x3 right, out Matrix4x3 result)
         {
             result.Row0 = left.Row0 - right.Row0;
             result.Row1 = left.Row1 - right.Row1;
@@ -860,7 +860,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix4x3 Invert(Matrix4x3 mat)
         {
-            Invert(ref mat, out Matrix4x3 result);
+            Invert(in mat, out Matrix4x3 result);
             return result;
         }
 
@@ -870,7 +870,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="mat">The matrix to invert.</param>
         /// <param name="result">The inverse of the given matrix if it has one, or the input if it is singular.</param>
         /// <exception cref="InvalidOperationException">Thrown if the Matrix4 is singular.</exception>
-        public static void Invert(ref Matrix4x3 mat, out Matrix4x3 result)
+        public static void Invert(in Matrix4x3 mat, out Matrix4x3 result)
         {
             var inverseRotation = new Matrix3(mat.Column0.Xyz, mat.Column1.Xyz, mat.Column2.Xyz);
             inverseRotation.Row0 /= inverseRotation.Row0.LengthSquared;
@@ -906,7 +906,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="mat">The matrix to transpose.</param>
         /// <param name="result">The result of the calculation.</param>
-        public static void Transpose(ref Matrix4x3 mat, out Matrix3x4 result)
+        public static void Transpose(in Matrix4x3 mat, out Matrix3x4 result)
         {
             result.Row0 = mat.Column0;
             result.Row1 = mat.Column1;

--- a/src/OpenToolkit.Mathematics/Matrix/Matrix4x3d.cs
+++ b/src/OpenToolkit.Mathematics/Matrix/Matrix4x3d.cs
@@ -372,7 +372,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="q">The quaternion to rotate by.</param>
         /// <param name="result">A matrix instance.</param>
-        public static void CreateFromQuaternion(ref Quaternion q, out Matrix4x3d result)
+        public static void CreateFromQuaternion(in Quaternion q, out Matrix4x3d result)
         {
             double x = q.X;
             double y = q.Y;
@@ -413,7 +413,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix4x3d CreateFromQuaternion(Quaternion q)
         {
-            CreateFromQuaternion(ref q, out Matrix4x3d result);
+            CreateFromQuaternion(in q, out Matrix4x3d result);
             return result;
         }
 
@@ -553,7 +553,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="vector">The translation vector.</param>
         /// <param name="result">The resulting Matrix4dinstance.</param>
-        public static void CreateTranslation(ref Vector3d vector, out Matrix4x3d result)
+        public static void CreateTranslation(in Vector3d vector, out Matrix4x3d result)
         {
             result.Row0.X = 1;
             result.Row0.Y = 0;
@@ -653,7 +653,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix4d Mult(Matrix4x3d left, Matrix3x4d right)
         {
-            Mult(ref left, ref right, out Matrix4d result);
+            Mult(in left, in right, out Matrix4d result);
             return result;
         }
 
@@ -664,7 +664,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the multiplication.</param>
         /// <param name="right">The right operand of the multiplication.</param>
         /// <param name="result">A new instance that is the result of the multiplication.</param>
-        public static void Mult(ref Matrix4x3d left, ref Matrix3x4d right, out Matrix4d result)
+        public static void Mult(in Matrix4x3d left, in Matrix3x4d right, out Matrix4d result)
         {
             double leftM11 = left.Row0.X;
             double leftM12 = left.Row0.Y;
@@ -718,7 +718,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix4x3d Mult(Matrix4x3d left, Matrix4x3d right)
         {
-            Mult(ref left, ref right, out Matrix4x3d result);
+            Mult(in left, in right, out Matrix4x3d result);
             return result;
         }
 
@@ -728,7 +728,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the multiplication.</param>
         /// <param name="right">The right operand of the multiplication.</param>
         /// <param name="result">A new instance that is the result of the multiplication.</param>
-        public static void Mult(ref Matrix4x3d left, ref Matrix4x3d right, out Matrix4x3d result)
+        public static void Mult(in Matrix4x3d left, in Matrix4x3d right, out Matrix4x3d result)
         {
             double leftM11 = left.Row0.X;
             double leftM12 = left.Row0.Y;
@@ -778,7 +778,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix4x3d Mult(Matrix4x3d left, double right)
         {
-            Mult(ref left, right, out Matrix4x3d result);
+            Mult(in left, right, out Matrix4x3d result);
             return result;
         }
 
@@ -788,7 +788,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the multiplication.</param>
         /// <param name="right">The right operand of the multiplication.</param>
         /// <param name="result">A new instance that is the result of the multiplication.</param>
-        public static void Mult(ref Matrix4x3d left, double right, out Matrix4x3d result)
+        public static void Mult(in Matrix4x3d left, double right, out Matrix4x3d result)
         {
             result.Row0 = left.Row0 * right;
             result.Row1 = left.Row1 * right;
@@ -805,7 +805,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix4x3d Add(Matrix4x3d left, Matrix4x3d right)
         {
-            Add(ref left, ref right, out Matrix4x3d result);
+            Add(in left, in right, out Matrix4x3d result);
             return result;
         }
 
@@ -815,7 +815,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the addition.</param>
         /// <param name="right">The right operand of the addition.</param>
         /// <param name="result">A new instance that is the result of the addition.</param>
-        public static void Add(ref Matrix4x3d left, ref Matrix4x3d right, out Matrix4x3d result)
+        public static void Add(in Matrix4x3d left, in Matrix4x3d right, out Matrix4x3d result)
         {
             result.Row0 = left.Row0 + right.Row0;
             result.Row1 = left.Row1 + right.Row1;
@@ -832,7 +832,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix4x3d Subtract(Matrix4x3d left, Matrix4x3d right)
         {
-            Subtract(ref left, ref right, out Matrix4x3d result);
+            Subtract(in left, in right, out Matrix4x3d result);
             return result;
         }
 
@@ -842,7 +842,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">The left operand of the subraction.</param>
         /// <param name="right">The right operand of the subraction.</param>
         /// <param name="result">A new instance that is the result of the subraction.</param>
-        public static void Subtract(ref Matrix4x3d left, ref Matrix4x3d right, out Matrix4x3d result)
+        public static void Subtract(in Matrix4x3d left, in Matrix4x3d right, out Matrix4x3d result)
         {
             result.Row0 = left.Row0 - right.Row0;
             result.Row1 = left.Row1 - right.Row1;
@@ -859,7 +859,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Matrix4x3d Invert(Matrix4x3d mat)
         {
-            Invert(ref mat, out Matrix4x3d result);
+            Invert(in mat, out Matrix4x3d result);
             return result;
         }
 
@@ -869,7 +869,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="mat">The matrix to invert.</param>
         /// <param name="result">The inverse of the given matrix if it has one, or the input if it is singular.</param>
         /// <exception cref="InvalidOperationException">Thrown if the Matrix4 is singular.</exception>
-        public static void Invert(ref Matrix4x3d mat, out Matrix4x3d result)
+        public static void Invert(in Matrix4x3d mat, out Matrix4x3d result)
         {
             var inverseRotation = new Matrix3d(mat.Column0.Xyz, mat.Column1.Xyz, mat.Column2.Xyz);
             inverseRotation.Row0 /= inverseRotation.Row0.LengthSquared;
@@ -905,7 +905,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="mat">The matrix to transpose.</param>
         /// <param name="result">The result of the calculation.</param>
-        public static void Transpose(ref Matrix4x3d mat, out Matrix3x4d result)
+        public static void Transpose(in Matrix4x3d mat, out Matrix3x4d result)
         {
             result.Row0 = mat.Column0;
             result.Row1 = mat.Column1;

--- a/src/OpenToolkit.Mathematics/Vector/Vector2.cs
+++ b/src/OpenToolkit.Mathematics/Vector/Vector2.cs
@@ -212,7 +212,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector2 Add(Vector2 a, Vector2 b)
         {
-            Add(ref a, ref b, out a);
+            Add(in a, in b, out a);
             return a;
         }
 
@@ -222,7 +222,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="a">Left operand.</param>
         /// <param name="b">Right operand.</param>
         /// <param name="result">Result of operation.</param>
-        public static void Add(ref Vector2 a, ref Vector2 b, out Vector2 result)
+        public static void Add(in Vector2 a, in Vector2 b, out Vector2 result)
         {
             result.X = a.X + b.X;
             result.Y = a.Y + b.Y;
@@ -237,7 +237,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector2 Subtract(Vector2 a, Vector2 b)
         {
-            Subtract(ref a, ref b, out a);
+            Subtract(in a, in b, out a);
             return a;
         }
 
@@ -247,7 +247,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="a">First operand.</param>
         /// <param name="b">Second operand.</param>
         /// <param name="result">Result of subtraction.</param>
-        public static void Subtract(ref Vector2 a, ref Vector2 b, out Vector2 result)
+        public static void Subtract(in Vector2 a, in Vector2 b, out Vector2 result)
         {
             result.X = a.X - b.X;
             result.Y = a.Y - b.Y;
@@ -262,7 +262,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector2 Multiply(Vector2 vector, float scale)
         {
-            Multiply(ref vector, scale, out vector);
+            Multiply(in vector, scale, out vector);
             return vector;
         }
 
@@ -272,7 +272,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="vector">Left operand.</param>
         /// <param name="scale">Right operand.</param>
         /// <param name="result">Result of the operation.</param>
-        public static void Multiply(ref Vector2 vector, float scale, out Vector2 result)
+        public static void Multiply(in Vector2 vector, float scale, out Vector2 result)
         {
             result.X = vector.X * scale;
             result.Y = vector.Y * scale;
@@ -287,7 +287,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector2 Multiply(Vector2 vector, Vector2 scale)
         {
-            Multiply(ref vector, ref scale, out vector);
+            Multiply(in vector, in scale, out vector);
             return vector;
         }
 
@@ -297,7 +297,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="vector">Left operand.</param>
         /// <param name="scale">Right operand.</param>
         /// <param name="result">Result of the operation.</param>
-        public static void Multiply(ref Vector2 vector, ref Vector2 scale, out Vector2 result)
+        public static void Multiply(in Vector2 vector, in Vector2 scale, out Vector2 result)
         {
             result.X = vector.X * scale.X;
             result.Y = vector.Y * scale.Y;
@@ -312,7 +312,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector2 Divide(Vector2 vector, float scale)
         {
-            Divide(ref vector, scale, out vector);
+            Divide(in vector, scale, out vector);
             return vector;
         }
 
@@ -322,7 +322,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="vector">Left operand.</param>
         /// <param name="scale">Right operand.</param>
         /// <param name="result">Result of the operation.</param>
-        public static void Divide(ref Vector2 vector, float scale, out Vector2 result)
+        public static void Divide(in Vector2 vector, float scale, out Vector2 result)
         {
             result.X = vector.X / scale;
             result.Y = vector.Y / scale;
@@ -337,7 +337,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector2 Divide(Vector2 vector, Vector2 scale)
         {
-            Divide(ref vector, ref scale, out vector);
+            Divide(in vector, in scale, out vector);
             return vector;
         }
 
@@ -347,7 +347,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="vector">Left operand.</param>
         /// <param name="scale">Right operand.</param>
         /// <param name="result">Result of the operation.</param>
-        public static void Divide(ref Vector2 vector, ref Vector2 scale, out Vector2 result)
+        public static void Divide(in Vector2 vector, in Vector2 scale, out Vector2 result)
         {
             result.X = vector.X / scale.X;
             result.Y = vector.Y / scale.Y;
@@ -373,7 +373,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="a">First operand.</param>
         /// <param name="b">Second operand.</param>
         /// <param name="result">The component-wise minimum.</param>
-        public static void ComponentMin(ref Vector2 a, ref Vector2 b, out Vector2 result)
+        public static void ComponentMin(in Vector2 a, in Vector2 b, out Vector2 result)
         {
             result.X = a.X < b.X ? a.X : b.X;
             result.Y = a.Y < b.Y ? a.Y : b.Y;
@@ -399,7 +399,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="a">First operand.</param>
         /// <param name="b">Second operand.</param>
         /// <param name="result">The component-wise maximum.</param>
-        public static void ComponentMax(ref Vector2 a, ref Vector2 b, out Vector2 result)
+        public static void ComponentMax(in Vector2 a, in Vector2 b, out Vector2 result)
         {
             result.X = a.X > b.X ? a.X : b.X;
             result.Y = a.Y > b.Y ? a.Y : b.Y;
@@ -425,7 +425,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">Left operand.</param>
         /// <param name="right">Right operand.</param>
         /// <param name="result">The magnitude-wise minimum.</param>
-        public static void MagnitudeMin(ref Vector2 left, ref Vector2 right, out Vector2 result)
+        public static void MagnitudeMin(in Vector2 left, in Vector2 right, out Vector2 result)
         {
             result = left.LengthSquared < right.LengthSquared ? left : right;
         }
@@ -450,7 +450,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">Left operand.</param>
         /// <param name="right">Right operand.</param>
         /// <param name="result">The magnitude-wise maximum.</param>
-        public static void MagnitudeMax(ref Vector2 left, ref Vector2 right, out Vector2 result)
+        public static void MagnitudeMax(in Vector2 left, in Vector2 right, out Vector2 result)
         {
             result = left.LengthSquared >= right.LengthSquared ? left : right;
         }
@@ -477,7 +477,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="min">Minimum vector.</param>
         /// <param name="max">Maximum vector.</param>
         /// <param name="result">The clamped vector.</param>
-        public static void Clamp(ref Vector2 vec, ref Vector2 min, ref Vector2 max, out Vector2 result)
+        public static void Clamp(in Vector2 vec, in Vector2 min, in Vector2 max, out Vector2 result)
         {
             result.X = vec.X < min.X ? min.X : vec.X > max.X ? max.X : vec.X;
             result.Y = vec.Y < min.Y ? min.Y : vec.Y > max.Y ? max.Y : vec.Y;
@@ -492,7 +492,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static float Distance(Vector2 vec1, Vector2 vec2)
         {
-            Distance(ref vec1, ref vec2, out float result);
+            Distance(in vec1, in vec2, out float result);
             return result;
         }
 
@@ -502,7 +502,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="vec1">The first vector.</param>
         /// <param name="vec2">The second vector.</param>
         /// <param name="result">The distance.</param>
-        public static void Distance(ref Vector2 vec1, ref Vector2 vec2, out float result)
+        public static void Distance(in Vector2 vec1, in Vector2 vec2, out float result)
         {
             result = (float)Math.Sqrt(((vec2.X - vec1.X) * (vec2.X - vec1.X)) + ((vec2.Y - vec1.Y) * (vec2.Y - vec1.Y)));
         }
@@ -516,7 +516,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static float DistanceSquared(Vector2 vec1, Vector2 vec2)
         {
-            DistanceSquared(ref vec1, ref vec2, out float result);
+            DistanceSquared(in vec1, in vec2, out float result);
             return result;
         }
 
@@ -526,7 +526,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="vec1">The first vector.</param>
         /// <param name="vec2">The second vector.</param>
         /// <param name="result">The squared distance.</param>
-        public static void DistanceSquared(ref Vector2 vec1, ref Vector2 vec2, out float result)
+        public static void DistanceSquared(in Vector2 vec1, in Vector2 vec2, out float result)
         {
             result = ((vec2.X - vec1.X) * (vec2.X - vec1.X)) + ((vec2.Y - vec1.Y) * (vec2.Y - vec1.Y));
         }
@@ -550,7 +550,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="vec">The input vector.</param>
         /// <param name="result">The normalized vector.</param>
-        public static void Normalize(ref Vector2 vec, out Vector2 result)
+        public static void Normalize(in Vector2 vec, out Vector2 result)
         {
             var scale = 1.0f / vec.Length;
             result.X = vec.X * scale;
@@ -576,7 +576,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="vec">The input vector.</param>
         /// <param name="result">The normalized vector.</param>
-        public static void NormalizeFast(ref Vector2 vec, out Vector2 result)
+        public static void NormalizeFast(in Vector2 vec, out Vector2 result)
         {
             var scale = MathHelper.InverseSqrtFast((vec.X * vec.X) + (vec.Y * vec.Y));
             result.X = vec.X * scale;
@@ -601,7 +601,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">First operand.</param>
         /// <param name="right">Second operand.</param>
         /// <param name="result">The dot product of the two inputs.</param>
-        public static void Dot(ref Vector2 left, ref Vector2 right, out float result)
+        public static void Dot(in Vector2 left, in Vector2 right, out float result)
         {
             result = (left.X * right.X) + (left.Y * right.Y);
         }
@@ -624,7 +624,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">First operand.</param>
         /// <param name="right">Second operand.</param>
         /// <param name="result">The perpendicular dot product of the two inputs.</param>
-        public static void PerpDot(ref Vector2 left, ref Vector2 right, out float result)
+        public static void PerpDot(in Vector2 left, in Vector2 right, out float result)
         {
             result = (left.X * right.Y) - (left.Y * right.X);
         }
@@ -651,7 +651,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="b">Second input vector.</param>
         /// <param name="blend">The blend factor. a when blend=0, b when blend=1.</param>
         /// <param name="result">a when blend=0, b when blend=1, and a linear combination otherwise.</param>
-        public static void Lerp(ref Vector2 a, ref Vector2 b, float blend, out Vector2 result)
+        public static void Lerp(in Vector2 a, in Vector2 b, float blend, out Vector2 result)
         {
             result.X = (blend * (b.X - a.X)) + a.X;
             result.Y = (blend * (b.Y - a.Y)) + a.Y;
@@ -686,9 +686,9 @@ namespace OpenToolkit.Mathematics
         /// </param>
         public static void BaryCentric
         (
-            ref Vector2 a,
-            ref Vector2 b,
-            ref Vector2 c,
+            in Vector2 a,
+            in Vector2 b,
+            in Vector2 c,
             float u,
             float v,
             out Vector2 result
@@ -697,14 +697,14 @@ namespace OpenToolkit.Mathematics
             result = a; // copy
 
             var temp = b; // copy
-            Subtract(ref temp, ref a, out temp);
-            Multiply(ref temp, u, out temp);
-            Add(ref result, ref temp, out result);
+            Subtract(in temp, in a, out temp);
+            Multiply(in temp, u, out temp);
+            Add(in result, in temp, out result);
 
             temp = c; // copy
-            Subtract(ref temp, ref a, out temp);
-            Multiply(ref temp, v, out temp);
-            Add(ref result, ref temp, out result);
+            Subtract(in temp, in a, out temp);
+            Multiply(in temp, v, out temp);
+            Add(in result, in temp, out result);
         }
 
         /// <summary>
@@ -716,7 +716,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector2 Transform(Vector2 vec, Quaternion quat)
         {
-            Transform(ref vec, ref quat, out Vector2 result);
+            Transform(in vec, in quat, out Vector2 result);
             return result;
         }
 
@@ -726,12 +726,12 @@ namespace OpenToolkit.Mathematics
         /// <param name="vec">The vector to transform.</param>
         /// <param name="quat">The quaternion to rotate the vector by.</param>
         /// <param name="result">The result of the operation.</param>
-        public static void Transform(ref Vector2 vec, ref Quaternion quat, out Vector2 result)
+        public static void Transform(in Vector2 vec, in Quaternion quat, out Vector2 result)
         {
             Quaternion v = new Quaternion(vec.X, vec.Y, 0, 0);
-            Quaternion.Invert(ref quat, out Quaternion i);
-            Quaternion.Multiply(ref quat, ref v, out Quaternion t);
-            Quaternion.Multiply(ref t, ref i, out v);
+            Quaternion.Invert(in quat, out Quaternion i);
+            Quaternion.Multiply(in quat, in v, out Quaternion t);
+            Quaternion.Multiply(in t, in i, out v);
 
             result.X = v.X;
             result.Y = v.Y;

--- a/src/OpenToolkit.Mathematics/Vector/Vector2d.cs
+++ b/src/OpenToolkit.Mathematics/Vector/Vector2d.cs
@@ -186,7 +186,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector2d Add(Vector2d a, Vector2d b)
         {
-            Add(ref a, ref b, out a);
+            Add(in a, in b, out a);
             return a;
         }
 
@@ -196,7 +196,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="a">Left operand.</param>
         /// <param name="b">Right operand.</param>
         /// <param name="result">Result of operation.</param>
-        public static void Add(ref Vector2d a, ref Vector2d b, out Vector2d result)
+        public static void Add(in Vector2d a, in Vector2d b, out Vector2d result)
         {
             result.X = a.X + b.X;
             result.Y = a.Y + b.Y;
@@ -211,7 +211,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector2d Subtract(Vector2d a, Vector2d b)
         {
-            Subtract(ref a, ref b, out a);
+            Subtract(in a, in b, out a);
             return a;
         }
 
@@ -221,7 +221,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="a">First operand.</param>
         /// <param name="b">Second operand.</param>
         /// <param name="result">Result of subtraction.</param>
-        public static void Subtract(ref Vector2d a, ref Vector2d b, out Vector2d result)
+        public static void Subtract(in Vector2d a, in Vector2d b, out Vector2d result)
         {
             result.X = a.X - b.X;
             result.Y = a.Y - b.Y;
@@ -236,7 +236,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector2d Multiply(Vector2d vector, double scale)
         {
-            Multiply(ref vector, scale, out vector);
+            Multiply(in vector, scale, out vector);
             return vector;
         }
 
@@ -246,7 +246,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="vector">Left operand.</param>
         /// <param name="scale">Right operand.</param>
         /// <param name="result">Result of the operation.</param>
-        public static void Multiply(ref Vector2d vector, double scale, out Vector2d result)
+        public static void Multiply(in Vector2d vector, double scale, out Vector2d result)
         {
             result.X = vector.X * scale;
             result.Y = vector.Y * scale;
@@ -261,7 +261,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector2d Multiply(Vector2d vector, Vector2d scale)
         {
-            Multiply(ref vector, ref scale, out vector);
+            Multiply(in vector, in scale, out vector);
             return vector;
         }
 
@@ -271,7 +271,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="vector">Left operand.</param>
         /// <param name="scale">Right operand.</param>
         /// <param name="result">Result of the operation.</param>
-        public static void Multiply(ref Vector2d vector, ref Vector2d scale, out Vector2d result)
+        public static void Multiply(in Vector2d vector, in Vector2d scale, out Vector2d result)
         {
             result.X = vector.X * scale.X;
             result.Y = vector.Y * scale.Y;
@@ -286,7 +286,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector2d Divide(Vector2d vector, double scale)
         {
-            Divide(ref vector, scale, out vector);
+            Divide(in vector, scale, out vector);
             return vector;
         }
 
@@ -296,7 +296,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="vector">Left operand.</param>
         /// <param name="scale">Right operand.</param>
         /// <param name="result">Result of the operation.</param>
-        public static void Divide(ref Vector2d vector, double scale, out Vector2d result)
+        public static void Divide(in Vector2d vector, double scale, out Vector2d result)
         {
             result.X = vector.X / scale;
             result.Y = vector.Y / scale;
@@ -311,7 +311,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector2d Divide(Vector2d vector, Vector2d scale)
         {
-            Divide(ref vector, ref scale, out vector);
+            Divide(in vector, in scale, out vector);
             return vector;
         }
 
@@ -321,7 +321,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="vector">Left operand.</param>
         /// <param name="scale">Right operand.</param>
         /// <param name="result">Result of the operation.</param>
-        public static void Divide(ref Vector2d vector, ref Vector2d scale, out Vector2d result)
+        public static void Divide(in Vector2d vector, in Vector2d scale, out Vector2d result)
         {
             result.X = vector.X / scale.X;
             result.Y = vector.Y / scale.Y;
@@ -347,7 +347,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="a">First operand.</param>
         /// <param name="b">Second operand.</param>
         /// <param name="result">The component-wise minimum.</param>
-        public static void ComponentMin(ref Vector2d a, ref Vector2d b, out Vector2d result)
+        public static void ComponentMin(in Vector2d a, in Vector2d b, out Vector2d result)
         {
             result.X = a.X < b.X ? a.X : b.X;
             result.Y = a.Y < b.Y ? a.Y : b.Y;
@@ -373,7 +373,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="a">First operand.</param>
         /// <param name="b">Second operand.</param>
         /// <param name="result">The component-wise maximum.</param>
-        public static void ComponentMax(ref Vector2d a, ref Vector2d b, out Vector2d result)
+        public static void ComponentMax(in Vector2d a, in Vector2d b, out Vector2d result)
         {
             result.X = a.X > b.X ? a.X : b.X;
             result.Y = a.Y > b.Y ? a.Y : b.Y;
@@ -399,7 +399,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">Left operand.</param>
         /// <param name="right">Right operand.</param>
         /// <param name="result">The magnitude-wise minimum.</param>
-        public static void MagnitudeMin(ref Vector2d left, ref Vector2d right, out Vector2d result)
+        public static void MagnitudeMin(in Vector2d left, in Vector2d right, out Vector2d result)
         {
             result = left.LengthSquared < right.LengthSquared ? left : right;
         }
@@ -424,7 +424,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">Left operand.</param>
         /// <param name="right">Right operand.</param>
         /// <param name="result">The magnitude-wise maximum.</param>
-        public static void MagnitudeMax(ref Vector2d left, ref Vector2d right, out Vector2d result)
+        public static void MagnitudeMax(in Vector2d left, in Vector2d right, out Vector2d result)
         {
             result = left.LengthSquared >= right.LengthSquared ? left : right;
         }
@@ -451,7 +451,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="min">Minimum vector.</param>
         /// <param name="max">Maximum vector.</param>
         /// <param name="result">The clamped vector.</param>
-        public static void Clamp(ref Vector2d vec, ref Vector2d min, ref Vector2d max, out Vector2d result)
+        public static void Clamp(in Vector2d vec, in Vector2d min, in Vector2d max, out Vector2d result)
         {
             result.X = vec.X < min.X ? min.X : vec.X > max.X ? max.X : vec.X;
             result.Y = vec.Y < min.Y ? min.Y : vec.Y > max.Y ? max.Y : vec.Y;
@@ -466,7 +466,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static double Distance(Vector2d vec1, Vector2d vec2)
         {
-            Distance(ref vec1, ref vec2, out double result);
+            Distance(in vec1, in vec2, out double result);
             return result;
         }
 
@@ -476,7 +476,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="vec1">The first vector.</param>
         /// <param name="vec2">The second vector.</param>
         /// <param name="result">The distance.</param>
-        public static void Distance(ref Vector2d vec1, ref Vector2d vec2, out double result)
+        public static void Distance(in Vector2d vec1, in Vector2d vec2, out double result)
         {
             result = Math.Sqrt(((vec2.X - vec1.X) * (vec2.X - vec1.X)) + ((vec2.Y - vec1.Y) * (vec2.Y - vec1.Y)));
         }
@@ -490,7 +490,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static double DistanceSquared(Vector2d vec1, Vector2d vec2)
         {
-            DistanceSquared(ref vec1, ref vec2, out double result);
+            DistanceSquared(in vec1, in vec2, out double result);
             return result;
         }
 
@@ -500,7 +500,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="vec1">The first vector.</param>
         /// <param name="vec2">The second vector.</param>
         /// <param name="result">The squared distance.</param>
-        public static void DistanceSquared(ref Vector2d vec1, ref Vector2d vec2, out double result)
+        public static void DistanceSquared(in Vector2d vec1, in Vector2d vec2, out double result)
         {
             result = ((vec2.X - vec1.X) * (vec2.X - vec1.X)) + ((vec2.Y - vec1.Y) * (vec2.Y - vec1.Y));
         }
@@ -524,7 +524,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="vec">The input vector.</param>
         /// <param name="result">The normalized vector.</param>
-        public static void Normalize(ref Vector2d vec, out Vector2d result)
+        public static void Normalize(in Vector2d vec, out Vector2d result)
         {
             var scale = 1.0 / vec.Length;
             result.X = vec.X * scale;
@@ -550,7 +550,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="vec">The input vector.</param>
         /// <param name="result">The normalized vector.</param>
-        public static void NormalizeFast(ref Vector2d vec, out Vector2d result)
+        public static void NormalizeFast(in Vector2d vec, out Vector2d result)
         {
             var scale = MathHelper.InverseSqrtFast((vec.X * vec.X) + (vec.Y * vec.Y));
             result.X = vec.X * scale;
@@ -575,7 +575,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">First operand.</param>
         /// <param name="right">Second operand.</param>
         /// <param name="result">The dot product of the two inputs.</param>
-        public static void Dot(ref Vector2d left, ref Vector2d right, out double result)
+        public static void Dot(in Vector2d left, in Vector2d right, out double result)
         {
             result = (left.X * right.X) + (left.Y * right.Y);
         }
@@ -602,7 +602,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="b">Second input vector.</param>
         /// <param name="blend">The blend factor. a when blend=0, b when blend=1.</param>
         /// <param name="result">a when blend=0, b when blend=1, and a linear combination otherwise.</param>
-        public static void Lerp(ref Vector2d a, ref Vector2d b, double blend, out Vector2d result)
+        public static void Lerp(in Vector2d a, in Vector2d b, double blend, out Vector2d result)
         {
             result.X = (blend * (b.X - a.X)) + a.X;
             result.Y = (blend * (b.Y - a.Y)) + a.Y;
@@ -648,14 +648,14 @@ namespace OpenToolkit.Mathematics
             result = a; // copy
 
             var temp = b; // copy
-            Subtract(ref temp, ref a, out temp);
-            Multiply(ref temp, u, out temp);
-            Add(ref result, ref temp, out result);
+            Subtract(in temp, in a, out temp);
+            Multiply(in temp, u, out temp);
+            Add(in result, in temp, out result);
 
             temp = c; // copy
-            Subtract(ref temp, ref a, out temp);
-            Multiply(ref temp, v, out temp);
-            Add(ref result, ref temp, out result);
+            Subtract(in temp, in a, out temp);
+            Multiply(in temp, v, out temp);
+            Add(in result, in temp, out result);
         }
 
         /// <summary>
@@ -667,7 +667,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector2d Transform(Vector2d vec, Quaterniond quat)
         {
-            Transform(ref vec, ref quat, out Vector2d result);
+            Transform(in vec, in quat, out Vector2d result);
             return result;
         }
 
@@ -677,12 +677,12 @@ namespace OpenToolkit.Mathematics
         /// <param name="vec">The vector to transform.</param>
         /// <param name="quat">The quaternion to rotate the vector by.</param>
         /// <param name="result">The result of the operation.</param>
-        public static void Transform(ref Vector2d vec, ref Quaterniond quat, out Vector2d result)
+        public static void Transform(in Vector2d vec, in Quaterniond quat, out Vector2d result)
         {
             Quaterniond v = new Quaterniond(vec.X, vec.Y, 0, 0);
-            Quaterniond.Invert(ref quat, out Quaterniond i);
-            Quaterniond.Multiply(ref quat, ref v, out Quaterniond t);
-            Quaterniond.Multiply(ref t, ref i, out v);
+            Quaterniond.Invert(in quat, out Quaterniond i);
+            Quaterniond.Multiply(in quat, in v, out Quaterniond t);
+            Quaterniond.Multiply(in t, in i, out v);
 
             result.X = v.X;
             result.Y = v.Y;
@@ -794,7 +794,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector2d operator *(Quaterniond quat, Vector2d vec)
         {
-            Transform(ref vec, ref quat, out Vector2d result);
+            Transform(in vec, in quat, out Vector2d result);
             return result;
         }
 

--- a/src/OpenToolkit.Mathematics/Vector/Vector2h.cs
+++ b/src/OpenToolkit.Mathematics/Vector/Vector2h.cs
@@ -126,7 +126,7 @@ namespace OpenToolkit.Mathematics
         /// Initializes a new instance of the <see cref="Vector2h"/> struct.
         /// </summary>
         /// <param name="v">The <see cref="Vector2"/> to convert.</param>
-        public Vector2h(ref Vector2 v)
+        public Vector2h(in Vector2 v)
         {
             X = new Half(v.X);
             Y = new Half(v.Y);
@@ -137,7 +137,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="v">The <see cref="Vector2"/> to convert.</param>
         /// <param name="throwOnError">Enable checks that will throw if the conversion result is not meaningful.</param>
-        public Vector2h(ref Vector2 v, bool throwOnError)
+        public Vector2h(in Vector2 v, bool throwOnError)
         {
             X = new Half(v.X, throwOnError);
             Y = new Half(v.Y, throwOnError);
@@ -168,7 +168,7 @@ namespace OpenToolkit.Mathematics
         /// Initializes a new instance of the <see cref="Vector2h"/> struct.
         /// </summary>
         /// <param name="v">The <see cref="Vector2d"/> to convert.</param>
-        public Vector2h(ref Vector2d v)
+        public Vector2h(in Vector2d v)
         {
             X = new Half(v.X);
             Y = new Half(v.Y);
@@ -179,7 +179,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="v">The <see cref="Vector2d"/> to convert.</param>
         /// <param name="throwOnError">Enable checks that will throw if the conversion result is not meaningful.</param>
-        public Vector2h(ref Vector2d v, bool throwOnError)
+        public Vector2h(in Vector2d v, bool throwOnError)
         {
             X = new Half(v.X, throwOnError);
             Y = new Half(v.Y, throwOnError);

--- a/src/OpenToolkit.Mathematics/Vector/Vector2i.cs
+++ b/src/OpenToolkit.Mathematics/Vector/Vector2i.cs
@@ -139,7 +139,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector2i Add(Vector2i a, Vector2i b)
         {
-            Add(ref a, ref b, out a);
+            Add(in a, in b, out a);
             return a;
         }
 
@@ -149,7 +149,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="a">Left operand.</param>
         /// <param name="b">Right operand.</param>
         /// <param name="result">Result of operation.</param>
-        public static void Add(ref Vector2i a, ref Vector2i b, out Vector2i result)
+        public static void Add(in Vector2i a, in Vector2i b, out Vector2i result)
         {
             result.X = a.X + b.X;
             result.Y = a.Y + b.Y;
@@ -164,7 +164,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector2i Subtract(Vector2i a, Vector2i b)
         {
-            Subtract(ref a, ref b, out a);
+            Subtract(in a, in b, out a);
             return a;
         }
 
@@ -174,7 +174,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="a">First operand.</param>
         /// <param name="b">Second operand.</param>
         /// <param name="result">Result of subtraction.</param>
-        public static void Subtract(ref Vector2i a, ref Vector2i b, out Vector2i result)
+        public static void Subtract(in Vector2i a, in Vector2i b, out Vector2i result)
         {
             result.X = a.X - b.X;
             result.Y = a.Y - b.Y;
@@ -189,7 +189,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector2i Multiply(Vector2i vector, int scale)
         {
-            Multiply(ref vector, scale, out vector);
+            Multiply(in vector, scale, out vector);
             return vector;
         }
 
@@ -199,7 +199,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="vector">Left operand.</param>
         /// <param name="scale">Right operand.</param>
         /// <param name="result">Result of the operation.</param>
-        public static void Multiply(ref Vector2i vector, int scale, out Vector2i result)
+        public static void Multiply(in Vector2i vector, int scale, out Vector2i result)
         {
             result.X = vector.X * scale;
             result.Y = vector.Y * scale;
@@ -214,7 +214,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector2i Multiply(Vector2i vector, Vector2i scale)
         {
-            Multiply(ref vector, ref scale, out vector);
+            Multiply(in vector, in scale, out vector);
             return vector;
         }
 
@@ -224,7 +224,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="vector">Left operand.</param>
         /// <param name="scale">Right operand.</param>
         /// <param name="result">Result of the operation.</param>
-        public static void Multiply(ref Vector2i vector, ref Vector2i scale, out Vector2i result)
+        public static void Multiply(in Vector2i vector, in Vector2i scale, out Vector2i result)
         {
             result.X = vector.X * scale.X;
             result.Y = vector.Y * scale.Y;
@@ -239,7 +239,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector2i Divide(Vector2i vector, int scale)
         {
-            Divide(ref vector, scale, out vector);
+            Divide(in vector, scale, out vector);
             return vector;
         }
 
@@ -249,7 +249,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="vector">Left operand.</param>
         /// <param name="scale">Right operand.</param>
         /// <param name="result">Result of the operation.</param>
-        public static void Divide(ref Vector2i vector, int scale, out Vector2i result)
+        public static void Divide(in Vector2i vector, int scale, out Vector2i result)
         {
             result.X = vector.X / scale;
             result.Y = vector.Y / scale;
@@ -264,7 +264,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector2i Divide(Vector2i vector, Vector2i scale)
         {
-            Divide(ref vector, ref scale, out vector);
+            Divide(in vector, in scale, out vector);
             return vector;
         }
 
@@ -274,7 +274,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="vector">Left operand.</param>
         /// <param name="scale">Right operand.</param>
         /// <param name="result">Result of the operation.</param>
-        public static void Divide(ref Vector2i vector, ref Vector2i scale, out Vector2i result)
+        public static void Divide(in Vector2i vector, in Vector2i scale, out Vector2i result)
         {
             result.X = vector.X / scale.X;
             result.Y = vector.Y / scale.Y;
@@ -300,7 +300,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="a">First operand.</param>
         /// <param name="b">Second operand.</param>
         /// <param name="result">The component-wise minimum.</param>
-        public static void ComponentMin(ref Vector2i a, ref Vector2i b, out Vector2i result)
+        public static void ComponentMin(in Vector2i a, in Vector2i b, out Vector2i result)
         {
             result.X = a.X < b.X ? a.X : b.X;
             result.Y = a.Y < b.Y ? a.Y : b.Y;
@@ -326,7 +326,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="a">First operand.</param>
         /// <param name="b">Second operand.</param>
         /// <param name="result">The component-wise maximum.</param>
-        public static void ComponentMax(ref Vector2i a, ref Vector2i b, out Vector2i result)
+        public static void ComponentMax(in Vector2i a, in Vector2i b, out Vector2i result)
         {
             result.X = a.X > b.X ? a.X : b.X;
             result.Y = a.Y > b.Y ? a.Y : b.Y;
@@ -354,7 +354,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="min">Minimum vector.</param>
         /// <param name="max">Maximum vector.</param>
         /// <param name="result">The clamped vector.</param>
-        public static void Clamp(ref Vector2i vec, ref Vector2i min, ref Vector2i max, out Vector2i result)
+        public static void Clamp(in Vector2i vec, in Vector2i min, in Vector2i max, out Vector2i result)
         {
             result.X = vec.X < min.X ? min.X : vec.X > max.X ? max.X : vec.X;
             result.Y = vec.Y < min.Y ? min.Y : vec.Y > max.Y ? max.Y : vec.Y;
@@ -388,7 +388,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="input">The given <see cref="Vector2i"/> to convert.</param>
         /// <param name="result">The resulting <see cref="Vector2"/>.</param>
-        public static void ToVector2(ref Vector2i input, out Vector2 result)
+        public static void ToVector2(in Vector2i input, out Vector2 result)
         {
             result.X = input.X;
             result.Y = input.Y;

--- a/src/OpenToolkit.Mathematics/Vector/Vector3.cs
+++ b/src/OpenToolkit.Mathematics/Vector/Vector3.cs
@@ -260,7 +260,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector3 Add(Vector3 a, Vector3 b)
         {
-            Add(ref a, ref b, out a);
+            Add(in a, in b, out a);
             return a;
         }
 
@@ -270,7 +270,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="a">Left operand.</param>
         /// <param name="b">Right operand.</param>
         /// <param name="result">Result of operation.</param>
-        public static void Add(ref Vector3 a, ref Vector3 b, out Vector3 result)
+        public static void Add(in Vector3 a, in Vector3 b, out Vector3 result)
         {
             result.X = a.X + b.X;
             result.Y = a.Y + b.Y;
@@ -286,7 +286,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector3 Subtract(Vector3 a, Vector3 b)
         {
-            Subtract(ref a, ref b, out a);
+            Subtract(in a, in b, out a);
             return a;
         }
 
@@ -296,7 +296,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="a">First operand.</param>
         /// <param name="b">Second operand.</param>
         /// <param name="result">Result of subtraction.</param>
-        public static void Subtract(ref Vector3 a, ref Vector3 b, out Vector3 result)
+        public static void Subtract(in Vector3 a, in Vector3 b, out Vector3 result)
         {
             result.X = a.X - b.X;
             result.Y = a.Y - b.Y;
@@ -312,7 +312,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector3 Multiply(Vector3 vector, float scale)
         {
-            Multiply(ref vector, scale, out vector);
+            Multiply(in vector, scale, out vector);
             return vector;
         }
 
@@ -322,7 +322,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="vector">Left operand.</param>
         /// <param name="scale">Right operand.</param>
         /// <param name="result">Result of the operation.</param>
-        public static void Multiply(ref Vector3 vector, float scale, out Vector3 result)
+        public static void Multiply(in Vector3 vector, float scale, out Vector3 result)
         {
             result.X = vector.X * scale;
             result.Y = vector.Y * scale;
@@ -338,7 +338,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector3 Multiply(Vector3 vector, Vector3 scale)
         {
-            Multiply(ref vector, ref scale, out vector);
+            Multiply(in vector, in scale, out vector);
             return vector;
         }
 
@@ -348,7 +348,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="vector">Left operand.</param>
         /// <param name="scale">Right operand.</param>
         /// <param name="result">Result of the operation.</param>
-        public static void Multiply(ref Vector3 vector, ref Vector3 scale, out Vector3 result)
+        public static void Multiply(in Vector3 vector, in Vector3 scale, out Vector3 result)
         {
             result.X = vector.X * scale.X;
             result.Y = vector.Y * scale.Y;
@@ -364,7 +364,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector3 Divide(Vector3 vector, float scale)
         {
-            Divide(ref vector, scale, out vector);
+            Divide(in vector, scale, out vector);
             return vector;
         }
 
@@ -374,7 +374,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="vector">Left operand.</param>
         /// <param name="scale">Right operand.</param>
         /// <param name="result">Result of the operation.</param>
-        public static void Divide(ref Vector3 vector, float scale, out Vector3 result)
+        public static void Divide(in Vector3 vector, float scale, out Vector3 result)
         {
             result.X = vector.X / scale;
             result.Y = vector.Y / scale;
@@ -390,7 +390,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector3 Divide(Vector3 vector, Vector3 scale)
         {
-            Divide(ref vector, ref scale, out vector);
+            Divide(in vector, in scale, out vector);
             return vector;
         }
 
@@ -400,7 +400,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="vector">Left operand.</param>
         /// <param name="scale">Right operand.</param>
         /// <param name="result">Result of the operation.</param>
-        public static void Divide(ref Vector3 vector, ref Vector3 scale, out Vector3 result)
+        public static void Divide(in Vector3 vector, in Vector3 scale, out Vector3 result)
         {
             result.X = vector.X / scale.X;
             result.Y = vector.Y / scale.Y;
@@ -428,7 +428,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="a">First operand.</param>
         /// <param name="b">Second operand.</param>
         /// <param name="result">The component-wise minimum.</param>
-        public static void ComponentMin(ref Vector3 a, ref Vector3 b, out Vector3 result)
+        public static void ComponentMin(in Vector3 a, in Vector3 b, out Vector3 result)
         {
             result.X = a.X < b.X ? a.X : b.X;
             result.Y = a.Y < b.Y ? a.Y : b.Y;
@@ -456,7 +456,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="a">First operand.</param>
         /// <param name="b">Second operand.</param>
         /// <param name="result">The component-wise maximum.</param>
-        public static void ComponentMax(ref Vector3 a, ref Vector3 b, out Vector3 result)
+        public static void ComponentMax(in Vector3 a, in Vector3 b, out Vector3 result)
         {
             result.X = a.X > b.X ? a.X : b.X;
             result.Y = a.Y > b.Y ? a.Y : b.Y;
@@ -483,7 +483,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">Left operand.</param>
         /// <param name="right">Right operand.</param>
         /// <param name="result">The magnitude-wise minimum.</param>
-        public static void MagnitudeMin(ref Vector3 left, ref Vector3 right, out Vector3 result)
+        public static void MagnitudeMin(in Vector3 left, in Vector3 right, out Vector3 result)
         {
             result = left.LengthSquared < right.LengthSquared ? left : right;
         }
@@ -508,7 +508,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">Left operand.</param>
         /// <param name="right">Right operand.</param>
         /// <param name="result">The magnitude-wise maximum.</param>
-        public static void MagnitudeMax(ref Vector3 left, ref Vector3 right, out Vector3 result)
+        public static void MagnitudeMax(in Vector3 left, in Vector3 right, out Vector3 result)
         {
             result = left.LengthSquared >= right.LengthSquared ? left : right;
         }
@@ -536,7 +536,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="min">Minimum vector.</param>
         /// <param name="max">Maximum vector.</param>
         /// <param name="result">The clamped vector.</param>
-        public static void Clamp(ref Vector3 vec, ref Vector3 min, ref Vector3 max, out Vector3 result)
+        public static void Clamp(in Vector3 vec, in Vector3 min, in Vector3 max, out Vector3 result)
         {
             result.X = vec.X < min.X ? min.X : vec.X > max.X ? max.X : vec.X;
             result.Y = vec.Y < min.Y ? min.Y : vec.Y > max.Y ? max.Y : vec.Y;
@@ -552,7 +552,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static float Distance(Vector3 vec1, Vector3 vec2)
         {
-            Distance(ref vec1, ref vec2, out float result);
+            Distance(in vec1, in vec2, out float result);
             return result;
         }
 
@@ -562,7 +562,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="vec1">The first vector.</param>
         /// <param name="vec2">The second vector.</param>
         /// <param name="result">The distance.</param>
-        public static void Distance(ref Vector3 vec1, ref Vector3 vec2, out float result)
+        public static void Distance(in Vector3 vec1, in Vector3 vec2, out float result)
         {
             result = (float)Math.Sqrt(((vec2.X - vec1.X) * (vec2.X - vec1.X)) + ((vec2.Y - vec1.Y) * (vec2.Y - vec1.Y)) +
                                       ((vec2.Z - vec1.Z) * (vec2.Z - vec1.Z)));
@@ -577,7 +577,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static float DistanceSquared(Vector3 vec1, Vector3 vec2)
         {
-            DistanceSquared(ref vec1, ref vec2, out float result);
+            DistanceSquared(in vec1, in vec2, out float result);
             return result;
         }
 
@@ -587,7 +587,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="vec1">The first vector.</param>
         /// <param name="vec2">The second vector.</param>
         /// <param name="result">The squared distance.</param>
-        public static void DistanceSquared(ref Vector3 vec1, ref Vector3 vec2, out float result)
+        public static void DistanceSquared(in Vector3 vec1, in Vector3 vec2, out float result)
         {
             result = ((vec2.X - vec1.X) * (vec2.X - vec1.X)) + ((vec2.Y - vec1.Y) * (vec2.Y - vec1.Y)) +
                      ((vec2.Z - vec1.Z) * (vec2.Z - vec1.Z));
@@ -613,7 +613,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="vec">The input vector.</param>
         /// <param name="result">The normalized vector.</param>
-        public static void Normalize(ref Vector3 vec, out Vector3 result)
+        public static void Normalize(in Vector3 vec, out Vector3 result)
         {
             var scale = 1.0f / vec.Length;
             result.X = vec.X * scale;
@@ -641,7 +641,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="vec">The input vector.</param>
         /// <param name="result">The normalized vector.</param>
-        public static void NormalizeFast(ref Vector3 vec, out Vector3 result)
+        public static void NormalizeFast(in Vector3 vec, out Vector3 result)
         {
             var scale = MathHelper.InverseSqrtFast((vec.X * vec.X) + (vec.Y * vec.Y) + (vec.Z * vec.Z));
             result.X = vec.X * scale;
@@ -667,7 +667,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">First operand.</param>
         /// <param name="right">Second operand.</param>
         /// <param name="result">The dot product of the two inputs.</param>
-        public static void Dot(ref Vector3 left, ref Vector3 right, out float result)
+        public static void Dot(in Vector3 left, in Vector3 right, out float result)
         {
             result = (left.X * right.X) + (left.Y * right.Y) + (left.Z * right.Z);
         }
@@ -681,7 +681,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector3 Cross(Vector3 left, Vector3 right)
         {
-            Cross(ref left, ref right, out Vector3 result);
+            Cross(in left, in right, out Vector3 result);
             return result;
         }
 
@@ -696,7 +696,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">First operand.</param>
         /// <param name="right">Second operand.</param>
         /// <param name="result">The cross product of the two inputs.</param>
-        public static void Cross(ref Vector3 left, ref Vector3 right, out Vector3 result)
+        public static void Cross(in Vector3 left, in Vector3 right, out Vector3 result)
         {
             result.X = (left.Y * right.Z) - (left.Z * right.Y);
             result.Y = (left.Z * right.X) - (left.X * right.Z);
@@ -726,7 +726,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="b">Second input vector.</param>
         /// <param name="blend">The blend factor. a when blend=0, b when blend=1.</param>
         /// <param name="result">a when blend=0, b when blend=1, and a linear combination otherwise.</param>
-        public static void Lerp(ref Vector3 a, ref Vector3 b, float blend, out Vector3 result)
+        public static void Lerp(in Vector3 a, in Vector3 b, float blend, out Vector3 result)
         {
             result.X = (blend * (b.X - a.X)) + a.X;
             result.Y = (blend * (b.Y - a.Y)) + a.Y;
@@ -763,9 +763,9 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static void BaryCentric
         (
-            ref Vector3 a,
-            ref Vector3 b,
-            ref Vector3 c,
+            in Vector3 a,
+            in Vector3 b,
+            in Vector3 c,
             float u,
             float v,
             out Vector3 result
@@ -774,14 +774,14 @@ namespace OpenToolkit.Mathematics
             result = a; // copy
 
             var temp = b; // copy
-            Subtract(ref temp, ref a, out temp);
-            Multiply(ref temp, u, out temp);
-            Add(ref result, ref temp, out result);
+            Subtract(in temp, in a, out temp);
+            Multiply(in temp, u, out temp);
+            Add(in result, in temp, out result);
 
             temp = c; // copy
-            Subtract(ref temp, ref a, out temp);
-            Multiply(ref temp, v, out temp);
-            Add(ref result, ref temp, out result);
+            Subtract(in temp, in a, out temp);
+            Multiply(in temp, v, out temp);
+            Add(in result, in temp, out result);
         }
 
         /// <summary>
@@ -794,7 +794,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector3 TransformVector(Vector3 vec, Matrix4 mat)
         {
-            TransformVector(ref vec, ref mat, out Vector3 result);
+            TransformVector(in vec, in mat, out Vector3 result);
             return result;
         }
 
@@ -809,7 +809,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="vec">The vector to transform.</param>
         /// <param name="mat">The desired transformation.</param>
         /// <param name="result">The transformed vector.</param>
-        public static void TransformVector(ref Vector3 vec, ref Matrix4 mat, out Vector3 result)
+        public static void TransformVector(in Vector3 vec, in Matrix4 mat, out Vector3 result)
         {
             result.X = (vec.X * mat.Row0.X) +
                        (vec.Y * mat.Row1.X) +
@@ -837,7 +837,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector3 TransformNormal(Vector3 norm, Matrix4 mat)
         {
-            TransformNormal(ref norm, ref mat, out Vector3 result);
+            TransformNormal(in norm, in mat, out Vector3 result);
             return result;
         }
 
@@ -851,10 +851,10 @@ namespace OpenToolkit.Mathematics
         /// <param name="norm">The normal to transform.</param>
         /// <param name="mat">The desired transformation.</param>
         /// <param name="result">The transformed normal.</param>
-        public static void TransformNormal(ref Vector3 norm, ref Matrix4 mat, out Vector3 result)
+        public static void TransformNormal(in Vector3 norm, in Matrix4 mat, out Vector3 result)
         {
             var inverse = Matrix4.Invert(mat);
-            TransformNormalInverse(ref norm, ref inverse, out result);
+            TransformNormalInverse(in norm, in inverse, out result);
         }
 
         /// <summary>
@@ -870,7 +870,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector3 TransformNormalInverse(Vector3 norm, Matrix4 invMat)
         {
-            TransformNormalInverse(ref norm, ref invMat, out Vector3 result);
+            TransformNormalInverse(in norm, in invMat, out Vector3 result);
             return result;
         }
 
@@ -884,7 +884,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="norm">The normal to transform.</param>
         /// <param name="invMat">The inverse of the desired transformation.</param>
         /// <param name="result">The transformed normal.</param>
-        public static void TransformNormalInverse(ref Vector3 norm, ref Matrix4 invMat, out Vector3 result)
+        public static void TransformNormalInverse(in Vector3 norm, in Matrix4 invMat, out Vector3 result)
         {
             result.X = (norm.X * invMat.Row0.X) +
                        (norm.Y * invMat.Row0.Y) +
@@ -908,7 +908,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector3 TransformPosition(Vector3 pos, Matrix4 mat)
         {
-            TransformPosition(ref pos, ref mat, out Vector3 result);
+            TransformPosition(in pos, in mat, out Vector3 result);
             return result;
         }
 
@@ -918,7 +918,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="pos">The position to transform.</param>
         /// <param name="mat">The desired transformation.</param>
         /// <param name="result">The transformed position.</param>
-        public static void TransformPosition(ref Vector3 pos, ref Matrix4 mat, out Vector3 result)
+        public static void TransformPosition(in Vector3 pos, in Matrix4 mat, out Vector3 result)
         {
             result.X = (pos.X * mat.Row0.X) +
                        (pos.Y * mat.Row1.X) +
@@ -945,7 +945,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector3 Transform(Vector3 vec, Matrix3 mat)
         {
-            Transform(ref vec, ref mat, out Vector3 result);
+            Transform(in vec, in mat, out Vector3 result);
             return result;
         }
 
@@ -955,7 +955,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="vec">The vector to transform.</param>
         /// <param name="mat">The desired transformation.</param>
         /// <param name="result">The transformed vector.</param>
-        public static void Transform(ref Vector3 vec, ref Matrix3 mat, out Vector3 result)
+        public static void Transform(in Vector3 vec, in Matrix3 mat, out Vector3 result)
         {
             result.X = (vec.X * mat.Row0.X) + (vec.Y * mat.Row1.X) + (vec.Z * mat.Row2.X);
             result.Y = (vec.X * mat.Row0.Y) + (vec.Y * mat.Row1.Y) + (vec.Z * mat.Row2.Y);
@@ -971,7 +971,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector3 Transform(Vector3 vec, Quaternion quat)
         {
-            Transform(ref vec, ref quat, out Vector3 result);
+            Transform(in vec, in quat, out Vector3 result);
             return result;
         }
 
@@ -981,17 +981,17 @@ namespace OpenToolkit.Mathematics
         /// <param name="vec">The vector to transform.</param>
         /// <param name="quat">The quaternion to rotate the vector by.</param>
         /// <param name="result">The result of the operation.</param>
-        public static void Transform(ref Vector3 vec, ref Quaternion quat, out Vector3 result)
+        public static void Transform(in Vector3 vec, in Quaternion quat, out Vector3 result)
         {
             // Since vec.W == 0, we can optimize quat * vec * quat^-1 as follows:
             // vec + 2.0 * cross(quat.xyz, cross(quat.xyz, vec) + quat.w * vec)
             Vector3 xyz = quat.Xyz;
-            Cross(ref xyz, ref vec, out Vector3 temp);
-            Multiply(ref vec, quat.W, out Vector3 temp2);
-            Add(ref temp, ref temp2, out temp);
-            Cross(ref xyz, ref temp, out temp2);
-            Multiply(ref temp2, 2f, out temp2);
-            Add(ref vec, ref temp2, out result);
+            Cross(in xyz, in vec, out Vector3 temp);
+            Multiply(in vec, quat.W, out Vector3 temp2);
+            Add(in temp, in temp2, out temp);
+            Cross(in xyz, in temp, out temp2);
+            Multiply(in temp2, 2f, out temp2);
+            Add(in vec, in temp2, out result);
         }
 
         /// <summary>
@@ -1003,7 +1003,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector3 Transform(Matrix3 mat, Vector3 vec)
         {
-            Transform(ref vec, ref mat, out Vector3 result);
+            Transform(in vec, in mat, out Vector3 result);
             return result;
         }
 
@@ -1013,7 +1013,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="mat">The desired transformation.</param>
         /// <param name="vec">The vector to transform.</param>
         /// <param name="result">The transformed vector.</param>
-        public static void Transform(ref Matrix3 mat, ref Vector3 vec, out Vector3 result)
+        public static void Transform(in Matrix3 mat, in Vector3 vec, out Vector3 result)
         {
             result.X = (mat.Row0.X * vec.X) + (mat.Row0.Y * vec.Y) + (mat.Row0.Z * vec.Z);
             result.Y = (mat.Row1.X * vec.X) + (mat.Row1.Y * vec.Y) + (mat.Row1.Z * vec.Z);
@@ -1029,7 +1029,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector3 TransformPerspective(Vector3 vec, Matrix4 mat)
         {
-            TransformPerspective(ref vec, ref mat, out Vector3 result);
+            TransformPerspective(in vec, in mat, out Vector3 result);
             return result;
         }
 
@@ -1039,10 +1039,10 @@ namespace OpenToolkit.Mathematics
         /// <param name="vec">The vector to transform.</param>
         /// <param name="mat">The desired transformation.</param>
         /// <param name="result">The transformed vector.</param>
-        public static void TransformPerspective(ref Vector3 vec, ref Matrix4 mat, out Vector3 result)
+        public static void TransformPerspective(in Vector3 vec, in Matrix4 mat, out Vector3 result)
         {
             var v = new Vector4(vec.X, vec.Y, vec.Z, 1);
-            Vector4.Transform(ref v, ref mat, out v);
+            Vector4.Transform(in v, in mat, out v);
             result.X = v.X / v.W;
             result.Y = v.Y / v.W;
             result.Z = v.Z / v.W;
@@ -1058,7 +1058,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static float CalculateAngle(Vector3 first, Vector3 second)
         {
-            CalculateAngle(ref first, ref second, out float result);
+            CalculateAngle(in first, in second, out float result);
             return result;
         }
 
@@ -1069,9 +1069,9 @@ namespace OpenToolkit.Mathematics
         /// <param name="second">The second vector.</param>
         /// <param name="result">Angle (in radians) between the vectors.</param>
         /// <remarks>Note that the returned angle is never bigger than the constant Pi.</remarks>
-        public static void CalculateAngle(ref Vector3 first, ref Vector3 second, out float result)
+        public static void CalculateAngle(in Vector3 first, in Vector3 second, out float result)
         {
-            Dot(ref first, ref second, out float temp);
+            Dot(in first, in second, out float temp);
             result = (float)Math.Acos(MathHelper.Clamp(temp / (first.Length * second.Length), -1.0, 1.0));
         }
 
@@ -1460,7 +1460,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector3 operator *(Vector3 vec, Matrix3 mat)
         {
-            Transform(ref vec, ref mat, out Vector3 result);
+            Transform(in vec, in mat, out Vector3 result);
             return result;
         }
 
@@ -1473,7 +1473,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector3 operator *(Matrix3 mat, Vector3 vec)
         {
-            Transform(ref mat, ref vec, out Vector3 result);
+            Transform(in mat, in vec, out Vector3 result);
             return result;
         }
 
@@ -1486,7 +1486,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector3 operator *(Quaternion quat, Vector3 vec)
         {
-            Transform(ref vec, ref quat, out Vector3 result);
+            Transform(in vec, in quat, out Vector3 result);
             return result;
         }
 

--- a/src/OpenToolkit.Mathematics/Vector/Vector3d.cs
+++ b/src/OpenToolkit.Mathematics/Vector/Vector3d.cs
@@ -257,7 +257,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector3d Add(Vector3d a, Vector3d b)
         {
-            Add(ref a, ref b, out a);
+            Add(in a, in b, out a);
             return a;
         }
 
@@ -267,7 +267,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="a">Left operand.</param>
         /// <param name="b">Right operand.</param>
         /// <param name="result">Result of operation.</param>
-        public static void Add(ref Vector3d a, ref Vector3d b, out Vector3d result)
+        public static void Add(in Vector3d a, in Vector3d b, out Vector3d result)
         {
             result.X = a.X + b.X;
             result.Y = a.Y + b.Y;
@@ -283,7 +283,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector3d Subtract(Vector3d a, Vector3d b)
         {
-            Subtract(ref a, ref b, out a);
+            Subtract(in a, in b, out a);
             return a;
         }
 
@@ -293,7 +293,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="a">First operand.</param>
         /// <param name="b">Second operand.</param>
         /// <param name="result">Result of subtraction.</param>
-        public static void Subtract(ref Vector3d a, ref Vector3d b, out Vector3d result)
+        public static void Subtract(in Vector3d a, in Vector3d b, out Vector3d result)
         {
             result.X = a.X - b.X;
             result.Y = a.Y - b.Y;
@@ -309,7 +309,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector3d Multiply(Vector3d vector, double scale)
         {
-            Multiply(ref vector, scale, out vector);
+            Multiply(in vector, scale, out vector);
             return vector;
         }
 
@@ -319,7 +319,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="vector">Left operand.</param>
         /// <param name="scale">Right operand.</param>
         /// <param name="result">Result of the operation.</param>
-        public static void Multiply(ref Vector3d vector, double scale, out Vector3d result)
+        public static void Multiply(in Vector3d vector, double scale, out Vector3d result)
         {
             result.X = vector.X * scale;
             result.Y = vector.Y * scale;
@@ -335,7 +335,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector3d Multiply(Vector3d vector, Vector3d scale)
         {
-            Multiply(ref vector, ref scale, out vector);
+            Multiply(in vector, in scale, out vector);
             return vector;
         }
 
@@ -345,7 +345,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="vector">Left operand.</param>
         /// <param name="scale">Right operand.</param>
         /// <param name="result">Result of the operation.</param>
-        public static void Multiply(ref Vector3d vector, ref Vector3d scale, out Vector3d result)
+        public static void Multiply(in Vector3d vector, in Vector3d scale, out Vector3d result)
         {
             result.X = vector.X * scale.X;
             result.Y = vector.Y * scale.Y;
@@ -361,7 +361,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector3d Divide(Vector3d vector, double scale)
         {
-            Divide(ref vector, scale, out vector);
+            Divide(in vector, scale, out vector);
             return vector;
         }
 
@@ -371,7 +371,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="vector">Left operand.</param>
         /// <param name="scale">Right operand.</param>
         /// <param name="result">Result of the operation.</param>
-        public static void Divide(ref Vector3d vector, double scale, out Vector3d result)
+        public static void Divide(in Vector3d vector, double scale, out Vector3d result)
         {
             result.X = vector.X / scale;
             result.Y = vector.Y / scale;
@@ -387,7 +387,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector3d Divide(Vector3d vector, Vector3d scale)
         {
-            Divide(ref vector, ref scale, out vector);
+            Divide(in vector, in scale, out vector);
             return vector;
         }
 
@@ -397,7 +397,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="vector">Left operand.</param>
         /// <param name="scale">Right operand.</param>
         /// <param name="result">Result of the operation.</param>
-        public static void Divide(ref Vector3d vector, ref Vector3d scale, out Vector3d result)
+        public static void Divide(in Vector3d vector, in Vector3d scale, out Vector3d result)
         {
             result.X = vector.X / scale.X;
             result.Y = vector.Y / scale.Y;
@@ -425,7 +425,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="a">First operand.</param>
         /// <param name="b">Second operand.</param>
         /// <param name="result">The component-wise minimum.</param>
-        public static void ComponentMin(ref Vector3d a, ref Vector3d b, out Vector3d result)
+        public static void ComponentMin(in Vector3d a, in Vector3d b, out Vector3d result)
         {
             result.X = a.X < b.X ? a.X : b.X;
             result.Y = a.Y < b.Y ? a.Y : b.Y;
@@ -453,7 +453,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="a">First operand.</param>
         /// <param name="b">Second operand.</param>
         /// <param name="result">The component-wise maximum.</param>
-        public static void ComponentMax(ref Vector3d a, ref Vector3d b, out Vector3d result)
+        public static void ComponentMax(in Vector3d a, in Vector3d b, out Vector3d result)
         {
             result.X = a.X > b.X ? a.X : b.X;
             result.Y = a.Y > b.Y ? a.Y : b.Y;
@@ -478,7 +478,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">Left operand.</param>
         /// <param name="right">Right operand.</param>
         /// <param name="result">The magnitude-wise minimum.</param>
-        public static void MagnitudeMin(ref Vector3d left, ref Vector3d right, out Vector3d result)
+        public static void MagnitudeMin(in Vector3d left, in Vector3d right, out Vector3d result)
         {
             result = left.LengthSquared < right.LengthSquared ? left : right;
         }
@@ -501,7 +501,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">Left operand.</param>
         /// <param name="right">Right operand.</param>
         /// <param name="result">The magnitude-wise maximum.</param>
-        public static void MagnitudeMax(ref Vector3d left, ref Vector3d right, out Vector3d result)
+        public static void MagnitudeMax(in Vector3d left, in Vector3d right, out Vector3d result)
         {
             result = left.LengthSquared >= right.LengthSquared ? left : right;
         }
@@ -529,7 +529,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="min">Minimum vector.</param>
         /// <param name="max">Maximum vector.</param>
         /// <param name="result">The clamped vector.</param>
-        public static void Clamp(ref Vector3d vec, ref Vector3d min, ref Vector3d max, out Vector3d result)
+        public static void Clamp(in Vector3d vec, in Vector3d min, in Vector3d max, out Vector3d result)
         {
             result.X = vec.X < min.X ? min.X : vec.X > max.X ? max.X : vec.X;
             result.Y = vec.Y < min.Y ? min.Y : vec.Y > max.Y ? max.Y : vec.Y;
@@ -545,7 +545,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static double Distance(Vector3d vec1, Vector3d vec2)
         {
-            Distance(ref vec1, ref vec2, out double result);
+            Distance(in vec1, in vec2, out double result);
             return result;
         }
 
@@ -555,7 +555,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="vec1">The first vector.</param>
         /// <param name="vec2">The second vector.</param>
         /// <param name="result">The distance.</param>
-        public static void Distance(ref Vector3d vec1, ref Vector3d vec2, out double result)
+        public static void Distance(in Vector3d vec1, in Vector3d vec2, out double result)
         {
             result = Math.Sqrt(((vec2.X - vec1.X) * (vec2.X - vec1.X)) + ((vec2.Y - vec1.Y) * (vec2.Y - vec1.Y)) +
                                ((vec2.Z - vec1.Z) * (vec2.Z - vec1.Z)));
@@ -570,7 +570,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static double DistanceSquared(Vector3d vec1, Vector3d vec2)
         {
-            DistanceSquared(ref vec1, ref vec2, out double result);
+            DistanceSquared(in vec1, in vec2, out double result);
             return result;
         }
 
@@ -580,7 +580,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="vec1">The first vector.</param>
         /// <param name="vec2">The second vector.</param>
         /// <param name="result">The squared distance.</param>
-        public static void DistanceSquared(ref Vector3d vec1, ref Vector3d vec2, out double result)
+        public static void DistanceSquared(in Vector3d vec1, in Vector3d vec2, out double result)
         {
             result = ((vec2.X - vec1.X) * (vec2.X - vec1.X)) + ((vec2.Y - vec1.Y) * (vec2.Y - vec1.Y)) +
                      ((vec2.Z - vec1.Z) * (vec2.Z - vec1.Z));
@@ -606,7 +606,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="vec">The input vector.</param>
         /// <param name="result">The normalized vector.</param>
-        public static void Normalize(ref Vector3d vec, out Vector3d result)
+        public static void Normalize(in Vector3d vec, out Vector3d result)
         {
             var scale = 1.0 / vec.Length;
             result.X = vec.X * scale;
@@ -634,7 +634,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="vec">The input vector.</param>
         /// <param name="result">The normalized vector.</param>
-        public static void NormalizeFast(ref Vector3d vec, out Vector3d result)
+        public static void NormalizeFast(in Vector3d vec, out Vector3d result)
         {
             var scale = MathHelper.InverseSqrtFast((vec.X * vec.X) + (vec.Y * vec.Y) + (vec.Z * vec.Z));
             result.X = vec.X * scale;
@@ -660,7 +660,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">First operand.</param>
         /// <param name="right">Second operand.</param>
         /// <param name="result">The dot product of the two inputs.</param>
-        public static void Dot(ref Vector3d left, ref Vector3d right, out double result)
+        public static void Dot(in Vector3d left, in Vector3d right, out double result)
         {
             result = (left.X * right.X) + (left.Y * right.Y) + (left.Z * right.Z);
         }
@@ -674,7 +674,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector3d Cross(Vector3d left, Vector3d right)
         {
-            Cross(ref left, ref right, out Vector3d result);
+            Cross(in left, in right, out Vector3d result);
             return result;
         }
 
@@ -689,7 +689,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">First operand.</param>
         /// <param name="right">Second operand.</param>
         /// <param name="result">The cross product of the two inputs.</param>
-        public static void Cross(ref Vector3d left, ref Vector3d right, out Vector3d result)
+        public static void Cross(in Vector3d left, in Vector3d right, out Vector3d result)
         {
             result.X = (left.Y * right.Z) - (left.Z * right.Y);
             result.Y = (left.Z * right.X) - (left.X * right.Z);
@@ -719,7 +719,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="b">Second input vector.</param>
         /// <param name="blend">The blend factor. a when blend=0, b when blend=1.</param>
         /// <param name="result">a when blend=0, b when blend=1, and a linear combination otherwise.</param>
-        public static void Lerp(ref Vector3d a, ref Vector3d b, double blend, out Vector3d result)
+        public static void Lerp(in Vector3d a, in Vector3d b, double blend, out Vector3d result)
         {
             result.X = (blend * (b.X - a.X)) + a.X;
             result.Y = (blend * (b.Y - a.Y)) + a.Y;
@@ -767,14 +767,14 @@ namespace OpenToolkit.Mathematics
             result = a; // copy
 
             var temp = b; // copy
-            Subtract(ref temp, ref a, out temp);
-            Multiply(ref temp, u, out temp);
-            Add(ref result, ref temp, out result);
+            Subtract(in temp, in a, out temp);
+            Multiply(in temp, u, out temp);
+            Add(in result, in temp, out result);
 
             temp = c; // copy
-            Subtract(ref temp, ref a, out temp);
-            Multiply(ref temp, v, out temp);
-            Add(ref result, ref temp, out result);
+            Subtract(in temp, in a, out temp);
+            Multiply(in temp, v, out temp);
+            Add(in result, in temp, out result);
         }
 
         /// <summary>
@@ -787,7 +787,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector3d TransformVector(Vector3d vec, Matrix4d mat)
         {
-            TransformVector(ref vec, ref mat, out Vector3d result);
+            TransformVector(in vec, in mat, out Vector3d result);
             return result;
         }
 
@@ -802,7 +802,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="vec">The vector to transform.</param>
         /// <param name="mat">The desired transformation.</param>
         /// <param name="result">The transformed vector.</param>
-        public static void TransformVector(ref Vector3d vec, ref Matrix4d mat, out Vector3d result)
+        public static void TransformVector(in Vector3d vec, in Matrix4d mat, out Vector3d result)
         {
             result.X = (vec.X * mat.Row0.X) +
                        (vec.Y * mat.Row1.X) +
@@ -844,10 +844,10 @@ namespace OpenToolkit.Mathematics
         /// <param name="norm">The normal to transform.</param>
         /// <param name="mat">The desired transformation.</param>
         /// <param name="result">The transformed normal.</param>
-        public static void TransformNormal(ref Vector3d norm, ref Matrix4d mat, out Vector3d result)
+        public static void TransformNormal(in Vector3d norm, in Matrix4d mat, out Vector3d result)
         {
             var inverse = Matrix4d.Invert(mat);
-            TransformNormalInverse(ref norm, ref inverse, out result);
+            TransformNormalInverse(in norm, in inverse, out result);
         }
 
         /// <summary>
@@ -863,7 +863,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector3d TransformNormalInverse(Vector3d norm, Matrix4d invMat)
         {
-            TransformNormalInverse(ref norm, ref invMat, out Vector3d result);
+            TransformNormalInverse(in norm, in invMat, out Vector3d result);
             return result;
         }
 
@@ -877,7 +877,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="norm">The normal to transform.</param>
         /// <param name="invMat">The inverse of the desired transformation.</param>
         /// <param name="result">The transformed normal.</param>
-        public static void TransformNormalInverse(ref Vector3d norm, ref Matrix4d invMat, out Vector3d result)
+        public static void TransformNormalInverse(in Vector3d norm, in Matrix4d invMat, out Vector3d result)
         {
             result.X = (norm.X * invMat.Row0.X) +
                        (norm.Y * invMat.Row0.Y) +
@@ -901,7 +901,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector3d TransformPosition(Vector3d pos, Matrix4d mat)
         {
-            TransformPosition(ref pos, ref mat, out Vector3d result);
+            TransformPosition(in pos, in mat, out Vector3d result);
             return result;
         }
 
@@ -911,7 +911,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="pos">The position to transform.</param>
         /// <param name="mat">The desired transformation.</param>
         /// <param name="result">The transformed position.</param>
-        public static void TransformPosition(ref Vector3d pos, ref Matrix4d mat, out Vector3d result)
+        public static void TransformPosition(in Vector3d pos, in Matrix4d mat, out Vector3d result)
         {
             result.X = (pos.X * mat.Row0.X) +
                        (pos.Y * mat.Row1.X) +
@@ -938,7 +938,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector3d Transform(Vector3d vec, Matrix4d mat)
         {
-            Transform(ref vec, ref mat, out Vector3d result);
+            Transform(in vec, in mat, out Vector3d result);
             return result;
         }
 
@@ -953,10 +953,10 @@ namespace OpenToolkit.Mathematics
         /// <param name="vec">The vector to transform.</param>
         /// <param name="mat">The desired transformation.</param>
         /// <param name="result">The transformed vector.</param>
-        public static void Transform(ref Vector3d vec, ref Matrix4d mat, out Vector3d result)
+        public static void Transform(in Vector3d vec, in Matrix4d mat, out Vector3d result)
         {
             var v4 = new Vector4d(vec.X, vec.Y, vec.Z, 1.0);
-            Vector4d.Transform(ref v4, ref mat, out v4);
+            Vector4d.Transform(in v4, in mat, out v4);
             result.X = v4.X;
             result.Y = v4.Y;
             result.Z = v4.Z;
@@ -971,7 +971,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector3d Transform(Vector3d vec, Quaterniond quat)
         {
-            Transform(ref vec, ref quat, out Vector3d result);
+            Transform(in vec, in quat, out Vector3d result);
             return result;
         }
 
@@ -981,17 +981,17 @@ namespace OpenToolkit.Mathematics
         /// <param name="vec">The vector to transform.</param>
         /// <param name="quat">The quaternion to rotate the vector by.</param>
         /// <param name="result">The result of the operation.</param>
-        public static void Transform(ref Vector3d vec, ref Quaterniond quat, out Vector3d result)
+        public static void Transform(in Vector3d vec, in Quaterniond quat, out Vector3d result)
         {
             // Since vec.W == 0, we can optimize quat * vec * quat^-1 as follows:
             // vec + 2.0 * cross(quat.xyz, cross(quat.xyz, vec) + quat.w * vec)
             Vector3d xyz = quat.Xyz;
-            Cross(ref xyz, ref vec, out Vector3d temp);
-            Multiply(ref vec, quat.W, out Vector3d temp2);
-            Add(ref temp, ref temp2, out temp);
-            Cross(ref xyz, ref temp, out temp2);
-            Multiply(ref temp2, 2f, out temp2);
-            Add(ref vec, ref temp2, out result);
+            Cross(in xyz, in vec, out Vector3d temp);
+            Multiply(in vec, quat.W, out Vector3d temp2);
+            Add(in temp, in temp2, out temp);
+            Cross(in xyz, in temp, out temp2);
+            Multiply(in temp2, 2f, out temp2);
+            Add(in vec, in temp2, out result);
         }
 
         /// <summary>
@@ -1003,7 +1003,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector3d TransformPerspective(Vector3d vec, Matrix4d mat)
         {
-            TransformPerspective(ref vec, ref mat, out Vector3d result);
+            TransformPerspective(in vec, in mat, out Vector3d result);
             return result;
         }
 
@@ -1013,10 +1013,10 @@ namespace OpenToolkit.Mathematics
         /// <param name="vec">The vector to transform.</param>
         /// <param name="mat">The desired transformation.</param>
         /// <param name="result">The transformed vector.</param>
-        public static void TransformPerspective(ref Vector3d vec, ref Matrix4d mat, out Vector3d result)
+        public static void TransformPerspective(in Vector3d vec, in Matrix4d mat, out Vector3d result)
         {
             var v = new Vector4d(vec.X, vec.Y, vec.Z, 1);
-            Vector4d.Transform(ref v, ref mat, out v);
+            Vector4d.Transform(in v, in mat, out v);
             result.X = v.X / v.W;
             result.Y = v.Y / v.W;
             result.Z = v.Z / v.W;
@@ -1032,7 +1032,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static double CalculateAngle(Vector3d first, Vector3d second)
         {
-            CalculateAngle(ref first, ref second, out double result);
+            CalculateAngle(in first, in second, out double result);
             return result;
         }
 
@@ -1043,9 +1043,9 @@ namespace OpenToolkit.Mathematics
         /// <param name="second">The second vector.</param>
         /// <param name="result">Angle (in radians) between the vectors.</param>
         /// <remarks>Note that the returned angle is never bigger than the constant Pi.</remarks>
-        public static void CalculateAngle(ref Vector3d first, ref Vector3d second, out double result)
+        public static void CalculateAngle(in Vector3d first, in Vector3d second, out double result)
         {
-            Dot(ref first, ref second, out double temp);
+            Dot(in first, in second, out double temp);
             result = Math.Acos(MathHelper.Clamp(temp / (first.Length * second.Length), -1.0, 1.0));
         }
 
@@ -1306,7 +1306,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector3d operator *(Quaterniond quat, Vector3d vec)
         {
-            Transform(ref vec, ref quat, out Vector3d result);
+            Transform(in vec, in quat, out Vector3d result);
             return result;
         }
 

--- a/src/OpenToolkit.Mathematics/Vector/Vector3h.cs
+++ b/src/OpenToolkit.Mathematics/Vector/Vector3h.cs
@@ -144,7 +144,7 @@ namespace OpenToolkit.Mathematics
         /// Initializes a new instance of the <see cref="Vector3h"/> struct.
         /// </summary>
         /// <param name="v">The <see cref="Vector3"/> to convert.</param>
-        public Vector3h(ref Vector3 v)
+        public Vector3h(in Vector3 v)
         {
             X = new Half(v.X);
             Y = new Half(v.Y);
@@ -156,7 +156,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="v">The <see cref="Vector3"/> to convert.</param>
         /// <param name="throwOnError">Enable checks that will throw if the conversion result is not meaningful.</param>
-        public Vector3h(ref Vector3 v, bool throwOnError)
+        public Vector3h(in Vector3 v, bool throwOnError)
         {
             X = new Half(v.X, throwOnError);
             Y = new Half(v.Y, throwOnError);
@@ -190,7 +190,7 @@ namespace OpenToolkit.Mathematics
         /// Initializes a new instance of the <see cref="Vector3h"/> struct.
         /// </summary>
         /// <param name="v">The <see cref="Vector3d"/> to convert.</param>
-        public Vector3h(ref Vector3d v)
+        public Vector3h(in Vector3d v)
         {
             X = new Half(v.X);
             Y = new Half(v.Y);
@@ -202,7 +202,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="v">The <see cref="Vector3d"/> to convert.</param>
         /// <param name="throwOnError">Enable checks that will throw if the conversion result is not meaningful.</param>
-        public Vector3h(ref Vector3d v, bool throwOnError)
+        public Vector3h(in Vector3d v, bool throwOnError)
         {
             X = new Half(v.X, throwOnError);
             Y = new Half(v.Y, throwOnError);

--- a/src/OpenToolkit.Mathematics/Vector/Vector3i.cs
+++ b/src/OpenToolkit.Mathematics/Vector/Vector3i.cs
@@ -153,7 +153,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector3i Add(Vector3i a, Vector3i b)
         {
-            Add(ref a, ref b, out a);
+            Add(in a, in b, out a);
             return a;
         }
 
@@ -163,7 +163,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="a">Left operand.</param>
         /// <param name="b">Right operand.</param>
         /// <param name="result">Result of operation.</param>
-        public static void Add(ref Vector3i a, ref Vector3i b, out Vector3i result)
+        public static void Add(in Vector3i a, in Vector3i b, out Vector3i result)
         {
             result.X = a.X + b.X;
             result.Y = a.Y + b.Y;
@@ -179,7 +179,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector3i Subtract(Vector3i a, Vector3i b)
         {
-            Subtract(ref a, ref b, out a);
+            Subtract(in a, in b, out a);
             return a;
         }
 
@@ -189,7 +189,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="a">First operand.</param>
         /// <param name="b">Second operand.</param>
         /// <param name="result">Result of subtraction.</param>
-        public static void Subtract(ref Vector3i a, ref Vector3i b, out Vector3i result)
+        public static void Subtract(in Vector3i a, in Vector3i b, out Vector3i result)
         {
             result.X = a.X - b.X;
             result.Y = a.Y - b.Y;
@@ -205,7 +205,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector3i Multiply(Vector3i vector, int scale)
         {
-            Multiply(ref vector, scale, out vector);
+            Multiply(in vector, scale, out vector);
             return vector;
         }
 
@@ -215,7 +215,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="vector">Left operand.</param>
         /// <param name="scale">Right operand.</param>
         /// <param name="result">Result of the operation.</param>
-        public static void Multiply(ref Vector3i vector, int scale, out Vector3i result)
+        public static void Multiply(in Vector3i vector, int scale, out Vector3i result)
         {
             result.X = vector.X * scale;
             result.Y = vector.Y * scale;
@@ -231,7 +231,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector3i Multiply(Vector3i vector, Vector3i scale)
         {
-            Multiply(ref vector, ref scale, out vector);
+            Multiply(in vector, in scale, out vector);
             return vector;
         }
 
@@ -241,7 +241,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="vector">Left operand.</param>
         /// <param name="scale">Right operand.</param>
         /// <param name="result">Result of the operation.</param>
-        public static void Multiply(ref Vector3i vector, ref Vector3i scale, out Vector3i result)
+        public static void Multiply(in Vector3i vector, in Vector3i scale, out Vector3i result)
         {
             result.X = vector.X * scale.X;
             result.Y = vector.Y * scale.Y;
@@ -257,7 +257,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector3i Divide(Vector3i vector, int scale)
         {
-            Divide(ref vector, scale, out vector);
+            Divide(in vector, scale, out vector);
             return vector;
         }
 
@@ -267,7 +267,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="vector">Left operand.</param>
         /// <param name="scale">Right operand.</param>
         /// <param name="result">Result of the operation.</param>
-        public static void Divide(ref Vector3i vector, int scale, out Vector3i result)
+        public static void Divide(in Vector3i vector, int scale, out Vector3i result)
         {
             result.X = vector.X / scale;
             result.Y = vector.Y / scale;
@@ -283,7 +283,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector3i Divide(Vector3i vector, Vector3i scale)
         {
-            Divide(ref vector, ref scale, out vector);
+            Divide(in vector, in scale, out vector);
             return vector;
         }
 
@@ -293,7 +293,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="vector">Left operand.</param>
         /// <param name="scale">Right operand.</param>
         /// <param name="result">Result of the operation.</param>
-        public static void Divide(ref Vector3i vector, ref Vector3i scale, out Vector3i result)
+        public static void Divide(in Vector3i vector, in Vector3i scale, out Vector3i result)
         {
             result.X = vector.X / scale.X;
             result.Y = vector.Y / scale.Y;
@@ -321,7 +321,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="a">First operand.</param>
         /// <param name="b">Second operand.</param>
         /// <param name="result">The component-wise minimum.</param>
-        public static void ComponentMin(ref Vector3i a, ref Vector3i b, out Vector3i result)
+        public static void ComponentMin(in Vector3i a, in Vector3i b, out Vector3i result)
         {
             result.X = a.X < b.X ? a.X : b.X;
             result.Y = a.Y < b.Y ? a.Y : b.Y;
@@ -349,7 +349,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="a">First operand.</param>
         /// <param name="b">Second operand.</param>
         /// <param name="result">The component-wise maximum.</param>
-        public static void ComponentMax(ref Vector3i a, ref Vector3i b, out Vector3i result)
+        public static void ComponentMax(in Vector3i a, in Vector3i b, out Vector3i result)
         {
             result.X = a.X > b.X ? a.X : b.X;
             result.Y = a.Y > b.Y ? a.Y : b.Y;
@@ -379,7 +379,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="min">Minimum vector.</param>
         /// <param name="max">Maximum vector.</param>
         /// <param name="result">The clamped vector.</param>
-        public static void Clamp(ref Vector3i vec, ref Vector3i min, ref Vector3i max, out Vector3i result)
+        public static void Clamp(in Vector3i vec, in Vector3i min, in Vector3i max, out Vector3i result)
         {
             result.X = vec.X < min.X ? min.X : vec.X > max.X ? max.X : vec.X;
             result.Y = vec.Y < min.Y ? min.Y : vec.Y > max.Y ? max.Y : vec.Y;
@@ -559,7 +559,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="input">The given <see cref="Vector3i"/> to convert.</param>
         /// <param name="result">The resulting <see cref="Vector3"/>.</param>
-        public static void ToVector3(ref Vector3i input, out Vector3 result)
+        public static void ToVector3(in Vector3i input, out Vector3 result)
         {
             result.X = input.X;
             result.Y = input.Y;

--- a/src/OpenToolkit.Mathematics/Vector/Vector4.cs
+++ b/src/OpenToolkit.Mathematics/Vector/Vector4.cs
@@ -303,7 +303,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector4 Add(Vector4 a, Vector4 b)
         {
-            Add(ref a, ref b, out a);
+            Add(in a, in b, out a);
             return a;
         }
 
@@ -313,7 +313,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="a">Left operand.</param>
         /// <param name="b">Right operand.</param>
         /// <param name="result">Result of operation.</param>
-        public static void Add(ref Vector4 a, ref Vector4 b, out Vector4 result)
+        public static void Add(in Vector4 a, in Vector4 b, out Vector4 result)
         {
             result.X = a.X + b.X;
             result.Y = a.Y + b.Y;
@@ -330,7 +330,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector4 Subtract(Vector4 a, Vector4 b)
         {
-            Subtract(ref a, ref b, out a);
+            Subtract(in a, in b, out a);
             return a;
         }
 
@@ -340,7 +340,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="a">First operand.</param>
         /// <param name="b">Second operand.</param>
         /// <param name="result">Result of subtraction.</param>
-        public static void Subtract(ref Vector4 a, ref Vector4 b, out Vector4 result)
+        public static void Subtract(in Vector4 a, in Vector4 b, out Vector4 result)
         {
             result.X = a.X - b.X;
             result.Y = a.Y - b.Y;
@@ -357,7 +357,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector4 Multiply(Vector4 vector, float scale)
         {
-            Multiply(ref vector, scale, out vector);
+            Multiply(in vector, scale, out vector);
             return vector;
         }
 
@@ -367,7 +367,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="vector">Left operand.</param>
         /// <param name="scale">Right operand.</param>
         /// <param name="result">Result of the operation.</param>
-        public static void Multiply(ref Vector4 vector, float scale, out Vector4 result)
+        public static void Multiply(in Vector4 vector, float scale, out Vector4 result)
         {
             result.X = vector.X * scale;
             result.Y = vector.Y * scale;
@@ -384,7 +384,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector4 Multiply(Vector4 vector, Vector4 scale)
         {
-            Multiply(ref vector, ref scale, out vector);
+            Multiply(in vector, in scale, out vector);
             return vector;
         }
 
@@ -394,7 +394,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="vector">Left operand.</param>
         /// <param name="scale">Right operand.</param>
         /// <param name="result">Result of the operation.</param>
-        public static void Multiply(ref Vector4 vector, ref Vector4 scale, out Vector4 result)
+        public static void Multiply(in Vector4 vector, in Vector4 scale, out Vector4 result)
         {
             result.X = vector.X * scale.X;
             result.Y = vector.Y * scale.Y;
@@ -411,7 +411,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector4 Divide(Vector4 vector, float scale)
         {
-            Divide(ref vector, scale, out vector);
+            Divide(in vector, scale, out vector);
             return vector;
         }
 
@@ -421,7 +421,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="vector">Left operand.</param>
         /// <param name="scale">Right operand.</param>
         /// <param name="result">Result of the operation.</param>
-        public static void Divide(ref Vector4 vector, float scale, out Vector4 result)
+        public static void Divide(in Vector4 vector, float scale, out Vector4 result)
         {
             result.X = vector.X / scale;
             result.Y = vector.Y / scale;
@@ -438,7 +438,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector4 Divide(Vector4 vector, Vector4 scale)
         {
-            Divide(ref vector, ref scale, out vector);
+            Divide(in vector, in scale, out vector);
             return vector;
         }
 
@@ -448,7 +448,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="vector">Left operand.</param>
         /// <param name="scale">Right operand.</param>
         /// <param name="result">Result of the operation.</param>
-        public static void Divide(ref Vector4 vector, ref Vector4 scale, out Vector4 result)
+        public static void Divide(in Vector4 vector, in Vector4 scale, out Vector4 result)
         {
             result.X = vector.X / scale.X;
             result.Y = vector.Y / scale.Y;
@@ -478,7 +478,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="a">First operand.</param>
         /// <param name="b">Second operand.</param>
         /// <param name="result">The component-wise minimum.</param>
-        public static void ComponentMin(ref Vector4 a, ref Vector4 b, out Vector4 result)
+        public static void ComponentMin(in Vector4 a, in Vector4 b, out Vector4 result)
         {
             result.X = a.X < b.X ? a.X : b.X;
             result.Y = a.Y < b.Y ? a.Y : b.Y;
@@ -508,7 +508,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="a">First operand.</param>
         /// <param name="b">Second operand.</param>
         /// <param name="result">The component-wise maximum.</param>
-        public static void ComponentMax(ref Vector4 a, ref Vector4 b, out Vector4 result)
+        public static void ComponentMax(in Vector4 a, in Vector4 b, out Vector4 result)
         {
             result.X = a.X > b.X ? a.X : b.X;
             result.Y = a.Y > b.Y ? a.Y : b.Y;
@@ -536,7 +536,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">Left operand.</param>
         /// <param name="right">Right operand.</param>
         /// <param name="result">The magnitude-wise minimum.</param>
-        public static void MagnitudeMin(ref Vector4 left, ref Vector4 right, out Vector4 result)
+        public static void MagnitudeMin(in Vector4 left, in Vector4 right, out Vector4 result)
         {
             result = left.LengthSquared < right.LengthSquared ? left : right;
         }
@@ -561,7 +561,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">Left operand.</param>
         /// <param name="right">Right operand.</param>
         /// <param name="result">The magnitude-wise maximum.</param>
-        public static void MagnitudeMax(ref Vector4 left, ref Vector4 right, out Vector4 result)
+        public static void MagnitudeMax(in Vector4 left, in Vector4 right, out Vector4 result)
         {
             result = left.LengthSquared >= right.LengthSquared ? left : right;
         }
@@ -590,7 +590,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="min">Minimum vector.</param>
         /// <param name="max">Maximum vector.</param>
         /// <param name="result">The clamped vector.</param>
-        public static void Clamp(ref Vector4 vec, ref Vector4 min, ref Vector4 max, out Vector4 result)
+        public static void Clamp(in Vector4 vec, in Vector4 min, in Vector4 max, out Vector4 result)
         {
             result.X = vec.X < min.X ? min.X : vec.X > max.X ? max.X : vec.X;
             result.Y = vec.Y < min.Y ? min.Y : vec.Y > max.Y ? max.Y : vec.Y;
@@ -619,7 +619,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="vec">The input vector.</param>
         /// <param name="result">The normalized vector.</param>
-        public static void Normalize(ref Vector4 vec, out Vector4 result)
+        public static void Normalize(in Vector4 vec, out Vector4 result)
         {
             var scale = 1.0f / vec.Length;
             result.X = vec.X * scale;
@@ -649,7 +649,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="vec">The input vector.</param>
         /// <param name="result">The normalized copy.</param>
-        public static void NormalizeFast(ref Vector4 vec, out Vector4 result)
+        public static void NormalizeFast(in Vector4 vec, out Vector4 result)
         {
             var scale = MathHelper.InverseSqrtFast((vec.X * vec.X) + (vec.Y * vec.Y) + (vec.Z * vec.Z) + (vec.W * vec.W));
             result.X = vec.X * scale;
@@ -676,7 +676,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">First operand.</param>
         /// <param name="right">Second operand.</param>
         /// <param name="result">The dot product of the two inputs.</param>
-        public static void Dot(ref Vector4 left, ref Vector4 right, out float result)
+        public static void Dot(in Vector4 left, in Vector4 right, out float result)
         {
             result = (left.X * right.X) + (left.Y * right.Y) + (left.Z * right.Z) + (left.W * right.W);
         }
@@ -705,7 +705,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="b">Second input vector.</param>
         /// <param name="blend">The blend factor. a when blend=0, b when blend=1.</param>
         /// <param name="result">a when blend=0, b when blend=1, and a linear combination otherwise.</param>
-        public static void Lerp(ref Vector4 a, ref Vector4 b, float blend, out Vector4 result)
+        public static void Lerp(in Vector4 a, in Vector4 b, float blend, out Vector4 result)
         {
             result.X = (blend * (b.X - a.X)) + a.X;
             result.Y = (blend * (b.Y - a.Y)) + a.Y;
@@ -742,9 +742,9 @@ namespace OpenToolkit.Mathematics
         /// </param>
         public static void BaryCentric
         (
-            ref Vector4 a,
-            ref Vector4 b,
-            ref Vector4 c,
+            in Vector4 a,
+            in Vector4 b,
+            in Vector4 c,
             float u,
             float v,
             out Vector4 result
@@ -753,14 +753,14 @@ namespace OpenToolkit.Mathematics
             result = a; // copy
 
             var temp = b; // copy
-            Subtract(ref temp, ref a, out temp);
-            Multiply(ref temp, u, out temp);
-            Add(ref result, ref temp, out result);
+            Subtract(in temp, in a, out temp);
+            Multiply(in temp, u, out temp);
+            Add(in result, in temp, out result);
 
             temp = c; // copy
-            Subtract(ref temp, ref a, out temp);
-            Multiply(ref temp, v, out temp);
-            Add(ref result, ref temp, out result);
+            Subtract(in temp, in a, out temp);
+            Multiply(in temp, v, out temp);
+            Add(in result, in temp, out result);
         }
 
         /// <summary>
@@ -772,7 +772,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector4 Transform(Vector4 vec, Matrix4 mat)
         {
-            Transform(ref vec, ref mat, out Vector4 result);
+            Transform(in vec, in mat, out Vector4 result);
             return result;
         }
 
@@ -782,7 +782,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="vec">The vector to transform.</param>
         /// <param name="mat">The desired transformation.</param>
         /// <param name="result">The transformed vector.</param>
-        public static void Transform(ref Vector4 vec, ref Matrix4 mat, out Vector4 result)
+        public static void Transform(in Vector4 vec, in Matrix4 mat, out Vector4 result)
         {
             result = new Vector4(
                 (vec.X * mat.Row0.X) + (vec.Y * mat.Row1.X) + (vec.Z * mat.Row2.X) + (vec.W * mat.Row3.X),
@@ -800,7 +800,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector4 Transform(Vector4 vec, Quaternion quat)
         {
-            Transform(ref vec, ref quat, out Vector4 result);
+            Transform(in vec, in quat, out Vector4 result);
             return result;
         }
 
@@ -810,12 +810,12 @@ namespace OpenToolkit.Mathematics
         /// <param name="vec">The vector to transform.</param>
         /// <param name="quat">The quaternion to rotate the vector by.</param>
         /// <param name="result">The result of the operation.</param>
-        public static void Transform(ref Vector4 vec, ref Quaternion quat, out Vector4 result)
+        public static void Transform(in Vector4 vec, in Quaternion quat, out Vector4 result)
         {
             Quaternion v = new Quaternion(vec.X, vec.Y, vec.Z, vec.W);
-            Quaternion.Invert(ref quat, out Quaternion i);
-            Quaternion.Multiply(ref quat, ref v, out Quaternion t);
-            Quaternion.Multiply(ref t, ref i, out v);
+            Quaternion.Invert(in quat, out Quaternion i);
+            Quaternion.Multiply(in quat, in v, out Quaternion t);
+            Quaternion.Multiply(in t, in i, out v);
 
             result.X = v.X;
             result.Y = v.Y;
@@ -832,7 +832,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector4 Transform(Matrix4 mat, Vector4 vec)
         {
-            Transform(ref mat, ref vec, out Vector4 result);
+            Transform(in mat, in vec, out Vector4 result);
             return result;
         }
 
@@ -842,7 +842,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="mat">The desired transformation.</param>
         /// <param name="vec">The vector to transform.</param>
         /// <param name="result">The transformed vector.</param>
-        public static void Transform(ref Matrix4 mat, ref Vector4 vec, out Vector4 result)
+        public static void Transform(in Matrix4 mat, in Vector4 vec, out Vector4 result)
         {
             result = new Vector4(
                 (mat.Row0.X * vec.X) + (mat.Row0.Y * vec.Y) + (mat.Row0.Z * vec.Z) + (mat.Row0.W * vec.W),
@@ -1915,7 +1915,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector4 operator *(Vector4 vec, Matrix4 mat)
         {
-            Transform(ref vec, ref mat, out Vector4 result);
+            Transform(in vec, in mat, out Vector4 result);
             return result;
         }
 
@@ -1928,7 +1928,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector4 operator *(Matrix4 mat, Vector4 vec)
         {
-            Transform(ref mat, ref vec, out Vector4 result);
+            Transform(in mat, in vec, out Vector4 result);
             return result;
         }
 
@@ -1941,7 +1941,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector4 operator *(Quaternion quat, Vector4 vec)
         {
-            Transform(ref vec, ref quat, out Vector4 result);
+            Transform(in vec, in quat, out Vector4 result);
             return result;
         }
 

--- a/src/OpenToolkit.Mathematics/Vector/Vector4d.cs
+++ b/src/OpenToolkit.Mathematics/Vector/Vector4d.cs
@@ -299,7 +299,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector4d Add(Vector4d a, Vector4d b)
         {
-            Add(ref a, ref b, out a);
+            Add(in a, in b, out a);
             return a;
         }
 
@@ -309,7 +309,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="a">Left operand.</param>
         /// <param name="b">Right operand.</param>
         /// <param name="result">Result of operation.</param>
-        public static void Add(ref Vector4d a, ref Vector4d b, out Vector4d result)
+        public static void Add(in Vector4d a, in Vector4d b, out Vector4d result)
         {
             result.X = a.X + b.X;
             result.Y = a.Y + b.Y;
@@ -326,7 +326,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector4d Subtract(Vector4d a, Vector4d b)
         {
-            Subtract(ref a, ref b, out a);
+            Subtract(in a, in b, out a);
             return a;
         }
 
@@ -336,7 +336,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="a">First operand.</param>
         /// <param name="b">Second operand.</param>
         /// <param name="result">Result of subtraction.</param>
-        public static void Subtract(ref Vector4d a, ref Vector4d b, out Vector4d result)
+        public static void Subtract(in Vector4d a, in Vector4d b, out Vector4d result)
         {
             result.X = a.X - b.X;
             result.Y = a.Y - b.Y;
@@ -353,7 +353,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector4d Multiply(Vector4d vector, double scale)
         {
-            Multiply(ref vector, scale, out vector);
+            Multiply(in vector, scale, out vector);
             return vector;
         }
 
@@ -363,7 +363,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="vector">Left operand.</param>
         /// <param name="scale">Right operand.</param>
         /// <param name="result">Result of the operation.</param>
-        public static void Multiply(ref Vector4d vector, double scale, out Vector4d result)
+        public static void Multiply(in Vector4d vector, double scale, out Vector4d result)
         {
             result.X = vector.X * scale;
             result.Y = vector.Y * scale;
@@ -380,7 +380,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector4d Multiply(Vector4d vector, Vector4d scale)
         {
-            Multiply(ref vector, ref scale, out vector);
+            Multiply(in vector, in scale, out vector);
             return vector;
         }
 
@@ -390,7 +390,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="vector">Left operand.</param>
         /// <param name="scale">Right operand.</param>
         /// <param name="result">Result of the operation.</param>
-        public static void Multiply(ref Vector4d vector, ref Vector4d scale, out Vector4d result)
+        public static void Multiply(in Vector4d vector, in Vector4d scale, out Vector4d result)
         {
             result.X = vector.X * scale.X;
             result.Y = vector.Y * scale.Y;
@@ -407,7 +407,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector4d Divide(Vector4d vector, double scale)
         {
-            Divide(ref vector, scale, out vector);
+            Divide(in vector, scale, out vector);
             return vector;
         }
 
@@ -417,7 +417,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="vector">Left operand.</param>
         /// <param name="scale">Right operand.</param>
         /// <param name="result">Result of the operation.</param>
-        public static void Divide(ref Vector4d vector, double scale, out Vector4d result)
+        public static void Divide(in Vector4d vector, double scale, out Vector4d result)
         {
             result.X = vector.X / scale;
             result.Y = vector.Y / scale;
@@ -434,7 +434,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector4d Divide(Vector4d vector, Vector4d scale)
         {
-            Divide(ref vector, ref scale, out vector);
+            Divide(in vector, in scale, out vector);
             return vector;
         }
 
@@ -444,7 +444,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="vector">Left operand.</param>
         /// <param name="scale">Right operand.</param>
         /// <param name="result">Result of the operation.</param>
-        public static void Divide(ref Vector4d vector, ref Vector4d scale, out Vector4d result)
+        public static void Divide(in Vector4d vector, in Vector4d scale, out Vector4d result)
         {
             result.X = vector.X / scale.X;
             result.Y = vector.Y / scale.Y;
@@ -474,7 +474,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="a">First operand.</param>
         /// <param name="b">Second operand.</param>
         /// <param name="result">The component-wise minimum.</param>
-        public static void ComponentMin(ref Vector4d a, ref Vector4d b, out Vector4d result)
+        public static void ComponentMin(in Vector4d a, in Vector4d b, out Vector4d result)
         {
             result.X = a.X < b.X ? a.X : b.X;
             result.Y = a.Y < b.Y ? a.Y : b.Y;
@@ -504,7 +504,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="a">First operand.</param>
         /// <param name="b">Second operand.</param>
         /// <param name="result">The component-wise maximum.</param>
-        public static void ComponentMax(ref Vector4d a, ref Vector4d b, out Vector4d result)
+        public static void ComponentMax(in Vector4d a, in Vector4d b, out Vector4d result)
         {
             result.X = a.X > b.X ? a.X : b.X;
             result.Y = a.Y > b.Y ? a.Y : b.Y;
@@ -530,7 +530,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">Left operand.</param>
         /// <param name="right">Right operand.</param>
         /// <param name="result">The magnitude-wise minimum.</param>
-        public static void MagnitudeMin(ref Vector4d left, ref Vector4d right, out Vector4d result)
+        public static void MagnitudeMin(in Vector4d left, in Vector4d right, out Vector4d result)
         {
             result = left.LengthSquared < right.LengthSquared ? left : right;
         }
@@ -553,7 +553,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">Left operand.</param>
         /// <param name="right">Right operand.</param>
         /// <param name="result">The magnitude-wise maximum.</param>
-        public static void MagnitudeMax(ref Vector4d left, ref Vector4d right, out Vector4d result)
+        public static void MagnitudeMax(in Vector4d left, in Vector4d right, out Vector4d result)
         {
             result = left.LengthSquared >= right.LengthSquared ? left : right;
         }
@@ -582,7 +582,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="min">Minimum vector.</param>
         /// <param name="max">Maximum vector.</param>
         /// <param name="result">The clamped vector.</param>
-        public static void Clamp(ref Vector4d vec, ref Vector4d min, ref Vector4d max, out Vector4d result)
+        public static void Clamp(in Vector4d vec, in Vector4d min, in Vector4d max, out Vector4d result)
         {
             result.X = vec.X < min.X ? min.X : vec.X > max.X ? max.X : vec.X;
             result.Y = vec.Y < min.Y ? min.Y : vec.Y > max.Y ? max.Y : vec.Y;
@@ -611,7 +611,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="vec">The input vector.</param>
         /// <param name="result">The normalized vector.</param>
-        public static void Normalize(ref Vector4d vec, out Vector4d result)
+        public static void Normalize(in Vector4d vec, out Vector4d result)
         {
             var scale = 1.0 / vec.Length;
             result.X = vec.X * scale;
@@ -641,7 +641,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="vec">The input vector.</param>
         /// <param name="result">The normalized vector.</param>
-        public static void NormalizeFast(ref Vector4d vec, out Vector4d result)
+        public static void NormalizeFast(in Vector4d vec, out Vector4d result)
         {
             var scale = MathHelper.InverseSqrtFast((vec.X * vec.X) + (vec.Y * vec.Y) + (vec.Z * vec.Z) + (vec.W * vec.W));
             result.X = vec.X * scale;
@@ -668,7 +668,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="left">First operand.</param>
         /// <param name="right">Second operand.</param>
         /// <param name="result">The dot product of the two inputs.</param>
-        public static void Dot(ref Vector4d left, ref Vector4d right, out double result)
+        public static void Dot(in Vector4d left, in Vector4d right, out double result)
         {
             result = (left.X * right.X) + (left.Y * right.Y) + (left.Z * right.Z) + (left.W * right.W);
         }
@@ -697,7 +697,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="b">Second input vector.</param>
         /// <param name="blend">The blend factor. a when blend=0, b when blend=1.</param>
         /// <param name="result">a when blend=0, b when blend=1, and a linear combination otherwise.</param>
-        public static void Lerp(ref Vector4d a, ref Vector4d b, double blend, out Vector4d result)
+        public static void Lerp(in Vector4d a, in Vector4d b, double blend, out Vector4d result)
         {
             result.X = (blend * (b.X - a.X)) + a.X;
             result.Y = (blend * (b.Y - a.Y)) + a.Y;
@@ -745,14 +745,14 @@ namespace OpenToolkit.Mathematics
             result = a; // copy
 
             var temp = b; // copy
-            Subtract(ref temp, ref a, out temp);
-            Multiply(ref temp, u, out temp);
-            Add(ref result, ref temp, out result);
+            Subtract(in temp, in a, out temp);
+            Multiply(in temp, u, out temp);
+            Add(in result, in temp, out result);
 
             temp = c; // copy
-            Subtract(ref temp, ref a, out temp);
-            Multiply(ref temp, v, out temp);
-            Add(ref result, ref temp, out result);
+            Subtract(in temp, in a, out temp);
+            Multiply(in temp, v, out temp);
+            Add(in result, in temp, out result);
         }
 
         /// <summary>
@@ -764,7 +764,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector4d Transform(Vector4d vec, Matrix4d mat)
         {
-            Transform(ref vec, ref mat, out Vector4d result);
+            Transform(in vec, in mat, out Vector4d result);
             return result;
         }
 
@@ -774,7 +774,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="vec">The vector to transform.</param>
         /// <param name="mat">The desired transformation.</param>
         /// <param name="result">The transformed vector.</param>
-        public static void Transform(ref Vector4d vec, ref Matrix4d mat, out Vector4d result)
+        public static void Transform(in Vector4d vec, in Matrix4d mat, out Vector4d result)
         {
             result = new Vector4d(
                 (vec.X * mat.Row0.X) + (vec.Y * mat.Row1.X) + (vec.Z * mat.Row2.X) + (vec.W * mat.Row3.X),
@@ -792,7 +792,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector4d Transform(Vector4d vec, Quaterniond quat)
         {
-            Transform(ref vec, ref quat, out Vector4d result);
+            Transform(in vec, in quat, out Vector4d result);
             return result;
         }
 
@@ -802,12 +802,12 @@ namespace OpenToolkit.Mathematics
         /// <param name="vec">The vector to transform.</param>
         /// <param name="quat">The quaternion to rotate the vector by.</param>
         /// <param name="result">The result of the operation.</param>
-        public static void Transform(ref Vector4d vec, ref Quaterniond quat, out Vector4d result)
+        public static void Transform(in Vector4d vec, in Quaterniond quat, out Vector4d result)
         {
             Quaterniond v = new Quaterniond(vec.X, vec.Y, vec.Z, vec.W);
-            Quaterniond.Invert(ref quat, out Quaterniond i);
-            Quaterniond.Multiply(ref quat, ref v, out Quaterniond t);
-            Quaterniond.Multiply(ref t, ref i, out v);
+            Quaterniond.Invert(in quat, out Quaterniond i);
+            Quaterniond.Multiply(in quat, in v, out Quaterniond t);
+            Quaterniond.Multiply(in t, in i, out v);
 
             result.X = v.X;
             result.Y = v.Y;
@@ -1879,7 +1879,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector4d operator *(Quaterniond quat, Vector4d vec)
         {
-            Transform(ref vec, ref quat, out Vector4d result);
+            Transform(in vec, in quat, out Vector4d result);
             return result;
         }
 

--- a/src/OpenToolkit.Mathematics/Vector/Vector4h.cs
+++ b/src/OpenToolkit.Mathematics/Vector/Vector4h.cs
@@ -157,7 +157,7 @@ namespace OpenToolkit.Mathematics
         /// Initializes a new instance of the <see cref="Vector4h"/> struct.
         /// </summary>
         /// <param name="v">The <see cref="Vector4"/> to convert.</param>
-        public Vector4h(ref Vector4 v)
+        public Vector4h(in Vector4 v)
         {
             X = new Half(v.X);
             Y = new Half(v.Y);
@@ -170,7 +170,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="v">The <see cref="Vector4"/> to convert.</param>
         /// <param name="throwOnError">Enable checks that will throw if the conversion result is not meaningful.</param>
-        public Vector4h(ref Vector4 v, bool throwOnError)
+        public Vector4h(in Vector4 v, bool throwOnError)
         {
             X = new Half(v.X, throwOnError);
             Y = new Half(v.Y, throwOnError);
@@ -207,7 +207,7 @@ namespace OpenToolkit.Mathematics
         /// Initializes a new instance of the <see cref="Vector4h"/> struct.
         /// </summary>
         /// <param name="v">The <see cref="Vector4d"/> to convert.</param>
-        public Vector4h(ref Vector4d v)
+        public Vector4h(in Vector4d v)
         {
             X = new Half(v.X);
             Y = new Half(v.Y);
@@ -220,7 +220,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="v">The <see cref="Vector4d"/> to convert.</param>
         /// <param name="throwOnError">Enable checks that will throw if the conversion result is not meaningful.</param>
-        public Vector4h(ref Vector4d v, bool throwOnError)
+        public Vector4h(in Vector4d v, bool throwOnError)
         {
             X = new Half(v.X, throwOnError);
             Y = new Half(v.Y, throwOnError);

--- a/src/OpenToolkit.Mathematics/Vector/Vector4i.cs
+++ b/src/OpenToolkit.Mathematics/Vector/Vector4i.cs
@@ -211,7 +211,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector4i Add(Vector4i a, Vector4i b)
         {
-            Add(ref a, ref b, out a);
+            Add(in a, in b, out a);
             return a;
         }
 
@@ -221,7 +221,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="a">Left operand.</param>
         /// <param name="b">Right operand.</param>
         /// <param name="result">Result of operation.</param>
-        public static void Add(ref Vector4i a, ref Vector4i b, out Vector4i result)
+        public static void Add(in Vector4i a, in Vector4i b, out Vector4i result)
         {
             result.X = a.X + b.X;
             result.Y = a.Y + b.Y;
@@ -238,7 +238,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector4i Subtract(Vector4i a, Vector4i b)
         {
-            Subtract(ref a, ref b, out a);
+            Subtract(in a, in b, out a);
             return a;
         }
 
@@ -248,7 +248,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="a">First operand.</param>
         /// <param name="b">Second operand.</param>
         /// <param name="result">Result of subtraction.</param>
-        public static void Subtract(ref Vector4i a, ref Vector4i b, out Vector4i result)
+        public static void Subtract(in Vector4i a, in Vector4i b, out Vector4i result)
         {
             result.X = a.X - b.X;
             result.Y = a.Y - b.Y;
@@ -265,7 +265,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector4i Multiply(Vector4i vector, int scale)
         {
-            Multiply(ref vector, scale, out vector);
+            Multiply(in vector, scale, out vector);
             return vector;
         }
 
@@ -275,7 +275,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="vector">Left operand.</param>
         /// <param name="scale">Right operand.</param>
         /// <param name="result">Result of the operation.</param>
-        public static void Multiply(ref Vector4i vector, int scale, out Vector4i result)
+        public static void Multiply(in Vector4i vector, int scale, out Vector4i result)
         {
             result.X = vector.X * scale;
             result.Y = vector.Y * scale;
@@ -292,7 +292,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector4i Multiply(Vector4i vector, Vector4i scale)
         {
-            Multiply(ref vector, ref scale, out vector);
+            Multiply(in vector, in scale, out vector);
             return vector;
         }
 
@@ -302,7 +302,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="vector">Left operand.</param>
         /// <param name="scale">Right operand.</param>
         /// <param name="result">Result of the operation.</param>
-        public static void Multiply(ref Vector4i vector, ref Vector4i scale, out Vector4i result)
+        public static void Multiply(in Vector4i vector, in Vector4i scale, out Vector4i result)
         {
             result.X = vector.X * scale.X;
             result.Y = vector.Y * scale.Y;
@@ -319,7 +319,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector4i Divide(Vector4i vector, int scale)
         {
-            Divide(ref vector, scale, out vector);
+            Divide(in vector, scale, out vector);
             return vector;
         }
 
@@ -329,7 +329,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="vector">Left operand.</param>
         /// <param name="scale">Right operand.</param>
         /// <param name="result">Result of the operation.</param>
-        public static void Divide(ref Vector4i vector, int scale, out Vector4i result)
+        public static void Divide(in Vector4i vector, int scale, out Vector4i result)
         {
             result.X = vector.X / scale;
             result.Y = vector.Y / scale;
@@ -346,7 +346,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector4i Divide(Vector4i vector, Vector4i scale)
         {
-            Divide(ref vector, ref scale, out vector);
+            Divide(in vector, in scale, out vector);
             return vector;
         }
 
@@ -356,7 +356,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="vector">Left operand.</param>
         /// <param name="scale">Right operand.</param>
         /// <param name="result">Result of the operation.</param>
-        public static void Divide(ref Vector4i vector, ref Vector4i scale, out Vector4i result)
+        public static void Divide(in Vector4i vector, in Vector4i scale, out Vector4i result)
         {
             result.X = vector.X / scale.X;
             result.Y = vector.Y / scale.Y;
@@ -386,7 +386,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="a">First operand.</param>
         /// <param name="b">Second operand.</param>
         /// <param name="result">The component-wise minimum.</param>
-        public static void ComponentMin(ref Vector4i a, ref Vector4i b, out Vector4i result)
+        public static void ComponentMin(in Vector4i a, in Vector4i b, out Vector4i result)
         {
             result.X = a.X < b.X ? a.X : b.X;
             result.Y = a.Y < b.Y ? a.Y : b.Y;
@@ -416,7 +416,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="a">First operand.</param>
         /// <param name="b">Second operand.</param>
         /// <param name="result">The component-wise maximum.</param>
-        public static void ComponentMax(ref Vector4i a, ref Vector4i b, out Vector4i result)
+        public static void ComponentMax(in Vector4i a, in Vector4i b, out Vector4i result)
         {
             result.X = a.X > b.X ? a.X : b.X;
             result.Y = a.Y > b.Y ? a.Y : b.Y;
@@ -448,7 +448,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="min">Minimum vector.</param>
         /// <param name="max">Maximum vector.</param>
         /// <param name="result">The clamped vector.</param>
-        public static void Clamp(ref Vector4i vec, ref Vector4i min, ref Vector4i max, out Vector4i result)
+        public static void Clamp(in Vector4i vec, in Vector4i min, in Vector4i max, out Vector4i result)
         {
             result.X = vec.X < min.X ? min.X : vec.X > max.X ? max.X : vec.X;
             result.Y = vec.Y < min.Y ? min.Y : vec.Y > max.Y ? max.Y : vec.Y;
@@ -1430,7 +1430,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="input">The given <see cref="Vector4i"/> to convert.</param>
         /// <param name="result">The resulting <see cref="Vector4"/>.</param>
-        public static void ToVector4(ref Vector4i input, out Vector4 result)
+        public static void ToVector4(in Vector4i input, out Vector4 result)
         {
             result.X = input.X;
             result.Y = input.Y;

--- a/tests/OpenToolkit.Tests/Matrix4Tests.fs
+++ b/tests/OpenToolkit.Tests/Matrix4Tests.fs
@@ -195,7 +195,7 @@ module Matrix4 =
             let R3 = Vector4(i, j, k, l) * scalar
             let R4 = Vector4(m, n, o, p) * scalar
 
-            let AScaled = Matrix4.Mult(ref A, scalar)
+            let AScaled = Matrix4.Mult(&A, scalar)
 
             Assert.Equal(R1, AScaled.Row0)
             Assert.Equal(R2, AScaled.Row1)

--- a/tests/OpenToolkit.Tests/Vector2Tests.fs
+++ b/tests/OpenToolkit.Tests/Vector2Tests.fs
@@ -39,7 +39,7 @@ module Vector2 =
 
         [<Property>]
         let ``Clamping one vector between two other vectors by reference clamps all components`` (a : Vector2, b : Vector2, w : Vector2) =
-            let res = Vector2.Clamp(ref w, ref a, ref b)
+            let res = Vector2.Clamp(&w, &a, &b)
 
             let expX = if w.X < a.X then a.X else if w.X > b.X then b.X else w.X
             let expY = if w.Y < a.Y then a.Y else if w.Y > b.Y then b.Y else w.Y
@@ -183,7 +183,7 @@ module Vector2 =
         let ``Static Vector2 addition method by reference is the same as component addition`` (a : Vector2, b : Vector2) =
 
             let v1 = Vector2(a.X + b.X, a.Y + b.Y)
-            let sum = Vector2.Add(ref a, ref b)
+            let sum = Vector2.Add(&a, &b)
 
             Assert.ApproximatelyEquivalent(v1, sum)
 
@@ -227,7 +227,7 @@ module Vector2 =
         let ``Static Vector2 multiplication method by reference is the same as component multiplication`` (a : Vector2, b : Vector2) =
 
             let v1 = Vector2(a.X * b.X, a.Y * b.Y)
-            let sum = Vector2.Multiply(ref a, ref b)
+            let sum = Vector2.Multiply(&a, &b)
 
             Assert.ApproximatelyEquivalent(v1, sum)
 
@@ -259,7 +259,7 @@ module Vector2 =
         let ``Static Vector2 subtraction method by reference is the same as component addition`` (a : Vector2, b : Vector2) =
 
             let v1 = Vector2(a.X - b.X, a.Y - b.Y)
-            let sum = Vector2.Subtract(ref a, ref b)
+            let sum = Vector2.Subtract(&a, &b)
 
             Assert.ApproximatelyEquivalent(v1, sum)
 
@@ -286,7 +286,7 @@ module Vector2 =
         let ``Static Vector2-Vector2 divison method by reference `` (a : Vector2, b : Vector2) =
             if not (anyZero2 a || anyZero2 b) then
                 let v1 = Vector2(a.X / b.X, a.Y / b.Y)
-                let sum = Vector2.Divide(ref a, ref b)
+                let sum = Vector2.Divide(&a, &b)
 
                 Assert.ApproximatelyEquivalent(v1, sum)
 
@@ -302,7 +302,7 @@ module Vector2 =
         let ``Static Vector2-scalar divison method by reference is the same as component division`` (a : Vector2, b : float32) =
             if not (approxEq b 0.0f) then
                 let v1 = Vector2(a.X / b, a.Y / b)
-                let sum = Vector2.Divide(ref a, b)
+                let sum = Vector2.Divide(&a, b)
 
                 Assert.ApproximatelyEquivalent(v1, sum)
 
@@ -372,7 +372,7 @@ module Vector2 =
 
             Assert.Equal(vExp, Vector2.Lerp(a, b, q))
 
-            let vRes = Vector2.Lerp(ref a, ref b, q)
+            let vRes = Vector2.Lerp(&a, &b, q)
             Assert.Equal(vExp, vRes)
 
         [<Property>]
@@ -382,7 +382,7 @@ module Vector2 =
 
             Assert.Equal(r, Vector2.BaryCentric(a, b, c, u, v))
 
-            let vRes = Vector2.BaryCentric(ref a, ref b, ref c, u, v)
+            let vRes = Vector2.BaryCentric(&a, &b, &c, u, v)
             Assert.Equal(r, vRes)
 
     [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
@@ -394,7 +394,7 @@ module Vector2 =
 
             Assert.Equal(dot, Vector2.Dot(a, b));
 
-            let vRes = Vector2.Dot(ref a, ref b)
+            let vRes = Vector2.Dot(&a, &b)
             Assert.Equal(dot, vRes)
 
         [<Property>]
@@ -403,7 +403,7 @@ module Vector2 =
 
             Assert.Equal(perpDot, Vector2.PerpDot(a, b));
 
-            let vRes = Vector2.PerpDot(ref a, ref b)
+            let vRes = Vector2.PerpDot(&a, &b)
             Assert.Equal(perpDot, vRes)
 
     [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
@@ -449,7 +449,7 @@ module Vector2 =
             // Zero-length vectors can't be normalized
             if not (approxEq a.Length 0.0f) then
                 let norm = a / a.Length
-                let vRes = Vector2.Normalize(ref a)
+                let vRes = Vector2.Normalize(&a)
 
                 Assert.ApproximatelyEquivalent(norm, vRes)
 
@@ -466,7 +466,7 @@ module Vector2 =
             let scale = MathHelper.InverseSqrtFast(a.X * a.X + a.Y * a.Y)
 
             let norm = a * scale
-            let vRes = Vector2.NormalizeFast(ref a)
+            let vRes = Vector2.NormalizeFast(&a)
 
             Assert.ApproximatelyEquivalent(norm, vRes)
 
@@ -520,7 +520,7 @@ module Vector2 =
                 let l1 = v1.LengthSquared
                 let l2 = v2.LengthSquared
 
-                let vMin = Vector2.MagnitudeMin(ref v1, ref v2)
+                let vMin = Vector2.MagnitudeMin(&v1, &v2)
 
                 if vMin = v1 then
                     let v1ShorterThanv2 = l1 < l2
@@ -536,7 +536,7 @@ module Vector2 =
                 let l1 = v1.LengthSquared
                 let l2 = v2.LengthSquared
 
-                let vMin = Vector2.MagnitudeMax(ref v1, ref v2)
+                let vMin = Vector2.MagnitudeMax(&v1, &v2)
 
                 if vMin = v1 then
                     let v1LongerThanOrEqualTov2 = l1 >= l2
@@ -566,7 +566,7 @@ module Vector2 =
 
         [<Property>]
         let ``ComponentMin by reference creates a new vector from the smallest components of given vectors`` (v1 : Vector2, v2: Vector2) =
-            let vMin = Vector2.ComponentMin(ref v1, ref v2)
+            let vMin = Vector2.ComponentMin(&v1, &v2)
             let isComponentSmallest smallComp comp1 comp2 = smallComp <= comp1 && smallComp <= comp2
 
             Assert.True(isComponentSmallest vMin.X v1.X v2.X)
@@ -574,7 +574,7 @@ module Vector2 =
 
         [<Property>]
         let ``ComponentMax by reference creates a new vector from the greatest components of given vectors`` (v1 : Vector2, v2: Vector2) =
-            let vMax = Vector2.ComponentMax(ref v1, ref v2)
+            let vMax = Vector2.ComponentMax(&v1, &v2)
             let isComponentLargest largeComp comp1 comp2 = largeComp >= comp1 && largeComp >= comp2
 
             Assert.True(isComponentLargest vMax.X v1.X v2.X)
@@ -601,7 +601,7 @@ module Vector2 =
             let transformedQuat = q * vectorQuat * inverse
             let transformedVector = Vector2(transformedQuat.X, transformedQuat.Y)
 
-            Assert.ApproximatelyEquivalent(transformedVector, Vector2.Transform(ref v, ref q))
+            Assert.ApproximatelyEquivalent(transformedVector, Vector2.Transform(&v, &q))
 
     [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Serialization =

--- a/tests/OpenToolkit.Tests/Vector3Tests.fs
+++ b/tests/OpenToolkit.Tests/Vector3Tests.fs
@@ -181,7 +181,7 @@ module Vector3 =
             // Zero-length vectors can't be normalized
             if not (approxEq a.Length 0.0f) then
                 let norm = a / a.Length
-                let vRes = Vector3.Normalize(ref a)
+                let vRes = Vector3.Normalize(&a)
 
                 Assert.ApproximatelyEquivalent(norm, vRes)
 
@@ -198,7 +198,7 @@ module Vector3 =
             let scale = MathHelper.InverseSqrtFast(a.X * a.X + a.Y * a.Y + a.Z * a.Z)
 
             let norm = a * scale
-            let vRes = Vector3.NormalizeFast(ref a)
+            let vRes = Vector3.NormalizeFast(&a)
 
             Assert.ApproximatelyEquivalent(norm, vRes)
 
@@ -247,7 +247,7 @@ module Vector3 =
         let ``Static Vector3 addition method by reference is the same as component addition`` (a : Vector3, b : Vector3) =
 
             let v1 = Vector3(a.X + b.X, a.Y + b.Y, a.Z + b.Z)
-            let sum = Vector3.Add(ref a, ref b)
+            let sum = Vector3.Add(&a, &b)
 
             Assert.ApproximatelyEquivalent(v1, sum)
 
@@ -274,7 +274,7 @@ module Vector3 =
         let ``Static Vector3 subtraction method by reference is the same as component addition`` (a : Vector3, b : Vector3) =
 
             let v1 = Vector3(a.X - b.X, a.Y - b.Y, a.Z - b.Z)
-            let sum = Vector3.Subtract(ref a, ref b)
+            let sum = Vector3.Subtract(&a, &b)
 
             Assert.ApproximatelyEquivalent(v1, sum)
 
@@ -355,7 +355,7 @@ module Vector3 =
         let ``Static Vector3 multiplication method by reference is the same as component multiplication`` (a : Vector3, b : Vector3) =
 
             let v1 = Vector3(a.X * b.X, a.Y * b.Y, a.Z * b.Z)
-            let sum = Vector3.Multiply(ref a, ref b)
+            let sum = Vector3.Multiply(&a, &b)
 
             Assert.ApproximatelyEquivalent(v1, sum)
 
@@ -383,7 +383,7 @@ module Vector3 =
         let ``Static Vector3-Vector3 divison method by reference is the same as component division`` (a : Vector3, b : Vector3) =
             if not (anyZero3 a || anyZero3 b) then
                 let v1 = Vector3(a.X / b.X, a.Y / b.Y, a.Z / b.Z)
-                let sum = Vector3.Divide(ref a, ref b)
+                let sum = Vector3.Divide(&a, &b)
 
                 Assert.ApproximatelyEquivalent(v1, sum)
 
@@ -399,7 +399,7 @@ module Vector3 =
         let ``Static Vector3-scalar divison method by reference is the same as component division`` (a : Vector3, b : float32) =
             if not (approxEq b 0.0f) then // we don't support diving by zero.
                 let v1 = Vector3(a.X / b, a.Y / b, a.Z / b)
-                let sum = Vector3.Divide(ref a, b)
+                let sum = Vector3.Divide(&a, b)
 
                 Assert.ApproximatelyEquivalent(v1, sum)
 
@@ -505,7 +505,7 @@ module Vector3 =
 
             Assert.Equal(vExp, Vector3.Lerp(a, b, q))
 
-            let vRes = Vector3.Lerp(ref a, ref b, q)
+            let vRes = Vector3.Lerp(&a, &b, q)
             Assert.Equal(vExp, vRes)
 
         [<Property>]
@@ -515,7 +515,7 @@ module Vector3 =
 
             Assert.Equal(r, Vector3.BaryCentric(a, b, c, u, v))
 
-            let vRes = Vector3.BaryCentric(ref a, ref b, ref c, u, v)
+            let vRes = Vector3.BaryCentric(&a, &b, &c, u, v)
             Assert.Equal(r, vRes)
 
     [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
@@ -527,7 +527,7 @@ module Vector3 =
 
             Assert.Equal(dot, Vector3.Dot(a, b));
 
-            let vRes = Vector3.Dot(ref a, ref b)
+            let vRes = Vector3.Dot(&a, &b)
             Assert.Equal(dot, vRes)
 
         [<Property>]
@@ -539,7 +539,7 @@ module Vector3 =
 
             Assert.Equal(cross, Vector3.Cross(a, b));
 
-            let vRes = Vector3.Cross(ref a, ref b)
+            let vRes = Vector3.Cross(&a, &b)
             Assert.Equal(cross, vRes)
 
     [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
@@ -584,7 +584,7 @@ module Vector3 =
                 let l1 = v1.LengthSquared
                 let l2 = v2.LengthSquared
 
-                let vMin = Vector3.MagnitudeMin(ref v1, ref v2)
+                let vMin = Vector3.MagnitudeMin(&v1, &v2)
 
                 if vMin = v1 then
                     let v1ShorterThanv2 = l1 < l2
@@ -600,7 +600,7 @@ module Vector3 =
                 let l1 = v1.LengthSquared
                 let l2 = v2.LengthSquared
 
-                let vMin = Vector3.MagnitudeMax(ref v1, ref v2)
+                let vMin = Vector3.MagnitudeMax(&v1, &v2)
 
                 if vMin = v1 then
                     let v1LongerThanOrEqualTov2 = l1 >= l2
@@ -632,7 +632,7 @@ module Vector3 =
 
         [<Property>]
         let ``ComponentMin by reference creates a new vector from the smallest components of given vectors`` (v1 : Vector3, v2: Vector3) =
-            let vMin = Vector3.ComponentMin(ref v1, ref v2)
+            let vMin = Vector3.ComponentMin(&v1, &v2)
             let isComponentSmallest smallComp comp1 comp2 = smallComp <= comp1 && smallComp <= comp2
 
             Assert.True(isComponentSmallest vMin.X v1.X v2.X)
@@ -641,7 +641,7 @@ module Vector3 =
 
         [<Property>]
         let ``ComponentMax by reference creates a new vector from the greatest components of given vectors`` (v1 : Vector3, v2: Vector3) =
-            let vMax = Vector3.ComponentMax(ref v1, ref v2)
+            let vMax = Vector3.ComponentMax(&v1, &v2)
             let isComponentLargest largeComp comp1 comp2 = largeComp >= comp1 && largeComp >= comp2
 
             Assert.True(isComponentLargest vMax.X v1.X v2.X)
@@ -665,7 +665,7 @@ module Vector3 =
 
         [<Property>]
         let ``Clamping one vector between two other vectors by reference clamps all components between corresponding components`` (a : Vector3, b : Vector3, w : Vector3) =
-            let res = Vector3.Clamp(ref w, ref a, ref b)
+            let res = Vector3.Clamp(&w, &a, &b)
 
             let expX = if w.X < a.X then a.X else if w.X > b.X then b.X else w.X
             let expY = if w.Y < a.Y then a.Y else if w.Y > b.Y then b.Y else w.Y
@@ -739,7 +739,7 @@ module Vector3 =
             let transformedQuat = q * vectorQuat * inverse
             let transformedVector = transformedQuat.Xyz
 
-            Assert.ApproximatelyEquivalent(transformedVector, Vector3.Transform(ref v, ref q))
+            Assert.ApproximatelyEquivalent(transformedVector, Vector3.Transform(&v, &q))
 
         [<Property>]
         let ``Transformation by quaternion by multiplication using right-handed notation is the same as multiplication by quaternion and its conjugate`` (v : Vector3, q : Quaternion) =

--- a/tests/OpenToolkit.Tests/Vector4Tests.fs
+++ b/tests/OpenToolkit.Tests/Vector4Tests.fs
@@ -196,7 +196,7 @@ module Vector4 =
             // Zero-length vectors can't be normalized
             if not (approxEq a.Length 0.0f) then
                 let norm = a / a.Length
-                let vRes = Vector4.Normalize(ref a)
+                let vRes = Vector4.Normalize(&a)
 
                 Assert.ApproximatelyEquivalent(norm, vRes)
 
@@ -213,7 +213,7 @@ module Vector4 =
             let scale = MathHelper.InverseSqrtFast(a.X * a.X + a.Y * a.Y + a.Z * a.Z + a.W * a.W)
 
             let norm = a * scale
-            let vRes = Vector4.NormalizeFast(ref a)
+            let vRes = Vector4.NormalizeFast(&a)
 
             Assert.ApproximatelyEquivalent(norm, vRes)
 
@@ -262,7 +262,7 @@ module Vector4 =
         let ``Static Vector4 addition method by reference is the same as component addition`` (a : Vector4, b : Vector4) =
 
             let v1 = Vector4(a.X + b.X, a.Y + b.Y, a.Z + b.Z, a.W + b.W)
-            let sum = Vector4.Add(ref a, ref b)
+            let sum = Vector4.Add(&a, &b)
 
             Assert.ApproximatelyEquivalent(v1, sum)
 
@@ -290,7 +290,7 @@ module Vector4 =
         let ``Static Vector4 subtraction method by reference is the same as component addition`` (a : Vector4, b : Vector4) =
 
             let v1 = Vector4(a.X - b.X, a.Y - b.Y, a.Z - b.Z, a.W - b.W)
-            let sum = Vector4.Subtract(ref a, ref b)
+            let sum = Vector4.Subtract(&a, &b)
 
             Assert.ApproximatelyEquivalent(v1, sum)
 
@@ -378,7 +378,7 @@ module Vector4 =
         let ``Static Vector4 multiplication method by reference is the same as component multiplication`` (a : Vector4, b : Vector4) =
 
             let v1 = Vector4(a.X * b.X, a.Y * b.Y, a.Z * b.Z, a.W * b.W)
-            let sum = Vector4.Multiply(ref a, ref b)
+            let sum = Vector4.Multiply(&a, &b)
 
             Assert.ApproximatelyEquivalent(v1, sum)
 
@@ -407,7 +407,7 @@ module Vector4 =
         let ``Static Vector4-Vector4 divison method by reference is the same as component division`` (a : Vector4, b : Vector4) =
             if not (anyZero4 a || anyZero4 b) then
                 let v1 = Vector4(a.X / b.X, a.Y / b.Y, a.Z / b.Z, a.W / b.W)
-                let sum = Vector4.Divide(ref a, ref b)
+                let sum = Vector4.Divide(&a, &b)
 
                 Assert.ApproximatelyEquivalent(v1, sum)
 
@@ -423,7 +423,7 @@ module Vector4 =
         let ``Static Vector4-scalar divison method by reference is the same as component division`` (a : Vector4, b : float32) =
             if not (approxEq b 0.0f) then // we don't support diving by zero.
                 let v1 = Vector4(a.X / b, a.Y / b, a.Z / b, a.W / b)
-                let sum = Vector4.Divide(ref a, b)
+                let sum = Vector4.Divide(&a, b)
 
                 Assert.ApproximatelyEquivalent(v1, sum)
 
@@ -674,7 +674,7 @@ module Vector4 =
 
             Assert.Equal(vExp, Vector4.Lerp(a, b, q))
 
-            let vRes = Vector4.Lerp(ref a, ref b, q)
+            let vRes = Vector4.Lerp(&a, &b, q)
             Assert.Equal(vExp, vRes)
 
         [<Property>]
@@ -684,7 +684,7 @@ module Vector4 =
 
             Assert.Equal(r, Vector4.BaryCentric(a, b, c, u, v))
 
-            let vRes = Vector4.BaryCentric(ref a, ref b, ref c, u, v)
+            let vRes = Vector4.BaryCentric(&a, &b, &c, u, v)
             Assert.Equal(r, vRes)
 
     [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
@@ -696,7 +696,7 @@ module Vector4 =
 
             Assert.Equal(dot, Vector4.Dot(a, b));
 
-            let vRes = Vector4.Dot(ref a, ref b)
+            let vRes = Vector4.Dot(&a, &b)
             Assert.Equal(dot, vRes)
 
     [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
@@ -741,7 +741,7 @@ module Vector4 =
                 let l1 = v1.LengthSquared
                 let l2 = v2.LengthSquared
 
-                let vMin = Vector4.MagnitudeMin(ref v1, ref v2)
+                let vMin = Vector4.MagnitudeMin(&v1, &v2)
 
                 if vMin = v1 then
                     let v1ShorterThanv2 = l1 < l2
@@ -757,7 +757,7 @@ module Vector4 =
                 let l1 = v1.LengthSquared
                 let l2 = v2.LengthSquared
 
-                let vMin = Vector4.MagnitudeMax(ref v1, ref v2)
+                let vMin = Vector4.MagnitudeMax(&v1, &v2)
 
                 if vMin = v1 then
                     let v1LongerThanOrEqualTov2 = l1 >= l2
@@ -791,7 +791,7 @@ module Vector4 =
 
         [<Property>]
         let ``ComponentMin by reference creates a new vector from the smallest components of given vectors`` (v1 : Vector4, v2: Vector4) =
-            let vMin = Vector4.ComponentMin(ref v1, ref v2)
+            let vMin = Vector4.ComponentMin(&v1, &v2)
             let isComponentSmallest smallComp comp1 comp2 = smallComp <= comp1 && smallComp <= comp2
 
             Assert.True(isComponentSmallest vMin.X v1.X v2.X)
@@ -801,7 +801,7 @@ module Vector4 =
 
         [<Property>]
         let ``ComponentMax by reference creates a new vector from the greatest components of given vectors`` (v1 : Vector4, v2: Vector4) =
-            let vMax = Vector4.ComponentMax(ref v1, ref v2)
+            let vMax = Vector4.ComponentMax(&v1, &v2)
             let isComponentLargest largeComp comp1 comp2 = largeComp >= comp1 && largeComp >= comp2
 
             Assert.True(isComponentLargest vMax.X v1.X v2.X)
@@ -834,7 +834,7 @@ module Vector4 =
             let expZ = if w.Z < a.Z then a.Z else if w.Z > b.Z then b.Z else w.Z
             let expW = if w.W < a.W then a.W else if w.W > b.W then b.W else w.W
 
-            let res = Vector4.Clamp(ref w, ref a, ref b)
+            let res = Vector4.Clamp(&w, &a, &b)
 
             Assert.Equal(expX, res.X)
             Assert.Equal(expY, res.Y)
@@ -911,7 +911,7 @@ module Vector4 =
             let transformedQuat = q * vectorQuat * inverse
             let transformedVector = Vector4(transformedQuat.X, transformedQuat.Y,transformedQuat.Z, transformedQuat.W)
 
-            Assert.ApproximatelyEquivalent(transformedVector, Vector4.Transform(ref v, ref q))
+            Assert.ApproximatelyEquivalent(transformedVector, Vector4.Transform(&v, &q))
 
         [<Property>]
         let ``Transformation by quaternion by multiplication using right-handed notation is the same as multiplication by quaternion and its conjugate`` (v : Vector4, q : Quaternion) =


### PR DESCRIPTION
### Purpose of this PR

* Description of feature/change.

I created this as a proof of concept/conversation starter after Varon suggested using `in` instead of `ref` in [this comment](https://github.com/opentk/opentk/pull/1011#pullrequestreview-360496235) on #1011

This change replaces all usages within the math library of OpenTK. It is based on an automatic find/replace within the source code, followed by modification of the unit tests to support the change in parameter type.

The technical rationale is that the `in` parameter marks the structs as read-only, potentially allowing for better compiler optimization than when using `ref`.

The drawback is that this constitutes a non-backwards compatible breaking change to the API.

* Which part of OpenTK does this affect (Math, OpenGL, Platform, Input, etc).

Math

* Links to screenshots, design docs, user docs, etc.

N/A

### Testing status

Passes all tests in build.cmd with commit 4842759769e3ebeeda8b0a03530ce937bfa8f5d5 as base.

I will follow up with attempts at benchmarking this in the comments.

### Comments

I looked into the option of using overloads for backwards compatibility, but that led to the following error message:

![image](https://user-images.githubusercontent.com/272217/74993474-6a3ec380-544b-11ea-80f2-ede14e471454.png)

