### PR TITLE
[3.0] Optimized Quaternion to Matrix3/4/3d/4d

### DIFF
--- a/src/OpenTK/Math/Matrix3.cs
+++ b/src/OpenTK/Math/Matrix3.cs
@@ -470,10 +470,35 @@ namespace OpenTK
         /// <param name="result">Matrix result.</param>
         public static void CreateFromQuaternion(ref Quaternion q, out Matrix3 result)
         {
-            Vector3 axis;
-            float angle;
-            q.ToAxisAngle(out axis, out angle);
-            CreateFromAxisAngle(axis, angle, out result);
+            // Adapted from https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation#Quaternion-derived_rotation_matrix
+            float sqx = q.X * q.X;
+            float sqy = q.Y * q.Y;
+            float sqz = q.Z * q.Z;
+            float sqw = q.W * q.W;
+
+            float xy = q.X * q.Y;
+            float xz = q.X * q.Z;
+            float xw = q.X * q.W;
+
+            float yz = q.Y * q.Z;
+            float yw = q.Y * q.W;
+
+            float zw = q.Z * q.W;
+
+            float s2 = 2f / (sqx + sqy + sqz + sqw);
+
+            result.Row0.X = 1f - (s2 * (sqy + sqz));
+            result.Row1.Y = 1f - (s2 * (sqx + sqz));
+            result.Row2.Z = 1f - (s2 * (sqx + sqy));
+
+            result.Row0.Y = s2 * (xy - zw);
+            result.Row1.X = s2 * (xy + zw);
+
+            result.Row2.X = s2 * (xz - yw);
+            result.Row0.Z = s2 * (xz + yw);
+
+            result.Row2.Y = s2 * (yz + xw);
+            result.Row1.Z = s2 * (yz - xw);
         }
 
         /// <summary>

--- a/src/OpenTK/Math/Matrix3.cs
+++ b/src/OpenTK/Math/Matrix3.cs
@@ -471,6 +471,7 @@ namespace OpenTK
         public static void CreateFromQuaternion(ref Quaternion q, out Matrix3 result)
         {
             // Adapted from https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation#Quaternion-derived_rotation_matrix
+            // with the caviat that opentk uses row-major matrices so the matrix we create is transposed
             float sqx = q.X * q.X;
             float sqy = q.Y * q.Y;
             float sqz = q.Z * q.Z;
@@ -491,14 +492,14 @@ namespace OpenTK
             result.Row1.Y = 1f - (s2 * (sqx + sqz));
             result.Row2.Z = 1f - (s2 * (sqx + sqy));
 
-            result.Row0.Y = s2 * (xy - zw);
-            result.Row1.X = s2 * (xy + zw);
+            result.Row0.Y = s2 * (xy + zw);
+            result.Row1.X = s2 * (xy - zw);
 
-            result.Row2.X = s2 * (xz - yw);
-            result.Row0.Z = s2 * (xz + yw);
+            result.Row2.X = s2 * (xz + yw);
+            result.Row0.Z = s2 * (xz - yw);
 
-            result.Row2.Y = s2 * (yz + xw);
-            result.Row1.Z = s2 * (yz - xw);
+            result.Row2.Y = s2 * (yz - xw);
+            result.Row1.Z = s2 * (yz + xw);
         }
 
         /// <summary>

--- a/src/OpenTK/Math/Matrix3d.cs
+++ b/src/OpenTK/Math/Matrix3d.cs
@@ -466,6 +466,7 @@ namespace OpenTK
         public static void CreateFromQuaternion(ref Quaterniond q, out Matrix3d result)
         {
             // Adapted from https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation#Quaternion-derived_rotation_matrix
+            // with the caviat that opentk uses row-major matrices so the matrix we create is transposed
             double sqx = q.X * q.X;
             double sqy = q.Y * q.Y;
             double sqz = q.Z * q.Z;
@@ -486,14 +487,14 @@ namespace OpenTK
             result.Row1.Y = 1d - (s2 * (sqx + sqz));
             result.Row2.Z = 1d - (s2 * (sqx + sqy));
 
-            result.Row0.Y = s2 * (xy - zw);
-            result.Row1.X = s2 * (xy + zw);
+            result.Row0.Y = s2 * (xy + zw);
+            result.Row1.X = s2 * (xy - zw);
 
-            result.Row2.X = s2 * (xz - yw);
-            result.Row0.Z = s2 * (xz + yw);
+            result.Row2.X = s2 * (xz + yw);
+            result.Row0.Z = s2 * (xz - yw);
 
-            result.Row2.Y = s2 * (yz + xw);
-            result.Row1.Z = s2 * (yz - xw);
+            result.Row2.Y = s2 * (yz - xw);
+            result.Row1.Z = s2 * (yz + xw);
         }
 
         /// <summary>

