### PR TITLE
Fix InputAction incorrect type

### DIFF
--- a/src/OpenToolkit.Windowing.Common/Enums/InputAction.cs
+++ b/src/OpenToolkit.Windowing.Common/Enums/InputAction.cs
@@ -14,7 +14,7 @@ namespace OpenToolkit.Windowing.Common
     /// <summary>
     /// Defines event information for <see cref="MouseButtonEventArgs.Action"/>.
     /// </summary>
-    public enum InputAction
+    public enum InputAction : byte
     {
         /// <summary>
         /// The key or mouse button was pressed.


### PR DESCRIPTION
### Fix InputAction incorrect type

* Fixes InputAction being int (default), should be byte according to GLFW docs
* Affects Input only
* https://www.glfw.org/docs/3.3/input_guide.html#joystick