### PR TITLE
Fixed IL codegen to use the correct instruction for loading the first element in an array.

### DIFF
--- a/src/Generator.Rewrite/Program.cs
+++ b/src/Generator.Rewrite/Program.cs
@@ -896,7 +896,15 @@ namespace OpenTK.Rewrite
                     param => param.Name == countParameter.Substring(1));
 
                 il.Emit(OpCodes.Ldarg, pointerParam.Index);
-                il.Emit(OpCodes.Ldind_I4);
+                if (pointerParam.ParameterType.IsArray)
+                {
+                    il.Emit(OpCodes.Ldc_I4_0);
+                    il.Emit(OpCodes.Ldelem_I4);
+                }
+                else
+                {
+                    il.Emit(OpCodes.Ldind_I4);
+                }
             }
             else
             {


### PR DESCRIPTION
### Purpose of this PR

Fixes an issue where the IL rewriter produced invalid IL code that caused AOT compilers to crash.

See:
https://github.com/dotnet/corert/issues/8346

This might also be related:
https://github.com/opentk/opentk/issues/324

### Testing status

Manually inspected the generated IL and looked at decompilation.
Ran the IL through `ilverify` but as it doesn't do a good job verifying unsafe code it wasn't super useful.
The OpenTK.Graphics dll works on normal functions, but as the only functions affected where obscure GLES extension functions I had no way of actually calling these functions (I suspect the codegen is broken too).

### Comments

This is probably applicable for OpenTK 3 too.
