### PR TITLE
Fixed test generator for quaternions and CreateFromQuaternion.

### DIFF
--- a/src/OpenTK.Mathematics/Matrix/Matrix3.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix3.cs
@@ -515,6 +515,7 @@ namespace OpenTK.Mathematics
         public static void CreateFromQuaternion(in Quaternion q, out Matrix3 result)
         {
             // Adapted from https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation#Quaternion-derived_rotation_matrix
+            // with the caviat that opentk uses row-major matrices so the matrix we create is transposed
             float sqx = q.X * q.X;
             float sqy = q.Y * q.Y;
             float sqz = q.Z * q.Z;
@@ -535,14 +536,14 @@ namespace OpenTK.Mathematics
             result.Row1.Y = 1f - (s2 * (sqx + sqz));
             result.Row2.Z = 1f - (s2 * (sqx + sqy));
 
-            result.Row0.Y = s2 * (xy - zw);
-            result.Row1.X = s2 * (xy + zw);
+            result.Row0.Y = s2 * (xy + zw);
+            result.Row1.X = s2 * (xy - zw);
 
-            result.Row2.X = s2 * (xz - yw);
-            result.Row0.Z = s2 * (xz + yw);
+            result.Row2.X = s2 * (xz + yw);
+            result.Row0.Z = s2 * (xz - yw);
 
-            result.Row2.Y = s2 * (yz + xw);
-            result.Row1.Z = s2 * (yz - xw);
+            result.Row2.Y = s2 * (yz - xw);
+            result.Row1.Z = s2 * (yz + xw);
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Matrix/Matrix3d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix3d.cs
@@ -511,6 +511,7 @@ namespace OpenTK.Mathematics
         public static void CreateFromQuaternion(in Quaterniond q, out Matrix3d result)
         {
             // Adapted from https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation#Quaternion-derived_rotation_matrix
+            // with the caviat that opentk uses row-major matrices so the matrix we create is transposed
             double sqx = q.X * q.X;
             double sqy = q.Y * q.Y;
             double sqz = q.Z * q.Z;
@@ -531,14 +532,14 @@ namespace OpenTK.Mathematics
             result.Row1.Y = 1d - (s2 * (sqx + sqz));
             result.Row2.Z = 1d - (s2 * (sqx + sqy));
 
-            result.Row0.Y = s2 * (xy - zw);
-            result.Row1.X = s2 * (xy + zw);
+            result.Row0.Y = s2 * (xy + zw);
+            result.Row1.X = s2 * (xy - zw);
 
-            result.Row2.X = s2 * (xz - yw);
-            result.Row0.Z = s2 * (xz + yw);
+            result.Row2.X = s2 * (xz + yw);
+            result.Row0.Z = s2 * (xz - yw);
 
-            result.Row2.Y = s2 * (yz + xw);
-            result.Row1.Z = s2 * (yz - xw);
+            result.Row2.Y = s2 * (yz - xw);
+            result.Row1.Z = s2 * (yz + xw);
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Matrix/Matrix4.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix4.cs
@@ -723,6 +723,7 @@ namespace OpenTK.Mathematics
         public static void CreateFromQuaternion(in Quaternion q, out Matrix4 result)
         {
             // Adapted from https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation#Quaternion-derived_rotation_matrix
+            // with the caviat that opentk uses row-major matrices so the matrix we create is transposed
             float sqx = q.X * q.X;
             float sqy = q.Y * q.Y;
             float sqz = q.Z * q.Z;
@@ -743,14 +744,14 @@ namespace OpenTK.Mathematics
             result.Row1.Y = 1f - (s2 * (sqx + sqz));
             result.Row2.Z = 1f - (s2 * (sqx + sqy));
 
-            result.Row0.Y = s2 * (xy - zw);
-            result.Row1.X = s2 * (xy + zw);
+            result.Row0.Y = s2 * (xy + zw);
+            result.Row1.X = s2 * (xy - zw);
 
-            result.Row2.X = s2 * (xz - yw);
-            result.Row0.Z = s2 * (xz + yw);
+            result.Row2.X = s2 * (xz + yw);
+            result.Row0.Z = s2 * (xz - yw);
 
-            result.Row2.Y = s2 * (yz + xw);
-            result.Row1.Z = s2 * (yz - xw);
+            result.Row2.Y = s2 * (yz - xw);
+            result.Row1.Z = s2 * (yz + xw);
 
             result.Row0.W = 0;
             result.Row1.W = 0;

--- a/src/OpenTK.Mathematics/Matrix/Matrix4d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix4d.cs
@@ -1106,6 +1106,7 @@ namespace OpenTK.Mathematics
         public static void CreateFromQuaternion(in Quaterniond q, out Matrix4d result)
         {
             // Adapted from https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation#Quaternion-derived_rotation_matrix
+            // with the caviat that opentk uses row-major matrices so the matrix we create is transposed
             double sqx = q.X * q.X;
             double sqy = q.Y * q.Y;
             double sqz = q.Z * q.Z;
@@ -1126,14 +1127,14 @@ namespace OpenTK.Mathematics
             result.Row1.Y = 1d - (s2 * (sqx + sqz));
             result.Row2.Z = 1d - (s2 * (sqx + sqy));
 
-            result.Row0.Y = s2 * (xy - zw);
-            result.Row1.X = s2 * (xy + zw);
+            result.Row0.Y = s2 * (xy + zw);
+            result.Row1.X = s2 * (xy - zw);
 
-            result.Row2.X = s2 * (xz - yw);
-            result.Row0.Z = s2 * (xz + yw);
+            result.Row2.X = s2 * (xz + yw);
+            result.Row0.Z = s2 * (xz - yw);
 
-            result.Row2.Y = s2 * (yz + xw);
-            result.Row1.Z = s2 * (yz - xw);
+            result.Row2.Y = s2 * (yz - xw);
+            result.Row1.Z = s2 * (yz + xw);
 
             result.Row0.W = 0;
             result.Row1.W = 0;

--- a/tests/OpenTK.Tests/Generators.fs
+++ b/tests/OpenTK.Tests/Generators.fs
@@ -49,8 +49,8 @@ module private Generators =
 
     let quat =
         singleArb
-        |> Gen.three
-        |> Gen.map (fun (x,y,z) -> Quaternion(x,y,z,0.0f) |> Quaternion.Normalize)
+        |> Gen.four
+        |> Gen.map (fun (x,y,z,w) -> Quaternion(x,y,z,w) |> Quaternion.Normalize)
         |> Gen.filter (fun q -> not <| (Single.IsNaN q.Length || Single.IsInfinity q.Length ))
         |> Arb.fromGen
 


### PR DESCRIPTION
### Purpose of this PR

This PR fixes the Quaternion generator that is used to produce quaternions used in testing.
Because the quaternion generation was broken the matrices these quaternions generated where all symmetric so that the matrices where transposed where not visible in the tests.
This change was made in #507 and I can't seem to find any written reasoning behind the decision.

With that said this PR also fixes the issue introduced in #1189 that made the result of `CreateFromQuaternion` the transpose of the expected matrix.

### Testing status

All quaternion tests still pass with the fixed generator.