### PR TITLE
Native Window VSync support

### DIFF
--- a/src/OpenTK.Windowing.Common/Interfaces/IGraphicsContext.cs
+++ b/src/OpenTK.Windowing.Common/Interfaces/IGraphicsContext.cs
@@ -13,6 +13,14 @@ namespace OpenTK.Windowing.Common
         bool IsCurrent { get; }
 
         /// <summary>
+        /// Gets or sets the swap interval (the number of screen updates to wait between swapping front and back buffers. See <see cref="SwapBuffers"/>).
+        /// </summary>
+        /// <value>
+        /// The swap interval.
+        /// </value>
+        int SwapInterval { get; set; }
+
+        /// <summary>
         /// Swaps the front and back buffers of the current GraphicsContext, presenting the rendered scene to the user.
         /// </summary>
         void SwapBuffers();
@@ -26,13 +34,5 @@ namespace OpenTK.Windowing.Common
         /// Makes no GraphicsContext current one on the calling thread.
         /// </summary>
         void MakeNoneCurrent();
-
-        /// <summary>
-        /// Gets or sets the swap interval (the number of screen updates to wait between calling <see cref="SwapBuffers"/>).
-        /// </summary>
-        /// <value>
-        /// The swap interval.
-        /// </value>
-        int SwapInterval { get; set; }
     }
 }

--- a/src/OpenTK.Windowing.Common/Interfaces/IGraphicsContext.cs
+++ b/src/OpenTK.Windowing.Common/Interfaces/IGraphicsContext.cs
@@ -26,5 +26,13 @@ namespace OpenTK.Windowing.Common
         /// Makes no GraphicsContext current one on the calling thread.
         /// </summary>
         void MakeNoneCurrent();
+
+        /// <summary>
+        /// Gets or sets the swap interval (the number of screen updates to wait between calling <see cref="SwapBuffers"/>).
+        /// </summary>
+        /// <value>
+        /// The swap interval.
+        /// </value>
+        int SwapInterval { get; set; }
     }
 }

--- a/src/OpenTK.Windowing.Desktop/GLFWGraphicsContext.cs
+++ b/src/OpenTK.Windowing.Desktop/GLFWGraphicsContext.cs
@@ -26,6 +26,19 @@ namespace OpenTK.Windowing.Desktop
         /// <inheritdoc />
         public bool IsCurrent => GLFW.GetCurrentContext() == _windowPtr;
 
+        private int _swapInterval;
+
+        /// <inheritdoc/>
+        public int SwapInterval
+        {
+            get => _swapInterval;
+            set
+            {
+                GLFW.SwapInterval(value);
+                _swapInterval = value;
+            }
+        }
+
         /// <inheritdoc />
         public void SwapBuffers()
         {

--- a/src/OpenTK.Windowing.Desktop/GameWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/GameWindow.cs
@@ -204,7 +204,7 @@ namespace OpenTK.Windowing.Desktop
                     case VSyncMode.Adaptive:
                         GLFW.SwapInterval(IsRunningSlowly ? 0 : 1);
                         break;
-                    }
+                }
 
                 _vSync = value;
             }

--- a/src/OpenTK.Windowing.Desktop/GameWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/GameWindow.cs
@@ -181,35 +181,6 @@ namespace OpenTK.Windowing.Desktop
             }
         }
 
-        private VSyncMode _vSync;
-
-        /// <summary>
-        /// Gets or sets the VSyncMode.
-        /// </summary>
-        public VSyncMode VSync
-        {
-            get => _vSync;
-            set
-            {
-                switch (value)
-                {
-                    case VSyncMode.On:
-                        GLFW.SwapInterval(1);
-                        break;
-
-                    case VSyncMode.Off:
-                        GLFW.SwapInterval(0);
-                        break;
-
-                    case VSyncMode.Adaptive:
-                        GLFW.SwapInterval(IsRunningSlowly ? 0 : 1);
-                        break;
-                }
-
-                _vSync = value;
-            }
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="GameWindow"/> class with sensible default attributes.
         /// </summary>
@@ -337,7 +308,7 @@ namespace OpenTK.Windowing.Desktop
                 OnRenderFrame(new FrameEventArgs(elapsed));
 
                 // Update VSync if set to adaptive
-                if (_vSync == VSyncMode.Adaptive)
+                if (VSync == VSyncMode.Adaptive)
                 {
                     GLFW.SwapInterval(IsRunningSlowly ? 0 : 1);
                 }

--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -117,6 +117,37 @@ namespace OpenTK.Windowing.Desktop
         /// <value><c>true</c> if any button is pressed; otherwise, <c>false</c>.</value>
         public bool IsAnyMouseButtonDown => MouseState.IsAnyButtonDown;
 
+        private VSyncMode _vSync;
+
+        /// <summary>
+        /// Gets or sets the VSync state of this <see cref="NativeWindow"/>.
+        /// </summary>
+        /// <value>
+        /// The VSync state.
+        /// </value>
+        public VSyncMode VSync
+        {
+            get => _vSync;
+
+            set
+            {
+                // We don't do anything here for adaptive because that's handled in GameWindow
+                switch (value)
+                {
+                    case VSyncMode.On:
+                        Context.SwapInterval = 1;
+                        break;
+
+                    case VSyncMode.Off:
+                        Context.SwapInterval = 0;
+                        break;
+                }
+
+                _vSync = value;
+            }
+        }
+
+
         private WindowIcon _icon;
 
         /// <summary>

--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -147,7 +147,6 @@ namespace OpenTK.Windowing.Desktop
             }
         }
 
-
         private WindowIcon _icon;
 
         /// <summary>

--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -131,7 +131,7 @@ namespace OpenTK.Windowing.Desktop
 
             set
             {
-                // We don't do anything here for adaptive because that's handled in GameWindow
+                // We don't do anything here for adaptive because that's handled in GameWindow.
                 switch (value)
                 {
                     case VSyncMode.On:


### PR DESCRIPTION
### Purpose of this PR

- Added SwapInterval to IGraphicsContext
- Moved VSync from GameWindow to NativeWindow (Adaptive mode is still handled by GameWindow)

### Testing status

I tested the changes on an example project outside of TK. However, it's a pretty straightforward change.

### Comments

I wanted to add `IGraphicsContext.SwapInterval` as that's how it used to be in 3.x and it was useful for me as I don't use `GameWindow` 9/10 on my projects. In my current project found [here](github.com/softwareantics/FinalEngine) I use `NativeWindow` and like to manage game time myself, however, upon updating to 4.6.4 I was no longer able to disable VSyncing with `IGraphicsContext`.