### PR TITLE
Problematic naming of Box2.Contains(Box2 other). Fixes Issue #1330.

### DIFF
--- a/src/OpenTK.Mathematics/Geometry/Box2.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box2.cs
@@ -154,15 +154,15 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
-        /// Returns whether the box contains the specified box (borders inclusive).
+        /// Returns whether the box completely contains the specified box (borders inclusive).
         /// </summary>
         /// <param name="other">The box to query.</param>
-        /// <returns>Whether this box contains the other box.</returns>
+        /// <returns>Whether this box completely contains the other box.</returns>
         [Pure]
         public bool Contains(Box2 other)
         {
-            return _max.X >= other._min.X && _min.X <= other._max.X &&
-                   _max.Y >= other._min.Y && _min.Y <= other._max.Y;
+            return _min.X <= other._min.X && other._max.X <= _max.X
+                && _min.Y <= other._min.Y && other._max.Y <= _max.Y;
         }
 
         /// <summary>
@@ -177,6 +177,18 @@ namespace OpenTK.Mathematics
                 Math.Max(0f, Math.Max(_min.X - point.X, point.X - _max.X)),
                 Math.Max(0f, Math.Max(_min.Y - point.Y, point.Y - _max.Y)));
             return distX.Length;
+        }
+
+        /// <summary>
+        /// Returns whether the box overlaps with the specified box (borders inclusive).
+        /// </summary>
+        /// <param name="other">The box to query.</param>
+        /// <returns>Whether this box overlaps with the other box.</returns>
+        [Pure]
+        public bool Overlaps(Box2 other)
+        {
+            return _max.X >= other._min.X && _min.X <= other._max.X &&
+                   _max.Y >= other._min.Y && _min.Y <= other._max.Y;
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Geometry/Box2d.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box2d.cs
@@ -154,15 +154,15 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
-        /// Returns whether the box contains the specified box (borders inclusive).
+        /// Returns whether the box completely contains the specified box (borders inclusive).
         /// </summary>
         /// <param name="other">The box to query.</param>
-        /// <returns>Whether this box contains the other box.</returns>
+        /// <returns>Whether this box completely contains the other box.</returns>
         [Pure]
         public bool Contains(Box2d other)
         {
-            return _max.X >= other._min.X && _min.X <= other._max.X &&
-                   _max.Y >= other._min.Y && _min.Y <= other._max.Y;
+            return _min.X <= other._min.X && other._max.X <= _max.X
+                && _min.Y <= other._min.Y && other._max.Y <= _max.Y;
         }
 
         /// <summary>
@@ -177,6 +177,18 @@ namespace OpenTK.Mathematics
                 Math.Max(0f, Math.Max(_min.X - point.X, point.X - _max.X)),
                 Math.Max(0f, Math.Max(_min.Y - point.Y, point.Y - _max.Y)));
             return distX.Length;
+        }
+
+        /// <summary>
+        /// Returns whether the box overlaps the specified box (borders inclusive).
+        /// </summary>
+        /// <param name="other">The box to query.</param>
+        /// <returns>Whether this box overlaps the other box.</returns>
+        [Pure]
+        public bool Overlaps(Box2d other)
+        {
+            return _max.X >= other._min.X && _min.X <= other._max.X &&
+                   _max.Y >= other._min.Y && _min.Y <= other._max.Y;
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Geometry/Box2i.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box2i.cs
@@ -145,15 +145,15 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
-        /// Returns whether the box contains the specified box (borders inclusive).
+        /// Returns whether the box completely contains the specified box (borders inclusive).
         /// </summary>
         /// <param name="other">The box to query.</param>
-        /// <returns>Whether this box contains the other box.</returns>
+        /// <returns>Whether this box completely contains the other box.</returns>
         [Pure]
         public bool Contains(Box2i other)
         {
-            return _max.X >= other._min.X && _min.X <= other._max.X &&
-                   _max.Y >= other._min.Y && _min.Y <= other._max.Y;
+            return _min.X <= other._min.X && other._max.X <= _max.X
+                && _min.Y <= other._min.Y && other._max.Y <= _max.Y;
         }
 
         /// <summary>
@@ -190,6 +190,18 @@ namespace OpenTK.Mathematics
                 Math.Max(0f, Math.Max(_min.X - point.X, point.X - _max.X)),
                 Math.Max(0f, Math.Max(_min.Y - point.Y, point.Y - _max.Y)));
             return dist.Length;
