### PR TITLE
[4.0] Set window/context bits explicitly if needed

### DIFF
--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -661,9 +661,13 @@ namespace OpenTK.Windowing.Desktop
             {
                 var monitor = settings.CurrentMonitor.ToUnsafePtr<GraphicsLibraryFramework.Monitor>();
                 var modePtr = GLFW.GetVideoMode(monitor);
-                GLFW.WindowHint(WindowHintInt.RedBits, modePtr->RedBits);
-                GLFW.WindowHint(WindowHintInt.GreenBits, modePtr->GreenBits);
-                GLFW.WindowHint(WindowHintInt.BlueBits, modePtr->BlueBits);
+                GLFW.WindowHint(WindowHintInt.RedBits, settings.SetBitsExplicitly ? settings.RedBits : modePtr->RedBits);
+                GLFW.WindowHint(WindowHintInt.GreenBits, settings.SetBitsExplicitly ? settings.GreenBits : modePtr->GreenBits);
+                GLFW.WindowHint(WindowHintInt.BlueBits, settings.SetBitsExplicitly ? settings.BlueBits : modePtr->BlueBits);
+                if (settings.SetBitsExplicitly)
+                {
+                    GLFW.WindowHint(WindowHintInt.AlphaBits, settings.AlphaBits);
+                }
                 GLFW.WindowHint(WindowHintInt.RefreshRate, modePtr->RefreshRate);
 
                 if (settings.WindowState == WindowState.Fullscreen && _isVisible)
@@ -679,6 +683,8 @@ namespace OpenTK.Windowing.Desktop
                 }
             }
 
+            GLFW.WindowHint(WindowHintInt.DepthBits, settings.DepthBits);
+            GLFW.WindowHint(WindowHintInt.StencilBits, settings.StencilBits);
             Context = new GLFWGraphicsContext(WindowPtr);
 
             Exists = true;

--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -668,6 +668,7 @@ namespace OpenTK.Windowing.Desktop
                 {
                     GLFW.WindowHint(WindowHintInt.AlphaBits, settings.AlphaBits.Value);
                 }
+
                 GLFW.WindowHint(WindowHintInt.RefreshRate, modePtr->RefreshRate);
 
                 if (settings.WindowState == WindowState.Fullscreen && _isVisible)
@@ -692,6 +693,7 @@ namespace OpenTK.Windowing.Desktop
             {
                 GLFW.WindowHint(WindowHintInt.StencilBits, settings.StencilBits.Value);
             }
+
             Context = new GLFWGraphicsContext(WindowPtr);
 
             Exists = true;

--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -661,12 +661,12 @@ namespace OpenTK.Windowing.Desktop
             {
                 var monitor = settings.CurrentMonitor.ToUnsafePtr<GraphicsLibraryFramework.Monitor>();
                 var modePtr = GLFW.GetVideoMode(monitor);
-                GLFW.WindowHint(WindowHintInt.RedBits, settings.SetBitsExplicitly ? settings.RedBits : modePtr->RedBits);
-                GLFW.WindowHint(WindowHintInt.GreenBits, settings.SetBitsExplicitly ? settings.GreenBits : modePtr->GreenBits);
-                GLFW.WindowHint(WindowHintInt.BlueBits, settings.SetBitsExplicitly ? settings.BlueBits : modePtr->BlueBits);
-                if (settings.SetBitsExplicitly)
+                GLFW.WindowHint(WindowHintInt.RedBits, settings.RedBits ?? modePtr->RedBits);
+                GLFW.WindowHint(WindowHintInt.GreenBits, settings.GreenBits ?? modePtr->GreenBits);
+                GLFW.WindowHint(WindowHintInt.BlueBits, settings.BlueBits ?? modePtr->BlueBits);
+                if (settings.AlphaBits.HasValue)
                 {
-                    GLFW.WindowHint(WindowHintInt.AlphaBits, settings.AlphaBits);
+                    GLFW.WindowHint(WindowHintInt.AlphaBits, settings.AlphaBits.Value);
                 }
                 GLFW.WindowHint(WindowHintInt.RefreshRate, modePtr->RefreshRate);
 
@@ -683,8 +683,15 @@ namespace OpenTK.Windowing.Desktop
                 }
             }
 
-            GLFW.WindowHint(WindowHintInt.DepthBits, settings.DepthBits);
-            GLFW.WindowHint(WindowHintInt.StencilBits, settings.StencilBits);
+            if (settings.DepthBits.HasValue)
+            {
+                GLFW.WindowHint(WindowHintInt.DepthBits, settings.DepthBits.Value);
+            }
+
+            if (settings.StencilBits.HasValue)
+            {
+                GLFW.WindowHint(WindowHintInt.StencilBits, settings.StencilBits.Value);
+            }
             Context = new GLFWGraphicsContext(WindowPtr);
 
             Exists = true;

