### PR TITLE
[5.0] Initial unit tests for context creation

### DIFF
--- a/OpenTK.sln
+++ b/OpenTK.sln
@@ -79,6 +79,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenTK.Benchmarks", "OpenTK
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenTK.Graphics", "src\OpenTK.Graphics\OpenTK.Graphics.csproj", "{83D53823-B146-442F-B650-EDE6664D38EB}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenTK.UnitTests", "tests\OpenTK.UnitTests\OpenTK.UnitTests.csproj", "{EC2CE980-F2AF-440F-A20E-EAF7FFCD3D32}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -153,6 +155,10 @@ Global
 		{83D53823-B146-442F-B650-EDE6664D38EB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{83D53823-B146-442F-B650-EDE6664D38EB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{83D53823-B146-442F-B650-EDE6664D38EB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EC2CE980-F2AF-440F-A20E-EAF7FFCD3D32}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EC2CE980-F2AF-440F-A20E-EAF7FFCD3D32}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EC2CE980-F2AF-440F-A20E-EAF7FFCD3D32}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EC2CE980-F2AF-440F-A20E-EAF7FFCD3D32}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -169,6 +175,7 @@ Global
 		{172C1E62-DA67-4203-BBCB-9DA4D9111EF0} = {BBBE802B-9F6E-4299-97CE-97CDA43802B9}
 		{51A92F39-3444-4E07-9C4F-99C2D8F11879} = {0B9B71A1-29F7-4CC5-9A9D-9DF122BE8B28}
 		{A31363E2-783D-4F6A-B447-130E7A344442} = {0B9B71A1-29F7-4CC5-9A9D-9DF122BE8B28}
+		{EC2CE980-F2AF-440F-A20E-EAF7FFCD3D32} = {0B9B71A1-29F7-4CC5-9A9D-9DF122BE8B28}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {82DDE6D6-0D55-49B4-9C64-B31B4A6E729F}

--- a/src/OpenTK.Windowing.GraphicsLibraryFramework/GLFWNative.cs
+++ b/src/OpenTK.Windowing.GraphicsLibraryFramework/GLFWNative.cs
@@ -51,8 +51,11 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
+                var architecture = RuntimeInformation.ProcessArchitecture == Architecture.X64
+                    ? "-x64"
+                    : "-x86";
                 libNameFormatter = (libName, ver) =>
