### PR TITLE
Fixed bug where Box2i and Box3i .Center property returned the wrong value + cleanup

### DIFF
--- a/src/OpenTK.Mathematics/Geometry/Box2i.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box2i.cs
@@ -20,6 +20,9 @@ namespace OpenTK.Mathematics
     [StructLayout(LayoutKind.Sequential)]
     public struct Box2i : IEquatable<Box2i>
     {
+        /// <summary>
+        /// An empty box with Min (0, 0) and Max (0, 0).
+        /// </summary>
         public static readonly Box2i Empty = new Box2i(0, 0, 0, 0);
 
         private Vector2i _min;
@@ -32,15 +35,7 @@ namespace OpenTK.Mathematics
             get => _min;
             set
             {
-                if (value.X > _max.X)
-                {
-                    _max.X = value.X;
-                }
-                if (value.Y > _max.Y)
-                {
-                    _max.Y = value.Y;
-                }
-
+                _max = Vector2i.ComponentMax(_max, value);
                 _min = value;
             }
         }
@@ -55,15 +50,7 @@ namespace OpenTK.Mathematics
             get => _max;
             set
             {
-                if (value.X < _min.X)
-                {
-                    _min.X = value.X;
-                }
-                if (value.Y < _min.Y)
-                {
-                    _min.Y = value.Y;
-                }
-
+                _min = Vector2i.ComponentMin(_min, value);
                 _max = value;
             }
         }
@@ -119,7 +106,7 @@ namespace OpenTK.Mathematics
         /// to avoid annoying off-by-one errors in box placement, no setter is provided for this property
         public Vector2 Center
         {
-            get => ((_min + _max).ToVector2() * 0.5f) + _min.ToVector2();
+            get => (_min + _max).ToVector2() * 0.5f;
         }
 
         /// <summary>
@@ -150,8 +137,11 @@ namespace OpenTK.Mathematics
                 return _min.X <= point.X && point.X <= _max.X &&
                        _min.Y <= point.Y && point.Y <= _max.Y;
             }
-            return _min.X < point.X && point.X < _max.X &&
+            else
+            {
+                return _min.X < point.X && point.X < _max.X &&
                    _min.Y < point.Y && point.Y < _max.Y;
+            }
         }
 
         /// <summary>
@@ -196,10 +186,10 @@ namespace OpenTK.Mathematics
         [Pure]
         public float DistanceToNearestEdge(Vector2i point)
         {
-            var distX = new Vector2(
+            var dist = new Vector2(
                 Math.Max(0f, Math.Max(_min.X - point.X, point.X - _max.X)),
                 Math.Max(0f, Math.Max(_min.Y - point.Y, point.Y - _max.Y)));
-            return distX.Length;
+            return dist.Length;
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Geometry/Box3i.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box3i.cs
@@ -20,6 +20,11 @@ namespace OpenTK.Mathematics
     [StructLayout(LayoutKind.Sequential)]
     public struct Box3i : IEquatable<Box3i>
     {
+        /// <summary>
+        /// An empty box with Min (0, 0, 0) and Max (0, 0, 0).
+        /// </summary>
+        public static readonly Box3i Empty = new Box3i(0, 0, 0, 0, 0, 0);
+
         private Vector3i _min;
 
         /// <summary>
@@ -30,19 +35,7 @@ namespace OpenTK.Mathematics
             get => _min;
             set
             {
-                if (value.X > _max.X)
-                {
-                    _max.X = value.X;
-                }
-                if (value.Y > _max.Y)
-                {
-                    _max.Y = value.Y;
-                }
-                if (value.Z > _max.Z)
-                {
-                    _max.Z = value.Z;
-                }
-
+                _max = Vector3i.ComponentMax(_max, value);
                 _min = value;
             }
         }
@@ -57,19 +50,7 @@ namespace OpenTK.Mathematics
             get => _max;
             set
             {
-                if (value.X < _min.X)
-                {
-                    _min.X = value.X;
-                }
-                if (value.Y < _min.Y)
-                {
-                    _min.Y = value.Y;
-                }
-                if (value.Z < _min.Z)
-                {
-                    _min.Z = value.Z;
-                }
-
+                _min = Vector3i.ComponentMin(_min, value);
                 _max = value;
             }
         }
@@ -127,7 +108,7 @@ namespace OpenTK.Mathematics
         /// to avoid annoying off-by-one errors in box placement, no setter is provided for this property
         public Vector3 Center
         {
-            get => ((_min + _max).ToVector3() * 0.5f) + _min.ToVector3();
+            get => (_min + _max).ToVector3() * 0.5f;
         }
 
         /// <summary>
@@ -160,9 +141,12 @@ namespace OpenTK.Mathematics
                        _min.Y <= point.Y && point.Y <= _max.Y &&
                        _min.Z <= point.Z && point.Z <= _max.Z;
             }
