### PR TITLE
Automatically load GL bindings when window gets created.

### DIFF
--- a/src/OpenToolkit.Windowing.Desktop/NativeWindowSettings.cs
+++ b/src/OpenToolkit.Windowing.Desktop/NativeWindowSettings.cs
@@ -82,6 +82,12 @@ namespace OpenToolkit.Windowing.Desktop
         public ContextFlags Flags { get; set; } = ContextFlags.Default;
 
         /// <summary>
+        /// Gets or sets a value indicating whether or not OpenGL bindings should be automatically loaded
+        /// when the window is created.
+        /// </summary>
+        public bool AutoLoadBindings { get; set; } = true;
+
+        /// <summary>
         /// Gets or sets a value representing the current version of the graphics API.
         /// </summary>
         /// <remarks>


### PR DESCRIPTION
### Purpose of this PR

Means users won't have to call `GL.LoadBindings` manually anymore if they're using `Windowing.Desktop`.

### Testing status

Tried a regular build and also a self-contained publish.
