### PR TITLE
[5.0] Correct OpenTK.Mathematics.* namespace for color types

### DIFF
--- a/src/OpenTK.Mathematics/Colors/Argb.cs
+++ b/src/OpenTK.Mathematics/Colors/Argb.cs
@@ -1,0 +1,9 @@
+﻿namespace OpenTK.Mathematics.Colors
+{
+    /// <summary>
+    /// Alpha, red, green, blue colorspace.
+    /// </summary>
+    public sealed class Argb : IColorSpace4
+    {
+    }
+}

--- a/src/OpenTK.Mathematics/Colors/Color3.cs
+++ b/src/OpenTK.Mathematics/Colors/Color3.cs
@@ -1,38 +1,8 @@
 ﻿using System;
 using System.Diagnostics.Contracts;
-using OpenTK.Mathematics;
 
-#pragma warning disable SA1649
-namespace OpenTK
+namespace OpenTK.Mathematics.Colors
 {
-    /// <summary>
-    /// Interface for ColorSpace phantom types with 3 elements.
-    /// </summary>
-    public interface IColorSpace3
-    {
-    }
-
-    /// <summary>
-    /// Red, green, blue colorspace.
-    /// </summary>
-    public sealed class Rgb : IColorSpace3
-    {
-    }
-
-    /// <summary>
-    /// Hue, saturation, value colorspace.
-    /// </summary>
-    public sealed class Hsv : IColorSpace3
-    {
-    }
-
-    /// <summary>
-    /// Hue, saturation, light colorspace.
-    /// </summary>
-    public sealed class Hsl : IColorSpace3
-    {
-    }
-
     /// <summary>
     /// To provide type-safety between different color spaces and allow extension by users to include additional and future color spaces, colors are marked with a special _phantom_ type parameter that indicates their color space.
     /// Typically these are four-letter abbreviations that indicate the components of the colors, such as <see cref="Rgb"/> or <see cref="Hsv"/>.
@@ -1237,4 +1207,3 @@ namespace OpenTK
         public static Color3<Rgb> Yellowgreen => new Color3<Rgb>(0.6039216f, 0.8039216f, 0.19607843f);
     }
 }
-#pragma warning restore SA1649

--- a/src/OpenTK.Mathematics/Colors/Color4.cs
+++ b/src/OpenTK.Mathematics/Colors/Color4.cs
@@ -1,45 +1,8 @@
 ﻿using System;
 using System.Diagnostics.Contracts;
-using OpenTK.Mathematics;
 
-#pragma warning disable SA1649
-namespace OpenTK.Mathematics
+namespace OpenTK.Mathematics.Colors
 {
-    /// <summary>
-    /// Interface for ColorSpace phantom types with 4 elements.
-    /// </summary>
-    public interface IColorSpace4
-    {
-    }
-
-    /// <summary>
-    /// Red, green, blue, alpha colorspace.
-    /// </summary>
-    public sealed class Rgba : IColorSpace4
-    {
-    }
-
-    /// <summary>
-    /// Alpha, red, green, blue colorspace.
-    /// </summary>
-    public sealed class Argb : IColorSpace4
-    {
-    }
-
-    /// <summary>
-    /// Hue, saturation, value, alpha colorspace.
-    /// </summary>
-    public sealed class Hsva : IColorSpace4
-    {
-    }
-
-    /// <summary>
-    /// Hue, saturation, light, alpha colorspace.
-    /// </summary>
-    public sealed class Hsla : IColorSpace4
-    {
-    }
-
     /// <summary>
     /// To provide type-safety between different color spaces and allow extension by users to include additional and future color spaces, colors are marked with a special _phantom_ type parameter that indicates their color space.<br/>
     /// Typically these are four-letter abbreviations that indicate the components of the colors, such as <see cref="Rgba"/> or <see cref="Hsva"/>.<br/><br/>
@@ -1101,4 +1064,3 @@ namespace OpenTK.Mathematics
         public static Color4<Rgba> Yellowgreen => new Color4<Rgba>(0.6039216f, 0.8039216f, 0.19607843f, 1f);
     }
 }
-#pragma warning restore SA1649

--- a/src/OpenTK.Mathematics/Colors/Hsl.cs
+++ b/src/OpenTK.Mathematics/Colors/Hsl.cs
@@ -1,0 +1,9 @@
+﻿namespace OpenTK.Mathematics.Colors
+{
+    /// <summary>
+    /// Hue, saturation, light colorspace.
+    /// </summary>
+    public sealed class Hsl : IColorSpace3
+    {
+    }
+}

