### PR TITLE
Made it a bit more Microsofty

### DIFF
--- a/src/OpenToolkit.Core/OpenToolkit.Core.csproj
+++ b/src/OpenToolkit.Core/OpenToolkit.Core.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <RootNamespace>OpenToolkit.Core</RootNamespace>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenToolkit.Graphics/OpenToolkit.Graphics.csproj
+++ b/src/OpenToolkit.Graphics/OpenToolkit.Graphics.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <RootNamespace>OpenToolkit.Graphics</RootNamespace>
   </PropertyGroup>

--- a/src/OpenToolkit.Input/OpenToolkit.Input.csproj
+++ b/src/OpenToolkit.Input/OpenToolkit.Input.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <Deterministic>true</Deterministic>
     <RootNamespace>OpenToolkit.Input</RootNamespace>
   </PropertyGroup>

--- a/src/OpenToolkit.Mathematics/Data/Color4.cs
+++ b/src/OpenToolkit.Mathematics/Data/Color4.cs
@@ -928,7 +928,7 @@ namespace OpenToolkit.Mathematics
             }
             else
             {
-                r = (float)Math.Pow((srgb.R + 0.055f) / (1.0f + 0.055f), 2.4f);
+                r = MathF.Pow((srgb.R + 0.055f) / (1.0f + 0.055f), 2.4f);
             }
 
             if (srgb.G <= 0.04045f)
@@ -937,7 +937,7 @@ namespace OpenToolkit.Mathematics
             }
             else
             {
-                g = (float)Math.Pow((srgb.G + 0.055f) / (1.0f + 0.055f), 2.4f);
+                g = MathF.Pow((srgb.G + 0.055f) / (1.0f + 0.055f), 2.4f);
             }
 
             if (srgb.B <= 0.04045f)
@@ -946,7 +946,7 @@ namespace OpenToolkit.Mathematics
             }
             else
             {
-                b = (float)Math.Pow((srgb.B + 0.055f) / (1.0f + 0.055f), 2.4f);
+                b = MathF.Pow((srgb.B + 0.055f) / (1.0f + 0.055f), 2.4f);
             }
 
             return new Color4(r, g, b, srgb.A);
@@ -970,7 +970,7 @@ namespace OpenToolkit.Mathematics
             }
             else
             {
-                r = ((1.0f + 0.055f) * (float)Math.Pow(rgb.R, 1.0f / 2.4f)) - 0.055f;
+                r = ((1.0f + 0.055f) * MathF.Pow(rgb.R, 1.0f / 2.4f)) - 0.055f;
             }
 
             if (rgb.G <= 0.0031308)
@@ -979,7 +979,7 @@ namespace OpenToolkit.Mathematics
             }
             else
             {
-                g = ((1.0f + 0.055f) * (float)Math.Pow(rgb.G, 1.0f / 2.4f)) - 0.055f;
+                g = ((1.0f + 0.055f) * MathF.Pow(rgb.G, 1.0f / 2.4f)) - 0.055f;
             }
 
             if (rgb.B <= 0.0031308)
@@ -988,7 +988,7 @@ namespace OpenToolkit.Mathematics
             }
             else
             {
-                b = ((1.0f + 0.055f) * (float)Math.Pow(rgb.B, 1.0f / 2.4f)) - 0.055f;
+                b = ((1.0f + 0.055f) * MathF.Pow(rgb.B, 1.0f / 2.4f)) - 0.055f;
             }
 
             return new Color4(r, g, b, rgb.A);

--- a/src/OpenToolkit.Mathematics/Data/Quaternion.cs
+++ b/src/OpenToolkit.Mathematics/Data/Quaternion.cs
@@ -80,12 +80,12 @@ namespace OpenToolkit.Mathematics
             rotationY *= 0.5f;
             rotationZ *= 0.5f;
 
-            var c1 = (float)Math.Cos(rotationX);
-            var c2 = (float)Math.Cos(rotationY);
-            var c3 = (float)Math.Cos(rotationZ);
-            var s1 = (float)Math.Sin(rotationX);
-            var s2 = (float)Math.Sin(rotationY);
-            var s3 = (float)Math.Sin(rotationZ);
+            var c1 = MathF.Cos(rotationX);
+            var c2 = MathF.Cos(rotationY);
+            var c3 = MathF.Cos(rotationZ);
+            var s1 = MathF.Sin(rotationX);
+            var s2 = MathF.Sin(rotationY);
+            var s3 = MathF.Sin(rotationZ);
 
             W = (c1 * c2 * c3) - (s1 * s2 * s3);
             Xyz.X = (s1 * c2 * c3) + (c1 * s2 * s3);
@@ -160,10 +160,10 @@ namespace OpenToolkit.Mathematics
 
             var result = new Vector4
             {
-                W = 2.0f * (float)Math.Acos(q.W) // angle
+                W = 2.0f * MathF.Acos(q.W) // angle
             };
 
-            var den = (float)Math.Sqrt(1.0 - (q.W * q.W));
+            var den = MathF.Sqrt(1.0f - (q.W * q.W));
             if (den > 0.0001f)
             {
                 result.Xyz = q.Xyz / den;
@@ -221,15 +221,15 @@ namespace OpenToolkit.Mathematics
             }
             else if (singularityTest < -SINGULARITY_THRESHOLD * unit)
             {
-                eulerAngles.Z = (float)(-2 * Math.Atan2(q.X, q.W));
+                eulerAngles.Z = -2 * MathF.Atan2(q.X, q.W);
                 eulerAngles.Y = -MathHelper.PiOver2;
                 eulerAngles.X = 0;
             }
             else
             {
-                eulerAngles.Z = (float)Math.Atan2(2 * ((q.W * q.Z) - (q.X * q.Y)), sqw + sqx - sqy - sqz);
-                eulerAngles.Y = (float)Math.Asin(2 * singularityTest / unit);
-                eulerAngles.X = (float)Math.Atan2(2 * ((q.W * q.X) - (q.Y * q.Z)), sqw - sqx - sqy + sqz);
+                eulerAngles.Z = MathF.Atan2(2 * ((q.W * q.Z) - (q.X * q.Y)), sqw + sqx - sqy - sqz);
+                eulerAngles.Y = MathF.Asin(2 * singularityTest / unit);
+                eulerAngles.X = MathF.Atan2(2 * ((q.W * q.X) - (q.Y * q.Z)), sqw - sqx - sqy + sqz);
             }
 
             return eulerAngles;
@@ -239,7 +239,7 @@ namespace OpenToolkit.Mathematics
         /// Gets the length (magnitude) of the quaternion.
         /// </summary>
         /// <seealso cref="LengthSquared"/>
-        public float Length => (float)Math.Sqrt((W * W) + Xyz.LengthSquared);
+        public float Length => MathF.Sqrt((W * W) + Xyz.LengthSquared);
 
         /// <summary>
         /// Gets the square of the quaternion length (magnitude).
@@ -507,8 +507,8 @@ namespace OpenToolkit.Mathematics
 
             angle *= 0.5f;
             axis.Normalize();
-            result.Xyz = axis * (float)Math.Sin(angle);
-            result.W = (float)Math.Cos(angle);
+            result.Xyz = axis * MathF.Sin(angle);
+            result.W = MathF.Cos(angle);
 
             return Normalize(result);
         }
