### PR TITLE
Use correct function in SetCharModsCallback

### DIFF
--- a/src/OpenTK.Windowing.GraphicsLibraryFramework/GLFW.cs
+++ b/src/OpenTK.Windowing.GraphicsLibraryFramework/GLFW.cs
@@ -4033,7 +4033,7 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
             Window* window,
             GLFWCallbacks.CharModsCallback callback)
         {
-            return glfwSetCharCallback(window, Marshal.GetFunctionPointerForDelegate(callback));
+            return glfwSetCharModsCallback(window, Marshal.GetFunctionPointerForDelegate(callback));
         }
 
         /// <summary>


### PR DESCRIPTION
Obvious mistake fixed where the wrapping function called the wrong native glfw function(glfwSetCharCallback was called instead of glfwSetCharModsCallback)