### PR TITLE
Fix #1071 StartVisible = false not working

### DIFF
--- a/src/OpenTK.Windowing.Desktop/GameWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/GameWindow.cs
@@ -229,9 +229,6 @@ namespace OpenTK.Windowing.Desktop
         /// </summary>
         public virtual void Run()
         {
-            // Make sure the GameWindow is visible when it first runs.
-            IsVisible = true;
-
             // Make sure that the gl contexts is current for OnLoad and the initial OnResize
             Context.MakeCurrent();
 


### PR DESCRIPTION
### Purpose of this PR
Fixes ``IsVisible`` being set to true in ``GameWindow``'s ``Run()`` which overwrites the previous value set by ``NativeWindowSettings`` causing the window to always be visible on startup.

### Testing status
Problem was reported as occurring on Windows 10.
I was able to test it on Fedora 32.