@@ -550,12 +550,12 @@ namespace OpenToolkit.Mathematics
         /// <param name="result">The equivalent Quaternion.</param>
         public static void FromEulerAngles(in Vector3 eulerAngles, out Quaternion result)
         {
-            var c1 = (float)Math.Cos(eulerAngles.X * 0.5f);
-            var c2 = (float)Math.Cos(eulerAngles.Y * 0.5f);
-            var c3 = (float)Math.Cos(eulerAngles.Z * 0.5f);
-            var s1 = (float)Math.Sin(eulerAngles.X * 0.5f);
-            var s2 = (float)Math.Sin(eulerAngles.Y * 0.5f);
-            var s3 = (float)Math.Sin(eulerAngles.Z * 0.5f);
+            var c1 = MathF.Cos(eulerAngles.X * 0.5f);
+            var c2 = MathF.Cos(eulerAngles.Y * 0.5f);
+            var c3 = MathF.Cos(eulerAngles.Z * 0.5f);
+            var s1 = MathF.Sin(eulerAngles.X * 0.5f);
+            var s2 = MathF.Sin(eulerAngles.Y * 0.5f);
+            var s3 = MathF.Sin(eulerAngles.Z * 0.5f);
 
             result.W = (c1 * c2 * c3) - (s1 * s2 * s3);
             result.Xyz.X = (s1 * c2 * c3) + (c1 * s2 * s3);
@@ -596,7 +596,7 @@ namespace OpenToolkit.Mathematics
 
             if (trace > 0)
             {
-                var s = (float)Math.Sqrt(trace + 1) * 2;
+                var s = MathF.Sqrt(trace + 1) * 2;
                 var invS = 1f / s;
 
                 result.W = s * 0.25f;
@@ -610,7 +610,7 @@ namespace OpenToolkit.Mathematics
 
                 if (m00 > m11 && m00 > m22)
                 {
-                    var s = (float)Math.Sqrt(1 + m00 - m11 - m22) * 2;
+                    var s = MathF.Sqrt(1 + m00 - m11 - m22) * 2;
                     var invS = 1f / s;
 
                     result.W = (matrix.Row2.Y - matrix.Row1.Z) * invS;
@@ -620,7 +620,7 @@ namespace OpenToolkit.Mathematics
                 }
                 else if (m11 > m22)
                 {
-                    var s = (float)Math.Sqrt(1 + m11 - m00 - m22) * 2;
+                    var s = MathF.Sqrt(1 + m11 - m00 - m22) * 2;
                     var invS = 1f / s;
 
                     result.W = (matrix.Row0.Z - matrix.Row2.X) * invS;
@@ -630,7 +630,7 @@ namespace OpenToolkit.Mathematics
                 }
                 else
                 {
-                    var s = (float)Math.Sqrt(1 + m22 - m00 - m11) * 2;
+                    var s = MathF.Sqrt(1 + m22 - m00 - m11) * 2;
                     var invS = 1f / s;
 
                     result.W = (matrix.Row1.X - matrix.Row0.Y) * invS;
@@ -687,11 +687,11 @@ namespace OpenToolkit.Mathematics
             if (cosHalfAngle < 0.99f)
             {
                 // do proper slerp for big angles
-                var halfAngle = (float)Math.Acos(cosHalfAngle);
-                var sinHalfAngle = (float)Math.Sin(halfAngle);
+                var halfAngle = MathF.Acos(cosHalfAngle);
+                var sinHalfAngle = MathF.Sin(halfAngle);
                 var oneOverSinHalfAngle = 1.0f / sinHalfAngle;
-                blendA = (float)Math.Sin(halfAngle * (1.0f - blend)) * oneOverSinHalfAngle;
-                blendB = (float)Math.Sin(halfAngle * blend) * oneOverSinHalfAngle;
+                blendA = MathF.Sin(halfAngle * (1.0f - blend)) * oneOverSinHalfAngle;
+                blendB = MathF.Sin(halfAngle * blend) * oneOverSinHalfAngle;
             }
             else
             {

--- a/src/OpenToolkit.Mathematics/Data/Quaterniond.cs
+++ b/src/OpenToolkit.Mathematics/Data/Quaterniond.cs
@@ -213,13 +213,13 @@ namespace OpenToolkit.Mathematics
             {
                 eulerAngles.Z = -Math.PI / 2; // -90 degrees
                 eulerAngles.Y = Math.Atan2(yawY, yawX);
-                eulerAngles.X = MathHelper.NormalizeRadians(-eulerAngles.Y - (2d * (float)Math.Atan2(q.Y, q.W)));
+                eulerAngles.X = MathHelper.NormalizeRadians(-eulerAngles.Y - (2d * Math.Atan2(q.Y, q.W)));
             }
             else if (singularityTest > SINGULARITY_THRESHOLD)
             {
                 eulerAngles.Z = Math.PI / 2; // 90 degrees
                 eulerAngles.Y = Math.Atan2(yawY, yawX);
-                eulerAngles.X = MathHelper.NormalizeRadians(eulerAngles.Y - (2d * (float)Math.Atan2(q.Y, q.W)));
+                eulerAngles.X = MathHelper.NormalizeRadians(eulerAngles.Y - (2d * Math.Atan2(q.Y, q.W)));
             }
             else
             {

--- a/src/OpenToolkit.Mathematics/Geometry/BezierCurve.cs
+++ b/src/OpenToolkit.Mathematics/Geometry/BezierCurve.cs
@@ -48,7 +48,7 @@ namespace OpenToolkit.Mathematics
                 throw new ArgumentNullException(nameof(points), "Must point to a valid list of Vector2 structures.");
             }
 
-            this._points = new List<Vector2>(points);
+            _points = new List<Vector2>(points);
             Parallel = 0.0f;
         }
 
@@ -63,7 +63,7 @@ namespace OpenToolkit.Mathematics
                 throw new ArgumentNullException(nameof(points), "Must point to a valid list of Vector2 structures.");
             }
 
-            this._points = new List<Vector2>(points);
+            _points = new List<Vector2>(points);
             Parallel = 0.0f;
         }
 
@@ -80,7 +80,7 @@ namespace OpenToolkit.Mathematics
             }
 
             Parallel = parallel;
-            this._points = new List<Vector2>(points);
+            _points = new List<Vector2>(points);
         }
 
         /// <summary>
@@ -96,7 +96,7 @@ namespace OpenToolkit.Mathematics
             }
 
             Parallel = parallel;
-            this._points = new List<Vector2>(points);
+            _points = new List<Vector2>(points);
         }
 
         /// <summary>

--- a/src/OpenToolkit.Mathematics/GlobalSuppressions.cs
+++ b/src/OpenToolkit.Mathematics/GlobalSuppressions.cs
@@ -6,7 +6,7 @@
 using System.Diagnostics.CodeAnalysis;
 
 [assembly: SuppressMessage(
-    "StyleCop.CSharp.NamingRules",
-    "SA1305:Field names should not use Hungarian notation",
-    Justification = "There are a lot of short variable names (especially for matrix elements) in the Mathematics library, so instead of changing 500-1000 variable names, we just suppress this message instead."
-)]
+                              "StyleCop.CSharp.NamingRules",
+                              "SA1305:Field names should not use Hungarian notation",
+                              Justification = "There are a lot of short variable names (especially for matrix elements) in the Mathematics library, so instead of changing 500-1000 variable names, we just suppress this message instead."
+                          )]

