### PR TITLE
[3.0] Fixes for keyboard / mice states & visibility in odd conditions

### DIFF
--- a/src/OpenTK/NativeWindow.cs
+++ b/src/OpenTK/NativeWindow.cs
@@ -50,6 +50,8 @@ namespace OpenTK
         private bool previous_cursor_grabbed = false;
         private bool previous_cursor_visible = true;
 
+        private bool firstFocusEvent = false;
+
         /// <summary>
         /// System.Threading.Thread.CurrentThread.ManagedThreadId of the thread that created this <see cref="OpenTK.NativeWindow"/>.
         /// </summary>
@@ -683,6 +685,18 @@ namespace OpenTK
         /// <param name="e">Not used.</param>
         protected virtual void OnFocusedChanged(EventArgs e)
         {
+            if (!firstFocusEvent)
+            {
+                /*
+                 * First focus event will always be when the Run() command spawns the window
+                 * If the cursor has been set to invisible before the first focus event
+                 * e.g. before the Run() command has been issued, we need to change the
+                 * previous_cursor_visible value appropriately
+                 */
+                previous_cursor_visible = CursorVisible;
+                firstFocusEvent = true;
+                return;
+            }
             if (!Focused)
             {
                 // Release cursor and make it visible when losing focus,

--- a/src/OpenTK/Platform/Windows/WinRawKeyboard.cs
+++ b/src/OpenTK/Platform/Windows/WinRawKeyboard.cs
@@ -50,7 +50,8 @@ namespace OpenTK.Platform.Windows
 
             this.window = windowHandle;
             RefreshDevices();
-
+            //Hook into the session switch event
+            SystemEvents.SessionSwitch += (SessionSwitch);
             Debug.Unindent();
         }
 
@@ -302,6 +303,19 @@ namespace OpenTK.Platform.Windows
                 {
                     return String.Empty;
                 }
+            }
+        }
+
+        private void SessionSwitch(object sender, SessionSwitchEventArgs e)
+        {
+            /*
+             * When locking or unlocking the computer, reset all keyboard states
+             * Otherwise, a key which is pressed when the session switch is initiated
+             * will remain pressed regardless until it is pressed and released again
+             */
+            for (int i = 0; i < keyboards.Count; i++)
+            {
+                keyboards[i] = new KeyboardState();
             }
         }
     }

--- a/src/OpenTK/Platform/Windows/WinRawMouse.cs
+++ b/src/OpenTK/Platform/Windows/WinRawMouse.cs
@@ -57,7 +57,8 @@ namespace OpenTK.Platform.Windows
 
             Window = window;
             RefreshDevices();
-
+            //Hook into the session switch event
+            SystemEvents.SessionSwitch += (SessionSwitch);
             Debug.Unindent();
         }
 
@@ -366,6 +367,25 @@ namespace OpenTK.Platform.Windows
             state.X = p.X;
             state.Y = p.Y;
             return state;
+        }
+
+        private void SessionSwitch(object sender, SessionSwitchEventArgs e)
+        {
+            /*
+             * When locking or unlocking the computer, reset all mice states
+             * Otherwise, a mouse button which is pressed when the session switch is initiated
+             * will remain pressed regardless until it is pressed and released again
+             *
+             * Note: This is much rarer than the similar condition with the keyboard
+             * (as the mouse will likely move slightly on unlock) but still...
+             */
+            lock (UpdateLock)
+            {
+                for (int i = 0; i < mice.Count; i++)
+                {
+                    mice[i] = new MouseState();
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
### Purpose of this PR

Closes https://github.com/opentk/opentk/issues/1102

https://github.com/opentk/opentk/commit/2d31165baa865c44cba30ba1d217e9f814b1a44e#diff-37631f23136d6ed41b2f84c8f626d10a5ddb62d3b77cd6674c1076e66e5de5dc
This commit introduces various improvements to checking the visibility of the mouse cursor, by storing the previous state of the cursor when the window was exited by the mouse.

It overlooks the following scenario:
The window is created with CursorVisible = false
When our window is spawned, it fires the OnFocusChanged() event, with the window in focus.
This then sets our cursor to the previous state.
However, the previous state is initialised with a default value of true, so the cursor is now visible, although this is not the user set state.

This commit adds a test as to whether the focus event is the first to be sent.
In this case, it simply sets the previous cursor state to the current.

---

Closes https://github.com/opentk/opentk/issues/1165

When the computer is locked, we are not recieving window pump messages from the raw input.
This means that if a key (or mouse button) is released, we know nothing about it.

This hooks into SystemEvents.SessionSwitch & resets the keyboard / mice states to default when a lock / unlock event is generated.

This has the slight side-effect that if a user deliberately unlocks / locks with a deliberately pressed key, this is then reset.
To me, this is better than the former behaviour, although not perfect.
This is the best we can do on that front.

### Testing status

Tested the behaviour of the code in the first linked issue on X11 VM.
Tested the behaviour of the code in the second linked issue on Win 10.

### Comments

N/A