### PR TITLE
Added Hwnd property to Desktop.NativeWindow

### DIFF
--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -29,6 +29,11 @@ namespace OpenTK.Windowing.Desktop
         /// </summary>
         protected unsafe Window* WindowPtr { get; }
 
+        /// <summary>
+        /// Gets the Windows specific window handle (HWND).
+        /// </summary>
+        protected IntPtr Hwnd { get; }
+
         // Used for delta calculation in the mouse pos changed event.
         private Vector2 _lastReportedMousePos;
 
@@ -565,10 +570,12 @@ namespace OpenTK.Windowing.Desktop
                 GLFW.WindowHint(WindowHintInt.BlueBits, modePtr->BlueBits);
                 GLFW.WindowHint(WindowHintInt.RefreshRate, modePtr->RefreshRate);
                 WindowPtr = GLFW.CreateWindow(modePtr->Width, modePtr->Height, _title, monitor, null);
+                Hwnd = GLFW.GlfwGetWin32Window(WindowPtr);
             }
             else
             {
                 WindowPtr = GLFW.CreateWindow(settings.Size.X, settings.Size.Y, _title, null, null);
+                Hwnd = GLFW.GlfwGetWin32Window(WindowPtr);
             }
 
             Exists = true;

--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -29,11 +29,6 @@ namespace OpenTK.Windowing.Desktop
         /// </summary>
         protected unsafe Window* WindowPtr { get; }
 
-        /// <summary>
-        /// Gets the Windows specific window handle (HWND).
-        /// </summary>
-        protected IntPtr Hwnd { get; }
-
         // Used for delta calculation in the mouse pos changed event.
         private Vector2 _lastReportedMousePos;
 
@@ -570,12 +565,10 @@ namespace OpenTK.Windowing.Desktop
                 GLFW.WindowHint(WindowHintInt.BlueBits, modePtr->BlueBits);
                 GLFW.WindowHint(WindowHintInt.RefreshRate, modePtr->RefreshRate);
                 WindowPtr = GLFW.CreateWindow(modePtr->Width, modePtr->Height, _title, monitor, null);
-                Hwnd = GLFW.GlfwGetWin32Window(WindowPtr);
             }
             else
             {
                 WindowPtr = GLFW.CreateWindow(settings.Size.X, settings.Size.Y, _title, null, null);
-                Hwnd = GLFW.GlfwGetWin32Window(WindowPtr);
             }
 
             Exists = true;

--- a/src/OpenTK.Windowing.GraphicsLibraryFramework/GLFW.cs
+++ b/src/OpenTK.Windowing.GraphicsLibraryFramework/GLFW.cs
@@ -3805,6 +3805,13 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
         public static unsafe void MaximizeWindow(Window* window) => glfwMaximizeWindow(window);
 
         /// <summary>
+        /// This function returns the Windows specific window handle (HWND).
+        /// </summary>
+        /// <param name="window">The window to query.</param>
+        /// <returns>The Windows specific window handle (HWND).</returns>
+        public static unsafe IntPtr GlfwGetWin32Window(Window* window) => glfwGetWin32Window(window);
+
+        /// <summary>
         /// <para>
         /// This function sets the maximization callback of the specified window,
         /// which is called when the window is maximized or restored.

--- a/src/OpenTK.Windowing.GraphicsLibraryFramework/GLFWNative.cs
+++ b/src/OpenTK.Windowing.GraphicsLibraryFramework/GLFWNative.cs
@@ -259,6 +259,9 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
         public static extern void glfwMaximizeWindow(Window* window);
 
         [DllImport(LibraryName)]
+        public static extern IntPtr glfwGetWin32Window(Window* window);
+
+        [DllImport(LibraryName)]
         public static extern void glfwPollEvents();
 
         [DllImport(LibraryName)]


### PR DESCRIPTION
### Purpose of this PR

* Exposing the HWND to OpenTK.Windowing.Desktop.NativeWindow

### Testing status

* Locally tested in our Engine where we need the HWND for the SpcaeMouse (and furthermore TouchDevice) implementation.
  See:  [RenderCanvasGameWindow#986](https://github.com/FUSEEProjectTeam/Fusee/blob/719bc93ce10817b3244776023d316116d74af393/src/Engine/Imp/Graphics/Desktop/RenderCanvasImp.cs#L986) and  [WindowsSpaceMouseDeviceImp#L250](https://github.com/FUSEEProjectTeam/Fusee/blob/719bc93ce10817b3244776023d316116d74af393/src/Engine/Imp/Graphics/Desktop/WindowsSpaceMouseDeviceImp.cs#L250)  
* Locally tested in Qt to set the GameWindow as a child of a QtWidget.