+        }
+
+        /// <summary>
+        /// Returns whether the box overlaps the specified box (borders inclusive).
+        /// </summary>
+        /// <param name="other">The box to query.</param>
+        /// <returns>Whether this box overlaps the other box.</returns>
+        [Pure]
+        public bool Overlaps(Box2i other)
+        {
+            return _max.X >= other._min.X && _min.X <= other._max.X &&
+                   _max.Y >= other._min.Y && _min.Y <= other._max.Y;
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Geometry/Box3.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box3.cs
@@ -167,16 +167,16 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
-        /// Returns whether the box contains the specified box (borders inclusive).
+        /// Returns whether the box completely contains the specified box (borders inclusive).
         /// </summary>
         /// <param name="other">The box to query.</param>
-        /// <returns>Whether this box contains the other box.</returns>
+        /// <returns>Whether this box completely contains the other box.</returns>
         [Pure]
         public bool Contains(Box3 other)
         {
-            return _max.X >= other._min.X && _min.X <= other._max.X &&
-                   _max.Y >= other._min.Y && _min.Y <= other._max.Y &&
-                   _max.Z >= other._min.Z && _min.Z <= other._max.Z;
+            return _min.X <= other._min.X && other._max.X <= _max.X
+                && _min.Y <= other._min.Y && other._max.Y <= _max.Y
+                && _min.Z <= other._min.Z && other._max.Z <= _max.Z;
         }
 
         /// <summary>
@@ -192,6 +192,19 @@ namespace OpenTK.Mathematics
                 Math.Max(0f, Math.Max(_min.Y - point.Y, point.Y - _max.Y)),
                 Math.Max(0f, Math.Max(_min.Z - point.Z, point.Z - _max.Z)));
             return distX.Length;
+        }
+
+        /// <summary>
+        /// Returns whether the box overlaps with the specified box (borders inclusive).
+        /// </summary>
+        /// <param name="other">The box to query.</param>
+        /// <returns>Whether this box overlaps with the other box.</returns>
+        [Pure]
+        public bool Overlaps(Box3 other)
+        {
+            return _max.X >= other._min.X && _min.X <= other._max.X &&
+                   _max.Y >= other._min.Y && _min.Y <= other._max.Y &&
+                   _max.Z >= other._min.Z && _min.Z <= other._max.Z;
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Geometry/Box3d.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box3d.cs
@@ -167,16 +167,16 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
-        /// Returns whether the box contains the specified box (borders inclusive).
+        /// Returns whether the box completely contains the specified box (borders inclusive).
         /// </summary>
         /// <param name="other">The box to query.</param>
-        /// <returns>Whether this box contains the other box.</returns>
+        /// <returns>Whether this box completely contains the other box.</returns>
         [Pure]
         public bool Contains(Box3d other)
         {
-            return _max.X >= other._min.X && _min.X <= other._max.X &&
-                   _max.Y >= other._min.Y && _min.Y <= other._max.Y &&
-                   _max.Z >= other._min.Z && _min.Z <= other._max.Z;
+            return _min.X <= other._min.X && other._max.X <= _max.X
+                && _min.Y <= other._min.Y && other._max.Y <= _max.Y
+                && _min.Z <= other._min.Z && other._max.Z <= _max.Z;
         }
 
         /// <summary>
@@ -192,6 +192,19 @@ namespace OpenTK.Mathematics
                 Math.Max(0f, Math.Max(_min.Y - point.Y, point.Y - _max.Y)),
                 Math.Max(0f, Math.Max(_min.Z - point.Z, point.Z - _max.Z)));
             return distX.Length;
+        }
+
+        /// <summary>
+        /// Returns whether the box overlaps with the specified box (borders inclusive).
+        /// </summary>
+        /// <param name="other">The box to query.</param>
+        /// <returns>Whether this box overlaps with the other box.</returns>
+        [Pure]
+        public bool Overlaps(Box3d other)
+        {
+            return _max.X >= other._min.X && _min.X <= other._max.X &&
+                   _max.Y >= other._min.Y && _min.Y <= other._max.Y &&
+                   _max.Z >= other._min.Z && _min.Z <= other._max.Z;
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Geometry/Box3i.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box3i.cs
@@ -150,16 +150,16 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
-        /// Returns whether the box contains the specified box (borders inclusive).
+        /// Returns whether the box completely contains the specified box (borders inclusive).
         /// </summary>
         /// <param name="other">The box to query.</param>
-        /// <returns>Whether this box contains the other box.</returns>
+        /// <returns>Whether this box completely contains the other box.</returns>
         [Pure]
         public bool Contains(Box3i other)
         {
-            return _max.X >= other._min.X && _min.X <= other._max.X &&
-                   _max.Y >= other._min.Y && _min.Y <= other._max.Y &&
-                   _max.Z >= other._min.Z && _min.Z <= other._max.Z;
+            return _min.X <= other._min.X && other._max.X <= _max.X
+                && _min.Y <= other._min.Y && other._max.Y <= _max.Y
+                && _min.Z <= other._min.Z && other._max.Z <= _max.Z;
         }
 
         /// <summary>
@@ -175,6 +175,19 @@ namespace OpenTK.Mathematics
                 Math.Max(0f, Math.Max(_min.Y - point.Y, point.Y - _max.Y)),
                 Math.Max(0f, Math.Max(_min.Z - point.Z, point.Z - _max.Z)));
             return dist.Length;
