### PR TITLE
Fix multi-targeted projects not being packaged correctly.

### DIFF
--- a/src/OpenTK.Graphics/paket
+++ b/src/OpenTK.Graphics/paket
@@ -6,7 +6,13 @@ dependencies
     framework: netstandard2.1
         OpenTK.Core ~> #VERSION#
         OpenTK.Mathematics ~> #VERSION#
+    framework: netcoreapp3.1
+        OpenTK.Core ~> #VERSION#
+        OpenTK.Mathematics ~> #VERSION#
 files
     bin\Release\netstandard2.1\OpenTK.Graphics.dll ==> lib\netstandard2.1
     bin\Release\netstandard2.1\OpenTK.Graphics.xml ==> lib\netstandard2.1
     bin\Release\netstandard2.1\OpenTK.Graphics.pdb ==> lib\netstandard2.1
+    bin\Release\netcoreapp3.1\OpenTK.Graphics.dll ==> lib\netcoreapp3.1
+    bin\Release\netcoreapp3.1\OpenTK.Graphics.xml ==> lib\netcoreapp3.1
+    bin\Release\netcoreapp3.1\OpenTK.Graphics.pdb ==> lib\netcoreapp3.1

--- a/src/OpenTK.Mathematics/Matrix/Matrix4.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix4.cs
@@ -20,6 +20,11 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
  */
 
+// Polyfill for older SDKs
+#if NETCOREAPP3_1
+#define NETCOREAPP3_1_OR_GREATER
+#endif
+
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;

--- a/src/OpenTK.Mathematics/OpenTK.Mathematics.csproj
+++ b/src/OpenTK.Mathematics/OpenTK.Mathematics.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Condition="'$(TargetFramework)' == 'netstandard2.1'" Version="5.0.0" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0" />
   </ItemGroup>
   <Import Project="..\..\props\common.props" />
   <Import Project="..\..\props\nuget-common.props" />

--- a/src/OpenTK.Mathematics/OpenTK.Mathematics.csproj
+++ b/src/OpenTK.Mathematics/OpenTK.Mathematics.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Condition="'$(TargetFramework)' == 'netstandard2.1'" Version="5.0.0" />
   </ItemGroup>
   <Import Project="..\..\props\common.props" />
   <Import Project="..\..\props\nuget-common.props" />

--- a/src/OpenTK.Mathematics/paket
+++ b/src/OpenTK.Mathematics/paket
@@ -6,6 +6,7 @@ dependencies
     framework: netstandard2.1
         System.Runtime.CompilerServices.Unsafe ~> 5.0.0
     framework: netcoreapp3.1
+        System.Runtime.CompilerServices.Unsafe ~> 5.0.0
 
 files
     bin\Release\netstandard2.1\OpenTK.Mathematics.dll ==> lib\netstandard2.1

--- a/src/OpenTK.Mathematics/paket
+++ b/src/OpenTK.Mathematics/paket
@@ -2,7 +2,15 @@ type file
 id OpenTK.Mathematics
 description
     A basic mathematics library developed primarily for rendering in 3d and 2d.
+dependencies
+    framework: netstandard2.1
+        System.Runtime.CompilerServices.Unsafe ~> 5.0.0
+    framework: netcoreapp3.1
+
 files
     bin\Release\netstandard2.1\OpenTK.Mathematics.dll ==> lib\netstandard2.1
     bin\Release\netstandard2.1\OpenTK.Mathematics.xml ==> lib\netstandard2.1
     bin\Release\netstandard2.1\OpenTK.Mathematics.pdb ==> lib\netstandard2.1
+    bin\Release\netcoreapp3.1\OpenTK.Mathematics.dll ==> lib\netcoreapp3.1
+    bin\Release\netcoreapp3.1\OpenTK.Mathematics.xml ==> lib\netcoreapp3.1
+    bin\Release\netcoreapp3.1\OpenTK.Mathematics.pdb ==> lib\netcoreapp3.1

--- a/src/OpenTK.Windowing.Common/paket
+++ b/src/OpenTK.Windowing.Common/paket
@@ -6,7 +6,13 @@ dependencies
     framework: netstandard2.1
         OpenTK.Core ~> #VERSION#
         OpenTK.Mathematics ~> #VERSION#
+    framework: netcoreapp3.1
+        OpenTK.Core ~> #VERSION#
+        OpenTK.Mathematics ~> #VERSION#
 files
     bin\Release\netstandard2.1\OpenTK.Windowing.Common.dll ==> lib\netstandard2.1
     bin\Release\netstandard2.1\OpenTK.Windowing.Common.xml ==> lib\netstandard2.1
     bin\Release\netstandard2.1\OpenTK.Windowing.Common.pdb ==> lib\netstandard2.1
+    bin\Release\netcoreapp3.1\OpenTK.Windowing.Common.dll ==> lib\netcoreapp3.1
+    bin\Release\netcoreapp3.1\OpenTK.Windowing.Common.xml ==> lib\netcoreapp3.1
+    bin\Release\netcoreapp3.1\OpenTK.Windowing.Common.pdb ==> lib\netcoreapp3.1


### PR DESCRIPTION
### Purpose of this PR

Fixes #1257

~~Also makes the dependency on `System.Runtime.CompilerServices.Unsafe` disabled on netcoreapp3.1.~~ Fixed `#if` so the SSE3 path is actually used.

### Testing status

Created nupkg files have all the required files in the right places and the manifests check out.
