### PR TITLE
Fixed scrolling so that you can actually detect per frame deltas.

### DIFF
--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -915,7 +915,7 @@ namespace OpenTK.Windowing.Desktop
         private unsafe void ScrollCallback(Window* window, double offsetX, double offsetY)
         {
             _mouseState.PreviousPosition = _mouseState.Scroll;
-            _mouseState.Scroll = new Vector2((float)offsetX, (float)offsetY);
+            _mouseState.Scroll += new Vector2((float)offsetX, (float)offsetY);
 
             OnMouseWheel(new MouseWheelEventArgs(_mouseState.Scroll));
         }

--- a/src/OpenTK.Windowing.GraphicsLibraryFramework/Input/MouseState.cs
+++ b/src/OpenTK.Windowing.GraphicsLibraryFramework/Input/MouseState.cs
@@ -165,6 +165,8 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
             _buttonsPrevious.Or(_buttons);
             PreviousPosition = Position;
 
+            PreviousScroll = Scroll;
+
             unsafe
             {
                 GLFW.GetCursorPos(_windowPtr, out var x, out var y);


### PR DESCRIPTION
### Purpose of this PR

This fix makes it so that the `DeltaScroll` variable doesn't just update when a scroll event happens.
Before the scroll values would be locked to the last value sent in the event.

This might not be the perfect solution, as multithreading and event things might affect the order of operations and a new scroll value might be detected as nothing (not sure this case actually happens though, as event processing is done inside of glfwProcessEvents)

### Testing status

Not tested.
