### PR TITLE
Fixes initial focused inconsistency between Windows and Linux(X11):

### DIFF
--- a/src/OpenToolkit.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenToolkit.Windowing.Desktop/NativeWindow.cs
@@ -611,6 +611,8 @@ namespace OpenToolkit.Windowing.Desktop
 
             GLFW.GetWindowPos(WindowPtr, out var x, out var y);
             _location = new Vector2i(x, y);
+
+            _isFocused = GLFW.GetWindowAttrib(WindowPtr, WindowAttributeGetter.Focused);
         }
 
         private static void InitializeGlBindings()


### PR DESCRIPTION
Now reads initial focused value from glfw window attributes.

### Purpose of this PR

While Windows and Linux(X11) windows opened by glfw are focused by default X11 raises a focus-changed-event whereas windows does not resulting in our Focused-Property having it being false on windows despite the window actually being in focus.
This change just reads the initial focused window attribute from glfw and sets the underlying field of the Focused property to that value.

### Testing status

* Manually teested on Windows and Linux(X11)