### PR TITLE
[5.0] Add missing overload for GL.CreateShaderProgramv to accept string

### DIFF
--- a/src/OpenTK.Graphics/OpenGL/GL.Manual.cs
+++ b/src/OpenTK.Graphics/OpenGL/GL.Manual.cs
@@ -15,11 +15,6 @@ namespace OpenTK.Graphics.OpenGL
     {
         public static void ShaderSource(uint shader, string shaderText)
         {
-            if (string.IsNullOrEmpty(shaderText))
-            {
-                throw new ArgumentNullException(nameof(shaderText));
-            }
-
             var shaderTextPtr = Marshal.StringToCoTaskMemAnsi(shaderText);
             var length = shaderText.Length;
             ShaderSource(shader, 1, (byte**)&shaderTextPtr, length);
@@ -49,11 +44,6 @@ namespace OpenTK.Graphics.OpenGL
         /// <exception cref="ArgumentNullException"></exception>
         public static void CreateShaderProgram(ShaderType shaderType, int count, string shaderText)
         {
-            if (string.IsNullOrEmpty(shaderText))
-            {
-                throw new ArgumentNullException(nameof(shaderText));
-            }
-
             var shaderTextPtr = Marshal.StringToCoTaskMemAnsi(shaderText);
             CreateShaderProgramv_(shaderType, count, (byte**)shaderTextPtr);
             Marshal.FreeCoTaskMem(shaderTextPtr);

--- a/src/OpenTK.Graphics/OpenGL/GL.Manual.cs
+++ b/src/OpenTK.Graphics/OpenGL/GL.Manual.cs
@@ -17,21 +17,21 @@ namespace OpenTK.Graphics.OpenGL
         {
             var shaderTextPtr = Marshal.StringToCoTaskMemAnsi(shaderText);
             var length = shaderText.Length;
-            ShaderSource(shader, 1, (byte**)&shaderTextPtr, length);
+            GL.ShaderSource(shader, 1, (byte**)&shaderTextPtr, length);
             Marshal.FreeCoTaskMem(shaderTextPtr);
         }
 
         public static void GetShaderInfoLog(uint shader, out string info)
         {
             int length = default;
-            GetShader(shader, ShaderParameterName.InfoLogLength, ref length);
+            GL.GetShader(shader, ShaderParameterName.InfoLogLength, ref length);
             if (length == 0)
             {
                 info = string.Empty;
             }
             else
             {
-                GetShaderInfoLog(shader, length, ref length, out info);
+                GL.GetShaderInfoLog(shader, length, ref length, out info);
             }
         }
 
@@ -44,7 +44,8 @@ namespace OpenTK.Graphics.OpenGL
         public static void CreateShaderProgram(ShaderType shaderType, string shaderText)
         {
             var shaderTextPtr = Marshal.StringToCoTaskMemAnsi(shaderText);
-            CreateShaderProgramv_(shaderType, 1, (byte**)shaderTextPtr);
+            // ReSharper disable once ArrangeStaticMemberQualifier
+            GL.CreateShaderProgramv_(shaderType, 1, (byte**)shaderTextPtr);
             Marshal.FreeCoTaskMem(shaderTextPtr);
         }
     }

--- a/src/OpenTK.Graphics/OpenGL/GL.Manual.cs
+++ b/src/OpenTK.Graphics/OpenGL/GL.Manual.cs
@@ -51,7 +51,7 @@ namespace OpenTK.Graphics.OpenGL
         {
             if (string.IsNullOrEmpty(shaderText))
             {
-                throw new ArgumentNullException(nameof(shaderText))
+                throw new ArgumentNullException(nameof(shaderText));
             }
 
             var shaderTextPtr = Marshal.StringToCoTaskMemAnsi(shaderText);

--- a/src/OpenTK.Graphics/OpenGL/GL.Manual.cs
+++ b/src/OpenTK.Graphics/OpenGL/GL.Manual.cs
@@ -29,14 +29,14 @@ namespace OpenTK.Graphics.OpenGL
         public static void GetShaderInfoLog(uint shader, out string info)
         {
             int length = default;
-            GL.GetShader(shader, ShaderParameterName.InfoLogLength, ref length);
+            GetShader(shader, ShaderParameterName.InfoLogLength, ref length);
             if (length == 0)
             {
                 info = string.Empty;
             }
             else
             {
-                GL.GetShaderInfoLog(shader, length, ref length, out info);
+                GetShaderInfoLog(shader, length, ref length, out info);
             }
         }
     }

--- a/src/OpenTK.Graphics/OpenGL/GL.Manual.cs
+++ b/src/OpenTK.Graphics/OpenGL/GL.Manual.cs
@@ -47,7 +47,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="count">Specifies the number of source code strings in the array strings</param>
         /// <param name="shaderText"></param>
         /// <exception cref="ArgumentNullException"></exception>
-        public static void CreateShaderProgramv(ShaderType shaderType, int count, string shaderText)
+        public static void CreateShaderProgram(ShaderType shaderType, int count, string shaderText)
         {
             if (string.IsNullOrEmpty(shaderText))
             {

--- a/src/OpenTK.Graphics/OpenGL/GL.Manual.cs
+++ b/src/OpenTK.Graphics/OpenGL/GL.Manual.cs
@@ -39,5 +39,24 @@ namespace OpenTK.Graphics.OpenGL
                 GetShaderInfoLog(shader, length, ref length, out info);
             }
         }
+
+        /// <summary>
+        /// Create a stand-alone program from an array of null-terminated source code strings
+        /// </summary>
+        /// <param name="shaderType">Specifies the type of shader to create</param>
+        /// <param name="count">Specifies the number of source code strings in the array strings</param>
+        /// <param name="shaderText"></param>
+        /// <exception cref="ArgumentNullException"></exception>
+        public static void CreateShaderProgramv(ShaderType shaderType, int count, string shaderText)
+        {
+            if (string.IsNullOrEmpty(shaderText))
+            {
+                throw new ArgumentNullException(nameof(shaderText))
+            }
+
+            var shaderTextPtr = Marshal.StringToCoTaskMemAnsi(shaderText);
+            CreateShaderProgramv_(shaderType, count, (byte**)shaderTextPtr);
+            Marshal.FreeCoTaskMem(shaderTextPtr);
+        }
     }
 }

