### PR TITLE
Feat: Added a method that centers the NativeWindow in the monitor it currently resides

### DIFF
--- a/src/OpenTK.Mathematics/Geometry/Box2i.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box2i.cs
@@ -20,6 +20,8 @@ namespace OpenTK.Mathematics
     [StructLayout(LayoutKind.Sequential)]
     public struct Box2i : IEquatable<Box2i>
     {
+        public static readonly Box2i Empty = new Box2i(0, 0, 0, 0);
+
         private Vector2i _min;
 
         /// <summary>
@@ -165,6 +167,28 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
+        /// Creates a rectangle that represents the intersection between a and
+        /// b. If there is no intersection, a empty <see cref="Box2i"/> is returned.
+        /// </summary>
+        /// <param name="a">First rectangle to intersect.</param>
+        /// <param name="b">Second rectangle to intersect.</param>
+        /// <returns>The <see cref="Box2i"/> that represents the intersection of both Box2i.</returns>
+        public static Box2i Intersect(Box2i a, Box2i b)
+        {
+            Vector2i min = Vector2i.ComponentMax(a.Min, b.Min);
+            Vector2i max = Vector2i.ComponentMin(a.Max, b.Max);
+
+            if (max.X >= min.X && max.Y >= min.Y)
+            {
+                return new Box2i(min, max);
+            }
+            else
+            {
+                return Empty;
+            }
+        }
+
+        /// <summary>
         /// Returns the distance between the nearest edge and the specified point.
         /// </summary>
         /// <param name="point">The point to find distance for.</param>
@@ -295,48 +319,6 @@ namespace OpenTK.Mathematics
         public override string ToString()
         {
             return $"{Min} - {Max}";
-        }
-
-        /// <summary>
-        /// Gets the x-coordinate of the left edge of this <see cref="Box2i"/> structure.
-        /// </summary>
-        public int Left => (int)Center.X - HalfSize.X;
-
-        /// <summary>
-        /// Gets the x-coordinate of the right edge of this <see cref="Box2i"/> structure.
-        /// </summary>
-        public int Right => (int)Center.X + HalfSize.X;
-
-        /// <summary>
-        /// Gets the y-coordinate of the bottom edge of this <see cref="Box2i"/> structure.
-        /// </summary>
-        public int Bottom => (int)Center.Y + HalfSize.Y;
-
-        /// <summary>
-        /// Gets the y-coordinate of the top edge of this <see cref="Box2i"/> structure.
-        /// </summary>
-        public int Top => (int)Center.Y - HalfSize.Y;
-
-        /// <summary>
-        /// Creates a rectangle that represents the intersection between a and
-        /// b. If there is no intersection, a empty <see cref="Box2i"/> is returned.
-        /// </summary>
-        /// <param name="a">First rectangle to intersect.</param>
-        /// <param name="b">Second rectangle to intersect.</param>
-        /// <returns>The <see cref="Box2i"/> that represents the intersection of both Box2i.</returns>
-        public static Box2i Intersect(Box2i a, Box2i b)
-        {
-            int x1 = Math.Max(a.Left, b.Left);
-            int x2 = Math.Min(a.Right, b.Right);
-            int y1 = Math.Max(a.Top, b.Top);
-            int y2 = Math.Min(a.Bottom, b.Bottom);
-
-            if (x2 >= x1 && y2 >= y1)
-            {
-                return new Box2i(x1, y1, x2, y2);
-            }
-
-            return new Box2i(0, 0, 0, 0);
         }
     }
 }

--- a/src/OpenTK.Mathematics/Geometry/Box2i.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box2i.cs
@@ -296,5 +296,47 @@ namespace OpenTK.Mathematics
         {
             return $"{Min} - {Max}";
         }
