### PR TITLE
Bugfix: Fix WindowState and StartVisible to behave correctly on MS Windows

### DIFF
--- a/src/OpenTK.Windowing.Common/Events/MaximizedEventArgs.cs
+++ b/src/OpenTK.Windowing.Common/Events/MaximizedEventArgs.cs
@@ -1,0 +1,33 @@
+﻿//
+// MaximizedEventArgs.cs
+//
+// Copyright (C) 2020 OpenTK
+//
+// This software may be modified and distributed under the terms
+// of the MIT license. See the LICENSE file for details.
+//
+
+namespace OpenTK.Windowing.Common
+{
+    /// <summary>
+    /// Defines the event data for the window maximizing event.
+    /// </summary>
+    public readonly struct MaximizedEventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MaximizedEventArgs"/> struct.
+        /// </summary>
+        /// <param name="isMaximized">
+        /// A value indicating whether the window is maximized.
+        /// </param>
+        public MaximizedEventArgs(bool isMaximized)
+        {
+            IsMaximized = isMaximized;
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the window is maximized.
+        /// </summary>
+        public bool IsMaximized { get; }
+    }
+}

--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -333,10 +333,10 @@ namespace OpenTK.Windowing.Desktop
                     }
 
                     var shouldCacheSizeAndLocation = _windowState != WindowState.Fullscreen && // Not fullscreen
-                        !GLFW.GetWindowAttrib(WindowPtr, WindowAttributeGetBool.Iconified) && // Not minimized
+                        _windowState != WindowState.Minimized && // Not minimized
                         value == WindowState.Fullscreen; // Intention on going full screen
 
-                    if (_windowState == WindowState.Fullscreen && value != WindowState.Fullscreen)
+                    if (_windowState == WindowState.Fullscreen && value != WindowState.Fullscreen && _isVisible)
                     {
                         // Get out of fullscreen mode.
                         GLFW.SetWindowMonitor(WindowPtr, null, _cachedWindowLocation.X, _cachedWindowLocation.Y, _cachedWindowClientSize.X, _cachedWindowClientSize.Y, 0);

--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -31,7 +31,7 @@ namespace OpenTK.Windowing.Desktop
         // When getting out of full screen mode, the location and size will be set to these value in all states other then minimized.
         private Vector2i _cachedWindowClientSize;
         private Vector2i _cachedWindowLocation;
-        private WindowState _previousWindowState;
+        private WindowState _unminimizedWindowState;
 
         // Used for delta calculation in the mouse position changed event.
         private Vector2 _lastReportedMousePos;
@@ -289,18 +289,14 @@ namespace OpenTK.Windowing.Desktop
             get => _isVisible;
             set
             {
-                unsafe
+                if (value != _isVisible)
                 {
-                    if (value)
-                    {
-                        GLFW.ShowWindow(WindowPtr);
-                    }
-                    else
-                    {
-                        GLFW.HideWindow(WindowPtr);
-                    }
-
                     _isVisible = value;
+
+                    unsafe
+                    {
+                        UpdateWindowForStateAndVisibility();
+                    }
                 }
             }
         }
@@ -318,73 +314,49 @@ namespace OpenTK.Windowing.Desktop
         /// </summary>
         public bool IsExiting { get; private set; }
 