--- a/src/OpenTK.Graphics/OpenGL/GL.Manual.cs
+++ b/src/OpenTK.Graphics/OpenGL/GL.Manual.cs
@@ -39,13 +39,12 @@ namespace OpenTK.Graphics.OpenGL
         /// Create a stand-alone program from an array of null-terminated source code strings
         /// </summary>
         /// <param name="shaderType">Specifies the type of shader to create</param>
-        /// <param name="count">Specifies the number of source code strings in the array strings</param>
         /// <param name="shaderText"></param>
         /// <exception cref="ArgumentNullException"></exception>
-        public static void CreateShaderProgram(ShaderType shaderType, int count, string shaderText)
+        public static void CreateShaderProgram(ShaderType shaderType, string shaderText)
         {
             var shaderTextPtr = Marshal.StringToCoTaskMemAnsi(shaderText);
-            CreateShaderProgramv_(shaderType, count, (byte**)shaderTextPtr);
+            CreateShaderProgramv_(shaderType, 1, (byte**)shaderTextPtr);
             Marshal.FreeCoTaskMem(shaderTextPtr);
         }
     }

--- a/src/OpenTK.Graphics/OpenGL/GL.Manual.cs
+++ b/src/OpenTK.Graphics/OpenGL/GL.Manual.cs
@@ -13,12 +13,17 @@ namespace OpenTK.Graphics.OpenGL
 
     public static unsafe partial class GL
     {
-        public static void ShaderSource(uint shader, string str)
+        public static void ShaderSource(uint shader, string shaderText)
         {
-            IntPtr str_iptr = Marshal.StringToCoTaskMemAnsi(str);
-            int length = str.Length;
-            GL.ShaderSource(shader, 1, (byte**)&str_iptr, length);
-            Marshal.FreeCoTaskMem(str_iptr);
+            if (string.IsNullOrEmpty(shaderText))
+            {
+                throw new ArgumentNullException(nameof(shaderText));
+            }
+
+            var shaderTextPtr = Marshal.StringToCoTaskMemAnsi(shaderText);
+            var length = shaderText.Length;
+            ShaderSource(shader, 1, (byte**)&shaderTextPtr, length);
+            Marshal.FreeCoTaskMem(shaderTextPtr);
         }
 
         public static void GetShaderInfoLog(uint shader, out string info)

--- a/src/OpenTK.Graphics/OpenGL/GL.Manual.cs
+++ b/src/OpenTK.Graphics/OpenGL/GL.Manual.cs
@@ -5,7 +5,7 @@ namespace OpenTK.Graphics.OpenGL
 {
     // FIXME: Remove this when it's fixed
     // This is here because there in the gl.xml
-    // one of the paramteres for "glSampleMaskIndexedNV"
+    // one of the parameters for "glSampleMaskIndexedNV"
     // is marked with a group named this, but this group is never referenced
     // anywhere else in the file.
     public enum SampleMaskNV


### PR DESCRIPTION
### Purpose of this PR

Add missing manual overload for `GL.CreateShaderProgramv` to accept `string` instead of just `byte**`.
