### PR TITLE
[3.0] Fix Vector3.Unproject

### DIFF
--- a/src/OpenTK/Math/Vector3.cs
+++ b/src/OpenTK/Math/Vector3.cs
@@ -1118,39 +1118,39 @@ namespace OpenTK
         /// </remarks>
         public static Vector3 Unproject(Vector3 vector, float x, float y, float width, float height, float minZ, float maxZ, Matrix4 inverseWorldViewProjection)
         {
-            Vector4 result;
+            
+            float X = (vector.X - x) / width * 2.0f - 1.0f;
+            float Y = (vector.Y - y) / height * 2.0f - 1.0f;
+            float Z = (vector.Z / (maxZ - minZ)) * 2.0f - 1.0f;
 
-            result.X = ((((vector.X - x) / width) * 2.0f) - 1.0f);
-            result.Y = ((((vector.Y - y) / height) * 2.0f) - 1.0f);
-            result.Z = (((vector.Z / (maxZ - minZ)) * 2.0f) - 1.0f);
-
+            Vector3 result;
             result.X =
-                result.X * inverseWorldViewProjection.M11 +
-                result.Y * inverseWorldViewProjection.M21 +
-                result.Z * inverseWorldViewProjection.M31 +
+                X * inverseWorldViewProjection.M11 +
+                Y * inverseWorldViewProjection.M21 +
+                Z * inverseWorldViewProjection.M31 +
                 inverseWorldViewProjection.M41;
 
             result.Y =
-                result.X * inverseWorldViewProjection.M12 +
-                result.Y * inverseWorldViewProjection.M22 +
-                result.Z * inverseWorldViewProjection.M32 +
+                X * inverseWorldViewProjection.M12 +
+                Y * inverseWorldViewProjection.M22 +
+                Z * inverseWorldViewProjection.M32 +
                 inverseWorldViewProjection.M42;
 
             result.Z =
-                result.X * inverseWorldViewProjection.M13 +
-                result.Y * inverseWorldViewProjection.M23 +
-                result.Z * inverseWorldViewProjection.M33 +
+                X * inverseWorldViewProjection.M13 +
+                Y * inverseWorldViewProjection.M23 +
+                Z * inverseWorldViewProjection.M33 +
                 inverseWorldViewProjection.M43;
 
-            result.W =
-                result.X * inverseWorldViewProjection.M14 +
-                result.Y * inverseWorldViewProjection.M24 +
-                result.Z * inverseWorldViewProjection.M34 +
+            float W =
+                X * inverseWorldViewProjection.M14 +
+                Y * inverseWorldViewProjection.M24 +
+                Z * inverseWorldViewProjection.M34 +
                 inverseWorldViewProjection.M44;
 
-            result /= result.W;
+            result /= W;
 
-            return new Vector3(result.X, result.Y, result.Z);
+            return result;
         }
 
         /// <summary>


### PR DESCRIPTION
Closes https://github.com/opentk/opentk/issues/1001 for v3.0

### Purpose of this PR
Fixes a bug in Vector3.Unproject;
We need temp working variables, not the modifying the final variable whilst working when doing an unproject, as otherwise the final result will be off for Y and Z.

### Testing status
Tested and looks OK.

No current tests for 3.0 on anything of this nature.

### Comments
Same bug exists in 4.0:
https://github.com/opentk/opentk/blob/master/src/OpenToolkit.Mathematics/Vector/Vector3.cs#L1189

Assuming this is OK & approved, I can stuff up a similar PR for 4.0, but the changes in constructor etc. mean it can't be auto-cherrypicked.

Not especially thrilled by the unnecessary similar use of a Vector4 in Project either, could tweak it slightly to eliminate this, but that's a different scope to a minor fix.

(Since I'd quite like a release bump for my other minor fix, decided it was good manners to scan for anything other and minor that can be popped in at the same time)
