### PR TITLE
[3.0] Fix: Allow setting of Unicode X11 window titles

### DIFF
--- a/src/OpenTK/Platform/X11/Functions.cs
+++ b/src/OpenTK/Platform/X11/Functions.cs
@@ -289,7 +289,7 @@ namespace OpenTK.Platform.X11
         public extern static int XChangeProperty(IntPtr display, IntPtr window, IntPtr property, IntPtr type, int format, PropertyMode mode, IntPtr atoms, int nelements);
 
         [DllImport("libX11", EntryPoint = "XChangeProperty", CharSet = CharSet.Ansi)]
-        public extern static int XChangeProperty(IntPtr display, IntPtr window, IntPtr property, IntPtr type, int format, PropertyMode mode, string text, int text_length);
+        public extern static int XChangeProperty(IntPtr display, IntPtr window, IntPtr property, IntPtr type, int format, PropertyMode mode, byte[] text, int text_length);
 
         [DllImport("libX11", EntryPoint = "XDeleteProperty")]
         public extern static int XDeleteProperty(IntPtr display, IntPtr window, IntPtr property);

--- a/src/OpenTK/Platform/X11/X11GLNative.cs
+++ b/src/OpenTK/Platform/X11/X11GLNative.cs
@@ -218,7 +218,8 @@ namespace OpenTK.Platform.X11
                     //Set window title via XChangeProperty too- This makes Unicode window titles work nicely
                     IntPtr windowTitle = Functions.XInternAtom(window.Display, "_NET_WM_NAME", false);
                     IntPtr propertyType = Functions.XInternAtom(window.Display, "UTF8_STRING", false);
-                    Functions.XChangeProperty(window.Display, window.Handle, windowTitle, propertyType, 8, PropertyMode.Replace, title, title.Length);
+                    byte[] stringBytes = Encoding.UTF8.GetBytes(title);
+                    Functions.XChangeProperty(window.Display, window.Handle, windowTitle, propertyType, 8, PropertyMode.Replace, stringBytes, stringBytes.Length);
                 }
             }
 
@@ -1798,7 +1799,8 @@ namespace OpenTK.Platform.X11
                         Functions.XStoreName(window.Display, window.Handle, value);
                         IntPtr windowTitle = Functions.XInternAtom(window.Display, "_NET_WM_NAME", false);
                         IntPtr propertyType = Functions.XInternAtom(window.Display, "UTF8_STRING", false);
-                        Functions.XChangeProperty(window.Display, window.Handle, windowTitle, propertyType, 8, PropertyMode.Replace, value, value.Length);
+                        byte[] stringBytes = Encoding.UTF8.GetBytes(value);
+                        Functions.XChangeProperty(window.Display, window.Handle, windowTitle, propertyType, 8, PropertyMode.Replace, stringBytes, stringBytes.Length);
                     }
                 }
 

--- a/src/OpenTK/Platform/X11/X11GLNative.cs
+++ b/src/OpenTK/Platform/X11/X11GLNative.cs
@@ -215,6 +215,10 @@ namespace OpenTK.Platform.X11
                 if (title != null)
                 {
                     Functions.XStoreName(window.Display, window.Handle, title);
+                    //Set window title via XChangeProperty too- This makes Unicode window titles work nicely
+                    IntPtr windowTitle = Functions.XInternAtom(window.Display, "_NET_WM_NAME", false);
+                    IntPtr propertyType = Functions.XInternAtom(window.Display, "UTF8_STRING", false);
+                    Functions.XChangeProperty(window.Display, window.Handle, windowTitle, propertyType, 8, PropertyMode.Replace, title, title.Length);
                 }
             }
 
@@ -1792,6 +1796,9 @@ namespace OpenTK.Platform.X11
                     using (new XLock(window.Display))
                     {
                         Functions.XStoreName(window.Display, window.Handle, value);
+                        IntPtr windowTitle = Functions.XInternAtom(window.Display, "_NET_WM_NAME", false);
+                        IntPtr propertyType = Functions.XInternAtom(window.Display, "UTF8_STRING", false);
+                        Functions.XChangeProperty(window.Display, window.Handle, windowTitle, propertyType, 8, PropertyMode.Replace, value, value.Length);
                     }
                 }
 


### PR DESCRIPTION
### Purpose of this PR

The X11 backend sets the window title via XStoreName. This doesn't support Unicode under most / all circumstances. (Stated to be ANSI, but implementation dependant)

Adds an additional call to XChangeProperty to set the Unicode window name.

### Testing status

Works correctly on Debian VM, builds & is using the standard approach (e.g. MPlayer: http://lists.mplayerhq.hu/pipermail/mplayer-dev-eng/2011-May/068348.html )

### Comments

Would appreciate a merge / update of the Nuget package for 3.0 :)
Minor tweak, but it's the niceties that count.