### PR TITLE
[3.0] New: Add HID device names via Joystick.GetName

### DIFF
--- a/src/OpenTK/Input/IJoystickDriver2.cs
+++ b/src/OpenTK/Input/IJoystickDriver2.cs
@@ -34,5 +34,6 @@ namespace OpenTK.Input
         JoystickState GetState(int index);
         JoystickCapabilities GetCapabilities(int index);
         Guid GetGuid(int index);
+        string GetName(int index);
     }
 }

--- a/src/OpenTK/Input/Joystick.cs
+++ b/src/OpenTK/Input/Joystick.cs
@@ -88,9 +88,16 @@ namespace OpenTK.Input
             return implementation.GetGuid(index);
         }
 
-        //public string GetName(int index)
-        //{
-        //    return implementation.GetName(index);
-        //}
+        /// Returns the name of the device connected at the specified index.
+        /// </summary>
+        /// <returns>
+        /// The name of the device at the specified index.
+        /// If no device is connected at this index than an empty string.
+        /// </returns>
+        /// <param name="index">The zero-based device index for the device to poll</param>
+        public static string GetName(int index)
+        {
+            return implementation.GetName(index);
+        }
     }
 }

--- a/src/OpenTK/Platform/Linux/LinuxJoystick.cs
+++ b/src/OpenTK/Platform/Linux/LinuxJoystick.cs
@@ -508,5 +508,15 @@ namespace OpenTK.Platform.Linux
             }
             return Guid.Empty;
         }
+
+        string IJoystickDriver2.GetName(int index)
+        {
+            LinuxJoystickDetails js = Sticks.FromIndex(index);
+            if (js != null)
+            {
+                return js.Name;
+            }
+            return String.Empty;
+        }
     }
 }

--- a/src/OpenTK/Platform/MacOS/HIDInput.cs
+++ b/src/OpenTK/Platform/MacOS/HIDInput.cs
@@ -1097,6 +1097,16 @@ namespace OpenTK.Platform.MacOS
             return new Guid();
         }
 
+        string IJoystickDriver2.GetName(int index)
+        {
+            JoystickData joystick = GetJoystick(index);
+            if (joystick != null)
+            {
+                return joystick.Name;
+            }
+            return String.Empty;
+        }
+
         private class NativeMethods
         {
             private const string hid = "/System/Library/Frameworks/IOKit.framework/Versions/Current/IOKit";

--- a/src/OpenTK/Platform/Windows/Bindings/HidProtocol.cs
+++ b/src/OpenTK/Platform/Windows/Bindings/HidProtocol.cs
@@ -120,24 +120,32 @@ namespace OpenTK.Platform.Windows
                 string DevType = Parts[0].Substring(Parts[0].IndexOf(@"?\", StringComparison.Ordinal) + 2);
                 string DeviceInstanceId = Parts[1];
                 string DeviceUniqueID = Parts[2];
-                string RegPath = @"SYSTEM\CurrentControlSet\Enum\" + DevType + "\\" + DeviceInstanceId + "\\" + DeviceUniqueID;
-                RegistryKey key = Registry.LocalMachine.OpenSubKey(RegPath);
-                if (key != null)
+                try
                 {
-                    object result = key.GetValue("FriendlyName");
-                    if (result != null)
+                    string RegPath = @"SYSTEM\CurrentControlSet\Enum\" + DevType + "\\" + DeviceInstanceId + "\\" + DeviceUniqueID;
+                    RegistryKey key = Registry.LocalMachine.OpenSubKey(RegPath);
+                    if (key != null)
                     {
-                        //User-set, so should be usable as-is
-                        return result.ToString();
-                    }
+                        object result = key.GetValue("FriendlyName");
+                        if (result != null)
+                        {
+                            //User-set, so should be usable as-is
+                            return result.ToString();
+                        }
                         
-                    result = key.GetValue("DeviceDesc");
-                    if (result != null)
-                    {
-                        //Always starts with the driver inf and other bits
-                        string[] splitResult = result.ToString().Split(';');
-                        return splitResult[splitResult.Length - 1];
+                        result = key.GetValue("DeviceDesc");
+                        if (result != null)
+                        {
+                            //Always starts with the driver inf and other bits
+                            string[] splitResult = result.ToString().Split(';');
+                            return splitResult[splitResult.Length - 1];
+                        }
                     }
+                }
+                catch
+                {
+                    //Error occured during registry operations
+                    return String.Empty;
                 }
             }
             return String.Empty;

--- a/src/OpenTK/Platform/Windows/WinRawJoystick.cs
+++ b/src/OpenTK/Platform/Windows/WinRawJoystick.cs
@@ -67,7 +67,6 @@ namespace OpenTK.Platform.Windows
                 Guid = guid;
                 IsXInput = is_xinput;
                 XInputIndex = xinput_index;
-
             }
 
             public void ClearButtons()
@@ -107,6 +106,11 @@ namespace OpenTK.Platform.Windows
             {
                 Capabilities.SetIsConnected(value);
                 State.SetIsConnected(value);
+                if (value == false)
+                {
+                    //The stick has disconnected, so reset the cached name
+                    Name = null;
+                }
             }
 
             public JoystickCapabilities GetCapabilities()

--- a/src/OpenTK/Platform/Windows/WinRawJoystick.cs
+++ b/src/OpenTK/Platform/Windows/WinRawJoystick.cs
@@ -59,12 +59,15 @@ namespace OpenTK.Platform.Windows
             private readonly Dictionary<int, JoystickHat> hats =
                 new Dictionary<int, JoystickHat>();
 
+            internal string Name = null;
+
             public Device(IntPtr handle, Guid guid, bool is_xinput, int xinput_index)
             {
                 Handle = handle;
                 Guid = guid;
                 IsXInput = is_xinput;
                 XInputIndex = xinput_index;
+
             }
 
             public void ClearButtons()
@@ -893,6 +896,39 @@ namespace OpenTK.Platform.Windows
                     }
                 }
                 return new Guid();
