### PR TITLE
Use delegates directly in DllImports instead of IntPtr

### DIFF
--- a/src/OpenTK.Windowing.GraphicsLibraryFramework/GLFW.cs
+++ b/src/OpenTK.Windowing.GraphicsLibraryFramework/GLFW.cs
@@ -3863,7 +3863,7 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
             Window* window,
             GLFWCallbacks.WindowMaximizeCallback callback)
         {
-            return glfwSetWindowMaximizeCallback(window, Marshal.GetFunctionPointerForDelegate(callback));
+            return glfwSetWindowMaximizeCallback(window, callback);
         }
 
         /// <summary>
@@ -3890,7 +3890,7 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
             Window* window,
             GLFWCallbacks.FramebufferSizeCallback callback)
         {
-            return glfwSetFramebufferSizeCallback(window, Marshal.GetFunctionPointerForDelegate(callback));
+            return glfwSetFramebufferSizeCallback(window, callback);
         }
 
         /// <summary>
@@ -3917,7 +3917,7 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
             Window* window,
             GLFWCallbacks.WindowContentScaleCallback callback)
         {
-            return glfwSetWindowContentScaleCallback(window, Marshal.GetFunctionPointerForDelegate(callback));
+            return glfwSetWindowContentScaleCallback(window, callback);
         }
 
         /// <summary>
@@ -4031,7 +4031,7 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
             Window* window,
             GLFWCallbacks.CharCallback callback)
         {
-            return glfwSetCharCallback(window, Marshal.GetFunctionPointerForDelegate(callback));
+            return glfwSetCharCallback(window, callback);
         }
 
         /// <summary>
@@ -4068,7 +4068,7 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
             Window* window,
             GLFWCallbacks.CharModsCallback callback)
         {
-            return glfwSetCharModsCallback(window, Marshal.GetFunctionPointerForDelegate(callback));
+            return glfwSetCharModsCallback(window, callback);
         }
 
         /// <summary>
@@ -4151,7 +4151,7 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
             Window* window,
             GLFWCallbacks.CursorEnterCallback callback)
         {
-            return glfwSetCursorEnterCallback(window, Marshal.GetFunctionPointerForDelegate(callback));
+            return glfwSetCursorEnterCallback(window, callback);
         }
 
         /// <summary>
@@ -4181,7 +4181,7 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
             Window* window,
             GLFWCallbacks.CursorPosCallback callback)
         {
-            return glfwSetCursorPosCallback(window, Marshal.GetFunctionPointerForDelegate(callback));
+            return glfwSetCursorPosCallback(window, callback);
         }
 
         /// <summary>
@@ -4212,7 +4212,7 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
             Window* window,
             GLFWCallbacks.DropCallback callback)
         {
-            return glfwSetDropCallback(window, Marshal.GetFunctionPointerForDelegate(callback));
+            return glfwSetDropCallback(window, callback);
         }
 
         /// <summary>
@@ -4245,7 +4245,7 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
         /// </remarks>
         public static IntPtr SetErrorCallback(GLFWCallbacks.ErrorCallback callback)
         {
-            return glfwSetErrorCallback(Marshal.GetFunctionPointerForDelegate(callback));
+            return glfwSetErrorCallback(callback);
         }
 
         /// <summary>
@@ -4369,7 +4369,7 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
         /// </remarks>
         public static IntPtr SetJoystickCallback(GLFWCallbacks.JoystickCallback callback)
         {
-            return glfwSetJoystickCallback(Marshal.GetFunctionPointerForDelegate(callback));
+            return glfwSetJoystickCallback(callback);
         }
 
         /// <summary>
@@ -4414,7 +4414,7 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
             Window* window,
             GLFWCallbacks.KeyCallback callback)
         {
-            return glfwSetKeyCallback(window, Marshal.GetFunctionPointerForDelegate(callback));
+            return glfwSetKeyCallback(window, callback);
         }
 
         /// <summary>
@@ -4443,7 +4443,7 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
             Window* window,
             GLFWCallbacks.ScrollCallback callback)
         {
-            return glfwSetScrollCallback(window, Marshal.GetFunctionPointerForDelegate(callback));
+            return glfwSetScrollCallback(window, callback);
         }
 
         /// <summary>
@@ -4466,7 +4466,7 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
         /// </remarks>
         public static IntPtr SetMonitorCallback(GLFWCallbacks.MonitorCallback callback)
         {
-            return glfwSetMonitorCallback(Marshal.GetFunctionPointerForDelegate(callback));
+            return glfwSetMonitorCallback(callback);
         }
 
         /// <summary>
