### PR TITLE
Fix/vector transforms

### DIFF
--- a/src/OpenToolkit.Mathematics/Vector/Vector2.cs
+++ b/src/OpenToolkit.Mathematics/Vector/Vector2.cs
@@ -721,9 +721,9 @@ namespace OpenToolkit.Mathematics
         /// <param name="mat">The desired transformation.</param>
         /// <returns>The transformed vector.</returns>
         [Pure]
-        public static Vector2 Transform(Vector2 vec, Matrix2 mat)
+        public static Vector2 TransformRow(Vector2 vec, Matrix2 mat)
         {
-            Transform(ref vec, ref mat, out Vector2 result);
+            TransformRow(in vec, in mat, out Vector2 result);
             return result;
         }
 
@@ -733,7 +733,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="vec">The vector to transform.</param>
         /// <param name="mat">The desired transformation.</param>
         /// <param name="result">The transformed vector.</param>
-        public static void Transform(ref Vector2 vec, ref Matrix2 mat, out Vector2 result)
+        public static void TransformRow(in Vector2 vec, in Matrix2 mat, out Vector2 result)
         {
             result = new Vector2(
                 (vec.X * mat.Row0.X) + (vec.Y * mat.Row1.X),
@@ -777,9 +777,9 @@ namespace OpenToolkit.Mathematics
         /// <param name="vec">The vector to transform.</param>
         /// <returns>The transformed vector.</returns>
         [Pure]
-        public static Vector2 Transform(Matrix2 mat, Vector2 vec)
+        public static Vector2 TransformColumn(Matrix2 mat, Vector2 vec)
         {
-            Transform(ref mat, ref vec, out Vector2 result);
+            TransformColumn(in mat, in vec, out Vector2 result);
             return result;
         }
 
@@ -789,7 +789,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="mat">The desired transformation.</param>
         /// <param name="vec">The vector to transform.</param>
         /// <param name="result">The transformed vector.</param>
-        public static void Transform(ref Matrix2 mat, ref Vector2 vec, out Vector2 result)
+        public static void TransformColumn(in Matrix2 mat, in Vector2 vec, out Vector2 result)
         {
             result.X = (mat.Row0.X * vec.X) + (mat.Row0.Y * vec.Y);
             result.Y = (mat.Row1.X * vec.X) + (mat.Row1.Y * vec.Y);
@@ -901,7 +901,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector2 operator *(Vector2 vec, Matrix2 mat)
         {
-            Transform(ref vec, ref mat, out Vector2 result);
+            TransformRow(in vec, in mat, out Vector2 result);
             return result;
         }
 
@@ -914,7 +914,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector2 operator *(Matrix2 mat, Vector2 vec)
         {
-            Transform(ref mat, ref vec, out Vector2 result);
+            TransformColumn(in mat, in vec, out Vector2 result);
             return result;
         }
 

--- a/src/OpenToolkit.Mathematics/Vector/Vector2d.cs
+++ b/src/OpenToolkit.Mathematics/Vector/Vector2d.cs
@@ -672,9 +672,9 @@ namespace OpenToolkit.Mathematics
         /// <param name="mat">The desired transformation.</param>
         /// <returns>The transformed vector.</returns>
         [Pure]
-        public static Vector2d Transform(Vector2d vec, Matrix2d mat)
+        public static Vector2d TransformRow(Vector2d vec, Matrix2d mat)
         {
-            Transform(ref vec, ref mat, out Vector2d result);
+            TransformRow(in vec, in mat, out Vector2d result);
             return result;
         }
 
@@ -684,7 +684,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="vec">The vector to transform.</param>
         /// <param name="mat">The desired transformation.</param>
         /// <param name="result">The transformed vector.</param>
-        public static void Transform(ref Vector2d vec, ref Matrix2d mat, out Vector2d result)
+        public static void TransformRow(in Vector2d vec, in Matrix2d mat, out Vector2d result)
         {
             result = new Vector2d(
                 (vec.X * mat.Row0.X) + (vec.Y * mat.Row1.X),
@@ -728,9 +728,9 @@ namespace OpenToolkit.Mathematics
         /// <param name="vec">The vector to transform.</param>
         /// <returns>The transformed vector.</returns>
         [Pure]
-        public static Vector2d Transform(Matrix2d mat, Vector2d vec)
+        public static Vector2d TransformColumn(Matrix2d mat, Vector2d vec)
         {
-            Transform(ref mat, ref vec, out Vector2d result);
+            TransformColumn(in mat, in vec, out Vector2d result);
             return result;
         }
 
@@ -740,7 +740,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="mat">The desired transformation.</param>
         /// <param name="vec">The vector to transform.</param>
         /// <param name="result">The transformed vector.</param>
-        public static void Transform(ref Matrix2d mat, ref Vector2d vec, out Vector2d result)
+        public static void TransformColumn(in Matrix2d mat, in Vector2d vec, out Vector2d result)
         {
             result.X = (mat.Row0.X * vec.X) + (mat.Row0.Y * vec.Y);
             result.Y = (mat.Row1.X * vec.X) + (mat.Row1.Y * vec.Y);
@@ -852,7 +852,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector2d operator *(Vector2d vec, Matrix2d mat)
         {
-            Transform(ref vec, ref mat, out Vector2d result);
+            TransformRow(in vec, in mat, out Vector2d result);
             return result;
         }
 
@@ -865,7 +865,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector2d operator *(Matrix2d mat, Vector2d vec)
         {
-            Transform(ref mat, ref vec, out Vector2d result);
+            TransformColumn(in mat, in vec, out Vector2d result);
             return result;
         }
 

--- a/src/OpenToolkit.Mathematics/Vector/Vector3.cs
+++ b/src/OpenToolkit.Mathematics/Vector/Vector3.cs
@@ -698,11 +698,6 @@ namespace OpenToolkit.Mathematics
         /// <summary>
         /// Caclulate the cross (vector) product of two vectors.
         /// </summary>
-        /// <remarks>
-        /// It is incorrect to call this method passing the same variable for
-        ///  <paramref name="result"/> as for <paramref name="left"/> or
-        ///  <paramref name="right"/>.
-        /// </remarks>
         /// <param name="left">First operand.</param>
         /// <param name="right">Second operand.</param>
         /// <param name="result">The cross product of the two inputs.</param>
@@ -809,10 +804,6 @@ namespace OpenToolkit.Mathematics
         /// Transform a direction vector by the given Matrix.
         /// Assumes the matrix has a bottom row of (0,0,0,1), that is the translation part is ignored.
         /// </summary>
-        /// <remarks>
-        /// It is incorrect to call this method passing the same variable for
-        ///  <paramref name="result"/> as for <paramref name="vec"/>.
-        /// </remarks>
         /// <param name="vec">The vector to transform.</param>
         /// <param name="mat">The desired transformation.</param>
         /// <param name="result">The transformed vector.</param>

--- a/src/OpenToolkit.Mathematics/Vector/Vector3.cs
+++ b/src/OpenToolkit.Mathematics/Vector/Vector3.cs
@@ -950,9 +950,9 @@ namespace OpenToolkit.Mathematics
         /// <param name="mat">The desired transformation.</param>
         /// <returns>The transformed vector.</returns>
         [Pure]
-        public static Vector3 Transform(Vector3 vec, Matrix3 mat)
+        public static Vector3 TransformRow(Vector3 vec, Matrix3 mat)
         {
-            Transform(in vec, in mat, out Vector3 result);
+            TransformRow(in vec, in mat, out Vector3 result);
             return result;
         }
 
@@ -962,7 +962,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="vec">The vector to transform.</param>
         /// <param name="mat">The desired transformation.</param>
         /// <param name="result">The transformed vector.</param>
-        public static void Transform(in Vector3 vec, in Matrix3 mat, out Vector3 result)
+        public static void TransformRow(in Vector3 vec, in Matrix3 mat, out Vector3 result)
         {
             result.X = (vec.X * mat.Row0.X) + (vec.Y * mat.Row1.X) + (vec.Z * mat.Row2.X);
             result.Y = (vec.X * mat.Row0.Y) + (vec.Y * mat.Row1.Y) + (vec.Z * mat.Row2.Y);
@@ -1008,9 +1008,9 @@ namespace OpenToolkit.Mathematics
         /// <param name="vec">The vector to transform.</param>
         /// <returns>The transformed vector.</returns>
         [Pure]
-        public static Vector3 Transform(Matrix3 mat, Vector3 vec)
+        public static Vector3 TransformColumn(Matrix3 mat, Vector3 vec)
         {
-            Transform(in vec, in mat, out Vector3 result);
+            TransformColumn(in mat, in vec, out Vector3 result);
             return result;
         }
 
@@ -1020,7 +1020,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="mat">The desired transformation.</param>
         /// <param name="vec">The vector to transform.</param>
         /// <param name="result">The transformed vector.</param>
-        public static void Transform(in Matrix3 mat, in Vector3 vec, out Vector3 result)
+        public static void TransformColumn(in Matrix3 mat, in Vector3 vec, out Vector3 result)
         {
             result.X = (mat.Row0.X * vec.X) + (mat.Row0.Y * vec.Y) + (mat.Row0.Z * vec.Z);
             result.Y = (mat.Row1.X * vec.X) + (mat.Row1.Y * vec.Y) + (mat.Row1.Z * vec.Z);
@@ -1049,7 +1049,7 @@ namespace OpenToolkit.Mathematics
         public static void TransformPerspective(in Vector3 vec, in Matrix4 mat, out Vector3 result)
         {
             var v = new Vector4(vec.X, vec.Y, vec.Z, 1);
-            Vector4.Transform(in v, in mat, out v);
+            Vector4.TransformRow(in v, in mat, out v);
             result.X = v.X / v.W;
             result.Y = v.Y / v.W;
             result.Z = v.Z / v.W;
@@ -1466,7 +1466,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector3 operator *(Vector3 vec, Matrix3 mat)
         {
-            Transform(in vec, in mat, out Vector3 result);
+            TransformRow(in vec, in mat, out Vector3 result);
             return result;
         }
 
@@ -1479,7 +1479,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector3 operator *(Matrix3 mat, Vector3 vec)
         {
-            Transform(in mat, in vec, out Vector3 result);
+            TransformColumn(in mat, in vec, out Vector3 result);
             return result;
         }
 

--- a/src/OpenToolkit.Mathematics/Vector/Vector3d.cs
+++ b/src/OpenToolkit.Mathematics/Vector/Vector3d.cs
@@ -691,11 +691,6 @@ namespace OpenToolkit.Mathematics
         /// <summary>
         /// Caclulate the cross (vector) product of two vectors.
         /// </summary>
-        /// <remarks>
-        /// It is incorrect to call this method passing the same variable for
-        ///  <paramref name="result"/> as for <paramref name="left"/> or
-        ///  <paramref name="right"/>.
-        /// </remarks>
         /// <param name="left">First operand.</param>
         /// <param name="right">Second operand.</param>
         /// <param name="result">The cross product of the two inputs.</param>
@@ -802,10 +797,6 @@ namespace OpenToolkit.Mathematics
         /// Transform a direction vector by the given Matrix.
         /// Assumes the matrix has a bottom row of (0,0,0,1), that is the translation part is ignored.
         /// </summary>
-        /// <remarks>
-        /// It is incorrect to call this method passing the same variable for
-        ///  <paramref name="result"/> as for <paramref name="vec"/>.
-        /// </remarks>
         /// <param name="vec">The vector to transform.</param>
         /// <param name="mat">The desired transformation.</param>
         /// <param name="result">The transformed vector.</param>
@@ -943,7 +934,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="mat">The desired transformation.</param>
         /// <returns>The transformed vector.</returns>
         [Pure]
-        public static Vector3d TransformRow(Vector3d vec, Matrix4d mat)
+        public static Vector3d TransformRow(Vector3d vec, Matrix3d mat)
         {
             TransformRow(in vec, in mat, out Vector3d result);
             return result;
@@ -952,21 +943,14 @@ namespace OpenToolkit.Mathematics
         /// <summary>
         /// Transform a Vector by the given Matrix.
         /// </summary>
-        /// <remarks>
-        /// It is incorrect to call this method passing the same variable for
-        ///  <paramref name="result"/> as for <paramref name="vec"/> or
-        ///  <paramref name="result"/>.
-        /// </remarks>
         /// <param name="vec">The vector to transform.</param>
         /// <param name="mat">The desired transformation.</param>
         /// <param name="result">The transformed vector.</param>
-        public static void TransformRow(in Vector3d vec, in Matrix4d mat, out Vector3d result)
+        public static void TransformRow(in Vector3d vec, in Matrix3d mat, out Vector3d result)
         {
-            var v4 = new Vector4d(vec.X, vec.Y, vec.Z, 1.0);
-            Vector4d.TransformRow(in v4, in mat, out v4);
-            result.X = v4.X;
-            result.Y = v4.Y;
-            result.Z = v4.Z;
+            result.X = (vec.X * mat.Row0.X) + (vec.Y * mat.Row1.X) + (vec.Z * mat.Row2.X);
+            result.Y = (vec.X * mat.Row0.Y) + (vec.Y * mat.Row1.Y) + (vec.Z * mat.Row2.Y);
+            result.Z = (vec.X * mat.Row0.Z) + (vec.Y * mat.Row1.Z) + (vec.Z * mat.Row2.Z);
         }
 
         /// <summary>
@@ -1328,6 +1312,32 @@ namespace OpenToolkit.Mathematics
             vec.Y *= scale.Y;
             vec.Z *= scale.Z;
             return vec;
+        }
+
+        /// <summary>
+        /// Transform a Vector by the given Matrix.
+        /// </summary>
+        /// <param name="vec">The vector to transform.</param>
+        /// <param name="mat">The desired transformation.</param>
+        /// <returns>The transformed vector.</returns>
+        [Pure]
+        public static Vector3d operator *(Vector3d vec, Matrix3d mat)
+        {
+            TransformRow(in vec, in mat, out Vector3d result);
+            return result;
+        }
+
+        /// <summary>
+        /// Transform a Vector by the given Matrix using right-handed notation.
+        /// </summary>
+        /// <param name="mat">The desired transformation.</param>
+        /// <param name="vec">The vector to transform.</param>
+        /// <returns>The transformed vector.</returns>
+        [Pure]
+        public static Vector3d operator *(Matrix3d mat, Vector3d vec)
+        {
+            TransformColumn(in mat, in vec, out Vector3d result);
+            return result;
         }
 
         /// <summary>

--- a/src/OpenToolkit.Mathematics/Vector/Vector3d.cs
+++ b/src/OpenToolkit.Mathematics/Vector/Vector3d.cs
@@ -943,9 +943,9 @@ namespace OpenToolkit.Mathematics
         /// <param name="mat">The desired transformation.</param>
         /// <returns>The transformed vector.</returns>
         [Pure]
-        public static Vector3d Transform(Vector3d vec, Matrix4d mat)
+        public static Vector3d TransformRow(Vector3d vec, Matrix4d mat)
         {
-            Transform(in vec, in mat, out Vector3d result);
+            TransformRow(in vec, in mat, out Vector3d result);
             return result;
         }
 
@@ -960,10 +960,10 @@ namespace OpenToolkit.Mathematics
         /// <param name="vec">The vector to transform.</param>
         /// <param name="mat">The desired transformation.</param>
         /// <param name="result">The transformed vector.</param>
-        public static void Transform(in Vector3d vec, in Matrix4d mat, out Vector3d result)
+        public static void TransformRow(in Vector3d vec, in Matrix4d mat, out Vector3d result)
         {
             var v4 = new Vector4d(vec.X, vec.Y, vec.Z, 1.0);
-            Vector4d.Transform(in v4, in mat, out v4);
+            Vector4d.TransformRow(in v4, in mat, out v4);
             result.X = v4.X;
             result.Y = v4.Y;
             result.Z = v4.Z;
@@ -1002,6 +1002,32 @@ namespace OpenToolkit.Mathematics
         }
 
         /// <summary>
+        /// Transform a Vector by the given Matrix using right-handed notation.
+        /// </summary>
+        /// <param name="mat">The desired transformation.</param>
+        /// <param name="vec">The vector to transform.</param>
+        /// <returns>The transformed vector.</returns>
+        [Pure]
+        public static Vector3d TransformColumn(Matrix3d mat, Vector3d vec)
+        {
+            TransformColumn(in mat, in vec, out Vector3d result);
+            return result;
+        }
+
+        /// <summary>
+        /// Transform a Vector by the given Matrix using right-handed notation.
+        /// </summary>
+        /// <param name="mat">The desired transformation.</param>
+        /// <param name="vec">The vector to transform.</param>
+        /// <param name="result">The transformed vector.</param>
+        public static void TransformColumn(in Matrix3d mat, in Vector3d vec, out Vector3d result)
+        {
+            result.X = (mat.Row0.X * vec.X) + (mat.Row0.Y * vec.Y) + (mat.Row0.Z * vec.Z);
+            result.Y = (mat.Row1.X * vec.X) + (mat.Row1.Y * vec.Y) + (mat.Row1.Z * vec.Z);
+            result.Z = (mat.Row2.X * vec.X) + (mat.Row2.Y * vec.Y) + (mat.Row2.Z * vec.Z);
+        }
+
+        /// <summary>
         /// Transform a Vector3d by the given Matrix, and project the resulting Vector4 back to a Vector3.
         /// </summary>
         /// <param name="vec">The vector to transform.</param>
@@ -1023,7 +1049,7 @@ namespace OpenToolkit.Mathematics
         public static void TransformPerspective(in Vector3d vec, in Matrix4d mat, out Vector3d result)
         {
             var v = new Vector4d(vec.X, vec.Y, vec.Z, 1);
-            Vector4d.Transform(in v, in mat, out v);
+            Vector4d.TransformRow(in v, in mat, out v);
             result.X = v.X / v.W;
             result.Y = v.Y / v.W;
             result.Z = v.Z / v.W;

--- a/src/OpenToolkit.Mathematics/Vector/Vector4.cs
+++ b/src/OpenToolkit.Mathematics/Vector/Vector4.cs
@@ -777,9 +777,9 @@ namespace OpenToolkit.Mathematics
         /// <param name="mat">The desired transformation.</param>
         /// <returns>The transformed vector.</returns>
         [Pure]
-        public static Vector4 Transform(Vector4 vec, Matrix4 mat)
+        public static Vector4 TransformRow(Vector4 vec, Matrix4 mat)
         {
-            Transform(in vec, in mat, out Vector4 result);
+            TransformRow(in vec, in mat, out Vector4 result);
             return result;
         }
 
@@ -789,7 +789,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="vec">The vector to transform.</param>
         /// <param name="mat">The desired transformation.</param>
         /// <param name="result">The transformed vector.</param>
-        public static void Transform(in Vector4 vec, in Matrix4 mat, out Vector4 result)
+        public static void TransformRow(in Vector4 vec, in Matrix4 mat, out Vector4 result)
         {
             result = new Vector4(
                 (vec.X * mat.Row0.X) + (vec.Y * mat.Row1.X) + (vec.Z * mat.Row2.X) + (vec.W * mat.Row3.X),
@@ -837,9 +837,9 @@ namespace OpenToolkit.Mathematics
         /// <param name="vec">The vector to transform.</param>
         /// <returns>The transformed vector.</returns>
         [Pure]
-        public static Vector4 Transform(Matrix4 mat, Vector4 vec)
+        public static Vector4 TransformColumn(Matrix4 mat, Vector4 vec)
         {
-            Transform(in mat, in vec, out Vector4 result);
+            TransformColumn(in mat, in vec, out Vector4 result);
             return result;
         }
 
@@ -849,7 +849,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="mat">The desired transformation.</param>
         /// <param name="vec">The vector to transform.</param>
         /// <param name="result">The transformed vector.</param>
-        public static void Transform(in Matrix4 mat, in Vector4 vec, out Vector4 result)
+        public static void TransformColumn(in Matrix4 mat, in Vector4 vec, out Vector4 result)
         {
             result = new Vector4(
                 (mat.Row0.X * vec.X) + (mat.Row0.Y * vec.Y) + (mat.Row0.Z * vec.Z) + (mat.Row0.W * vec.W),
@@ -1922,7 +1922,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector4 operator *(Vector4 vec, Matrix4 mat)
         {
-            Transform(in vec, in mat, out Vector4 result);
+            TransformRow(in vec, in mat, out Vector4 result);
             return result;
         }
 
@@ -1935,7 +1935,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static Vector4 operator *(Matrix4 mat, Vector4 vec)
         {
-            Transform(in mat, in vec, out Vector4 result);
+            TransformColumn(in mat, in vec, out Vector4 result);
             return result;
         }
 

--- a/src/OpenToolkit.Mathematics/Vector/Vector4d.cs
+++ b/src/OpenToolkit.Mathematics/Vector/Vector4d.cs
@@ -32,6 +32,9 @@ namespace OpenToolkit.Mathematics
     /// <summary>
     /// Represents a 4D vector using four double-precision floating-point numbers.
     /// </summary>
+    /// <remarks>
+    /// The Vector4 structure is suitable for interoperation with unmanaged code requiring four consecutive doubles.
+    /// </remarks>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
     public struct Vector4d : IEquatable<Vector4d>
@@ -763,15 +766,15 @@ namespace OpenToolkit.Mathematics
         }
 
         /// <summary>
-        /// Transform a Vector by the given Matrix.
+        /// Transform a Vector by the given Matrix using right-handed notation.
         /// </summary>
         /// <param name="vec">The vector to transform.</param>
         /// <param name="mat">The desired transformation.</param>
         /// <returns>The transformed vector.</returns>
         [Pure]
-        public static Vector4d Transform(Vector4d vec, Matrix4d mat)
+        public static Vector4d TransformRow(Vector4d vec, Matrix4d mat)
         {
-            Transform(in vec, in mat, out Vector4d result);
+            TransformRow(in vec, in mat, out Vector4d result);
             return result;
         }
 
@@ -781,7 +784,7 @@ namespace OpenToolkit.Mathematics
         /// <param name="vec">The vector to transform.</param>
         /// <param name="mat">The desired transformation.</param>
         /// <param name="result">The transformed vector.</param>
-        public static void Transform(in Vector4d vec, in Matrix4d mat, out Vector4d result)
+        public static void TransformRow(in Vector4d vec, in Matrix4d mat, out Vector4d result)
         {
             result = new Vector4d(
                 (vec.X * mat.Row0.X) + (vec.Y * mat.Row1.X) + (vec.Z * mat.Row2.X) + (vec.W * mat.Row3.X),
@@ -820,6 +823,34 @@ namespace OpenToolkit.Mathematics
             result.Y = v.Y;
             result.Z = v.Z;
             result.W = v.W;
+        }
+
+        /// <summary>
+        /// Transform a Vector by the given Matrix using right-handed notation.
+        /// </summary>
+        /// <param name="mat">The desired transformation.</param>
+        /// <param name="vec">The vector to transform.</param>
+        /// <returns>The transformed vector.</returns>
+        [Pure]
+        public static Vector4d TransformColumn(Matrix4d mat, Vector4d vec)
+        {
+            TransformColumn(in mat, in vec, out Vector4d result);
+            return result;
+        }
+
+        /// <summary>
+        /// Transform a Vector by the given Matrix using right-handed notation.
+        /// </summary>
+        /// <param name="mat">The desired transformation.</param>
+        /// <param name="vec">The vector to transform.</param>
+        /// <param name="result">The transformed vector.</param>
+        public static void TransformColumn(in Matrix4d mat, in Vector4d vec, out Vector4d result)
+        {
+            result = new Vector4d(
+                (mat.Row0.X * vec.X) + (mat.Row0.Y * vec.Y) + (mat.Row0.Z * vec.Z) + (mat.Row0.W * vec.W),
+                (mat.Row1.X * vec.X) + (mat.Row1.Y * vec.Y) + (mat.Row1.Z * vec.Z) + (mat.Row1.W * vec.W),
+                (mat.Row2.X * vec.X) + (mat.Row2.Y * vec.Y) + (mat.Row2.Z * vec.Z) + (mat.Row2.W * vec.W),
+                (mat.Row3.X * vec.X) + (mat.Row3.Y * vec.Y) + (mat.Row3.Z * vec.Z) + (mat.Row3.W * vec.W));
         }
 
         /// <summary>
@@ -1875,6 +1906,32 @@ namespace OpenToolkit.Mathematics
             vec.Z *= scale.Z;
             vec.W *= scale.W;
             return vec;
+        }
+
+        /// <summary>
+        /// Transform a Vector by the given Matrix.
+        /// </summary>
+        /// <param name="vec">The vector to transform.</param>
+        /// <param name="mat">The desired transformation.</param>
+        /// <returns>The transformed vector.</returns>
+        [Pure]
+        public static Vector4d operator *(Vector4d vec, Matrix4d mat)
+        {
+            TransformRow(in vec, in mat, out Vector4d result);
+            return result;
+        }
+
+        /// <summary>
+        /// Transform a Vector by the given Matrix using right-handed notation.
+        /// </summary>
+        /// <param name="mat">The desired transformation.</param>
+        /// <param name="vec">The vector to transform.</param>
+        /// <returns>The transformed vector.</returns>
+        [Pure]
+        public static Vector4d operator *(Matrix4d mat, Vector4d vec)
+        {
+            TransformColumn(in mat, in vec, out Vector4d result);
+            return result;
         }
 
         /// <summary>

--- a/tests/OpenToolkit.Tests/Vector2Tests.fs
+++ b/tests/OpenToolkit.Tests/Vector2Tests.fs
@@ -229,8 +229,8 @@ module Vector2 =
         [<Property>]
         let ``Vector2-Matrix2 multiplication using right-handed notation is consistent across overloads`` (a : Matrix2, b : Vector2) =
             let r1 = a * b;
-            let r2 = Vector2.Transform(a, b);
-            let r3 = Vector2.Transform(ref a, ref b);
+            let r2 = Vector2.TransformColumn(a, b);
+            let r3 = Vector2.TransformColumn(&a, &b);
 
             Assert.Equal(r1, r2)
             Assert.Equal(r2, r3)
@@ -249,8 +249,8 @@ module Vector2 =
         [<Property>]
         let ``Vector2-Matrix2 multiplication using left-handed notation is consistent across overloads`` (a : Matrix2, b : Vector2) =
             let r1 = b * a;
-            let r2 = Vector2.Transform(b, a);
-            let r3 = Vector2.Transform(ref b, ref a);
+            let r2 = Vector2.TransformRow(b, a);
+            let r3 = Vector2.TransformRow(&b, &a);
 
             Assert.Equal(r1, r2)
             Assert.Equal(r2, r3)

--- a/tests/OpenToolkit.Tests/Vector3Tests.fs
+++ b/tests/OpenToolkit.Tests/Vector3Tests.fs
@@ -332,6 +332,15 @@ module Vector3 =
             Assert.Equal(exp, res)
 
         [<Property>]
+        let ``Vector3-Matrix3 multiplication using right-handed notation is consistent across overloads`` (a : Matrix3, b : Vector3) =
+            let r1 = a * b;
+            let r2 = Vector3.TransformColumn(a, b);
+            let r3 = Vector3.TransformColumn(&a, &b);
+
+            Assert.Equal(r1, r2)
+            Assert.Equal(r2, r3)
+
+        [<Property>]
         let ``Vector3-Matrix3 multiplication using left-handed notation is the same as vector/column multiplication and summation`` (a : Matrix3, b : Vector3) =
             let res = b*a
 
@@ -342,6 +351,15 @@ module Vector3 =
             let exp = Vector3(c1, c2, c3)
 
             Assert.Equal(exp, res)
+
+        [<Property>]
+        let ``Vector3-Matrix3 multiplication using left-handed notation is consistent across overloads`` (a : Matrix3, b : Vector3) =
+            let r1 = b * a;
+            let r2 = Vector3.TransformRow(b, a);
+            let r3 = Vector3.TransformRow(&b, &a);
+
+            Assert.Equal(r1, r2)
+            Assert.Equal(r2, r3)
 
         [<Property>]
         let ``Static Vector3 multiplication method is the same as component multiplication`` (a : Vector3, b : Vector3) =


### PR DESCRIPTION
### Purpose of this PR

* Fixes some inconsistencies between the different vectors(e.g. double vs float vectors)
* Renamed Transform functions - where the vector parameter is before matrix parameter - to TransformRow for vector*Matrix where vector is to be interpreted as a row vector
* Renamed Transform functions - where the vector parameter is after matrix parameter -  to TransformColumn for Matrix*vector where vector is to be interpreted as a column vector

This is a deliberate breaking change for the Transform functions, as they weren't correct in older releases, to help people migrate their previously sometimes wrong Transform functions to the correct ones without a silent change, where the functionality does change but the ABI does not.