--- a/src/OpenTK.Mathematics/Colors/Hsla.cs
+++ b/src/OpenTK.Mathematics/Colors/Hsla.cs
@@ -1,0 +1,9 @@
+﻿namespace OpenTK.Mathematics.Colors
+{
+    /// <summary>
+    /// Hue, saturation, light, alpha colorspace.
+    /// </summary>
+    public sealed class Hsla : IColorSpace4
+    {
+    }
+}

--- a/src/OpenTK.Mathematics/Colors/Hsv.cs
+++ b/src/OpenTK.Mathematics/Colors/Hsv.cs
@@ -1,0 +1,9 @@
+﻿namespace OpenTK.Mathematics.Colors
+{
+    /// <summary>
+    /// Hue, saturation, value colorspace.
+    /// </summary>
+    public sealed class Hsv : IColorSpace3
+    {
+    }
+}

--- a/src/OpenTK.Mathematics/Colors/Hsva.cs
+++ b/src/OpenTK.Mathematics/Colors/Hsva.cs
@@ -1,0 +1,9 @@
+﻿namespace OpenTK.Mathematics.Colors
+{
+    /// <summary>
+    /// Hue, saturation, value, alpha colorspace.
+    /// </summary>
+    public sealed class Hsva : IColorSpace4
+    {
+    }
+}

--- a/src/OpenTK.Mathematics/Colors/IColorSpace3.cs
+++ b/src/OpenTK.Mathematics/Colors/IColorSpace3.cs
@@ -1,0 +1,9 @@
+﻿namespace OpenTK.Mathematics.Colors
+{
+    /// <summary>
+    /// Interface for ColorSpace phantom types with 3 elements.
+    /// </summary>
+    public interface IColorSpace3
+    {
+    }
+}

--- a/src/OpenTK.Mathematics/Colors/IColorSpace4.cs
+++ b/src/OpenTK.Mathematics/Colors/IColorSpace4.cs
@@ -1,0 +1,9 @@
+﻿namespace OpenTK.Mathematics.Colors
+{
+    /// <summary>
+    /// Interface for ColorSpace phantom types with 4 elements.
+    /// </summary>
+    public interface IColorSpace4
+    {
+    }
+}

--- a/src/OpenTK.Mathematics/Colors/Rgb.cs
+++ b/src/OpenTK.Mathematics/Colors/Rgb.cs
@@ -1,0 +1,9 @@
+﻿namespace OpenTK.Mathematics.Colors
+{
+    /// <summary>
+    /// Red, green, blue colorspace.
+    /// </summary>
+    public sealed class Rgb : IColorSpace3
+    {
+    }
+}

--- a/src/OpenTK.Mathematics/Colors/Rgba.cs
+++ b/src/OpenTK.Mathematics/Colors/Rgba.cs
@@ -1,0 +1,9 @@
+﻿namespace OpenTK.Mathematics.Colors
+{
+    /// <summary>
+    /// Red, green, blue, alpha colorspace.
+    /// </summary>
+    public sealed class Rgba : IColorSpace4
+    {
+    }
+}

--- a/tests/OpenTK.Tests/Assertions.fs
+++ b/tests/OpenTK.Tests/Assertions.fs
@@ -2,12 +2,9 @@
 
 open Xunit
 open FsCheck
-open FsCheck.Xunit
 open System
-open System
-open System
-open OpenTK
 open OpenTK.Mathematics
+open OpenTK.Mathematics.Colors
 
 [<AutoOpen>]
 module private AssertHelpers =

--- a/tests/OpenTK.Tests/Color4Tests.fs
+++ b/tests/OpenTK.Tests/Color4Tests.fs
@@ -7,6 +7,7 @@ open System
 open System.Runtime.InteropServices
 open OpenTK
 open OpenTK.Mathematics
+open OpenTK.Mathematics.Colors
 
 module Color4 =
     [<Literal>]

--- a/tests/OpenTK.Tests/Generators.fs
+++ b/tests/OpenTK.Tests/Generators.fs
@@ -1,11 +1,9 @@
 ﻿namespace OpenTK.Tests
 
-open Xunit
 open FsCheck
-open FsCheck.Xunit
 open System
-open OpenTK
 open OpenTK.Mathematics
+open OpenTK.Mathematics.Colors
 
 /// An angle from -89 to +89
 [<Struct>]


### PR DESCRIPTION
### Purpose of this PR

for color types and also move individual types out into their own files

We should adhere to well established common conventions when it comes to c# And the general consensus is, one file per type, as well as project folders are namespace providers.

I would also be OK to omit `Colors` in the namespace.



