### PR TITLE
UpdateTime and RenderTime to use the same values as frame events

### DIFF
--- a/src/OpenTK.Windowing.Desktop/GameWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/GameWindow.cs
@@ -297,9 +297,8 @@ namespace OpenTK.Windowing.Desktop
             while (elapsed > 0 && elapsed + _updateEpsilon >= updatePeriod)
             {
                 _watchUpdate.Restart();
-                OnUpdateFrame(new FrameEventArgs(elapsed));
-
                 UpdateTime = elapsed;
+                OnUpdateFrame(new FrameEventArgs(elapsed));
 
                 // Calculate difference (positive or negative) between
                 // actual elapsed time and target elapsed time. We must
@@ -334,9 +333,8 @@ namespace OpenTK.Windowing.Desktop
             if (elapsed > 0 && elapsed >= renderPeriod)
             {
                 _watchRender.Restart();
-                OnRenderFrame(new FrameEventArgs(elapsed));
-
                 RenderTime = elapsed;
+                OnRenderFrame(new FrameEventArgs(elapsed));
 
                 // Update VSync if set to adaptive
                 if (_vSync == VSyncMode.Adaptive)

--- a/src/OpenTK.Windowing.Desktop/GameWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/GameWindow.cs
@@ -299,7 +299,7 @@ namespace OpenTK.Windowing.Desktop
                 _watchUpdate.Restart();
                 OnUpdateFrame(new FrameEventArgs(elapsed));
 
-                UpdateTime = _watchUpdate.Elapsed.TotalSeconds;
+                UpdateTime = elapsed;
 
                 // Calculate difference (positive or negative) between
                 // actual elapsed time and target elapsed time. We must
@@ -336,7 +336,7 @@ namespace OpenTK.Windowing.Desktop
                 _watchRender.Restart();
                 OnRenderFrame(new FrameEventArgs(elapsed));
 
-                RenderTime = _watchRender.Elapsed.TotalSeconds;
+                RenderTime = elapsed;
 
                 // Update VSync if set to adaptive
                 if (_vSync == VSyncMode.Adaptive)


### PR DESCRIPTION
Purpose of this PR
https://github.com/opentk/opentk/issues/1265

Testing status
I ran build.cmd and it seemed to succeed 🤔 Can't imagine this would break anything even if it were wrong because these were introduced only a few weeks ago.

Comments
Due to the convolution of this function in general it's hard to say exactly why the current code isn't right, but they certainly don't match up, this change will ensure that. My suspicion is due to the _watchUpdate.Restart on 299 it is discarding the elapsed time for the previous frame, which is accounted for by caching it in elapsed before the loop. I think it's probably losing the time it takes to render the previous frame which is where it's going wrong.

Fixed my small brain issue from last PR where there would have been a frame lag.