### PR TITLE
Added video mode information to MonitorInfo

### DIFF
--- a/src/OpenTK.Windowing.Desktop/MonitorInfo.cs
+++ b/src/OpenTK.Windowing.Desktop/MonitorInfo.cs
@@ -159,8 +159,6 @@ namespace OpenTK.Windowing.Desktop
             return *GLFW.GetVideoMode(HandleAsPtr);
         }
 
-
-
         /// <summary>
         /// Calculates dpi from a pixel count and a length in mm.
         /// </summary>

--- a/src/OpenTK.Windowing.Desktop/MonitorInfo.cs
+++ b/src/OpenTK.Windowing.Desktop/MonitorInfo.cs
@@ -32,6 +32,11 @@ namespace OpenTK.Windowing.Desktop
         public MonitorHandle Handle => _handle;
 
         /// <summary>
+        /// Human-readable name for this monitor. Not guaranteed to be unique among the connected monitors.
+        /// </summary>
+        public string Name { get; private set; }
+
+        /// <summary>
         /// Gets the client area of the monitor (in the virtual screen-space).
         /// </summary>
         public Box2i ClientArea { get; private set; }
@@ -113,6 +118,8 @@ namespace OpenTK.Windowing.Desktop
 
             _handle = handle;
 
+            Name = GLFW.GetMonitorName(HandleAsPtr);
+
             GLFW.GetMonitorPos(HandleAsPtr, out int x, out int y);
             var videoMode = GLFW.GetVideoMode(HandleAsPtr);
             ClientArea = new Box2i(x, y, x + videoMode->Width, y + videoMode->Height);
@@ -133,6 +140,26 @@ namespace OpenTK.Windowing.Desktop
             HorizontalRawDpi = CalculateDpi(HorizontalResolution, PhysicalWidth);
             VerticalRawDpi = CalculateDpi(VerticalResolution, PhysicalHeight);
         }
+
+        /// <summary>
+        /// Returns an array of supported video modes for this monitor.
+        /// </summary>
+        /// <returns>An array of supported video modes.</returns>
+        public VideoMode[] GetSupportedVideoModes()
+        {
+            return GLFW.GetVideoModes(HandleAsPtr);
+        }
+
+        /// <summary>
+        /// Returns the current VideoMode used by this monitor.
+        /// </summary>
+        /// <returns>The current video mode.</returns>
+        public unsafe VideoMode GetCurrentVideoMode()
+        {
+            return *GLFW.GetVideoMode(HandleAsPtr);
+        }
+
+
 
         /// <summary>
         /// Calculates dpi from a pixel count and a length in mm.

--- a/src/OpenTK.Windowing.Desktop/MonitorInfo.cs
+++ b/src/OpenTK.Windowing.Desktop/MonitorInfo.cs
@@ -42,6 +42,13 @@ namespace OpenTK.Windowing.Desktop
         public Box2i ClientArea { get; private set; }
 
         /// <summary>
+        /// Get the work area of the monitor.
+        /// The work area is defined as the area of the monitor not occluded by the operating system task bar where present.
+        /// If no task bar exists then the work area is the monitor resolution in screen coordinates.
+        /// </summary>
+        public Box2i WorkArea { get; private set; }
+
+        /// <summary>
         /// Gets the horizontal resolution of the monitor.
         /// </summary>
         public int HorizontalResolution => ClientArea.Size.X;
@@ -123,6 +130,9 @@ namespace OpenTK.Windowing.Desktop
             GLFW.GetMonitorPos(HandleAsPtr, out int x, out int y);
             var videoMode = GLFW.GetVideoMode(HandleAsPtr);
             ClientArea = new Box2i(x, y, x + videoMode->Width, y + videoMode->Height);
+
+            GLFW.GetMonitorWorkarea(HandleAsPtr, out int workAreaX, out int workAreaY, out int workAreaWidth, out int workAreaHeight);
+            WorkArea = new Box2i(workAreaX, workAreaY, workAreaWidth, workAreaHeight);
 
             GLFW.GetMonitorPhysicalSize(HandleAsPtr, out int width, out int height);
             PhysicalWidth = width;

--- a/src/OpenTK.Windowing.Desktop/MonitorInfo.cs
+++ b/src/OpenTK.Windowing.Desktop/MonitorInfo.cs
@@ -104,6 +104,21 @@ namespace OpenTK.Windowing.Desktop
         /// </remarks>
         public float VerticalRawDpi { get; private set; }
 