+        private WindowState _windowState = WindowState.Normal;
+
         /// <summary>
         /// Gets or sets the <see cref="WindowState" /> for this window.
         /// </summary>
         public unsafe WindowState WindowState
         {
-            get
-            {
-                if (GLFW.GetWindowAttrib(WindowPtr, WindowAttributeGetBool.Iconified))
-                {
-                    return WindowState.Minimized;
-                }
-
-                if (GLFW.GetWindowAttrib(WindowPtr, WindowAttributeGetBool.Maximized))
-                {
-                    return WindowState.Maximized;
-                }
-
-                if (GLFW.GetWindowMonitor(WindowPtr) != null)
-                {
-                    return WindowState.Fullscreen;
-                }
-
-                return WindowState.Normal;
-            }
+            get => _windowState;
 
             set
             {
-                _previousWindowState = WindowState;
-
-                var canLeaveFullScreenMode = GLFW.GetWindowMonitor(WindowPtr) != null // Is full screen
-                    && value != WindowState.Fullscreen
-                    && _cachedWindowClientSize.ManhattanLength > 0;
-
-                var shouldCacheSizeAndLocation = GLFW.GetWindowMonitor(WindowPtr) == null && // Not fullscreen
-                    !GLFW.GetWindowAttrib(WindowPtr, WindowAttributeGetBool.Iconified) && // Not minimized
-                    value == WindowState.Fullscreen && // Intention on going full screen
-                    ClientSize.ManhattanLength > 0;
-
-                if (canLeaveFullScreenMode)
+                if (_windowState != value)
                 {
-                    // Get out of fullscreen mode
-                    GLFW.SetWindowMonitor(WindowPtr, null, _cachedWindowLocation.X, _cachedWindowLocation.Y, _cachedWindowClientSize.X, _cachedWindowClientSize.Y, 0);
-                }
+                    if (value != WindowState.Minimized)
+                    {
+                        _unminimizedWindowState = value;
+                    }
 
-                if (shouldCacheSizeAndLocation)
-                {
-                    // Only cache the size and location if the window is not in full screen mode
-                    _cachedWindowClientSize = ClientSize;
-                    _cachedWindowLocation = Location;
-                }
+                    var canLeaveFullScreenMode = GLFW.GetWindowMonitor(WindowPtr) != null // Is full screen
+                        && value != WindowState.Fullscreen
+                        && _cachedWindowClientSize.ManhattanLength > 0;
 
-                switch (value)
-                {
-                    case WindowState.Normal:
-                        GLFW.RestoreWindow(WindowPtr);
-                        break;
-                    case WindowState.Minimized:
-                        GLFW.IconifyWindow(WindowPtr);
-                        break;
-                    case WindowState.Maximized:
-                        GLFW.MaximizeWindow(WindowPtr);
-                        break;
-                    case WindowState.Fullscreen:
-                        var monitor = CurrentMonitor.ToUnsafePtr<GraphicsLibraryFramework.Monitor>();
-                        var mode = GLFW.GetVideoMode(monitor);
-                        GLFW.SetWindowMonitor(WindowPtr, monitor, 0, 0, mode->Width, mode->Height, mode->RefreshRate);
-                        break;
+                    var shouldCacheSizeAndLocation = GLFW.GetWindowMonitor(WindowPtr) == null && // Not fullscreen
+                        !GLFW.GetWindowAttrib(WindowPtr, WindowAttributeGetBool.Iconified) && // Not minimized
+                        value == WindowState.Fullscreen && // Intention on going full screen
+                        ClientSize.ManhattanLength > 0;
+
+                    if (canLeaveFullScreenMode)
+                    {
+                        // Get out of fullscreen mode
+                        GLFW.SetWindowMonitor(WindowPtr, null, _cachedWindowLocation.X, _cachedWindowLocation.Y, _cachedWindowClientSize.X, _cachedWindowClientSize.Y, 0);
+                    }
+
+                    if (shouldCacheSizeAndLocation)
+                    {
+                        // Only cache the size and location if the window is not in full screen mode
+                        _cachedWindowClientSize = ClientSize;
+                        _cachedWindowLocation = Location;
+                    }
+
+                    _windowState = value;
+
+                    UpdateWindowForStateAndVisibility();
                 }
             }
         }
@@ -685,7 +657,11 @@ namespace OpenTK.Windowing.Desktop
 
             GLFW.WindowHint(WindowHintInt.Samples, settings.NumberOfSamples);
 
