### PR TITLE
Throw an InvalidOperationException if bindings are uninitialized.

### DIFF
--- a/src/Generator.Bind/CSharpSpecWriter.cs
+++ b/src/Generator.Bind/CSharpSpecWriter.cs
@@ -191,6 +191,7 @@ namespace Bind
             sw.Unindent();
             sw.WriteLine("};");
             sw.WriteLine("EntryPoints = new IntPtr[EntryPointNames.Length];");
+            sw.WriteLine("InitializeDummyEntryPoints(EntryPoints);");
             sw.Unindent();
             sw.WriteLine("}");
             sw.WriteLine();

--- a/src/OpenToolkit.Graphics/BindingsBase.cs
+++ b/src/OpenToolkit.Graphics/BindingsBase.cs
@@ -174,5 +174,22 @@ namespace OpenToolkit.Graphics
             }
             Marshal.FreeHGlobal(ptr);
         }
+
+        private protected static void InitializeDummyEntryPoints(IntPtr[] entryPoints)
+        {
+            var ptr = Marshal.GetFunctionPointerForDelegate(UninitializedDelegate);
+
+            for (var i = 0; i < entryPoints.Length; i++)
+            {
+                entryPoints[i] = ptr;
+            }
+        }
+
+        private static readonly Action UninitializedDelegate = Uninitialized;
+
+        private static void Uninitialized()
+        {
+            throw new InvalidOperationException("You need to initialize the OpenGL binding first by calling LoadBindings() or creating a compatible OpenGL window.");
+        }
     }
 }


### PR DESCRIPTION
### Purpose of this PR

This makes it so that instead of getting an `AccessViolationException`, you get a nice descriptive `InvalidOperationException`.

### Testing status

Throws when you forget to initialize, doesn't do anything when you don't.

### Comments

This is done by initializing all the entry points to a dummy method that just throws the exception When the OpenGL bindings load these get overriden by the regular function pointers so there's no performance overhead.
