### PR TITLE
Optimize barycentric interpolation

### DIFF
--- a/src/OpenToolkit.Mathematics/Vector/Vector2.cs
+++ b/src/OpenToolkit.Mathematics/Vector/Vector2.cs
@@ -669,7 +669,8 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector2 BaryCentric(Vector2 a, Vector2 b, Vector2 c, float u, float v)
         {
-            return a + (u * (b - a)) + (v * (c - a));
+            BaryCentric(ref a, ref b, ref c, u, v, out var result);
+            return result;
         }
 
         /// <summary>

--- a/src/OpenToolkit.Mathematics/Vector/Vector2d.cs
+++ b/src/OpenToolkit.Mathematics/Vector/Vector2d.cs
@@ -620,7 +620,8 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector2d BaryCentric(Vector2d a, Vector2d b, Vector2d c, double u, double v)
         {
-            return a + (u * (b - a)) + (v * (c - a));
+            BaryCentric(ref a, ref b, ref c, u, v, out var result);
+            return result;
         }
 
         /// <summary>

--- a/src/OpenToolkit.Mathematics/Vector/Vector3.cs
+++ b/src/OpenToolkit.Mathematics/Vector/Vector3.cs
@@ -745,7 +745,8 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector3 BaryCentric(Vector3 a, Vector3 b, Vector3 c, float u, float v)
         {
-            return a + (u * (b - a)) + (v * (c - a));
+            BaryCentric(ref a, ref b, ref c, u, v, out var result);
+            return result;
         }
 
         /// <summary>

--- a/src/OpenToolkit.Mathematics/Vector/Vector3d.cs
+++ b/src/OpenToolkit.Mathematics/Vector/Vector3d.cs
@@ -738,7 +738,8 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector3d BaryCentric(Vector3d a, Vector3d b, Vector3d c, double u, double v)
         {
-            return a + (u * (b - a)) + (v * (c - a));
+            BaryCentric(ref a, ref b, ref c, u, v, out var result);
+            return result;
         }
 
         /// <summary>

--- a/src/OpenToolkit.Mathematics/Vector/Vector4.cs
+++ b/src/OpenToolkit.Mathematics/Vector/Vector4.cs
@@ -725,7 +725,8 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector4 BaryCentric(Vector4 a, Vector4 b, Vector4 c, float u, float v)
         {
-            return a + (u * (b - a)) + (v * (c - a));
+            BaryCentric(ref a, ref b, ref c, u, v, out var result);
+            return result;
         }
 
         /// <summary>

--- a/src/OpenToolkit.Mathematics/Vector/Vector4d.cs
+++ b/src/OpenToolkit.Mathematics/Vector/Vector4d.cs
@@ -717,7 +717,8 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector4d BaryCentric(Vector4d a, Vector4d b, Vector4d c, double u, double v)
         {
-            return a + (u * (b - a)) + (v * (c - a));
+            BaryCentric(ref a, ref b, ref c, u, v, out var result);
+            return result;
         }
 
         /// <summary>


### PR DESCRIPTION
### Purpose of this PR

* Description of feature/change.

I noticed during benchmarking math operations that one of the Barycentric overloads was four times slower than the other.

Turns out the [slow version](https://github.com/opentk/opentk/blob/a2e1be1293cc7cefe8307bb404d0d92c82369317/src/OpenToolkit.Mathematics/Vector/Vector3.cs#L746) contains a naive implementation using operator overloads (leading to a number of unnecessary copies/allocations), while the [fast version](https://github.com/opentk/opentk/blob/a2e1be1293cc7cefe8307bb404d0d92c82369317/src/OpenToolkit.Mathematics/Vector/Vector3.cs#L764) has an optimized implementation that passes all parameters by reference.

This change replaces the naive implementations with a call to the optimized method instead.

* Which part of OpenTK does this affect (Math, OpenGL, Platform, Input, etc).

Math

* Links to screenshots, design docs, user docs, etc.

Se comments for impact of current approach.

### Testing status

* Explanation of what’s tested, how tested and existing or new automation tests.

Ran unit tests, and verified the Barycentric ones all passed. Note that the double variants of the vectors do not have existing test coverage.

### Comments

Benchmark of current implementations as of a2e1be1293cc7cefe8307bb404d0d92c82369317:

|                                                                                                           Method |       Runtime |       Mean |      Error |     StdDev |     Median | Ratio | RatioSD |
|----------------------------------------------------------------------------------------------------------------- |-------------- |-----------:|-----------:|-----------:|-----------:|------:|--------:|
| &#39;Vector3.BaryCentric(Vector3 a, Vector3 b, Vector3 c, float u, float v)&#39;                                 | .NET Core 3.1 |  29.595 ns |  0.0812 ns |  0.0720 ns |  29.596 ns |  0.99 |    0.00 |
| &#39;Vector3.BaryCentric(ref Vector3 a, ref Vector3 b, ref Vector3 c, float u, float v, out Vector3 result)&#39; | .NET Core 3.1 |   7.048 ns |  0.1418 ns |  0.1326 ns |   7.082 ns |  0.96 |    0.02 |