### PR TITLE
Fix for LastJoystickStates with same values as JoystickStates

### DIFF
--- a/src/OpenTK.Windowing.Common/Input/JoystickState.cs
+++ b/src/OpenTK.Windowing.Common/Input/JoystickState.cs
@@ -15,7 +15,7 @@ namespace OpenTK.Windowing.Common.Input
     /// <summary>
     /// Encapsulates the state of a joystick device.
     /// </summary>
-    public struct JoystickState : IEquatable<JoystickState>
+    public struct JoystickState : IEquatable<JoystickState>, ICloneable
     {
         private Hat[] _hats;
         private float[] _axes;
@@ -209,6 +209,40 @@ namespace OpenTK.Windowing.Common.Input
             hashCode ^= Name.GetHashCode();
 
             return hashCode;
+        }
+
+        /// <summary>
+        /// Creates a copy with new arrays.
+        /// </summary>
+        /// <returns>A completely new <see cref="JoystickState"/>.</returns>
+        public object Clone()
+        {
+            Hat[] hats = null;
+            float[] axes = null;
+            bool[] buttons = null;
+
+            if (this._hats != null)
+            {
+                hats = new Hat[this._hats.Length];
+
+                Array.Copy(this._hats, hats, hats.Length);
+            }
+
+            if (this._axes != null)
+            {
+                axes = new float[this._axes.Length];
+
+                Array.Copy(this._axes, axes, axes.Length);
+            }
+
+            if (this._buttons != null)
+            {
+                buttons = new bool[this._buttons.Length];
+
+                Array.Copy(this._buttons, buttons, buttons.Length);
+            }
+
+            return new JoystickState(hats, axes, buttons, Id, Name);
         }
 
         /// <inheritdoc/>

--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -24,6 +24,8 @@ namespace OpenTK.Windowing.Desktop
     /// </summary>
     public class NativeWindow : INativeWindow
     {
+        private const int JoystickStatesCount = 16;
+
         /// <summary>
         /// Gets the native <see cref="Window"/> pointer for use with <see cref="GLFW"/> API.
         /// </summary>
@@ -48,13 +50,15 @@ namespace OpenTK.Windowing.Desktop
         /// <inheritdoc />
         public KeyboardState LastKeyboardState { get; private set; }
 
-        private readonly JoystickState[] _joystickStates = new JoystickState[16];
+        private readonly JoystickState[] _joystickStates = new JoystickState[JoystickStatesCount];
+
+        private readonly JoystickState[] _lastJoystickStates = new JoystickState[JoystickStatesCount];
 
         /// <inheritdoc/>
         public JoystickState[] JoystickStates { get => _joystickStates; }
 
         /// <inheritdoc/>
-        public JoystickState[] LastJoystickStates { get; private set; }
+        public JoystickState[] LastJoystickStates { get => _lastJoystickStates; }
 
         /// <inheritdoc />
         public Vector2 MousePosition

--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -899,8 +899,12 @@ namespace OpenTK.Windowing.Desktop
         {
             LastKeyboardState = KeyboardState;
             LastMouseState = MouseState;
-            LastJoystickStates = JoystickStates;
             MouseDelta = Vector2.Zero;
+
+            for (int i = 0; i < JoystickStates.Length; i++)
+            {
+                LastJoystickStates[i] = JoystickStates[i];
+            }
 
             if (IsExiting)
             {

--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -907,7 +907,7 @@ namespace OpenTK.Windowing.Desktop
 
             for (int i = 0; i < JoystickStates.Length; i++)
             {
-                LastJoystickStates[i] = JoystickStates[i];
+                LastJoystickStates[i] = (JoystickState)JoystickStates[i].Clone();
             }
 
             if (IsExiting)


### PR DESCRIPTION
### Purpose of this PR

- Fixes the last input and current input having the same values for joysticks
- Only affects Windowing / Input

### Testing status

- Local testing in my own projects, I was seeing a "reference equals" on `LastJoystickStates._buttons` and `JoystickStates._buttons`