-                    libName + (string.IsNullOrEmpty(ver) ? string.Empty : ver) + ".dll";
+                    libName + (string.IsNullOrEmpty(ver) ? string.Empty : ver) + $"{architecture}.dll";
             }
             else
             {

--- a/tests/OpenTK.UnitTests/OpenTK.UnitTests.csproj
+++ b/tests/OpenTK.UnitTests/OpenTK.UnitTests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1"/>
+    <PackageReference Include="xunit" Version="2.4.1"/>
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="1.3.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="opentoolkit.redist.glfw" Version="3.3.0-pre20190419183326"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\OpenTK.Graphics\OpenTK.Graphics.csproj"/>
+    <ProjectReference Include="..\..\src\OpenTK.Windowing.Desktop\OpenTK.Windowing.Desktop.csproj"/>
+    <ProjectReference Include="..\..\src\OpenTK.Windowing.GraphicsLibraryFramework\OpenTK.Windowing.GraphicsLibraryFramework.csproj"/>
+  </ItemGroup>
+
+</Project>

--- a/tests/OpenTK.UnitTests/OpenTK.UnitTests.csproj
+++ b/tests/OpenTK.UnitTests/OpenTK.UnitTests.csproj
@@ -7,8 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1"/>
-    <PackageReference Include="xunit" Version="2.4.1"/>
+    <PackageReference Include="JetBrains.Annotations" Version="2021.1.0">
+      <PrivateAssets>all</PrivateAssets>      
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
@@ -17,13 +20,13 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="opentoolkit.redist.glfw" Version="3.3.0-pre20190419183326"/>
+    <PackageReference Include="opentoolkit.redist.glfw" Version="3.3.0-pre20190419183326" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\OpenTK.Graphics\OpenTK.Graphics.csproj"/>
-    <ProjectReference Include="..\..\src\OpenTK.Windowing.Desktop\OpenTK.Windowing.Desktop.csproj"/>
-    <ProjectReference Include="..\..\src\OpenTK.Windowing.GraphicsLibraryFramework\OpenTK.Windowing.GraphicsLibraryFramework.csproj"/>
+    <ProjectReference Include="..\..\src\OpenTK.Graphics\OpenTK.Graphics.csproj" />
+    <ProjectReference Include="..\..\src\OpenTK.Windowing.Desktop\OpenTK.Windowing.Desktop.csproj" />
+    <ProjectReference Include="..\..\src\OpenTK.Windowing.GraphicsLibraryFramework\OpenTK.Windowing.GraphicsLibraryFramework.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/OpenTK.UnitTests/Setup/TestFrameworkDiscoverer.cs
+++ b/tests/OpenTK.UnitTests/Setup/TestFrameworkDiscoverer.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace OpenTK.UnitTests.Setup
+{
+    internal sealed class TestFrameworkDiscoverer : XunitTestFrameworkDiscoverer
+    {
+        public TestFrameworkDiscoverer(
+            IAssemblyInfo assemblyInfo,
+            ISourceInformationProvider sourceProvider,
+            IMessageSink diagnosticMessageSink,
+            IXunitTestCollectionFactory collectionFactory = null)
+            : base(assemblyInfo, sourceProvider, diagnosticMessageSink, collectionFactory)
+        {
+        }
+
+        protected override bool IsValidTestClass(ITypeInfo type)
+            => base.IsValidTestClass(type) && CanRunOnLocalMachine(type);
+
+        private static bool CanRunOnLocalMachine(ITypeInfo type)
+        {
+            var ci = Environment.GetEnvironmentVariable("CI"); // "true" on appveyor & github actions
+            var isRunningOnGithubActionsOrAppveyor = !string.IsNullOrEmpty(ci) && ci.ToLower() == "true";
+            return !isRunningOnGithubActionsOrAppveyor;
+        }
+    }
+}

--- a/tests/OpenTK.UnitTests/Setup/TestFrameworkDiscovererFactory.cs
+++ b/tests/OpenTK.UnitTests/Setup/TestFrameworkDiscovererFactory.cs
@@ -1,0 +1,22 @@
+﻿using JetBrains.Annotations;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+[assembly: TestFramework("OpenTK.UnitTests.Setup.TestFrameworkDiscovererFactory", "OpenTK.UnitTests")]
+
+namespace OpenTK.UnitTests.Setup
+{
+    [UsedImplicitly]
+    internal sealed class TestFrameworkDiscovererFactory : XunitTestFramework
+    {
+        public TestFrameworkDiscovererFactory(IMessageSink messageSink)
+            : base(messageSink)
+        {
+        }
+
+        protected override ITestFrameworkDiscoverer CreateDiscoverer(
+            IAssemblyInfo assemblyInfo)
+            => new TestFrameworkDiscoverer(assemblyInfo, SourceInformationProvider, DiagnosticMessageSink);
+    }
+}

--- a/tests/OpenTK.UnitTests/WindowAndContextTests.cs
+++ b/tests/OpenTK.UnitTests/WindowAndContextTests.cs
@@ -1,0 +1,125 @@
+using System;
+using OpenTK.Windowing.Common;
+using OpenTK.Windowing.Desktop;
+using Xunit;
+
+namespace OpenTK.UnitTests
+{
+    public class WindowAndContextTests
+    {
+        [Theory]
+        [InlineData(ContextProfile.Any)]
+        public void Can_Create_Window_With_GL20_Context(ContextProfile contextProfile)
+        {
+            using var window = CreateGameWindow(contextProfile, new Version(2, 0));
+        }
+
+        [Theory]
+        [InlineData(ContextProfile.Any)]
+        public void Can_Create_Window_With_GL30_Context(ContextProfile contextProfile)
+        {
+            using var window = CreateGameWindow(contextProfile, new Version(3, 0));
+        }
+
+        [Theory]
+        [InlineData(ContextProfile.Any)]
+        public void Can_Create_Window_With_GL31_Context(ContextProfile contextProfile)
+        {
+            using var window = CreateGameWindow(contextProfile, new Version(3, 1));
+        }
+
+        [Theory]
+        [InlineData(ContextProfile.Any)]
+        [InlineData(ContextProfile.Compatability)]
+        [InlineData(ContextProfile.Core)]
+        public void Can_Create_Window_With_GL32_Context(ContextProfile contextProfile)
+        {
+            using var window = CreateGameWindow(contextProfile, new Version(3, 2));
+        }
+
+        [Theory]
+        [InlineData(ContextProfile.Any)]
+        [InlineData(ContextProfile.Compatability)]
+        [InlineData(ContextProfile.Core)]
+        public void Can_Create_Window_With_GL33_Context(ContextProfile contextProfile)
+        {
+            using var window = CreateGameWindow(contextProfile, new Version(3, 3));
+        }
+
+        [Theory]
+        [InlineData(ContextProfile.Any)]
+        [InlineData(ContextProfile.Compatability)]
+        [InlineData(ContextProfile.Core)]
+        public void Can_Create_Window_With_GL40_Context(ContextProfile contextProfile)
+        {
+            using var window = CreateGameWindow(contextProfile, new Version(4, 0));
+        }
+
+        [Theory]
+        [InlineData(ContextProfile.Any)]
+        [InlineData(ContextProfile.Compatability)]
+        [InlineData(ContextProfile.Core)]
+        public void Can_Create_Window_With_GL41_Context(ContextProfile contextProfile)
+        {
+            using var window = CreateGameWindow(contextProfile, new Version(4, 1));
+        }
+
+        [Theory]
+        [InlineData(ContextProfile.Any)]
+        [InlineData(ContextProfile.Compatability)]
+        [InlineData(ContextProfile.Core)]
+        public void Can_Create_Window_With_GL42_Context(ContextProfile contextProfile)
+        {
+            using var window = CreateGameWindow(contextProfile, new Version(4, 2));
+        }
+
+        [Theory]
+        [InlineData(ContextProfile.Any)]
+        [InlineData(ContextProfile.Compatability)]
+        [InlineData(ContextProfile.Core)]
+        public void Can_Create_Window_With_GL43_Context(ContextProfile contextProfile)
+        {
+            using var window = CreateGameWindow(contextProfile, new Version(4, 3));
+        }
+
+        [Theory]
+        [InlineData(ContextProfile.Any)]
+        [InlineData(ContextProfile.Compatability)]
+        [InlineData(ContextProfile.Core)]
+        public void Can_Create_Window_With_GL44_Context(ContextProfile contextProfile)
+        {
+            using var window = CreateGameWindow(contextProfile, new Version(4, 4));
+        }
+
+        [Theory]
+        [InlineData(ContextProfile.Any)]
+        [InlineData(ContextProfile.Compatability)]
+        [InlineData(ContextProfile.Core)]
+        public void Can_Create_Window_With_GL45_Context(ContextProfile contextProfile)
+        {
+            using var window = CreateGameWindow(contextProfile, new Version(4, 5));
+        }
+
+        [Theory]
+        [InlineData(ContextProfile.Any)]
+        [InlineData(ContextProfile.Compatability)]
+        [InlineData(ContextProfile.Core)]
+        public void Can_Create_Window_With_GL46_Context(ContextProfile contextProfile)
+        {
+            using var window = CreateGameWindow(contextProfile, new Version(4, 6));
+        }
+
+        private GameWindow CreateGameWindow(ContextProfile contextProfile, Version version)
+        {
+            var gameWindowSettings = GameWindowSettings.Default;
+            var nativeWindowSettings = NativeWindowSettings.Default;
+            nativeWindowSettings.Profile = contextProfile;
+            nativeWindowSettings.StartVisible = false;
+            nativeWindowSettings.StartFocused = false;
+            nativeWindowSettings.API = ContextAPI.OpenGL;
+            nativeWindowSettings.AutoLoadBindings = true;
+            nativeWindowSettings.APIVersion = version;
+            return new GameWindow(gameWindowSettings, nativeWindowSettings);
+        }
+    }
+}


### PR DESCRIPTION
### Purpose of this PR

We should not just unit-test if Vector3s can be added together, but also the rest of the library.

This PR will introduces a new UnitTest project to contain all sorts of tests. In this instance GameWindow creation with various GL version/profiles is tested.

The idea behind is also to test if the Generator is spitting out the right function calls. As we've seen with OTK5-pre4 its not the case and could be could with such tests :)
