### PR TITLE
Fixed the check to see if a Matrix4 is singular so that it's the same for both versions

### DIFF
--- a/src/OpenTK.Mathematics/Matrix/Matrix4.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix4.cs
@@ -1695,7 +1695,7 @@ namespace OpenTK.Mathematics
             // detM = _mm_sub_ps(detM, tr);
             detM = Sse.Subtract(detM, tr);
 
-            if (MathF.Abs(detM.GetElement(0)) < 0.000001f)
+            if (MathF.Abs(detM.GetElement(0)) < float.Epsilon)
             {
                 throw new InvalidOperationException("Matrix is singular and cannot be inverted.");
             }


### PR DESCRIPTION
### Purpose of this PR

Make both paths in `Matrix4.Invert()` have the same check for throwing an exception.

### Testing status

Not tested 

### Comments

This could be a bug on platforms where `float.Epsilon == 0.0f`.