-            if (settings.WindowState == WindowState.Fullscreen)
+            // We do the work to set the hint bits outside of the CreateWindow conditional
+            // so that the window will get the correct fullscreen red/green/blue bits stored
+            // in its hidden fields regardless of how it gets created.  (The extra curly
+            // braces here keep the local `monitor` definition from conflicting with the
+            // _monitorCallback lambda below.)
             {
                 var monitor = settings.CurrentMonitor.ToUnsafePtr<GraphicsLibraryFramework.Monitor>();
                 var modePtr = GLFW.GetVideoMode(monitor);
@@ -693,11 +669,15 @@ namespace OpenTK.Windowing.Desktop
                 GLFW.WindowHint(WindowHintInt.GreenBits, modePtr->GreenBits);
                 GLFW.WindowHint(WindowHintInt.BlueBits, modePtr->BlueBits);
                 GLFW.WindowHint(WindowHintInt.RefreshRate, modePtr->RefreshRate);
-                WindowPtr = GLFW.CreateWindow(modePtr->Width, modePtr->Height, _title, monitor, (Window*)(settings.SharedContext?.WindowPtr ?? IntPtr.Zero));
-            }
-            else
-            {
-                WindowPtr = GLFW.CreateWindow(settings.Size.X, settings.Size.Y, _title, null, (Window*)(settings.SharedContext?.WindowPtr ?? IntPtr.Zero));
+
+                if (settings.WindowState == WindowState.Fullscreen && _isVisible)
+                {
+                    WindowPtr = GLFW.CreateWindow(modePtr->Width, modePtr->Height, _title, monitor, (Window*)(settings.SharedContext?.WindowPtr ?? IntPtr.Zero));
+                }
+                else
+                {
+                    WindowPtr = GLFW.CreateWindow(settings.Size.X, settings.Size.Y, _title, null, (Window*)(settings.SharedContext?.WindowPtr ?? IntPtr.Zero));
+                }
             }
 
             Context = new GLFWGraphicsContext(WindowPtr);
@@ -721,6 +701,7 @@ namespace OpenTK.Windowing.Desktop
             _windowPosCallback = (w, posX, posY) => OnMove(new WindowPositionEventArgs(posX, posY));
             _windowSizeCallback = (w, argsWidth, argsHeight) => OnResize(new ResizeEventArgs(argsWidth, argsHeight));
             _windowIconifyCallback = (w, iconified) => OnMinimized(new MinimizedEventArgs(iconified));
+            _windowMaximizeCallback = (w, maximized) => OnMaximized(new MaximizedEventArgs(maximized));
             _windowFocusCallback = (w, focused) => OnFocusedChanged(new FocusedChangedEventArgs(focused));
             _charCallback = (w, codepoint) => OnTextInput(new TextInputEventArgs((int)codepoint));
             _scrollCallback = ScrollCallback;
@@ -823,9 +804,71 @@ namespace OpenTK.Windowing.Desktop
             ClientSize = new Vector2i(width, height);
         }
 
+        /// <summary>
+        /// Not all OSes observe the same behavior about managing window state, and
+        /// GLFW doesn't abstract away the underlying OS behavior consistently enough.
+        /// So this method simultaneously updates both window state and visibility to
+        /// match our internal state, so that what the user sees always matches what
+        /// the programmer intended.
+        /// </summary>
+        private unsafe void UpdateWindowForStateAndVisibility()
+        {
+            // OS hacks are bad.  But we have no choice here, because MS Windows is just plain weird.
+            bool isMsWindows = Environment.OSVersion.Platform == PlatformID.Win32NT;
+
+            // If it's not supposed to be visible, simply hide it, and don't bother
+            // telling the OS what its intended window state is.  We will fix the intended
+            // window state when the window becomes visible.
+            if (!_isVisible)
+            {
+                GLFW.HideWindow(WindowPtr);
+                return;
+            }
+
+            // Show it.  On Windows, this can also alter the window state, so we have to be
+            // careful not to affect the window state if we only intended to unhide it.
+            if (!isMsWindows)
+            {
+                GLFW.ShowWindow(WindowPtr);
+            }
+
+            // On all OSes, update its window state to match what we expect.  This is slightly
+            // headachey on MS Windows, since it's hard to get consistent results out of it.
+            switch (_windowState)
+            {
+                case WindowState.Normal:
+                    GLFW.RestoreWindow(WindowPtr);
+                    break;
+
+                case WindowState.Minimized:
+                    GLFW.IconifyWindow(WindowPtr);
+                    break;
+
+                case WindowState.Maximized:
+                    if (isMsWindows)
+                    {
+                        GLFW.RestoreWindow(WindowPtr);  // MS Windows can't convert a minimized window directly to maximized.
+                    }
+                    GLFW.MaximizeWindow(WindowPtr);
+                    break;
+
+                case WindowState.Fullscreen:
+                    if (isMsWindows)
+                    {
+                        GLFW.ShowWindow(WindowPtr);     // MS Windows can't convert a hidden window directly to fullscreen.
+                        GLFW.RestoreWindow(WindowPtr);  // Or a non-normal window.
+                    }
+                    var monitor = CurrentMonitor.ToUnsafePtr<GraphicsLibraryFramework.Monitor>();
+                    var modePtr = GLFW.GetVideoMode(monitor);
+                    GLFW.SetWindowMonitor(WindowPtr, monitor, 0, 0, modePtr->Width, modePtr->Height, modePtr->RefreshRate);
+                    break;
+            }
+        }
+
         private readonly GLFWCallbacks.WindowPosCallback _windowPosCallback;
         private readonly GLFWCallbacks.WindowSizeCallback _windowSizeCallback;
         private readonly GLFWCallbacks.WindowIconifyCallback _windowIconifyCallback;
