### PR TITLE
Avoid allocating a float array for joystick axes every frame

### DIFF
--- a/src/OpenTK.Windowing.GraphicsLibraryFramework/GLFW.cs
+++ b/src/OpenTK.Windowing.GraphicsLibraryFramework/GLFW.cs
@@ -1845,22 +1845,9 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
         /// Possible errors include <see cref="ErrorCode.NotInitialized"/>, <see cref="ErrorCode.InvalidEnum"/> and <see cref="ErrorCode.PlatformError"/>.
         /// </para>
         /// </remarks>
-        public static unsafe float[] GetJoystickAxes(int jid)
+        public static unsafe Span<float> GetJoystickAxes(int jid)
         {
-            var ptr = GetJoystickAxesRaw(jid, out var count);
-
-            if (ptr == null)
-            {
-                return null;
-            }
-
-            var array = new float[count];
-            for (var i = 0; i < count; i++)
-            {
-                array[i] = ptr[i];
-            }
-
-            return array;
+            return new Span<float>(GetJoystickAxesRaw(jid, out var count), count);
         }
 
         /// <summary>

--- a/src/OpenTK.Windowing.GraphicsLibraryFramework/Input/JoystickState.cs
+++ b/src/OpenTK.Windowing.GraphicsLibraryFramework/Input/JoystickState.cs
@@ -153,9 +153,13 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void SetAxes(float[] axes)
+        private void SetAxes(Span<float> axes)
         {
-            _axes = axes;
+            if (axes.Length > _axes.Length)
+            {
+                _axes = new float[axes.Length];
+            }
+            axes.CopyTo(_axes);
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
### Purpose of this PR

This makes use of Span to avoid allocating a new array of floats every frame for Joystick axes.

### Testing status

I have tested this with a tiny test program. The changes are fairly trivial.

### Comments

When combined with #1156, OpenTK does not do any allocations every frame in my tiny test.
