### PR TITLE
[5.0] Added overloader for removing c function type postfixes.

### DIFF
--- a/src/GeneratorV2/GeneratorV2.csproj
+++ b/src/GeneratorV2/GeneratorV2.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <LangVersion>Preview</LangVersion>
+    <!--<LangVersion>Preview</LangVersion>-->
     <TargetFramework>net5.0</TargetFramework>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/GeneratorV2/Parsing/Parser.cs
+++ b/src/GeneratorV2/Parsing/Parser.cs
@@ -281,11 +281,11 @@ namespace GeneratorV2.Parsing
                     "GLintptrARB" => PrimitiveType.IntPtr,
                     "GLsizeiptr" => PrimitiveType.Nint,
                     "GLsizeiptrARB" => PrimitiveType.Nint,
-                    "GLint64" => PrimitiveType.Int,
-                    "GLint64EXT" => PrimitiveType.Int,
-                    "GLuint64" => PrimitiveType.Uint,
-                    "GLuint64EXT" => PrimitiveType.Uint,
-                    "GLhalfNV" => PrimitiveType.Ushort,
+                    "GLint64" => PrimitiveType.Long,
+                    "GLint64EXT" => PrimitiveType.Long,
+                    "GLuint64" => PrimitiveType.Ulong,
+                    "GLuint64EXT" => PrimitiveType.Ulong,
+                    "GLhalfNV" => PrimitiveType.Half,
                     "GLvdpauSurfaceNV" => PrimitiveType.IntPtr,
 
                     // FIXME

--- a/src/GeneratorV2/Process/Processor.cs
+++ b/src/GeneratorV2/Process/Processor.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
+using System.Text.RegularExpressions;
 
 namespace GeneratorV2.Process
 {
@@ -385,6 +386,8 @@ namespace GeneratorV2.Process
         // This is to ensure that correct scoping for the new return variables.
         static readonly IOverloader[] Overloaders = new IOverloader[]
         {
+            new TrimNameOverloader(),
+
             new StringReturnOverloader(),
 
             new VoidPtrToIntPtrOverloader(),
@@ -458,6 +461,69 @@ namespace GeneratorV2.Process
             {
                 changeNativeName = false;
                 return Array.Empty<Overload>();
+            }
+        }
+
+        class TrimNameOverloader : IOverloader
+        {
+            private static readonly Regex Endings = new Regex(
+                @"([fd]v?|u?[isb](64)?v?|v|i_v|fi)$",
+                RegexOptions.Compiled);
+
+            private static readonly Regex EndingsNotToTrim = new Regex(
+                "(sh|ib|[tdrey]s|[eE]n[vd]|bled" +
+                "|Attrib|Access|Boolean|Coord|Depth|Feedbacks|Finish|Flag" +
+                "|Groups|IDs|Indexed|Instanced|Pixels|Queries|Status|Tess|Through" +
+                "|Uniforms|Varyings|Weight|Width)$",
+                RegexOptions.Compiled);
+
+            private static readonly Regex EndingsAddV = new Regex("^0", RegexOptions.Compiled);
+
+            public bool TryGenerateOverloads(Overload overload, [NotNullWhen(true)] out List<Overload>? newOverloads)
+            {
+                // See: https://github.com/opentk/opentk/blob/082c8d228d0def042b11424ac002776432f44f47/src/Generator.Bind/FuncProcessor.cs#L417
+
+                string name = overload.OverloadName;
+                string trimmedName = name;
+                // FIXME: Remove extension name before we trim endings
+                Match m = EndingsNotToTrim.Match(name);
+                if ((m.Index + m.Length) != name.Length)
+                {
+                    m = Endings.Match(name);
+
+                    if (m.Length > 0 && m.Index + m.Length == name.Length)
+                    {
+                        // Only trim endings, not internal matches.
+                        if (m.Value[m.Length - 1] == 'v' && EndingsAddV.IsMatch(name) &&
+                            !name.StartsWith("Get") && !name.StartsWith("MatrixIndex"))
+                        {
+                            // Only trim ending 'v' when there is a number
+                            trimmedName = name.Substring(0, m.Index) + "v";
+                        }
+                        else
+                        {
+                            if (!name.EndsWith("xedv"))
+                            {
+                                trimmedName = name.Substring(0, m.Index);
+                            }
+                            else
+                            {
+                                trimmedName = name.Substring(0, m.Index + 1);
+                            }
+                        }
+                    }
+                }
+
+                if (trimmedName != name)
+                {
+                    newOverloads = new List<Overload>() { overload with { OverloadName = trimmedName } };
+                    return true;
+                }
+                else
+                {
+                    newOverloads = default;
+                    return false;
+                }
             }
         }
 

--- a/src/OpenTK.Graphics/OpenGL/Compatibility/GL.Manual.cs
+++ b/src/OpenTK.Graphics/OpenGL/Compatibility/GL.Manual.cs
@@ -20,5 +20,19 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             GL.ShaderSource(shader, 1, (byte**)&str_iptr, length);
             Marshal.FreeCoTaskMem(str_iptr);
         }
