### PR TITLE
Adding fallback to dlsym when NSLookupSymbolInImage doesnt work.

### DIFF
--- a/src/OpenTK/Platform/MacOS/CocoaContext.cs
+++ b/src/OpenTK/Platform/MacOS/CocoaContext.cs
@@ -66,6 +66,9 @@ namespace OpenTK
         // if this will be fixed by Apple in the future. dlsym still works, but is about 20x slower.
         // We will try to detect if NSLookup works by looking up 'glClear' and fallback to dlsym 
         // if it returns NULL.
+        //
+        // More information here: 
+        // https://github.com/opentk/opentk/issues/1308
 
         static unsafe void DetectBindingMethod()
         {
@@ -78,8 +81,14 @@ namespace OpenTK
 
                 if (symbol == IntPtr.Zero)
                 {
-                    // Need to reload the library with dlopen. NSAddImage doesnt return
-                    // the same data structure. 
+                    // Need to reload the library with dlopen since NSAddImage doesnt return
+                    // the same data structure. We cannot unload a library that was loaded
+                    // with NSAddImage unfortunately, there is not API for this. 
+                    //
+                    // That being said, there is evidence that the library isnt actually loaded 
+                    // twice since on systems that supports both methods (pre-Monterey Beta), they 
+                    // both will return the same exact function pointers.
+
                     opengl   = NS.LoadLibrary("/System/Library/Frameworks/OpenGL.framework/OpenGL");
                     opengles = NS.LoadLibrary("/System/Library/Frameworks/OpenGL.framework/OpenGLES");
 

--- a/src/OpenTK/Platform/MacOS/NS.cs
+++ b/src/OpenTK/Platform/MacOS/NS.cs
@@ -155,10 +155,19 @@ namespace OpenTK.Platform.MacOS
             return dlsym(handle, symbol);
         }
 
-        public static IntPtr LoadLibrary(string fileName)
+        public static IntPtr LoadLibrary(string fileName, bool first = false)
         {
             const int RTLD_NOW = 2;
-            return dlopen(fileName, RTLD_NOW);
+            const int RTLD_FIRST = 0x100;
+
+            int flags = RTLD_NOW;
+
+            if (first)
+            {
+                flags |= RTLD_FIRST;
+            }
+
+            return dlopen(fileName, flags);
         }
 
         public static void FreeLibrary(IntPtr handle)


### PR DESCRIPTION
This is to work around issues in MacOS Monterey beta, following the discussion of this issue:

https://github.com/opentk/opentk/issues/1308

### Purpose of this PR

* Fix crashes at startup on all OpenTK 3.x app running on MacOS Monterey. By doing this "auto-detection", if Apple ends up fising the bug, we will be back where we started.

### Testing status

* Unfortunately, im not in a position where I can run the F# test suite on the Monterey VM. So I ran 2 tests:
    * I ran a simple "GameWindow" app that simple shows a window and clears the background a random color every frame.
    * I swapped the OpenTK.dll of my app (FamiStudio) and ran it on Monterey and confirmed that it ran file. This is a more substantial test, although it only uses OpenGL 1.0, 1.1 or 1.2.

### Comments

* Thank you for OpenTK!