--- a/src/OpenToolkit.Mathematics/MathHelper.cs
+++ b/src/OpenToolkit.Mathematics/MathHelper.cs
@@ -18,44 +18,34 @@ namespace OpenToolkit.Mathematics
     public static class MathHelper
     {
         /// <summary>
-        /// Defines the value of Pi as a <see cref="float"/>.
-        /// </summary>
-        public const float Pi = 3.1415927f;
-
-        /// <summary>
         /// Defines the value of Pi divided by two as a <see cref="float"/>.
         /// </summary>
-        public const float PiOver2 = Pi / 2;
+        public const float PiOver2 = MathF.PI / 2;
 
         /// <summary>
         /// Defines the value of Pi divided by three as a <see cref="float"/>.
         /// </summary>
-        public const float PiOver3 = Pi / 3;
+        public const float PiOver3 = MathF.PI / 3;
 
         /// <summary>
         /// Defines the value of  Pi divided by four as a <see cref="float"/>.
         /// </summary>
-        public const float PiOver4 = Pi / 4;
+        public const float PiOver4 = MathF.PI / 4;
 
         /// <summary>
         /// Defines the value of Pi divided by six as a <see cref="float"/>.
         /// </summary>
-        public const float PiOver6 = Pi / 6;
+        public const float PiOver6 = MathF.PI / 6;
 
         /// <summary>
         /// Defines the value of Pi multiplied by two as a <see cref="float"/>.
         /// </summary>
-        public const float TwoPi = 2 * Pi;
+        public const float TwoPi = 2 * MathF.PI;
 
         /// <summary>
         /// Defines the value of Pi multiplied by 3 and divided by two as a <see cref="float"/>.
         /// </summary>
-        public const float ThreePiOver2 = 3 * Pi / 2;
-
-        /// <summary>
-        /// Defines the value of E as a <see cref="float"/>.
-        /// </summary>
-        public const float E = 2.7182817f;
+        public const float ThreePiOver2 = 3 * MathF.PI / 2;
 
         /// <summary>
         /// Defines the base-10 logarithm of E.
@@ -66,626 +56,6 @@ namespace OpenToolkit.Mathematics
         /// Defines the base-2 logarithm of E.
         /// </summary>
         public const float Log2E = 1.442695f;
-
-        /// <summary>
-        /// Returns the absolute value of a decimal number.
-        /// </summary>
-        /// <param name="n">A number that is greater than or equal to MinValue, but less than or equal to MaxValue.</param>
-        /// <returns>A decimal number, x, such that 0 ≤ x ≤ MaxValue.</returns>
-        [Pure]
-        public static decimal Abs(decimal n) => Math.Abs(n);
-
-        /// <summary>
-        /// Returns the absolute value of a double number.
-        /// </summary>
-        /// <param name="n">A number that is greater than or equal to MinValue, but less than or equal to MaxValue.</param>
-        /// <returns>A double number, x, such that 0 ≤ x ≤ MaxValue.</returns>
-        [Pure]
-        public static double Abs(double n) => Math.Abs(n);
-
-        /// <summary>
-        /// Returns the absolute value of a short number.
-        /// </summary>
-        /// <param name="n">A number that is greater than or equal to MinValue, but less than or equal to MaxValue.</param>
-        /// <returns>A short number, x, such that 0 ≤ x ≤ MaxValue.</returns>
-        [Pure]
-        public static short Abs(short n) => Math.Abs(n);
-
-        /// <summary>
-        /// Returns the absolute value of a int number.
-        /// </summary>
-        /// <param name="n">A number that is greater than or equal to MinValue, but less than or equal to MaxValue.</param>
-        /// <returns>A int number, x, such that 0 ≤ x ≤ MaxValue.</returns>
-        [Pure]
-        public static int Abs(int n) => Math.Abs(n);
-
-        /// <summary>
-        /// Returns the absolute value of a long number.
-        /// </summary>
-        /// <param name="n">A number that is greater than or equal to MinValue, but less than or equal to MaxValue.</param>
-        /// <returns>A long number, x, such that 0 ≤ x ≤ MaxValue.</returns>
-        [Pure]
-        public static long Abs(long n) => Math.Abs(n);
-
-        /// <summary>
-        /// Returns the absolute value of a sbyte number.
-        /// </summary>
-        /// <param name="n">A number that is greater than or equal to MinValue, but less than or equal to MaxValue.</param>
-        /// <returns>A sbyte number, x, such that 0 ≤ x ≤ MaxValue.</returns>
-        [Pure]
-        public static sbyte Abs(sbyte n) => Math.Abs(n);
-
-        /// <summary>
-        /// Returns the absolute value of a float number.
-        /// </summary>
-        /// <param name="n">A number that is greater than or equal to MinValue, but less than or equal to MaxValue.</param>
-        /// <returns>A float number, x, such that 0 ≤ x ≤ MaxValue.</returns>
-        [Pure]
-        public static float Abs(float n) => Math.Abs(n);
-
-        /// <summary>
-        /// Returns the sine of the specified angle.
-        /// </summary>
-        /// <param name="radians">The specified angle.</param>
-        /// <returns>Sine of the angle. If radians is equal to NaN, NegativeInfinity, or PositiveInfinity, this method returns NaN.</returns>
-        [Pure]
-        public static double Sin(double radians) => Math.Sin(radians);
-
-        /// <summary>
-        /// Returns the hyperbolic sine of the specified angle.
-        /// </summary>
-        /// <param name="radians">The specified angle.</param>
-        /// <returns>Hyperbolic sine of the specified angle. If radians is equal to NaN, NegativeInfinity, or PositiveInfinity, this method returns NaN.</returns>
-        [Pure]
-        public static double Sinh(double radians) => Math.Sinh(radians);
-
-        /// <summary>
-        /// Returns the arc sine of the specified angle.
-        /// </summary>
-        /// <param name="radians">The specified angle.</param>
-        /// <returns>Arc sine of the specified angle. If radians is equal to NaN, NegativeInfinity, or PositiveInfinity, this method returns NaN.</returns>
-        [Pure]
-        public static double Asin(double radians) => Math.Asin(radians);
-
-        /// <summary>
-        /// Returns the cosine of the specified angle.
-        /// </summary>
-        /// <param name="radians">The specified angle.</param>
-        /// <returns>Cosine of the angle. If radians is equal to NaN, NegativeInfinity, or PositiveInfinity, this method returns NaN.</returns>
-        [Pure]
-        public static double Cos(double radians) => Math.Cos(radians);
-
-        /// <summary>
-        /// Returns the hyperbolic cosine of the specified angle.
-        /// </summary>
-        /// <param name="radians">The specified angle.</param>
-        /// <returns>Hyperbolic cosine of the specified angle. If radians is equal to NaN, NegativeInfinity, or PositiveInfinity, this method returns NaN.</returns>
-        [Pure]
-        public static double Cosh(double radians) => Math.Cosh(radians);
-
-        /// <summary>
-        /// Returns the arc sine of the specified angle.
-        /// </summary>
-        /// <param name="radians">The specified angle.</param>
-        /// <returns>Arc sine of the specified angle. If radians is equal to NaN, NegativeInfinity, or PositiveInfinity, this method returns NaN.</returns>
-        [Pure]
-        public static double Acos(double radians) => Math.Acos(radians);
-
-        /// <summary>
-        /// Returns the tangent of the specified angle.
-        /// </summary>
-        /// <param name="radians">The specified angle.</param>
-        /// <returns>Tangent of the specified angle. If radians is equal to NaN, NegativeInfinity, or PositiveInfinity, this method returns NaN.</returns>
-        [Pure]
-        public static double Tan(double radians) => Math.Tan(radians);
-
-        /// <summary>
-        /// Returns the hyperbolic tangent of the specified angle.
-        /// </summary>
-        /// <param name="radians">The specified angle.</param>
-        /// <returns>Hyperbolic tangent of the specified angle. If radians is equal to NaN, NegativeInfinity, or PositiveInfinity, this method returns NaN.</returns>
-        [Pure]
-        public static double Tanh(double radians) => Math.Tanh(radians);
-
-        /// <summary>
-        /// Returns the arc tangent of the specified angle.
-        /// </summary>
-        /// <param name="radians">The specified angle.</param>
-        /// <returns>Arc tangent of the specified angle. If radians is equal to NaN, NegativeInfinity, or PositiveInfinity, this method returns NaN.</returns>
-        [Pure]
-        public static double Atan(double radians) => Math.Atan(radians);
-
-        /// <summary>
-        /// Returns the angle whose tangent is the quotient of two specified numbers.
-        /// </summary>
-        /// <param name="y">The y coordinate of a point.</param>
-        /// <param name="x">The x coordinate of a point.</param>
-        /// <returns>An angle, θ, measured in radians, such that -π ≤ θ ≤ π, and tan(θ) = y / x, where (x, y) is a point in the Cartesian plane.</returns>
-        [Pure]
-        public static double Atan2(double y, double x) => Math.Atan2(y, x);
-
-        /// <summary>
-        /// Produces the full product of two 32-bit numbers.
-        /// </summary>
-        /// <param name="a">The first number to multiply.</param>
-        /// <param name="b">The second number to multiply.</param>
-        /// <returns>The number containing the product of the specified numbers.</returns>
-        [Pure]
-        public static long BigMul(int a, int b) => Math.BigMul(a, b);
-
-        /// <summary>
-        /// Returns the square root of a specified number.
-        /// </summary>
-        /// <param name="n">The number whose square root is to be found.</param>
-        /// <returns>The positive square root of n.</returns>
-        [Pure]
-        public static double Sqrt(double n) => Math.Sqrt(n);
-
-        /// <summary>
-        /// Returns a specified number raised to the specified power.
-        /// </summary>
-        /// <param name="x">A double-precision floating-point number to be raised to a power.</param>
-        /// <param name="y">A double-precision floating-point number that specifies a power.</param>
-        /// <returns>The number x raised to the power y.</returns>
-        [Pure]
-        public static double Pow(double x, double y) => Math.Pow(x, y);
-
-        /// <summary>
-        /// Returns the smallest integral value greater than or equal to the specified number.
-        /// </summary>
-        /// <param name="n">A decimal number.</param>
-        /// <returns>The smallest integral value that is greater than or equal to n. Note that this method returns a Decimal instead of an integral type.</returns>
-        [Pure]
-        public static decimal Ceiling(decimal n) => Math.Ceiling(n);
-
-        /// <summary>
-        /// Returns the smallest integral value greater than or equal to the specified number.
-        /// </summary>
-        /// <param name="n">A double-precision floating-point number.</param>
-        /// <returns>The smallest integral value that is greater than or equal to n. If n is equal to NaN, NegativeInfinity, or PositiveInfinity, that value is returned.
-        /// Note that this method returns a Double instead of an integral type.</returns>
-        [Pure]
-        public static double Ceiling(double n) => Math.Ceiling(n);
-
-        /// <summary>
-        /// Returns the largest integral value less than or equal to the specified number.
-        /// </summary>
-        /// <param name="n">A decimal number.</param>
-        /// <returns>Returns the largest integral value less than or equal to the specified decimal number.</returns>
-        [Pure]
-        public static decimal Floor(decimal n) => Math.Floor(n);
-
-        /// <summary>
-        /// Returns the largest integral value less than or equal to the specified number.
-        /// </summary>
-        /// <param name="n">A double-precision floating-point number.</param>
-        /// <returns>Returns the largest integral value less than or equal to the specified double-precision floating-point number.</returns>
-        [Pure]
-        public static double Floor(double n) => Math.Floor(n);
-
-        /// <summary>
-        /// Calculates the quotient of two integers and also returns the remainder in an output parameter.
-        /// </summary>
-        /// <param name="a">The dividend.</param>
-        /// <param name="b">The divisor.</param>
-        /// <param name="result">The remainder.</param>
-        /// <returns>The quotient of the specified numbers.</returns>
-        /// <exception cref="DivideByZeroException">b is zero.</exception>
-        [Pure]
-        public static int DivRem(int a, int b, out int result) => Math.DivRem(a, b, out result);
-
-        /// <summary>
-        /// Calculates the quotient of two longs and also returns the remainder in an output parameter.
-        /// </summary>
-        /// <param name="a">The dividend.</param>
-        /// <param name="b">The divisor.</param>
-        /// <param name="result">The remainder.</param>
-        /// <returns>The quotient of the specified numbers.</returns>
-        /// <exception cref="DivideByZeroException">b is zero.</exception>
-        [Pure]
-        public static long DivRem(long a, long b, out long result) => Math.DivRem(a, b, out result);
-
-        /// <summary>
-        /// Returns the natural (base e) logarithm of a specified number.
-        /// </summary>
-        /// <param name="n">A number whose logarithm is to be found.</param>
-        /// <returns>The natural logarithm of n.</returns>
-        [Pure]
-        public static double Log(double n) => Math.Log(n);
-
-        /// <summary>
-        /// Returns the logarithm of a specified number in a specified base.
-        /// </summary>
-        /// <param name="n">The specified number.</param>
-        /// <param name="newBase">The specified base.</param>
-        /// <returns>The base newBase logarithm of n.</returns>
-        [Pure]
-        public static double Log(double n, double newBase) => Math.Log(n, newBase);
-
-        /// <summary>
-        /// Returns the base 10 logarithm of a specified number.
-        /// </summary>
-        /// <param name="n">The specified number.</param>
-        /// <returns>The base 10 log of n.</returns>
-        [Pure]
-        public static double Log10(double n) => Math.Log10(n);
-
-        /// <summary>
-        /// Returns the base 2 logarithm of a specified number.
-        /// </summary>
-        /// <param name="n">The specified number.</param>
-        /// <returns>The base 2 log of n.</returns>
-        /// <remarks>This one will be implemented by System.Math from .netcore 3.0 and onwards.</remarks>
-        [Pure]
-        public static double Log2(double n) => Math.Log(n, 2);
-
-        /// <summary>
-        /// Returns e raised to the specified power.
-        /// </summary>
-        /// <param name="n">The specified power.</param>
-        /// <returns>The number e raised to the power n. If n equals NaN or PositiveInfinity, that value is returned. If n equals NegativeInfinity, 0 is returned.</returns>
-        [Pure]
-        public static double Exp(double n) => Math.Exp(n);
-
-        /// <summary>
-        /// Returns the remainder resulting from the division of a specified number by another specified number.
-        /// </summary>
-        /// <param name="a">A dividend.</param>
-        /// <param name="b">A divisor.</param>
-        /// <returns>A number equal to a - (b Q), where Q is the quotient of a / b rounded to the nearest integer (if a / b falls halfway between two integers, the even integer is returned).
-        /// If a - (b Q) is zero, the value +0 is returned if a is positive, or -0 if a is negative.
-        /// If b = 0, NaN is returned.</returns>
-        [Pure]
-        public static double IEEERemainder(double a, double b) => Math.IEEERemainder(a, b);
-
-        /// <summary>
-        /// Returns the larger of two bytes.
-        /// </summary>
-        /// <param name="a">The first of two bytes to compare.</param>
-        /// <param name="b">The second of two bytes to compare.</param>
-        /// <returns>Parameter a or b, whichever is larger.</returns>
-        [Pure]
-        public static byte Max(byte a, byte b) => Math.Max(a, b);
-
-        /// <summary>
-        /// Returns the larger of two sbytes.
-        /// </summary>
-        /// <param name="a">The first of two sbytes to compare.</param>
-        /// <param name="b">The second of two sbytes to compare.</param>
-        /// <returns>Parameter a or b, whichever is larger.</returns>
-        [Pure]
-        public static sbyte Max(sbyte a, sbyte b) => Math.Max(a, b);
-
-        /// <summary>
-        /// Returns the larger of two shorts.
-        /// </summary>
-        /// <param name="a">The first of two shorts to compare.</param>
-        /// <param name="b">The second of two shorts to compare.</param>
-        /// <returns>Parameter a or b, whichever is larger.</returns>
-        [Pure]
-        public static short Max(short a, short b) => Math.Max(a, b);
-
-        /// <summary>
-        /// Returns the larger of two ushorts.
-        /// </summary>
-        /// <param name="a">The first of two ushorts to compare.</param>
-        /// <param name="b">The second of two ushorts to compare.</param>
-        /// <returns>Parameter a or b, whichever is larger.</returns>
-        [Pure]
-        public static ushort Max(ushort a, ushort b) => Math.Max(a, b);
-
-        /// <summary>
-        /// Returns the larger of two decimals.
-        /// </summary>
-        /// <param name="a">The first of two decimals to compare.</param>
-        /// <param name="b">The second of two decimals to compare.</param>
-        /// <returns>Parameter a or b, whichever is larger.</returns>
-        [Pure]
-        public static decimal Max(decimal a, decimal b) => Math.Max(a, b);
-
-        /// <summary>
-        /// Returns the larger of two ints.
-        /// </summary>
-        /// <param name="a">The first of two ints to compare.</param>
-        /// <param name="b">The second of two ints to compare.</param>
-        /// <returns>Parameter a or b, whichever is larger.</returns>
-        [Pure]
-        public static int Max(int a, int b) => Math.Max(a, b);
-
-        /// <summary>
-        /// Returns the larger of two uints.
-        /// </summary>
-        /// <param name="a">The first of two uints to compare.</param>
-        /// <param name="b">The second of two uints to compare.</param>
-        /// <returns>Parameter a or b, whichever is larger.</returns>
-        [Pure]
-        public static uint Max(uint a, uint b) => Math.Max(a, b);
-
-        /// <summary>
-        /// Returns the larger of two floats.
-        /// </summary>
-        /// <param name="a">The first of two floats to compare.</param>
-        /// <param name="b">The second of two floats to compare.</param>
-        /// <returns>Parameter a or b, whichever is larger.</returns>
-        [Pure]
-        public static float Max(float a, float b) => Math.Max(a, b);
-
-        /// <summary>
-        /// Returns the larger of two longs.
-        /// </summary>
-        /// <param name="a">The first of two longs to compare.</param>
-        /// <param name="b">The second of two longs to compare.</param>
-        /// <returns>Parameter a or b, whichever is larger.</returns>
-        [Pure]
-        public static long Max(long a, long b) => Math.Max(a, b);
-
-        /// <summary>
-        /// Returns the larger of two ulongs.
-        /// </summary>
-        /// <param name="a">The first of two ulongs to compare.</param>
-        /// <param name="b">The second of two ulongs to compare.</param>
-        /// <returns>Parameter a or b, whichever is larger.</returns>
-        [Pure]
-        public static ulong Max(ulong a, ulong b) => Math.Max(a, b);
-
-        /// <summary>
-        /// Returns the smaller of two bytes.
-        /// </summary>
-        /// <param name="a">The first of two bytes to compare.</param>
-        /// <param name="b">The second of two bytes to compare.</param>
-        /// <returns>Parameter a or b, whichever is smaller.</returns>
-        [Pure]
-        public static byte Min(byte a, byte b) => Math.Min(a, b);
-
-        /// <summary>
-        /// Returns the smaller of two sbytes.
-        /// </summary>
-        /// <param name="a">The first of two sbytes to compare.</param>
-        /// <param name="b">The second of two sbytes to compare.</param>
-        /// <returns>Parameter a or b, whichever is smaller.</returns>
-        [Pure]
-        public static sbyte Min(sbyte a, sbyte b) => Math.Min(a, b);
-
-        /// <summary>
-        /// Returns the smaller of two shorts.
-        /// </summary>
-        /// <param name="a">The first of two shorts to compare.</param>
-        /// <param name="b">The second of two shorts to compare.</param>
-        /// <returns>Parameter a or b, whichever is smaller.</returns>
-        [Pure]
-        public static short Min(short a, short b) => Math.Min(a, b);
-
-        /// <summary>
-        /// Returns the smaller of two ushorts.
-        /// </summary>
-        /// <param name="a">The first of two ushorts to compare.</param>
-        /// <param name="b">The second of two ushorts to compare.</param>
-        /// <returns>Parameter a or b, whichever is smaller.</returns>
-        [Pure]
-        public static ushort Min(ushort a, ushort b) => Math.Min(a, b);
-
-        /// <summary>
-        /// Returns the smaller of two decimals.
-        /// </summary>
-        /// <param name="a">The first of two decimals to compare.</param>
-        /// <param name="b">The second of two decimals to compare.</param>
-        /// <returns>Parameter a or b, whichever is smaller.</returns>
-        [Pure]
-        public static decimal Min(decimal a, decimal b) => Math.Min(a, b);
-
-        /// <summary>
-        /// Returns the smaller of two ints.
-        /// </summary>
-        /// <param name="a">The first of two ints to compare.</param>
-        /// <param name="b">The second of two ints to compare.</param>
-        /// <returns>Parameter a or b, whichever is smaller.</returns>
-        [Pure]
-        public static int Min(int a, int b) => Math.Min(a, b);
-
-        /// <summary>
-        /// Returns the smaller of two uints.
-        /// </summary>
-        /// <param name="a">The first of two uints to compare.</param>
-        /// <param name="b">The second of two uints to compare.</param>
-        /// <returns>Parameter a or b, whichever is smaller.</returns>
-        [Pure]
-        public static uint Min(uint a, uint b) => Math.Min(a, b);
-
-        /// <summary>
-        /// Returns the smaller of two floats.
-        /// </summary>
-        /// <param name="a">The first of two floats to compare.</param>
-        /// <param name="b">The second of two floats to compare.</param>
-        /// <returns>Parameter a or b, whichever is smaller.</returns>
-        [Pure]
-        public static float Min(float a, float b) => Math.Min(a, b);
-
-        /// <summary>
-        /// Returns the smaller of two floats.
-        /// </summary>
-        /// <param name="a">The first of two floats to compare.</param>
-        /// <param name="b">The second of two floats to compare.</param>
-        /// <returns>Parameter a or b, whichever is smaller.</returns>
-        [Pure]
-        public static double Min(double a, double b) => Math.Min(a, b);
-
-        /// <summary>
-        /// Returns the smaller of two longs.
-        /// </summary>
-        /// <param name="a">The first of two longs to compare.</param>
-        /// <param name="b">The second of two longs to compare.</param>
-        /// <returns>Parameter a or b, whichever is smaller.</returns>
-        [Pure]
-        public static long Min(long a, long b) => Math.Min(a, b);
-
-        /// <summary>
-        /// Returns the smaller of two ulongs.
-        /// </summary>
-        /// <param name="a">The first of two ulongs to compare.</param>
-        /// <param name="b">The second of two ulongs to compare.</param>
-        /// <returns>Parameter a or b, whichever is smaller.</returns>
-        [Pure]
-        public static ulong Min(ulong a, ulong b) => Math.Min(a, b);
-
-        /// <summary>
-        /// Rounds a decimal value to a specified number of fractional digits, and uses the specified rounding convention for midpoint values.
-        /// </summary>
-        /// <param name="d">A decimal number to be rounded.</param>
-        /// <param name="digits">The number of decimal places in the return value.</param>
-        /// <param name="mode">Specification for how to round d if it is midway between two other numbers.</param>
-        /// <returns>The number nearest to d that contains a number of fractional digits equal to digits. If d has fewer fractional digits than digits, d is returned unchanged.</returns>
-        /// <exception cref="ArgumentOutOfRangeException">digits is less than 0 or greater than 28.</exception>
-        /// <exception cref="ArgumentException">mode is not a valid value of MidpointRounding.</exception>
-        /// <exception cref="OverflowException">The result is outside the range of a Decimal.</exception>
-        [Pure]
-        public static decimal Round(decimal d, int digits, MidpointRounding mode) => Math.Round(d, digits, mode);
-
-        /// <summary>
-        /// Rounds a double-precision floating-point value to a specified number of fractional digits, and uses the specified rounding convention for midpoint values.
-        /// </summary>
-        /// <param name="d">A double-precision floating-point number to be rounded.</param>
-        /// <param name="digits">The number of fractional digits in the return value.</param>
-        /// <param name="mode">Specification for how to round d if it is midway between two other numbers.</param>
-        /// <returns>The number nearest to d that has a number of fractional digits equal to digits. If d has fewer fractional digits than digits, d is returned unchanged.</returns>
-        /// <exception cref="ArgumentOutOfRangeException">digits is less than 0 or greater than 15.</exception>
-        /// <exception cref="ArgumentException">mode is not a valid value of MidpointRounding.</exception>
-        [Pure]
-        public static double Round(double d, int digits, MidpointRounding mode) => Math.Round(d, digits, mode);
-
-        /// <summary>
-        /// Rounds a decimal value to the nearest integer, and uses the specified rounding convention for midpoint values.
-        /// </summary>
-        /// <param name="d">A decimal number to be rounded.</param>
-        /// <param name="mode">Specification for how to round d if it is midway between two other numbers.</param>
-        /// <returns>The integer nearest d. If d is halfway between two numbers, one of which is even and the other odd, then mode determines which of the two is returned.
-        /// Note that this method returns a Decimal instead of an integral type.</returns>
-        /// <exception cref="ArgumentException">mode is not a valid value of MidpointRounding.</exception>
-        /// <exception cref="OverflowException">The result is outside the range of a Decimal.</exception>
-        [Pure]
-        public static decimal Round(decimal d, MidpointRounding mode) => Math.Round(d, mode);
-
-        /// <summary>
-        /// Rounds a double-precision floating-point value to the nearest integer, and uses the specified rounding convention for midpoint values.
-        /// </summary>
-        /// <param name="d">A double-precision floating-point number to be rounded.</param>
-        /// <param name="mode">Specification for how to round d if it is midway between two other numbers.</param>
-        /// <returns>The integer nearest d. If d is halfway between two integers, one of which is even and the other odd, then mode determines which of the two is returned.
-        /// Note that this method returns a Double instead of an integral type.</returns>
-        /// <exception cref="ArgumentException">mode is not a valid value of MidpointRounding.</exception>
-        [Pure]
-        public static double Round(double d, MidpointRounding mode) => Math.Round(d, mode);
-
-        /// <summary>
-        /// Rounds a decimal value to a specified number of fractional digits, and rounds midpoint values to the nearest even number.
-        /// </summary>
-        /// <param name="d">A decimal number to be rounded.</param>
-        /// <param name="digits">The number of fractional digits in the return value.</param>
-        /// <returns>The number nearest to d that contains a number of fractional digits equal to digits.</returns>
-        /// <exception cref="ArgumentOutOfRangeException"> digits is less than 0 or greater than 15.</exception>
-        /// <exception cref="OverflowException">The result is outside the range of a Decimal.</exception>
-        [Pure]
-        public static decimal Round(decimal d, int digits) => Math.Round(d, digits);
-
-        /// <summary>
-        /// Rounds a double-precision floating-point value to a specified number of fractional digits, and rounds midpoint values to the nearest even number.
-        /// </summary>
-        /// <param name="d">A double-precision floating-point number to be rounded.</param>
-        /// <param name="digits">The number of fractional digits in the return value.</param>
-        /// <returns>The number nearest to value that contains a number of fractional digits equal to digits.</returns>
-        /// <exception cref="ArgumentOutOfRangeException"> digits is less than 0 or greater than 15.</exception>
-        [Pure]
-        public static double Round(double d, int digits) => Math.Round(d, digits);
-
-        /// <summary>
-        /// Rounds a decimal value to the nearest integral value, and rounds midpoint values to the nearest even number.
-        /// </summary>
-        /// <param name="d">A decimal number to be rounded.</param>
-        /// <returns>The integer nearest the d parameter. If the fractional component of d is halfway between two integers, one of which is even and the other odd, the even number is returned.
-        /// Note that this method returns a Decimal instead of an integral type.</returns>
-        /// <exception cref="OverflowException">The result is outside the range of a Decimal.</exception>
-        [Pure]
-        public static decimal Round(decimal d) => Math.Round(d);
-
-        /// <summary>
-        /// Rounds a double-precision floating-point value to the nearest integral value, and rounds midpoint values to the nearest even number.
-        /// </summary>
-        /// <param name="d">A double-precision floating-point number to be rounded.</param>
-        /// <returns>The integer nearest d. If the fractional component of d is halfway between two integers, one of which is even and the other odd, then the even number is returned.
-        /// Note that this method returns a Double instead of an integral type.</returns>
-        [Pure]
-        public static double Round(double d) => Math.Round(d);
-
-        /// <summary>
-        /// Calculates the integral part of a specified decimal number.
-        /// </summary>
-        /// <param name="d">A number to truncate.</param>
-        /// <returns>The integral part of d; that is, the number that remains after any fractional digits have been discarded.</returns>
-        [Pure]
-        public static decimal Truncate(decimal d) => Math.Truncate(d);
-
-        /// <summary>
-        /// Calculates the integral part of a specified double-precision floating-point number.
-        /// </summary>
-        /// <param name="d">A number to truncate.</param>
-        /// <returns>The integral part of d; that is, the number that remains after any fractional digits have been discarded, or one of the values listed in the following table.</returns>
-        [Pure]
-        public static double Truncate(double d) => Math.Truncate(d);
-
-        /// <summary>
-        /// Returns an integer that indicates the sign of a sbyte.
-        /// </summary>
-        /// <param name="d">A signed number.</param>
-        /// <returns>If d ≤ -1 returns -1, if 1 ≤ d returns 1 and if d = 0 returns 0.</returns>
-        [Pure]
-        public static int Sign(sbyte d) => Math.Sign(d);
-
-        /// <summary>
-        /// Returns an integer that indicates the sign of a short.
-        /// </summary>
-        /// <param name="d">A signed number.</param>
-        /// <returns>If d ≤ -1 returns -1, if 1 ≤ d returns 1 and if d = 0 returns 0.</returns>
-        [Pure]
-        public static int Sign(short d) => Math.Sign(d);
-
-        /// <summary>
-        /// Returns an integer that indicates the sign of a int.
-        /// </summary>
-        /// <param name="d">A signed number.</param>
-        /// <returns>If d ≤ -1 returns -1, if 1 ≤ d returns 1 and if d = 0 returns 0.</returns>
-        [Pure]
-        public static int Sign(int d) => Math.Sign(d);
-
-        /// <summary>
-        /// Returns an integer that indicates the sign of a float.
-        /// </summary>
-        /// <param name="d">A signed number.</param>
-        /// <returns>If d ≤ -1 returns -1, if 1 ≤ d returns 1 and if d = 0 returns 0.</returns>
-        [Pure]
-        public static int Sign(float d) => Math.Sign(d);
-
-        /// <summary>
-        /// Returns an integer that indicates the sign of a decimal.
-        /// </summary>
-        /// <param name="d">A signed number.</param>
-        /// <returns>If d ≤ -1 returns -1, if 1 ≤ d returns 1 and if d = 0 returns 0.</returns>
-        [Pure]
-        public static int Sign(decimal d) => Math.Sign(d);
-
-        /// <summary>
-        /// Returns an integer that indicates the sign of a double.
-        /// </summary>
-        /// <param name="d">A signed number.</param>
-        /// <returns>If d ≤ -1 returns -1, if 1 ≤ d returns 1 and if d = 0 returns 0.</returns>
-        [Pure]
-        public static int Sign(double d) => Math.Sign(d);
-
-        /// <summary>
-        /// Returns an integer that indicates the sign of a long.
-        /// </summary>
-        /// <param name="d">A signed number.</param>
-        /// <returns>If d ≤ -1 returns -1, if 1 ≤ d returns 1 and if d = 0 returns 0.</returns>
-        [Pure]
-        public static int Sign(long d) => Math.Sign(d);
 
         /// <summary>
         /// Returns the next power of two that is greater than or equal to the specified number.
@@ -882,72 +252,22 @@ namespace OpenToolkit.Mathematics
         }
 
         /// <summary>
