### PR TITLE
Added multisampling to glfw NativeWindowSettings

### DIFF
--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -564,6 +564,8 @@ namespace OpenTK.Windowing.Desktop
             _isVisible = settings.StartVisible;
             GLFW.WindowHint(WindowHintBool.Visible, _isVisible);
 
+            GLFW.WindowHint(WindowHintInt.Samples, settings.NumberOfSamples);
+
             if (settings.WindowState == WindowState.Fullscreen)
             {
                 var monitor = settings.CurrentMonitor.ToUnsafePtr<GraphicsLibraryFramework.Monitor>();

--- a/src/OpenTK.Windowing.Desktop/NativeWindowSettings.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindowSettings.cs
@@ -162,5 +162,14 @@ namespace OpenTK.Windowing.Desktop
         /// Gets or sets a value indicating whether the window should start fullscreen.
         /// </summary>
         public bool IsFullscreen { get; set; } = false;
+
+        /// <summary>
+        /// Gets or sets a value indicating the number of samples that should be used.
+        /// </summary>
+        /// <remarks>
+        /// <c>0</c> indicates that no multisampling should be used;
+        /// otherwise multisampling is used if available. The actual number of samples is the closest matching the given number that is supported.
+        /// </remarks>
+        public int NumberOfSamples { get; set; }
     }
 }


### PR DESCRIPTION
### Purpose of this PR

* Adds multisampling capability directly usable without direct interaction to glfw
* Basically fixes https://github.com/opentk/opentk/issues/1131

### Testing status

* Tested locally(Linux) and it indeed did do multisampling correctly
