### PR TITLE
Load glfw library using a version string

### DIFF
--- a/src/OpenToolkit.Windowing.GraphicsLibraryFramework/GLFWNative.cs
+++ b/src/OpenToolkit.Windowing.GraphicsLibraryFramework/GLFWNative.cs
@@ -22,27 +22,7 @@ namespace OpenToolkit.Windowing.GraphicsLibraryFramework
                     return IntPtr.Zero;
                 }
 
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-                {
-                    return NativeLibrary.Load("libglfw.so.3", assembly, path);
-                }
-
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-                {
-                    return NativeLibrary.Load("libglfw.3.dylib", assembly, path);
-                }
-
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                {
-                    if (IntPtr.Size == 8)
-                    {
-                        return NativeLibrary.Load("glfw3-x64.dll", assembly, path);
-                    }
-
-                    return NativeLibrary.Load("glfw3-x86.dll", assembly, path);
-                }
-
-                return IntPtr.Zero;
+                return LibraryLoadHelper.LoadLibrary("glfw", new Version(3, 3), assembly, path);
             });
         }
 #endif

--- a/src/OpenToolkit.Windowing.GraphicsLibraryFramework/LibraryLoadHelper.cs
+++ b/src/OpenToolkit.Windowing.GraphicsLibraryFramework/LibraryLoadHelper.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace OpenToolkit.Windowing.GraphicsLibraryFramework
+{
+    /// <summary>
+    /// Helper class for library loading.
+    /// </summary>
+    public static class LibraryLoadHelper
+    {
+#if NETCOREAPP
+        /// <summary>
+        /// Tries to load and resolve versioned libraries by library file name.
+        /// </summary>
+        /// <param name="libraryName">The base library name.</param>
+        /// <param name="version">The version of the library to load.</param>
+        /// <param name="assembly">The assembly loading the native library.</param>
+        /// <param name="searchPath">The search path.</param>
+        /// <returns>The handle for the loaded library.</returns>
+        public static IntPtr LoadLibrary(string libraryName, Version version, Assembly assembly, DllImportSearchPath? searchPath)
+        {
+            IEnumerable<string> GetNextVersion()
+            {
+                for (var i = 2; i >= 0; i--)
+                {
+                    yield return version.ToString(i);
+                }
+            }
+
+            Func<string, string, string> libNameFormatter = null;
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                libNameFormatter = (libName, ver) =>
+                    libName + ".so" + (string.IsNullOrEmpty(ver) ? string.Empty : "." + ver);
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                libNameFormatter = (libName, ver) =>
+                    libName + (string.IsNullOrEmpty(ver) ? string.Empty : "." + ver) + ".dylib";
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                libNameFormatter = (libName, ver) =>
+                    libName + (string.IsNullOrEmpty(ver) ? string.Empty : ver) + ".dll";
+            }
+            else
+            {
+                return IntPtr.Zero;
+            }
+
+            foreach (var ver in GetNextVersion())
+            {
+                if (NativeLibrary.TryLoad(libNameFormatter(libraryName, ver), assembly, searchPath, out var handle))
+                {
+                    return handle;
+                }
+            }
+            return NativeLibrary.Load(libraryName, assembly, searchPath);
+        }
+#endif
+    }
+}

--- a/src/OpenToolkit.Windowing.GraphicsLibraryFramework/OpenToolkit.Windowing.GraphicsLibraryFramework.csproj
+++ b/src/OpenToolkit.Windowing.GraphicsLibraryFramework/OpenToolkit.Windowing.GraphicsLibraryFramework.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
       <TargetFrameworks>net472;netcoreapp3.0</TargetFrameworks>
-      <RootNamespace>OpenToolkit.GraphicsLibraryFramework</RootNamespace>
+      <RootNamespace>OpenToolkit.Windowing.GraphicsLibraryFramework</RootNamespace>
       <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
     
@@ -40,6 +40,6 @@
         <_ReferencePathToRemove Include="@(ReferencePath)" Condition="'%(ReferencePath.NuGetPackageId)'=='System.Memory'" />
         <ReferencePath Remove="@(_ReferencePathToRemove)" />
       </ItemGroup>
-      <Message Text="Removing System.Memory for mono compatibility" Importance="high"/>
+      <Message Text="Removing System.Memory for mono compatibility" Importance="high" />
     </Target>
 </Project>


### PR DESCRIPTION
### Purpose of this PR

* Loads library using a version number and if possible try to load an assembly containing a version string
* should fix loading of glfw with nuget .redist.glfw package on Linux
* Should fix https://github.com/opentk/opentk/issues/1064

### Testing status

* Tested locally and seems to work(on Linux)

### Comments

Unfortunately it doesn't fix it for mono. DllMaps as far as I understand do not have the possibility to search for multiple assemblies. And I don't think that we want to hardcode it to version 3.3 because that would mean someone having version 3.4 couldn't use it anymore.
One possible workaround for that would be to change the name in the opentoolkit.redist.glfw.nupkg to libglfw.so.3 instead of having the full version, because we know exactly what version it is. It's not necessarily nice, but it should work.