-        /// Swaps two double values.
+        /// Swaps two values.
         /// </summary>
         /// <param name="a">The first value.</param>
         /// <param name="b">The second value.</param>
-        public static void Swap(ref double a, ref double b)
+        /// <typeparam name="T">The type of the values to be swapped.</typeparam>
+        public static void Swap<T>(ref T a, ref T b) where T : struct
         {
-            var temp = a;
+            T temp = a;
             a = b;
             b = temp;
-        }
-
-        /// <summary>
-        /// Swaps two float values.
-        /// </summary>
-        /// <param name="a">The first value.</param>
-        /// <param name="b">The second value.</param>
-        public static void Swap(ref float a, ref float b)
-        {
-            var temp = a;
-            a = b;
-            b = temp;
-        }
-
-        /// <summary>
-        /// Clamps a number between a minimum and a maximum.
-        /// </summary>
-        /// <param name="n">The number to clamp.</param>
-        /// <param name="min">The minimum allowed value.</param>
-        /// <param name="max">The maximum allowed value.</param>
-        /// <returns>min, if n is lower than min; max, if n is higher than max; n otherwise.</returns>
-        [Pure]
-        public static int Clamp(int n, int min, int max)
-        {
-            return Math.Max(Math.Min(n, max), min);
-        }
-
-        /// <summary>
-        /// Clamps a number between a minimum and a maximum.
-        /// </summary>
-        /// <param name="n">The number to clamp.</param>
-        /// <param name="min">The minimum allowed value.</param>
-        /// <param name="max">The maximum allowed value.</param>
-        /// <returns>min, if n is lower than min; max, if n is higher than max; n otherwise.</returns>
-        [Pure]
-        public static float Clamp(float n, float min, float max)
-        {
-            return Math.Max(Math.Min(n, max), min);
-        }
-
-        /// <summary>
-        /// Clamps a number between a minimum and a maximum.
-        /// </summary>
-        /// <param name="n">The number to clamp.</param>
-        /// <param name="min">The minimum allowed value.</param>
-        /// <param name="max">The maximum allowed value.</param>
-        /// <returns>min, if n is lower than min; max, if n is higher than max; n otherwise.</returns>
-        [Pure]
-        public static double Clamp(double n, double min, double max)
-        {
-            return Math.Max(Math.Min(n, max), min);
         }
 
         [Pure]
         private static unsafe int FloatToInt32Bits(float f)
         {
-            return *((int*)&f);
+            return *(int*)&f;
         }
 
         /// <summary>