+        }
+
+        /// <summary>
+        /// Returns whether the box overlaps with the specified box (borders inclusive).
+        /// </summary>
+        /// <param name="other">The box to query.</param>
+        /// <returns>Whether this box overlaps with the other box.</returns>
+        [Pure]
+        public bool Overlaps(Box3i other)
+        {
+            return _max.X >= other._min.X && _min.X <= other._max.X &&
+                   _max.Y >= other._min.Y && _min.Y <= other._max.Y &&
+                   _max.Z >= other._min.Z && _min.Z <= other._max.Z;
         }
 
         /// <summary>

--- a/tests/OpenTK.Tests/Box2Tests.fs
+++ b/tests/OpenTK.Tests/Box2Tests.fs
@@ -190,8 +190,8 @@ module Box2 =
             Assert.Equal(c, b1.Contains(v1))
 
         [<Property>]
-        let ``Box2.Contains should only return true if the other box is partly within in the box`` (b1 : Box2, b2 : Box2) =
-            let c = b1.Min.X <= b2.Max.X && b1.Max.X >= b2.Min.X && b1.Min.Y <= b2.Max.Y && b1.Max.Y >= b2.Min.Y
+        let ``Box2.Contains should only return true if the other box is completely within in the box`` (b1 : Box2, b2 : Box2) =
+            let c = b1.Min.X <= b2.Min.X && b1.Max.X >= b2.Max.X && b1.Min.Y <= b2.Min.Y && b1.Max.Y >= b2.Max.Y
             
             Assert.Equal(c, b1.Contains(b2))
                 
@@ -212,3 +212,11 @@ module Box2 =
         let ``Any box should be equal to itself`` (b1 : Box2) =
             Assert.Equal(b1, b1)
             Assert.True(b1.Equals(b1))
+
+    [<Properties(Arbitrary = [|typeof<OpenTKGen>|])>]
+    module Overlaps =
+        [<Property>]
+        let ``Box2.Overlaps should only return true if the other box is partly within in the box`` (b1 : Box2, b2 : Box2) =
+            let c = b1.Min.X <= b2.Max.X && b1.Max.X >= b2.Min.X && b1.Min.Y <= b2.Max.Y && b1.Max.Y >= b2.Min.Y
+        
+            Assert.Equal(c, b1.Overlaps(b2))

--- a/tests/OpenTK.Tests/Box3Tests.fs
+++ b/tests/OpenTK.Tests/Box3Tests.fs
@@ -191,7 +191,7 @@ module Box3 =
 
         [<Property>]
         let ``Box3.Contains should only return true if the other box is partly within in the box`` (b1 : Box3, b2 : Box3) =
-            let c = b1.Min.X <= b2.Max.X && b1.Max.X >= b2.Min.X && b1.Min.Y <= b2.Max.Y && b1.Max.Y >= b2.Min.Y && b1.Min.Z <= b2.Max.Z && b1.Max.Z >= b2.Min.Z
+            let c = b1.Min.X <= b2.Min.X && b1.Max.X >= b2.Max.X && b1.Min.Y <= b2.Min.Y && b1.Max.Y >= b2.Max.Y && b1.Min.Z <= b2.Min.Z && b1.Max.Z >= b2.Max.Z
             
             Assert.Equal(c, b1.Contains(b2))
                 
@@ -212,3 +212,11 @@ module Box3 =
         let ``Any box should be equal to itself`` (b1 : Box3) =
             Assert.Equal(b1, b1)
             Assert.True(b1.Equals(b1))
+
+    [<Properties(Arbitrary = [|typeof<OpenTKGen>|])>]
+    module Overlaps =
+        [<Property>]
+        let ``Box3.Overlaps should only return true if the other box is partly within in the box`` (b1 : Box3, b2 : Box3) =
+            let c = b1.Min.X <= b2.Max.X && b1.Max.X >= b2.Min.X && b1.Min.Y <= b2.Max.Y && b1.Max.Y >= b2.Min.Y && b1.Min.Z <= b2.Max.Z && b1.Max.Z >= b2.Min.Z
+    
+            Assert.Equal(c, b1.Overlaps(b2))


### PR DESCRIPTION
### Purpose of this PR

Fixing the issue #1330 by changing `Box2.Contains(Box2 other)` to implement a "to have within"  or "superset" operation in the mathematical sense. The current code 
```C#
public bool Contains(Box2 other)
{
    return _max.X >= other._min.X && _min.X <= other._max.X &&
    _max.Y >= other._min.Y && _min.Y <= other._max.Y;
}
```
tests for overlap/intersection, so I will move it to a new `Box2.Overlaps(Box2 other)` method.

* This affects the Math part of OpenTK

### Testing status

* I will change the current tests regarding `Box2.Contains(Box2 other)` to test the new `Box2.Overlaps(Box2 other)` and include new unit test for the new `Box2.Contains(Box2 other)` code.