+        private readonly GLFWCallbacks.WindowMaximizeCallback _windowMaximizeCallback;
         private readonly GLFWCallbacks.WindowFocusCallback _windowFocusCallback;
         private readonly GLFWCallbacks.CharCallback _charCallback;
         private readonly GLFWCallbacks.ScrollCallback _scrollCallback;
@@ -844,6 +887,7 @@ namespace OpenTK.Windowing.Desktop
             GLFW.SetWindowPosCallback(WindowPtr, _windowPosCallback);
             GLFW.SetWindowSizeCallback(WindowPtr, _windowSizeCallback);
             GLFW.SetWindowIconifyCallback(WindowPtr, _windowIconifyCallback);
+            GLFW.SetWindowMaximizeCallback(WindowPtr, _windowMaximizeCallback);
             GLFW.SetWindowFocusCallback(WindowPtr, _windowFocusCallback);
             GLFW.SetCharCallback(WindowPtr, _charCallback);
             GLFW.SetScrollCallback(WindowPtr, _scrollCallback);
@@ -1155,6 +1199,11 @@ namespace OpenTK.Windowing.Desktop
         /// Occurs when the window is minimized.
         /// </summary>
         public event Action<MinimizedEventArgs> Minimized;
+
+        /// <summary>
+        /// Occurs when the window is maximized.
+        /// </summary>
+        public event Action<MaximizedEventArgs> Maximized;
 
         /// <summary>
         /// Occurs when a joystick is connected or disconnected.
@@ -1518,15 +1567,24 @@ namespace OpenTK.Windowing.Desktop
         /// <summary>
         /// Raises the <see cref="OnMinimized"/> event.
         /// </summary>
-        /// <param name="e">A <see cref="MouseWheelEventArgs"/> that contains the event data.</param>
+        /// <param name="e">A <see cref="MinimizedEventArgs"/> that contains the event data.</param>
         protected virtual void OnMinimized(MinimizedEventArgs e)
         {
-            if (_previousWindowState == WindowState.Fullscreen && !e.IsMinimized)
-            {
-                WindowState = WindowState.Fullscreen;
-            }
+            _windowState = e.IsMinimized ? WindowState.Minimized : _unminimizedWindowState;
 
             Minimized?.Invoke(e);
+        }
+
+        /// <summary>
+        /// Raises the <see cref="OnMaximized"/> event.
+        /// </summary>
+        /// <param name="e">A <see cref="MaximizedEventArgs"/> that contains the event data.</param>
+        protected virtual void OnMaximized(MaximizedEventArgs e)
+        {
+            _windowState = e.IsMaximized ? WindowState.Maximized : WindowState.Normal;
+            _unminimizedWindowState = _windowState;
+
+            Maximized?.Invoke(e);
         }
 
         /// <summary>

--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -332,18 +332,13 @@ namespace OpenTK.Windowing.Desktop
                         _unminimizedWindowState = value;
                     }
 
-                    var canLeaveFullScreenMode = GLFW.GetWindowMonitor(WindowPtr) != null // Is full screen
-                        && value != WindowState.Fullscreen
-                        && _cachedWindowClientSize.ManhattanLength > 0;
-
-                    var shouldCacheSizeAndLocation = GLFW.GetWindowMonitor(WindowPtr) == null && // Not fullscreen
+                    var shouldCacheSizeAndLocation = _windowState != WindowState.Fullscreen && // Not fullscreen
                         !GLFW.GetWindowAttrib(WindowPtr, WindowAttributeGetBool.Iconified) && // Not minimized
