### PR TITLE
Fixing Box3 documentation referencing 2D concepts

### DIFF
--- a/src/OpenTK.Mathematics/Geometry/Box3.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box3.cs
@@ -15,7 +15,7 @@ using System.Runtime.InteropServices;
 namespace OpenTK.Mathematics
 {
     /// <summary>
-    /// Defines an axis-aligned 2d box (rectangle).
+    /// Defines an axis-aligned 3d box (rectangular prism).
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct Box3 : IEquatable<Box3>
@@ -77,8 +77,8 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Box3"/> struct.
         /// </summary>
-        /// <param name="min">The minimum point on the XY plane this box encloses.</param>
-        /// <param name="max">The maximum point on the XY plane this box encloses.</param>
+        /// <param name="min">The minimum point in 3D space this box encloses.</param>
+        /// <param name="max">The maximum point in 3D space this box encloses.</param>
         public Box3(Vector3 min, Vector3 max)
         {
             _min = Vector3.ComponentMin(min, max);
@@ -299,7 +299,7 @@ namespace OpenTK.Mathematics
         public static readonly Box3 Empty = new Box3(0, 0, 0, 0, 0, 0);
 
         /// <summary>
-        /// Gets a box with a location 0,0,9 with the a size of 1.
+        /// Gets a box with a location 0,0,0 with size 1 on each axis.
         /// </summary>
         public static readonly Box3 UnitSquare = new Box3(0, 0, 0, 1, 1, 1);
 
@@ -317,8 +317,8 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Box3"/> struct.
         /// </summary>
-        /// <param name="min">The minimum point on the XY plane this box encloses.</param>
-        /// <param name="max">The maximum point on the XY plane this box encloses.</param>
+        /// <param name="min">The minimum point in 3D space this box encloses.</param>
+        /// <param name="max">The maximum point in 3D space this box encloses.</param>
         /// <returns>A box.</returns>
         public static Box3 FromPositions(Vector3 min, Vector3 max)
         {

--- a/src/OpenTK.Mathematics/Geometry/Box3d.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box3d.cs
@@ -15,7 +15,7 @@ using System.Runtime.InteropServices;
 namespace OpenTK.Mathematics
 {
     /// <summary>
-    /// Defines an axis-aligned 2d box (rectangle).
+    /// Defines an axis-aligned 3d box (rectangular prism).
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct Box3d : IEquatable<Box3d>
@@ -77,8 +77,8 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Box3d"/> struct.
         /// </summary>
-        /// <param name="min">The minimum point on the XY plane this box encloses.</param>
-        /// <param name="max">The maximum point on the XY plane this box encloses.</param>
+        /// <param name="min">The minimum point in 3D space this box encloses.</param>
+        /// <param name="max">The maximum point in 3D space this box encloses.</param>
         public Box3d(Vector3d min, Vector3d max)
         {
             _min = Vector3d.ComponentMin(min, max);
@@ -299,7 +299,7 @@ namespace OpenTK.Mathematics
         public static readonly Box3d Empty = new Box3d(0, 0, 0, 0, 0, 0);
 
         /// <summary>
-        /// Gets a box with a location 0,0,9 with the a size of 1.
+        /// Gets a box with a location 0,0,0 with size 1 on each axis.
         /// </summary>
         public static readonly Box3d UnitSquare = new Box3d(0, 0, 0, 1, 1, 1);
 
@@ -317,8 +317,8 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Box3"/> struct.
         /// </summary>
-        /// <param name="min">The minimum point on the XY plane this box encloses.</param>
-        /// <param name="max">The maximum point on the XY plane this box encloses.</param>
+        /// <param name="min">The minimum point in 3D space this box encloses.</param>
+        /// <param name="max">The maximum point in 3D space this box encloses.</param>
         /// <returns>A box.</returns>
         public static Box3d FromPositions(Vector3d min, Vector3d max)
         {

--- a/src/OpenTK.Mathematics/Geometry/Box3i.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box3i.cs
@@ -15,7 +15,7 @@ using System.Runtime.InteropServices;
 namespace OpenTK.Mathematics
 {
     /// <summary>
-    /// Defines an axis-aligned 2d box (rectangle).
+    /// Defines an axis-aligned 3d box (rectangular prism).
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct Box3i : IEquatable<Box3i>
@@ -53,8 +53,8 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Box3i"/> struct.
         /// </summary>
-        /// <param name="min">The minimum point on the XY plane this box encloses.</param>
-        /// <param name="max">The maximum point on the XY plane this box encloses.</param>
+        /// <param name="min">The minimum point in 3D space this box encloses.</param>
+        /// <param name="max">The maximum point in 3D space this box encloses.</param>
         public Box3i(Vector3i min, Vector3i max)
         {
             _min = Vector3i.ComponentMin(min, max);
@@ -274,7 +274,7 @@ namespace OpenTK.Mathematics
         public static readonly Box3i Empty = new Box3i(0, 0, 0, 0, 0, 0);
 
         /// <summary>
-        /// Gets a box with a location 0,0,9 with the a size of 1.
+        /// Gets a box with a location 0,0,0 with size 1 on each axis.
         /// </summary>
         public static readonly Box3i UnitSquare = new Box3i(0, 0, 0, 1, 1, 1);
 
@@ -292,8 +292,8 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Box3"/> struct.
         /// </summary>
-        /// <param name="min">The minimum point on the XY plane this box encloses.</param>
-        /// <param name="max">The maximum point on the XY plane this box encloses.</param>
+        /// <param name="min">The minimum point in 3D space this box encloses.</param>
+        /// <param name="max">The maximum point in 3D space this box encloses.</param>
         /// <returns>A box.</returns>
         public static Box3i FromPositions(Vector3i min, Vector3i max)
         {


### PR DESCRIPTION
### Purpose of this PR
The 3 `Box3` structs appear to have been derived from `Box2` and some of the documentation comments were not updated from the 2D counterparts. I've fixed all the incorrect info I noticed.

### Testing status
No testing required, as the only changes are to existing documentation comments. No code/functional changes were made.

### Comments
How has this not been noticed for years?