@@ -974,7 +294,7 @@ namespace OpenToolkit.Mathematics
                 throw new ArgumentOutOfRangeException();
             }
 
-            value = Clamp(value, valueMin, valueMax);
+            value = Math.Clamp(value, valueMin, valueMax);
 
             var range = resultMax - resultMin;
             long temp = (value - valueMin) * range; // need long to avoid overflow
@@ -1144,7 +464,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static float Lerp(float start, float end, float t)
         {
-            t = Clamp(t, 0, 1);
+            t = Math.Clamp(t, 0, 1);
             return start + (t * (end - start));
         }
 
@@ -1199,7 +519,7 @@ namespace OpenToolkit.Mathematics
             if (angle > PiOver2)
             {
                 // shift angle to range (-π, π]
-                angle -= 2 * Pi;
+                angle -= 2 * MathF.PI;
             }
 
             return angle;
@@ -1218,7 +538,7 @@ namespace OpenToolkit.Mathematics
             if (angle > PiOver2)
             {
                 // shift angle to range (-π, π]
-                angle -= 2 * Pi;
+                angle -= 2 * MathF.PI;
             }
 
             return angle;
@@ -1235,7 +555,7 @@ namespace OpenToolkit.Mathematics
             angle %= 360f;
 
             // abs angle so it's in the range [0, 360)
