### PR TITLE
[3.0] Change: Add a little safety to the x64 P/Invoke logic

### DIFF
--- a/src/OpenTK/Toolkit.cs
+++ b/src/OpenTK/Toolkit.cs
@@ -152,10 +152,27 @@ namespace OpenTK
                          * NOTE:
                          * Non-Windows platforms should be handled via the OpenTK.dll.config file as appropriate
                          */
-                        string path = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
-                        path = Path.Combine(path, IntPtr.Size == 4 ? "x86" : "x64");
-                        bool ok = SetDllDirectory(path);
-                        if (!ok) throw new System.ComponentModel.Win32Exception();
+                        Assembly entryAssembly = Assembly.GetEntryAssembly();
+                        if (entryAssembly != null)
+                        {
+                            try
+                            {
+                                string assemblyLocation = entryAssembly.Location;
+                                string path = Path.GetDirectoryName(assemblyLocation);
+                                path = Path.Combine(path, IntPtr.Size == 4 ? "x86" : "x64");
+                                bool ok = SetDllDirectory(path);
+                                if (!ok)
+                                {
+                                    //A fairly fundamental Win32 syscall failed. Developer probably wants to know about this, but not necessarily users
+                                    throw new System.ComponentModel.Win32Exception("Windows reported that attempting to set the DLL search path failed");
+                                }
+                            }
+                            catch
+                            {
+                                //A fairly fundamental Win32 syscall failed. Developer probably wants to know about this, but not necessarily users
+                                throw new System.ComponentModel.Win32Exception("An unexpected Win32 error occured when attempting to set the DLL search path");
+                            }
+                        }
                     }
 
                     // The actual initialization takes place in the

--- a/src/OpenTK/Toolkit.cs
+++ b/src/OpenTK/Toolkit.cs
@@ -173,6 +173,10 @@ namespace OpenTK
                                 throw new System.ComponentModel.Win32Exception("An unexpected Win32 error occured when attempting to set the DLL search path");
                             }
                         }
+                        else
+                        {
+                            Trace.WriteLine("Could not get assebly location, we will not set separate x86 and x64 dll import folders. This means you won't get architecture specific dll imports.");
+                        }
                     }
 
                     // The actual initialization takes place in the

--- a/src/OpenTK/Toolkit.cs
+++ b/src/OpenTK/Toolkit.cs
@@ -170,7 +170,7 @@ namespace OpenTK
                             catch (Exception e)
                             {
 #if DEBUG
-                                throw e;
+                                throw;
 #else
                                 Trace.TraceWarning($"Exception when trying to set x86/x64 dll directory. {e}");
 #endif

--- a/src/OpenTK/Toolkit.cs
+++ b/src/OpenTK/Toolkit.cs
@@ -178,7 +178,7 @@ namespace OpenTK
                         }
                         else
                         {
-                            Trace.TraceWarning("Could not get assebly location, we will not set separate x86 and x64 dll import folders. This means you won't get architecture specific dll imports.");
+                            Trace.TraceWarning("Could not get assembly location, we will not set separate x86 and x64 dll import folders. This means you won't get architecture specific dll imports.");
                         }
                     }
 

--- a/src/OpenTK/Toolkit.cs
+++ b/src/OpenTK/Toolkit.cs
@@ -155,22 +155,14 @@ namespace OpenTK
                         Assembly entryAssembly = Assembly.GetEntryAssembly();
                         if (entryAssembly != null)
                         {
-                            try
-                            {
-                                string assemblyLocation = entryAssembly.Location;
-                                string path = Path.GetDirectoryName(assemblyLocation);
-                                path = Path.Combine(path, IntPtr.Size == 4 ? "x86" : "x64");
-                                bool ok = SetDllDirectory(path);
-                                if (!ok)
-                                {
-                                    //A fairly fundamental Win32 syscall failed. Developer probably wants to know about this, but not necessarily users
-                                    throw new System.ComponentModel.Win32Exception("Windows reported that attempting to set the DLL search path failed");
-                                }
-                            }
-                            catch
+                            string assemblyLocation = entryAssembly.Location;
+                            string path = Path.GetDirectoryName(assemblyLocation);
+                            path = Path.Combine(path, IntPtr.Size == 4 ? "x86" : "x64");
+                            bool ok = SetDllDirectory(path);
+                            if (!ok)
                             {
                                 //A fairly fundamental Win32 syscall failed. Developer probably wants to know about this, but not necessarily users
-                                throw new System.ComponentModel.Win32Exception("An unexpected Win32 error occured when attempting to set the DLL search path");
+                                throw new System.ComponentModel.Win32Exception("Setting x86/x64 specific dll import directory failed.");
                             }
                         }
                         else


### PR DESCRIPTION
### Purpose of this PR

https://github.com/opentk/opentk/pull/1223
This seems to have caused some test failures. 
I can't reproduce these.

This adds a null check, and wraps some bits into a try / catch block and debug only.

### Testing status

Works at this end, as did the first :/

### Comments

n/a
