### PR TITLE
Fixed MapRange Methods

### DIFF
--- a/src/OpenTK.Mathematics/MathHelper.cs
+++ b/src/OpenTK.Mathematics/MathHelper.cs
@@ -947,7 +947,7 @@ namespace OpenTK.Mathematics
         [Pure]
         public static int MapRange(int value, int valueMin, int valueMax, int resultMin, int resultMax)
         {
-            int inRange = valueMax - valueMax;
+            int inRange = valueMax - valueMin;
             int resultRange = resultMax - resultMin;
             return resultMin + (resultRange * ((value - valueMin) / inRange));
         }
@@ -965,7 +965,7 @@ namespace OpenTK.Mathematics
         [Pure]
         public static float MapRange(float value, float valueMin, float valueMax, float resultMin, float resultMax)
         {
-            float inRange = valueMax - valueMax;
+            float inRange = valueMax - valueMin;
             float resultRange = resultMax - resultMin;
             return resultMin + (resultRange * ((value - valueMin) / inRange));
         }
@@ -983,7 +983,7 @@ namespace OpenTK.Mathematics
         [Pure]
         public static double MapRange(double value, double valueMin, double valueMax, double resultMin, double resultMax)
         {
-            double inRange = valueMax - valueMax;
+            double inRange = valueMax - valueMin;
             double resultRange = resultMax - resultMin;
             return resultMin + (resultRange * ((value - valueMin) / inRange));
         }


### PR DESCRIPTION
Fixed `inRange` calculation in all three `MapRange` overloads

### Purpose of this PR

* MapRange will return `infinity` or `NaN` regardless of the inputs
* Fixed the calculation of `inRange` in all three overloads of the `MapRange` method

### Testing status

* No testing done, I don't have the project setup to build on my work computer (found this while using the OpenTK nuget package in a program). I figured for a change like this a PR was a nicer option than opening a Bug Report.

### Comments

* This is my first contribution to an open source project, hope it's more help than hurt!
