### PR TITLE
[5.0] Fix GLFWNative.LoadLibrary to look for the right glfw3.dll

### DIFF
--- a/src/OpenTK.Windowing.GraphicsLibraryFramework/GLFWNative.cs
+++ b/src/OpenTK.Windowing.GraphicsLibraryFramework/GLFWNative.cs
@@ -51,8 +51,11 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
+                var architecture = RuntimeInformation.ProcessArchitecture == Architecture.X64
+                    ? "-x64"
+                    : "-x86";
                 libNameFormatter = (libName, ver) =>
-                    libName + (string.IsNullOrEmpty(ver) ? string.Empty : ver) + ".dll";
+                    libName + (string.IsNullOrEmpty(ver) ? string.Empty : ver) + $"{architecture}.dll";
             }
             else
             {


### PR DESCRIPTION
### Purpose of this PR

While trying to get local unit-tests going, I noticed OpenTK being unable to load the right glfw3.dll

`GLFWNative.cs` looks for `glfw3.dll` only, but that file does not exist. `glfw3-x86.dll` and `glfw3-x64.dll` however do exist.

This PR takes the architecture into account to look for the right dll. At least on windows and with this change in place, I can create a unit test project and create windows with gl contexts successfully.

I am a bit confused as to why the existing OTK nugets work as is - seemingly. I have not dug into all corners of the sources to see/check whether dlls are being renamed or some other odd logic is running to point at the right dll at the end.