+
+        public static void GetShaderInfoLog(uint shader, out string info)
+        {
+            int length = default;
+            GL.GetShader(shader, ShaderParameterName.InfoLogLength, ref length);
+            if (length == 0)
+            {
+                info = string.Empty;
+            }
+            else
+            {
+                GL.GetShaderInfoLog(shader, length, ref length, out info);
+            }
+        }
     }
 }

--- a/src/OpenTK.Graphics/OpenGL/GL.Manual.cs
+++ b/src/OpenTK.Graphics/OpenGL/GL.Manual.cs
@@ -20,5 +20,19 @@ namespace OpenTK.Graphics.OpenGL
             GL.ShaderSource(shader, 1, (byte**)&str_iptr, length);
             Marshal.FreeCoTaskMem(str_iptr);
         }
+
+        public static void GetShaderInfoLog(uint shader, out string info)
+        {
+            int length = default;
+            GL.GetShader(shader, ShaderParameterName.InfoLogLength, ref length);
+            if (length == 0)
+            {
+                info = string.Empty;
+            }
+            else
+            {
+                GL.GetShaderInfoLog(shader, length, ref length, out info);
+            }
+        }
     }
 }

--- a/src/OpenTK.Graphics/OpenGLES3/GL.Manual.cs
+++ b/src/OpenTK.Graphics/OpenGLES3/GL.Manual.cs
@@ -20,5 +20,19 @@ namespace OpenTK.Graphics.OpenGLES3
             GL.ShaderSource(shader, 1, (byte**)&str_iptr, length);
             Marshal.FreeCoTaskMem(str_iptr);
         }
+
+        public static void GetShaderInfoLog(uint shader, out string info)
+        {
+            int length = default;
+            GL.GetShader(shader, ShaderParameterName.InfoLogLength, ref length);
+            if (length == 0)
+            {
+                info = string.Empty;
+            }
+            else
+            {
+                GL.GetShaderInfoLog(shader, length, ref length, out info);
+            }
+        }
     }
 }


### PR DESCRIPTION
### Purpose of this PR

Ripped the logic for removing c function type overload postfixes from the old opentk binder.
An example would be `glGetShaderiv` should be `GL.GetShader` in OpenTK.
We might want to re-write this logic without the regexes, but they seem to work for the most part.

One thing I don't handle at the moment is postfixes that are before extension names, so this is something we want to handle.

Also:
* Fixed parsing errors where GLint64 and other 64 bit types where parsed to System.Int32 instead of System.Int64.
* Added manual overload for GetShaderInfoLog (this is mostly a test of the postfix removing, we want to make a more complete coverage of convenient *InfoLog overloads).

### Testing status

`OpenTK.Graphics` compiles after running `GeneratorV2`.
