### PR TITLE
[WIP] More box rework

### DIFF
--- a/src/OpenTK.Mathematics/Geometry/Box2.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box2.cs
@@ -158,109 +158,54 @@ namespace OpenTK.Mathematics
         // --
 
         /// <summary>
-        /// Gets or sets the width of the box.
-        /// </summary>
-        public float Width
-        {
-            get => _max.X - _min.X;
-            set => _max.X = _min.X + value;
-        }
-
-        /// <summary>
-        /// Gets or sets the height of the box.
-        /// </summary>
-        public float Height
-        {
-            get => _max.Y - _min.Y;
-            set => _max.Y = _min.Y + value;
-        }
-
-        /// <summary>
         /// Gets or sets the left location of the box.
+        /// This is equivalent to <c>Min.X</c>.
         /// </summary>
         public float Left
         {
-            get => _min.X;
-            set => _min.X = value;
+            get => Min.X;
+            set => Min.X = value;
         }
 
         /// <summary>
         /// Gets or sets the top location of the box.
+        /// This is equivalent to <c>Min.Y</c>.
         /// </summary>
         public float Top
         {
-            get => _min.Y;
-            set => _min.Y = value;
+            get => Min.Y;
+            set => Min.Y = value;
         }
 
         /// <summary>
         /// Gets or sets the right location of the box.
+        /// This is equivalent to <c>Max.X</c>.
         /// </summary>
         public float Right
         {
-            get => _max.X;
-            set => _max.X = value;
+            get => Max.X;
+            set => Max.X = value;
         }
 
         /// <summary>
         /// Gets or sets the bottom location of the box.
+        /// This is equivalent to <c>Max.Y</c>.
         /// </summary>
         public float Bottom
         {
-            get => _max.Y;
-            set => _max.Y = value;
-        }
-
-        /// <summary>
-        /// Gets or sets the X location of the box.
-        /// </summary>
-        public float X
-        {
-            get => _min.X;
-            set => _min.X = value;
-        }
-
-        /// <summary>
-        /// Gets or sets the Y location of the box.
-        /// </summary>
-        public float Y
-        {
-            get => _min.Y;
-            set => _min.Y = value;
-        }
-
-        /// <summary>
-        /// Gets or sets the horizontal size.
-        /// </summary>
-        public float SizeX
-        {
-            get => _max.X - _min.X;
-            set => _max.X = _min.X + value;
-        }
-
-        /// <summary>
-        /// Gets or sets the vertical size.
-        /// </summary>
-        public float SizeY
-        {
-            get => _max.Y - _min.Y;
-            set => _max.Y = _min.Y + value;
+            get => Max.Y;
+            set => Max.Y = value;
         }
 
         /// <summary>
         /// Gets the location of the box.
         /// </summary>
-        public Vector2 Location => _min;
+        public Vector2 Location => Min;
 
         /// <summary>
         /// Gets a value indicating whether all values are zero.
         /// </summary>
-        public bool IsZero => _min.X == 0 && _min.Y == 0 && _max.X == 0 && _max.Y == 0;
-
-        /// <summary>
-        /// Gets a box with all components zero.
-        /// </summary>
-        public static readonly Box2 Empty = new Box2(0, 0, 0, 0);
+        public bool IsZero => Min == Vector2.Zero && Max == Vector2.Zero;
 
         /// <summary>
         /// Gets a box with a location 0,0 with the a size of 1.
@@ -268,7 +213,7 @@ namespace OpenTK.Mathematics
         public static readonly Box2 UnitSquare = new Box2(0, 0, 1, 1);
 
         /// <summary>
-        /// Creates a box.
+        /// Creates a box from a location and size.
         /// </summary>
         /// <param name="location">The location of the box.</param>
         /// <param name="size">The size of the box.</param>
@@ -281,8 +226,8 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Box2"/> struct.
         /// </summary>
-        /// <param name="min">The minimum point on the XY plane this box encloses.</param>
-        /// <param name="max">The maximum point on the XY plane this box encloses.</param>
+        /// <param name="min">The minimum point this box encloses.</param>
+        /// <param name="max">The maximum point this box encloses.</param>
         /// <returns>A box.</returns>
         public static Box2 FromPositions(Vector2 min, Vector2 max)
         {
@@ -303,47 +248,44 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
-        /// Replaces this Box with the intersection of itself and the specified Box.
+        /// Replaces this Box with the intersection of itself and the specified Box or <see cref="Empty"/> if the boxes do not intersect.
         /// </summary>
         /// <param name="other">The Box with which to intersect.</param>
         public void Intersect(Box2 other)
         {
-            Box2 result = Intersect(other, this);
-
-            X = result.X;
-            Y = result.Y;
-            Width = result.Width;
-            Height = result.Height;
+            this = Intersect(this, other);
         }
 
         /// <summary>
-        /// Returns the intersection of two Boxes.
+        /// Returns the intersection of two Boxes or <see cref="Empty"/> if the boxes do not intersect.
         /// </summary>
         /// <param name="a">The first box.</param>
         /// <param name="b">The second box.</param>
         /// <returns>The intersection of two Boxes.</returns>
         public static Box2 Intersect(Box2 a, Box2 b)
         {
-            float minX = a._min.X > b._min.X ? a._min.X : b._min.X;
-            float minY = a._min.Y > b._min.Y ? a._min.Y : b._min.Y;
-            float maxX = a._max.X < b._max.X ? a._max.X : b._max.X;
-            float maxY = a._max.Y < b._max.Y ? a._max.Y : b._max.Y;
+            Box2 result;
+            result.Min = Vector2.ComponentMax(a.Min, b.Min);
+            result.Max = Vector2.ComponentMin(a.Max, b.Max);
 
-            if (maxX >= minX && maxY >= minY)
+            if (result.Max.X >= result.Min.X && result.Max.Y >= result.Min.Y)
             {
-                return new Box2(minX, minY, maxX, maxY);
+                return result;
             }
-            return Box2.Empty;
+            else
+            {
+                return Box2.Empty;
+            }
         }
 
         /// <summary>
-        /// Returns the intersection of itself and the specified Box.
+        /// Returns the intersection of itself and the specified Box or <see cref="Empty"/> if the boxes do not intersect.
         /// </summary>
         /// <param name="other">The Box with which to intersect.</param>
         /// <returns>The intersection of itself and the specified Box.</returns>
         public Box2 Intersected(Box2 other)
         {
-            return Intersect(other, this);
+            return Intersect(this, other);
         }
 
         /// <summary>
@@ -353,10 +295,10 @@ namespace OpenTK.Mathematics
         /// <returns>This method returns true if there is any intersection, otherwise false.</returns>
         public bool IntersectsWith(Box2 other)
         {
-            return other._min.X < _max.X
-                && _min.X < other._max.X
-                && other._min.Y < _max.Y
-                && _min.Y < other._max.Y;
+            return other.Min.X < Max.X
+                && Min.X < other.Max.X
+                && other.Min.Y < Max.Y
+                && Min.Y < other.Max.Y;
         }
 
         /// <summary>
@@ -366,10 +308,10 @@ namespace OpenTK.Mathematics
         /// <returns>This method returns true if there is any intersection or touches, otherwise false.</returns>
         public bool TouchWith(Box2 other)
         {
-            return other._min.X <= _max.X
-                && _min.X <= other._max.X
-                && other._min.Y <= _max.Y
-                && _min.Y <= other._max.Y;
+            return other.Min.X <= Max.X
+                && Min.X <= other.Max.X
+                && other.Min.Y <= Max.Y
+                && Min.Y <= other.Max.Y;
         }
 
         /// <summary>
@@ -380,10 +322,8 @@ namespace OpenTK.Mathematics
         public static Box2i Round(Box2 value)
         {
             return new Box2i(
-                (int)MathHelper.Round(value.Min.X),
-                (int)MathHelper.Round(value.Min.Y),
-                (int)MathHelper.Round(value.Max.X),
-                (int)MathHelper.Round(value.Max.Y));
+                Vector2.Round(value.Min),
+                Vector2.Round(value.Max));
         }
 
         /// <summary>
