### PR TITLE
traverse correctly buttons in JoystickState ToString

### DIFF
--- a/src/OpenTK.Windowing.GraphicsLibraryFramework/Input/JoystickState.cs
+++ b/src/OpenTK.Windowing.GraphicsLibraryFramework/Input/JoystickState.cs
@@ -171,7 +171,7 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
 
             var buttonBuilder = new StringBuilder();
 
-            for (int i = 0; i < _buttons.Length * 8; i++)
+            for (int i = 0; i < _buttons.Length; i++)
             {
                 buttonBuilder.Append($", {(IsButtonDown(i) ? "down" : "up")}");
             }


### PR DESCRIPTION
### Purpose of this PR

* ToString on JoystickState fails traversing buttons.
* Input is affected.

### Testing status

Tested on linux https://github.com/albfan/test-joysticks

### Comments

* Looks like now states (keyboard, mouse, joysticks are tied to a GameWindow)