### PR TITLE
Removed old license notices

### DIFF
--- a/Short-LICENSE.md
+++ b/Short-LICENSE.md
@@ -1,9 +1,0 @@
-# OpenTK TL;DR License Summary
-* Use OpenTK under the MIT/X11 license<sup>[<a href="LICENSE.md">1</a>]</sup>.
-  * Essentially, do whatever you want as long as the OpenTK project still has copyright.
-* If you use AdvancedDLSupport outside of direct use via OpenTK<sup>[<a href="AdvancedDLSupport-LICENSE.pdf">2</a>]</sup>, follow its license<sup>[<a href="https://github.com/Firwood-Software/AdvanceDLSupport/blob/master/LICENSE">3</a>]</sup> (LGPLv3).
-
-#### Citations
-- <sup>[<a href="LICENSE.md">1</a>]</sup> OpenTK's MIT license.
-- <sup>[<a href="AdvancedDLSupport-LICENSE.pdf">2</a>]</sup> OpenTK's AdvancedDLSupport custom license grant.
-- <sup>[<a href="https://github.com/Firwood-Software/AdvanceDLSupport/blob/master/LICENSE">3</a>]</sup> The LGPLv3 license, as seen in the AdvancedDLSupport repository.

--- a/THIRD_PARTIES.md
+++ b/THIRD_PARTIES.md
@@ -1,11 +1,5 @@
 # Third parties
 
-## AdvancedDLSupport
-> OpenTK uses AdvancedDLSupport for native interoperability. To enable compatibility with the LGPLv3 License, Firwood has given us a licensing exception.
-
-* Read the [license grant](AdvancedDLSupport-LICENSE.pdf).
-* Read the [license summary](Short-LICENSE.md) for an easy-to-understand version.
-
 ## OpenEXR
 
 > OpenTK.Half offers Half-to-Single and Single-to-Half conversions based on OpenEXR source code, which is covered by the following license:


### PR DESCRIPTION
### Purpose of this PR

Removed old license notices regarding AdvancedDLSupport.

Before this is merged I think we should take a look at the AL Extensions project that still references ADL (though the project is not part of the final build and doesn't even compile atm),

### Testing status

Nothing to test.
