### PR TITLE
Added NormalizedPosition to MouseState

### DIFF
--- a/src/OpenTK.Windowing.Common/Input/MouseState.cs
+++ b/src/OpenTK.Windowing.Common/Input/MouseState.cs
@@ -30,6 +30,18 @@ namespace OpenTK.Windowing.Common.Input
         public Vector2 Position { get; set; }
 
         /// <summary>
+        /// Gets or sets or a <see cref="Vector2"/> representing the normalized position of the pointer,
+        /// relative to the center of the contents of the window.
+        /// <para>
+        /// Both the domain and range for this property are [-1, 1].
+        /// </para>
+        /// <para>
+        /// Examples: Bottom left = (-1, -1), Top right = (1, 1).
+        /// </para>
+        /// </summary>
+        public Vector2 NormalizedPosition { get; set; }
+
+        /// <summary>
         /// Gets a <see cref="bool" /> indicating whether the specified
         ///  <see cref="MouseButton" /> is pressed.
         /// </summary>

--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -5,7 +5,6 @@ using System;
 using System.ComponentModel;
 using System.Reflection;
 using System.Runtime.InteropServices;
-using System.Threading;
 using OpenTK.Core;
 using OpenTK.Mathematics;
 using OpenTK.Windowing.Common;
@@ -68,6 +67,7 @@ namespace OpenTK.Windowing.Desktop
                 }
 
                 _mouseState.Position = value;
+                _mouseState.NormalizedPosition = NormalizeMousePosition(value);
             }
         }
 
@@ -784,6 +784,7 @@ namespace OpenTK.Windowing.Desktop
                     MouseDelta += delta;
 
                     _lastReportedMousePos = _mouseState.Position = newPos;
+                    _mouseState.NormalizedPosition = NormalizeMousePosition(newPos);
 
                     OnMouseMove(new MouseMoveEventArgs(newPos, delta));
                 };
@@ -948,7 +949,9 @@ namespace OpenTK.Windowing.Desktop
         private unsafe void ProcessInputEvents()
         {
             GLFW.GetCursorPos(WindowPtr, out var x, out var y);
-            _mouseState.Position = new Vector2((float)x, (float)y);
+            Vector2 newPos = new Vector2((float)x, (float)y);
+            _mouseState.Position = newPos;
+            _mouseState.NormalizedPosition = NormalizeMousePosition(newPos);
 
             for (var i = 0; i < JoystickStates.Length; i++)
             {
@@ -1549,6 +1552,11 @@ namespace OpenTK.Windowing.Desktop
                 default:
                     throw new ArgumentOutOfRangeException(nameof(shape), shape, null);
             }
+        }
+
+        private Vector2 NormalizeMousePosition(Vector2 mousePosition)
+        {
+            return new Vector2((2 * mousePosition.X / Size.X) - 1, 1 - (2 * mousePosition.Y / Size.Y));
         }
     }
 }

--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -1556,6 +1556,10 @@ namespace OpenTK.Windowing.Desktop
 
         private Vector2 NormalizeMousePosition(Vector2 mousePosition)
         {
+            if (Size.X == 0 || Size.Y == 0)
+            {
+                return Vector2.Zero;
+            }
             return new Vector2((2 * mousePosition.X / Size.X) - 1, 1 - (2 * mousePosition.Y / Size.Y));
         }
     }


### PR DESCRIPTION
### Purpose of this PR

Add a normalized mouse position to the MouseState class. Will add a bit of convenience for transforming mouse coordinates to 3D space.

### Testing status

I've tested the NormalizeMousePosition method, other than that admittedly no testing. Fairly straightforward changes though, any time _mouseState.Position is set I just added the NormalizedPosition set.

### Comments

In my pull request for ObjectTK I've added a method to the Camera class that takes the normalized coordinates and returns a Ray starting from camera position with direction towards the point on the near plane that was clicked. 