### PR TITLE
Assign APIVersion in constructor

### DIFF
--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -616,6 +616,8 @@ namespace OpenTK.Windowing.Desktop
             GLFW.WindowHint(WindowHintInt.ContextVersionMajor, settings.APIVersion.Major);
             GLFW.WindowHint(WindowHintInt.ContextVersionMinor, settings.APIVersion.Minor);
 
+            APIVersion = settings.APIVersion;
+
             Flags = settings.Flags;
             if (settings.Flags.HasFlag(ContextFlags.ForwardCompatible))
             {


### PR DESCRIPTION
### Purpose of this PR

Assign APIVersion to settings.APIVersion in NativeWindow constructor.

### Testing status

Tested, works.