+            }
+        }
+
+        public string GetName(int index)
+        {
+            lock (UpdateLock)
+            {
+                if (IsValid(index))
+                {
+                    Device dev = Devices.FromIndex(index);
+                    if (dev.Name != null)
+                    {
+                        //Name already cached, so return it
+                        return dev.Name;
+                    }
+                    if (dev.IsXInput)
+                    {
+                        //XInput- Return specific string for this
+                        return XInput.GetName(dev.XInputIndex);
+                    }
+                    //Pull out the HID name string
+                    int size = 0;
+                    Functions.GetRawInputDeviceInfo(dev.Handle, RawInputDeviceInfoEnum.DEVICENAME, IntPtr.Zero, ref size);
+                    IntPtr name_ptr = Marshal.AllocHGlobal((IntPtr)size);
+                    Functions.GetRawInputDeviceInfo(dev.Handle, RawInputDeviceInfoEnum.DEVICENAME, name_ptr, ref size);
+                    string name = Marshal.PtrToStringAnsi(name_ptr);
+                    Marshal.FreeHGlobal(name_ptr);
+                    //Parse the registry & store
+                    dev.Name = HidProtocol.GetDeviceName(name);
+                    return dev.Name;
+                }
+                //Not valid, so let's return an empty string
+                return String.Empty;
             }
         }
     }

--- a/src/OpenTK/Platform/Windows/XInputJoystick.cs
+++ b/src/OpenTK/Platform/Windows/XInputJoystick.cs
@@ -147,7 +147,7 @@ namespace OpenTK.Platform.Windows
 
         public string GetName(int index)
         {
-            return String.Empty;
+            return "XInput Controller " + index;
         }
 
         public Guid GetGuid(int index)


### PR DESCRIPTION
### Purpose of this PR

Allows access to the HID joystick name via Joystick.GetName(Index);
Largely based upon https://github.com/opentk/opentk/pull/651
This got shelved with 3.0, and it marginally annoyed me whilst testing the Xbox controllers....

### Testing status
Some testing-
Xbox 360 pad and a random generic joystick, both report names as expected.
Windows:
* New function to pull the HID name from the registry. This is cached on first access.
Linux:
* Appears to already have been implemented correctly, just needed the accessor.
Mac:
* Again appears to have already been implemented correctly, just needed the accessor.

### Comments
Relatively marginal / trivial.
I'd quite like this merged if only because it makes things a little nicer when viewing my main menu if multiple sticks are connected, but it's nowhere near urgent.
Not a bugfix either, so quite whether we want to merge it I don't know :)