+
+        /// <summary>
+        /// Gets the x-coordinate of the left edge of this <see cref="Box2i"/> structure.
+        /// </summary>
+        public int Left => (int)Center.X - HalfSize.X;
+
+        /// <summary>
+        /// Gets the x-coordinate of the right edge of this <see cref="Box2i"/> structure.
+        /// </summary>
+        public int Right => (int)Center.X + HalfSize.X;
+
+        /// <summary>
+        /// Gets the y-coordinate of the bottom edge of this <see cref="Box2i"/> structure.
+        /// </summary>
+        public int Bottom => (int)Center.Y + HalfSize.Y;
+
+        /// <summary>
+        /// Gets the y-coordinate of the top edge of this <see cref="Box2i"/> structure.
+        /// </summary>
+        public int Top => (int)Center.Y - HalfSize.Y;
+
+        /// <summary>
+        /// Creates a rectangle that represents the intersection between a and
+        /// b. If there is no intersection, a empty <see cref="Box2i"/> is returned.
+        /// </summary>
+        /// <param name="a">First rectangle to intersect.</param>
+        /// <param name="b">Second rectangle to intersect.</param>
+        /// <returns>The <see cref="Box2i"/> that represents the intersection of both Box2i.</returns>
+        public static Box2i Intersect(Box2i a, Box2i b)
+        {
+            int x1 = Math.Max(a.Left, b.Left);
+            int x2 = Math.Min(a.Right, b.Right);
+            int y1 = Math.Max(a.Top, b.Top);
+            int y2 = Math.Min(a.Bottom, b.Bottom);
+
+            if (x2 >= x1 && y2 >= y1)
+            {
+                return new Box2i(x1, y1, x2, y2);
+            }
+
+            return new Box2i(0, 0, 0, 0);
+        }
     }
 }

--- a/src/OpenTK.Windowing.Desktop/MonitorInfo.cs
+++ b/src/OpenTK.Windowing.Desktop/MonitorInfo.cs
@@ -8,7 +8,7 @@
 //
 
 using System;
-using System.Drawing;
+using OpenTK.Mathematics;
 using OpenTK.Windowing.Common;
 using OpenTK.Windowing.GraphicsLibraryFramework;
 
@@ -34,17 +34,17 @@ namespace OpenTK.Windowing.Desktop
         /// <summary>
         /// Gets the client area of the monitor (in the virtual screen-space).
         /// </summary>
-        public Rectangle ClientArea { get; private set; }
+        public Box2i ClientArea { get; private set; }
 
         /// <summary>
         /// Gets the horizontal resolution of the monitor.
         /// </summary>
-        public int HorizontalResolution => ClientArea.Width;
+        public int HorizontalResolution => ClientArea.Size.X;
 
         /// <summary>
         /// Gets the vertical resolution of the monitor.
         /// </summary>
-        public int VerticalResolution => ClientArea.Height;
+        public int VerticalResolution => ClientArea.Size.Y;
 
         /// <summary>
         /// Gets the scale of the monitor in the horizontal axis.
@@ -130,7 +130,7 @@ namespace OpenTK.Windowing.Desktop
             GLFW.GetMonitorPos(HandleAsPtr, out int x, out int y);
             var videoMode = GLFW.GetVideoMode(HandleAsPtr);
 
-            ClientArea = new Rectangle(x, y, videoMode->Width, videoMode->Height);
+            ClientArea = new Box2i(x, y, x + videoMode->Width, y + videoMode->Height);
         }
 
         /// <summary>

--- a/src/OpenTK.Windowing.Desktop/Monitors.cs
+++ b/src/OpenTK.Windowing.Desktop/Monitors.cs
@@ -9,9 +9,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Linq;
 using System.Runtime.InteropServices;
+using OpenTK.Mathematics;
 using OpenTK.Windowing.Common;
 using OpenTK.Windowing.GraphicsLibraryFramework;
 
@@ -68,10 +68,10 @@ namespace OpenTK.Windowing.Desktop
             }
         }
 
-        private static int GetRectangleIntersectionArea(Rectangle a, Rectangle b)
+        private static int GetRectangleIntersectionArea(Box2i a, Box2i b)
         {
-            var area = Rectangle.Intersect(a, b);
-            return area.Width * area.Height;
+            var area = Box2i.Intersect(a, b);
+            return area.Size.X * area.Size.Y;
         }
 
         /// <summary>
@@ -90,12 +90,12 @@ namespace OpenTK.Windowing.Desktop
                 throw new Exception("This method can only be called from the main GLFW thread.");
             }
 
-            Rectangle windowArea;
+            Box2i windowArea;
             {
                 int windowX, windowY, windowWidth, windowHeight;
                 GLFW.GetWindowPos(window, out windowX, out windowY);
                 GLFW.GetWindowSize(window, out windowWidth, out windowHeight);
-                windowArea = new Rectangle(windowX, windowY, windowWidth, windowHeight);
+                windowArea = new Box2i(windowX, windowY, windowX + windowWidth, windowY + windowHeight);
             }
 
             int selectedIndex = 0;