-            angle = Abs(angle);
+            angle = MathF.Abs(angle);
 
             return angle;
         }
@@ -1251,7 +571,7 @@ namespace OpenToolkit.Mathematics
             angle %= 360f;
 
             // abs angle so it's in the range [0, 360)
-            angle = Abs(angle);
+            angle = Math.Abs(angle);
 
             return angle;
         }
@@ -1264,10 +584,10 @@ namespace OpenToolkit.Mathematics
         public static float ClampRadians(float angle)
         {
             // mod angle so it's in the range (-2π,2π)
-            angle %= 2 * Pi;
+            angle %= 2 * MathF.PI;
 
             // abs angle so it's in the range [0,2π)
-            angle = Abs(angle);
+            angle = Math.Abs(angle);
 
             return angle;
         }
@@ -1280,10 +600,10 @@ namespace OpenToolkit.Mathematics
         public static double ClampRadians(double angle)
         {
             // mod angle so it's in the range (-2π,2π)
-            angle %= 2 * Pi;
+            angle %= 2 * MathF.PI;
 
             // abs angle so it's in the range [0,2π)
-            angle = Abs(angle);
+            angle = Math.Abs(angle);
 
             return angle;
         }

--- a/src/OpenToolkit.Mathematics/MathHelper.cs
+++ b/src/OpenToolkit.Mathematics/MathHelper.cs
@@ -732,7 +732,7 @@ namespace OpenToolkit.Mathematics
                 throw new ArgumentOutOfRangeException(nameof(n), "Must be positive.");
             }
 
-            return (float)Math.Pow(2, Math.Ceiling(Math.Log(n, 2)));
+            return MathF.Pow(2, MathF.Ceiling(MathF.Log(n, 2)));
         }
 
         /// <summary>
@@ -841,7 +841,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static float DegreesToRadians(float degrees)
         {
-            const float degToRad = (float)Math.PI / 180.0f;
+            const float degToRad = MathF.PI / 180.0f;
             return degrees * degToRad;
         }
 
@@ -853,7 +853,7 @@ namespace OpenToolkit.Mathematics
         [Pure]
         public static float RadiansToDegrees(float radians)
         {
-            const float radToDeg = 180.0f / (float)Math.PI;
+            const float radToDeg = 180.0f / MathF.PI;
             return radians * radToDeg;
         }
 

