### PR TITLE
Change "learn OpenTK" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ Use OpenTK to add cross-platform 3d graphics, audio, compute and haptics to your
 
 OpenTK comes with simple and easy to follow tutorials for learning *modern* OpenGL. These are written by the community and represent all of the best practices to get you started.
 
-#### Learn how to use OpenTK here: https://opentk.net/learn/index.html
+#### Learn how to use OpenTK here: https://github.com/opentk/LearnOpenTK
 
-Sample projects that accompany the tutorial can be found here: https://github.com/opentk/LearnOpenTK
+Older OpenTK 3 tutorials here: https://opentk.net/learn/index.html
 
 Project website: https://opentk.net
 


### PR DESCRIPTION
I changed the "learn OpenTK" link to the updated sample code, since the one on the website is for an older version. This should help avoid confusion. This can be changed back when the website has been updated.