--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -1712,13 +1712,10 @@ namespace OpenTK.Windowing.Desktop
         }
 
         /// <summary>
-        /// Tries to center the <see cref="NativeWindow"/> on the monitor where resides.
+        /// Centers the <see cref="NativeWindow"/> on the monitor where resides.
         /// </summary>
-        /// <returns><c>true</c>, if current the window was successfully centered, <c>false</c> otherwise.</returns>
-        public bool TryCenterWindow()
+        public void CenterWindow()
         {
-            int x, y;
-
             // Find out which monitor the window is already on.  If we can't find that out, then
             // just try to find the first monitor attached to the computer and use that instead.
             MonitorHandle currentMonitor = Monitors.GetMonitorFromWindow(this);
@@ -1728,30 +1725,28 @@ namespace OpenTK.Windowing.Desktop
                 // Calculate a suitable upper-left corner for the window, based on this monitor's
                 // coordinates.  This should work correctly even in unusual multi-monitor layouts.
                 Box2i monitorRectangle = monitorInfo.ClientArea;
-                x = (monitorRectangle.Right + monitorRectangle.Left - Size.X) / 2;
-                y = (monitorRectangle.Bottom + monitorRectangle.Top - Size.Y) / 2;
+                int x = (monitorRectangle.Min.X + monitorRectangle.Max.X - Size.X) / 2;
+                int y = (monitorRectangle.Min.Y + monitorRectangle.Max.Y - Size.Y) / 2;
 
                 // Avoid putting it offscreen.
-                if (x < monitorRectangle.Left)
+                if (x < monitorRectangle.Min.X)
                 {
-                    x = monitorRectangle.Left;
+                    x = monitorRectangle.Min.X;
                 }
 
-                if (y < monitorRectangle.Top)
+                if (y < monitorRectangle.Min.Y)
                 {
-                    y = monitorRectangle.Top;
+                    y = monitorRectangle.Min.Y;
                 }
+
+                // Actually move the window.
+                ClientRectangle = new Box2i(x, y, x + Size.X, y + Size.Y);
             }
             else
             {
-                // No idea what monitor this is, so return false to let the user implement its
-                // default behavior for when the method fails,
-                return false;
+                // Something in GLFW has gone wrong, and we can't get monitor information.
+                throw new GLFWException("Could not get information about the current monitor nor the default monitor. Something is probably broken in GLFW.");
             }
-
-            // Actually move the window.
-            ClientRectangle = new Box2i(x, y, x + Size.X, y + Size.Y);
-            return true;
         }
     }
 }

--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -4,11 +4,11 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Drawing;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Drawing;
 using OpenTK.Core;
 using OpenTK.Mathematics;
 using OpenTK.Windowing.Common;
@@ -1713,7 +1713,7 @@ namespace OpenTK.Windowing.Desktop
         }
 
         /// <summary>
-        /// Tries to center the <see cref="NativeWindow"/> on the monitor where resides
+        /// Tries to center the <see cref="NativeWindow"/> on the monitor where resides.
         /// </summary>
         /// <returns><c>true</c>, if current the window was successfully centered, <c>false</c> otherwise.</returns>
         public bool TryCenterWindow()
@@ -1733,13 +1733,20 @@ namespace OpenTK.Windowing.Desktop
                 y = (monitorRectangle.Bottom + monitorRectangle.Top - Size.Y) / 2;
 
                 // Avoid putting it offscreen.
-                if (x < monitorRectangle.Left) x = monitorRectangle.Left;
-                if (y < monitorRectangle.Top) y = monitorRectangle.Top;
+                if (x < monitorRectangle.Left)
+                {
+                    x = monitorRectangle.Left;
+                }
+
+                if (y < monitorRectangle.Top)
+                {
+                    y = monitorRectangle.Top;
+                }
             }
             else
             {
                 // No idea what monitor this is, so return false to let the user implement its
-                // default behavior for when the mothod fails,
+                // default behavior for when the method fails,
                 return false;
             }
 