+        private VideoMode[] _supportedVideoModes;
+
+        /// <summary>
+        /// A list of supported video modes for this monitor.
+        /// </summary>
+        public System.Collections.Generic.IReadOnlyList<VideoMode> SupportedVideoModes
+        {
+            get => _supportedVideoModes;
+        }
+
+        /// <summary>
+        /// The current VideoMode used by this monitor.
+        /// </summary>
+        public VideoMode CurrentVideoMode { get; private set; }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="MonitorInfo"/> class.
         /// </summary>
@@ -149,24 +164,9 @@ namespace OpenTK.Windowing.Desktop
 
             HorizontalRawDpi = CalculateDpi(HorizontalResolution, PhysicalWidth);
             VerticalRawDpi = CalculateDpi(VerticalResolution, PhysicalHeight);
-        }
 
-        /// <summary>
-        /// Returns an array of supported video modes for this monitor.
-        /// </summary>
-        /// <returns>An array of supported video modes.</returns>
-        public VideoMode[] GetSupportedVideoModes()
-        {
-            return GLFW.GetVideoModes(HandleAsPtr);
-        }
-
-        /// <summary>
-        /// Returns the current VideoMode used by this monitor.
-        /// </summary>
-        /// <returns>The current video mode.</returns>
-        public unsafe VideoMode GetCurrentVideoMode()
-        {
-            return *GLFW.GetVideoMode(HandleAsPtr);
+            _supportedVideoModes = GLFW.GetVideoModes(HandleAsPtr);
+            CurrentVideoMode = *GLFW.GetVideoMode(HandleAsPtr);
         }
 
         /// <summary>

--- a/src/OpenTK.Windowing.Desktop/Monitors.cs
+++ b/src/OpenTK.Windowing.Desktop/Monitors.cs
@@ -75,6 +75,34 @@ namespace OpenTK.Windowing.Desktop
         }
 
         /// <summary>
+        /// Get the primary monitor. This is usually the monitor where elements like the task bar or global menu bar are located.
+        /// </summary>
+        /// <returns>The primary monitor.</returns>
+        public static unsafe MonitorInfo GetPrimaryMonitor()
+        {
+            MonitorHandle monitor = new MonitorHandle((IntPtr)GLFW.GetPrimaryMonitor());
+            return new MonitorInfo(monitor);
+        }
+
+        /// <summary>
+        /// Retrives a list of connected monitors.
+        /// </summary>
+        /// <returns>A list of connected monitors.</returns>
+        public static unsafe List<MonitorInfo> GetMonitors()
+        {
+            Monitor** monitorsRaw = GLFW.GetMonitorsRaw(out int count);
+
+            List<MonitorInfo> monitors = new List<MonitorInfo>(count);
+
+            for (int i = 0; i < count; i++)
+            {
+                monitors.Add(new MonitorInfo(new MonitorHandle((IntPtr)monitorsRaw[i])));
+            }
+
+            return monitors;
+        }
+
+        /// <summary>
         /// Find the monitor a window is in.
         /// </summary>
         /// <param name="window">The window to find.</param>
@@ -141,24 +169,6 @@ namespace OpenTK.Windowing.Desktop
         /// intersection area with the given monitor.
         /// </remarks>
         public static unsafe MonitorInfo GetMonitorFromWindow(NativeWindow window) => GetMonitorFromWindow(window.WindowPtr);
