### PR TITLE
A bunch of fixups, cleanups and convenience features.

### DIFF
--- a/src/OpenAL/OpenTK.OpenAL.Extensions/OpenTK.OpenAL.Extensions.csproj
+++ b/src/OpenAL/OpenTK.OpenAL.Extensions/OpenTK.OpenAL.Extensions.csproj
@@ -10,11 +10,14 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Buffers" Version="4.5.0" />
+        <PackageReference Include="System.Buffers" Version="4.5.1" />
     </ItemGroup>
 
     <Import Project="..\..\..\props\common.props" />
     <Import Project="$(OpenTKSolutionRoot)\props\nuget-common.props" />
     <Import Project="$(OpenTKSolutionRoot)\props\stylecop.props" />
+    <ItemGroup>
+      <PackageReference Update="StyleCop.Analyzers" Version="1.1.118" />
+    </ItemGroup>
 
 </Project>

--- a/src/OpenAL/OpenTK.OpenAL/OpenTK.OpenAL.csproj
+++ b/src/OpenAL/OpenTK.OpenAL/OpenTK.OpenAL.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Buffers" Version="4.5.0" />
+    <PackageReference Include="System.Buffers" Version="4.5.1" />
   </ItemGroup>
 
   <ItemGroup>
@@ -34,4 +34,7 @@
   <Import Project="..\..\..\props\common.props" />
   <Import Project="$(OpenTKSolutionRoot)\props\nuget-common.props" />
   <Import Project="$(OpenTKSolutionRoot)\props\stylecop.props" />
+  <ItemGroup>
+    <PackageReference Update="StyleCop.Analyzers" Version="1.1.118" />
+  </ItemGroup>
 </Project>

--- a/src/OpenTK.Core/OpenTK.Core.csproj
+++ b/src/OpenTK.Core/OpenTK.Core.csproj
@@ -22,4 +22,7 @@
   <Import Project="..\..\props\common.props" />
   <Import Project="..\..\props\nuget-common.props" />
   <Import Project="..\..\props\stylecop.props" />
+  <ItemGroup>
+    <PackageReference Update="StyleCop.Analyzers" Version="1.1.118" />
+  </ItemGroup>
 </Project>

--- a/src/OpenTK.Input/OpenTK.Input.csproj
+++ b/src/OpenTK.Input/OpenTK.Input.csproj
@@ -12,4 +12,7 @@
   <Import Project="..\..\props\common.props" />
   <Import Project="..\..\props\nuget-common.props" />
   <Import Project="..\..\props\stylecop.props" />
+  <ItemGroup>
+    <PackageReference Update="StyleCop.Analyzers" Version="1.1.118" />
+  </ItemGroup>
 </Project>

--- a/src/OpenTK.Mathematics/MathHelper.cs
+++ b/src/OpenTK.Mathematics/MathHelper.cs
@@ -883,23 +883,12 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
-        /// Swaps two double values.
-        /// </summary>
-        /// <param name="a">The first value.</param>
-        /// <param name="b">The second value.</param>
-        public static void Swap(ref double a, ref double b)
-        {
-            var temp = a;
-            a = b;
-            b = temp;
-        }
-
-        /// <summary>
         /// Swaps two float values.
         /// </summary>
+        /// <typeparam name="T">The type of the values to swap.</typeparam>
         /// <param name="a">The first value.</param>
         /// <param name="b">The second value.</param>
-        public static void Swap(ref float a, ref float b)
+        public static void Swap<T>(ref T a, ref T b)
         {
             var temp = a;
             a = b;
@@ -945,15 +934,10 @@ namespace OpenTK.Mathematics
             return Math.Max(Math.Min(n, max), min);
         }
 
-        [Pure]
-        private static unsafe int FloatToInt32Bits(float f)
-        {
-            return *((int*)&f);
-        }
-
         /// <summary>
         /// Scales the specified number linearly between a minimum and a maximum.
         /// </summary>
+        /// <remarks>If the value range is zero, this function will throw a divide by zero exception.</remarks>
         /// <param name="value">The number to scale.</param>
         /// <param name="valueMin">The minimum expected number (inclusive).</param>
         /// <param name="valueMax">The maximum expected number (inclusive).</param>
@@ -961,25 +945,47 @@ namespace OpenTK.Mathematics
         /// <param name="resultMax">The maximum output number (inclusive).</param>
         /// <returns>The number, scaled linearly between min and max.</returns>
         [Pure]
-        public static int ScaleValue
-        (
-            int value,
-            int valueMin,
-            int valueMax,
-            int resultMin,
-            int resultMax
-        )
+        public static int Map(int value, int valueMin, int valueMax, int resultMin, int resultMax)
         {
-            if (valueMin >= valueMax || resultMin >= resultMax)
-            {
-                throw new ArgumentOutOfRangeException();
-            }
+            int inRange = valueMax - valueMax;
+            int resultRange = resultMax - resultMin;
+            return resultMin + (resultRange * ((value - valueMin) / inRange));
+        }
 
-            value = Clamp(value, valueMin, valueMax);
+        /// <summary>
+        /// Scales the specified number linearly between a minimum and a maximum.
+        /// </summary>
+        /// <remarks>If the value range is zero, this function will throw a divide by zero exception.</remarks>
+        /// <param name="value">The number to scale.</param>
+        /// <param name="valueMin">The minimum expected number (inclusive).</param>
+        /// <param name="valueMax">The maximum expected number (inclusive).</param>
+        /// <param name="resultMin">The minimum output number (inclusive).</param>
+        /// <param name="resultMax">The maximum output number (inclusive).</param>
+        /// <returns>The number, scaled linearly between min and max.</returns>
+        [Pure]
+        public static float Map(float value, float valueMin, float valueMax, float resultMin, float resultMax)
+        {
+            float inRange = valueMax - valueMax;
+            float resultRange = resultMax - resultMin;
+            return resultMin + (resultRange * ((value - valueMin) / inRange));
+        }
 
