### PR TITLE
Fix opentk.redist.glfw dependency version warning

### DIFF
--- a/src/OpenTK.Windowing.GraphicsLibraryFramework/paket
+++ b/src/OpenTK.Windowing.GraphicsLibraryFramework/paket
@@ -5,7 +5,7 @@ description
 dependencies
     framework: netcoreapp3.1
         OpenTK.Core ~> #VERSION#
-        OpenTK.redist.glfw ~> 3.3.0-pre20190419183326
+        OpenTK.redist.glfw ~> 3.3.0-pre20200830200122
 files
     bin\Release\netcoreapp3.1\OpenTK.Windowing.GraphicsLibraryFramework.dll ==> lib\netcoreapp3.1
     bin\Release\netcoreapp3.1\OpenTK.Windowing.GraphicsLibraryFramework.xml ==> lib\netcoreapp3.1


### PR DESCRIPTION
### Purpose of this PR

Should fix https://github.com/opentk/opentk/issues/1130

### Testing status

Untested, but imho the reason for that warning was pretty clear :D