### PR TITLE
NativeWindow Improvements

### DIFF
--- a/src/OpenTK.Windowing.Desktop/GameWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/GameWindow.cs
@@ -253,14 +253,13 @@ namespace OpenTK.Windowing.Desktop
             while (true)
             {
                 ProcessEvents();
+                DispatchUpdateFrame();
 
                 if (!Exists || IsExiting)
                 {
                     DestroyWindow();
                     return;
                 }
-
-                DispatchUpdateFrame();
 
                 if (!IsMultiThreaded)
                 {

--- a/src/OpenTK.Windowing.Desktop/GameWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/GameWindow.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // GameWindow.cs
 //
 // Copyright (C) 2018 OpenTK
@@ -256,6 +256,7 @@ namespace OpenTK.Windowing.Desktop
 
                 if (!Exists || IsExiting)
                 {
+                    DestroyWindow();
                     return;
                 }
 

--- a/src/OpenTK.Windowing.Desktop/GameWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/GameWindow.cs
@@ -309,6 +309,7 @@ namespace OpenTK.Windowing.Desktop
                 }
 
                 IsRunningSlowly = _updateEpsilon >= updatePeriod;
+
                 if (IsRunningSlowly && --isRunningSlowlyRetries == 0)
                 {
                     // If UpdateFrame consistently takes longer than TargetUpdateFrame
@@ -317,12 +318,6 @@ namespace OpenTK.Windowing.Desktop
                 }
 
                 elapsed = _watchUpdate.Elapsed.TotalSeconds;
-            }
-
-            // Update VSync if set to adaptive
-            if (_vSync == VSyncMode.Adaptive)
-            {
-                GLFW.SwapInterval(IsRunningSlowly ? 0 : 1);
             }
         }
 
@@ -334,6 +329,12 @@ namespace OpenTK.Windowing.Desktop
             {
                 _watchRender.Restart();
                 OnRenderFrame(new FrameEventArgs(elapsed));
+
+                // Update VSync if set to adaptive
+                if (_vSync == VSyncMode.Adaptive)
+                {
+                    GLFW.SwapInterval(IsRunningSlowly ? 0 : 1);
+                }
             }
         }
 

--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -986,7 +986,7 @@ namespace OpenTK.Windowing.Desktop
             Context.MakeCurrent();
         }
 
-        private unsafe void DestroyWindow()
+        protected unsafe void DestroyWindow()
         {
             if (Exists)
             {
@@ -1513,9 +1513,6 @@ namespace OpenTK.Windowing.Desktop
             if (disposing)
             {
             }
-
-            // Free unmanaged resources
-            DestroyWindow();
 
             _disposedValue = true;
         }

--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -25,7 +25,7 @@ namespace OpenTK.Windowing.Desktop
         /// </summary>
         public unsafe Window* WindowPtr { get; }
 
-        // Used for delta calculation in the mouse pos changed event.
+        // Used for delta calculation in the mouse position changed event.
         private Vector2 _lastReportedMousePos;
 
         // GLFW cursor we assigned to the window.
@@ -63,8 +63,8 @@ namespace OpenTK.Windowing.Desktop
 
         /// <summary>
         ///     Gets or sets the position of the mouse relative to the content area of this window.
-        ///     NOTE: It is not necessary to centre the mouse on each frame. Use CursorGrabbed = true;
-        ///     to enable this behaviour.
+        ///     NOTE: It is not necessary to center the mouse on each frame. Use CursorGrabbed = true;
+        ///     to enable this behavior.
         /// </summary>
         public Vector2 MousePosition
         {
@@ -254,7 +254,7 @@ namespace OpenTK.Windowing.Desktop
             }
         }
 
-        // This is updated by the constructor and by the the OnFocusChanged event. We presume that OnFocusChanged will fire after a call to GLFW.FocusWindow.
+        // This is updated by the constructor and by the OnFocusChanged event. We presume that OnFocusChanged will fire after a call to GLFW.FocusWindow.
         private bool _isFocused;
 
         /// <summary>
@@ -451,7 +451,7 @@ namespace OpenTK.Windowing.Desktop
         /// <summary>
         /// Gets or sets a <see cref="OpenTK.Mathematics.Box2i" /> structure that contains the internal bounds of this window,
         /// in client coordinates.
-        /// The internal bounds include the drawing area of the window, but exclude the titlebar and window borders.
+        /// The internal bounds include the drawing area of the window, but exclude the title bar and window borders.
         /// </summary>
         public Box2i ClientRectangle
         {
@@ -1298,7 +1298,7 @@ namespace OpenTK.Windowing.Desktop
         /// <returns><c>true</c>, if current monitor's dpi was gotten correctly, <c>false</c> otherwise.</returns>
         /// <remarks>
         /// This methods approximates the dpi of the monitor by multiplying
-        /// the monitor scale recieved from <see cref="TryGetCurrentMonitorScale(out float, out float)"/>
+        /// the monitor scale received from <see cref="TryGetCurrentMonitorScale(out float, out float)"/>
         /// by each platforms respective default dpi (72 for macOS and 96 for other systems).
         /// </remarks>
         public unsafe bool TryGetCurrentMonitorDpi(out float horizontalDpi, out float verticalDpi) =>


### PR DESCRIPTION
## Purpose of this PR

### Description of feature/change:
This PR involves improving various things in the `GameWindow` and `NativeWindow` based on conversations about how resources should be disposed, to prevent **GL** calls after **GL Context** destruction etc.
These were conversations held in the discord **development** channel between 
**Improvement List:**
1. Improve how the **NativeWindow** resources are disposed of
2. Movement of the logic involved with swapping intervals when **VSync** is set to **Adaptive**, to the render loop instead of the update loop
   * Involves the [GLFW.SwapInterval()](https://www.glfw.org/docs/latest/group__context.html#ga6d4e0cdf151b5e579bd67f13202994ed) call
   * Still maintains the **GLFW swap interval** call to be thread safe
3. Moves the **Update Loop** call in the internal main loop above loop exit logic
   * This is to prevent any **GL** calls from being invoked if the user decides to call `GameWindow.Close()` in the update loop.  This helps the window close and dispose of resources gracefully without issue.
4. Moves the **destroy window process** from the `GameWindow` close call stack to the main loop right before the main loop exists.
   * This is make sure that the destruction of the **window** occurs at the correct time which also improves the resource disposal process

**Which part of OpenTK does this affect:**
   * `OpenTK.Windowing.Desktop` namespace
   * `GameWindow` class
   * `NativeWindow` class

### Testing:

1. Create a class form the `GameWindow` class and add a `SwapBuffers()` call in the update loop
2. Run the application and close the window via the methods below and verify that no exceptions are thrown
   * Call `Close()` method programmatically
   * Close the window via the mouse and the X window button in the top right corner
   * Close the window using the keyboard combination **Alt + F4**

### Comments

* Any other comments to help understand the change.
