### PR TITLE
Fix IL generation for some edge case GLES functions.

### DIFF
--- a/src/Generator.Rewrite/Program.cs
+++ b/src/Generator.Rewrite/Program.cs
@@ -908,8 +908,6 @@ namespace OpenTK.Rewrite
                     il.Emit(OpCodes.Ldind_I4);
                 }
 
-                Console.WriteLine(method);
-
                 il.Emit(OpCodes.Stloc, countVariable.Index);
             }
             else

--- a/src/Generator.Rewrite/Program.cs
+++ b/src/Generator.Rewrite/Program.cs
@@ -848,15 +848,17 @@ namespace OpenTK.Rewrite
 
         private static object GetAttributeProperty(CustomAttribute attribute, string name)
         {
-            try
+            if (attribute.Properties.Count == 0) return null;
+
+            foreach (var property in attribute.Properties)
             {
-                var field = attribute.Properties.First(f => f.Name == name);
-                return field.Argument.Value;
+                if (property.Name == name)
+                {
+                    return property.Argument.Value;
+                }
             }
-            catch (InvalidOperationException)
-            {
-                return null;
-            }
+
+            return null;
         }
 
         private static CountAttribute GetCountAttribute(ParameterDefinition parameter)
@@ -905,6 +907,10 @@ namespace OpenTK.Rewrite
                 {
                     il.Emit(OpCodes.Ldind_I4);
                 }
