### PR TITLE
Create no Context, when Context API = none

### DIFF
--- a/src/OpenTK.Windowing.Desktop/GameWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/GameWindow.cs
@@ -314,7 +314,12 @@ namespace OpenTK.Windowing.Desktop
         /// </summary>
         public virtual void SwapBuffers()
         {
-            Context?.SwapBuffers();
+            if (Context == null)
+            {
+                throw new InvalidOperationException("Cannot use SwapBuffers when running with ContextAPI.NoAPI.");
+            }
+
+            Context.SwapBuffers();
         }
 
         /// <inheritdoc />

--- a/src/OpenTK.Windowing.Desktop/GameWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/GameWindow.cs
@@ -206,7 +206,7 @@ namespace OpenTK.Windowing.Desktop
         public virtual unsafe void Run()
         {
             // Make sure that the gl contexts is current for OnLoad and the initial OnResize
-            Context.MakeCurrent();
+            Context?.MakeCurrent();
 
             // Send the OnLoad event, to load all user code.
             OnLoad();
@@ -218,7 +218,7 @@ namespace OpenTK.Windowing.Desktop
             if (IsMultiThreaded)
             {
                 // We want to move the context to the render thread so make sure it's no longer current
-                Context.MakeNoneCurrent();
+                Context?.MakeNoneCurrent();
 
                 _renderThread = new Thread(StartRenderThread);
                 _renderThread.Start();
@@ -242,7 +242,7 @@ namespace OpenTK.Windowing.Desktop
         {
             // If we are starting a render thread we want the context to be current there.
             // So when creating the render thread the graphics context needs to be made not current on the thread creating the render thread.
-            Context.MakeCurrent();
+            Context?.MakeCurrent();
 
             OnRenderThreadStarted();
             _watchRender.Start();
@@ -314,7 +314,7 @@ namespace OpenTK.Windowing.Desktop
         /// </summary>
         public virtual void SwapBuffers()
         {
-            Context.SwapBuffers();
+            Context?.SwapBuffers();
         }
 
         /// <inheritdoc />

--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -127,26 +127,34 @@ namespace OpenTK.Windowing.Desktop
         /// </value>
         public VSyncMode VSync
         {
-            get => _vSync;
+            get
+            {
+                if (Context == null)
+                {
+                    throw new InvalidOperationException("Cannot control vsync when running with ContextAPI.NoAPI.");
+                }
+
+                return _vSync;
+            }
 
             set
             {
-                // We don't do anything here for adaptive because that's handled in GameWindow.
-
-                if (Context != null)
+                if (Context == null)
                 {
-                    switch (value)
-                    {
-                        case VSyncMode.On:
-                            Context.SwapInterval = 1;
-                            break;
-
-                        case VSyncMode.Off:
-                            Context.SwapInterval = 0;
-                            break;
-                    }
+                    throw new InvalidOperationException("Cannot control vsync when running with ContextAPI.NoAPI.");
                 }
 
+                // We don't do anything here for adaptive because that's handled in GameWindow.
+                switch (value)
+                {
+                    case VSyncMode.On:
+                        Context.SwapInterval = 1;
+                        break;
+
+                    case VSyncMode.Off:
+                        Context.SwapInterval = 0;
+                        break;
+                }
                 _vSync = value;
             }
         }
@@ -1131,6 +1139,11 @@ namespace OpenTK.Windowing.Desktop
         /// </summary>
         public void MakeCurrent()
         {
+            if (Context == null)
+            {
+                throw new InvalidOperationException("Cannot make a context current when running with ContextAPI.NoAPI.");
+            }
+
             Context?.MakeCurrent();
         }
 

--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -132,15 +132,19 @@ namespace OpenTK.Windowing.Desktop
             set
             {
                 // We don't do anything here for adaptive because that's handled in GameWindow.
-                switch (value)
-                {
-                    case VSyncMode.On:
-                        Context.SwapInterval = 1;
-                        break;
 
-                    case VSyncMode.Off:
-                        Context.SwapInterval = 0;
-                        break;
+                if (Context != null)
+                {
+                    switch (value)
+                    {
+                        case VSyncMode.On:
+                            Context.SwapInterval = 1;
+                            break;
+
+                        case VSyncMode.Off:
+                            Context.SwapInterval = 0;
+                            break;
+                    }
                 }
 
                 _vSync = value;
@@ -723,13 +727,22 @@ namespace OpenTK.Windowing.Desktop
                 GLFW.WindowHint(WindowHintInt.StencilBits, settings.StencilBits.Value);
             }
 
-            Context = new GLFWGraphicsContext(WindowPtr);
+            // For Vulkan, we need to pass ContextAPI.NoAPI, otherweise we will get an exception.
+            // See https://github.com/glfw/glfw/blob/56a4cb0a3a2c7a44a2fd8ab3335adf915e19d30c/src/vulkan.c#L320
+            //
+            // But Calling MakeCurrent while using NoApi, we will get an exception from GLFW,
+            // because Vulkan does not have that concept.
+            // See https://github.com/glfw/glfw/blob/fd79b02840a36b74e4289cc53dc332de6403b8fd/src/context.c#L618
+            if (settings.API != ContextAPI.NoAPI)
+            {
+                Context = new GLFWGraphicsContext(WindowPtr);
+            }
 
             Exists = true;
 
             if (isOpenGl)
             {
-                Context.MakeCurrent();
+                Context?.MakeCurrent();
 
                 if (settings.AutoLoadBindings)
                 {
@@ -1118,7 +1131,7 @@ namespace OpenTK.Windowing.Desktop
         /// </summary>
         public void MakeCurrent()
         {
-            Context.MakeCurrent();
+            Context?.MakeCurrent();
         }
 
         /// <summary>


### PR DESCRIPTION
### Purpose of this PR

For Vulkan, we need to pass `ContextAPI.NoAPI`, otherweise we will get an exception when calling `CreateWindowSurface`:
See https://github.com/glfw/glfw/blob/56a4cb0a3a2c7a44a2fd8ab3335adf915e19d30c/src/vulkan.c#L320

But Calling `MakeCurrent` while using `NoApi`, we will get an exception from GLFW, because Vulkan does not have that concept.
See https://github.com/glfw/glfw/blob/fd79b02840a36b74e4289cc53dc332de6403b8fd/src/context.c#L618

### Testing status

Tested by bypassing `MakeCurrent` by overriding the Run-Method:
https://github.com/AximoGames/VulkanTest/blob/45c20e941663a58753716e8b229daf95795c9f57/VulkanTest/Application.cs#L18