### PR TITLE
Fix: Index typo

### DIFF
--- a/src/OpenTK/Platform/Windows/WinRawJoystick.cs
+++ b/src/OpenTK/Platform/Windows/WinRawJoystick.cs
@@ -223,7 +223,7 @@ namespace OpenTK.Platform.Windows
                 device.SetConnected(false);
             }
 
-            int lastDiscoveredXinputID = 0;
+            int lastDiscoveredXinputID = -1;
             // Discover joystick devices
             RawInputDeviceList[] deviceList = WinRawInput.GetDeviceList();
             foreach (RawInputDeviceList dev in deviceList)


### PR DESCRIPTION
Fixes a index typo in https://github.com/opentk/opentk/pull/1175

Set the first found pad index to -1 (to allow pad 0 to be recognised first)

Got missed when I commited first time.....
