### PR TITLE
Free context after loading of GL bindings

### DIFF
--- a/src/OpenToolkit.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenToolkit.Windowing.Desktop/NativeWindow.cs
@@ -581,6 +581,8 @@ namespace OpenToolkit.Windowing.Desktop
                 {
                     InitializeGlBindings();
                 }
+
+                GLFW.MakeContextCurrent(null);
             }
 
             // Enables the caps lock modifier to be detected and updated


### PR DESCRIPTION
Make context non current after initialization of gl bindings, to be able to use it in the render thread later on
Should fix https://github.com/opentk/opentk/issues/1052