@@ -4499,7 +4499,7 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
             Window* window,
             GLFWCallbacks.MouseButtonCallback callback)
         {
-            return glfwSetMouseButtonCallback(window, Marshal.GetFunctionPointerForDelegate(callback));
+            return glfwSetMouseButtonCallback(window, callback);
         }
 
         /// <summary>
@@ -4536,7 +4536,7 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
             Window* window,
             GLFWCallbacks.WindowCloseCallback callback)
         {
-            return glfwSetWindowCloseCallback(window, Marshal.GetFunctionPointerForDelegate(callback));
+            return glfwSetWindowCloseCallback(window, callback);
         }
 
         /// <summary>
@@ -4567,7 +4567,7 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
             Window* window,
             GLFWCallbacks.WindowFocusCallback callback)
         {
-            return glfwSetWindowFocusCallback(window, Marshal.GetFunctionPointerForDelegate(callback));
+            return glfwSetWindowFocusCallback(window, callback);
         }
 
         /// <summary>
@@ -4667,7 +4667,7 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
             Window* window,
             GLFWCallbacks.WindowIconifyCallback callback)
         {
-            return glfwSetWindowIconifyCallback(window, Marshal.GetFunctionPointerForDelegate(callback));
+            return glfwSetWindowIconifyCallback(window, callback);
         }
 
         /// <summary>
@@ -4784,7 +4784,7 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
             Window* window,
             GLFWCallbacks.WindowPosCallback callback)
         {
-            return glfwSetWindowPosCallback(window, Marshal.GetFunctionPointerForDelegate(callback));
+            return glfwSetWindowPosCallback(window, callback);
         }
 
         /// <summary>
@@ -4819,7 +4819,7 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
             Window* window,
             GLFWCallbacks.WindowRefreshCallback callback)
         {
-            return glfwSetWindowRefreshCallback(window, Marshal.GetFunctionPointerForDelegate(callback));
+            return glfwSetWindowRefreshCallback(window, callback);
         }
 
         /// <summary>
@@ -4885,7 +4885,7 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
             Window* window,
             GLFWCallbacks.WindowSizeCallback callback)
         {
-            return glfwSetWindowSizeCallback(window, Marshal.GetFunctionPointerForDelegate(callback));
+            return glfwSetWindowSizeCallback(window, callback);
         }
 
         /// <summary>

--- a/src/OpenTK.Windowing.GraphicsLibraryFramework/GLFWNative.cs
+++ b/src/OpenTK.Windowing.GraphicsLibraryFramework/GLFWNative.cs
@@ -352,22 +352,22 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
         public static extern void* glfwGetWindowUserPointer(Window* window);
 
         [DllImport(LibraryName)]
-        public static extern IntPtr glfwSetCharCallback(Window* window, IntPtr callback);
+        public static extern IntPtr glfwSetCharCallback(Window* window, GLFWCallbacks.CharCallback callback);
 
         [DllImport(LibraryName)]
-        public static extern IntPtr glfwSetCharModsCallback(Window* window, IntPtr callback);
+        public static extern IntPtr glfwSetCharModsCallback(Window* window, GLFWCallbacks.CharModsCallback callback);
 
         [DllImport(LibraryName)]
-        public static extern IntPtr glfwSetCursorEnterCallback(Window* window, IntPtr callback);
+        public static extern IntPtr glfwSetCursorEnterCallback(Window* window, GLFWCallbacks.CursorEnterCallback callback);
 
         [DllImport(LibraryName)]
-        public static extern IntPtr glfwSetCursorPosCallback(Window* window, IntPtr callback);
+        public static extern IntPtr glfwSetCursorPosCallback(Window* window, GLFWCallbacks.CursorPosCallback callback);
 
         [DllImport(LibraryName)]
-        public static extern IntPtr glfwSetDropCallback(Window* window, IntPtr callback);
+        public static extern IntPtr glfwSetDropCallback(Window* window, GLFWCallbacks.DropCallback callback);
 
         [DllImport(LibraryName)]
-        public static extern IntPtr glfwSetErrorCallback(IntPtr callback);
+        public static extern IntPtr glfwSetErrorCallback(GLFWCallbacks.ErrorCallback callback);
 
         [DllImport(LibraryName)]
         public static extern void glfwSetInputMode(Window* window, CursorStateAttribute mode, CursorModeValue value);
@@ -379,40 +379,40 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
         public static extern void glfwSetInputMode(Window* window, LockKeyModAttribute mode, int value);
 
         [DllImport(LibraryName)]
-        public static extern IntPtr glfwSetJoystickCallback(IntPtr callback);
+        public static extern IntPtr glfwSetJoystickCallback(GLFWCallbacks.JoystickCallback callback);
 
         [DllImport(LibraryName)]
