### PR TITLE
Remove unused Fody and AdvancedDLSupport library references

### DIFF
--- a/FodyWeavers.xml
+++ b/FodyWeavers.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<Weavers>
-  <JetBrainsAnnotations/> 
-</Weavers>

--- a/THIRD_PARTIES.md
+++ b/THIRD_PARTIES.md
@@ -1,11 +1,5 @@
 # Third parties
 
-## AdvancedDLSupport
-> OpenTK uses AdvancedDLSupport for native interoperability. To enable compatibility with the LGPLv3 License, Firwood has given us a licensing exception.
-
-* Read the [license grant](AdvancedDLSupport-LICENSE.pdf).
-* Read the [license summary](Short-LICENSE.md) for an easy-to-understand version.
-
 ## OpenEXR
 
 > OpenTK.Half offers Half-to-Single and Single-to-Half conversions based on OpenEXR source code, which is covered by the following license:

--- a/src/OpenAL/OpenTK.OpenAL.Extensions/Creative.EFX/EffectExtension.cs
+++ b/src/OpenAL/OpenTK.OpenAL.Extensions/Creative.EFX/EffectExtension.cs
@@ -7,7 +7,6 @@
 // of the MIT license. See the LICENSE file for details.
 //
 
-using AdvancedDLSupport;
 using OpenTK.Core.Extensions;
 using OpenTK.Core.Loader;
 using OpenTK.Mathematics;

--- a/src/OpenAL/OpenTK.OpenAL.Extensions/Creative.EFX/EffectExtensionContext.cs
+++ b/src/OpenAL/OpenTK.OpenAL.Extensions/Creative.EFX/EffectExtensionContext.cs
@@ -8,7 +8,6 @@
 //
 
 using System;
-using AdvancedDLSupport;
 using OpenTK.Core.Extensions;
 using OpenTK.Core.Loader;
 

--- a/src/OpenAL/OpenTK.OpenAL.Extensions/Creative.EFX/Interfaces/IEFX.cs
+++ b/src/OpenAL/OpenTK.OpenAL.Extensions/Creative.EFX/Interfaces/IEFX.cs
@@ -7,7 +7,6 @@
 // of the MIT license. See the LICENSE file for details.
 //
 
