### PR TITLE
Fix wrong binding code generation on some locales

### DIFF
--- a/src/Generator.Bind/Main.cs
+++ b/src/Generator.Bind/Main.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.Reflection;
 using System.Security;
 using System.Text.RegularExpressions;
@@ -37,6 +38,13 @@ namespace Bind
 
         private static void Main(string[] arguments)
         {
+            // These prevent us to accidently generate wrong code because of
+            // locale dependent string functions.
+            CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+            CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
+            CultureInfo.DefaultThreadCurrentCulture = CultureInfo.InvariantCulture;
+            CultureInfo.DefaultThreadCurrentUICulture = CultureInfo.InvariantCulture;
+
             Debug.AutoFlush = true;
             Trace.Listeners.Clear();
             Trace.Listeners.Add(new TextWriterTraceListener(Console.Out));

--- a/src/Generator.Converter/Main.cs
+++ b/src/Generator.Converter/Main.cs
@@ -24,6 +24,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Xml;
@@ -66,6 +67,15 @@ namespace OpenTK.Convert
 
         private static void Main(string[] args)
         {
+            // These prevent us to accidently generate wrong code because of
+            // locale dependent string functions. Whether it actually affects
+            // this program in particular have not been tested yet, but better
+            // be safe than sorry.
+            CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+            CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
+            CultureInfo.DefaultThreadCurrentCulture = CultureInfo.InvariantCulture;
+            CultureInfo.DefaultThreadCurrentUICulture = CultureInfo.InvariantCulture;
+            
             Parser.Default.ParseArguments<Options>(args)
                 .WithParsed(result => CLIOptions = result)
                 .WithNotParsed(error => Environment.Exit(-1));

--- a/src/Generator.Rewrite/Program.cs
+++ b/src/Generator.Rewrite/Program.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using CommandLine;
@@ -33,6 +34,15 @@ namespace OpenTK.Rewrite
 
         private static void Main(string[] args)
         {
+            // These prevent us to accidently generate wrong code because of
+            // locale dependent string functions (probably not relevant here
+            // since this program supposed just rewrite IL bytecode but we do it
+            // anyway just to be safe).
+            CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+            CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
+            CultureInfo.DefaultThreadCurrentCulture = CultureInfo.InvariantCulture;
+            CultureInfo.DefaultThreadCurrentUICulture = CultureInfo.InvariantCulture;
+
             Parser.Default.ParseArguments<Options>(args)
                 .WithParsed(result => Options = result)
                 .WithNotParsed(error => Environment.Exit(-1));

--- a/src/Generator/Program.fs
+++ b/src/Generator/Program.fs
@@ -8,6 +8,7 @@ open Constants
 open System.IO
 open System.Runtime
 open CommandLine
+open System.Globalization
 
 type options =
     { [<Option('i', "input", Required = true,
@@ -289,6 +290,13 @@ let generateCode basePath (typecheckAndAggregateResults: TypecheckAndAggregateRe
 
 [<EntryPoint>]
 let main argv =
+    // These prevent us to accidently generate wrong code because of
+    // locale dependent string functions.
+    CultureInfo.CurrentCulture <- CultureInfo.InvariantCulture
+    CultureInfo.CurrentUICulture <- CultureInfo.InvariantCulture
+    CultureInfo.DefaultThreadCurrentCulture <- CultureInfo.InvariantCulture
+    CultureInfo.DefaultThreadCurrentUICulture <- CultureInfo.InvariantCulture
+    
     printfn
         "Welcome to the OpenTK4.0 binding generator F#ast edition!"
     let result = CommandLine.Parser.Default.ParseArguments<options>(argv)


### PR DESCRIPTION
### Purpose of this PR
Fix wrong binding code generation on locales such as "tr-TR" and possibly others.

### Testing Status
No unittesting have been done locally as trying to run tests seems to trigger OpenAL build which fails as it is currently in a non-compilable state.

### Comments
More info on this if want to learn a bit more: http://www.moserware.com/2008/02/does-your-code-pass-turkey-test.html