### PR TITLE
[WIP] Background context creation

### DIFF
--- a/src/OpenTK.Windowing.Desktop/BackgroundContext.cs
+++ b/src/OpenTK.Windowing.Desktop/BackgroundContext.cs
@@ -1,0 +1,109 @@
+﻿//
+// GameWindow.cs
+//
+// Copyright (C) 2018 OpenTK
+//
+// This software may be modified and distributed under the terms
+// of the MIT license. See the LICENSE file for details.
+//
+
+using System;
+using System.Reflection;
+using OpenTK.Windowing.Common;
+using OpenTK.Windowing.GraphicsLibraryFramework;
+
+namespace OpenTK.Windowing.Desktop
+{
+    public class BackgroundContext
+    {
+        private readonly unsafe Window* _window;
+
+        private static readonly GLFWCallbacks.ErrorCallback ErrorCallback =
+            (errorCode, description) => throw new GLFWException(description, errorCode);
+
+        public BackgroundContext(Version apiVersion, ContextAPI api, ContextProfile profile)
+        {
+            GLFW.Init();
+            GLFW.SetErrorCallback(ErrorCallback);
+
+            switch (api)
+            {
+                case ContextAPI.NoAPI:
+                    GLFW.WindowHint(WindowHintClientApi.ClientApi, ClientApi.NoApi);
+                    break;
+
+                case ContextAPI.OpenGLES:
+                    GLFW.WindowHint(WindowHintClientApi.ClientApi, ClientApi.OpenGlEsApi);
+                    break;
+
+                case ContextAPI.OpenGL:
+                    GLFW.WindowHint(WindowHintClientApi.ClientApi, ClientApi.OpenGlApi);
+                    break;
+
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+
+            GLFW.WindowHint(WindowHintInt.ContextVersionMajor, apiVersion.Major);
+            GLFW.WindowHint(WindowHintInt.ContextVersionMinor, apiVersion.Minor);
+            GLFW.WindowHint(WindowHintBool.Visible, false);
+            GLFW.WindowHint(WindowHintInt.Samples, 2);
+
+            switch (profile)
+            {
+                case ContextProfile.Any:
+                    GLFW.WindowHint(WindowHintOpenGlProfile.OpenGlProfile, OpenGlProfile.Any);
+                    break;
+                case ContextProfile.Compatability:
+                    GLFW.WindowHint(WindowHintOpenGlProfile.OpenGlProfile, OpenGlProfile.Compat);
+                    break;
+                case ContextProfile.Core:
+                    GLFW.WindowHint(WindowHintOpenGlProfile.OpenGlProfile, OpenGlProfile.Core);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+
+            GLFWGraphicsContext context;
+            unsafe
+            {
+                this._window = GLFW.CreateWindow(10, 10, string.Empty, null, (Window*)IntPtr.Zero);
+                context = new GLFWGraphicsContext(this._window);
+            }
+            context.MakeCurrent();
+            InitializeGlBindings();
+        }
+
+        public void Dispose()
+        {
+            unsafe
+            {
+                GLFW.DestroyWindow(this._window);
+            }
+        }
+
+        private static void InitializeGlBindings()
+        {
+            var assembly = Assembly.Load("OpenTK.Graphics");
+            var provider = new GLFWBindingsContext();
+
+            void LoadBindings(string typeNamespace)
+            {
+                var type = assembly.GetType($"OpenTK.Graphics.{typeNamespace}.GL");
+                if (type == null)
+                {
+                    return;
+                }
+
+                var load = type.GetMethod("LoadBindings");
+                load.Invoke(null, new object[] { provider });
+            }
+
+            LoadBindings("ES11");
+            LoadBindings("ES20");
+            LoadBindings("ES30");
+            LoadBindings("OpenGL");
+            LoadBindings("OpenGL4");
+        }
+    }
+}

--- a/src/OpenTK.Windowing.Desktop/BackgroundContext.cs
+++ b/src/OpenTK.Windowing.Desktop/BackgroundContext.cs
@@ -1,13 +1,4 @@
-﻿//
-// GameWindow.cs
-//
-// Copyright (C) 2018 OpenTK
-//
-// This software may be modified and distributed under the terms
-// of the MIT license. See the LICENSE file for details.
-//
-
-using System;
+﻿using System;
 using System.Reflection;
 using OpenTK.Windowing.Common;
 using OpenTK.Windowing.GraphicsLibraryFramework;


### PR DESCRIPTION
### Enable OpenTK to be used in backgound without a UI thread

* Since the classes `GameWindow` and `NativeWindow` check if they are created and disposed on an UI thread they can not be used for pure background functionality. In my application I only use OpenTK to render to a texture in background and then store that texture as a bitmap. With the `GameWindow` class I would have to make sure to hook into the UI thread for context creation and disposing which makes things very ugly.

* I already added a very similar class to my project and got it up and running, but since I think this might be useful for a lot of other developers I created this draft PR and will update this to a somewhat merge-ready state if it finds acceptance.

* Which part of OpenTK does this affect: Windowing
* Links to screenshots, design docs, user docs, etc.

### Testing status

* Explanation of what’s tested, how tested and existing or new automation tests.
* Can include manual testing by self.
* Specify test plans.
* Rarely acceptable to have no testing.

### Comments

* Any other comments to help understand the change.
