### PR TITLE
Fix void* to IntPtr overloader

### DIFF
--- a/src/GeneratorV2/Process/Processor.cs
+++ b/src/GeneratorV2/Process/Processor.cs
@@ -1117,7 +1117,7 @@ namespace GeneratorV2.Process
                 {
                     foreach ((Parameter vPtr, Parameter iPtr) in ParameterNames)
                     {
-                        writer.WriteLine($"void* {nameTable[vPtr]} = &{nameTable[iPtr]};");
+                        writer.WriteLine($"void* {nameTable[vPtr]} = (void*){nameTable[iPtr]};");
                     }
                 }
 


### PR DESCRIPTION
### Purpose of this PR

Fixes the `void*` to `IntPtr` overloader so that it doesn't cause crashes.

### Testing status

Generated code compiles.
