### PR TITLE
Fixed some AL.DeleteSources functions calling alDeleteBuffers instead of alDeleteSources.

### DIFF
--- a/OpenALTest/ALTest.cs
+++ b/OpenALTest/ALTest.cs
@@ -190,7 +190,7 @@ namespace OpenTK.Audio.OpenAL
             // Test double format extension
             if (EXTDouble.IsExtensionPresent())
             {
-                Console.WriteLine("Testing float32 format extension with a saw wave...");
+                Console.WriteLine("Testing float64 format extension with a saw wave...");
 
                 double[] saw = new double[44100 * 2];
                 for (int i = 0; i < saw.Length; i++)

--- a/src/OpenAL/OpenTK.OpenAL/AL/AL.cs
+++ b/src/OpenAL/OpenTK.OpenAL/AL/AL.cs
@@ -407,14 +407,14 @@ namespace OpenTK.Audio.OpenAL
             {
                 throw new ArgumentNullException(nameof(sources));
             }
-            DeleteBuffers(sources.Length, ref sources[0]);
+            DeleteSources(sources.Length, ref sources[0]);
         }
 
         /// <summary>This function deletes one or more sources.</summary>
         /// <param name="sources">An array of source names identifying the sources to be deleted.</param>
         public static void DeleteSources(Span<int> sources)
         {
-            DeleteBuffers(sources.Length, ref sources[0]);
+            DeleteSources(sources.Length, ref sources[0]);
         }
 
         /// <summary>This function deletes one source only.</summary>


### PR DESCRIPTION
### Purpose of this PR

See title.
Also fixed a typo in the output of the ALTest project.
Fixes #1224

### Testing status

Compiles.
AL test project runs.