### PR TITLE
OpenGL interop for OpenTK.Compute

### DIFF
--- a/src/OpenTK.Compute/OpenCL/CL.cs
+++ b/src/OpenTK.Compute/OpenCL/CL.cs
@@ -199,6 +199,13 @@ namespace OpenTK.Compute.OpenCL
 		/// <summary>
 		/// Introduced in OpenCL 1.0
 		/// </summary>
+		[DllImport(LibName, CallingConvention = CallingConvention, EntryPoint = "clCreateContextFromType")]
+		public static extern CLContext CreateContextFromType([In] IntPtr[] properties, [In] DeviceType deviceType,
+			[In] IntPtr notificationCallback, [In] IntPtr userData, [Out] out CLResultCode resultCode);
+
+		/// <summary>
+		/// Introduced in OpenCL 1.0
+		/// </summary>
 		[DllImport(LibName, CallingConvention = CallingConvention, EntryPoint = "clRetainContext")]
 		public static extern CLResultCode RetainContext([In] CLContext context);
 

--- a/src/OpenTK.Compute/OpenCL/CL.cs
+++ b/src/OpenTK.Compute/OpenCL/CL.cs
@@ -11,7 +11,7 @@ namespace OpenTK.Compute.OpenCL
 			CLBase.RegisterOpenCLResolver();
 		}
 
-		private const string LibName = "libOpenCL";
+		private const string LibName = "opencl";
 		private const CallingConvention CallingConvention = System.Runtime.InteropServices.CallingConvention.Cdecl;
 
 		public delegate void ClEventCallback(IntPtr waitEvent, IntPtr userData);

--- a/src/OpenTK.Compute/OpenCL/CL.cs
+++ b/src/OpenTK.Compute/OpenCL/CL.cs
@@ -16,6 +16,8 @@ namespace OpenTK.Compute.OpenCL
 
 		public delegate void ClEventCallback(IntPtr waitEvent, IntPtr userData);
 
+		public static readonly IntPtr ContextPlatform = (IntPtr)0x1084;
+
 		#region Platform API
 
 		/// <summary>
@@ -165,6 +167,27 @@ namespace OpenTK.Compute.OpenCL
 			return CreateContext(properties, (uint)devices.Length, devices, notificationCallback, userData,
 				out resultCode);
 		}
+
+
+		/// <summary>
+		/// Introduced in OpenCL 1.0
+		/// </summary>
+		[DllImport(LibName, CallingConvention = CallingConvention, EntryPoint = "clCreateContext")]
+		public static extern CLContext CreateContext([In] IntPtr[] properties, [In] uint numberOfDevices,
+			[In] CLDevice[] devices,
+			[In] IntPtr notificationCallback, [In] IntPtr userData, [Out] out CLResultCode resultCode);
+
+		/// <summary>
+		/// Introduced in OpenCL 1.0
+		/// </summary>
+		public static CLContext CreateContext(IntPtr[] properties, CLDevice[] devices,
+			IntPtr notificationCallback,
+			IntPtr userData, out CLResultCode resultCode)
+		{
+			return CreateContext(properties, (uint)devices.Length, devices, notificationCallback, userData,
+				out resultCode);
+		}
+
 
 		/// <summary>
 		/// Introduced in OpenCL 1.0

--- a/src/OpenTK.Compute/OpenCL/CL.cs
+++ b/src/OpenTK.Compute/OpenCL/CL.cs
@@ -16,7 +16,6 @@ namespace OpenTK.Compute.OpenCL
 
 		public delegate void ClEventCallback(IntPtr waitEvent, IntPtr userData);
 
-		public static readonly IntPtr ContextPlatform = (IntPtr)0x1084;
 
 		#region Platform API
 

--- a/src/OpenTK.Compute/OpenCL/CLGL.cs
+++ b/src/OpenTK.Compute/OpenCL/CLGL.cs
@@ -67,6 +67,13 @@ namespace OpenTK.Compute.OpenCL
 		/// <summary>
 		/// Introduced in Opencl 1.2
 		/// </summary>