--- a/src/OpenTK.Windowing.Desktop/NativeWindowSettings.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindowSettings.cs
@@ -170,5 +170,59 @@ namespace OpenTK.Windowing.Desktop
         /// otherwise multisampling is used if available. The actual number of samples is the closest matching the given number that is supported.
         /// </remarks>
         public int NumberOfSamples { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating the number of stencil bits used for OpenGL context creation.
+        /// </summary>
+        /// <remarks>
+        /// Default value is 8.
+        /// </remarks>
+        public int StencilBits { get; set; } = 8;
+
+        /// <summary>
+        /// Gets or sets a value indicating the number of depth bits used for OpenGL context creation.
+        /// </summary>
+        /// <remarks>
+        /// Default value is 24.
+        /// </remarks>
+        public int DepthBits { get; set; } = 24;
+
+        /// <summary>
+        /// Gets or sets a value indicating the number of red bits used for OpenGL context creation.
+        /// </summary>
+        /// <remarks>
+        /// Default value is 8.
+        /// </remarks>
+        public int RedBits { get; set; } = 8;
+
+        /// <summary>
+        /// Gets or sets a value indicating the number of green bits used for OpenGL context creation.
+        /// </summary>
+        /// <remarks>
+        /// Default value is 8.
+        /// </remarks>
+        public int GreenBits { get; set; } = 8;
+
+        /// <summary>
+        /// Gets or sets a value indicating the number of blue bits used for OpenGL context creation.
+        /// </summary>
+        /// <remarks>
+        /// Default value is 8.
+        /// </remarks>
+        public int BlueBits { get; set; } = 8;
+
+        /// <summary>
+        /// Gets or sets a value indicating the number of alpha bits used for OpenGL context creation.
+        /// </summary>
+        /// <remarks>
+        /// Default value is 8.
+        /// </remarks>
+        public int AlphaBits { get; set; } = 8;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether red/green/blue-bits, depth/stencil bits should be set explicitly.
+        /// If false red/green/blue bits are determined from the currently set video mode of the current monitor.
+        /// </summary>
+        public bool SetBitsExplicitly { get; set; } = false;
     }
 }

--- a/src/OpenTK.Windowing.Desktop/NativeWindowSettings.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindowSettings.cs
@@ -177,7 +177,7 @@ namespace OpenTK.Windowing.Desktop
         /// <remarks>
         /// Default value is 8.
         /// </remarks>
-        public int StencilBits { get; set; } = 8;
+        public int? StencilBits { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating the number of depth bits used for OpenGL context creation.
@@ -185,7 +185,7 @@ namespace OpenTK.Windowing.Desktop
         /// <remarks>
         /// Default value is 24.
         /// </remarks>
-        public int DepthBits { get; set; } = 24;
+        public int? DepthBits { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating the number of red bits used for OpenGL context creation.
@@ -193,7 +193,7 @@ namespace OpenTK.Windowing.Desktop
         /// <remarks>
         /// Default value is 8.
         /// </remarks>
-        public int RedBits { get; set; } = 8;
+        public int? RedBits { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating the number of green bits used for OpenGL context creation.
@@ -201,7 +201,7 @@ namespace OpenTK.Windowing.Desktop
         /// <remarks>
         /// Default value is 8.
         /// </remarks>
-        public int GreenBits { get; set; } = 8;
+        public int? GreenBits { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating the number of blue bits used for OpenGL context creation.
@@ -209,7 +209,7 @@ namespace OpenTK.Windowing.Desktop
         /// <remarks>
         /// Default value is 8.
         /// </remarks>
-        public int BlueBits { get; set; } = 8;
+        public int? BlueBits { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating the number of alpha bits used for OpenGL context creation.
@@ -217,12 +217,6 @@ namespace OpenTK.Windowing.Desktop
         /// <remarks>
         /// Default value is 8.
         /// </remarks>
-        public int AlphaBits { get; set; } = 8;
-
-        /// <summary>
-        /// Gets or sets a value indicating whether red/green/blue-bits, depth/stencil bits should be set explicitly.
-        /// If false red/green/blue bits are determined from the currently set video mode of the current monitor.
-        /// </summary>
-        public bool SetBitsExplicitly { get; set; } = false;
+        public int? AlphaBits { get; set; }
     }
 }


### PR DESCRIPTION
### Purpose of this PR

when `NativeWindowSettings.SetBitsExplicitly` is set to `true` (default is `false`), then set red/green/blue bits explicitly and not use the values from the detected video mode. This will also set alpha/depth and stencil bits.

Default values:
red/green/blue/alpha = 8
depth = 24
stencil = 8
