### PR TITLE
[3.0] Fix: XInput issues with multiple / disconnected pads

### DIFF
--- a/src/OpenTK/Platform/Windows/XInputJoystick.cs
+++ b/src/OpenTK/Platform/Windows/XInputJoystick.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // XInputJoystick.cs
 //
 // Author:
@@ -352,6 +352,28 @@ namespace OpenTK.Platform.Windows
         {
             public XInputBatteryType Type;
             public XInputBatteryLevel Level;
+        }
+
+        internal int FindNextValidID(int index)
+        {
+            if (index > 3 || index < 0)
+            {
+                //Valid XinputIDs are 0 - 3
+                //Return -1 to indicate we haven't found a valid ID
+                return -1;
+            }
+            XInputDeviceCapabilities xcaps;
+            XInputErrorCode error = xinput.GetCapabilities(
+                (XInputUserIndex)index,
+                XInputCapabilitiesFlags.Default,
+                out xcaps);
+            if (error != XInputErrorCode.Success)
+            {
+                //This ID isn't actually connected, so loop around & try the next
+                return FindNextValidID(index + 1);
+            }
+            //This is connected!
+            return index;
         }
 
         private class XInput : IDisposable


### PR DESCRIPTION
### Purpose of this PR

This is perhaps a slightly obscure fix, but it addresses a very real issue I discovered when testing reconnection of pads.

**Take the following scenario:**
A Windows machine, using the WinRawInput backend.
A single Xbox pad.
Disconnect the pad.
Reconnect the pad.
If Windows assigns the pad an ID of anything other than zero (and assuming pad 0 is not connected), the current code breaks.
This is because it made the assumption that all pads were connected from 0 upwards.

**Changes:**
This adds a new function to find the first / next valid XInput ID, instead of assuming that the first found pad is at index 0.
This also adds a test for the XInput ID when determining whether a pad is a duplicate (as XInput uses a single GUID), which was preventing multiple XInput pads from being recognised at once.

### Testing status

Tested on Windows 10, works as expected.

### Comments

The reconnection / pad numbering logic is pretty critical (although obscure); I can't be reccomending people reboot after plugging / unplugging an Xbox pad....

(This is purely a bugfix, would *really* appreciate a version bump)