### PR TITLE
Added properties ButtonCount, AxisCount, and HatCount to JoystickState

### DIFF
--- a/src/OpenTK.Windowing.GraphicsLibraryFramework/Input/JoystickState.cs
+++ b/src/OpenTK.Windowing.GraphicsLibraryFramework/Input/JoystickState.cs
@@ -42,6 +42,21 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
         /// </summary>
         public string Name { get; }
 
+        /// <summary>
+        /// Gets the number of buttons on the joystick this state describes.
+        /// </summary>
+        public int ButtonCount { get => _buttons.Length; }
+
+        /// <summary>
+        /// Gets the number of axes on the joystick this state describes.
+        /// </summary>
+        public int AxisCount { get => _axes.Length; }
+
+        /// <summary>
+        /// Gets the number of hats on the joystick this state describes.
+        /// </summary>
+        public int HatCount { get => _hats.Length; }
+
         internal JoystickState(int hatCount, int axesCount, int buttonCount, int id, string name)
         {
             _hats = new Hat[hatCount];


### PR DESCRIPTION
### Purpose of this PR

* Adds properties that allow the caller to query for the number of buttons, axes, and hats on a joystick
* Modified OpenTK.Windowing.GraphicsLibraryFramework.Input.JoystickState.cs

### Testing status

* Ran manual tests on Windows, was able to get back 14, 6, and 1 for ButtonCount, AxisCount, and HatCount respectively on my Xbox One Elite controller.

### Comments

* Joystick state allows you to query for the state of a button given the integer index of the button, but does not tell you how many buttons there are to query. With the removal of JoystickCapabilities from 3.0 to 4.0, this information will now be exposed on JoystickState.
