### PR TITLE
Fix input regression for IsKeyReleased and IsKeyPressed

### DIFF
--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -1029,6 +1029,8 @@ namespace OpenTK.Windowing.Desktop
                 return;
             }
 
+            ProcessInputEvents();
+
             if (IsEventDriven)
             {
                 GLFW.WaitEvents();
@@ -1037,8 +1039,6 @@ namespace OpenTK.Windowing.Desktop
             {
                 GLFW.PollEvents();
             }
-
-            ProcessInputEvents();
         }
 
         private unsafe void ProcessInputEvents()


### PR DESCRIPTION
### Purpose of this PR
``IsKeyPressed`` and ``IsKeyReleased`` both suffered regressions in the last batch of commits. Moving ``ProcessInputEvents();`` above ``GLFW.PollEvents();`` fixes this.

### Testing status
Confirmed both of the functions above are broken on Windows 10 (Thanks @utkumaden) and Fedora 32. Should to be working now.