### PR TITLE
Start of window border bug fix

### DIFF
--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -370,31 +370,28 @@ namespace OpenTK.Windowing.Desktop
 
             set
             {
-                if (GLFW.GetWindowAttrib(WindowPtr, WindowAttributeGetBool.Decorated))
+                GLFW.GetVersion(out var major, out var minor, out _);
+
+                // It isn't possible to implement this in versions of GLFW older than 3.3,
+                // as SetWindowAttrib didn't exist before then.
+                if ((major == 3) && (minor < 3))
                 {
-                    GLFW.GetVersion(out var major, out var minor, out _);
+                    throw new NotSupportedException("Cannot be implemented in GLFW 3.2.");
+                }
 
-                    // It isn't possible to implement this in versions of GLFW older than 3.3,
-                    // as SetWindowAttrib didn't exist before then.
-                    if ((major == 3) && (minor < 3))
-                    {
-                        throw new NotSupportedException("Cannot be implemented in GLFW 3.2.");
-                    }
-
-                    switch (value)
-                    {
-                        case WindowBorder.Hidden:
-                            GLFW.SetWindowAttrib(WindowPtr, WindowAttribute.Decorated, false);
-                            break;
-
-                        case WindowBorder.Resizable:
-                            GLFW.SetWindowAttrib(WindowPtr, WindowAttribute.Resizable, true);
-                            break;
-
-                        case WindowBorder.Fixed:
-                            GLFW.SetWindowAttrib(WindowPtr, WindowAttribute.Resizable, false);
-                            break;
-                    }
+                switch (value)
+                {
+                    case WindowBorder.Hidden:
+                        GLFW.SetWindowAttrib(WindowPtr, WindowAttribute.Decorated, false);
+                        break;
+                    case WindowBorder.Resizable:
+                        GLFW.SetWindowAttrib(WindowPtr, WindowAttribute.Decorated, true);
+                        GLFW.SetWindowAttrib(WindowPtr, WindowAttribute.Resizable, true);
+                        break;
+                    case WindowBorder.Fixed:
+                        GLFW.SetWindowAttrib(WindowPtr, WindowAttribute.Decorated, true);
+                        GLFW.SetWindowAttrib(WindowPtr, WindowAttribute.Resizable, false);
+                        break;
                 }
 
                 _windowBorder = value;


### PR DESCRIPTION
### Purpose of this PR

* Description:
Fixes a bug where when setting the window border to **Hidden** prevents the border from becoming visible again if trying to set the border back to **Resizable** or **Fixed*.
* Which part of OpenTK does this affect?
Native Window/GLFW.  Specifically in the **OpenTK.Windowing.Desktop** namespace in the **NativeWindow** class.

### Testing status

Testing performed is manual.  Testing involves setting the border to **Hidden**, then back to **Resizable** and/or **Fixed** to see if the window decorations are set back to visible. Planning on working with **Offenbash** to test this on linux.

### Comments

Discussions with **Offenbash** about letting him test this out on linux because he has a linux setup to use to test it out.
