### PR TITLE
Fix OpenAL loading of extension function that are not present.

### DIFF
--- a/src/OpenAL/OpenTK.OpenAL/Native/ALBase.cs
+++ b/src/OpenAL/OpenTK.OpenAL/Native/ALBase.cs
@@ -8,7 +8,9 @@
 //
 
 using System;
+using System.Linq;
 using System.Reflection;
+using System.Reflection.Emit;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -38,7 +40,30 @@ namespace OpenTK.Audio.OpenAL
         protected internal static TDelegate LoadDelegate<TDelegate>(string name) where TDelegate : Delegate
         {
             IntPtr ptr = AL.GetProcAddress(name);
-            return Marshal.GetDelegateForFunctionPointer<TDelegate>(ptr);
+            if (ptr == IntPtr.Zero)
+            {
+                MethodInfo invoke = typeof(TDelegate).GetMethod("Invoke");
+                Type returnType = invoke.ReturnType;
+                Type[] parameters = invoke.GetParameters().Select(p => p.ParameterType).ToArray();
+                DynamicMethod method = new DynamicMethod(
+                    "OpenAL_AL_Extension_Null_GetProcAddress_Exception_Delegate_" + Guid.NewGuid(),
+                    returnType,
+                    parameters);
+                ILGenerator generator = method.GetILGenerator();
+
+                // Here we are generating a delegate that looks like this:
+                // ((<the arguments that the delegate type takes>) =>
+                // throw new Exception(<error string>);
+                generator.Emit(OpCodes.Ldstr, $"This OpenAL function could not be loaded. This likely means that this extension isn't present in the current context.");
+                generator.Emit(OpCodes.Newobj, typeof(Exception).GetConstructor(new[] { typeof(string) }));
+                generator.Emit(OpCodes.Throw);
+
+                return (TDelegate)method.CreateDelegate(typeof(TDelegate));
+            }
+            else
+            {
+                return Marshal.GetDelegateForFunctionPointer<TDelegate>(ptr);
+            }
         }
     }
 }

--- a/src/OpenAL/OpenTK.OpenAL/Native/ALBase.cs
+++ b/src/OpenAL/OpenTK.OpenAL/Native/ALBase.cs
@@ -42,6 +42,8 @@ namespace OpenTK.Audio.OpenAL
             IntPtr ptr = AL.GetProcAddress(name);
             if (ptr == IntPtr.Zero)
             {
+                // If we can't load the function for whatever reason we dynamically generate a delegate to
+                // give the user an error message that is actually understandable.
                 MethodInfo invoke = typeof(TDelegate).GetMethod("Invoke");
                 Type returnType = invoke.ReturnType;
                 Type[] parameters = invoke.GetParameters().Select(p => p.ParameterType).ToArray();


### PR DESCRIPTION
### Purpose of this PR

Fixes an issue where checking if an OpenAL extension is present while the device and context doesn't have that extension present throws an error because it tries to load all of the extensions methods and fails.

Calling the extensions functions without it being present now gives a helpful error message.

### Testing status

Manually tested checking for a made up non-existent AL extension which didn't crash.

### Comments

This is not great for AOT style use cases as it generates IL at runtime. (we don't have any AOT use cases atm)
But this could be put behind if checks or static ifs if needed.