-        public static extern IntPtr glfwSetKeyCallback(Window* window, IntPtr callback);
+        public static extern IntPtr glfwSetKeyCallback(Window* window, GLFWCallbacks.KeyCallback callback);
 
         [DllImport(LibraryName)]
-        public static extern IntPtr glfwSetScrollCallback(Window* window, IntPtr callback);
+        public static extern IntPtr glfwSetScrollCallback(Window* window, GLFWCallbacks.ScrollCallback callback);
 
         [DllImport(LibraryName)]
-        public static extern IntPtr glfwSetMonitorCallback(IntPtr callback);
+        public static extern IntPtr glfwSetMonitorCallback(GLFWCallbacks.MonitorCallback callback);
 
         [DllImport(LibraryName)]
-        public static extern IntPtr glfwSetMouseButtonCallback(Window* window, IntPtr callback);
+        public static extern IntPtr glfwSetMouseButtonCallback(Window* window, GLFWCallbacks.MouseButtonCallback callback);
 
         [DllImport(LibraryName)]
-        public static extern IntPtr glfwSetWindowCloseCallback(Window* window, IntPtr callback);
+        public static extern IntPtr glfwSetWindowCloseCallback(Window* window, GLFWCallbacks.WindowCloseCallback callback);
 
         [DllImport(LibraryName)]
-        public static extern IntPtr glfwSetWindowFocusCallback(Window* window, IntPtr callback);
+        public static extern IntPtr glfwSetWindowFocusCallback(Window* window, GLFWCallbacks.WindowFocusCallback callback);
 
         [DllImport(LibraryName)]
         public static extern void glfwSetWindowIcon(Window* window, int count, Image* images);
 
         [DllImport(LibraryName)]
-        public static extern IntPtr glfwSetWindowIconifyCallback(Window* window, IntPtr callback);
+        public static extern IntPtr glfwSetWindowIconifyCallback(Window* window, GLFWCallbacks.WindowIconifyCallback callback);
 
         [DllImport(LibraryName)]
-        public static extern IntPtr glfwSetWindowMaximizeCallback(Window* window, IntPtr callback);
+        public static extern IntPtr glfwSetWindowMaximizeCallback(Window* window, GLFWCallbacks.WindowMaximizeCallback callback);
 
         [DllImport(LibraryName)]
-        public static extern IntPtr glfwSetFramebufferSizeCallback(Window* window, IntPtr callback);
+        public static extern IntPtr glfwSetFramebufferSizeCallback(Window* window, GLFWCallbacks.FramebufferSizeCallback callback);
 
         [DllImport(LibraryName)]
-        public static extern IntPtr glfwSetWindowContentScaleCallback(Window* window, IntPtr callback);
+        public static extern IntPtr glfwSetWindowContentScaleCallback(Window* window, GLFWCallbacks.WindowContentScaleCallback callback);
 
         [DllImport(LibraryName)]
         public static extern void glfwSetWindowTitle(Window* window, byte* title);
@@ -424,7 +424,7 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
         public static extern void glfwSetWindowSize(Window* window, int width, int height);
 
         [DllImport(LibraryName)]
-        public static extern IntPtr glfwSetWindowSizeCallback(Window* window, IntPtr callback);
+        public static extern IntPtr glfwSetWindowSizeCallback(Window* window, GLFWCallbacks.WindowSizeCallback callback);
 
         [DllImport(LibraryName)]
         public static extern void glfwSetWindowShouldClose(Window* window, int value);
@@ -436,10 +436,10 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
         public static extern void glfwSetWindowPos(Window* window, int x, int y);
 
         [DllImport(LibraryName)]
-        public static extern IntPtr glfwSetWindowPosCallback(Window* window, IntPtr callback);
+        public static extern IntPtr glfwSetWindowPosCallback(Window* window, GLFWCallbacks.WindowPosCallback callback);
 
         [DllImport(LibraryName)]
-        public static extern IntPtr glfwSetWindowRefreshCallback(Window* window, IntPtr callback);
+        public static extern IntPtr glfwSetWindowRefreshCallback(Window* window, GLFWCallbacks.WindowRefreshCallback callback);
 
         [DllImport(LibraryName)]
         public static extern void glfwSwapInterval(int interval);


### PR DESCRIPTION
### Purpose of this PR

* Fixes https://github.com/opentk/opentk/issues/1063

### Testing status

* Test application still works
* Setting null for GLFW callbacks does not crash anymore
### Comments

Perhaps we would want to have IntPtr overload too, but I think it makes more sense to create overloads later on for .Net 5 with native function pointers