--- a/src/OpenToolkit.Mathematics/Matrix/Matrix2.cs
+++ b/src/OpenToolkit.Mathematics/Matrix/Matrix2.cs
@@ -241,8 +241,8 @@ namespace OpenToolkit.Mathematics
         /// <param name="result">The resulting Matrix2 instance.</param>
         public static void CreateRotation(float angle, out Matrix2 result)
         {
-            var cos = (float)Math.Cos(angle);
-            var sin = (float)Math.Sin(angle);
+            var cos = MathF.Cos(angle);
+            var sin = MathF.Sin(angle);
 
             result.Row0.X = cos;
             result.Row0.Y = sin;

--- a/src/OpenToolkit.Mathematics/Matrix/Matrix2x3.cs
+++ b/src/OpenToolkit.Mathematics/Matrix/Matrix2x3.cs
@@ -237,8 +237,8 @@ namespace OpenToolkit.Mathematics
         /// <param name="result">The resulting Matrix2x3 instance.</param>
         public static void CreateRotation(float angle, out Matrix2x3 result)
         {
-            var cos = (float)Math.Cos(angle);
-            var sin = (float)Math.Sin(angle);
+            var cos = MathF.Cos(angle);
+            var sin = MathF.Sin(angle);
 
             result.Row0.X = cos;
             result.Row0.Y = sin;

--- a/src/OpenToolkit.Mathematics/Matrix/Matrix2x4.cs
+++ b/src/OpenToolkit.Mathematics/Matrix/Matrix2x4.cs
@@ -270,8 +270,8 @@ namespace OpenToolkit.Mathematics
         /// <param name="result">The resulting Matrix2x4 instance.</param>
         public static void CreateRotation(float angle, out Matrix2x4 result)
         {
-            var cos = (float)Math.Cos(angle);
-            var sin = (float)Math.Sin(angle);
+            var cos = MathF.Cos(angle);
+            var sin = MathF.Sin(angle);
 
             result.Row0.X = cos;
             result.Row0.Y = sin;

--- a/src/OpenToolkit.Mathematics/Matrix/Matrix3.cs
+++ b/src/OpenToolkit.Mathematics/Matrix/Matrix3.cs
@@ -467,8 +467,8 @@ namespace OpenToolkit.Mathematics
             float axisX = axis.X, axisY = axis.Y, axisZ = axis.Z;
 
             // calculate angles
-            var cos = (float)Math.Cos(-angle);
-            var sin = (float)Math.Sin(-angle);
+            var cos = MathF.Cos(-angle);
+            var sin = MathF.Sin(-angle);
             var t = 1.0f - cos;
 
             // do the conversion math once
@@ -537,8 +537,8 @@ namespace OpenToolkit.Mathematics
         /// <param name="result">The resulting Matrix3 instance.</param>
         public static void CreateRotationX(float angle, out Matrix3 result)
         {
-            var cos = (float)Math.Cos(angle);
-            var sin = (float)Math.Sin(angle);
+            var cos = MathF.Cos(angle);
+            var sin = MathF.Sin(angle);
 
             result = Identity;
             result.Row1.Y = cos;
@@ -566,8 +566,8 @@ namespace OpenToolkit.Mathematics
         /// <param name="result">The resulting Matrix3 instance.</param>
         public static void CreateRotationY(float angle, out Matrix3 result)
         {
-            var cos = (float)Math.Cos(angle);
-            var sin = (float)Math.Sin(angle);
+            var cos = MathF.Cos(angle);
+            var sin = MathF.Sin(angle);
 
             result = Identity;
             result.Row0.X = cos;
@@ -595,8 +595,8 @@ namespace OpenToolkit.Mathematics
         /// <param name="result">The resulting Matrix3 instance.</param>
         public static void CreateRotationZ(float angle, out Matrix3 result)
         {
-            var cos = (float)Math.Cos(angle);
-            var sin = (float)Math.Sin(angle);
+            var cos = MathF.Cos(angle);
+            var sin = MathF.Sin(angle);
 
             result = Identity;
             result.Row0.X = cos;

--- a/src/OpenToolkit.Mathematics/Matrix/Matrix3x2.cs
+++ b/src/OpenToolkit.Mathematics/Matrix/Matrix3x2.cs
@@ -244,8 +244,8 @@ namespace OpenToolkit.Mathematics
         /// <param name="result">The resulting Matrix3x2 instance.</param>
         public static void CreateRotation(float angle, out Matrix3x2 result)
         {
-            var cos = (float)Math.Cos(angle);
-            var sin = (float)Math.Sin(angle);
+            var cos = MathF.Cos(angle);
+            var sin = MathF.Sin(angle);
 
             result.Row0.X = cos;
             result.Row0.Y = sin;

--- a/src/OpenToolkit.Mathematics/Matrix/Matrix3x4.cs
+++ b/src/OpenToolkit.Mathematics/Matrix/Matrix3x4.cs
@@ -312,8 +312,8 @@ namespace OpenToolkit.Mathematics
             axis.Normalize();
             float axisX = axis.X, axisY = axis.Y, axisZ = axis.Z;
 
-            var cos = (float)Math.Cos(angle);
-            var sin = (float)Math.Sin(angle);
+            var cos = MathF.Cos(angle);
+            var sin = MathF.Sin(angle);
             var t = 1.0f - cos;
 
             float tXX = t * axisX * axisX;
@@ -411,8 +411,8 @@ namespace OpenToolkit.Mathematics
         /// <param name="result">The resulting Matrix4 instance.</param>
         public static void CreateRotationX(float angle, out Matrix3x4 result)
         {
-            var cos = (float)Math.Cos(angle);
-            var sin = (float)Math.Sin(angle);
+            var cos = MathF.Cos(angle);
+            var sin = MathF.Sin(angle);
 
             result.Row0.X = 1;
             result.Row0.Y = 0;
@@ -447,8 +447,8 @@ namespace OpenToolkit.Mathematics
         /// <param name="result">The resulting Matrix4 instance.</param>
         public static void CreateRotationY(float angle, out Matrix3x4 result)
         {
-            var cos = (float)Math.Cos(angle);
-            var sin = (float)Math.Sin(angle);
+            var cos = MathF.Cos(angle);
+            var sin = MathF.Sin(angle);
 
             result.Row0.X = cos;
             result.Row0.Y = 0;
@@ -483,8 +483,8 @@ namespace OpenToolkit.Mathematics
         /// <param name="result">The resulting Matrix4 instance.</param>
         public static void CreateRotationZ(float angle, out Matrix3x4 result)
         {
-            var cos = (float)Math.Cos(angle);
-            var sin = (float)Math.Sin(angle);
+            var cos = MathF.Cos(angle);
+            var sin = MathF.Sin(angle);
 
             result.Row0.X = cos;
             result.Row0.Y = sin;

--- a/src/OpenToolkit.Mathematics/Matrix/Matrix4.cs
+++ b/src/OpenToolkit.Mathematics/Matrix/Matrix4.cs
@@ -671,8 +671,8 @@ namespace OpenToolkit.Mathematics
             float axisX = axis.X, axisY = axis.Y, axisZ = axis.Z;
 
             // calculate angles
-            var cos = (float)Math.Cos(-angle);
-            var sin = (float)Math.Sin(-angle);
+            var cos = MathF.Cos(-angle);
+            var sin = MathF.Sin(-angle);
             var t = 1.0f - cos;
 
             // do the conversion math once
@@ -745,8 +745,8 @@ namespace OpenToolkit.Mathematics
         /// <param name="result">The resulting Matrix4 instance.</param>
         public static void CreateRotationX(float angle, out Matrix4 result)
         {
-            var cos = (float)Math.Cos(angle);
-            var sin = (float)Math.Sin(angle);
+            var cos = MathF.Cos(angle);
+            var sin = MathF.Sin(angle);
 
             result = Identity;
             result.Row1.Y = cos;
@@ -774,8 +774,8 @@ namespace OpenToolkit.Mathematics
         /// <param name="result">The resulting Matrix4 instance.</param>
         public static void CreateRotationY(float angle, out Matrix4 result)
         {
-            var cos = (float)Math.Cos(angle);
-            var sin = (float)Math.Sin(angle);
+            var cos = MathF.Cos(angle);
+            var sin = MathF.Sin(angle);
 
             result = Identity;
             result.Row0.X = cos;
@@ -803,8 +803,8 @@ namespace OpenToolkit.Mathematics
         /// <param name="result">The resulting Matrix4 instance.</param>
         public static void CreateRotationZ(float angle, out Matrix4 result)
         {
-            var cos = (float)Math.Cos(angle);
-            var sin = (float)Math.Sin(angle);
+            var cos = MathF.Cos(angle);
+            var sin = MathF.Sin(angle);
 
             result = Identity;
             result.Row0.X = cos;
@@ -1094,7 +1094,7 @@ namespace OpenToolkit.Mathematics
                 throw new ArgumentOutOfRangeException(nameof(depthFar));
             }
 
-            var maxY = depthNear * (float)Math.Tan(0.5f * fovy);
+            var maxY = depthNear * MathF.Tan(0.5f * fovy);
             var minY = -maxY;
             var minX = minY * aspect;
             var maxX = maxY * aspect;

--- a/src/OpenToolkit.Mathematics/Matrix/Matrix4x2.cs
+++ b/src/OpenToolkit.Mathematics/Matrix/Matrix4x2.cs
@@ -284,8 +284,8 @@ namespace OpenToolkit.Mathematics
         /// <param name="result">The resulting Matrix3x2 instance.</param>
         public static void CreateRotation(float angle, out Matrix4x2 result)
         {
-            var cos = (float)Math.Cos(angle);
-            var sin = (float)Math.Sin(angle);
+            var cos = MathF.Cos(angle);
+            var sin = MathF.Sin(angle);
 
             result.Row0.X = cos;
             result.Row0.Y = sin;

--- a/src/OpenToolkit.Mathematics/Matrix/Matrix4x3.cs
+++ b/src/OpenToolkit.Mathematics/Matrix/Matrix4x3.cs
@@ -325,8 +325,8 @@ namespace OpenToolkit.Mathematics
             axis.Normalize();
             float axisX = axis.X, axisY = axis.Y, axisZ = axis.Z;
 
-            var cos = (float)Math.Cos(-angle);
-            var sin = (float)Math.Sin(-angle);
+            var cos = MathF.Cos(-angle);
+            var sin = MathF.Sin(-angle);
             var t = 1.0f - cos;
 
             float tXX = t * axisX * axisX;
@@ -424,8 +424,8 @@ namespace OpenToolkit.Mathematics
         /// <param name="result">The resulting Matrix4 instance.</param>
         public static void CreateRotationX(float angle, out Matrix4x3 result)
         {
-            var cos = (float)Math.Cos(angle);
-            var sin = (float)Math.Sin(angle);
+            var cos = MathF.Cos(angle);
+            var sin = MathF.Sin(angle);
 
             result.Row0.X = 1;
             result.Row0.Y = 0;
@@ -460,8 +460,8 @@ namespace OpenToolkit.Mathematics
         /// <param name="result">The resulting Matrix4 instance.</param>
         public static void CreateRotationY(float angle, out Matrix4x3 result)
         {
-            var cos = (float)Math.Cos(angle);
-            var sin = (float)Math.Sin(angle);
+            var cos = MathF.Cos(angle);
+            var sin = MathF.Sin(angle);
 
             result.Row0.X = cos;
             result.Row0.Y = 0;
@@ -496,8 +496,8 @@ namespace OpenToolkit.Mathematics
         /// <param name="result">The resulting Matrix4 instance.</param>
         public static void CreateRotationZ(float angle, out Matrix4x3 result)
         {
-            var cos = (float)Math.Cos(angle);
-            var sin = (float)Math.Sin(angle);
+            var cos = MathF.Cos(angle);
+            var sin = MathF.Sin(angle);
 
             result.Row0.X = cos;
             result.Row0.Y = sin;

--- a/src/OpenToolkit.Mathematics/OpenToolkit.Mathematics.csproj
+++ b/src/OpenToolkit.Mathematics/OpenToolkit.Mathematics.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Deterministic>true</Deterministic>
   </PropertyGroup>

--- a/src/OpenToolkit.Mathematics/OpenToolkit.Mathematics.csproj
+++ b/src/OpenToolkit.Mathematics/OpenToolkit.Mathematics.csproj
@@ -3,7 +3,6 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Deterministic>true</Deterministic>
-    <RootNamespace>OpenToolkit.Mathematics</RootNamespace>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -11,7 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.2" />
+    <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0-preview.7.20364.11" />
   </ItemGroup>
   <Import Project="..\..\props\common.props" />
   <Import Project="..\..\props\nuget-common.props" />

--- a/src/OpenToolkit.Mathematics/Vector/Vector2.cs
+++ b/src/OpenToolkit.Mathematics/Vector/Vector2.cs
@@ -39,6 +39,22 @@ namespace OpenToolkit.Mathematics
     public struct Vector2 : IEquatable<Vector2>
     {
         /// <summary>
+        /// Returns the System.Numerics.Vector2 representation of the given Vector.
+        /// </summary>
+        /// <param name="src">The source Vector.</param>
+        /// <returns>The System.Numerics.Vector2.</returns>
+        public static implicit operator System.Numerics.Vector2(Vector2 src) =>
+            new System.Numerics.Vector2(src.X, src.Y);
+
+        /// <summary>
+        /// Returns the OpenTK.Mathematics.Vector2 representation of the given Vector.
+        /// </summary>
+        /// <param name="src">The source Vector.</param>
+        /// <returns>The OpenTK.Mathematics.Vector2.</returns>
+        public static implicit operator Vector2(System.Numerics.Vector2 src) =>
+            new Vector2(src.X, src.Y);
+
+        /// <summary>
         /// The X component of the Vector2.
         /// </summary>
         public float X;
@@ -514,7 +530,8 @@ namespace OpenToolkit.Mathematics
         /// <param name="result">The distance.</param>
         public static void Distance(in Vector2 vec1, in Vector2 vec2, out float result)
         {
-            result = (float)Math.Sqrt(((vec2.X - vec1.X) * (vec2.X - vec1.X)) + ((vec2.Y - vec1.Y) * (vec2.Y - vec1.Y)));
+            result =
+                (float)Math.Sqrt(((vec2.X - vec1.X) * (vec2.X - vec1.X)) + ((vec2.Y - vec1.Y) * (vec2.Y - vec1.Y)));
         }
 
         /// <summary>
@@ -736,8 +753,8 @@ namespace OpenToolkit.Mathematics
         public static void TransformRow(in Vector2 vec, in Matrix2 mat, out Vector2 result)
         {
             result = new Vector2(
-                (vec.X * mat.Row0.X) + (vec.Y * mat.Row1.X),
-                (vec.X * mat.Row0.Y) + (vec.Y * mat.Row1.Y));
+                                 (vec.X * mat.Row0.X) + (vec.Y * mat.Row1.X),
+                                 (vec.X * mat.Row0.Y) + (vec.Y * mat.Row1.Y));
         }
 
         /// <summary>
@@ -793,6 +810,29 @@ namespace OpenToolkit.Mathematics
         {
             result.X = (mat.Row0.X * vec.X) + (mat.Row0.Y * vec.Y);
             result.Y = (mat.Row1.X * vec.X) + (mat.Row1.Y * vec.Y);
+        }
+
+        /// <summary>
+        /// Returns a Vector where the components are the absolute values of the source Vector's elements.
+        /// </summary>
+        /// <param name="source">The source Vector.</param>
+        /// <returns>The absolute Vector.</returns>
+        [Pure]
+        public static Vector2 Abs(Vector2 source)
+        {
+            Abs(in source, out Vector2 result);
+            return result;
+        }
+
+        /// <summary>
+        /// Returns a Vector where the components are the absolute values of the source Vector's elements.
+        /// </summary>
+        /// <param name="source">The source Vector.</param>
+        /// <param name="result">The absolute Vector.</param>
+        public static void Abs(in Vector2 source, out Vector2 result)
+        {
+            result.X = Math.Abs(source.X);
+            result.Y = Math.Abs(source.Y);
         }
 
         /// <summary>

--- a/src/OpenToolkit.Mathematics/Vector/Vector2.cs
+++ b/src/OpenToolkit.Mathematics/Vector/Vector2.cs
@@ -129,7 +129,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <see cref="LengthFast"/>
         /// <seealso cref="LengthSquared"/>
-        public float Length => (float)Math.Sqrt((X * X) + (Y * Y));
+        public float Length => MathF.Sqrt((X * X) + (Y * Y));
 
         /// <summary>
         /// Gets an approximation of the vector length (magnitude).
@@ -531,7 +531,7 @@ namespace OpenToolkit.Mathematics
         public static void Distance(in Vector2 vec1, in Vector2 vec2, out float result)
         {
             result =
-                (float)Math.Sqrt(((vec2.X - vec1.X) * (vec2.X - vec1.X)) + ((vec2.Y - vec1.Y) * (vec2.Y - vec1.Y)));
+                MathF.Sqrt(((vec2.X - vec1.X) * (vec2.X - vec1.X)) + ((vec2.Y - vec1.Y) * (vec2.Y - vec1.Y)));
         }
 
         /// <summary>

--- a/src/OpenToolkit.Mathematics/Vector/Vector3.cs
+++ b/src/OpenToolkit.Mathematics/Vector/Vector3.cs
@@ -40,6 +40,22 @@ namespace OpenToolkit.Mathematics
     public struct Vector3 : IEquatable<Vector3>
     {
         /// <summary>
+        /// Returns the System.Numerics.Vector3 representation of the given Vector.
+        /// </summary>
+        /// <param name="src">The source Vector.</param>
+        /// <returns>The System.Numerics.Vector3.</returns>
+        public static implicit operator System.Numerics.Vector3(Vector3 src) =>
+            new System.Numerics.Vector3(src.X, src.Y, src.Z);
+
+        /// <summary>
+        /// Returns the OpenTK.Mathematics.Vector3 representation of the given Vector.
+        /// </summary>
+        /// <param name="src">The source Vector.</param>
+        /// <returns>The OpenTK.Mathematics.Vector3.</returns>
+        public static implicit operator Vector3(System.Numerics.Vector3 src) =>
+            new Vector3(src.X, src.Y, src.Z);
+
+        /// <summary>
         /// The X component of the Vector3.
         /// </summary>
         public float X;
@@ -164,7 +180,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <see cref="LengthFast"/>
         /// <seealso cref="LengthSquared"/>
-        public float Length => (float)Math.Sqrt((X * X) + (Y * Y) + (Z * Z));
+        public float Length => MathF.Sqrt((X * X) + (Y * Y) + (Z * Z));
 
         /// <summary>
         /// Gets an approximation of the vector length (magnitude).
@@ -574,8 +590,8 @@ namespace OpenToolkit.Mathematics
         /// <param name="result">The distance.</param>
         public static void Distance(in Vector3 vec1, in Vector3 vec2, out float result)
         {
-            result = (float)Math.Sqrt(((vec2.X - vec1.X) * (vec2.X - vec1.X)) + ((vec2.Y - vec1.Y) * (vec2.Y - vec1.Y)) +
-                                      ((vec2.Z - vec1.Z) * (vec2.Z - vec1.Z)));
+            result = MathF.Sqrt(((vec2.X - vec1.X) * (vec2.X - vec1.X)) + ((vec2.Y - vec1.Y) * (vec2.Y - vec1.Y)) +
+                                ((vec2.Z - vec1.Z) * (vec2.Z - vec1.Z)));
         }
 
         /// <summary>
@@ -1070,7 +1086,7 @@ namespace OpenToolkit.Mathematics
         public static void CalculateAngle(in Vector3 first, in Vector3 second, out float result)
         {
             Dot(in first, in second, out float temp);
-            result = (float)Math.Acos(MathHelper.Clamp(temp / (first.Length * second.Length), -1.0, 1.0));
+            result = MathF.Acos((float)Math.Clamp(temp / (first.Length * second.Length), -1.0, 1.0));
         }
 
         /// <summary>

--- a/src/OpenToolkit.Mathematics/Vector/Vector3d.cs
+++ b/src/OpenToolkit.Mathematics/Vector/Vector3d.cs
@@ -1063,7 +1063,7 @@ namespace OpenToolkit.Mathematics
         public static void CalculateAngle(in Vector3d first, in Vector3d second, out double result)
         {
             Dot(in first, in second, out double temp);
-            result = Math.Acos(MathHelper.Clamp(temp / (first.Length * second.Length), -1.0, 1.0));
+            result = Math.Acos(Math.Clamp(temp / (first.Length * second.Length), -1.0, 1.0));
         }
 
         /// <summary>

--- a/src/OpenToolkit.Mathematics/Vector/Vector4.cs
+++ b/src/OpenToolkit.Mathematics/Vector/Vector4.cs
@@ -148,7 +148,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <param name="v">The Vector3 to copy components from.</param>
         /// <remarks>
-        ///  .<seealso cref="Vector4(Vector3, float)"/>
+        ///  .<seealso cref="Vector4(Vector3,float)"/>
         /// </remarks>
         public Vector4(Vector3 v)
         {

--- a/src/OpenToolkit.Mathematics/Vector/Vector4.cs
+++ b/src/OpenToolkit.Mathematics/Vector/Vector4.cs
@@ -40,6 +40,22 @@ namespace OpenToolkit.Mathematics
     public struct Vector4 : IEquatable<Vector4>
     {
         /// <summary>
+        /// Returns the System.Numerics.Vector2 representation of the given Vector.
+        /// </summary>
+        /// <param name="src">The source Vector.</param>
+        /// <returns>The System.Numerics.Vector2.</returns>
+        public static implicit operator System.Numerics.Vector4(Vector4 src) =>
+            new System.Numerics.Vector4(src.X, src.Y, src.Z, src.W);
+
+        /// <summary>
+        /// Returns the OpenTK.Mathematics.Vector2 representation of the given Vector.
+        /// </summary>
+        /// <param name="src">The source Vector.</param>
+        /// <returns>The OpenTK.Mathematics.Vector2.</returns>
+        public static implicit operator Vector4(System.Numerics.Vector4 src) =>
+            new Vector4(src.X, src.Y, src.Z, src.W);
+
+        /// <summary>
         /// The X component of the Vector4.
         /// </summary>
         public float X;
@@ -245,7 +261,7 @@ namespace OpenToolkit.Mathematics
         /// </summary>
         /// <see cref="LengthFast"/>
         /// <seealso cref="LengthSquared"/>
-        public float Length => (float)Math.Sqrt((X * X) + (Y * Y) + (Z * Z) + (W * W));
+        public float Length => MathF.Sqrt((X * X) + (Y * Y) + (Z * Z) + (W * W));
 
         /// <summary>
         /// Gets an approximation of the vector length (magnitude).

--- a/src/OpenToolkit.Windowing.Common/OpenToolkit.Windowing.Common.csproj
+++ b/src/OpenToolkit.Windowing.Common/OpenToolkit.Windowing.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <RootNamespace>OpenToolkit.Windowing.Common</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/OpenToolkit.Windowing.Desktop/OpenToolkit.Windowing.Desktop.csproj
+++ b/src/OpenToolkit.Windowing.Desktop/OpenToolkit.Windowing.Desktop.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-      <TargetFrameworks>net472;netcoreapp3.0</TargetFrameworks>
+      <TargetFrameworks>net48;netcoreapp3.1</TargetFrameworks>
       <RootNamespace>OpenToolkit.Windowing.Desktop</RootNamespace>
       <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
@@ -35,6 +35,6 @@
         <_ReferencePathToRemove Include="@(ReferencePath)" Condition="'%(ReferencePath.NuGetPackageId)'=='System.Memory'" />
         <ReferencePath Remove="@(_ReferencePathToRemove)" />
       </ItemGroup>
-      <Message Text="Removing System.Memory for mono compatibility" Importance="high"/>
+      <Message Text="Removing System.Memory for mono compatibility" Importance="high" />
     </Target>
 </Project>

--- a/src/OpenToolkit.Windowing.Desktop/OpenToolkit.Windowing.Desktop.csproj
+++ b/src/OpenToolkit.Windowing.Desktop/OpenToolkit.Windowing.Desktop.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-      <TargetFrameworks>net48;netcoreapp3.1</TargetFrameworks>
+      <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
       <RootNamespace>OpenToolkit.Windowing.Desktop</RootNamespace>
       <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>

--- a/src/OpenToolkit.Windowing.GraphicsLibraryFramework/OpenToolkit.Windowing.GraphicsLibraryFramework.csproj
+++ b/src/OpenToolkit.Windowing.GraphicsLibraryFramework/OpenToolkit.Windowing.GraphicsLibraryFramework.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-      <TargetFrameworks>net472;netcoreapp3.0</TargetFrameworks>
+      <TargetFrameworks>net48;netcoreapp3.1</TargetFrameworks>
       <RootNamespace>OpenToolkit.GraphicsLibraryFramework</RootNamespace>
       <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>

--- a/src/OpenToolkit.Windowing.GraphicsLibraryFramework/OpenToolkit.Windowing.GraphicsLibraryFramework.csproj
+++ b/src/OpenToolkit.Windowing.GraphicsLibraryFramework/OpenToolkit.Windowing.GraphicsLibraryFramework.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-      <TargetFrameworks>net48;netcoreapp3.1</TargetFrameworks>
+      <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
       <RootNamespace>OpenToolkit.GraphicsLibraryFramework</RootNamespace>
       <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>


### PR DESCRIPTION
### .net compatibility

* Changes:
Bumped target frameworks to netstandard 2.1
Added implicit casts for Vector_n_ types to and from System.Numerics.Vector_n_
Removed redundant _stuff_ from MathHelper, i.e. functionality already available in System.Math and System.MathF
Changed (float)Math._Method_ calls to MathF._Method_ calls where appropriate

* Affects:
Mathematics

### Testing status

* Rarely acceptable to have no testing.
I know, but this is not changing behaviour.

### Notes

Contributing guidelines appear out of date and not strictly followed.