### PR TITLE
Keyboard wrong state fix

### DIFF
--- a/src/OpenTK.Windowing.Common/Events/MouseMoveEventArgs.cs
+++ b/src/OpenTK.Windowing.Common/Events/MouseMoveEventArgs.cs
@@ -58,17 +58,17 @@ namespace OpenTK.Windowing.Common
         public Vector2 Position { get; }
 
         /// <summary>
-        /// Gets the change in X position produced by this event.
+        /// Gets the change in X position since the last event.
         /// </summary>
         public float DeltaX => Delta.X;
 
         /// <summary>
-        /// Gets the change in Y position produced by this event.
+        /// Gets the change in Y position since the last event.
         /// </summary>
         public float DeltaY => Delta.Y;
 
         /// <summary>
-        /// Gets the change in position produced by this event.
+        /// Gets the change in position since the last event.
         /// </summary>
         public Vector2 Delta { get; }
     }

--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -738,6 +738,9 @@ namespace OpenTK.Windowing.Desktop
             GLFW.GetWindowPos(WindowPtr, out var x, out var y);
             _location = new Vector2i(x, y);
 
+            GLFW.GetCursorPos(WindowPtr, out var mousex, out var mousey);
+            _lastReportedMousePos = new Vector2((float)mousex, (float)mousey);
+
             _isFocused = GLFW.GetWindowAttrib(WindowPtr, WindowAttributeGetBool.Focused);
         }
 

--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -900,7 +900,7 @@ namespace OpenTK.Windowing.Desktop
             var newPos = new Vector2((float)posX, (float)posY);
             var delta = _lastReportedMousePos - newPos;
 
-            _lastReportedMousePos = _mouseState.Position = newPos;
+            _lastReportedMousePos = newPos;
 
             OnMouseMove(new MouseMoveEventArgs(newPos, delta));
         }

--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -740,6 +740,7 @@ namespace OpenTK.Windowing.Desktop
 
             GLFW.GetCursorPos(WindowPtr, out var mousex, out var mousey);
             _lastReportedMousePos = new Vector2((float)mousex, (float)mousey);
+            _mouseState.Position = _lastReportedMousePos;
 
             _isFocused = GLFW.GetWindowAttrib(WindowPtr, WindowAttributeGetBool.Focused);
         }

--- a/src/OpenTK.Windowing.GraphicsLibraryFramework/Input/KeyboardState.cs
+++ b/src/OpenTK.Windowing.GraphicsLibraryFramework/Input/KeyboardState.cs
@@ -186,7 +186,7 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
 
         internal void Update()
         {
-            Utils.Swap(ref _keys, ref _keysPrevious);
+            _keysPrevious = (BitArray)_keys.Clone();
         }
 
         /// <summary>

--- a/src/OpenTK.Windowing.GraphicsLibraryFramework/Input/MouseState.cs
+++ b/src/OpenTK.Windowing.GraphicsLibraryFramework/Input/MouseState.cs
@@ -143,7 +143,7 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
 
         internal void Update()
         {
-            Utils.Swap(ref _buttons, ref _buttonsPrevious);
+            _buttonsPrevious = (BitArray)_buttons.Clone();
             PreviousPosition = Position;
 
             unsafe


### PR DESCRIPTION
Quick fix to wrong _keys array on frame tick, applied the same fix to MouseState. These classes rely on events, while JoystickState relies on polling - thus in the case of Keys and Mouse, the current state needs to be preserved between frames.

Also fixed MouseState position being corrupted by CursorPosCallback
Also fixed MouseMoveEventArgs XMLDoc
Also fixed MouseState and OnMouseMove reporting "phantom" deltas on first frame / first event