### PR TITLE
fix: save Size property value to _size field

### DIFF
--- a/src/OpenToolkit.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenToolkit.Windowing.Desktop/NativeWindow.cs
@@ -362,7 +362,12 @@ namespace OpenToolkit.Windowing.Desktop
         public unsafe Vector2i Size
         {
             get => _size;
-            set => GLFW.SetWindowSize(WindowPtr, value.X, value.Y);
+            set
+            {
+                _size.X = value.X;
+                _size.Y = value.Y;
+                GLFW.SetWindowSize(WindowPtr, value.X, value.Y);
+            }
         }
 
         /// <inheritdoc />

--- a/src/OpenToolkit.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenToolkit.Windowing.Desktop/NativeWindow.cs
@@ -364,8 +364,7 @@ namespace OpenToolkit.Windowing.Desktop
             get => _size;
             set
             {
-                _size.X = value.X;
-                _size.Y = value.Y;
+                _size = value;
                 GLFW.SetWindowSize(WindowPtr, value.X, value.Y);
             }
         }


### PR DESCRIPTION
### Purpose of this PR

* Description of feature/change.

save XY size to the inner _size field of NativeWindow when invoke Size property setter

* Which part of OpenTK does this affect (Math, OpenGL, Platform, Input, etc).

OpenToolkit.Windowing.Desktop

* Links to screenshots, design docs, user docs, etc.

### Testing status

* Explanation of what’s tested, how tested and existing or new automation tests.

applying Size to GameWindow through property change the window size but reading back Size from property get old values

executing this code

```cs
protected override Avalonia.Size MeasureOverride(Avalonia.Size availableSize)
        {
            System.Console.WriteLine($"measure size:{availableSize}");
            win.Size = new OpenToolkit.Mathematics.Vector2i((int)availableSize.Width, (int)availableSize.Height);
            System.Console.WriteLine($"win size after measure override:{win.Size}");

            return availableSize;
        }  
```

generates this output

```sh
measure size:1261.8, 737
win size after measure override:(640, 480)
```

* Can include manual testing by self.
* Specify test plans.
* Rarely acceptable to have no testing.

### Comments

* Any other comments to help understand the change.

I see that NativeWindow HandleResize should update back the _size field, 

```cs
private unsafe void HandleResize(int width, int height)
        {
            _size.X = width;
            _size.Y = height;

            GLFW.GetFramebufferSize(WindowPtr, out width, out height);

            ClientSize = new Vector2i(width, height);
        }
```

but from a breakpoint hit test this is touched from NativeWindow constructor and doesn't reach any more after I change Size property.
