### PR TITLE
Outsourced JoystickCallback to separate class

### DIFF
--- a/src/OpenTK.Windowing.Desktop/Joysticks.cs
+++ b/src/OpenTK.Windowing.Desktop/Joysticks.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using OpenTK.Windowing.GraphicsLibraryFramework;
+
+namespace OpenTK.Windowing.Desktop
+{
+    internal static class Joysticks
+    {
+        public static event GLFWCallbacks.JoystickCallback JoystickCallback;
+
+        private static readonly GLFWCallbacks.JoystickCallback _joystickCallback;
+
+        static Joysticks()
+        {
+            GLFWProvider.EnsureInitialized();
+
+            if (!GLFWProvider.IsOnMainThread)
+            {
+                throw new InvalidOperationException("Only GLFW main thread can access this class.");
+            }
+
+            _joystickCallback = (id, state) => JoystickCallback(id, state);
+
+            GLFW.SetJoystickCallback(_joystickCallback);
+        }
+    }
+}

--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -952,7 +952,6 @@ namespace OpenTK.Windowing.Desktop
         private GLFWCallbacks.MouseButtonCallback _mouseButtonCallback;
         private GLFWCallbacks.CursorPosCallback _cursorPosCallback;
         private GLFWCallbacks.DropCallback _dropCallback;
-        private GLFWCallbacks.JoystickCallback _joystickCallback;
 
         [Obsolete("Use the Monitors.OnMonitorConnected event instead.", true)]
         private GLFWCallbacks.MonitorCallback _monitorCallback;
@@ -981,8 +980,6 @@ namespace OpenTK.Windowing.Desktop
 
             _dropCallback = DropCallback;
 
-            _joystickCallback = JoystickCallback;
-
             GLFW.SetWindowPosCallback(WindowPtr, _windowPosCallback);
             GLFW.SetWindowSizeCallback(WindowPtr, _windowSizeCallback);
             GLFW.SetWindowCloseCallback(WindowPtr, _windowCloseCallback);
@@ -1001,7 +998,12 @@ namespace OpenTK.Windowing.Desktop
 
             GLFW.SetDropCallback(WindowPtr, _dropCallback);
 
-            GLFW.SetJoystickCallback(_joystickCallback);
+            Joysticks.JoystickCallback += JoystickCallback;
+        }
+
+        private void UnregisterWindowCallbacks()
+        {
+            Joysticks.JoystickCallback -= JoystickCallback;
         }
 
         private unsafe void InitialiseJoystickStates()
@@ -1690,6 +1692,8 @@ namespace OpenTK.Windowing.Desktop
         /// </summary>
         protected virtual void OnClosed()
         {
+            UnregisterWindowCallbacks();
+
             Closed?.Invoke();
         }
 

--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -952,6 +952,7 @@ namespace OpenTK.Windowing.Desktop
         private GLFWCallbacks.MouseButtonCallback _mouseButtonCallback;
         private GLFWCallbacks.CursorPosCallback _cursorPosCallback;
         private GLFWCallbacks.DropCallback _dropCallback;
+        private GLFWCallbacks.JoystickCallback _joystickCallback;
 
         [Obsolete("Use the Monitors.OnMonitorConnected event instead.", true)]
         private GLFWCallbacks.MonitorCallback _monitorCallback;
@@ -980,6 +981,8 @@ namespace OpenTK.Windowing.Desktop
 
             _dropCallback = DropCallback;
 
+            _joystickCallback = JoystickCallback;
+
             GLFW.SetWindowPosCallback(WindowPtr, _windowPosCallback);
             GLFW.SetWindowSizeCallback(WindowPtr, _windowSizeCallback);
             GLFW.SetWindowCloseCallback(WindowPtr, _windowCloseCallback);
@@ -998,12 +1001,12 @@ namespace OpenTK.Windowing.Desktop
 
             GLFW.SetDropCallback(WindowPtr, _dropCallback);
 
-            Joysticks.JoystickCallback += JoystickCallback;
+            Joysticks.JoystickCallback += _joystickCallback;
         }
 
         private void UnregisterWindowCallbacks()
         {
-            Joysticks.JoystickCallback -= JoystickCallback;
+            Joysticks.JoystickCallback -= _joystickCallback;
         }
 
         private unsafe void InitialiseJoystickStates()
@@ -1429,6 +1432,7 @@ namespace OpenTK.Windowing.Desktop
         /// <summary>
         /// Occurs after the window has closed.
         /// </summary>
+        [Obsolete("This event will never be invoked.")]
         public event Action Closed;
 
         /// <summary>
@@ -1690,10 +1694,9 @@ namespace OpenTK.Windowing.Desktop
         /// <summary>
         /// Raises the <see cref="Closed"/> event.
         /// </summary>
+        [Obsolete("This method will never be called.")]
         protected virtual void OnClosed()
         {
-            UnregisterWindowCallbacks();
-
             Closed?.Invoke();
         }
 
@@ -1857,6 +1860,7 @@ namespace OpenTK.Windowing.Desktop
 
             if (GLFWProvider.IsOnMainThread)
             {
+                UnregisterWindowCallbacks();
                 GLFW.DestroyWindow(WindowPtr);
                 Exists = false;
             }


### PR DESCRIPTION
### Purpose of this PR
As the JoystickCallback of glfw is window independant it got overwritten with each new window.
Therefore use a separate class for subscribing to the glfw callback and pass it through to all windows

### Testing status
Tested locally

### Comments
Perhaps one could outsource more joystick functionallity to the Joysticks class, but I did not do that, because it would cause further needed changes of the API, also one would need to call the event loop for the joysticks in that class.