### PR TITLE
[3.0] Fix: Incorrect parameter order in QuaternionD constructor

### DIFF
--- a/src/OpenTK/Math/Quaterniond.cs
+++ b/src/OpenTK/Math/Quaterniond.cs
@@ -86,8 +86,8 @@ namespace OpenTK
 
             W = c1 * c2 * c3 - s1 * s2 * s3;
             Xyz.X = s1 * s2 * c3 + c1 * c2 * s3;
-            Xyz.Y = s1 * c2 * c3 + c1 * s2 * s3;
-            Xyz.Z = c1 * s2 * c3 - s1 * c2 * s3;
+            Xyz.Y = s1 * c2 * c3 - c1 * s2 * s3;
+            Xyz.Z = c1 * s2 * c3 + s1 * c2 * s3;
         }
 
         /// <summary>


### PR DESCRIPTION
### Purpose of this PR

Parameter order was reversed in the QuaternionD constructor, causing incorrect results.

### Testing status

Manual test, now returns the same results as a Quaternion.

### Comments

Closes https://github.com/opentk/opentk/issues/1065 for 3.0
I haven't tested / looked for other behaviour differences, one thing at a time :)
(Skating through a few more of the simple issues at the minute seeing if I can see anything obvious)