@@ -393,12 +333,9 @@ namespace OpenTK.Mathematics
         /// <returns>A Box structure that contains rounded up integers.</returns>
         public static Box2i Ceiling(Box2 value)
         {
-            int x = (int)MathHelper.Ceiling(value._min.X);
-            int y = (int)MathHelper.Ceiling(value._min.Y);
-            int sizeX = (int)MathHelper.Ceiling(value.Width);
-            int sizeY = (int)MathHelper.Ceiling(value.Height);
-
-            return new Box2i(x, y, x + sizeX, y + sizeY);
+            return new Box2i(
+                Vector2.Ceiling(value.Min),
+                Vector2.Ceiling(value.Max));
         }
 
         /// <summary>
@@ -408,12 +345,9 @@ namespace OpenTK.Mathematics
         /// <returns>A Box structure that contains rounded down integers.</returns>
         public static Box2i Floor(Box2 value)
         {
-            int x = (int)MathHelper.Floor(value._min.X);
-            int y = (int)MathHelper.Floor(value._min.Y);
-            int sizeX = (int)MathHelper.Floor(value.Width);
-            int sizeY = (int)MathHelper.Floor(value.Height);
-
-            return new Box2i(x, y, x + sizeX, y + sizeY);
+            return new Box2i(
+                Vector2.Floor(value.Min),
+                Vector2.Floor(value.Max));
         }
 
         // --
@@ -446,8 +380,11 @@ namespace OpenTK.Mathematics
                 return Min.X <= point.X && point.X <= Max.X &&
                        Min.Y <= point.Y && point.Y <= Max.Y;
             }
-            return Min.X < point.X && point.X < Max.X &&
+            else
+            {
+                return Min.X < point.X && point.X < Max.X &&
                    Min.Y < point.Y && point.Y < Max.Y;
+            }
         }
 
         /// <summary>
@@ -532,10 +469,10 @@ namespace OpenTK.Mathematics
         [Pure]
         public float DistanceToNearestEdge(Vector2 point)
         {
-            var distX = new Vector2(
-                Math.Max(0f, Math.Max(Min.X - point.X, point.X - Max.X)),
-                Math.Max(0f, Math.Max(Min.Y - point.Y, point.Y - Max.Y)));
-            return distX.Length;
+            Vector2 dist = Vector2.ComponentMax(
+                Vector2.Zero,
+                Vector2.ComponentMax(Min - point, point - Max));
+            return dist.Length;
         }
 
         /// <summary>
@@ -546,10 +483,35 @@ namespace OpenTK.Mathematics
         /// <returns>The distance between the specified point and the nearest edge.</returns>
         public static float DistanceToNearestEdge(in Box2 box, Vector2 point)
         {
-            var distX = new Vector2(
-                   Math.Max(0f, Math.Max(box.Min.X - point.X, point.X - box.Max.X)),
-                   Math.Max(0f, Math.Max(box.Min.Y - point.Y, point.Y - box.Max.Y)));
-            return distX.Length;
+            Vector2 dist = Vector2.ComponentMax(
+               Vector2.Zero,
+               Vector2.ComponentMax(box.Min - point, point - box.Max));
+            return dist.Length;
+        }
+
+        /// <summary>
+        /// Finds the closest point on the box to a point.
+        /// If the point is inside the box the same point is returned.
+        /// </summary>
+        /// <param name="point">The point to find the closest point for.</param>
+        /// <returns>The distance between the specified point and the nearest edge.</returns>
+        [Pure]
+        public Vector2 ClosestPoint(Vector2 point)
+        {
+            return Vector2.Clamp(point, Min, Max);
+        }
+
+        /// <summary>
+        /// Finds the closest point on the box to a point.
+        /// If the point is inside the box the same point is returned.
+        /// </summary>
+        /// <param name="box">The box to find the closest point on.</param>
+        /// <param name="point">The point to find the closest point for.</param>
+        /// <returns>The distance between the specified point and the nearest edge.</returns>
+        [Pure]
+        public static Vector2 ClosestPoint(in Box2 box, Vector2 point)
+        {
+            return Vector2.Clamp(point, box.Min, box.Max);
         }
 
         /// <summary>
