### PR TITLE
Fix 1321

### DIFF
--- a/src/Generator/Process/Overloaders.cs
+++ b/src/Generator/Process/Overloaders.cs
@@ -1224,7 +1224,7 @@ namespace Generator.Process
                 }
                 else if (i != oldParameters.Length - 1)
                 {
-                    newParameters[outParameter != null ? i + 1 : i] = parameter;
+                    newParameters[outParameter != null ? i - 1 : i] = parameter;
                 }
             }
 

--- a/src/Generator/Process/Overloaders.cs
+++ b/src/Generator/Process/Overloaders.cs
@@ -1208,6 +1208,7 @@ namespace Generator.Process
             Parameter[] newParameters = new Parameter[oldParameters.Length - 1];
             Parameter? outParameter = null;
             CSRef? outType = null;
+            int newIndex = 0; // The destination index of parameters
             for (int i = 0; i < oldParameters.Length; i++)
             {
                 var parameter = oldParameters[i];
@@ -1222,9 +1223,10 @@ namespace Generator.Process
                     outType = pRef;
                     outParameter = parameter;
                 }
-                else if (i != oldParameters.Length - 1)
+                else if (newIndex != oldParameters.Length - 1)
                 {
-                    newParameters[outParameter != null ? i - 1 : i] = parameter;
+                    newParameters[newIndex] = parameter;
+                    newIndex++;
                 }
             }
 


### PR DESCRIPTION
### Purpose of this PR

* Fixes #1321
* Concerns the v5 Code Generator

### Testing status

* Made sure the generator runs against <https://raw.githubusercontent.com/KhronosGroup/OpenGL-Registry/acc094d2dc2a78b1f774dc1899e2e6f6850ec5ea/xml/gl.xml>:

Before change:

```
...
[Info 2021-09-02 02:23:21:75660 Overloaders.cs#849] glGetPerfQueryIdByNameINTEL is missing a len attribute for parameter 'queryName'
[Warning 2021-09-02 02:23:21:75743 Overloaders.cs#946] Char pointer leaked from earlier overloaders: "glGetPerfQueryIdByNameINTEL" (Parameter { Type = CSPointer { BaseType = CSChar8 { Constant = False }, Constant = False }, Name = queryName, Length =  })
[Warning 2021-09-02 02:23:21:75821 Overloaders.cs#1140] CSPointer { BaseType = CSChar8 { Constant = False }, Constant = False } is not supported by the ref overloader.
Unhandled exception. System.IndexOutOfRangeException: Index was outside the bounds of the array.
   at Generator.Process.OutToReturnOverloader.TryGenerateOverloads(Overload overload, List`1& newOverloads) in C:\work\repositories\_opengl\opentk-5\src\Generator\Process\Overloaders.cs:line 1232
   at Generator.Process.Processor.GenerateOverloads(NativeFunction nativeFunction) in C:\work\repositories\_opengl\opentk-5\src\Generator\Process\Processor.cs:line 427
   at Generator.Process.Processor.ProcessSpec(Specification spec) in C:\work\repositories\_opengl\opentk-5\src\Generator\Process\Processor.cs:line 54
   at Generator.Program.Main(String[] args) in C:\work\repositories\_opengl\opentk-5\src\Generator\Program.cs:line 28
```

After change:

```
...
[Info 2021-09-02 11:57:41:04132 Overloaders.cs#849] glGetPerfQueryIdByNameINTEL is missing a len attribute for parameter 'queryName'
[Warning 2021-09-02 11:57:41:04148 Overloaders.cs#946] Char pointer leaked from earlier overloaders: "glGetPerfQueryIdByNameINTEL" (Parameter { Type = CSPointer { BaseType = CSChar8 { Constant = False }, Constant = False }, Name = queryName, Length =  })
[Warning 2021-09-02 11:57:41:04164 Overloaders.cs#1140] CSPointer { BaseType = CSChar8 { Constant = False }, Constant = False } is not supported by the ref overloader.
[Info 2021-09-02 11:57:41:04181 Overloaders.cs#849] glGetPerfQueryInfoINTEL is missing a len attribute for parameter 'queryName'
[Warning 2021-09-02 11:57:41:04196 Overloaders.cs#946] Char pointer leaked from earlier overloaders: "glGetPerfQueryInfoINTEL" (Parameter { Type = CSPointer { BaseType = CSChar8 { Constant = False }, Constant = False }, Name = queryName, Length =  })
[Warning 2021-09-02 11:57:41:04212 Overloaders.cs#1140] CSPointer { BaseType = CSChar8 { Constant = False }, Constant = False } is not supported by the ref overloader.
...
[Info 2021-09-02 11:57:41:53489 Program.cs#35] 1581

```

### Comments

* The issue was caused by a flawed logic inside `OutToReturnOverloader.TryGenerateOverloads` regarding the way the *new* parameters array was filled in the case the out parameter to be transformed into a return value is not the last one.
