### PR TITLE
Fix GameWindow UpdateFrequency & RenderFrequency

### DIFF
--- a/src/OpenToolkit.Windowing.Desktop/GameWindow.cs
+++ b/src/OpenToolkit.Windowing.Desktop/GameWindow.cs
@@ -235,12 +235,13 @@ namespace OpenToolkit.Windowing.Desktop
         private void DispatchUpdateFrame()
         {
             var isRunningSlowlyRetries = 4;
-            var elapsed = _watchUpdate.Elapsed.TotalMilliseconds;
+            var elapsed = _watchUpdate.Elapsed.TotalSeconds;
 
             var updatePeriod = UpdateFrequency == 0 ? 0 : 1 / UpdateFrequency;
 
             while (elapsed > 0 && elapsed + _updateEpsilon >= updatePeriod)
             {
+                _watchUpdate.Restart();
                 OnUpdateFrame(new FrameEventArgs(elapsed));
 
                 // Calculate difference (positive or negative) between
@@ -263,6 +264,8 @@ namespace OpenToolkit.Windowing.Desktop
                     // stop raising events to avoid hanging inside the UpdateFrame loop.
                     break;
                 }
+
+                elapsed = _watchUpdate.Elapsed.TotalSeconds;
             }
 
             // Update VSync if set to adaptive
@@ -270,8 +273,6 @@ namespace OpenToolkit.Windowing.Desktop
             {
                 GLFW.SwapInterval(IsRunningSlowly ? 0 : 1);
             }
-
-            _watchUpdate.Restart();
         }
 
         private void DispatchRenderFrame()

--- a/src/OpenToolkit.Windowing.Desktop/GameWindow.cs
+++ b/src/OpenToolkit.Windowing.Desktop/GameWindow.cs
@@ -277,9 +277,13 @@ namespace OpenToolkit.Windowing.Desktop
 
         private void DispatchRenderFrame()
         {
-            var timestamp = _watchRender.Elapsed.TotalMilliseconds;
-            OnRenderFrame(new FrameEventArgs(timestamp));
-            _watchRender.Restart();
+            var elapsed = _watchRender.Elapsed.TotalSeconds;
+            var renderPeriod = RenderFrequency == 0 ? 0 : 1 / RenderFrequency;
+            if (elapsed > 0 && elapsed >= renderPeriod)
+            {
+                _watchRender.Restart();
+                OnRenderFrame(new FrameEventArgs(elapsed));
+            }
         }
 
         /// <inheritdoc />

--- a/tests/OpenToolkit.Tests.Integration/GameWindowTests.fs
+++ b/tests/OpenToolkit.Tests.Integration/GameWindowTests.fs
@@ -190,3 +190,40 @@ module GameWindow =
             if dpisuccess && scalesuccess then
                 Assert.True(fuzzyequals(dpix/scalex, defaultDpi(), 1.0f)) // precision is up to discussion.
                 Assert.True(fuzzyequals(dpiy/scaley, defaultDpi(), 1.0f))
+
+// module UpdateFrequency =
+        [<Fact>]
+        let ``Does UpdateFrequency limit the timing of UpdateFrame`` () =
+            use gw = openGW()
+            gw.UpdateFrequency <- 10.0
+            let mutable calls = 0
+            let mutable reportedElapsed = 0.0
+            let totalCalls = 10
+            let expectedElapsed = 1.0/gw.UpdateFrequency * (float totalCalls)
+            gw.add_UpdateFrame(fun e -> calls <- calls+1; reportedElapsed <- reportedElapsed+e.Time; if calls = totalCalls then gw.Close())
+            let st = new Stopwatch()
+            st.Start()
+            gw.Run()
+            st.Stop();
+            let realElapsed = st.Elapsed.TotalSeconds
+            Assert.True(Math.Abs(realElapsed - reportedElapsed) <= 0.1, sprintf "Reported %f but actually took %f" reportedElapsed realElapsed)
+            Assert.True(Math.Abs(expectedElapsed - realElapsed) <= 0.1, sprintf "Took %f instead of the expected %f" realElapsed expectedElapsed)
+
+//
+    module RenderFrequency =
+        [<Fact>]
+        let ``Does RenderFrequency limit the timing of RenderFrame`` () =
+            use gw = openGW()
+            gw.RenderFrequency <- 10.0
+            let mutable calls = 0
+            let mutable reportedElapsed = 0.0
+            let totalCalls = 10
+            let expectedElapsed = 1.0/gw.RenderFrequency * (float totalCalls)
+            gw.add_RenderFrame(fun e -> calls <- calls+1; reportedElapsed <- reportedElapsed+e.Time; if calls = totalCalls then gw.Close())
+            let st = new Stopwatch()
+            st.Start()
+            gw.Run()
+            st.Stop();
+            let realElapsed = st.Elapsed.TotalSeconds
+            Assert.True(Math.Abs(realElapsed - reportedElapsed) <= 0.1, sprintf "Reported %f but actually took %f" reportedElapsed realElapsed)
+            Assert.True(Math.Abs(expectedElapsed - realElapsed) <= 0.1, sprintf "Took %f instead of the expected %f" realElapsed expectedElapsed)

