### PR TITLE
Added check for invalid keys in window key callback

### DIFF
--- a/src/OpenToolkit.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenToolkit.Windowing.Desktop/NativeWindow.cs
@@ -696,12 +696,12 @@ namespace OpenToolkit.Windowing.Desktop
                 {
                     int index = (int)key;
 
-                    if (index < 0 || index >= GlfwKeyMapping.Length)
-                    {
-                        return;
-                    }
+                    var ourKey = Key.Unknown;
 
-                    var ourKey = GlfwKeyMapping[index];
+                    if (index >= 0 && index < GlfwKeyMapping.Length)
+                    {
+                        ourKey = GlfwKeyMapping[index];
+                    }
 
                     var args = new KeyboardKeyEventArgs(
                         ourKey,

--- a/src/OpenToolkit.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenToolkit.Windowing.Desktop/NativeWindow.cs
@@ -694,7 +694,14 @@ namespace OpenToolkit.Windowing.Desktop
 
                 _keyCallback = (window, key, scancode, action, mods) =>
                 {
-                    var ourKey = GlfwKeyMapping[(int)key];
+                    int index = (int)key;
+
+                    if (index < 0 || index >= GlfwKeyMapping.Length)
+                    {
+                        return;
+                    }
+
+                    var ourKey = GlfwKeyMapping[index];
 
                     var args = new KeyboardKeyEventArgs(
                         ourKey,


### PR DESCRIPTION
### Purpose of this PR

- Fixes out of bounds access to `GlfwKeyMapping` in NativeWindow when pressing `alt+printscreen`.

### Testing status

- Tested on my own project, doesn't crash anymore.

### Comments

I'm still debugging trying to figure out what the scancode is for this key, that being said, this check will always be relevant I think. prevents the application from crashing all together!