### PR TITLE
[3.x] Change: Allow architecture specific dependancies

### DIFF
--- a/OptionalDependancies.md
+++ b/OptionalDependancies.md
@@ -1,0 +1,43 @@
+Optional Dependancies
+=====================
+
+OpenTK supports various optional dependancies. These are meant for your convenience and are completely optional to use.
+
+### SDL2
+**SDL2.dll libSDL2.dylib libSDL2.so**
+
+The Simple DirectMedia Library compiled for Windows, Mac OS X and Android.
+
+http://libsdl.org
+
+Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.
+
+### OpenAL Soft
+
+**OpenAL32.dll**
+
+OpenAL Soft is an LGPL-licensed, cross-platform, software implementation of the OpenAL 3D audio API, and is required to use OpenAL on Windows. Linux and Mac OS X support OpenAL out of the box.
+
+
+### ANGLE
+**libEGL.dll libGLESv2.dll d3dcompiler_46.dll**
+
+The goal of ANGLE is to allow Windows users to seamlessly run WebGL and other OpenGL ES 2.0 content by translating OpenGL ES 2.0 API calls to DirectX 9 or DirectX 11 API calls.
+
+
+Windows Architecture Specific Dependancies
+==========================================
+
+On Windows, OpenTK supports the following additional DLL seach paths:
+**OpenTK Folder\x86** - Place x86 architecture specific files in this subfolder.
+**OpenTK Folder\x64** - Place x64 architecture specific files in this subfolder.
+
+Please also see the following Microsoft link for a full explanation on the DLL search order:
+https://docs.microsoft.com/en-us/windows/win32/dlls/dynamic-link-library-search-order
+
+Linux and OS-X Dependancies
+===========================
+
+Under Linux and Mac OS X, the search path for these optional dependancies may be found in the **OpenTK.dll.config** file, which should be placed next to **OpenTK.dll**
+The Mono documentation for this file may be found at the following page:
+https://www.mono-project.com/docs/advanced/pinvoke/dllmap/

--- a/README.md
+++ b/README.md
@@ -188,8 +188,8 @@ Requirements
 ============
 
 - Windows (XP/Vista/7/8,10), Linux, Mac OS X, *BSD, SteamOS, Android or iOS