-using AdvancedDLSupport;
 
 namespace OpenTK.OpenAL.Extensions.Creative.EFX
 {

--- a/src/OpenAL/OpenTK.OpenAL.Extensions/Creative.EFX/Interfaces/IEFXContext.cs
+++ b/src/OpenAL/OpenTK.OpenAL.Extensions/Creative.EFX/Interfaces/IEFXContext.cs
@@ -8,7 +8,6 @@
 //
 
 using System;
-using AdvancedDLSupport;
 
 // ReSharper disable ExplicitCallerInfoArgument
 namespace OpenTK.OpenAL.Extensions.Creative.EFX

--- a/src/OpenAL/OpenTK.OpenAL.Extensions/Creative.EFX/Interfaces/IEFXEffectSlots.cs
+++ b/src/OpenAL/OpenTK.OpenAL.Extensions/Creative.EFX/Interfaces/IEFXEffectSlots.cs
@@ -7,7 +7,6 @@
 // of the MIT license. See the LICENSE file for details.
 //
 
-using AdvancedDLSupport;
 
 // ReSharper disable ExplicitCallerInfoArgument
 namespace OpenTK.OpenAL.Extensions.Creative.EFX

--- a/src/OpenAL/OpenTK.OpenAL.Extensions/Creative.EFX/Interfaces/IEFXEffects.cs
+++ b/src/OpenAL/OpenTK.OpenAL.Extensions/Creative.EFX/Interfaces/IEFXEffects.cs
@@ -7,7 +7,6 @@
 // of the MIT license. See the LICENSE file for details.
 //
 
-using AdvancedDLSupport;
 using OpenTK.Mathematics;
 
 // ReSharper disable ExplicitCallerInfoArgument

--- a/src/OpenAL/OpenTK.OpenAL.Extensions/Creative.EFX/Interfaces/IEFXFilters.cs
+++ b/src/OpenAL/OpenTK.OpenAL.Extensions/Creative.EFX/Interfaces/IEFXFilters.cs
@@ -7,7 +7,6 @@
 // of the MIT license. See the LICENSE file for details.
 //
 
-using AdvancedDLSupport;
 
 // ReSharper disable ExplicitCallerInfoArgument
 namespace OpenTK.OpenAL.Extensions.Creative.EFX

--- a/src/OpenAL/OpenTK.OpenAL.Extensions/Creative.EFX/Interfaces/IEFXListeners.cs
+++ b/src/OpenAL/OpenTK.OpenAL.Extensions/Creative.EFX/Interfaces/IEFXListeners.cs
@@ -7,7 +7,6 @@
 // of the MIT license. See the LICENSE file for details.
 //
 
-using AdvancedDLSupport;
 
 // ReSharper disable ExplicitCallerInfoArgument
 namespace OpenTK.OpenAL.Extensions.Creative.EFX

--- a/src/OpenAL/OpenTK.OpenAL.Extensions/Creative.EFX/Interfaces/IEFXSources.cs
+++ b/src/OpenAL/OpenTK.OpenAL.Extensions/Creative.EFX/Interfaces/IEFXSources.cs
@@ -8,7 +8,6 @@
 //
 
 using System.Runtime.InteropServices;
-using AdvancedDLSupport;
 
 // ReSharper disable ExplicitCallerInfoArgument
 namespace OpenTK.OpenAL.Extensions.Creative.EFX

--- a/src/OpenAL/OpenTK.OpenAL.Extensions/Creative.MultiChannelBuffers/Interfaces/IMultiChannelBuffers.cs
+++ b/src/OpenAL/OpenTK.OpenAL.Extensions/Creative.MultiChannelBuffers/Interfaces/IMultiChannelBuffers.cs
@@ -7,7 +7,6 @@
 // of the MIT license. See the LICENSE file for details.
 //
 
-using AdvancedDLSupport;
 
 namespace OpenTK.OpenAL.Extensions.Creative.MultiChannelBuffers
 {

--- a/src/OpenAL/OpenTK.OpenAL.Extensions/Creative.MultiChannelBuffers/MultiChannelBuffers.cs
+++ b/src/OpenAL/OpenTK.OpenAL.Extensions/Creative.MultiChannelBuffers/MultiChannelBuffers.cs
@@ -7,7 +7,6 @@
 // of the MIT license. See the LICENSE file for details.
 //
 
-using AdvancedDLSupport;
 using OpenTK.Core.Extensions;
 using OpenTK.Core.Loader;
 

--- a/src/OpenAL/OpenTK.OpenAL.Extensions/Creative.XRam/Interfaces/IXRam.cs
+++ b/src/OpenAL/OpenTK.OpenAL.Extensions/Creative.XRam/Interfaces/IXRam.cs
@@ -8,7 +8,6 @@
 //
 
 using System;
-using AdvancedDLSupport;
 using OpenTK.OpenAL.Interfaces;
 
 namespace OpenTK.OpenAL.Extensions.Creative.XRam

--- a/src/OpenAL/OpenTK.OpenAL.Extensions/Creative.XRam/XRam.cs
+++ b/src/OpenAL/OpenTK.OpenAL.Extensions/Creative.XRam/XRam.cs
@@ -10,7 +10,6 @@
 using System;
 using System.Buffers;
 using System.ComponentModel;
-using AdvancedDLSupport;
 using OpenTK.Core.Extensions;
 using OpenTK.Core.Loader;
 

--- a/src/OpenAL/OpenTK.OpenAL.Extensions/EXT.ALAWFormat/ALAWFormat.cs
+++ b/src/OpenAL/OpenTK.OpenAL.Extensions/EXT.ALAWFormat/ALAWFormat.cs
@@ -7,7 +7,6 @@
 // of the MIT license. See the LICENSE file for details.
 //
 
-using AdvancedDLSupport;
 using OpenTK.Core.Extensions;
 using OpenTK.Core.Loader;
 

--- a/src/OpenAL/OpenTK.OpenAL.Extensions/EXT.ALAWFormat/Interfaces/IALAWFormat.cs
+++ b/src/OpenAL/OpenTK.OpenAL.Extensions/EXT.ALAWFormat/Interfaces/IALAWFormat.cs
@@ -7,7 +7,6 @@
 // of the MIT license. See the LICENSE file for details.
 //
 
-using AdvancedDLSupport;
 
 namespace OpenTK.OpenAL.Extensions.EXT.ALAWFormat
 {

--- a/src/OpenAL/OpenTK.OpenAL.Extensions/EXT.Capture.Enumeration/CaptureEnumerationEnumeration.cs
+++ b/src/OpenAL/OpenTK.OpenAL.Extensions/EXT.Capture.Enumeration/CaptureEnumerationEnumeration.cs
@@ -10,7 +10,6 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
-using AdvancedDLSupport;
 using OpenTK.Core.Extensions;
 using OpenTK.Core.Loader;
 using OpenTK.OpenAL.Extensions.EXT.Capture.Enumeration;

--- a/src/OpenAL/OpenTK.OpenAL.Extensions/EXT.Capture.Enumeration/Interfaces/ICaptureEnumerationContextState.cs
+++ b/src/OpenAL/OpenTK.OpenAL.Extensions/EXT.Capture.Enumeration/Interfaces/ICaptureEnumerationContextState.cs
@@ -7,7 +7,6 @@
 // of the MIT license. See the LICENSE file for details.
 //
 
-using AdvancedDLSupport;
 
 // ReSharper disable ExplicitCallerInfoArgument
 namespace OpenTK.OpenAL.Extensions.EXT.Capture.Enumeration

--- a/src/OpenAL/OpenTK.OpenAL.Extensions/EXT.Capture/Capture.cs
+++ b/src/OpenAL/OpenTK.OpenAL.Extensions/EXT.Capture/Capture.cs
@@ -8,7 +8,6 @@
 //
 
 using System;
-using AdvancedDLSupport;
 using OpenTK.Core.Extensions;
 using OpenTK.Core.Loader;
 using OpenTK.OpenAL.Attributes;

--- a/src/OpenAL/OpenTK.OpenAL.Extensions/EXT.Capture/Interfaces/ICaptureContext.cs
+++ b/src/OpenAL/OpenTK.OpenAL.Extensions/EXT.Capture/Interfaces/ICaptureContext.cs
@@ -7,7 +7,6 @@
 // of the MIT license. See the LICENSE file for details.
 //
 
-using AdvancedDLSupport;
 
 namespace OpenTK.OpenAL.Extensions.EXT.Capture
 {

--- a/src/OpenAL/OpenTK.OpenAL.Extensions/EXT.Capture/Interfaces/ICaptureContextState.cs
+++ b/src/OpenAL/OpenTK.OpenAL.Extensions/EXT.Capture/Interfaces/ICaptureContextState.cs
@@ -7,7 +7,6 @@
 // of the MIT license. See the LICENSE file for details.
 //
 
-using AdvancedDLSupport;
 
 namespace OpenTK.OpenAL.Extensions.EXT.Capture
 {

--- a/src/OpenAL/OpenTK.OpenAL.Extensions/EXT.IMA4Format/IMA4Format.cs
+++ b/src/OpenAL/OpenTK.OpenAL.Extensions/EXT.IMA4Format/IMA4Format.cs
@@ -7,7 +7,6 @@
 // of the MIT license. See the LICENSE file for details.
 //
 
-using AdvancedDLSupport;
 using OpenTK.Core.Extensions;
 using OpenTK.Core.Loader;
 using OpenTK.OpenAL.Extensions;

--- a/src/OpenAL/OpenTK.OpenAL.Extensions/EXT.IMA4Format/Interfaces/IIMA4Format.cs
+++ b/src/OpenAL/OpenTK.OpenAL.Extensions/EXT.IMA4Format/Interfaces/IIMA4Format.cs
@@ -7,7 +7,6 @@
 // of the MIT license. See the LICENSE file for details.
 //
 
-using AdvancedDLSupport;
 
 namespace OpenTK.OpenAL.Native.Extensions.EXT.IMA4Format
 {

--- a/src/OpenAL/OpenTK.OpenAL.Extensions/EXT.MP3Format/Interfaces/IMP3Format.cs
+++ b/src/OpenAL/OpenTK.OpenAL.Extensions/EXT.MP3Format/Interfaces/IMP3Format.cs
@@ -7,7 +7,6 @@
 // of the MIT license. See the LICENSE file for details.
 //
 
-using AdvancedDLSupport;
 
 namespace OpenTK.OpenAL.Extensions.EXT.MP3Format
 {

--- a/src/OpenAL/OpenTK.OpenAL.Extensions/EXT.MP3Format/MP3Format.cs
+++ b/src/OpenAL/OpenTK.OpenAL.Extensions/EXT.MP3Format/MP3Format.cs
@@ -7,7 +7,6 @@
 // of the MIT license. See the LICENSE file for details.
 //
 
-using AdvancedDLSupport;
 using OpenTK.Core.Extensions;
 using OpenTK.Core.Loader;
 

--- a/src/OpenAL/OpenTK.OpenAL.Extensions/EXT.MULAWFormat/Interfaces/IMULAWFormat.cs
+++ b/src/OpenAL/OpenTK.OpenAL.Extensions/EXT.MULAWFormat/Interfaces/IMULAWFormat.cs
@@ -7,7 +7,6 @@
 // of the MIT license. See the LICENSE file for details.
 //
 
-using AdvancedDLSupport;
 
 namespace OpenTK.OpenAL.Extensions.EXT.MULAWFormat
 {

--- a/src/OpenAL/OpenTK.OpenAL.Extensions/EXT.MULAWFormat/MULAWFormat.cs
+++ b/src/OpenAL/OpenTK.OpenAL.Extensions/EXT.MULAWFormat/MULAWFormat.cs
@@ -7,7 +7,6 @@
 // of the MIT license. See the LICENSE file for details.
 //
 
-using AdvancedDLSupport;
 using OpenTK.Core.Extensions;
 using OpenTK.Core.Loader;
 

--- a/src/OpenAL/OpenTK.OpenAL.Extensions/EXT.VorbisFormat/Interfaces/IVorbisFormat.cs
+++ b/src/OpenAL/OpenTK.OpenAL.Extensions/EXT.VorbisFormat/Interfaces/IVorbisFormat.cs
@@ -7,7 +7,6 @@
 // of the MIT license. See the LICENSE file for details.
 //
 
-using AdvancedDLSupport;
 
 namespace OpenTK.OpenAL.Extensions.EXT.VorbisFormat
 {

--- a/src/OpenAL/OpenTK.OpenAL.Extensions/EXT.VorbisFormat/VorbisFormat.cs
+++ b/src/OpenAL/OpenTK.OpenAL.Extensions/EXT.VorbisFormat/VorbisFormat.cs
@@ -7,7 +7,6 @@
 // of the MIT license. See the LICENSE file for details.
 //
 
-using AdvancedDLSupport;
 using OpenTK.Core.Extensions;
 using OpenTK.Core.Loader;
 

--- a/src/OpenAL/OpenTK.OpenAL.Extensions/Soft.DeferredUpdates/DeferredUpdates.cs
+++ b/src/OpenAL/OpenTK.OpenAL.Extensions/Soft.DeferredUpdates/DeferredUpdates.cs
@@ -7,7 +7,6 @@
 // of the MIT license. See the LICENSE file for details.
 //
 
-using AdvancedDLSupport;
 using OpenTK.Core.Extensions;
 
 namespace OpenTK.OpenAL.Extensions.Soft.DeferredUpdates

--- a/src/OpenAL/OpenTK.OpenAL.Extensions/Soft.DeferredUpdates/Interfaces/IDeferredUpdatesState.cs
+++ b/src/OpenAL/OpenTK.OpenAL.Extensions/Soft.DeferredUpdates/Interfaces/IDeferredUpdatesState.cs
@@ -7,7 +7,6 @@
 // of the MIT license. See the LICENSE file for details.
 //
 
-using AdvancedDLSupport;
 using OpenTK.OpenAL.Interfaces;
 
 // ReSharper disable ExplicitCallerInfoArgument

--- a/src/OpenAL/OpenTK.OpenAL.Extensions/Soft/Interfaces/IStateSoft.cs
+++ b/src/OpenAL/OpenTK.OpenAL.Extensions/Soft/Interfaces/IStateSoft.cs
@@ -8,7 +8,6 @@
 //
 
 using System;
-using AdvancedDLSupport;
 using OpenTK.OpenAL.Interfaces;
 
 // ReSharper disable ExplicitCallerInfoArgument

--- a/src/OpenAL/OpenTK.OpenAL.Extensions/Soft/Soft.cs
+++ b/src/OpenAL/OpenTK.OpenAL.Extensions/Soft/Soft.cs
@@ -8,7 +8,6 @@
 //
 
 using System;
-using AdvancedDLSupport;
 using OpenTK.Core.Extensions;
 
 namespace OpenTK.OpenAL.Extensions.Soft


### PR DESCRIPTION
### Purpose of this PR

* Remove references to Fody and ADL as we no longer use them.
