### PR TITLE
Fixes for allocations in KeyboardState.Update and MouseState.Update

### DIFF
--- a/src/OpenTK.Windowing.GraphicsLibraryFramework/Input/KeyboardState.cs
+++ b/src/OpenTK.Windowing.GraphicsLibraryFramework/Input/KeyboardState.cs
@@ -186,7 +186,10 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
 
         internal void Update()
         {
-            _keysPrevious = (BitArray)_keys.Clone();
+            foreach (var index in (int[])Enum.GetValues(typeof(Keys)))
+            {
+                _keysPrevious[index] = _keys[index];
+            }
         }
 
         /// <summary>

--- a/src/OpenTK.Windowing.GraphicsLibraryFramework/Input/KeyboardState.cs
+++ b/src/OpenTK.Windowing.GraphicsLibraryFramework/Input/KeyboardState.cs
@@ -171,11 +171,12 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
             builder.Append('{');
             var first = true;
 
-            foreach (Keys key in (Keys[])Enum.GetValues(typeof(Keys)))
+            for (Keys key = 0; key <= Keys.LastKey; key++)
             {
                 if (IsKeyDown(key))
                 {
                     builder.AppendFormat("{0}{1}", key, !first ? ", " : string.Empty);
+                    first = false;
                 }
             }
 
@@ -186,10 +187,8 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
 
         internal void Update()
         {
-            foreach (var index in (int[])Enum.GetValues(typeof(Keys)))
-            {
-                _keysPrevious[index] = _keys[index];
-            }
+            _keysPrevious.SetAll(false);
+            _keysPrevious.Or(_keys);
         }
 
         /// <summary>

--- a/src/OpenTK.Windowing.GraphicsLibraryFramework/Input/MouseState.cs
+++ b/src/OpenTK.Windowing.GraphicsLibraryFramework/Input/MouseState.cs
@@ -24,7 +24,7 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
         /// <summary>
         /// The maximum number of buttons a <see cref="MouseState"/> can represent.
         /// </summary>
-        internal const int MaxButtons = 16; // we are storing in an ushort
+        internal const int MaxButtons = 16;
 
         private BitArray _buttons = new BitArray(MaxButtons);
         private BitArray _buttonsPrevious = new BitArray(MaxButtons);
@@ -143,7 +143,10 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
 
         internal void Update()
         {
-            _buttonsPrevious = (BitArray)_buttons.Clone();
+            for (var i = 0; i < MaxButtons; i++)
+            {
+                _buttonsPrevious[i] = _buttons[i];
+            }
             PreviousPosition = Position;
 
             unsafe

--- a/src/OpenTK.Windowing.GraphicsLibraryFramework/Input/MouseState.cs
+++ b/src/OpenTK.Windowing.GraphicsLibraryFramework/Input/MouseState.cs
@@ -143,10 +143,8 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
 
         internal void Update()
         {
-            for (var i = 0; i < MaxButtons; i++)
-            {
-                _buttonsPrevious[i] = _buttons[i];
-            }
+            _buttonsPrevious.SetAll(false);
+            _buttonsPrevious.Or(_buttons);
             PreviousPosition = Position;
 
             unsafe


### PR DESCRIPTION
Bizarrely BitArray doesn't cast to Array and there are no memcopy methods that suit (that I could find)
Even BitArray.Copy does not copy to BitArray.

For KeyboardState, BitArray makes the code much cleaner.

In the case of MouseState, this is a toss-up between needing to work out bitmasks for a ushort on every get and set, and needing to iterate over the bits one at a time on each Update