### PR TITLE
[5.0] Fix native call names '_' postfix

### DIFF
--- a/src/GeneratorV2/Process/Overloaders.cs
+++ b/src/GeneratorV2/Process/Overloaders.cs
@@ -60,7 +60,7 @@ namespace GeneratorV2.Process
 
             if (trimmedName != name)
             {
-                newOverloads = new List<Overload>() {overload with
+                newOverloads = new List<Overload>() { overload with
                 {
                     OverloadName = trimmedName,
                     NestedOverload = overload,

--- a/src/GeneratorV2/Process/Overloaders.cs
+++ b/src/GeneratorV2/Process/Overloaders.cs
@@ -60,7 +60,12 @@ namespace GeneratorV2.Process
 
             if (trimmedName != name)
             {
-                newOverloads = new List<Overload>() {overload with {OverloadName = trimmedName}};
+                newOverloads = new List<Overload>() {overload with
+                {
+                    OverloadName = trimmedName,
+                    NestedOverload = overload,
+                    MarshalLayerToNested = null
+                }};
                 return true;
             }
             else

--- a/src/GeneratorV2/Process/Processor.cs
+++ b/src/GeneratorV2/Process/Processor.cs
@@ -430,15 +430,18 @@ namespace GeneratorV2.Process
                 // Replace the old overloads with the new overloads
                 overloads = newOverloads;
             }
-
             if (overloadedOnce)
             {
-                changeNativeName = true;
+                changeNativeName = false;
                 foreach (var overload in overloads)
                 {
-                    if (function.Parameters.Count != overload.InputParameters.Length)
+                    if (function.Parameters.Count != overload.InputParameters.Length ||
+                        overload.OverloadName != function.FunctionName)
+                    {
                         continue;
+                    }
 
+                    changeNativeName = true;
                     for (int i = 0; i < function.Parameters.Count; i++)
                     {
                         if (!function.Parameters[i].Type.Equals(overload.InputParameters[i].Type))

--- a/src/OpenTK.Graphics/OpenGL/GL.Manual.cs
+++ b/src/OpenTK.Graphics/OpenGL/GL.Manual.cs
@@ -44,7 +44,7 @@ namespace OpenTK.Graphics.OpenGL
         public static void CreateShaderProgram(ShaderType shaderType, string shaderText)
         {
             var shaderTextPtr = Marshal.StringToCoTaskMemAnsi(shaderText);
-            GL.CreateShaderProgramv_(shaderType, 1, (byte**)&shaderTextPtr);
+            GL.CreateShaderProgramv(shaderType, 1, (byte**)&shaderTextPtr);
             Marshal.FreeCoTaskMem(shaderTextPtr);
         }
     }

--- a/src/OpenTK.Graphics/OpenGLES3/GL.Manual.cs
+++ b/src/OpenTK.Graphics/OpenGLES3/GL.Manual.cs
@@ -44,7 +44,7 @@ namespace OpenTK.Graphics.OpenGLES3
         public static void CreateShaderProgram(ShaderType shaderType, string shaderText)
         {
             var shaderTextPtr = Marshal.StringToCoTaskMemAnsi(shaderText);
-            GL.CreateShaderProgramv_(shaderType, 1, (byte**)&shaderTextPtr);
+            GL.CreateShaderProgramv(shaderType, 1, (byte**)&shaderTextPtr);
             Marshal.FreeCoTaskMem(shaderTextPtr);
         }
     }


### PR DESCRIPTION
### Purpose of this PR

* Previously there was like 28 different methods with the '_' postfix indicating they had overloads with the same function signature.
* I managed to hunt down why this was happening and now we only do this for two methods.
* Those two are string return methods that actually return the string. So not sure what we can really do about removing the postfix for those.

### Testing status

* Builds and compiles.
* Tested how many methods had the _ with regex before and after.