--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -8,6 +8,7 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Drawing;
 using OpenTK.Core;
 using OpenTK.Mathematics;
 using OpenTK.Windowing.Common;
@@ -1712,10 +1713,10 @@ namespace OpenTK.Windowing.Desktop
         }
 
         /// <summary>
-        /// Centers the <see cref="NativeWindow"/> on the monitor where resizes,
-        /// If no monitor is found it is placed in the upper-left corner of what's hopefully a monitor
+        /// Tries to center the <see cref="NativeWindow"/> on the monitor where resides
         /// </summary>
-        public void CenterWindow()
+        /// <returns><c>true</c>, if current the window was successfully centered, <c>false</c> otherwise.</returns>
+        public bool TryCenterWindow()
         {
             int x, y;
 
@@ -1737,15 +1738,14 @@ namespace OpenTK.Windowing.Desktop
             }
             else
             {
-                // No idea what monitor this is, so just try to put the window somewhere reasonable,
-                // like the upper-left corner of what's hopefully *a* monitor.  Alternatively, you
-                // could throw an exception here.
-                x = 32;
-                y = 64;
+                // No idea what monitor this is, so return false to let the user implement its
+                // default behavior for when the mothod fails,
+                return false;
             }
 
             // Actually move the window.
             ClientRectangle = new Box2i(x, y, x + Size.X, y + Size.Y);
+            return true;
         }
     }
 }

--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -1710,5 +1710,42 @@ namespace OpenTK.Windowing.Desktop
                     throw new ArgumentOutOfRangeException(nameof(shape), shape, null);
             }
         }
+
+        /// <summary>
+        /// Centers the <see cref="NativeWindow"/> on the monitor where resizes,
+        /// If no monitor is found it is placed in the upper-left corner of what's hopefully a monitor
+        /// </summary>
+        public void CenterWindow()
+        {
+            int x, y;
+
+            // Find out which monitor the window is already on.  If we can't find that out, then
+            // just try to find the first monitor attached to the computer and use that instead.
+            MonitorHandle currentMonitor = Monitors.GetMonitorFromWindow(this);
+            if (Monitors.TryGetMonitorInfo(currentMonitor, out MonitorInfo monitorInfo)
+                || Monitors.TryGetMonitorInfo(0, out monitorInfo))
+            {
+                // Calculate a suitable upper-left corner for the window, based on this monitor's
+                // coordinates.  This should work correctly even in unusual multi-monitor layouts.
+                Rectangle monitorRectangle = monitorInfo.ClientArea;
+                x = (monitorRectangle.Right + monitorRectangle.Left - Size.X) / 2;
+                y = (monitorRectangle.Bottom + monitorRectangle.Top - Size.Y) / 2;
+
+                // Avoid putting it offscreen.
+                if (x < monitorRectangle.Left) x = monitorRectangle.Left;
+                if (y < monitorRectangle.Top) y = monitorRectangle.Top;
+            }
+            else
+            {
+                // No idea what monitor this is, so just try to put the window somewhere reasonable,
+                // like the upper-left corner of what's hopefully *a* monitor.  Alternatively, you
+                // could throw an exception here.
+                x = 32;
+                y = 64;
+            }
+
+            // Actually move the window.
+            ClientRectangle = new Box2i(x, y, x + Size.X, y + Size.Y);
+        }
     }
 }

--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Drawing;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -1728,7 +1727,7 @@ namespace OpenTK.Windowing.Desktop
             {
                 // Calculate a suitable upper-left corner for the window, based on this monitor's
                 // coordinates.  This should work correctly even in unusual multi-monitor layouts.
-                Rectangle monitorRectangle = monitorInfo.ClientArea;
+                Box2i monitorRectangle = monitorInfo.ClientArea;
                 x = (monitorRectangle.Right + monitorRectangle.Left - Size.X) / 2;
                 y = (monitorRectangle.Bottom + monitorRectangle.Top - Size.Y) / 2;
 


### PR DESCRIPTION
### Purpose of this PR

* Added a method that centers the NativeWindow in the monitor it currently resides,
* Modified `OpenTK.OpenTK.Windowing.Desktop.NativeWindow` class

### Testing status

* I have tested this in my own projects as it is and it appears to work correctly, however I am not sure what kind of test plan could be implemented for this feature.

### Comments

*  Refer to Issue #1213 for reference and an explanation of the method
