### PR TITLE
Fixed LoadBindings for OpenGL namespace

### DIFF
--- a/src/OpenToolkit.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenToolkit.Windowing.Desktop/NativeWindow.cs
@@ -639,11 +639,11 @@ namespace OpenToolkit.Windowing.Desktop
                 load.Invoke(null, new object[] { provider });
             }
 
-            LoadBindings("ES11");
-            LoadBindings("ES20");
-            LoadBindings("ES30");
-            LoadBindings("OpenGL2");
-            LoadBindings("OpenGL4");
+            LoadBindings(nameof(OpenToolkit.Graphics.ES11));
+            LoadBindings(nameof(OpenToolkit.Graphics.ES20));
+            LoadBindings(nameof(OpenToolkit.Graphics.ES30));
+            LoadBindings(nameof(OpenToolkit.Graphics.OpenGL));
+            LoadBindings(nameof(OpenToolkit.Graphics.OpenGL4));
         }
 
         private GLFWCallbacks.WindowPosCallback _posCallback;

--- a/src/OpenToolkit.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenToolkit.Windowing.Desktop/NativeWindow.cs
@@ -639,11 +639,11 @@ namespace OpenToolkit.Windowing.Desktop
                 load.Invoke(null, new object[] { provider });
             }
 
-            LoadBindings(nameof(OpenToolkit.Graphics.ES11));
-            LoadBindings(nameof(OpenToolkit.Graphics.ES20));
-            LoadBindings(nameof(OpenToolkit.Graphics.ES30));
-            LoadBindings(nameof(OpenToolkit.Graphics.OpenGL));
-            LoadBindings(nameof(OpenToolkit.Graphics.OpenGL4));
+            LoadBindings("ES11");
+            LoadBindings("ES20");
+            LoadBindings("ES30");
+            LoadBindings("OpenGL");
+            LoadBindings("OpenGL4");
         }
 
         private GLFWCallbacks.WindowPosCallback _posCallback;


### PR DESCRIPTION
### Purpose of this PR

- Fixed "OpenGL2" string supposed to be "OpenGL" in `LoadBindings`

### Testing status

To reproduce the issue, create a `GameWindow` and make any call to `OpenToolkit.Graphics.OpenGL.GL` in Load event.