-
-        /// <summary>
-        /// Retrives a list of connected monitors.
-        /// </summary>
-        /// <returns>A list of connected monitors.</returns>
-        public static unsafe List<MonitorInfo> GetMonitors()
-        {
-            Monitor** monitorsRaw = GLFW.GetMonitorsRaw(out int count);
-
-            List<MonitorInfo> monitors = new List<MonitorInfo>(count);
-
-            for (int i = 0; i < count; i++)
-            {
-                monitors.Add(new MonitorInfo(new MonitorHandle((IntPtr)monitorsRaw[i])));
-            }
-
-            return monitors;
-        }
 
         private static unsafe void MonitorCallback(Monitor* monitor, ConnectedState state)
         {

--- a/src/OpenTK.Windowing.GraphicsLibraryFramework/GLFW.cs
+++ b/src/OpenTK.Windowing.GraphicsLibraryFramework/GLFW.cs
@@ -471,6 +471,75 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
 
         /// <summary>
         /// <para>
+        /// This function returns the position, in screen coordinates, of the upper-left corner of the work area of the specified monitor along with the work area size in screen coordinates.
+        /// The work area is defined as the area of the monitor not occluded by the operating system task bar where present.
+        /// If no task bar exists then the work area is the monitor resolution in screen coordinates.
+        /// </para>
+        /// <para>
+        /// Any or all of the position and size arguments may be NULL.If an error occurs, all non-NULL position and size arguments will be set to zero.
+        /// </para>
+        /// </summary>
+        /// <param name="monitor">The monitor to query.</param>
+        /// <param name="x">Where to store the monitor x-coordinate.</param>
+        /// <param name="y">Where to store the monitor y-coordinate.</param>
+        /// <param name="width">Where to store the monitor width.</param>
+        /// <param name="height">Where to store the monitor height.</param>
+        /// <remarks>
+        /// <para>
+        /// This function must only be called from the main thread.
+        /// </para>
+        /// <para>
+        /// Possible errors include GLFW_NOT_INITIALIZED and GLFW_PLATFORM_ERROR.
+        /// </para>
+        /// <para>
+        /// Added in version GLFW 3.3.
+        /// </para>
+        /// </remarks>
+        public static unsafe void GetMonitorWorkarea(Monitor* monitor, out int x, out int y, out int width, out int height)
+        {
+            int localX, localY, localWidth, localHeight;
+
+            glfwGetMonitorWorkarea(monitor, &localX, &localY, &localWidth, &localHeight);
+
+            x = localX;
+            y = localY;
+            width = localWidth;
+            height = localHeight;
+        }
+
+        /// <summary>
+        /// <para>
+        /// This function returns the position, in screen coordinates, of the upper-left corner of the work area of the specified monitor along with the work area size in screen coordinates.
+        /// The work area is defined as the area of the monitor not occluded by the operating system task bar where present.
+        /// If no task bar exists then the work area is the monitor resolution in screen coordinates.
+        /// </para>
+        /// <para>
+        /// Any or all of the position and size arguments may be NULL.If an error occurs, all non-NULL position and size arguments will be set to zero.
+        /// </para>
+        /// </summary>
+        /// <param name="monitor">The monitor to query.</param>
+        /// <param name="x">Where to store the monitor x-coordinate, or NULL.</param>
+        /// <param name="y">Where to store the monitor y-coordinate, or NULL.</param>
+        /// <param name="width">Where to store the monitor width, or NULL.</param>
+        /// <param name="height">Where to store the monitor height, or NULL.</param>
+        /// <remarks>
+        /// <para>
+        /// This function must only be called from the main thread.
+        /// </para>
+        /// <para>
+        /// Possible errors include GLFW_NOT_INITIALIZED and GLFW_PLATFORM_ERROR.
+        /// </para>
+        /// <para>
+        /// Added in version GLFW 3.3.
+        /// </para>
+        /// </remarks>
+        public static unsafe void GetMonitorWorkarea(Monitor* monitor, int* x, int* y, int* width, int* height)
+        {
+            glfwGetMonitorWorkarea(monitor, x, y, width, height);
+        }
+
+        /// <summary>
+        /// <para>
         /// This function returns the size, in millimetres, of the display area of the specified monitor.
         /// </para>
         /// <para>

--- a/src/OpenTK.Windowing.GraphicsLibraryFramework/GLFWNative.cs
+++ b/src/OpenTK.Windowing.GraphicsLibraryFramework/GLFWNative.cs
@@ -96,6 +96,9 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
         public static extern void glfwGetMonitorPos(Monitor* monitor, int* x, int* y);
 
         [DllImport(LibraryName)]
+        public static extern void glfwGetMonitorWorkarea(Monitor* monitor, int* xpos, int* ypos, int* width, int* height);
+
+        [DllImport(LibraryName)]
         public static extern void glfwGetMonitorPhysicalSize(Monitor* monitor, int* width, int* height);
 
         [DllImport(LibraryName)]


### PR DESCRIPTION
### Purpose of this PR

Fixes #1221

Also adds a function for getting the primary monitor.

Now also adds `glfwGetMonitorWorkArea` to the GLFW bindings and adds this information to `MonitorInfo`. 
Fixes #1365 

### Testing status

Not tested.

### Comments

The way that `MonitorInfo` works atm there is the potential of having multiple object referring to the same monitor with different properties as if the monitor has any of it's properties changed the `MonitorInfo` object will not be updated.