--- a/src/OpenTK/Math/Matrix3d.cs
+++ b/src/OpenTK/Math/Matrix3d.cs
@@ -465,10 +465,35 @@ namespace OpenTK
         /// <param name="result">Matrix result.</param>
         public static void CreateFromQuaternion(ref Quaterniond q, out Matrix3d result)
         {
-            Vector3d axis;
-            double angle;
-            q.ToAxisAngle(out axis, out angle);
-            CreateFromAxisAngle(axis, angle, out result);
+            // Adapted from https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation#Quaternion-derived_rotation_matrix
+            double sqx = q.X * q.X;
+            double sqy = q.Y * q.Y;
+            double sqz = q.Z * q.Z;
+            double sqw = q.W * q.W;
+
+            double xy = q.X * q.Y;
+            double xz = q.X * q.Z;
+            double xw = q.X * q.W;
+
+            double yz = q.Y * q.Z;
+            double yw = q.Y * q.W;
+
+            double zw = q.Z * q.W;
+
+            double s2 = 2d / (sqx + sqy + sqz + sqw);
+
+            result.Row0.X = 1d - (s2 * (sqy + sqz));
+            result.Row1.Y = 1d - (s2 * (sqx + sqz));
+            result.Row2.Z = 1d - (s2 * (sqx + sqy));
+
+            result.Row0.Y = s2 * (xy - zw);
+            result.Row1.X = s2 * (xy + zw);
+
+            result.Row2.X = s2 * (xz - yw);
+            result.Row0.Z = s2 * (xz + yw);
+
+            result.Row2.Y = s2 * (yz + xw);
+            result.Row1.Z = s2 * (yz - xw);
         }
 
         /// <summary>

--- a/src/OpenTK/Math/Matrix4.cs
+++ b/src/OpenTK/Math/Matrix4.cs
@@ -585,10 +585,40 @@ namespace OpenTK
         /// <param name="result">A matrix instance.</param>
         public static void CreateFromQuaternion(ref Quaternion q, out Matrix4 result)
         {
-            Vector3 axis;
-            float angle;
-            q.ToAxisAngle(out axis, out angle);
-            CreateFromAxisAngle(axis, angle, out result);
+            // Adapted from https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation#Quaternion-derived_rotation_matrix
+            float sqx = q.X * q.X;
+            float sqy = q.Y * q.Y;
+            float sqz = q.Z * q.Z;
+            float sqw = q.W * q.W;
+
+            float xy = q.X * q.Y;
+            float xz = q.X * q.Z;
+            float xw = q.X * q.W;
+
+            float yz = q.Y * q.Z;
+            float yw = q.Y * q.W;
+
+            float zw = q.Z * q.W;
+
+            float s2 = 2f / (sqx + sqy + sqz + sqw);
+
+            result.Row0.X = 1f - (s2 * (sqy + sqz));
+            result.Row1.Y = 1f - (s2 * (sqx + sqz));
+            result.Row2.Z = 1f - (s2 * (sqx + sqy));
+
+            result.Row0.Y = s2 * (xy - zw);
+            result.Row1.X = s2 * (xy + zw);
+
+            result.Row2.X = s2 * (xz - yw);
+            result.Row0.Z = s2 * (xz + yw);
+
+            result.Row2.Y = s2 * (yz + xw);
+            result.Row1.Z = s2 * (yz - xw);
+
+            result.Row0.W = 0;
+            result.Row1.W = 0;
+            result.Row2.W = 0;
+            result.Row3 = new Vector4(0, 0, 0, 1);
         }
 
         /// <summary>