--- a/tests/OpenToolkit.Tests.Integration/OpenToolkit.Tests.Integration.fsproj
+++ b/tests/OpenToolkit.Tests.Integration/OpenToolkit.Tests.Integration.fsproj
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Windowing\OpenToolkit.Windowing.Desktop\OpenToolkit.Windowing.Desktop.csproj" />
+    <ProjectReference Include="..\..\src\OpenToolkit.Windowing.Desktop\OpenToolkit.Windowing.Desktop.csproj" />
   </ItemGroup>
 
   <Import Project="..\..\props\common.props" />

--- a/tests/OpenToolkit.Tests/Color4Tests.fs
+++ b/tests/OpenToolkit.Tests/Color4Tests.fs
@@ -10,8 +10,8 @@ open OpenToolkit.Mathematics
 
 module Color4 =
     [<Literal>]
-    let private epsilon:float32 = 1e-6f
-    let private epsilonXYZ:float32 = 1e-4f
+    let private epsilon:float32 = 1.0e-6f
+    let private epsilonXYZ:float32 = 1.0e-4f
 
     [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Covertions =

--- a/tests/OpenToolkit.Tests/MathHelperTests.fs
+++ b/tests/OpenToolkit.Tests/MathHelperTests.fs
@@ -112,15 +112,15 @@ module MathHelper =
             Assert.NotApproximatelyEqualEpsilon(-0.00000001f, 0.0f);
             Assert.NotApproximatelyEqualEpsilon(0.0f, -0.00000001f);
 
-            Assert.ApproximatelyEqualEpsilon(0.0f, 1e-40f, 0.01f);
-            Assert.ApproximatelyEqualEpsilon(1e-40f, 0.0f, 0.01f);
-            Assert.NotApproximatelyEqualEpsilon(1e-40f, 0.0f, 0.000001f);
-            Assert.NotApproximatelyEqualEpsilon(0.0f, 1e-40f, 0.000001f);
+            Assert.ApproximatelyEqualEpsilon(0.0f, 1.0e-40f, 0.01f);
+            Assert.ApproximatelyEqualEpsilon(1.0e-40f, 0.0f, 0.01f);
+            Assert.NotApproximatelyEqualEpsilon(1.0e-40f, 0.0f, 0.000001f);
+            Assert.NotApproximatelyEqualEpsilon(0.0f, 1.0e-40f, 0.000001f);
 
-            Assert.ApproximatelyEqualEpsilon(0.0f, -1e-40f, 0.1f);
-            Assert.ApproximatelyEqualEpsilon(-1e-40f, 0.0f, 0.1f);
-            Assert.NotApproximatelyEqualEpsilon(-1e-40f, 0.0f, 0.00000001f);
-            Assert.NotApproximatelyEqualEpsilon(0.0f, -1e-40f, 0.00000001f);
+            Assert.ApproximatelyEqualEpsilon(0.0f, -1.0e-40f, 0.1f);
+            Assert.ApproximatelyEqualEpsilon(-1.0e-40f, 0.0f, 0.1f);
+            Assert.NotApproximatelyEqualEpsilon(-1.0e-40f, 0.0f, 0.00000001f);
+            Assert.NotApproximatelyEqualEpsilon(0.0f, -1.0e-40f, 0.00000001f);
 
         [<Fact>]
         let ``ApproximatelyEqual (single precision) is correct for extreme values with overflow potential``() =

--- a/tests/OpenToolkit.Tests/OpenToolkit.Tests.fsproj
+++ b/tests/OpenToolkit.Tests/OpenToolkit.Tests.fsproj
@@ -41,7 +41,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\OpenToolkit.Mathematics\OpenToolkit.Mathematics.csproj" />
-    <ProjectReference Include="..\..\src\Windowing\OpenToolkit.Windowing.Common\OpenToolkit.Windowing.Common.csproj" />
+    <ProjectReference Include="..\..\src\OpenToolkit.Windowing.Common\OpenToolkit.Windowing.Common.csproj" />
   </ItemGroup>
 
   <Import Project="..\..\props\common.props" />


### PR DESCRIPTION
### Purpose of this PR

* Fixes UpdateFrequency & RenderFrequency of the GameWindow to properly limit
* Ensures [FrameEventArgs](https://opentk.net/api/OpenTK.FrameEventArgs.html) contains elapsed seconds as documented
* Affects OpenToolkit.Windowing.Desktop

### Testing status

* Added two unit tests two prove both methods
* Manually tested in my own projects

### Comments

The old logic for UpdateFrequency incorrectly used TotalMilliseconds instead of TotalSeconds.  Also the StopWatch keeping track of the elapsed time was always being reset, even if no call was made to UpdateFrame.  RenderFrame wasn't being limited at all. See issue #1029.

In order to get unit tests to run, I fixed up two project references, and a few floating point numbers that FSharp (currently) requires to include a dot.