### PR TITLE
Invert GetWindowAttrib Decorated check for window border

### DIFF
--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -370,7 +370,7 @@ namespace OpenTK.Windowing.Desktop
 
             set
             {
-                if (!GLFW.GetWindowAttrib(WindowPtr, WindowAttributeGetBool.Decorated))
+                if (GLFW.GetWindowAttrib(WindowPtr, WindowAttributeGetBool.Decorated))
                 {
                     GLFW.GetVersion(out var major, out var minor, out _);
 


### PR DESCRIPTION
### Give users the ability to set resizeable and decorated

Previously setting ``WindowBorder`` to ``Fixed``, ``Resizeable`` or ``Hidden`` did nothing because the window is default decorated and:
```if (!GLFW.GetWindowAttrib(WindowPtr, WindowAttributeGetBool.Decorated))```
only passes if it is _not_ decorated.

This enables setting ``WindowBorder`` to properly change the window's attribute.

GLFW docs state the window should only be user resizeable if the window is decorated.
https://www.glfw.org/docs/latest/window_guide.html#GLFW_DECORATED_hint
>> GLFW_DECORATED specifies whether the windowed mode window will have window decorations such as a border, a close widget, etc. An undecorated window will not be resizable by the user but will still allow the user to generate close events on some platforms. Possible values are GLFW_TRUE and GLFW_FALSE. This hint is ignored for full screen windows.