+
+                Console.WriteLine(method);
+
+                il.Emit(OpCodes.Stloc, countVariable.Index);
             }
             else
             {


### PR DESCRIPTION
### Purpose of this PR

This PR fixes a IL generation issue where bad IL was generated for `glExtGetProgramBinarySourceQCOM`.
This issue was found in https://github.com/dotnet/runtime/issues/59138 where the AoT compiler didn't want to compile the function because there where more stuff on the stack than there was supposed to.
In reality this function was fundamentally broken and would not have worked when called, this PR fixes this.

This PR also modifies one function so that it doesn't throw exceptions that where then caught, hopefully improving performance of the rewriting step.

### Testing status

Builds.
The IL has been checked in ILSpy and it generates reasonable decompilation results compared to before these changes.

This code has now been put through the AOT compiler and it compiles as it should.

### Comments

The issue was that the modified function should have stored the result in a local variable and not leave anything on the stack. This is what all of the branches in this function where doing except in the case where the length parameter is a simple dereference.

#1286 is somewhat related to this fix.

Here follows a list of the overloads that are fixed by this change:
```
ES30.GL/Qcom::ExtGetProgramBinarySource(System.Int32,OpenTK.Graphics.ES30.All,System.String&,System.Int32[])
ES30.GL/Qcom::ExtGetProgramBinarySource(System.Int32,OpenTK.Graphics.ES30.All,System.String&,System.Int32&)
ES30.GL/Qcom::ExtGetProgramBinarySource(System.Int32,OpenTK.Graphics.ES30.All,System.String&,System.Int32*)
ES30.GL/Qcom::ExtGetProgramBinarySource(System.Int32,OpenTK.Graphics.ES30.ShaderType,System.String&,System.Int32[])
ES30.GL/Qcom::ExtGetProgramBinarySource(System.Int32,OpenTK.Graphics.ES30.ShaderType,System.String&,System.Int32&)
ES30.GL/Qcom::ExtGetProgramBinarySource(System.Int32,OpenTK.Graphics.ES30.ShaderType,System.String&,System.Int32*)
ES30.GL/Qcom::ExtGetProgramBinarySource(System.UInt32,OpenTK.Graphics.ES30.All,System.String&,System.Int32[])
ES30.GL/Qcom::ExtGetProgramBinarySource(System.UInt32,OpenTK.Graphics.ES30.All,System.String&,System.Int32&)
ES30.GL/Qcom::ExtGetProgramBinarySource(System.UInt32,OpenTK.Graphics.ES30.All,System.String&,System.Int32*)
ES30.GL/Qcom::ExtGetProgramBinarySource(System.UInt32,OpenTK.Graphics.ES30.ShaderType,System.String&,System.Int32[])
ES30.GL/Qcom::ExtGetProgramBinarySource(System.UInt32,OpenTK.Graphics.ES30.ShaderType,System.String&,System.Int32&)
ES30.GL/Qcom::ExtGetProgramBinarySource(System.UInt32,OpenTK.Graphics.ES30.ShaderType,System.String&,System.Int32*)
ES20.GL/Qcom::ExtGetProgramBinarySource(System.Int32,OpenTK.Graphics.ES20.All,System.String&,System.Int32[])
ES20.GL/Qcom::ExtGetProgramBinarySource(System.Int32,OpenTK.Graphics.ES20.All,System.String&,System.Int32&)
ES20.GL/Qcom::ExtGetProgramBinarySource(System.Int32,OpenTK.Graphics.ES20.All,System.String&,System.Int32*)
ES20.GL/Qcom::ExtGetProgramBinarySource(System.Int32,OpenTK.Graphics.ES20.ShaderType,System.String&,System.Int32[])
ES20.GL/Qcom::ExtGetProgramBinarySource(System.Int32,OpenTK.Graphics.ES20.ShaderType,System.String&,System.Int32&)
ES20.GL/Qcom::ExtGetProgramBinarySource(System.Int32,OpenTK.Graphics.ES20.ShaderType,System.String&,System.Int32*)
ES20.GL/Qcom::ExtGetProgramBinarySource(System.UInt32,OpenTK.Graphics.ES20.All,System.String&,System.Int32[])
ES20.GL/Qcom::ExtGetProgramBinarySource(System.UInt32,OpenTK.Graphics.ES20.All,System.String&,System.Int32&)
ES20.GL/Qcom::ExtGetProgramBinarySource(System.UInt32,OpenTK.Graphics.ES20.All,System.String&,System.Int32*)
ES20.GL/Qcom::ExtGetProgramBinarySource(System.UInt32,OpenTK.Graphics.ES20.ShaderType,System.String&,System.Int32[])
ES20.GL/Qcom::ExtGetProgramBinarySource(System.UInt32,OpenTK.Graphics.ES20.ShaderType,System.String&,System.Int32&)
ES20.GL/Qcom::ExtGetProgramBinarySource(System.UInt32,OpenTK.Graphics.ES20.ShaderType,System.String&,System.Int32*)
ES11.GL/Qcom::ExtGetProgramBinarySource(System.Int32,OpenTK.Graphics.ES11.All,System.String&,System.Int32[])
ES11.GL/Qcom::ExtGetProgramBinarySource(System.Int32,OpenTK.Graphics.ES11.All,System.String&,System.Int32&)
ES11.GL/Qcom::ExtGetProgramBinarySource(System.Int32,OpenTK.Graphics.ES11.All,System.String&,System.Int32*)
ES11.GL/Qcom::ExtGetProgramBinarySource(System.Int32,OpenTK.Graphics.ES11.ShaderType,System.String&,System.Int32[])
ES11.GL/Qcom::ExtGetProgramBinarySource(System.Int32,OpenTK.Graphics.ES11.ShaderType,System.String&,System.Int32&)
ES11.GL/Qcom::ExtGetProgramBinarySource(System.Int32,OpenTK.Graphics.ES11.ShaderType,System.String&,System.Int32*)
ES11.GL/Qcom::ExtGetProgramBinarySource(System.UInt32,OpenTK.Graphics.ES11.All,System.String&,System.Int32[])
ES11.GL/Qcom::ExtGetProgramBinarySource(System.UInt32,OpenTK.Graphics.ES11.All,System.String&,System.Int32&)
ES11.GL/Qcom::ExtGetProgramBinarySource(System.UInt32,OpenTK.Graphics.ES11.All,System.String&,System.Int32*)
ES11.GL/Qcom::ExtGetProgramBinarySource(System.UInt32,OpenTK.Graphics.ES11.ShaderType,System.String&,System.Int32[])
ES11.GL/Qcom::ExtGetProgramBinarySource(System.UInt32,OpenTK.Graphics.ES11.ShaderType,System.String&,System.Int32&)
ES11.GL/Qcom::ExtGetProgramBinarySource(System.UInt32,OpenTK.Graphics.ES11.ShaderType,System.String&,System.Int32*)
```