-            return _min.X < point.X && point.X < _max.X &&
-                   _min.Y < point.Y && point.Y < _max.Y &&
-                   _min.Z < point.Z && point.Z < _max.Z;
+            else
+            {
+                return _min.X < point.X && point.X < _max.X &&
+                       _min.Y < point.Y && point.Y < _max.Y &&
+                       _min.Z < point.Z && point.Z < _max.Z;
+            }
         }
 
         /// <summary>
@@ -186,11 +170,11 @@ namespace OpenTK.Mathematics
         [Pure]
         public float DistanceToNearestEdge(Vector3i point)
         {
-            var distX = new Vector3(
+            var dist = new Vector3(
                 Math.Max(0f, Math.Max(_min.X - point.X, point.X - _max.X)),
                 Math.Max(0f, Math.Max(_min.Y - point.Y, point.Y - _max.Y)),
                 Math.Max(0f, Math.Max(_min.Z - point.Z, point.Z - _max.Z)));
-            return distX.Length;
+            return dist.Length;
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Vector/Vector3i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3i.cs
@@ -331,9 +331,10 @@ namespace OpenTK.Mathematics
         [Pure]
         public static Vector3i ComponentMin(Vector3i a, Vector3i b)
         {
-            a.X = a.X < b.X ? a.X : b.X;
-            a.Y = a.Y < b.Y ? a.Y : b.Y;
-            a.Z = a.Z < b.Z ? a.Z : b.Z;
+            Vector3i result;
+            result.X = Math.Min(a.X, b.X);
+            result.Y = Math.Min(a.Y, b.Y);
+            result.Z = Math.Min(a.Z, b.Z);
             return a;
         }
 
@@ -345,9 +346,9 @@ namespace OpenTK.Mathematics
         /// <param name="result">The component-wise minimum.</param>
         public static void ComponentMin(in Vector3i a, in Vector3i b, out Vector3i result)
         {
-            result.X = a.X < b.X ? a.X : b.X;
-            result.Y = a.Y < b.Y ? a.Y : b.Y;
-            result.Z = a.Z < b.Z ? a.Z : b.Z;
+            result.X = Math.Min(a.X, b.X);
+            result.Y = Math.Min(a.Y, b.Y);
+            result.Z = Math.Min(a.Z, b.Z);
         }
 
         /// <summary>
@@ -359,10 +360,11 @@ namespace OpenTK.Mathematics
         [Pure]
         public static Vector3i ComponentMax(Vector3i a, Vector3i b)
         {
-            a.X = a.X > b.X ? a.X : b.X;
-            a.Y = a.Y > b.Y ? a.Y : b.Y;
-            a.Z = a.Z > b.Z ? a.Z : b.Z;
-            return a;
+            Vector3i result;
+            result.X = Math.Max(a.X, b.X);
+            result.Y = Math.Max(a.Y, b.Y);
+            result.Z = Math.Max(a.Z, b.Z);
+            return result;
         }
 
         /// <summary>
@@ -373,9 +375,9 @@ namespace OpenTK.Mathematics
         /// <param name="result">The component-wise maximum.</param>
         public static void ComponentMax(in Vector3i a, in Vector3i b, out Vector3i result)
         {
-            result.X = a.X > b.X ? a.X : b.X;
-            result.Y = a.Y > b.Y ? a.Y : b.Y;
-            result.Z = a.Z > b.Z ? a.Z : b.Z;
+            result.X = Math.Max(a.X, b.X);
+            result.Y = Math.Max(a.Y, b.Y);
+            result.Z = Math.Max(a.Z, b.Z);
         }
 
         /// <summary>
@@ -388,10 +390,11 @@ namespace OpenTK.Mathematics
         [Pure]
         public static Vector3i Clamp(Vector3i vec, Vector3i min, Vector3i max)
         {
-            vec.X = MathHelper.Clamp(vec.X, min.X, max.X);
-            vec.Y = MathHelper.Clamp(vec.Y, min.Y, max.Y);
-            vec.Z = MathHelper.Clamp(vec.Z, min.Z, max.Z);
-            return vec;
+            Vector3i result;
+            result.X = MathHelper.Clamp(vec.X, min.X, max.X);
+            result.Y = MathHelper.Clamp(vec.Y, min.Y, max.Y);
+            result.Z = MathHelper.Clamp(vec.Z, min.Z, max.Z);
+            return result;
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Vector/Vector4i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4i.cs
@@ -459,11 +459,12 @@ namespace OpenTK.Mathematics
         [Pure]
         public static Vector4i Clamp(Vector4i vec, Vector4i min, Vector4i max)
         {
-            vec.X = MathHelper.Clamp(vec.X, min.X, max.X);
-            vec.Y = MathHelper.Clamp(vec.Y, min.Y, max.Y);
-            vec.Z = MathHelper.Clamp(vec.Z, min.Z, max.Z);
-            vec.W = MathHelper.Clamp(vec.W, min.W, max.W);
-            return vec;
+            Vector4i result;
+            result.X = MathHelper.Clamp(vec.X, min.X, max.X);
+            result.Y = MathHelper.Clamp(vec.Y, min.Y, max.Y);
+            result.Z = MathHelper.Clamp(vec.Z, min.Z, max.Z);
+            result.W = MathHelper.Clamp(vec.W, min.W, max.W);
+            return result;
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Vector/Vector4i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4i.cs
@@ -396,11 +396,12 @@ namespace OpenTK.Mathematics
         [Pure]
         public static Vector4i ComponentMin(Vector4i a, Vector4i b)
         {
-            a.X = a.X < b.X ? a.X : b.X;
-            a.Y = a.Y < b.Y ? a.Y : b.Y;
-            a.Z = a.Z < b.Z ? a.Z : b.Z;
-            a.W = a.W < b.W ? a.W : b.W;
-            return a;
+            Vector4i result;
+            result.X = Math.Min(a.X, b.X);
+            result.Y = Math.Min(a.Y, b.Y);
+            result.Z = Math.Min(a.Z, b.Z);
+            result.W = Math.Min(a.W, b.W);
+            return result;
         }
 
         /// <summary>
@@ -411,10 +412,10 @@ namespace OpenTK.Mathematics
         /// <param name="result">The component-wise minimum.</param>
         public static void ComponentMin(in Vector4i a, in Vector4i b, out Vector4i result)
         {
-            result.X = a.X < b.X ? a.X : b.X;
-            result.Y = a.Y < b.Y ? a.Y : b.Y;
-            result.Z = a.Z < b.Z ? a.Z : b.Z;
-            result.W = a.W < b.W ? a.W : b.W;
+            result.X = Math.Min(a.X, b.X);
+            result.Y = Math.Min(a.Y, b.Y);
+            result.Z = Math.Min(a.Z, b.Z);
+            result.W = Math.Min(a.W, b.W);
         }
 
         /// <summary>
@@ -426,11 +427,12 @@ namespace OpenTK.Mathematics
         [Pure]
         public static Vector4i ComponentMax(Vector4i a, Vector4i b)
         {
-            a.X = a.X > b.X ? a.X : b.X;
-            a.Y = a.Y > b.Y ? a.Y : b.Y;
-            a.Z = a.Z > b.Z ? a.Z : b.Z;
-            a.W = a.W > b.W ? a.W : b.W;
-            return a;
+            Vector4i result;
+            result.X = Math.Max(a.X, b.X);
+            result.Y = Math.Max(a.Y, b.Y);
+            result.Z = Math.Max(a.Z, b.Z);
+            result.W = Math.Max(a.W, b.W);
+            return result;
         }
 
         /// <summary>
@@ -441,10 +443,10 @@ namespace OpenTK.Mathematics
         /// <param name="result">The component-wise maximum.</param>
         public static void ComponentMax(in Vector4i a, in Vector4i b, out Vector4i result)
         {
-            result.X = a.X > b.X ? a.X : b.X;
-            result.Y = a.Y > b.Y ? a.Y : b.Y;
-            result.Z = a.Z > b.Z ? a.Z : b.Z;
-            result.W = a.W > b.W ? a.W : b.W;
+            result.X = Math.Max(a.X, b.X);
+            result.Y = Math.Max(a.Y, b.Y);
+            result.Z = Math.Max(a.Z, b.Z);
+            result.W = Math.Max(a.W, b.W);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #1325 

### Cleanup:

Switched `Vector3i/4i` to use `Math.Min/Max` for `ComponentMin/Max`.
A little bit of cleanup in Box2i and Box3i.

### Testing status

Tests pass (though they don't test `Box2i` and `Box3i`).