-            var range = resultMax - resultMin;
-            long temp = (value - valueMin) * range; // need long to avoid overflow
-            return (int)((temp / (valueMax - valueMin)) + resultMin);
+        /// <summary>
+        /// Scales the specified number linearly between a minimum and a maximum.
+        /// </summary>
+        /// <remarks>If the value range is zero, this function will throw a divide by zero exception.</remarks>
+        /// <param name="value">The number to scale.</param>
+        /// <param name="valueMin">The minimum expected number (inclusive).</param>
+        /// <param name="valueMax">The maximum expected number (inclusive).</param>
+        /// <param name="resultMin">The minimum output number (inclusive).</param>
+        /// <param name="resultMax">The maximum output number (inclusive).</param>
+        /// <returns>The number, scaled linearly between min and max.</returns>
+        [Pure]
+        public static double Map(double value, double valueMin, double valueMax, double resultMin, double resultMax)
+        {
+            double inRange = valueMax - valueMax;
+            double resultRange = resultMax - resultMin;
+            return resultMin + (resultRange * ((value - valueMin) / inRange));
         }
 
         /// <summary>
@@ -996,13 +1002,13 @@ namespace OpenTK.Mathematics
         public static bool ApproximatelyEqual(float a, float b, int maxDeltaBits)
         {
             // we use longs here, otherwise we run into a two's complement problem, causing this to fail with -2 and 2.0
-            long k = FloatToInt32Bits(a);
+            long k = BitConverter.SingleToInt32Bits(a);
             if (k < 0)
             {
                 k = int.MinValue - k;
             }
 
-            long l = FloatToInt32Bits(b);
+            long l = BitConverter.SingleToInt32Bits(b);
             if (l < 0)
             {
                 l = int.MinValue - l;
@@ -1140,12 +1146,26 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="start">Start value.</param>
         /// <param name="end">End value.</param>
-        /// <param name="t">Value of the interpollation between a and b.</param>
+        /// <param name="t">Value of the interpollation between a and b. Clamped to [0, 1].</param>
         /// <returns>The interpolated result between the a and b values.</returns>
         [Pure]
         public static float Lerp(float start, float end, float t)
         {
-            t = Clamp(t, 0, 1);
+            t = Math.Clamp(t, 0, 1);
+            return start + (t * (end - start));
+        }
+
+        /// <summary>
+        /// Linearly interpolates between a and b by t.
+        /// </summary>
+        /// <param name="start">Start value.</param>
+        /// <param name="end">End value.</param>
+        /// <param name="t">Value of the interpollation between a and b. Clamped to [0, 1].</param>
+        /// <returns>The interpolated result between the a and b values.</returns>
+        [Pure]
+        public static double Lerp(double start, double end, double t)
+        {
+            t = Math.Clamp(t, 0, 1);
             return start + (t * (end - start));
         }
 

--- a/src/OpenTK.Mathematics/MathHelper.cs
+++ b/src/OpenTK.Mathematics/MathHelper.cs
@@ -945,7 +945,7 @@ namespace OpenTK.Mathematics
         /// <param name="resultMax">The maximum output number (inclusive).</param>
         /// <returns>The number, scaled linearly between min and max.</returns>
         [Pure]
-        public static int Map(int value, int valueMin, int valueMax, int resultMin, int resultMax)
+        public static int MapRange(int value, int valueMin, int valueMax, int resultMin, int resultMax)
         {
             int inRange = valueMax - valueMax;
             int resultRange = resultMax - resultMin;
@@ -963,7 +963,7 @@ namespace OpenTK.Mathematics
         /// <param name="resultMax">The maximum output number (inclusive).</param>
         /// <returns>The number, scaled linearly between min and max.</returns>
         [Pure]
-        public static float Map(float value, float valueMin, float valueMax, float resultMin, float resultMax)
+        public static float MapRange(float value, float valueMin, float valueMax, float resultMin, float resultMax)
         {
             float inRange = valueMax - valueMax;
             float resultRange = resultMax - resultMin;
@@ -981,7 +981,7 @@ namespace OpenTK.Mathematics
         /// <param name="resultMax">The maximum output number (inclusive).</param>
         /// <returns>The number, scaled linearly between min and max.</returns>
         [Pure]
-        public static double Map(double value, double valueMin, double valueMax, double resultMin, double resultMax)
+        public static double MapRange(double value, double valueMin, double valueMax, double resultMin, double resultMax)
         {
             double inRange = valueMax - valueMax;
             double resultRange = resultMax - resultMin;

--- a/src/OpenTK.Mathematics/OpenTK.Mathematics.csproj
+++ b/src/OpenTK.Mathematics/OpenTK.Mathematics.csproj
@@ -11,9 +11,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.2" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" />
   </ItemGroup>
   <Import Project="..\..\props\common.props" />
   <Import Project="..\..\props\nuget-common.props" />
   <Import Project="..\..\props\stylecop.props" />
+  <ItemGroup>
+    <PackageReference Update="StyleCop.Analyzers" Version="1.1.118" />
+  </ItemGroup>
 </Project>

--- a/src/OpenTK.Mathematics/Vector/Vector2i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2i.cs
@@ -97,6 +97,16 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
+        /// Gets the manhattan length of the vector.
+        /// </summary>
+        public int ManhattanLength => X + Y;
+
+        /// <summary>
+        /// Gets the euclidian length of the vector.
+        /// </summary>
+        public float EuclideanLength => MathF.Sqrt((X * X) + (Y * Y));
+
+        /// <summary>
         /// Gets the perpendicular vector on the right side of this vector.
         /// </summary>
         public Vector2i PerpendicularRight => new Vector2i(Y, -X);
@@ -290,8 +300,8 @@ namespace OpenTK.Mathematics
         [Pure]
         public static Vector2i ComponentMin(Vector2i a, Vector2i b)
         {
-            a.X = a.X < b.X ? a.X : b.X;
-            a.Y = a.Y < b.Y ? a.Y : b.Y;
+            a.X = Math.Min(a.X, b.X);
+            a.Y = Math.Min(a.Y, b.Y);
             return a;
         }
 
@@ -303,8 +313,8 @@ namespace OpenTK.Mathematics
         /// <param name="result">The component-wise minimum.</param>
         public static void ComponentMin(in Vector2i a, in Vector2i b, out Vector2i result)
         {
-            result.X = a.X < b.X ? a.X : b.X;
-            result.Y = a.Y < b.Y ? a.Y : b.Y;
+            result.X = Math.Min(a.X, b.X);
+            result.Y = Math.Min(a.Y, b.Y);
         }
 
         /// <summary>
@@ -316,8 +326,8 @@ namespace OpenTK.Mathematics
         [Pure]
         public static Vector2i ComponentMax(Vector2i a, Vector2i b)
         {
-            a.X = a.X > b.X ? a.X : b.X;
-            a.Y = a.Y > b.Y ? a.Y : b.Y;
+            a.X = Math.Max(a.X, b.X);
+            a.Y = Math.Max(a.Y, b.Y);
             return a;
         }
 
@@ -329,8 +339,8 @@ namespace OpenTK.Mathematics
         /// <param name="result">The component-wise maximum.</param>
         public static void ComponentMax(in Vector2i a, in Vector2i b, out Vector2i result)
         {
-            result.X = a.X > b.X ? a.X : b.X;
-            result.Y = a.Y > b.Y ? a.Y : b.Y;
+            result.X = Math.Max(a.X, b.X);
+            result.Y = Math.Max(a.Y, b.Y);
         }
 
         /// <summary>
@@ -343,8 +353,8 @@ namespace OpenTK.Mathematics
         [Pure]
         public static Vector2i Clamp(Vector2i vec, Vector2i min, Vector2i max)
         {
-            vec.X = vec.X < min.X ? min.X : vec.X > max.X ? max.X : vec.X;
-            vec.Y = vec.Y < min.Y ? min.Y : vec.Y > max.Y ? max.Y : vec.Y;
+            vec.X = MathHelper.Clamp(vec.X, min.X, max.X);
+            vec.Y = MathHelper.Clamp(vec.Y, min.Y, max.Y);
             return vec;
         }
 
@@ -357,8 +367,8 @@ namespace OpenTK.Mathematics
         /// <param name="result">The clamped vector.</param>
         public static void Clamp(in Vector2i vec, in Vector2i min, in Vector2i max, out Vector2i result)
         {
-            result.X = vec.X < min.X ? min.X : vec.X > max.X ? max.X : vec.X;
-            result.Y = vec.Y < min.Y ? min.Y : vec.Y > max.Y ? max.Y : vec.Y;
+            result.X = MathHelper.Clamp(vec.X, min.X, max.X);
+            result.Y = MathHelper.Clamp(vec.Y, min.Y, max.Y);
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Vector/Vector2i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2i.cs
@@ -99,7 +99,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Gets the manhattan length of the vector.
         /// </summary>
-        public int ManhattanLength => X + Y;
+        public int ManhattanLength => Math.Abs(X) + Math.Abs(Y);
 
         /// <summary>
         /// Gets the euclidian length of the vector.

--- a/src/OpenTK.Mathematics/Vector/Vector3i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3i.cs
@@ -139,7 +139,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Gets the manhattan length of the vector.
         /// </summary>
-        public int ManhattanLength => X + Y + Z;
+        public int ManhattanLength => Math.Abs(X) + Math.Abs(Y) + Math.Abs(Z);
 
         /// <summary>
         /// Gets the euclidian length of the vector.

--- a/src/OpenTK.Mathematics/Vector/Vector3i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3i.cs
@@ -77,6 +77,18 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="Vector3i"/> struct.
+        /// </summary>
+        /// <param name="v">The <see cref="Vector2i"/> to copy components from.</param>
+        /// <param name="z">The z component of the new Vector3.</param>
+        public Vector3i(Vector2i v, int z)
+        {
+            X = v.X;
+            Y = v.Y;
+            Z = z;
+        }
+
+        /// <summary>
         /// Gets or sets the value at the index of the vector.
         /// </summary>
         /// <param name="index">The index of the component from the vector.</param>
@@ -123,6 +135,16 @@ namespace OpenTK.Mathematics
                 }
             }
         }
+
+        /// <summary>
+        /// Gets the manhattan length of the vector.
+        /// </summary>
+        public int ManhattanLength => X + Y + Z;
+
+        /// <summary>
+        /// Gets the euclidian length of the vector.
+        /// </summary>
+        public float EuclideanLength => MathF.Sqrt((X * X) + (Y * Y) + (Z * Z));
 
         /// <summary>
         /// Defines a unit-length Vector3i that points towards the X-axis.
@@ -366,9 +388,9 @@ namespace OpenTK.Mathematics
         [Pure]
         public static Vector3i Clamp(Vector3i vec, Vector3i min, Vector3i max)
         {
-            vec.X = vec.X < min.X ? min.X : vec.X > max.X ? max.X : vec.X;
-            vec.Y = vec.Y < min.Y ? min.Y : vec.Y > max.Y ? max.Y : vec.Y;
-            vec.Z = vec.Z < min.Z ? min.Z : vec.Z > max.Z ? max.Z : vec.Z;
+            vec.X = MathHelper.Clamp(vec.X, min.X, max.X);
+            vec.Y = MathHelper.Clamp(vec.Y, min.Y, max.Y);
+            vec.Z = MathHelper.Clamp(vec.Z, min.Z, max.Z);
             return vec;
         }
 
@@ -381,9 +403,9 @@ namespace OpenTK.Mathematics
         /// <param name="result">The clamped vector.</param>
         public static void Clamp(in Vector3i vec, in Vector3i min, in Vector3i max, out Vector3i result)
         {
-            result.X = vec.X < min.X ? min.X : vec.X > max.X ? max.X : vec.X;
-            result.Y = vec.Y < min.Y ? min.Y : vec.Y > max.Y ? max.Y : vec.Y;
-            result.Z = vec.Z < min.Z ? min.Z : vec.Z > max.Z ? max.Z : vec.Z;
+            result.X = MathHelper.Clamp(vec.X, min.X, max.X);
+            result.Y = MathHelper.Clamp(vec.Y, min.Y, max.Y);
+            result.Z = MathHelper.Clamp(vec.Z, min.Z, max.Z);
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Vector/Vector4i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4i.cs
@@ -183,7 +183,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Gets the manhattan length of the vector.
         /// </summary>
-        public int ManhattanLength => X + Y + Z + W;
+        public int ManhattanLength => Math.Abs(X) + Math.Abs(Y) + Math.Abs(Z) + Math.Abs(W);
 
         /// <summary>
         /// Gets the euclidian length of the vector.

--- a/src/OpenTK.Mathematics/Vector/Vector4i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4i.cs
@@ -47,41 +47,6 @@ namespace OpenTK.Mathematics
         public int W;
 
         /// <summary>
-        /// Defines a unit-length <see cref="Vector4i"/> that points towards the X-axis.
-        /// </summary>
-        public static readonly Vector4i UnitX = new Vector4i(1, 0, 0, 0);
-
-        /// <summary>
-        /// Defines a unit-length <see cref="Vector4i"/> that points towards the Y-axis.
-        /// </summary>
-        public static readonly Vector4i UnitY = new Vector4i(0, 1, 0, 0);
-
-        /// <summary>
-        /// Defines a unit-length <see cref="Vector4i"/> that points towards the Z-axis.
-        /// </summary>
-        public static readonly Vector4i UnitZ = new Vector4i(0, 0, 1, 0);
-
-        /// <summary>
-        /// Defines a unit-length <see cref="Vector4i"/> that points towards the W-axis.
-        /// </summary>
-        public static readonly Vector4i UnitW = new Vector4i(0, 0, 0, 1);
-
-        /// <summary>
-        /// Defines a zero-length <see cref="Vector4i"/>.
-        /// </summary>
-        public static readonly Vector4i Zero = new Vector4i(0, 0, 0, 0);
-
-        /// <summary>
-        /// Defines an instance with all components set to 1.
-        /// </summary>
-        public static readonly Vector4i One = new Vector4i(1, 1, 1, 1);
-
-        /// <summary>
-        /// Defines the size of the <see cref="Vector4i"/> struct in bytes.
-        /// </summary>
-        public static readonly int SizeInBytes = Unsafe.SizeOf<Vector4i>();
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="Vector4i"/> struct.
         /// </summary>
         /// <param name="value">The value that will initialize this instance.</param>
@@ -111,13 +76,26 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector4i"/> struct.
         /// </summary>
-        /// <param name="v">The Vector2 to copy components from.</param>
+        /// <param name="v">The <see cref="Vector2i"/> to copy components from.</param>
         public Vector4i(Vector2i v)
         {
             X = v.X;
             Y = v.Y;
             Z = 0;
             W = 0;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector4i"/> struct.
+        /// </summary>
+        /// <param name="v1">The <see cref="Vector2i"/> to get the X and Y components for the Vector4.</param>
+        /// <param name="v2">The <see cref="Vector2i"/> to get the Z and W components for the Vector4.</param>
+        public Vector4i(Vector2i v1, Vector2i v2)
+        {
+            X = v1.X;
+            Y = v1.Y;
+            Z = v2.X;
+            W = v2.Y;
         }
 
         /// <summary>
@@ -201,6 +179,51 @@ namespace OpenTK.Mathematics
                 }
             }
         }
+
+        /// <summary>
+        /// Gets the manhattan length of the vector.
+        /// </summary>
+        public int ManhattanLength => X + Y + Z + W;
+
+        /// <summary>
+        /// Gets the euclidian length of the vector.
+        /// </summary>
+        public float EuclideanLength => MathF.Sqrt((X * X) + (Y * Y) + (Z * Z) + (W * W));
+
+        /// <summary>
+        /// Defines a unit-length <see cref="Vector4i"/> that points towards the X-axis.
+        /// </summary>
+        public static readonly Vector4i UnitX = new Vector4i(1, 0, 0, 0);
+
+        /// <summary>
+        /// Defines a unit-length <see cref="Vector4i"/> that points towards the Y-axis.
+        /// </summary>
+        public static readonly Vector4i UnitY = new Vector4i(0, 1, 0, 0);
+
+        /// <summary>
+        /// Defines a unit-length <see cref="Vector4i"/> that points towards the Z-axis.
+        /// </summary>
+        public static readonly Vector4i UnitZ = new Vector4i(0, 0, 1, 0);
+
+        /// <summary>
+        /// Defines a unit-length <see cref="Vector4i"/> that points towards the W-axis.
+        /// </summary>
+        public static readonly Vector4i UnitW = new Vector4i(0, 0, 0, 1);
+
+        /// <summary>
+        /// Defines a zero-length <see cref="Vector4i"/>.
+        /// </summary>
+        public static readonly Vector4i Zero = new Vector4i(0, 0, 0, 0);
+
+        /// <summary>
+        /// Defines an instance with all components set to 1.
+        /// </summary>
+        public static readonly Vector4i One = new Vector4i(1, 1, 1, 1);
+
+        /// <summary>
+        /// Defines the size of the <see cref="Vector4i"/> struct in bytes.
+        /// </summary>
+        public static readonly int SizeInBytes = Unsafe.SizeOf<Vector4i>();
 
         /// <summary>
         /// Adds two vectors.
@@ -434,10 +457,10 @@ namespace OpenTK.Mathematics
         [Pure]
         public static Vector4i Clamp(Vector4i vec, Vector4i min, Vector4i max)
         {
-            vec.X = vec.X < min.X ? min.X : vec.X > max.X ? max.X : vec.X;
-            vec.Y = vec.Y < min.Y ? min.Y : vec.Y > max.Y ? max.Y : vec.Y;
-            vec.Z = vec.Z < min.Z ? min.Z : vec.Z > max.Z ? max.Z : vec.Z;
-            vec.W = vec.W < min.W ? min.W : vec.W > max.W ? max.W : vec.W;
+            vec.X = MathHelper.Clamp(vec.X, min.X, max.X);
+            vec.Y = MathHelper.Clamp(vec.Y, min.Y, max.Y);
+            vec.Z = MathHelper.Clamp(vec.Z, min.Z, max.Z);
+            vec.W = MathHelper.Clamp(vec.W, min.W, max.W);
             return vec;
         }
 
@@ -450,10 +473,10 @@ namespace OpenTK.Mathematics
         /// <param name="result">The clamped vector.</param>
         public static void Clamp(in Vector4i vec, in Vector4i min, in Vector4i max, out Vector4i result)
         {
-            result.X = vec.X < min.X ? min.X : vec.X > max.X ? max.X : vec.X;
-            result.Y = vec.Y < min.Y ? min.Y : vec.Y > max.Y ? max.Y : vec.Y;
-            result.Z = vec.Z < min.Z ? min.Z : vec.Z > max.Z ? max.Z : vec.Z;
-            result.W = vec.W < min.W ? min.W : vec.W > max.W ? max.W : vec.W;
+            result.X = MathHelper.Clamp(vec.X, min.X, max.X);
+            result.Y = MathHelper.Clamp(vec.Y, min.Y, max.Y);
+            result.Z = MathHelper.Clamp(vec.Z, min.Z, max.Z);
+            result.W = MathHelper.Clamp(vec.W, min.W, max.W);
         }
 
         /// <summary>

--- a/src/OpenTK.Windowing.Common/Events/JoystickEventArgs.cs
+++ b/src/OpenTK.Windowing.Common/Events/JoystickEventArgs.cs
@@ -13,7 +13,7 @@ using OpenTK.Windowing.Common;
 namespace OpenTK.Windowing.Common
 {
     /// <summary>
-    /// Defines the event data for the <see cref="INativeWindow.JoystickConnected"/> event.
+    /// Defines the event data for the <see cref="NativeWindow.JoystickConnected"/> event.
     /// </summary>
     public readonly struct JoystickEventArgs
     {

--- a/src/OpenTK.Windowing.Common/Events/MonitorEventArgs.cs
+++ b/src/OpenTK.Windowing.Common/Events/MonitorEventArgs.cs
@@ -10,7 +10,7 @@
 namespace OpenTK.Windowing.Common
 {
     /// <summary>
-    /// Defines the event data for the <see cref="INativeWindow.MonitorConnected"/> event.
+    /// Defines the event data for the <see cref="NativeWindow.MonitorConnected"/> event.
     /// </summary>
     public readonly struct MonitorEventArgs // TODO: merge with JoystickEventArgs?
     {

--- a/src/OpenTK.Windowing.Common/Events/MouseMoveEventArgs.cs
+++ b/src/OpenTK.Windowing.Common/Events/MouseMoveEventArgs.cs
@@ -12,7 +12,7 @@ using OpenTK.Mathematics;
 namespace OpenTK.Windowing.Common
 {
     /// <summary>
-    /// Defines the event data for <see cref="IWindowEvents.MouseMove" /> events.
+    /// Defines the event data for <see cref="NativeWindow.MouseMove"/> events.
     /// </summary>
     public readonly struct MouseMoveEventArgs
     {

--- a/src/OpenTK.Windowing.Common/Events/MouseWheelEventArgs.cs
+++ b/src/OpenTK.Windowing.Common/Events/MouseWheelEventArgs.cs
@@ -12,7 +12,7 @@ using OpenTK.Mathematics;
 namespace OpenTK.Windowing.Common
 {
     /// <summary>
-    /// Defines the event data for <see cref="INativeWindow.MouseWheel" /> events.
+    /// Defines the event data for <see cref="NativeWindow.MouseWheel" /> events.
     /// </summary>
     public readonly struct MouseWheelEventArgs
     {

--- a/src/OpenTK.Windowing.Common/OpenTK.Windowing.Common.csproj
+++ b/src/OpenTK.Windowing.Common/OpenTK.Windowing.Common.csproj
@@ -24,4 +24,7 @@
   <Import Project="..\..\props\common.props" />
   <Import Project="..\..\props\nuget-common.props" />
   <Import Project="..\..\props\stylecop.props" />
+  <ItemGroup>
+    <PackageReference Update="StyleCop.Analyzers" Version="1.1.118" />
+  </ItemGroup>
 </Project>

--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -32,7 +32,6 @@ namespace OpenTK.Windowing.Desktop
         private Vector2i _cachedWindowClientSize;
         private Vector2i _cachedWindowLocation;
         private WindowState _previousWindowState;
-        private static object _lockObject = new object();
 
         // Used for delta calculation in the mouse position changed event.
         private Vector2 _lastReportedMousePos;
@@ -88,8 +87,6 @@ namespace OpenTK.Windowing.Desktop
             }
         }
 
-        private MouseState _mouseState;
-
         /// <summary>
         ///     Gets the amount that the mouse moved since the last frame.
         ///     This does not necessarily correspond to pixels, for example in the case of raw input.
@@ -100,7 +97,7 @@ namespace OpenTK.Windowing.Desktop
         /// <summary>
         ///     Gets the current state of the mouse as of the last time the window processed events.
         /// </summary>
-        public MouseState MouseState => _mouseState;
+        public MouseState MouseState { get; } = new MouseState();
 
         /// <summary>
         ///     Gets the previous keyboard state.
@@ -119,7 +116,7 @@ namespace OpenTK.Windowing.Desktop
         /// Gets a value indicating whether any mouse button is pressed.
         /// </summary>
         /// <value><c>true</c> if any button is pressed; otherwise, <c>false</c>.</value>
-        public bool IsAnyMouseButtonDown => _mouseState.IsAnyButtonDown;
+        public bool IsAnyMouseButtonDown => MouseState.IsAnyButtonDown;
 
         private WindowIcon _icon;
 
@@ -183,7 +180,6 @@ namespace OpenTK.Windowing.Desktop
                     return GLFW.GetClipboardString(WindowPtr);
                 }
             }
-
             set
             {
                 unsafe
@@ -251,13 +247,13 @@ namespace OpenTK.Windowing.Desktop
                 var monitor = value.ToUnsafePtr<GraphicsLibraryFramework.Monitor>();
                 var mode = GLFW.GetVideoMode(monitor);
                 GLFW.SetWindowMonitor(
-                WindowPtr,
-                monitor,
-                _location.X,
-                _location.Y,
-                _size.X,
-                _size.Y,
-                mode->RefreshRate);
+                    WindowPtr,
+                    monitor,
+                    _location.X,
+                    _location.Y,
+                    _size.X,
+                    _size.Y,
+                    mode->RefreshRate);
 
                 _currentMonitor = value;
             }
@@ -350,16 +346,14 @@ namespace OpenTK.Windowing.Desktop
             {
                 _previousWindowState = WindowState;
 
-                bool sizeNotEmpty(Vector2i vector) => vector.X != 0 && vector.Y != 0;
-
                 var canLeaveFullScreenMode = GLFW.GetWindowMonitor(WindowPtr) != null // Is full screen
                     && value != WindowState.Fullscreen
-                    && sizeNotEmpty(_cachedWindowClientSize);
+                    && _cachedWindowClientSize.ManhattanLength > 0;
 
                 var shouldCacheSizeAndLocation = GLFW.GetWindowMonitor(WindowPtr) == null && // Not fullscreen
                     !GLFW.GetWindowAttrib(WindowPtr, WindowAttributeGetBool.Iconified) && // Not minimized
                     value == WindowState.Fullscreen && // Intention on going full screen
-                    sizeNotEmpty(ClientSize);
+                    ClientSize.ManhattanLength > 0;
 
                 if (canLeaveFullScreenMode)
                 {
@@ -601,7 +595,7 @@ namespace OpenTK.Windowing.Desktop
         /// <summary>
         /// Initializes a new instance of the <see cref="NativeWindow"/> class.
         /// </summary>
-        /// <param name="settings">The <see cref="INativeWindow"/> related settings.</param>
+        /// <param name="settings">The <see cref="NativeWindow"/> related settings.</param>
         public unsafe NativeWindow(NativeWindowSettings settings)
         {
             GLFWProvider.EnsureInitialized();
@@ -705,7 +699,7 @@ namespace OpenTK.Windowing.Desktop
                 WindowPtr = GLFW.CreateWindow(settings.Size.X, settings.Size.Y, _title, null, (Window*)(settings.SharedContext?.WindowPtr ?? IntPtr.Zero));
             }
 
-            _mouseState = new MouseState(WindowPtr);
+            MouseState = new MouseState(WindowPtr);
 
             Context = new GLFWGraphicsContext(WindowPtr);
 
@@ -775,7 +769,7 @@ namespace OpenTK.Windowing.Desktop
 
             GLFW.GetCursorPos(WindowPtr, out var mousex, out var mousey);
             _lastReportedMousePos = new Vector2((float)mousex, (float)mousey);
-            _mouseState.Position = _lastReportedMousePos;
+            MouseState.Position = _lastReportedMousePos;
 
             _isFocused = GLFW.GetWindowAttrib(WindowPtr, WindowAttributeGetBool.Focused);
         }
@@ -924,12 +918,12 @@ namespace OpenTK.Windowing.Desktop
 
             if (action == InputAction.Release)
             {
-                _mouseState[button] = false;
+                MouseState[button] = false;
                 OnMouseUp(args);
             }
             else
             {
-                _mouseState[button] = true;
+                MouseState[button] = true;
                 OnMouseDown(args);
             }
         }
@@ -947,10 +941,10 @@ namespace OpenTK.Windowing.Desktop
         private unsafe void ScrollCallback(Window* window, double offsetX, double offsetY)
         {
             // TODO: Think more about when we want to move the current scroll to the previous one
-            _mouseState.PreviousScroll = _mouseState.Scroll;
-            _mouseState.Scroll += new Vector2((float)offsetX, (float)offsetY);
+            MouseState.PreviousScroll = MouseState.Scroll;
+            MouseState.Scroll += new Vector2((float)offsetX, (float)offsetY);
 
-            OnMouseWheel(new MouseWheelEventArgs(_mouseState.Scroll));
+            OnMouseWheel(new MouseWheelEventArgs(MouseState.Scroll));
         }
 
         private unsafe void JoystickCallback(int joy, ConnectedState eventCode)
@@ -1046,7 +1040,7 @@ namespace OpenTK.Windowing.Desktop
         }
 
         /// <summary>
-        /// Processes pending window events and waits <paramref cref="timeout"/> seconds for events.
+        /// Processes pending window events and waits <paramref name="timeout"/> seconds for events.
         /// </summary>
         /// <param name="timeout">The timeout in seconds.</param>
         /// <returns><c>true</c> if events where processed; otherwise <c>false</c>
@@ -1090,6 +1084,9 @@ namespace OpenTK.Windowing.Desktop
         {
             MouseState.Update();
             KeyboardState.Update();
+
+            GLFW.GetCursorPos(WindowPtr, out var x, out var y);
+            MouseState.Position = new Vector2((float)x, (float)y);
 
             for (var i = 0; i < _joystickStates.Length; i++)
             {
@@ -1166,7 +1163,7 @@ namespace OpenTK.Windowing.Desktop
         public event Action<JoystickEventArgs> JoystickConnected;
 
         /// <summary>
-        /// Occurs when the <see cref="INativeWindowProperties.IsFocused" /> property of the window changes.
+        /// Occurs when the <see cref="NativeWindow.IsFocused" /> property of the window changes.
         /// </summary>
         public event Action<FocusedChangedEventArgs> FocusedChanged;
 
@@ -1191,12 +1188,12 @@ namespace OpenTK.Windowing.Desktop
         public event Action<MonitorEventArgs> MonitorConnected;
 
         /// <summary>
-        /// Occurs whenever the mouse cursor leaves the window <see cref="INativeWindowProperties.Bounds" />.
+        /// Occurs whenever the mouse cursor leaves the window <see cref="NativeWindow.Bounds" />.
         /// </summary>
         public event Action MouseLeave;
 
         /// <summary>
-        /// Occurs whenever the mouse cursor enters the window <see cref="INativeWindowProperties.Bounds" />.
+        /// Occurs whenever the mouse cursor enters the window <see cref="NativeWindow.Bounds" />.
         /// </summary>
         public event Action MouseEnter;
 
@@ -1268,7 +1265,7 @@ namespace OpenTK.Windowing.Desktop
         /// <returns><c>true</c> if <paramref name="button"/> is in the down state; otherwise, <c>false</c>.</returns>
         public bool IsMouseButtonDown(MouseButton button)
         {
-            return _mouseState.IsButtonDown(button);
+            return MouseState.IsButtonDown(button);
         }
 
         /// <summary>
@@ -1281,7 +1278,7 @@ namespace OpenTK.Windowing.Desktop
         /// <returns>True if the button is pressed in this frame, but not the last frame.</returns>
         public bool IsMouseButtonPressed(MouseButton button)
         {
-            return _mouseState.IsButtonDown(button) && !_mouseState.WasButtonDown(button);
+            return MouseState.IsButtonDown(button) && !MouseState.WasButtonDown(button);
         }
 
         /// <summary>
@@ -1294,7 +1291,7 @@ namespace OpenTK.Windowing.Desktop
         /// <returns>True if the button is released in this frame, but pressed the last frame.</returns>
         public bool IsMouseButtonReleased(MouseButton button)
         {
-            return !_mouseState.IsButtonDown(button) && _mouseState.WasButtonDown(button);
+            return !MouseState.IsButtonDown(button) && MouseState.WasButtonDown(button);
         }
 
         private unsafe GraphicsLibraryFramework.Monitor* GetDpiMonitor()

--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -180,6 +180,7 @@ namespace OpenTK.Windowing.Desktop
                     return GLFW.GetClipboardString(WindowPtr);
                 }
             }
+
             set
             {
                 unsafe
@@ -698,8 +699,6 @@ namespace OpenTK.Windowing.Desktop
             {
                 WindowPtr = GLFW.CreateWindow(settings.Size.X, settings.Size.Y, _title, null, (Window*)(settings.SharedContext?.WindowPtr ?? IntPtr.Zero));
             }
-
-            MouseState = new MouseState(WindowPtr);
 
             Context = new GLFWGraphicsContext(WindowPtr);
 

--- a/src/OpenTK.Windowing.Desktop/OpenTK.Windowing.Desktop.csproj
+++ b/src/OpenTK.Windowing.Desktop/OpenTK.Windowing.Desktop.csproj
@@ -37,4 +37,7 @@
       </ItemGroup>
       <Message Text="Removing System.Memory for mono compatibility" Importance="high" />
     </Target>
+    <ItemGroup>
+      <PackageReference Update="StyleCop.Analyzers" Version="1.1.118" />
+    </ItemGroup>
 </Project>

--- a/src/OpenTK.Windowing.GraphicsLibraryFramework/GLFWNative.cs
+++ b/src/OpenTK.Windowing.GraphicsLibraryFramework/GLFWNative.cs
@@ -38,7 +38,7 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
                 }
             }
 
-            Func<string, string, string> libNameFormatter = null;
+            Func<string, string, string> libNameFormatter;
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
                 libNameFormatter = (libName, ver) =>

--- a/src/OpenTK.Windowing.GraphicsLibraryFramework/Input/KeyboardState.cs
+++ b/src/OpenTK.Windowing.GraphicsLibraryFramework/Input/KeyboardState.cs
@@ -23,8 +23,8 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
     public class KeyboardState
     {
         // These arrays will mostly be empty since the last integer used is 384. That's only 48 bytes though.
-        private BitArray _keys = new BitArray((int)Keys.LastKey + 1);
-        private BitArray _keysPrevious = new BitArray((int)Keys.LastKey + 1);
+        private readonly BitArray _keys = new BitArray((int)Keys.LastKey + 1);
+        private readonly BitArray _keysPrevious = new BitArray((int)Keys.LastKey + 1);
 
         private KeyboardState(KeyboardState source)
         {
@@ -37,8 +37,7 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
         }
 
         /// <summary>
-        /// Gets a <see cref="bool" /> indicating whether the specified
-        ///  <see cref="Key" /> is currently down.
+        /// Gets a <see cref="bool" /> indicating whether the specified <see cref="Keys" /> is currently down.
         /// </summary>
         /// <param name="key">The <see cref="Keys">key</see> to check.</param>
         /// <returns><c>true</c> if key is down; <c>false</c> otherwise.</returns>

--- a/src/OpenTK.Windowing.GraphicsLibraryFramework/Input/MouseState.cs
+++ b/src/OpenTK.Windowing.GraphicsLibraryFramework/Input/MouseState.cs
@@ -26,14 +26,11 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
         /// </summary>
         internal const int MaxButtons = 16;
 
-        private BitArray _buttons = new BitArray(MaxButtons);
-        private BitArray _buttonsPrevious = new BitArray(MaxButtons);
+        private readonly BitArray _buttons = new BitArray(MaxButtons);
+        private readonly BitArray _buttonsPrevious = new BitArray(MaxButtons);
 
-        private unsafe Window* _windowPtr;
-
-        internal unsafe MouseState(Window* windowPtr)
+        internal MouseState()
         {
-            _windowPtr = windowPtr;
         }
 
         private MouseState(MouseState source)
@@ -163,15 +160,9 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
         {
             _buttonsPrevious.SetAll(false);
             _buttonsPrevious.Or(_buttons);
+
             PreviousPosition = Position;
-
             PreviousScroll = Scroll;
-
-            unsafe
-            {
-                GLFW.GetCursorPos(_windowPtr, out var x, out var y);
-                Position = new Vector2((float)x, (float)y);
-            }
         }
 
         /// <summary>

--- a/src/OpenTK.Windowing.GraphicsLibraryFramework/OpenTK.Windowing.GraphicsLibraryFramework.csproj
+++ b/src/OpenTK.Windowing.GraphicsLibraryFramework/OpenTK.Windowing.GraphicsLibraryFramework.csproj
@@ -44,4 +44,7 @@
       </ItemGroup>
       <Message Text="Removing System.Memory for mono compatibility" Importance="high" />
     </Target>
+    <ItemGroup>
+      <PackageReference Update="StyleCop.Analyzers" Version="1.1.118" />
+    </ItemGroup>
 </Project>


### PR DESCRIPTION
### Purpose of this PR

Added Manhattan and Euclidean length properties to integer vectors.
Removed float and double versions of `MathHelper.Swap()` and replaced them with a generic version `MathHelper.Swap<>()`.
Renamed `ScaleValue()` to ~~`Map()`~~`MapRange()` and introduced more useful overloads.
Changed to `BitConverter.SingleToInt32Bits()` instead of MathHelper version.
Double overload for `MathHelper.Lerp()`.
Changed to using `Math.Min()`/`Math.Max()` for integer vector componentwise min/max.
Changed to using `MathHelper.Clamp()` instead of nested ternary expressions for integer vector clamp (We don't use `Math.Clamp` as that can throw exceptions, and we don't use this for floating point because of worse code generation).
Fixes to some `cref` attributes not resolving and changed `paramref`correctly use `name=` instead of `cref=`.

Removed the glfw window pointer from `MouseState` and moved the mouse position update code into `NativeWindow.ProcessInputEvents()`.
Made `NativeWindow.MouseState` an autoproperty matching `KeyboardState`.
Made the internal `BitArray` of `KeyboardState` and `MouseState` `readonly` (not the contents, just the `BitArray` object).

Removed local function `sizeNotEmpty(Vector2i)` in favor of `ManhattanLength > 0`.

Updated to the latest stable version of StyleCop.Analyzers nuget package.

### Testing status

Compiles.
All math tests pass.
`NativeWindow` changes not tested.