--- a/src/OpenTK/Math/Matrix4.cs
+++ b/src/OpenTK/Math/Matrix4.cs
@@ -586,6 +586,7 @@ namespace OpenTK
         public static void CreateFromQuaternion(ref Quaternion q, out Matrix4 result)
         {
             // Adapted from https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation#Quaternion-derived_rotation_matrix
+            // with the caviat that opentk uses row-major matrices so the matrix we create is transposed
             float sqx = q.X * q.X;
             float sqy = q.Y * q.Y;
             float sqz = q.Z * q.Z;
@@ -606,14 +607,14 @@ namespace OpenTK
             result.Row1.Y = 1f - (s2 * (sqx + sqz));
             result.Row2.Z = 1f - (s2 * (sqx + sqy));
 
-            result.Row0.Y = s2 * (xy - zw);
-            result.Row1.X = s2 * (xy + zw);
+            result.Row0.Y = s2 * (xy + zw);
+            result.Row1.X = s2 * (xy - zw);
 
-            result.Row2.X = s2 * (xz - yw);
-            result.Row0.Z = s2 * (xz + yw);
+            result.Row2.X = s2 * (xz + yw);
+            result.Row0.Z = s2 * (xz - yw);
 
-            result.Row2.Y = s2 * (yz + xw);
-            result.Row1.Z = s2 * (yz - xw);
+            result.Row2.Y = s2 * (yz - xw);
+            result.Row1.Z = s2 * (yz + xw);
 
             result.Row0.W = 0;
             result.Row1.W = 0;

--- a/src/OpenTK/Math/Matrix4d.cs
+++ b/src/OpenTK/Math/Matrix4d.cs
@@ -921,6 +921,7 @@ namespace OpenTK
         public static void CreateFromQuaternion(ref Quaterniond q, out Matrix4d result)
         {
             // Adapted from https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation#Quaternion-derived_rotation_matrix
+            // with the caviat that opentk uses row-major matrices so the matrix we create is transposed
             double sqx = q.X * q.X;
             double sqy = q.Y * q.Y;
             double sqz = q.Z * q.Z;
@@ -941,14 +942,14 @@ namespace OpenTK
             result.Row1.Y = 1d - (s2 * (sqx + sqz));
             result.Row2.Z = 1d - (s2 * (sqx + sqy));
 
-            result.Row0.Y = s2 * (xy - zw);
-            result.Row1.X = s2 * (xy + zw);
+            result.Row0.Y = s2 * (xy + zw);
+            result.Row1.X = s2 * (xy - zw);
 
-            result.Row2.X = s2 * (xz - yw);
-            result.Row0.Z = s2 * (xz + yw);
+            result.Row2.X = s2 * (xz + yw);
+            result.Row0.Z = s2 * (xz - yw);
 
-            result.Row2.Y = s2 * (yz + xw);
-            result.Row1.Z = s2 * (yz - xw);
+            result.Row2.Y = s2 * (yz - xw);
+            result.Row1.Z = s2 * (yz + xw);
 
             result.Row0.W = 0;
             result.Row1.W = 0;

--- a/src/OpenTK/Math/Matrix4d.cs
+++ b/src/OpenTK/Math/Matrix4d.cs
@@ -920,10 +920,40 @@ namespace OpenTK
         /// <param name="result">Matrix result.</param>
         public static void CreateFromQuaternion(ref Quaterniond q, out Matrix4d result)
         {
-            Vector3d axis;
-            double angle;
-            q.ToAxisAngle(out axis, out angle);
-            CreateFromAxisAngle(axis, angle, out result);
+            // Adapted from https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation#Quaternion-derived_rotation_matrix
+            double sqx = q.X * q.X;
+            double sqy = q.Y * q.Y;
+            double sqz = q.Z * q.Z;
+            double sqw = q.W * q.W;
+
+            double xy = q.X * q.Y;
+            double xz = q.X * q.Z;
+            double xw = q.X * q.W;
+
+            double yz = q.Y * q.Z;
+            double yw = q.Y * q.W;
+
+            double zw = q.Z * q.W;
+
+            double s2 = 2d / (sqx + sqy + sqz + sqw);
+
+            result.Row0.X = 1d - (s2 * (sqy + sqz));
+            result.Row1.Y = 1d - (s2 * (sqx + sqz));
+            result.Row2.Z = 1d - (s2 * (sqx + sqy));
+
+            result.Row0.Y = s2 * (xy - zw);
+            result.Row1.X = s2 * (xy + zw);
+
+            result.Row2.X = s2 * (xz - yw);
+            result.Row0.Z = s2 * (xz + yw);
+
+            result.Row2.Y = s2 * (yz + xw);
+            result.Row1.Z = s2 * (yz - xw);
+
+            result.Row0.W = 0;
+            result.Row1.W = 0;
+            result.Row2.W = 0;
+            result.Row3 = new Vector4d(0, 0, 0, 1d);
         }
 
         /// <summary>

--- a/tests/OpenTK.Tests.Generators/Generators.fs
+++ b/tests/OpenTK.Tests.Generators/Generators.fs
@@ -39,8 +39,8 @@ module private Generators =
 
     let quat =
         singleArb
-        |> Gen.three
-        |> Gen.map (fun (x,y,z) -> Quaternion(x,y,z,0.0f) |> Quaternion.Normalize)
+        |> Gen.four
+        |> Gen.map (fun (x,y,z,w) -> Quaternion(x,y,z,w) |> Quaternion.Normalize)
         |> Gen.filter (fun q -> not <| (Single.IsNaN q.Length || Single.IsInfinity q.Length ))
         |> Arb.fromGen
 


### PR DESCRIPTION
### Purpose of this PR

Optimize the `CreateFromQuaternion` function for `Matrix3/4/3d/4d`.
This is the same change as #1189 

### Testing status

Could not get 3.3 to compile on my computer due to missing `AssemblyInfo` file and a whole bunch of other errors.
