### PR TITLE
[4.0] Fix: Vector3.Unproject returning incorrect result

### DIFF
--- a/src/OpenToolkit.Mathematics/Vector/Vector3.cs
+++ b/src/OpenToolkit.Mathematics/Vector/Vector3.cs
@@ -1179,39 +1179,38 @@ namespace OpenToolkit.Mathematics
             Matrix4 inverseWorldViewProjection
         )
         {
-            Vector4 result;
+            float tempX = ((vector.X - x) / width * 2.0f) - 1.0f;
+            float tempY = ((vector.Y - y) / height * 2.0f) - 1.0f;
+            float tempZ = (vector.Z / (maxZ - minZ) * 2.0f) - 1.0f;
 
-            result.X = ((vector.X - x) / width * 2.0f) - 1.0f;
-            result.Y = ((vector.Y - y) / height * 2.0f) - 1.0f;
-            result.Z = (vector.Z / (maxZ - minZ) * 2.0f) - 1.0f;
-
+            Vector3 result;
             result.X =
-                (result.X * inverseWorldViewProjection.M11) +
-                (result.Y * inverseWorldViewProjection.M21) +
-                (result.Z * inverseWorldViewProjection.M31) +
+                (tempX * inverseWorldViewProjection.M11) +
+                (tempY * inverseWorldViewProjection.M21) +
+                (tempZ * inverseWorldViewProjection.M31) +
                 inverseWorldViewProjection.M41;
 
             result.Y =
-                (result.X * inverseWorldViewProjection.M12) +
-                (result.Y * inverseWorldViewProjection.M22) +
-                (result.Z * inverseWorldViewProjection.M32) +
+                (tempX * inverseWorldViewProjection.M12) +
+                (tempY * inverseWorldViewProjection.M22) +
+                (tempZ * inverseWorldViewProjection.M32) +
                 inverseWorldViewProjection.M42;
 
             result.Z =
-                (result.X * inverseWorldViewProjection.M13) +
-                (result.Y * inverseWorldViewProjection.M23) +
-                (result.Z * inverseWorldViewProjection.M33) +
+                (tempX * inverseWorldViewProjection.M13) +
+                (tempY * inverseWorldViewProjection.M23) +
+                (tempZ * inverseWorldViewProjection.M33) +
                 inverseWorldViewProjection.M43;
 
-            result.W =
-                (result.X * inverseWorldViewProjection.M14) +
-                (result.Y * inverseWorldViewProjection.M24) +
-                (result.Z * inverseWorldViewProjection.M34) +
+            float tempW =
+                (tempX * inverseWorldViewProjection.M14) +
+                (tempY * inverseWorldViewProjection.M24) +
+                (tempZ * inverseWorldViewProjection.M34) +
                 inverseWorldViewProjection.M44;
 
-            result /= result.W;
+            result /= tempW;
 
-            return new Vector3(result.X, result.Y, result.Z);
+            return result;
         }
 
         /// <summary>


### PR DESCRIPTION
Closes https://github.com/opentk/opentk/issues/1001 for v4.0

### Purpose of this PR
Fixes a bug in Vector3.Unproject;
We need temp working variables, not the modifying the final variable whilst working when doing an unproject, as otherwise the final result will be off for Y and Z.

### Testing status
Tested and looks OK.

No current tests for 4.0 on anything of this nature.

### Comments
See also https://github.com/opentk/opentk/pull/1081 for 3.0