-                        value == WindowState.Fullscreen && // Intention on going full screen
-                        ClientSize.ManhattanLength > 0;
+                        value == WindowState.Fullscreen; // Intention on going full screen
 
-                    if (canLeaveFullScreenMode)
+                    if (_windowState == WindowState.Fullscreen && value != WindowState.Fullscreen)
                     {
-                        // Get out of fullscreen mode
+                        // Get out of fullscreen mode.
                         GLFW.SetWindowMonitor(WindowPtr, null, _cachedWindowLocation.X, _cachedWindowLocation.Y, _cachedWindowClientSize.X, _cachedWindowClientSize.Y, 0);
                     }
 
@@ -672,6 +667,9 @@ namespace OpenTK.Windowing.Desktop
 
                 if (settings.WindowState == WindowState.Fullscreen && _isVisible)
                 {
+                    _windowState = WindowState.Fullscreen;
+                    _cachedWindowLocation = settings.Location ?? new Vector2i(32, 32);  // Better than nothing.
+                    _cachedWindowClientSize = settings.Size;
                     WindowPtr = GLFW.CreateWindow(modePtr->Width, modePtr->Height, _title, monitor, (Window*)(settings.SharedContext?.WindowPtr ?? IntPtr.Zero));
                 }
                 else

--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -334,7 +334,7 @@ namespace OpenTK.Windowing.Desktop
 
                     var shouldCacheSizeAndLocation = _windowState != WindowState.Fullscreen && // Not fullscreen
                         _windowState != WindowState.Minimized && // Not minimized
-                        value == WindowState.Fullscreen; // Intention on going full screen
+                        (value == WindowState.Fullscreen || value == WindowState.Minimized); // Intention on going full screen or minimized
 
                     if (_windowState == WindowState.Fullscreen && value != WindowState.Fullscreen && _isVisible)
                     {


### PR DESCRIPTION
### Purpose of this PR

This addresses the known issues in `WindowState.StartVisible` and `NativeWindow.IsVisible` and `NativeWindow.WindowState` misbehaving on MS Windows.  It appears from our testing that with these changes, `StartVisible`, `IsVisible`, and `WindowState` now behave correctly in all known scenarios.

### Testing status

* This is difficult to test automatically; if it were easy, there'd likely already be unit tests.
* I tested every state transition on Windows 10 that I can think of, and they all seem to work now in every case I have tried.  Every pair (X --> Y) of `WindowState` or `IsVisible` transitions has been tested, and most triples (X --> Y --> Z) have been tested as well.
* @Offenbach tested it on Linux in a similarly large number of cases, and I didn't issue this PR until he was unable to make it break anymore.

### Comments

The solution was to acknowledge that GLFW doesn't abstract away Windows's underlying behavior, and instead is a thin wrapper around Windows's underlying window-state logic, which is limited and quirky.  The new code maintains the _actual_ window state internally in fields, and issues calls to GLFW to transition it from known current states to specific target states, instead of assuming that GLFW will always do the right, platform-independent thing.  Only in rare cases now where the new code cannot be certain as to the window state (due to an external state change) does it as GLFW for the state.

So `IsVisible` and `WindowState` mostly now just set `_isVisible` and `_windowState` fields, and then invoke `UpdateWindowForStateAndVisibility()`, which combines both fields together and issues calls to GLFW as necessary to change to the new state (with ugly platform-specific hacks for MS Windows's known misbehaviors).  Only when an `OnMinimized()` or `OnMaximized()` message is sent back from the OS will it query the window state, since the resulting window state may vary by OS.

This also optimizes `IsVisible` and `WindowState` so that repeated assignments of the same value do not repeatedly invoke GLFW functions, which may yield undesirable behavior.

I did my best to avoid making changes to code outside the scope of the problem.  This does, however, introduce a `virtual OnMaximized()` event handler, which has a nearly-identical design to the existing `virtual OnMinimized()` event handler.