### PR TITLE
Added Profile Any

### DIFF
--- a/src/OpenToolkit.Windowing.Common/Enums/ContextProfile.cs
+++ b/src/OpenToolkit.Windowing.Common/Enums/ContextProfile.cs
@@ -15,6 +15,10 @@ namespace OpenToolkit.Windowing.Common
     public enum ContextProfile
     {
         /// <summary>
+        /// Used for unknown OpenGL profile or OpenGL ES.
+        /// </summary>
+        Any,
+        /// <summary>
         /// Selects compatability profile. You should only use this if maintaining legacy code.
         /// </summary>
         Compatability,

--- a/src/OpenToolkit.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenToolkit.Windowing.Desktop/NativeWindow.cs
@@ -532,6 +532,9 @@ namespace OpenToolkit.Windowing.Desktop
 
             switch (settings.Profile)
             {
+                case ContextProfile.Any:
+                    GLFW.WindowHint(WindowHintOpenGlProfile.OpenGlProfile, OpenGlProfile.Any);
+                    break;
                 case ContextProfile.Compatability:
                     GLFW.WindowHint(WindowHintOpenGlProfile.OpenGlProfile, OpenGlProfile.Compat);
                     break;


### PR DESCRIPTION
Added the `Any` Profile to NativeWindowSettings. This is usefull for running Render tests on gpu-less machines, for example via xvfb/xvnc/softpipe/OSMesa.

Without the `Any` Profile, it's unpossible to create an offscreen Window:
```
The active test run was aborted. Reason: Test host process crashed : Unhandled exception. OpenToolkit.Windowing.GraphicsLibraryFramework.GLFWException: OSMesa: Failed to create context
   at OpenToolkit.Windowing.Desktop.GLFWProvider.<>c.<.cctor>b__5_0(ErrorCode errorCode, String description)
   at OpenToolkit.Windowing.GraphicsLibraryFramework.GLFWNative.glfwCreateWindow(Int32 width, Int32 height, Byte* title, Monitor* monitor, Window* share)
 ```

With the `Any` Profile, i was able to call `GLFW.CreateWindow` and got a valid pointer, calling `MakeCurrentContext`, and some `GL.GetString` give that output:

```
Vendor: Brian Paul, version: 2.1 Mesa 13.0.6, shadinglangVersion: 1.20, renderer: Mesa OffScreen
```