+		/// <param name="context"></param>
+		/// <param name="flags"></param>
+		/// <param name="target">This corresponds to the texture target used in OpenGL; e.g. (int)TextureTarget.Texture2D</param>
+		/// <param name="mipLevel"></param>
+		/// <param name="texture"></param>
+		/// <param name="error"></param>
+		/// <returns></returns>
 		[DllImport(LibName, CallingConvention = CallingConvention, EntryPoint = "clCreateFromGLTexture")]
 		public static extern CLBuffer CreateFromGLTexture(
 			[In] CLContext context,
@@ -147,7 +154,6 @@ namespace OpenTK.Compute.OpenCL
 		public static extern CLBuffer CreateFromGLTexture2D(
 			[In] CLContext context,
 			[In] MemoryFlags flags,
-			//TODO FIX
 			[In] int target,
 			[In] int mipLevel,
 			[In] int texture,
@@ -162,7 +168,6 @@ namespace OpenTK.Compute.OpenCL
 		public static extern CLBuffer CreateFromGLTexture3D(
 			[In] CLContext context,
 			[In] MemoryFlags flags,
-			//TODO FIX
 			[In] int target,
 			[In] int mipLevel,
 			[In] int texture,
@@ -177,7 +182,7 @@ namespace OpenTK.Compute.OpenCL
 			DevicesForGlContextKHR = 0x2007
 		}
 
-		public enum ContextProperties : uint
+		public enum ContextProperties : int
 		{
 			GlContextKHR = 0x2008,
 			EglDisplayKHR = 0x2009,

--- a/src/OpenTK.Compute/OpenCL/CLGL.cs
+++ b/src/OpenTK.Compute/OpenCL/CLGL.cs
@@ -1,0 +1,212 @@
+using System;
+using System.Runtime.InteropServices;
+using OpenTK.Compute.Native;
+
+namespace OpenTK.Compute.OpenCL
+{
+	public class CLGL : CLBase
+	{
+		public enum ObjectType : uint
+		{
+			ObjectBuffer = 0x2000,
+			ObjectTexture2D = 0x2001,
+			ObjectTexture3D = 0x2002,
+			ObjectRenderBuffer = 0x2003,
+
+			/// <summary>
+			/// Introduced in OpenCL 1.2
+			/// </summary>
+			ObjectTexture2DArray = 0x200E,
+
+			/// <summary>
+			/// Introduced in OpenCL 1.2
+			/// </summary>
+			ObjectTexture1D = 0x200F,
+
+			/// <summary>
+			/// Introduced in OpenCL 1.2
+			/// </summary>
+			ObjectTexture1DArray = 0x2010,
+
+			/// <summary>
+			/// Introduced in OpenCL 1.2
+			/// </summary>
+			ObjectTextureBuffer = 0x2011,
+		}
+
+		public enum TextureInfo : uint
+		{
+			TextureTarget = 0x2004,
+			MipmapLevel = 0x2005,
+
+			/// <summary>
+			/// Introduced in OpenCL 1.2
+			/// </summary>
+			NumSamples = 0x2012,
+		}
+
+		static CLGL()
+		{
+			CLBase.RegisterOpenCLResolver();
+		}
+
+		private const string LibName = "libOpenCL";
+		private const CallingConvention CallingConvention = System.Runtime.InteropServices.CallingConvention.Cdecl;
+
+		/// <summary>
+		/// Introduced in OpenCL 1.0
+		/// </summary>
+		[DllImport(LibName, CallingConvention = CallingConvention, EntryPoint = "clCreateFromGLBuffer")]
+		public static extern CLBuffer CreateFromGLBuffer(
+			[In] CLContext context,
+			[In] MemoryFlags flags,
+			[In] int glBuffer,
+			[Out] out CLResultCode error
+		);
+
+		/// <summary>
+		/// Introduced in Opencl 1.2
+		/// </summary>
+		[DllImport(LibName, CallingConvention = CallingConvention, EntryPoint = "clCreateFromGLTexture")]
+		public static extern CLBuffer CreateFromGLTexture(
+			[In] CLContext context,
+			[In] MemoryFlags flags,
+			//TODO FIX
+			[In] int target,
+			[In] int mipLevel,
+			[In] int texture,
+			[Out] out CLResultCode error
+		);
+
+		/// <summary>
+		/// Introduced in Opencl 1.0
+		/// </summary>
+		[DllImport(LibName, CallingConvention = CallingConvention, EntryPoint = "clCreateFromGLRenderbuffer")]
+		public static extern CLBuffer CreateFromGLRenderbuffer(
+			[In] CLContext context,
+			[In] MemoryFlags flags,
+			[In] int renderBuffer,
+			[Out] out CLResultCode error
+		);
+
+		/// <summary>
+		/// Introduced in Opencl 1.0
+		/// </summary>
+		[DllImport(LibName, CallingConvention = CallingConvention, EntryPoint = "clGetGLObjectInfo")]
+		public static extern CLResultCode GetGLObjectInfo(
+			[In] CLBuffer memObject,
+			[Out] out ObjectType glObjectType,
+			[Out] out int glObjectName
+		);
+
+		/// <summary>
+		/// Introduced in Opencl 1.0
+		/// </summary>
+		[DllImport(LibName, CallingConvention = CallingConvention, EntryPoint = "clGetGLTextureInfo")]
+		public static extern CLResultCode GetGLTextureInfo(
+			[In] CLBuffer memObject,
+			[In] TextureInfo paramName,
+			[In] UIntPtr paramValueSize,
+			[Out] byte[] paramValue,
+			[Out] out UIntPtr paramValueSizeReturned
+		);
+
+		/// <summary>
+		/// Introduced in Opencl 1.0
+		/// </summary>
+		[DllImport(LibName, CallingConvention = CallingConvention, EntryPoint = "clEnqueueAcquireGLObjects")]
+		public static extern CLResultCode EnqueueAcquireGLObjects(
+			[In] CLCommandQueue commandQueue,
+			[In] uint numberOfObjects,
+			[In] CLBuffer[] memoryObjects,
+			[In] uint numEventsInWaitList,
+			[In] CLEvent[] eventWaitList,
+			[Out] out CLEvent @event
+		);
+
+		/// <summary>
+		/// Introduced in Opencl 1.0
+		/// </summary>
+		[DllImport(LibName, CallingConvention = CallingConvention, EntryPoint = "clEnqueueReleaseGLObjects")]
+		public static extern CLResultCode EnqueueReleaseGLObjects(
+			[In] CLCommandQueue commandQueue,
+			[In] uint numberOfObjects,
+			[In] CLBuffer[] memoryObjects,
+			[In] uint numEventsInWaitList,
+			[In] CLEvent[] eventWaitList,
+			[Out] out CLEvent @event
+		);
+
+		#region Deprecated OpenCL 1.1 APIs
+
+		/// <summary>
+		/// Introduced in Opencl 1.1; [DEPRECATED]
+		/// </summary>
+		[Obsolete]
+		[DllImport(LibName, CallingConvention = CallingConvention, EntryPoint = "clCreateFromGLTexture2D")]
+		public static extern CLBuffer CreateFromGLTexture2D(
+			[In] CLContext context,
+			[In] MemoryFlags flags,
+			//TODO FIX
+			[In] int target,
+			[In] int mipLevel,
+			[In] int texture,
+			[Out] out CLResultCode error
+		);
+
+		/// <summary>
+		/// Introduced in Opencl 1.1; [DEPRECATED]
+		/// </summary>
+		[Obsolete]
+		[DllImport(LibName, CallingConvention = CallingConvention, EntryPoint = "clCreateFromGLTexture3D")]
+		public static extern CLBuffer CreateFromGLTexture3D(
+			[In] CLContext context,
+			[In] MemoryFlags flags,
+			//TODO FIX
+			[In] int target,
+			[In] int mipLevel,
+			[In] int texture,
+			[Out] out CLResultCode error
+		);
+
+		#endregion
+
+		public enum CLGLContextInfo : uint
+		{
+			CurrentDeviceForGlContextKHR = 0x2006,
+			DevicesForGlContextKHR = 0x2007
+		}
+
+		public enum ContextProperties
+		{
+			GlContextKHR = 0x2008,
+			EglDisplayKHR = 0x2009,
+			GlxDisplayKHR = 0x200A,
+			WglHDCKHR = 0x200B,
+			CglShareGroupKHR = 0x200C,
+		}
+
+		/// <summary>
+		/// Introduced in Opencl 1.0
+		/// </summary>
+		[DllImport(LibName, CallingConvention = CallingConvention, EntryPoint = "clGetGLContextInfoKHR")]
+		public static extern CLResultCode GetGLContextInfoKHR(
+			[In] ref ContextProperties properties,
+			[In] ContextInfo paramName,
+			[In] UIntPtr paramValueSize,
+			[Out] byte[] paramValue,
+			[Out] out UIntPtr paramValueSizeReturned
+		);
+
+		/*
+		/// <summary>
+		/// Introduced in Opencl 1.1
+		/// </summary>
+		[DllImport(LibName, CallingConvention = CallingConvention, EntryPoint = "clCreateEventFromGLsyncKHR")]
+		public static extern CLEvent CreateEventFromGLsyncKHR(
+			[In] CLContext context,
+			[In] uint sync,
+			[Out] out CLResultCode error
+		);*/
+	}
+}

--- a/src/OpenTK.Compute/OpenCL/CLGL.cs
+++ b/src/OpenTK.Compute/OpenCL/CLGL.cs
@@ -171,13 +171,13 @@ namespace OpenTK.Compute.OpenCL
 
 		#endregion
 
-		public enum CLGLContextInfo : uint
+		public enum ContextInfo : uint
 		{
 			CurrentDeviceForGlContextKHR = 0x2006,
 			DevicesForGlContextKHR = 0x2007
 		}
 
-		public enum ContextProperties
+		public enum ContextProperties : uint
 		{
 			GlContextKHR = 0x2008,
 			EglDisplayKHR = 0x2009,
@@ -191,22 +191,21 @@ namespace OpenTK.Compute.OpenCL
 		/// </summary>
 		[DllImport(LibName, CallingConvention = CallingConvention, EntryPoint = "clGetGLContextInfoKHR")]
 		public static extern CLResultCode GetGLContextInfoKHR(
-			[In] ref ContextProperties properties,
+			[In] IntPtr[] properties,
 			[In] ContextInfo paramName,
 			[In] UIntPtr paramValueSize,
 			[Out] byte[] paramValue,
 			[Out] out UIntPtr paramValueSizeReturned
 		);
 
-		/*
 		/// <summary>
 		/// Introduced in Opencl 1.1
 		/// </summary>
 		[DllImport(LibName, CallingConvention = CallingConvention, EntryPoint = "clCreateEventFromGLsyncKHR")]
 		public static extern CLEvent CreateEventFromGLsyncKHR(
 			[In] CLContext context,
-			[In] uint sync,
+			[In] IntPtr sync,
 			[Out] out CLResultCode error
-		);*/
+		);
 	}
 }

--- a/src/OpenTK.Compute/OpenCL/CLGL.cs
+++ b/src/OpenTK.Compute/OpenCL/CLGL.cs
@@ -50,7 +50,7 @@ namespace OpenTK.Compute.OpenCL
 			CLBase.RegisterOpenCLResolver();
 		}
 
-		private const string LibName = "libOpenCL";
+		private const string LibName = "opencl";
 		private const CallingConvention CallingConvention = System.Runtime.InteropServices.CallingConvention.Cdecl;
 
 		/// <summary>

--- a/src/OpenTK.Compute/OpenCL/Enums.cs
+++ b/src/OpenTK.Compute/OpenCL/Enums.cs
@@ -2,6 +2,11 @@ using System;
 
 namespace OpenTK.Compute.OpenCL
 {
+	public enum ContextProperties : int
+	{
+		ContextPlatform = 0x1084
+	}
+
 	public enum PlatformInfo : uint
 	{
 		Profile = 0x0900,


### PR DESCRIPTION
### Purpose of this PR

* OpenTK.Compute affected
* Added IntPtr[] overloads for the CL.CreateContext method, shouldn't cause any problems with existing code but will make passing properties for creating the context easier
* Started adding Opengl related extension for opencl

### Testing status

* THE EXTENSIONS ARE NOT TESTED (some issues with creating a valid context for sharing data between opencl and opengl)

### Comments

* Any other comments to help understand the change.
