### PR TITLE
start of JoystickState button and connectivity fix

### DIFF
--- a/src/OpenToolkit.Windowing.Common/Input/JoystickState.cs
+++ b/src/OpenToolkit.Windowing.Common/Input/JoystickState.cs
@@ -32,6 +32,11 @@ namespace OpenToolkit.Windowing.Common.Input
         public string Name { get; }
 
         /// <summary>
+        /// Gets a value indicating whether the joystick is active and connected.
+        /// </summary>
+        public bool IsConnected { get; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="JoystickState"/> struct.
         /// </summary>
         /// <param name="hatCount">The amount of hats.</param>
@@ -46,6 +51,7 @@ namespace OpenToolkit.Windowing.Common.Input
             _buttons = new byte[(buttonCount + 7) / 8];
             Id = id;
             Name = name;
+            IsConnected = true;
         }
 
         /// <summary>
@@ -62,6 +68,7 @@ namespace OpenToolkit.Windowing.Common.Input
             _axes = axes;
             Id = id;
             Name = name;
+            IsConnected = true;
 
             _buttons = new byte[(buttons.Length + 7) / 8];
             for (int i = 0; i < buttons.Length; i++)

--- a/src/OpenToolkit.Windowing.Common/Input/JoystickState.cs
+++ b/src/OpenToolkit.Windowing.Common/Input/JoystickState.cs
@@ -43,7 +43,7 @@ namespace OpenToolkit.Windowing.Common.Input
         {
             _hats = new Hat[hatCount];
             _axes = new float[axesCount];
-            _buttons = new byte[buttonCount / 8];
+            _buttons = new byte[(buttonCount + 7) / 8];
             Id = id;
             Name = name;
         }
@@ -63,7 +63,7 @@ namespace OpenToolkit.Windowing.Common.Input
             Id = id;
             Name = name;
 
-            _buttons = new byte[buttons.Length / 8];
+            _buttons = new byte[(buttons.Length + 7) / 8];
             for (int i = 0; i < buttons.Length; i++)
             {
                 SetButtonDown(i, buttons[i]);

--- a/src/OpenToolkit.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenToolkit.Windowing.Desktop/NativeWindow.cs
@@ -824,7 +824,7 @@ namespace OpenToolkit.Windowing.Desktop
                 GLFW.SetJoystickCallback(_joystickCallback);
 
                 // Check for Joysticks that are connected at application launch
-                for (int i = 0, j = JoystickStates.Length; i < j; i++)
+                for (int i = 0; i < JoystickStates.Length; i++)
                 {
                     if (GLFW.JoystickPresent(i))
                     {

--- a/src/OpenToolkit.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenToolkit.Windowing.Desktop/NativeWindow.cs
@@ -823,6 +823,20 @@ namespace OpenToolkit.Windowing.Desktop
                 };
                 GLFW.SetJoystickCallback(_joystickCallback);
 
+                // Check for Joysticks that are connected at application launch
+                for (int i = 0, j = JoystickStates.Length; i < j; i++)
+                {
+                    if (GLFW.JoystickPresent(i))
+                    {
+                        GLFW.GetJoystickHatsRaw(i, out var hatCount);
+                        GLFW.GetJoystickAxesRaw(i, out var axisCount);
+                        GLFW.GetJoystickButtonsRaw(i, out var buttonCount);
+                        var name = GLFW.GetJoystickName(i);
+
+                        JoystickStates[i] = new JoystickState(hatCount, axisCount, buttonCount, i, name);
+                    }
+                }
+
                 _monitorCallback = (monitor, eventCode) =>
                 {
                     OnMonitorConnected(new MonitorEventArgs(new Monitor((IntPtr)monitor), eventCode == ConnectedState.Connected));


### PR DESCRIPTION
### Purpose of this PR

* Fix a bug where joysticks and gamepads with more than 8 buttons cause an exception when creating JoystickState
* Fix for joystick having to connect to system post launch of application, otherwise `ConnectedState.Connected` callback will not trigger and the JoystickState will never be instantiated, causing updates to the state to never happen.
* Which part of OpenTK does this affect (Windowing.Common).

### Testing status

Test 1:
* Connect any gamepad or joystick to your computer before starting the application.
* Bug was that the gamepad would never be registered and its state would never update

Test 2:
* Start the application, and once started connect the gamepad with more than 8 buttons (a standard XBOX gamepad will work as it registers 14 buttons)
* Bug was that JoystickState would be created but throw an exception due to conflicting bit logic that become apparent with more than 8 buttons.

### Comments