@@ -689,7 +651,6 @@ namespace OpenTK.Mathematics
         /// <param name="result">The unioned box.</param>
         public static void Union(in Box2 a, in Box2 b, out Box2 result)
         {
-            Vector2.ComponentMin(a.Min, b.Min, out result.Min);
             result.Min = Vector2.ComponentMin(a.Min, b.Min);
             result.Max = Vector2.ComponentMax(a.Max, b.Max);
         }
@@ -702,12 +663,10 @@ namespace OpenTK.Mathematics
         /// <returns>A Box structure that bounds the union of the two Box structures.</returns>
         public static Box2 Union(Box2 a, Box2 b)
         {
-            float minX = a._min.X < b._min.X ? a._min.X : b._min.X;
-            float minY = a._min.Y < b._min.Y ? a._min.Y : b._min.Y;
-            float maxX = a._max.X > b._max.X ? a._max.X : b._max.X;
-            float maxY = a._max.Y > b._max.Y ? a._max.Y : b._max.Y;
-
-            return new Box2(minX, minY, maxX, maxY);
+            Box2 result;
+            result.Min = Vector2.ComponentMin(a.Min, b.Min);
+            result.Max = Vector2.ComponentMax(a.Max, b.Max);
+            return result;
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Geometry/Box2.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box2.cs
@@ -20,51 +20,25 @@ namespace OpenTK.Mathematics
     [StructLayout(LayoutKind.Sequential)]
     public struct Box2 : IEquatable<Box2>
     {
-        private Vector2 _min;
+        /// <summary>
+        /// An empty box with Min (0, 0) and Max (0, 0).
+        /// </summary>
+        public static readonly Box2 Empty = new Box2(0, 0, 0, 0);
 
         /// <summary>
-        /// Gets or sets the minimum boundary of the structure.
+        /// A unit square with Min (0, 0) and Max (1, 1).
         /// </summary>
-        public Vector2 Min
-        {
-            get => _min;
-            set
-            {
-                if (value.X > _max.X)
-                {
-                    _max.X = value.X;
-                }
-                if (value.Y > _max.Y)
-                {
-                    _max.Y = value.Y;
-                }
-
-                _min = value;
-            }
-        }
-
-        private Vector2 _max;
+        public static readonly Box2 UnitBox = new Box2(0, 0, 1, 1);
 
         /// <summary>
-        /// Gets or sets the maximum boundary of the structure.
+        /// The minimum boundary of the structure. The user is responsible for keeping Max >= Min.
         /// </summary>
-        public Vector2 Max
-        {
-            get => _max;
-            set
-            {
-                if (value.X < _min.X)
-                {
-                    _min.X = value.X;
-                }
-                if (value.Y < _min.Y)
-                {
-                    _min.Y = value.Y;
-                }
+        public Vector2 Min;
 
-                _max = value;
-            }
-        }
+        /// <summary>
+        /// The minimum boundary of the structure. The user is responsible for keeping Min &lt;= Max.
+        /// </summary>
+        public Vector2 Max;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Box2"/> struct.
@@ -73,8 +47,8 @@ namespace OpenTK.Mathematics
         /// <param name="max">The maximum point on the XY plane this box encloses.</param>
         public Box2(Vector2 min, Vector2 max)
         {
-            _min = Vector2.ComponentMin(min, max);
-            _max = Vector2.ComponentMax(min, max);
+            Min = min;
+            Max = max;
         }
 
         /// <summary>
@@ -85,12 +59,24 @@ namespace OpenTK.Mathematics
         /// <param name="maxX">The maximum X value to be enclosed.</param>
         /// <param name="maxY">The maximum Y value to be enclosed.</param>
         public Box2(float minX, float minY, float maxX, float maxY)
-            : this(new Vector2(minX, minY), new Vector2(maxX, maxY))
         {
+            Min = new Vector2(minX, minY);
+            Max = new Vector2(maxX, maxY);
         }
 
         /// <summary>
-        /// Gets or sets a vector describing the size of the Box2 structure.
+        /// Gets or sets the size of the Box2 structure.
+        /// Setting this value will expand/shrink the box while keeping Min at it's original value.
+        /// </summary>
+        public Vector2 Size
+        {
+            get => Max - Min;
+            set => Max = Min + value;
+        }
+
+        /// <summary>
+        /// Gets or sets the centered size of the Box2 structure.
+        /// This will change Min and Max while keeping their center at the same location.
         /// </summary>
         public Vector2 CenteredSize
         {
@@ -98,8 +84,56 @@ namespace OpenTK.Mathematics
             set
             {
                 Vector2 center = Center;
-                _min = center - (value * 0.5f);
-                _max = center + (value * 0.5f);
+                Min = center - (value * 0.5f);
+                Max = center + (value * 0.5f);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the width of the box.
+        /// Setting this value will expand/shrink the box while keeping Min.X at it's original value.
+        /// </summary>
+        public float Width
+        {
+            get => Max.X - Min.X;
+            set => Max.X = Min.X + value;
+        }
+
+        /// <summary>
+        /// Sets the centered width of the Box2 structure.
+        /// This will change Min.X and Max.X while keeping their center at the same location.
+        /// </summary>
+        public float CenteredWidth
+        {
+            set
+            {
+                float centerX = Center.X;
+                Min.X = centerX - value;
+                Max.X = centerX + value;
+            }
+        }
+
+        /// <summary>
+        /// Gets the height of the box.
+        /// Setting this value will expand/shrink the box while keeping Min.Y at it's original value.
+        /// </summary>
+        public float Height
+        {
+            get => Max.Y - Min.Y;
+            set => Max.Y = Min.Y + value;
+        }
+
+        /// <summary>
+        /// Sets the centered width of the Box2 structure.
+        /// This will change Min.X and Max.X while keeping their center at the same location.
+        /// </summary>
+        public float CenteredHeight
+        {
+            set
+            {
+                float centerX = Center.X;
+                Min.X = centerX - value;
+                Max.X = centerX + value;
             }
         }
 
@@ -117,7 +151,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public Vector2 Center
         {
-            get => HalfSize + _min;
+            get => HalfSize + Min;
             set => Translate(value - Center);
         }
 
@@ -211,19 +245,6 @@ namespace OpenTK.Mathematics
         {
             get => _max.Y - _min.Y;
             set => _max.Y = _min.Y + value;
-        }
-
-        /// <summary>
-        /// Gets or sets the size of the box.
-        /// </summary>
-        public Vector2 Size
-        {
-            get => new Vector2(_max.X - _min.X, _max.Y - _min.Y);
-            set
-            {
-                _max.X = _min.X + value.X;
-                _max.Y = _min.Y + value.Y;
-            }
         }
 
         /// <summary>
@@ -352,22 +373,6 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
-        /// Gets a Box structure that contains the union of two Box structures.
-        /// </summary>
-        /// <param name="a">A Box to union.</param>
-        /// <param name="b">a box to union.</param>
-        /// <returns>A Box structure that bounds the union of the two Box structures.</returns>
-        public static Box2 Union(Box2 a, Box2 b)
-        {
-            float minX = a._min.X < b._min.X ? a._min.X : b._min.X;
-            float minY = a._min.Y < b._min.Y ? a._min.Y : b._min.Y;
-            float maxX = a._max.X > b._max.X ? a._max.X : b._max.X;
-            float maxY = a._max.Y > b._max.Y ? a._max.Y : b._max.Y;
-
-            return new Box2(minX, minY, maxX, maxY);
-        }
-
-        /// <summary>
         /// Gets a Box structure that contains rounded integers.
         /// </summary>
         /// <param name="value">A Box to round.</param>
@@ -421,8 +426,8 @@ namespace OpenTK.Mathematics
         [Pure]
         public bool Contains(Vector2 point)
         {
-            return _min.X < point.X && point.X < _max.X &&
-                   _min.Y < point.Y && point.Y < _max.Y;
+            return Min.X < point.X && point.X < Max.X &&
+                   Min.Y < point.Y && point.Y < Max.Y;
         }
 
         /// <summary>
@@ -438,11 +443,11 @@ namespace OpenTK.Mathematics
         {
             if (boundaryInclusive)
             {
-                return _min.X <= point.X && point.X <= _max.X &&
-                       _min.Y <= point.Y && point.Y <= _max.Y;
+                return Min.X <= point.X && point.X <= Max.X &&
+                       Min.Y <= point.Y && point.Y <= Max.Y;
             }
-            return _min.X < point.X && point.X < _max.X &&
-                   _min.Y < point.Y && point.Y < _max.Y;
+            return Min.X < point.X && point.X < Max.X &&
+                   Min.Y < point.Y && point.Y < Max.Y;
         }
 
         /// <summary>
@@ -453,12 +458,74 @@ namespace OpenTK.Mathematics
         [Pure]
         public bool Contains(Box2 other)
         {
-            return _max.X >= other._min.X && _min.X <= other._max.X &&
-                   _max.Y >= other._min.Y && _min.Y <= other._max.Y;
+            return Contains(in this, in other);
         }
 
         /// <summary>
-        /// Returns the distance between the nearest edge and the specified point.
+        /// Checks if <paramref name="bigger"/> fully contains <paramref name="smaller"/> (inclusive bounds).
+        /// </summary>
+        /// <param name="bigger">The box to check contains the other box.</param>
+        /// <param name="smaller">The box to check if contained by the other box.</param>
+        /// <returns>If <paramref name="smaller"/> was fully contained in <paramref name="bigger"/>.</returns>
+        public static bool Contains(in Box2 bigger, in Box2 smaller)
+        {
+            return bigger.Min.X <= smaller.Min.X && bigger.Max.X >= smaller.Max.X &&
+                   bigger.Min.Y <= smaller.Min.Y && bigger.Max.Y >= smaller.Max.Y;
+        }
+
+        /// <summary>
+        /// <see cref="Touches(Box2)"/> for the same check with exclusive bounds.
+        /// </summary>
+        /// <param name="other">The box to test.</param>
+        /// <returns>Wether the box intersected this box.</returns>
+        public bool Intersects(Box2 other)
+        {
+            return Intersects(this, other);
+        }
+
+        /// <summary>
+        /// Checks if the boxes intersect not including the bounds.
+        /// <see cref="Touches(Box2, Box2)"/> for the same check with exclusive bounds.
+        /// </summary>
+        /// <param name="a">The first box to check intersection with.</param>
+        /// <param name="b">The second box to check intersection with.</param>
+        /// <returns>If the boxes intersected (excluding bounds).</returns>
+        public static bool Intersects(Box2 a, Box2 b)
+        {
+            return a.Min.X < b.Max.X &&
+                   b.Min.X < a.Max.X &&
+                   a.Min.Y < b.Max.Y &&
+                   b.Min.Y < a.Max.Y;
+        }
+
+        /// <summary>
+        /// Determines if this Box intersects or touches with another Box.
+        /// <see cref="Intersects(Box2)"/> for the same check with exclusive bounds.
+        /// </summary>
+        /// <param name="other">The Box to test.</param>
+        /// <returns>This method returns true if there is any intersection or touches, otherwise false.</returns>
+        public bool Touches(Box2 other)
+        {
+            return Touches(this, other);
+        }
+
+        /// <summary>
+        /// Determines if this Box intersects or touches with another Box.
+        /// <see cref="Intersects(Box2, Box2)"/> for the same check with exclusive bounds.
+        /// </summary>
+        /// <param name="a">asdf.</param>
+        /// <param name="b">aasdf.</param>
+        /// <returns>This method returns true if there is any intersection or touches, otherwise false.</returns>
+        public static bool Touches(Box2 a, Box2 b)
+        {
+            return a.Min.X <= b.Max.X &&
+                   b.Min.X <= a.Max.X &&
+                   a.Min.Y <= b.Max.Y &&
+                   b.Min.Y <= a.Max.Y;
+        }
+
+        /// <summary>
+        /// Get the distance to the nearset edge from a point.
         /// </summary>
         /// <param name="point">The point to find distance for.</param>
         /// <returns>The distance between the specified point and the nearest edge.</returns>
@@ -466,83 +533,181 @@ namespace OpenTK.Mathematics
         public float DistanceToNearestEdge(Vector2 point)
         {
             var distX = new Vector2(
-                Math.Max(0f, Math.Max(_min.X - point.X, point.X - _max.X)),
-                Math.Max(0f, Math.Max(_min.Y - point.Y, point.Y - _max.Y)));
+                Math.Max(0f, Math.Max(Min.X - point.X, point.X - Max.X)),
+                Math.Max(0f, Math.Max(Min.Y - point.Y, point.Y - Max.Y)));
             return distX.Length;
         }
 
         /// <summary>
-        /// Translates this Box2 by the given amount.
+        /// Get the distance to the nearset edge from a point.
         /// </summary>
-        /// <param name="distance">The distance to translate the box.</param>
-        public void Translate(Vector2 distance)
+        /// <param name="box">The box which edges to meeasure from.</param>
+        /// <param name="point">The point to find distance for.</param>
+        /// <returns>The distance between the specified point and the nearest edge.</returns>
+        public static float DistanceToNearestEdge(in Box2 box, Vector2 point)
         {
-            _min += distance;
-            _max += distance;
+            var distX = new Vector2(
+                   Math.Max(0f, Math.Max(box.Min.X - point.X, point.X - box.Max.X)),
+                   Math.Max(0f, Math.Max(box.Min.Y - point.Y, point.Y - box.Max.Y)));
+            return distX.Length;
         }
 
         /// <summary>
-        /// Returns a Box2 translated by the given amount.
+        /// Translate a Box2 by the given offset.
         /// </summary>
-        /// <param name="distance">The distance to translate the box.</param>
+        /// <param name="offset">The distance to translate the box.</param>
+        public void Translate(Vector2 offset)
+        {
+            Min += offset;
+            Max += offset;
+        }
+
+        /// <summary>
+        /// Translate a Box2 by the given offset.
+        /// </summary>
+        /// <param name="box">The box to translate.</param>
+        /// <param name="offset">The distance to translate the box.</param>
         /// <returns>The translated box.</returns>
         [Pure]
-        public Box2 Translated(Vector2 distance)
+        public static Box2 Translated(in Box2 box, Vector2 offset)
         {
-            // create a local copy of this box
-            Box2 box = this;
-            box.Translate(distance);
-            return box;
+            Translate(box, offset, out Box2 result);
+            return result;
+        }
+
+        /// <summary>
+        /// Translate a Box2 by the given offset.
+        /// </summary>
+        /// <param name="box">The box to translate.</param>
+        /// <param name="offset">The offset.</param>
+        /// <param name="result">The translated box.</param>
+        public static void Translate(in Box2 box, Vector2 offset, out Box2 result)
+        {
+            result.Min = box.Min + offset;
+            result.Max = box.Max + offset;
         }
 
         /// <summary>
         /// Scales this Box2 by the given amount.
         /// </summary>
-        /// <param name="scale">The scale to scale the box.</param>
-        /// <param name="anchor">The anchor to scale the box from.</param>
+        /// <param name="scale">The scale.</param>
+        /// <param name="anchor">The anchor to scale from.</param>
         public void Scale(Vector2 scale, Vector2 anchor)
         {
-            _min = anchor + ((_min - anchor) * scale);
-            _max = anchor + ((_max - anchor) * scale);
+            Min = anchor + ((Min - anchor) * scale);
+            Max = anchor + ((Max - anchor) * scale);
         }
 
         /// <summary>
         /// Returns a Box2 scaled by a given amount from an anchor point.
         /// </summary>
-        /// <param name="scale">The scale to scale the box.</param>
-        /// <param name="anchor">The anchor to scale the box from.</param>
+        /// <param name="scale">The scale.</param>
+        /// <param name="anchor">The anchor to scale from.</param>
         /// <returns>The scaled box.</returns>
         [Pure]
         public Box2 Scaled(Vector2 scale, Vector2 anchor)
         {
-            // create a local copy of this box
-            Box2 box = this;
-            box.Scale(scale, anchor);
-            return box;
+            Scale(this, scale, anchor, out Box2 result);
+            return result;
         }
 
         /// <summary>
-        /// Inflate this Box2 to encapsulate a given point.
+        /// Scale a box by a given amount from an anchor point.
         /// </summary>
-        /// <param name="point">The point to query.</param>
+        /// <param name="box">The box to scale.</param>
+        /// <param name="scale">The scale.</param>
+        /// <param name="anchor">The anchor to scale from.</param>
+        /// <param name="result">The scaled box.</param>
+        public static void Scale(in Box2 box, Vector2 scale, Vector2 anchor, out Box2 result)
+        {
+            result.Min = anchor + ((box.Min - anchor) * scale);
+            result.Max = anchor + ((box.Max - anchor) * scale);
+        }
+
+        /// <summary>
+        /// Inflate a Box2 to encapsulate a given point.
+        /// </summary>
+        /// <param name="point">The point to encapsulate.</param>
         public void Inflate(Vector2 point)
         {
-            _min = Vector2.ComponentMin(_min, point);
-            _max = Vector2.ComponentMax(_max, point);
+            Min = Vector2.ComponentMin(Min, point);
+            Max = Vector2.ComponentMax(Max, point);
         }
 
         /// <summary>
-        /// Inflate this Box2 to encapsulate a given point.
+        /// Inflate a Box2 to encapsulate a given point.
         /// </summary>
-        /// <param name="point">The point to query.</param>
+        /// <param name="point">The point to encapsulate.</param>
         /// <returns>The inflated box.</returns>
         [Pure]
         public Box2 Inflated(Vector2 point)
         {
-            // create a local copy of this box
-            Box2 box = this;
-            box.Inflate(point);
-            return box;
+            Inflate(this, point, out Box2 result);
+            return result;
+        }
+
+        /// <summary>
+        /// Inflate a Box2 to encapsulate a given point.
+        /// </summary>
+        /// <param name="box">The box to inflate.</param>
+        /// <param name="point">The point to encapsulate.</param>
+        /// <param name="result">The inflated box.</param>
+        public static void Inflate(in Box2 box, Vector2 point, out Box2 result)
+        {
+            result.Min = Vector2.ComponentMin(box.Min, point);
+            result.Max = Vector2.ComponentMax(box.Max, point);
+        }
+
+        /// <summary>
+        /// Union two boxes to get a box that contains both.
+        /// </summary>
+        /// <param name="other">TODO.</param>
+        public void Union(in Box2 other)
+        {
+            Min = Vector2.ComponentMin(Min, other.Min);
+            Max = Vector2.ComponentMax(Max, other.Max);
+        }
+
+        /// <summary>
+        /// Union two boxes to get a box that contains both.
+        /// </summary>
+        /// <param name="other">TODO.</param>
+        /// <returns>TODO2.</returns>
+        public Box2 Unioned(in Box2 other)
+        {
+            Box2 result;
+            result.Min = Vector2.ComponentMin(Min, other.Min);
+            result.Max = Vector2.ComponentMax(Max, other.Max);
+            return result;
+        }
+
+        /// <summary>
+        /// Union two boxes to get a box that contains both.
+        /// </summary>
+        /// <param name="a">The first box.</param>
+        /// <param name="b">The second box.</param>
+        /// <param name="result">The unioned box.</param>
+        public static void Union(in Box2 a, in Box2 b, out Box2 result)
+        {
+            Vector2.ComponentMin(a.Min, b.Min, out result.Min);
+            result.Min = Vector2.ComponentMin(a.Min, b.Min);
+            result.Max = Vector2.ComponentMax(a.Max, b.Max);
+        }
+
+        /// <summary>
+        /// Gets a Box structure that contains the union of two Box structures.
+        /// </summary>
+        /// <param name="a">A Box to union.</param>
+        /// <param name="b">a box to union.</param>
+        /// <returns>A Box structure that bounds the union of the two Box structures.</returns>
+        public static Box2 Union(Box2 a, Box2 b)
+        {
+            float minX = a._min.X < b._min.X ? a._min.X : b._min.X;
+            float minY = a._min.Y < b._min.Y ? a._min.Y : b._min.Y;
+            float maxX = a._max.X > b._max.X ? a._max.X : b._max.X;
+            float maxY = a._max.Y > b._max.Y ? a._max.Y : b._max.Y;
+
+            return new Box2(minX, minY, maxX, maxY);
         }
 
         /// <summary>
@@ -574,14 +739,14 @@ namespace OpenTK.Mathematics
         /// <inheritdoc/>
         public bool Equals(Box2 other)
         {
-            return _min.Equals(other._min) &&
-                   _max.Equals(other._max);
+            return Min.Equals(other.Min) &&
+                   Max.Equals(other.Max);
         }
 
         /// <inheritdoc/>
         public override int GetHashCode()
         {
-            return HashCode.Combine(_min, _max);
+            return HashCode.Combine(Min, Max);
         }
 
         /// <inheritdoc/>

--- a/src/OpenTK.Mathematics/MathHelper.cs
+++ b/src/OpenTK.Mathematics/MathHelper.cs
@@ -11,6 +11,11 @@ using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
 using System.Globalization;
 
+#if NETCOREAPP3_1_OR_GREATER
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+#endif
+
 namespace OpenTK.Mathematics
 {
     /// <summary>
@@ -122,7 +127,7 @@ namespace OpenTK.Mathematics
         /// <param name="n">A number that is greater than or equal to MinValue, but less than or equal to MaxValue.</param>
         /// <returns>A float number, x, such that 0 ≤ x ≤ MaxValue.</returns>
         [Pure]
-        public static float Abs(float n) => Math.Abs(n);
+        public static float Abs(float n) => MathF.Abs(n);
 
         /// <summary>
         /// Returns the sine of the specified angle.
@@ -409,7 +414,30 @@ namespace OpenTK.Mathematics
         /// <param name="b">The second of two floats to compare.</param>
         /// <returns>Parameter a or b, whichever is larger.</returns>
         [Pure]
-        public static float Max(float a, float b) => Math.Max(a, b);
+        public static float Max(float a, float b) => MathF.Max(a, b);
+
+        /// <summary>
+        /// Returns the larger of two float. This function tries to use hardware instrinsics to improve performance.
+        /// The guarantees for that happens with +0 and -0 might not be correct. ??
+        /// </summary>
+        /// <param name="a">The first of two floats to compare.</param>
+        /// <param name="b">The second of two floats to compare.</param>
+        /// <returns>Parameter a or b, whichever is larger.</returns>
+        public static float MaxFast(float a, float b)
+        {
+#if NETCOREAPP3_1_OR_GREATER
+
+            Vector128<float> va = Vector128.CreateScalarUnsafe(a);
+            Vector128<float> vb = Vector128.CreateScalarUnsafe(b);
+
+            var tmp1 = Sse.MaxScalar(va, vb);
+            var tmp2 = Sse.MaxScalar(vb, va);
+            var result = Sse.Or(tmp1, tmp2);
+            return result.ToScalar();
+#else
+            return MathF.Max(a, b);
+#endif
+        }
 
         /// <summary>
         /// Returns the larger of two longs.
@@ -499,7 +527,30 @@ namespace OpenTK.Mathematics
         /// <param name="b">The second of two floats to compare.</param>
         /// <returns>Parameter a or b, whichever is smaller.</returns>
         [Pure]
-        public static float Min(float a, float b) => Math.Min(a, b);
+        public static float Min(float a, float b) => MathF.Min(a, b);
+
+        /// <summary>
+        /// Returns the smaller of two floats.
+        /// </summary>
+        /// <param name="a">The first of two floats to compare.</param>
+        /// <param name="b">The second of two floats to compare.</param>
+        /// <returns>Parameter a or b, whichever is smaller.</returns>
+        [Pure]
+        public static float MinFast(float a, float b)
+        {
+#if NETCOREAPP3_1_OR_GREATER
+
+            Vector128<float> va = Vector128.CreateScalarUnsafe(a);
+            Vector128<float> vb = Vector128.CreateScalarUnsafe(b);
+
+            var tmp1 = Sse.MinScalar(va, vb);
+            var tmp2 = Sse.MinScalar(vb, va);
+            var result = Sse.Or(tmp1, tmp2);
+            return result.ToScalar();
+#else
+            return MathF.Min(a, b);
+#endif
+        }
 
         /// <summary>
         /// Returns the smaller of two floats.
@@ -662,7 +713,7 @@ namespace OpenTK.Mathematics
         /// <param name="d">A signed number.</param>
         /// <returns>If d ≤ -1 returns -1, if 1 ≤ d returns 1 and if d = 0 returns 0.</returns>
         [Pure]
-        public static int Sign(float d) => Math.Sign(d);
+        public static int Sign(float d) => MathF.Sign(d);
 
         /// <summary>
         /// Returns an integer that indicates the sign of a decimal.
@@ -918,7 +969,7 @@ namespace OpenTK.Mathematics
         [Pure]
         public static float Clamp(float n, float min, float max)
         {
-            return Math.Max(Math.Min(n, max), min);
+            return MathF.Max(MathF.Min(n, max), min);
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Vector/Vector2.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2.cs
@@ -373,9 +373,10 @@ namespace OpenTK.Mathematics
         [Pure]
         public static Vector2 ComponentMin(Vector2 a, Vector2 b)
         {
-            a.X = a.X < b.X ? a.X : b.X;
-            a.Y = a.Y < b.Y ? a.Y : b.Y;
-            return a;
+            Vector2 result;
+            result.X = MathHelper.MinFast(a.X, b.X);
+            result.Y = MathHelper.MinFast(a.Y, b.Y);
+            return result;
         }
 
         /// <summary>
@@ -386,8 +387,8 @@ namespace OpenTK.Mathematics
         /// <param name="result">The component-wise minimum.</param>
         public static void ComponentMin(in Vector2 a, in Vector2 b, out Vector2 result)
         {
-            result.X = a.X < b.X ? a.X : b.X;
-            result.Y = a.Y < b.Y ? a.Y : b.Y;
+            result.X = MathHelper.MinFast(a.X, b.X);
+            result.Y = MathHelper.MinFast(a.Y, b.Y);
         }
 
         /// <summary>
@@ -399,9 +400,10 @@ namespace OpenTK.Mathematics
         [Pure]
         public static Vector2 ComponentMax(Vector2 a, Vector2 b)
         {
-            a.X = a.X > b.X ? a.X : b.X;
-            a.Y = a.Y > b.Y ? a.Y : b.Y;
-            return a;
+            Vector2 result;
+            result.X = MathHelper.MaxFast(a.X, b.X);
+            result.Y = MathHelper.MaxFast(a.Y, b.Y);
+            return result;
         }
 
         /// <summary>
@@ -412,8 +414,8 @@ namespace OpenTK.Mathematics
         /// <param name="result">The component-wise maximum.</param>
         public static void ComponentMax(in Vector2 a, in Vector2 b, out Vector2 result)
         {
-            result.X = a.X > b.X ? a.X : b.X;
-            result.Y = a.Y > b.Y ? a.Y : b.Y;
+            result.X = MathHelper.MaxFast(a.X, b.X);
+            result.Y = MathHelper.MaxFast(a.Y, b.Y);
         }
 
         /// <summary>
@@ -794,6 +796,72 @@ namespace OpenTK.Mathematics
         {
             result.X = (mat.Row0.X * vec.X) + (mat.Row0.Y * vec.Y);
             result.Y = (mat.Row1.X * vec.X) + (mat.Row1.Y * vec.Y);
+        }
+
+        /// <summary>
+        /// Rounds a Vector2 to the closest Vector2i.
+        /// </summary>
+        /// <param name="vec">The vector to round.</param>
+        /// <returns>The rounded vector.</returns>
+        public static Vector2i Round(Vector2 vec)
+        {
+            Round(vec, out Vector2i result);
+            return result;
+        }
+
+        /// <summary>
+        /// Rounds a Vector2 to the closest Vector2i.
+        /// </summary>
+        /// <param name="vec">The vector to round.</param>
+        /// <param name="result">The rounded vector.</param>
+        public static void Round(Vector2 vec, out Vector2i result)
+        {
+            result.X = (int)MathHelper.Round(vec.X);
+            result.Y = (int)MathHelper.Round(vec.Y);
+        }
+
+        /// <summary>
+        /// Rounds a Vector2 up to a Vector2i.
+        /// </summary>
+        /// <param name="vec">The vector to ceil.</param>
+        /// <returns>The ceiled vector.</returns>
+        public static Vector2i Ceiling(Vector2 vec)
+        {
+            Ceiling(vec, out Vector2i result);
+            return result;
+        }
+
+        /// <summary>
+        /// Rounds a Vector2 up to a Vector2i.
+        /// </summary>
+        /// <param name="vec">The vector to ceil.</param>
+        /// <param name="result">The ceiled vector.</param>
+        public static void Ceiling(Vector2 vec, out Vector2i result)
+        {
+            result.X = (int)MathHelper.Ceiling(vec.X);
+            result.Y = (int)MathHelper.Ceiling(vec.Y);
+        }
+
+        /// <summary>
+        /// Rounds a Vector2 down to a Vector2i.
+        /// </summary>
+        /// <param name="vec">The vector to floor.</param>
+        /// <returns>The floored vector.</returns>
+        public static Vector2i Floor(Vector2 vec)
+        {
+            Floor(vec, out Vector2i result);
+            return result;
+        }
+
+        /// <summary>
+        /// Rounds a Vector2 down to a Vector2i.
+        /// </summary>
+        /// <param name="vec">The vector to floor.</param>
+        /// <param name="result">The floored vector.</param>
+        public static void Floor(Vector2 vec, out Vector2i result)
+        {
+            result.X = (int)MathHelper.Floor(vec.X);
+            result.Y = (int)MathHelper.Floor(vec.Y);
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Vector/Vector3.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3.cs
@@ -1201,6 +1201,75 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
+        /// Rounds a Vector3 to the closest Vector3i.
+        /// </summary>
+        /// <param name="vec">The vector to round.</param>
+        /// <returns>The rounded vector.</returns>
+        public static Vector3i Round(Vector3 vec)
+        {
+            Round(vec, out Vector3i result);
+            return result;
+        }
+
+        /// <summary>
+        /// Rounds a Vector3 to the closest Vector3i.
+        /// </summary>
+        /// <param name="vec">The vector to round.</param>
+        /// <param name="result">The rounded vector.</param>
+        public static void Round(in Vector3 vec, out Vector3i result)
+        {
+            result.X = (int)MathHelper.Round(vec.X);
+            result.Y = (int)MathHelper.Round(vec.Y);
+            result.Z = (int)MathHelper.Round(vec.Z);
+        }
+
+        /// <summary>
+        /// Rounds a Vector3 up to a Vector3i.
+        /// </summary>
+        /// <param name="vec">The vector to ceil.</param>
+        /// <returns>The ceiled vector.</returns>
+        public static Vector3i Ceiling(Vector3 vec)
+        {
+            Ceiling(vec, out Vector3i result);
+            return result;
+        }
+
+        /// <summary>
+        /// Rounds a Vector3 up to a Vector3i.
+        /// </summary>
+        /// <param name="vec">The vector to ceil.</param>
+        /// <param name="result">The ceiled vector.</param>
+        public static void Ceiling(in Vector3 vec, out Vector3i result)
+        {
+            result.X = (int)MathHelper.Ceiling(vec.X);
+            result.Y = (int)MathHelper.Ceiling(vec.Y);
+            result.Z = (int)MathHelper.Ceiling(vec.Z);
+        }
+
+        /// <summary>
+        /// Rounds a Vector3 down to a Vector3i.
+        /// </summary>
+        /// <param name="vec">The vector to floor.</param>
+        /// <returns>The floored vector.</returns>
+        public static Vector3i Floor(Vector3 vec)
+        {
+            Floor(vec, out Vector3i result);
+            return result;
+        }
+
+        /// <summary>
+        /// Rounds a Vector3 down to a Vector3i.
+        /// </summary>
+        /// <param name="vec">The vector to floor.</param>
+        /// <param name="result">The floored vector.</param>
+        public static void Floor(Vector3 vec, out Vector3i result)
+        {
+            result.X = (int)MathHelper.Floor(vec.X);
+            result.Y = (int)MathHelper.Floor(vec.Y);
+            result.Z = (int)MathHelper.Floor(vec.Z);
+        }
+
+        /// <summary>
         /// Gets or sets an OpenTK.Vector2 with the X and Y components of this instance.
         /// </summary>
         [XmlIgnore]

--- a/src/OpenTK.Mathematics/Vector/Vector4.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4.cs
@@ -859,6 +859,78 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
+        /// Rounds a Vector4 to the closest Vector4i.
+        /// </summary>
+        /// <param name="vec">The vector to round.</param>
+        /// <returns>The rounded vector.</returns>
+        public static Vector4i Round(Vector4 vec)
+        {
+            Round(vec, out Vector4i result);
+            return result;
+        }
+
+        /// <summary>
+        /// Rounds a Vector4 to the closest Vector4i.
+        /// </summary>
+        /// <param name="vec">The vector to round.</param>
+        /// <param name="result">The rounded vector.</param>
+        public static void Round(in Vector4 vec, out Vector4i result)
+        {
+            result.X = (int)MathHelper.Round(vec.X);
+            result.Y = (int)MathHelper.Round(vec.Y);
+            result.Z = (int)MathHelper.Round(vec.Z);
+            result.W = (int)MathHelper.Round(vec.W);
+        }
+
+        /// <summary>
+        /// Rounds a Vector4 up to a Vector4i.
+        /// </summary>
+        /// <param name="vec">The vector to ceil.</param>
+        /// <returns>The ceiled vector.</returns>
+        public static Vector4i Ceiling(Vector4 vec)
+        {
+            Ceiling(vec, out Vector4i result);
+            return result;
+        }
+
+        /// <summary>
+        /// Rounds a Vector4 up to a Vector4i.
+        /// </summary>
+        /// <param name="vec">The vector to ceil.</param>
+        /// <param name="result">The ceiled vector.</param>
+        public static void Ceiling(in Vector4 vec, out Vector4i result)
+        {
+            result.X = (int)MathHelper.Ceiling(vec.X);
+            result.Y = (int)MathHelper.Ceiling(vec.Y);
+            result.Z = (int)MathHelper.Ceiling(vec.Z);
+            result.W = (int)MathHelper.Ceiling(vec.W);
+        }
+
+        /// <summary>
+        /// Rounds a Vector4 down to a Vector4i.
+        /// </summary>
+        /// <param name="vec">The vector to floor.</param>
+        /// <returns>The floored vector.</returns>
+        public static Vector4i Floor(Vector4 vec)
+        {
+            Floor(vec, out Vector4i result);
+            return result;
+        }
+
+        /// <summary>
+        /// Rounds a Vector4 down to a Vector4i.
+        /// </summary>
+        /// <param name="vec">The vector to floor.</param>
+        /// <param name="result">The floored vector.</param>
+        public static void Floor(Vector4 vec, out Vector4i result)
+        {
+            result.X = (int)MathHelper.Floor(vec.X);
+            result.Y = (int)MathHelper.Floor(vec.Y);
+            result.Z = (int)MathHelper.Floor(vec.Z);
+            result.W = (int)MathHelper.Floor(vec.W);
+        }
+
+        /// <summary>
         /// Gets or sets an OpenTK.Vector2 with the X and Y components of this instance.
         /// </summary>
         [XmlIgnore]


### PR DESCRIPTION
### Purpose of this PR

This PR aims to complete the box rework that started in #1037 .
It adds more functions to boxes and optimizes some functions.

This PR also makes Min and Max raw public fields of the Box struct to fall in line more with other math types in OpenTK.

One notable addition is Nan preserving min/max operations. 
This is technically a breaking change for `Vector2.ComponentMin` and `Vector2.ComponentMax` but having them be NaN preserving should be the correct behavior.

TODO:
- [x] Box2
- [ ] Box2i
- [ ] Box3
- [ ] Box3i


This PR also adds `Round`, `Ceiling`, and `Floor` functions to `Vector2`, `Vector3`, and `Vector4`.

### Testing status

Current box unit-tests pass but these should be extended.
Before this PR is done the aim is to have some more unit tests.