-- For graphics, OpenGL drivers or a suitable emulator, such as [ANGLE](https://github.com/opentk/opentk/tree/develop/Dependencies/Readme.txt)
-- For audio, OpenAL drivers or [OpenAL Soft](https://github.com/opentk/opentk/tree/develop/Dependencies/Readme.txt)
+- For graphics, OpenGL drivers or a suitable emulator, such as *ANGLE*
+- For audio, OpenAL drivers or *OpenAL Soft*
 - To develop desktop applications: Visual Studio, Rider, or the command line tools.
 - To develop Android applications: Visual Studio and Xamarin
 - To develop iOS applications: Visual Studio, Xamarin and XCode

--- a/README.md
+++ b/README.md
@@ -194,6 +194,9 @@ Requirements
 - To develop Android applications: Visual Studio and Xamarin
 - To develop iOS applications: Visual Studio, Xamarin and XCode
 
+Please also see the following file for further details:
+[Optional Dependancies](OptionalDepenancies.md)
+
 
 Documentation
 =============

--- a/src/OpenTK/Toolkit.cs
+++ b/src/OpenTK/Toolkit.cs
@@ -26,6 +26,9 @@
 using System;
 using OpenTK.Platform;
 using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using System.Runtime.InteropServices;
 
 namespace OpenTK
 {
@@ -129,7 +132,14 @@ namespace OpenTK
                     initialized = true;
                     Configuration.Init(options);
                     Options = options;
-
+                    /*
+                     * If shipping an AnyCPU build and OpenALSoft / SDL, these are architecture specific PInvokes
+                     * Add the appropriate search path so this will work
+                     */
+                    string path = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
+                    path = Path.Combine(path, IntPtr.Size == 4 ? "x86" : "x64");
+                    bool ok = SetDllDirectory(path);
+                    if (!ok) throw new System.ComponentModel.Win32Exception();
                     // The actual initialization takes place in the
                     // platform-specific factory constructors.
                     toolkit = new Toolkit(new Factory());
@@ -177,5 +187,8 @@ namespace OpenTK
             // as that will crash on many operating systems.
         }
         #endif
+        
+        [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        private static extern bool SetDllDirectory(string path);
     }
 }

--- a/src/OpenTK/Toolkit.cs
+++ b/src/OpenTK/Toolkit.cs
@@ -132,14 +132,19 @@ namespace OpenTK
                     initialized = true;
                     Configuration.Init(options);
                     Options = options;
-                    /*
-                     * If shipping an AnyCPU build and OpenALSoft / SDL, these are architecture specific PInvokes
-                     * Add the appropriate search path so this will work
-                     */
-                    string path = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
-                    path = Path.Combine(path, IntPtr.Size == 4 ? "x86" : "x64");
-                    bool ok = SetDllDirectory(path);
-                    if (!ok) throw new System.ComponentModel.Win32Exception();
+                    if (Environment.OSVersion.Platform == PlatformID.Win32S | Environment.OSVersion.Platform == PlatformID.Win32Windows | Environment.OSVersion.Platform == PlatformID.Win32NT)
+                    {
+                        /*
+                        *  If shipping an AnyCPU build and OpenALSoft / SDL, these are architecture specific PInvokes
+                        *  Add the appropriate search path so this will work (common convention)
+                         * Non-Windows platforms should be handled via the OpenTK.dll.config file as appropriate
+                        */
+                        string path = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
+                        path = Path.Combine(path, IntPtr.Size == 4 ? "x86" : "x64");
+                        bool ok = SetDllDirectory(path);
+                        if (!ok) throw new System.ComponentModel.Win32Exception();
+                    }
+
                     // The actual initialization takes place in the
                     // platform-specific factory constructors.
                     toolkit = new Toolkit(new Factory());

--- a/src/OpenTK/Toolkit.cs
+++ b/src/OpenTK/Toolkit.cs
@@ -132,13 +132,26 @@ namespace OpenTK
                     initialized = true;
                     Configuration.Init(options);
                     Options = options;
-                    if (Environment.OSVersion.Platform == PlatformID.Win32S | Environment.OSVersion.Platform == PlatformID.Win32Windows | Environment.OSVersion.Platform == PlatformID.Win32NT)
+                    if (Environment.OSVersion.Platform == PlatformID.Win32S || Environment.OSVersion.Platform == PlatformID.Win32Windows || Environment.OSVersion.Platform == PlatformID.Win32NT)
                     {
                         /*
-                        *  If shipping an AnyCPU build and OpenALSoft / SDL, these are architecture specific PInvokes
-                        *  Add the appropriate search path so this will work (common convention)
+                         * https://docs.microsoft.com/en-us/windows/win32/dlls/dynamic-link-library-search-order
+                         *
+                         * If shipping an AnyCPU build and C++ DLLImports such as OpenALSoft / SDL
+                         * we need to use architecture specific P/Invokes.
+                         * Windows will attempt to locate an appropriate file using the search order listed
+                         * in the document above. However, we want to avoid putting 'our' copy of these files
+                         * into the system cache.
+                         *
+                         * Thus, a common convention is to use an x86 / x64 subfolder to store the architecture
+                         * specific DLLImports. (Architecture independant files can be stored in the same
+                         * folder as the main DLL)
+                         *
+                         * For this to work, we need to add the appropriate search path to SetDLLDirectory
+                         *
+                         * NOTE:
                          * Non-Windows platforms should be handled via the OpenTK.dll.config file as appropriate
-                        */
+                         */
                         string path = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
                         path = Path.Combine(path, IntPtr.Size == 4 ? "x86" : "x64");
                         bool ok = SetDllDirectory(path);


### PR DESCRIPTION
### Purpose of this PR

TLDR:
I'm planning on shipping a 64-build at some not too distant stage in the future, but for legacy reasons I still want to maintain 32-bit compatability also.

I currently ship the 32-bit version of OpenALSoft, but this obviously doesn't work on 64-bit.

This PR is dead simple, and allows architecture specific PInvokes to SDL and OpenALSoft, by using the common convention of adding **x86** and **x64** to the DLL search directory list when the tookit is initialised.
Only potential flaw I can see is if OpenAL is called before attempting to init the toolkit itself (is this even possible? I haven't tried....)


### Testing status

* Simple adding of a alternate path to the PInvoke search directories using native Windows function. Works fine.

### Comments

n/a