### PR TITLE
Move Box changes to OpenTK 5

### DIFF
--- a/src/OpenTK.Mathematics/Geometry/Box2.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box2.cs
@@ -281,6 +281,10 @@ namespace OpenTK.Mathematics
             return new Box2(minX, minY, maxX, maxY);
         }
 
+        /// <summary>
+        /// Replaces this Box with the intersection of itself and the specified Box.
+        /// </summary>
+        /// <param name="other">The Box with which to intersect.</param>
         public void Intersect(Box2 other)
         {
             Box2 result = Intersect(other, this);
@@ -291,6 +295,12 @@ namespace OpenTK.Mathematics
             Height = result.Height;
         }
 
+        /// <summary>
+        /// Returns the intersection of two Boxes.
+        /// </summary>
+        /// <param name="a">The first box.</param>
+        /// <param name="b">The second box.</param>
+        /// <returns>The intersection of two Boxes.</returns>
         public static Box2 Intersect(Box2 a, Box2 b)
         {
             float minX = a._min.X > b._min.X ? a._min.X : b._min.X;
@@ -305,11 +315,21 @@ namespace OpenTK.Mathematics
             return Box2.Zero;
         }
 
+        /// <summary>
+        /// Returns the intersection of itself and the specified Box.
+        /// </summary>
+        /// <param name="other">The Box with which to intersect.</param>
+        /// <returns>The intersection of itself and the specified Box.</returns>
         public Box2 Intersected(Box2 other)
         {
             return Intersect(other, this);
         }
 
+        /// <summary>
+        /// Determines if this Box intersects with another Box.
+        /// </summary>
+        /// <param name="other">The Box to test.</param>
+        /// <returns>This method returns true if there is any intersection, otherwise false.</returns>
         public bool IntersectsWith(Box2 other)
         {
             return other._min.X < _max.X
@@ -318,6 +338,11 @@ namespace OpenTK.Mathematics
                 && _min.Y < other._max.Y;
         }
 
+        /// <summary>
+        /// Determines if this Box intersects or touches with another Box.
+        /// </summary>
+        /// <param name="other">The Box to test.</param>
+        /// <returns>This method returns true if there is any intersection or touches, otherwise false.</returns>
         public bool TouchWith(Box2 other)
         {
             return other._min.X <= _max.X
@@ -326,6 +351,12 @@ namespace OpenTK.Mathematics
                 && _min.Y <= other._max.Y;
         }
 
+        /// <summary>
+        /// Gets a Box structure that contains the union of two Box structures.
+        /// </summary>
+        /// <param name="a">A Box to union.</param>
+        /// <param name="b">a box to union.</param>
+        /// <returns>A Box structure that bounds the union of the two Box structures.</returns>
         public static Box2 Union(Box2 a, Box2 b)
         {
             float minX = a._min.X < b._min.X ? a._min.X : b._min.X;
@@ -336,6 +367,11 @@ namespace OpenTK.Mathematics
             return new Box2(minX, minY, maxX, maxY);
         }
 
+        /// <summary>
+        /// Gets a Box structure that contains rounded integers.
+        /// </summary>
+        /// <param name="value">A Box to round.</param>
+        /// <returns>A Box structure that contains rounded integers.</returns>
         public static Box2i Round(Box2 value)
         {
             return new Box2i(
@@ -345,12 +381,32 @@ namespace OpenTK.Mathematics
                 (int)MathHelper.Round(value.Max.Y));
         }
 
+        /// <summary>
+        /// Gets a Box structure that contains rounded up integers.
+        /// </summary>
+        /// <param name="value">A Box to round.</param>
+        /// <returns>A Box structure that contains rounded up integers.</returns>
         public static Box2i Ceiling(Box2 value)
         {
             int x = (int)MathHelper.Ceiling(value._min.X);
             int y = (int)MathHelper.Ceiling(value._min.Y);
             int sizeX = (int)MathHelper.Ceiling(value.Width);
             int sizeY = (int)MathHelper.Ceiling(value.Height);
+
+            return new Box2i(x, y, x + sizeX, y + sizeY);
+        }
+
+        /// <summary>
+        /// Gets a Box structure that contains rounded down integers.
+        /// </summary>
+        /// <param name="value">A Box to round.</param>
+        /// <returns>A Box structure that contains rounded down integers.</returns>
+        public static Box2i Floor(Box2 value)
+        {
+            int x = (int)MathHelper.Floor(value._min.X);
+            int y = (int)MathHelper.Floor(value._min.Y);
+            int sizeX = (int)MathHelper.Floor(value.Width);
+            int sizeY = (int)MathHelper.Floor(value.Height);
 
             return new Box2i(x, y, x + sizeX, y + sizeY);
         }

--- a/src/OpenTK.Mathematics/Geometry/Box2.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box2.cs
@@ -234,12 +234,12 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Gets a value indicating whether all values are zero.
         /// </summary>
-        public bool IsZero => _min.X == 0 && _min.Y == 0 && _max.X == 0 && _max.Y == 0;
+        public bool IsEmpty => _min.X == 0 && _min.Y == 0 && _max.X == 0 && _max.Y == 0;
 
         /// <summary>
         /// Gets a box with all components zero.
         /// </summary>
-        public static readonly Box2 Zero = new Box2(0, 0, 0, 0);
+        public static readonly Box2 Empty = new Box2(0, 0, 0, 0);
 
         /// <summary>
         /// Gets a box with a location 0,0 with the a size of 1.
@@ -312,7 +312,7 @@ namespace OpenTK.Mathematics
             {
                 return new Box2(minX, minY, maxX, maxY);
             }
-            return Box2.Zero;
+            return Box2.Empty;
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Geometry/Box2.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box2.cs
@@ -92,7 +92,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Gets or sets a vector describing the size of the Box2 structure.
         /// </summary>
-        public Vector2 Size
+        public Vector2 CenteredSize
         {
             get => Max - Min;
             set
@@ -108,8 +108,8 @@ namespace OpenTK.Mathematics
         /// </summary>
         public Vector2 HalfSize
         {
-            get => Size / 2;
-            set => Size = value * 2;
+            get => CenteredSize / 2;
+            set => CenteredSize = value * 2;
         }
 
         /// <summary>
@@ -123,82 +123,159 @@ namespace OpenTK.Mathematics
 
         // --
 
+        /// <summary>
+        /// Gets or sets the width of the box.
+        /// </summary>
         public float Width
         {
             get => _max.X - _min.X;
             set => _max.X = _min.X + value;
         }
 
+        /// <summary>
+        /// Gets or sets the height of the box.
+        /// </summary>
         public float Height
         {
             get => _max.Y - _min.Y;
             set => _max.Y = _min.Y + value;
         }
 
+        /// <summary>
+        /// Gets or sets the left location of the box.
+        /// </summary>
         public float Left
         {
             get => _min.X;
             set => _min.X = value;
         }
 
+        /// <summary>
+        /// Gets or sets the top location of the box.
+        /// </summary>
         public float Top
         {
             get => _min.Y;
             set => _min.Y = value;
         }
 
+        /// <summary>
+        /// Gets or sets the right location of the box.
+        /// </summary>
         public float Right
         {
             get => _max.X;
             set => _max.X = value;
         }
 
+        /// <summary>
+        /// Gets or sets the bottom location of the box.
+        /// </summary>
         public float Bottom
         {
             get => _max.Y;
             set => _max.Y = value;
         }
 
+        /// <summary>
+        /// Gets or sets the X location of the box.
+        /// </summary>
         public float X
         {
             get => _min.X;
             set => _min.X = value;
         }
 
+        /// <summary>
+        /// Gets or sets the Y location of the box.
+        /// </summary>
         public float Y
         {
             get => _min.Y;
             set => _min.Y = value;
         }
 
+        /// <summary>
+        /// Gets or sets the horizontal size.
+        /// </summary>
         public float SizeX
         {
             get => _max.X - _min.X;
+            set => _max.X = _min.X + value;
         }
 
+        /// <summary>
+        /// Gets or sets the vertical size.
+        /// </summary>
         public float SizeY
         {
             get => _max.Y - _min.Y;
+            set => _max.Y = _min.Y + value;
         }
 
+        /// <summary>
+        /// Gets or sets the size of the box.
+        /// </summary>
+        public Vector2 Size
+        {
+            get => new Vector2(_max.X - _min.X, _max.Y - _min.Y);
+            set
+            {
+                _max.X = _min.X + value.X;
+                _max.Y = _min.Y + value.Y;
+            }
+        }
+
+        /// <summary>
+        /// Gets the location of the box.
+        /// </summary>
         public Vector2 Location => _min;
 
-        public bool IsEmpty => _min.X == 0 && _min.Y == 0 && _max.X == 0 && _max.Y == 0;
+        /// <summary>
+        /// Gets a value indicating whether all values are zero.
+        /// </summary>
+        public bool IsZero => _min.X == 0 && _min.Y == 0 && _max.X == 0 && _max.Y == 0;
 
+        /// <summary>
+        /// Gets a box with all components zero.
+        /// </summary>
         public static readonly Box2 Zero = new Box2(0, 0, 0, 0);
 
-        public static readonly Box2 Identity = new Box2(0, 0, 1, 1);
+        /// <summary>
+        /// Gets a box with a location 0,0 with the a size of 1.
+        /// </summary>
+        public static readonly Box2 UnitSquare = new Box2(0, 0, 1, 1);
 
+        /// <summary>
+        /// Creates a box.
+        /// </summary>
+        /// <param name="location">The location of the box.</param>
+        /// <param name="size">The size of the box.</param>
+        /// <returns>A box.</returns>
         public static Box2 FromSize(Vector2 location, Vector2 size)
         {
             return new Box2(location, location + size);
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Box2"/> struct.
+        /// </summary>
+        /// <param name="min">The minimum point on the XY plane this box encloses.</param>
+        /// <param name="max">The maximum point on the XY plane this box encloses.</param>
+        /// <returns>A box.</returns>
         public static Box2 FromPositions(Vector2 min, Vector2 max)
         {
             return new Box2(min, max);
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Box2"/> struct.
+        /// </summary>
+        /// <param name="minX">The minimum X value to be enclosed.</param>
+        /// <param name="minY">The minimum Y value to be enclosed.</param>
+        /// <param name="maxX">The maximum X value to be enclosed.</param>
+        /// <param name="maxY">The maximum Y value to be enclosed.</param>
+        /// <returns>A box.</returns>
         public static Box2 FromPositions(float minX, float minY, float maxX, float maxY)
         {
             return new Box2(minX, minY, maxX, maxY);
@@ -206,7 +283,7 @@ namespace OpenTK.Mathematics
 
         public void Intersect(Box2 other)
         {
-            Box2 result = Box2.Intersect(other, this);
+            Box2 result = Intersect(other, this);
 
             X = result.X;
             Y = result.Y;
@@ -226,6 +303,11 @@ namespace OpenTK.Mathematics
                 return new Box2(minX, minY, maxX, maxY);
             }
             return Box2.Zero;
+        }
+
+        public Box2 Intersected(Box2 other)
+        {
+            return Intersect(other, this);
         }
 
         public bool IntersectsWith(Box2 other)

--- a/src/OpenTK.Mathematics/Geometry/Box2.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box2.cs
@@ -234,7 +234,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Gets a value indicating whether all values are zero.
         /// </summary>
-        public bool IsEmpty => _min.X == 0 && _min.Y == 0 && _max.X == 0 && _max.Y == 0;
+        public bool IsZero => _min.X == 0 && _min.Y == 0 && _max.X == 0 && _max.Y == 0;
 
         /// <summary>
         /// Gets a box with all components zero.

--- a/src/OpenTK.Mathematics/Geometry/Box2.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box2.cs
@@ -121,6 +121,160 @@ namespace OpenTK.Mathematics
             set => Translate(value - Center);
         }
 
+        // --
+
+        public float Width
+        {
+            get => _max.X - _min.X;
+            set => _max.X = _min.X + value;
+        }
+
+        public float Height
+        {
+            get => _max.Y - _min.Y;
+            set => _max.Y = _min.Y + value;
+        }
+
+        public float Left
+        {
+            get => _min.X;
+            set => _min.X = value;
+        }
+
+        public float Top
+        {
+            get => _min.Y;
+            set => _min.Y = value;
+        }
+
+        public float Right
+        {
+            get => _max.X;
+            set => _max.X = value;
+        }
+
+        public float Bottom
+        {
+            get => _max.Y;
+            set => _max.Y = value;
+        }
+
+        public float X
+        {
+            get => _min.X;
+            set => _min.X = value;
+        }
+
+        public float Y
+        {
+            get => _min.Y;
+            set => _min.Y = value;
+        }
+
+        public float SizeX
+        {
+            get => _max.X - _min.X;
+        }
+
+        public float SizeY
+        {
+            get => _max.Y - _min.Y;
+        }
+
+        public Vector2 Location => _min;
+
+        public bool IsEmpty => _min.X == 0 && _min.Y == 0 && _max.X == 0 && _max.Y == 0;
+
+        public static readonly Box2 Zero = new Box2(0, 0, 0, 0);
+
+        public static readonly Box2 Identity = new Box2(0, 0, 1, 1);
+
+        public static Box2 FromSize(Vector2 location, Vector2 size)
+        {
+            return new Box2(location, location + size);
+        }
+
+        public static Box2 FromPositions(Vector2 min, Vector2 max)
+        {
+            return new Box2(min, max);
+        }
+
+        public static Box2 FromPositions(float minX, float minY, float maxX, float maxY)
+        {
+            return new Box2(minX, minY, maxX, maxY);
+        }
+
+        public void Intersect(Box2 other)
+        {
+            Box2 result = Box2.Intersect(other, this);
+
+            X = result.X;
+            Y = result.Y;
+            Width = result.Width;
+            Height = result.Height;
+        }
+
+        public static Box2 Intersect(Box2 a, Box2 b)
+        {
+            float minX = a._min.X > b._min.X ? a._min.X : b._min.X;
+            float minY = a._min.Y > b._min.Y ? a._min.Y : b._min.Y;
+            float maxX = a._max.X < b._max.X ? a._max.X : b._max.X;
+            float maxY = a._max.Y < b._max.Y ? a._max.Y : b._max.Y;
+
+            if (maxX >= minX && maxY >= minY)
+            {
+                return new Box2(minX, minY, maxX, maxY);
+            }
+            return Box2.Zero;
+        }
+
+        public bool IntersectsWith(Box2 other)
+        {
+            return other._min.X < _max.X
+                && _min.X < other._max.X
+                && other._min.Y < _max.Y
+                && _min.Y < other._max.Y;
+        }
+
+        public bool TouchWith(Box2 other)
+        {
+            return other._min.X <= _max.X
+                && _min.X <= other._max.X
+                && other._min.Y <= _max.Y
+                && _min.Y <= other._max.Y;
+        }
+
+        public static Box2 Union(Box2 a, Box2 b)
+        {
+            float minX = a._min.X < b._min.X ? a._min.X : b._min.X;
+            float minY = a._min.Y < b._min.Y ? a._min.Y : b._min.Y;
+            float maxX = a._max.X > b._max.X ? a._max.X : b._max.X;
+            float maxY = a._max.Y > b._max.Y ? a._max.Y : b._max.Y;
+
+            return new Box2(minX, minY, maxX, maxY);
+        }
+
+        public static Box2i Round(Box2 value)
+        {
+            return new Box2i(
+                (int)MathHelper.Round(value.Min.X),
+                (int)MathHelper.Round(value.Min.Y),
+                (int)MathHelper.Round(value.Max.X),
+                (int)MathHelper.Round(value.Max.Y));
+        }
+
+        public static Box2i Ceiling(Box2 value)
+        {
+            int x = (int)MathHelper.Ceiling(value._min.X);
+            int y = (int)MathHelper.Ceiling(value._min.Y);
+            int sizeX = (int)MathHelper.Ceiling(value.Width);
+            int sizeY = (int)MathHelper.Ceiling(value.Height);
+
+            return new Box2i(x, y, x + sizeX, y + sizeY);
+        }
+
+        // --
+
         /// <summary>
         /// Returns whether the box contains the specified point (borders exclusive).
         /// </summary>

--- a/src/OpenTK.Mathematics/Geometry/Box2d.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box2d.cs
@@ -92,7 +92,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Gets or sets a vector describing the size of the Box2d structure.
         /// </summary>
-        public Vector2d Size
+        public Vector2d CenteredSize
         {
             get => Max - Min;
             set
@@ -108,8 +108,8 @@ namespace OpenTK.Mathematics
         /// </summary>
         public Vector2d HalfSize
         {
-            get => Size / 2;
-            set => Size = value * 2;
+            get => CenteredSize / 2;
+            set => CenteredSize = value * 2;
         }
 
         /// <summary>
@@ -120,6 +120,298 @@ namespace OpenTK.Mathematics
             get => HalfSize + _min;
             set => Translate(value - Center);
         }
+
+        // --
+
+        /// <summary>
+        /// Gets or sets the width of the box.
+        /// </summary>
+        public double Width
+        {
+            get => _max.X - _min.X;
+            set => _max.X = _min.X + value;
+        }
+
+        /// <summary>
+        /// Gets or sets the height of the box.
+        /// </summary>
+        public double Height
+        {
+            get => _max.Y - _min.Y;
+            set => _max.Y = _min.Y + value;
+        }
+
+        /// <summary>
+        /// Gets or sets the left location of the box.
+        /// </summary>
+        public double Left
+        {
+            get => _min.X;
+            set => _min.X = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the top location of the box.
+        /// </summary>
+        public double Top
+        {
+            get => _min.Y;
+            set => _min.Y = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the right location of the box.
+        /// </summary>
+        public double Right
+        {
+            get => _max.X;
+            set => _max.X = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the bottom location of the box.
+        /// </summary>
+        public double Bottom
+        {
+            get => _max.Y;
+            set => _max.Y = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the X location of the box.
+        /// </summary>
+        public double X
+        {
+            get => _min.X;
+            set => _min.X = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the Y location of the box.
+        /// </summary>
+        public double Y
+        {
+            get => _min.Y;
+            set => _min.Y = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the horizontal size.
+        /// </summary>
+        public double SizeX
+        {
+            get => _max.X - _min.X;
+            set => _max.X = _min.X + value;
+        }
+
+        /// <summary>
+        /// Gets or sets the vertical size.
+        /// </summary>
+        public double SizeY
+        {
+            get => _max.Y - _min.Y;
+            set => _max.Y = _min.Y + value;
+        }
+
+        /// <summary>
+        /// Gets or sets the size of the box.
+        /// </summary>
+        public Vector2d Size
+        {
+            get => new Vector2d(_max.X - _min.X, _max.Y - _min.Y);
+            set
+            {
+                _max.X = _min.X + value.X;
+                _max.Y = _min.Y + value.Y;
+            }
+        }
+
+        /// <summary>
+        /// Gets the location of the box.
+        /// </summary>
+        public Vector2d Location => _min;
+
+        /// <summary>
+        /// Gets a value indicating whether all values are zero.
+        /// </summary>
+        public bool IsZero => _min.X == 0 && _min.Y == 0 && _max.X == 0 && _max.Y == 0;
+
+        /// <summary>
+        /// Gets a box with all components zero.
+        /// </summary>
+        public static readonly Box2d Zero = new Box2d(0, 0, 0, 0);
+
+        /// <summary>
+        /// Gets a box with a location 0,0 with the a size of 1.
+        /// </summary>
+        public static readonly Box2d UnitSquare = new Box2d(0, 0, 1, 1);
+
+        /// <summary>
+        /// Creates a box.
+        /// </summary>
+        /// <param name="location">The location of the box.</param>
+        /// <param name="size">The size of the box.</param>
+        /// <returns>A box.</returns>
+        public static Box2d FromSize(Vector2d location, Vector2d size)
+        {
+            return new Box2d(location, location + size);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Box2"/> struct.
+        /// </summary>
+        /// <param name="min">The minimum point on the XY plane this box encloses.</param>
+        /// <param name="max">The maximum point on the XY plane this box encloses.</param>
+        /// <returns>A box.</returns>
+        public static Box2d FromPositions(Vector2d min, Vector2d max)
+        {
+            return new Box2d(min, max);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Box2"/> struct.
+        /// </summary>
+        /// <param name="minX">The minimum X value to be enclosed.</param>
+        /// <param name="minY">The minimum Y value to be enclosed.</param>
+        /// <param name="maxX">The maximum X value to be enclosed.</param>
+        /// <param name="maxY">The maximum Y value to be enclosed.</param>
+        /// <returns>A box.</returns>
+        public static Box2d FromPositions(double minX, double minY, double maxX, double maxY)
+        {
+            return new Box2d(minX, minY, maxX, maxY);
+        }
+
+        /// <summary>
+        /// Replaces this Box with the intersection of itself and the specified Box.
+        /// </summary>
+        /// <param name="other">The Box with which to intersect.</param>
+        public void Intersect(Box2d other)
+        {
+            Box2d result = Intersect(other, this);
+
+            X = result.X;
+            Y = result.Y;
+            Width = result.Width;
+            Height = result.Height;
+        }
+
+        /// <summary>
+        /// Returns the intersection of two Boxes.
+        /// </summary>
+        /// <param name="a">The first box.</param>
+        /// <param name="b">The second box.</param>
+        /// <returns>The intersection of two Boxes.</returns>
+        public static Box2d Intersect(Box2d a, Box2d b)
+        {
+            double minX = a._min.X > b._min.X ? a._min.X : b._min.X;
+            double minY = a._min.Y > b._min.Y ? a._min.Y : b._min.Y;
+            double maxX = a._max.X < b._max.X ? a._max.X : b._max.X;
+            double maxY = a._max.Y < b._max.Y ? a._max.Y : b._max.Y;
+
+            if (maxX >= minX && maxY >= minY)
+            {
+                return new Box2d(minX, minY, maxX, maxY);
+            }
+            return Box2d.Zero;
+        }
+
+        /// <summary>
+        /// Returns the intersection of itself and the specified Box.
+        /// </summary>
+        /// <param name="other">The Box with which to intersect.</param>
+        /// <returns>The intersection of itself and the specified Box.</returns>
+        public Box2d Intersected(Box2d other)
+        {
+            return Intersect(other, this);
+        }
+
+        /// <summary>
+        /// Determines if this Box intersects with another Box.
+        /// </summary>
+        /// <param name="other">The Box to test.</param>
+        /// <returns>This method returns true if there is any intersection, otherwise false.</returns>
+        public bool IntersectsWith(Box2d other)
+        {
+            return other._min.X < _max.X
+                && _min.X < other._max.X
+                && other._min.Y < _max.Y
+                && _min.Y < other._max.Y;
+        }
+
+        /// <summary>
+        /// Determines if this Box intersects or touches with another Box.
+        /// </summary>
+        /// <param name="other">The Box to test.</param>
+        /// <returns>This method returns true if there is any intersection or touches, otherwise false.</returns>
+        public bool TouchWith(Box2d other)
+        {
+            return other._min.X <= _max.X
+                && _min.X <= other._max.X
+                && other._min.Y <= _max.Y
+                && _min.Y <= other._max.Y;
+        }
+
+        /// <summary>
+        /// Gets a Box structure that contains the union of two Box structures.
+        /// </summary>
+        /// <param name="a">A Box to union.</param>
+        /// <param name="b">a box to union.</param>
+        /// <returns>A Box structure that bounds the union of the two Box structures.</returns>
+        public static Box2d Union(Box2d a, Box2d b)
+        {
+            double minX = a._min.X < b._min.X ? a._min.X : b._min.X;
+            double minY = a._min.Y < b._min.Y ? a._min.Y : b._min.Y;
+            double maxX = a._max.X > b._max.X ? a._max.X : b._max.X;
+            double maxY = a._max.Y > b._max.Y ? a._max.Y : b._max.Y;
+
+            return new Box2d(minX, minY, maxX, maxY);
+        }
+
+        /// <summary>
+        /// Gets a Box structure that contains rounded integers.
+        /// </summary>
+        /// <param name="value">A Box to round.</param>
+        /// <returns>A Box structure that contains rounded integers.</returns>
+        public static Box2i Round(Box2d value)
+        {
+            return new Box2i(
+                (int)MathHelper.Round(value.Min.X),
+                (int)MathHelper.Round(value.Min.Y),
+                (int)MathHelper.Round(value.Max.X),
+                (int)MathHelper.Round(value.Max.Y));
+        }
+
+        /// <summary>
+        /// Gets a Box structure that contains rounded up integers.
+        /// </summary>
+        /// <param name="value">A Box to round.</param>
+        /// <returns>A Box structure that contains rounded up integers.</returns>
+        public static Box2i Ceiling(Box2d value)
+        {
+            int x = (int)MathHelper.Ceiling(value._min.X);
+            int y = (int)MathHelper.Ceiling(value._min.Y);
+            int sizeX = (int)MathHelper.Ceiling(value.Width);
+            int sizeY = (int)MathHelper.Ceiling(value.Height);
+
+            return new Box2i(x, y, x + sizeX, y + sizeY);
+        }
+
+        /// <summary>
+        /// Gets a Box structure that contains rounded down integers.
+        /// </summary>
+        /// <param name="value">A Box to round.</param>
+        /// <returns>A Box structure that contains rounded down integers.</returns>
+        public static Box2i Floor(Box2d value)
+        {
+            int x = (int)MathHelper.Floor(value._min.X);
+            int y = (int)MathHelper.Floor(value._min.Y);
+            int sizeX = (int)MathHelper.Floor(value.Width);
+            int sizeY = (int)MathHelper.Floor(value.Height);
+
+            return new Box2i(x, y, x + sizeX, y + sizeY);
+        }
+
+        // --
 
         /// <summary>
         /// Returns whether the box contains the specified point (borders inclusive).

--- a/src/OpenTK.Mathematics/Geometry/Box2d.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box2d.cs
@@ -234,7 +234,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Gets a value indicating whether all values are zero.
         /// </summary>
-        public bool IsEmpty => _min.X == 0 && _min.Y == 0 && _max.X == 0 && _max.Y == 0;
+        public bool IsZero => _min.X == 0 && _min.Y == 0 && _max.X == 0 && _max.Y == 0;
 
         /// <summary>
         /// Gets a box with all components zero.

--- a/src/OpenTK.Mathematics/Geometry/Box2d.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box2d.cs
@@ -234,12 +234,12 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Gets a value indicating whether all values are zero.
         /// </summary>
-        public bool IsZero => _min.X == 0 && _min.Y == 0 && _max.X == 0 && _max.Y == 0;
+        public bool IsEmpty => _min.X == 0 && _min.Y == 0 && _max.X == 0 && _max.Y == 0;
 
         /// <summary>
         /// Gets a box with all components zero.
         /// </summary>
-        public static readonly Box2d Zero = new Box2d(0, 0, 0, 0);
+        public static readonly Box2d Empty = new Box2d(0, 0, 0, 0);
 
         /// <summary>
         /// Gets a box with a location 0,0 with the a size of 1.
@@ -312,7 +312,7 @@ namespace OpenTK.Mathematics
             {
                 return new Box2d(minX, minY, maxX, maxY);
             }
-            return Box2d.Zero;
+            return Box2d.Empty;
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Geometry/Box2i.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box2i.cs
@@ -20,8 +20,6 @@ namespace OpenTK.Mathematics
     [StructLayout(LayoutKind.Sequential)]
     public struct Box2i : IEquatable<Box2i>
     {
-        public static readonly Box2i Empty = new Box2i(0, 0, 0, 0);
-
         private Vector2i _min;
 
         /// <summary>
@@ -236,6 +234,11 @@ namespace OpenTK.Mathematics
         /// Gets a value indicating whether all values are zero.
         /// </summary>
         public bool IsEmpty => _min.X == 0 && _min.Y == 0 && _max.X == 0 && _max.Y == 0;
+
+        /// <summary>
+        /// Gets a box with all components zero.
+        /// </summary>
+        public static readonly Box2i Empty = new Box2i(0, 0, 0, 0);
 
         /// <summary>
         /// Gets a box with a location 0,0 with the a size of 1.

--- a/src/OpenTK.Mathematics/Geometry/Box2i.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box2i.cs
@@ -233,7 +233,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Gets a value indicating whether all values are zero.
         /// </summary>
-        public bool IsEmpty => _min.X == 0 && _min.Y == 0 && _max.X == 0 && _max.Y == 0;
+        public bool IsZero => _min.X == 0 && _min.Y == 0 && _max.X == 0 && _max.Y == 0;
 
         /// <summary>
         /// Gets a box with all components zero.

--- a/src/OpenTK.Mathematics/Geometry/Box2i.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box2i.cs
@@ -94,7 +94,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Gets a vector describing the size of the Box2i structure.
         /// </summary>
-        public Vector2i Size
+        public Vector2i CenteredSize
         {
             get => Max - Min;
         }
@@ -104,7 +104,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public Vector2i HalfSize
         {
-            get => Size / 2;
+            get => CenteredSize / 2;
             set
             {
                 Vector2i center = new Vector2i((int)Center.X, (int)Center.Y);
@@ -121,6 +121,229 @@ namespace OpenTK.Mathematics
         {
             get => ((_min + _max).ToVector2() * 0.5f) + _min.ToVector2();
         }
+
+        // --
+
+        /// <summary>
+        /// Gets or sets the width of the box.
+        /// </summary>
+        public int Width
+        {
+            get => _max.X - _min.X;
+            set => _max.X = _min.X + value;
+        }
+
+        /// <summary>
+        /// Gets or sets the height of the box.
+        /// </summary>
+        public int Height
+        {
+            get => _max.Y - _min.Y;
+            set => _max.Y = _min.Y + value;
+        }
+
+        /// <summary>
+        /// Gets or sets the left location of the box.
+        /// </summary>
+        public int Left
+        {
+            get => _min.X;
+            set => _min.X = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the top location of the box.
+        /// </summary>
+        public int Top
+        {
+            get => _min.Y;
+            set => _min.Y = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the right location of the box.
+        /// </summary>
+        public int Right
+        {
+            get => _max.X;
+            set => _max.X = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the bottom location of the box.
+        /// </summary>
+        public int Bottom
+        {
+            get => _max.Y;
+            set => _max.Y = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the X location of the box.
+        /// </summary>
+        public int X
+        {
+            get => _min.X;
+            set => _min.X = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the Y location of the box.
+        /// </summary>
+        public int Y
+        {
+            get => _min.Y;
+            set => _min.Y = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the horizontal size.
+        /// </summary>
+        public int SizeX
+        {
+            get => _max.X - _min.X;
+            set => _max.X = _min.X + value;
+        }
+
+        /// <summary>
+        /// Gets or sets the vertical size.
+        /// </summary>
+        public int SizeY
+        {
+            get => _max.Y - _min.Y;
+            set => _max.Y = _min.Y + value;
+        }
+
+        /// <summary>
+        /// Gets or sets the size of the box.
+        /// </summary>
+        public Vector2i Size
+        {
+            get => new Vector2i(_max.X - _min.X, _max.Y - _min.Y);
+            set
+            {
+                _max.X = _min.X + value.X;
+                _max.Y = _min.Y + value.Y;
+            }
+        }
+
+        /// <summary>
+        /// Gets the location of the box.
+        /// </summary>
+        public Vector2i Location => _min;
+
+        /// <summary>
+        /// Gets a value indicating whether all values are zero.
+        /// </summary>
+        public bool IsEmpty => _min.X == 0 && _min.Y == 0 && _max.X == 0 && _max.Y == 0;
+
+        /// <summary>
+        /// Gets a box with a location 0,0 with the a size of 1.
+        /// </summary>
+        public static readonly Box2i UnitSquare = new Box2i(0, 0, 1, 1);
+
+        /// <summary>
+        /// Creates a box.
+        /// </summary>
+        /// <param name="location">The location of the box.</param>
+        /// <param name="size">The size of the box.</param>
+        /// <returns>A box.</returns>
+        public static Box2i FromSize(Vector2i location, Vector2i size)
+        {
+            return new Box2i(location, location + size);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Box2"/> struct.
+        /// </summary>
+        /// <param name="min">The minimum point on the XY plane this box encloses.</param>
+        /// <param name="max">The maximum point on the XY plane this box encloses.</param>
+        /// <returns>A box.</returns>
+        public static Box2i FromPositions(Vector2i min, Vector2i max)
+        {
+            return new Box2i(min, max);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Box2"/> struct.
+        /// </summary>
+        /// <param name="minX">The minimum X value to be enclosed.</param>
+        /// <param name="minY">The minimum Y value to be enclosed.</param>
+        /// <param name="maxX">The maximum X value to be enclosed.</param>
+        /// <param name="maxY">The maximum Y value to be enclosed.</param>
+        /// <returns>A box.</returns>
+        public static Box2i FromPositions(int minX, int minY, int maxX, int maxY)
+        {
+            return new Box2i(minX, minY, maxX, maxY);
+        }
+
+        /// <summary>
+        /// Replaces this Box with the intersection of itself and the specified Box.
+        /// </summary>
+        /// <param name="other">The Box with which to intersect.</param>
+        public void Intersect(Box2i other)
+        {
+            Box2i result = Intersect(other, this);
+
+            X = result.X;
+            Y = result.Y;
+            Width = result.Width;
+            Height = result.Height;
+        }
+
+        /// <summary>
+        /// Returns the intersection of itself and the specified Box.
+        /// </summary>
+        /// <param name="other">The Box with which to intersect.</param>
+        /// <returns>The intersection of itself and the specified Box.</returns>
+        public Box2i Intersected(Box2i other)
+        {
+            return Intersect(other, this);
+        }
+
+        /// <summary>
+        /// Determines if this Box intersects with another Box.
+        /// </summary>
+        /// <param name="other">The Box to test.</param>
+        /// <returns>This method returns true if there is any intersection, otherwise false.</returns>
+        public bool IntersectsWith(Box2i other)
+        {
+            return other._min.X < _max.X
+                && _min.X < other._max.X
+                && other._min.Y < _max.Y
+                && _min.Y < other._max.Y;
+        }
+
+        /// <summary>
+        /// Determines if this Box intersects or touches with another Box.
+        /// </summary>
+        /// <param name="other">The Box to test.</param>
+        /// <returns>This method returns true if there is any intersection or touches, otherwise false.</returns>
+        public bool TouchWith(Box2i other)
+        {
+            return other._min.X <= _max.X
+                && _min.X <= other._max.X
+                && other._min.Y <= _max.Y
+                && _min.Y <= other._max.Y;
+        }
+
+        /// <summary>
+        /// Gets a Box structure that contains the union of two Box structures.
+        /// </summary>
+        /// <param name="a">A Box to union.</param>
+        /// <param name="b">a box to union.</param>
+        /// <returns>A Box structure that bounds the union of the two Box structures.</returns>
+        public static Box2i Union(Box2i a, Box2i b)
+        {
+            int minX = a._min.X < b._min.X ? a._min.X : b._min.X;
+            int minY = a._min.Y < b._min.Y ? a._min.Y : b._min.Y;
+            int maxX = a._max.X > b._max.X ? a._max.X : b._max.X;
+            int maxY = a._max.Y > b._max.Y ? a._max.Y : b._max.Y;
+
+            return new Box2i(minX, minY, maxX, maxY);
+        }
+
+        // --
 
         /// <summary>
         /// Returns whether the box contains the specified point (borders inclusive).

--- a/src/OpenTK.Mathematics/Geometry/Box3.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box3.cs
@@ -290,7 +290,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Gets a value indicating whether all values are zero.
         /// </summary>
-        public bool IsEmpty => _min.X == 0 && _min.Y == 0 && _min.Z == 0
+        public bool IsZero => _min.X == 0 && _min.Y == 0 && _min.Z == 0
                            && _max.X == 0 && _max.Y == 0 && _max.Z == 0;
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Geometry/Box3.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box3.cs
@@ -102,7 +102,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Gets or sets a vector describing the size of the Box3 structure.
         /// </summary>
-        public Vector3 Size
+        public Vector3 CenteredSize
         {
             get => Max - Min;
             set
@@ -118,8 +118,8 @@ namespace OpenTK.Mathematics
         /// </summary>
         public Vector3 HalfSize
         {
-            get => Size / 2;
-            set => Size = value * 2;
+            get => CenteredSize / 2;
+            set => CenteredSize = value * 2;
         }
 
         /// <summary>
@@ -130,6 +130,364 @@ namespace OpenTK.Mathematics
             get => HalfSize + _min;
             set => Translate(value - Center);
         }
+
+        // --
+
+        /// <summary>
+        /// Gets or sets the width of the box.
+        /// </summary>
+        public float Width
+        {
+            get => _max.X - _min.X;
+            set => _max.X = _min.X + value;
+        }
+
+        /// <summary>
+        /// Gets or sets the height of the box.
+        /// </summary>
+        public float Height
+        {
+            get => _max.Y - _min.Y;
+            set => _max.Y = _min.Y + value;
+        }
+
+        /// <summary>
+        /// Gets or sets the depth of the box.
+        /// </summary>
+        public float Depth
+        {
+            get => _max.Z - _min.Z;
+            set => _max.Z = _min.Z + value;
+        }
+
+        /// <summary>
+        /// Gets or sets the left location of the box.
+        /// </summary>
+        public float Left
+        {
+            get => _min.X;
+            set => _min.X = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the top location of the box.
+        /// </summary>
+        public float Top
+        {
+            get => _min.Y;
+            set => _min.Y = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the right location of the box.
+        /// </summary>
+        public float Right
+        {
+            get => _max.X;
+            set => _max.X = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the bottom location of the box.
+        /// </summary>
+        public float Bottom
+        {
+            get => _max.Y;
+            set => _max.Y = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the front location of the box.
+        /// </summary>
+        public float Front
+        {
+            get => _min.Z;
+            set => _min.Z = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the back location of the box.
+        /// </summary>
+        public float Back
+        {
+            get => _max.Z;
+            set => _max.Z = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the X location of the box.
+        /// </summary>
+        public float X
+        {
+            get => _min.X;
+            set => _min.X = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the Y location of the box.
+        /// </summary>
+        public float Y
+        {
+            get => _min.Y;
+            set => _min.Y = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the Z location of the box.
+        /// </summary>
+        public float Z
+        {
+            get => _min.Z;
+            set => _min.Z = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the horizontal size.
+        /// </summary>
+        public float SizeX
+        {
+            get => _max.X - _min.X;
+            set => _max.X = _min.X + value;
+        }
+
+        /// <summary>
+        /// Gets or sets the vertical size.
+        /// </summary>
+        public float SizeY
+        {
+            get => _max.Y - _min.Y;
+            set => _max.Y = _min.Y + value;
+        }
+
+        /// <summary>
+        /// Gets or sets the vertical size.
+        /// </summary>
+        public float SizeZ
+        {
+            get => _max.Z - _min.Z;
+            set => _max.Z = _min.Z + value;
+        }
+
+        /// <summary>
+        /// Gets or sets the size of the box.
+        /// </summary>
+        public Vector3 Size
+        {
+            get => new Vector3(_max.X - _min.X, _max.Y - _min.Y, _max.Z - _min.Z);
+            set
+            {
+                _max.X = _min.X + value.X;
+                _max.Y = _min.Y + value.Y;
+                _max.Z = _min.Z + value.Z;
+            }
+        }
+
+        /// <summary>
+        /// Gets the location of the box.
+        /// </summary>
+        public Vector3 Location => _min;
+
+        /// <summary>
+        /// Gets a value indicating whether all values are zero.
+        /// </summary>
+        public bool IsZero => _min.X == 0 && _min.Y == 0 && _min.Z == 0
+                           && _max.X == 0 && _max.Y == 0 && _max.Z == 0;
+
+        /// <summary>
+        /// Gets a box with all components zero.
+        /// </summary>
+        public static readonly Box3 Zero = new Box3(0, 0, 0, 0, 0, 0);
+
+        /// <summary>
+        /// Gets a box with a location 0,0,9 with the a size of 1.
+        /// </summary>
+        public static readonly Box3 UnitSquare = new Box3(0, 0, 0, 1, 1, 1);
+
+        /// <summary>
+        /// Creates a box.
+        /// </summary>
+        /// <param name="location">The location of the box.</param>
+        /// <param name="size">The size of the box.</param>
+        /// <returns>A box.</returns>
+        public static Box3 FromSize(Vector3 location, Vector3 size)
+        {
+            return new Box3(location, location + size);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Box3"/> struct.
+        /// </summary>
+        /// <param name="min">The minimum point on the XY plane this box encloses.</param>
+        /// <param name="max">The maximum point on the XY plane this box encloses.</param>
+        /// <returns>A box.</returns>
+        public static Box3 FromPositions(Vector3 min, Vector3 max)
+        {
+            return new Box3(min, max);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Box2"/> struct.
+        /// </summary>
+        /// <param name="minX">The minimum X value to be enclosed.</param>
+        /// <param name="minY">The minimum Y value to be enclosed.</param>
+        /// <param name="minZ">The minimum Z value to be enclosed.</param>
+        /// <param name="maxX">The maximum X value to be enclosed.</param>
+        /// <param name="maxY">The maximum Y value to be enclosed.</param>
+        /// <param name="maxZ">The maximum Z value to be enclosed.</param>
+        /// <returns>A box.</returns>
+        public static Box3 FromPositions(float minX, float minY, float minZ, float maxX, float maxY, float maxZ)
+        {
+            return new Box3(minX, minY, minZ, maxX, maxY, maxZ);
+        }
+
+        /// <summary>
+        /// Replaces this Box with the intersection of itself and the specified Box.
+        /// </summary>
+        /// <param name="other">The Box with which to intersect.</param>
+        public void Intersect(Box3 other)
+        {
+            Box3 result = Intersect(other, this);
+
+            X = result.X;
+            Y = result.Y;
+            Z = result.Z;
+            Width = result.Width;
+            Height = result.Height;
+            Depth = result.Depth;
+        }
+
+        /// <summary>
+        /// Returns the intersection of two Boxes.
+        /// </summary>
+        /// <param name="a">The first box.</param>
+        /// <param name="b">The second box.</param>
+        /// <returns>The intersection of two Boxes.</returns>
+        public static Box3 Intersect(Box3 a, Box3 b)
+        {
+            float minX = a._min.X > b._min.X ? a._min.X : b._min.X;
+            float minY = a._min.Y > b._min.Y ? a._min.Y : b._min.Y;
+            float minZ = a._min.Z > b._min.Z ? a._min.Z : b._min.Z;
+            float maxX = a._max.X < b._max.X ? a._max.X : b._max.X;
+            float maxY = a._max.Y < b._max.Y ? a._max.Y : b._max.Y;
+            float maxZ = a._max.Z < b._max.Z ? a._max.Z : b._max.Z;
+
+            if (maxX >= minX && maxY >= minY && maxZ >= minZ)
+            {
+                return new Box3(minX, minY, minZ, maxX, maxY, maxZ);
+            }
+
+            return Zero;
+        }
+
+        /// <summary>
+        /// Returns the intersection of itself and the specified Box.
+        /// </summary>
+        /// <param name="other">The Box with which to intersect.</param>
+        /// <returns>The intersection of itself and the specified Box.</returns>
+        public Box3 Intersected(Box3 other)
+        {
+            return Intersect(other, this);
+        }
+
+        /// <summary>
+        /// Determines if this Box intersects with another Box.
+        /// </summary>
+        /// <param name="other">The Box to test.</param>
+        /// <returns>This method returns true if there is any intersection, otherwise false.</returns>
+        public bool IntersectsWith(Box3 other)
+        {
+            return other._min.X < _max.X
+                && _min.X < other._max.X
+                && other._min.Y < _max.Y
+                && _min.Y < other._max.Y
+                && other._min.Z < _max.Z
+                && _min.Z < other._max.Z;
+        }
+
+        /// <summary>
+        /// Determines if this Box intersects or touches with another Box.
+        /// </summary>
+        /// <param name="other">The Box to test.</param>
+        /// <returns>This method returns true if there is any intersection or touches, otherwise false.</returns>
+        public bool TouchWith(Box3 other)
+        {
+            return other._min.X <= _max.X
+                && _min.X <= other._max.X
+                && other._min.Y <= _max.Y
+                && _min.Y <= other._max.Y
+                && other._min.Z <= _max.Z
+                && _min.Z <= other._max.Z;
+        }
+
+        /// <summary>
+        /// Gets a Box structure that contains the union of two Box structures.
+        /// </summary>
+        /// <param name="a">A Box to union.</param>
+        /// <param name="b">a box to union.</param>
+        /// <returns>A Box structure that bounds the union of the two Box structures.</returns>
+        public static Box3 Union(Box3 a, Box3 b)
+        {
+            float minX = a._min.X < b._min.X ? a._min.X : b._min.X;
+            float minY = a._min.Y < b._min.Y ? a._min.Y : b._min.Y;
+            float minZ = a._min.Z < b._min.Z ? a._min.Z : b._min.Z;
+            float maxX = a._max.X > b._max.X ? a._max.X : b._max.X;
+            float maxY = a._max.Y > b._max.Y ? a._max.Y : b._max.Y;
+            float maxZ = a._max.Z > b._max.Z ? a._max.Z : b._max.Z;
+
+            return new Box3(minX, minY, minZ, maxX, maxY, maxZ);
+        }
+
+        /// <summary>
+        /// Gets a Box structure that contains rounded integers.
+        /// </summary>
+        /// <param name="value">A Box to round.</param>
+        /// <returns>A Box structure that contains rounded integers.</returns>
+        public static Box3i Round(Box3 value)
+        {
+            return new Box3i(
+                (int)MathHelper.Round(value.Min.X),
+                (int)MathHelper.Round(value.Min.Y),
+                (int)MathHelper.Round(value.Min.Z),
+                (int)MathHelper.Round(value.Max.X),
+                (int)MathHelper.Round(value.Max.Y),
+                (int)MathHelper.Round(value.Max.Z));
+        }
+
+        /// <summary>
+        /// Gets a Box structure that contains rounded up integers.
+        /// </summary>
+        /// <param name="value">A Box to round.</param>
+        /// <returns>A Box structure that contains rounded up integers.</returns>
+        public static Box3i Ceiling(Box3 value)
+        {
+            int x = (int)MathHelper.Ceiling(value._min.X);
+            int y = (int)MathHelper.Ceiling(value._min.Y);
+            int z = (int)MathHelper.Ceiling(value._min.Z);
+            int sizeX = (int)MathHelper.Ceiling(value.Width);
+            int sizeY = (int)MathHelper.Ceiling(value.Height);
+            int sizeZ = (int)MathHelper.Ceiling(value.Depth);
+
+            return new Box3i(x, y, z, x + sizeX, y + sizeY, z + sizeZ);
+        }
+
+        /// <summary>
+        /// Gets a Box structure that contains rounded down integers.
+        /// </summary>
+        /// <param name="value">A Box to round.</param>
+        /// <returns>A Box structure that contains rounded down integers.</returns>
+        public static Box3i Floor(Box3 value)
+        {
+            int x = (int)MathHelper.Floor(value._min.X);
+            int y = (int)MathHelper.Floor(value._min.Y);
+            int z = (int)MathHelper.Floor(value._min.Z);
+            int sizeX = (int)MathHelper.Floor(value.Width);
+            int sizeY = (int)MathHelper.Floor(value.Height);
+            int sizeZ = (int)MathHelper.Floor(value.Depth);
+
+            return new Box3i(x, y, z, x + sizeX, y + sizeY, z + sizeZ);
+        }
+
+        // --
 
         /// <summary>
         /// Returns whether the box contains the specified point (borders inclusive).

--- a/src/OpenTK.Mathematics/Geometry/Box3.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box3.cs
@@ -326,7 +326,7 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="Box2"/> struct.
+        /// Initializes a new instance of the <see cref="Box3"/> struct.
         /// </summary>
         /// <param name="minX">The minimum X value to be enclosed.</param>
         /// <param name="minY">The minimum Y value to be enclosed.</param>

--- a/src/OpenTK.Mathematics/Geometry/Box3.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box3.cs
@@ -290,13 +290,13 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Gets a value indicating whether all values are zero.
         /// </summary>
-        public bool IsZero => _min.X == 0 && _min.Y == 0 && _min.Z == 0
+        public bool IsEmpty => _min.X == 0 && _min.Y == 0 && _min.Z == 0
                            && _max.X == 0 && _max.Y == 0 && _max.Z == 0;
 
         /// <summary>
         /// Gets a box with all components zero.
         /// </summary>
-        public static readonly Box3 Zero = new Box3(0, 0, 0, 0, 0, 0);
+        public static readonly Box3 Empty = new Box3(0, 0, 0, 0, 0, 0);
 
         /// <summary>
         /// Gets a box with a location 0,0,9 with the a size of 1.
@@ -376,7 +376,7 @@ namespace OpenTK.Mathematics
                 return new Box3(minX, minY, minZ, maxX, maxY, maxZ);
             }
 
-            return Zero;
+            return Empty;
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Geometry/Box3d.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box3d.cs
@@ -290,7 +290,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Gets a value indicating whether all values are zero.
         /// </summary>
-        public bool IsEmpty => _min.X == 0 && _min.Y == 0 && _min.Z == 0
+        public bool IsZero => _min.X == 0 && _min.Y == 0 && _min.Z == 0
                            && _max.X == 0 && _max.Y == 0 && _max.Z == 0;
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Geometry/Box3d.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box3d.cs
@@ -102,7 +102,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Gets or sets a vector describing the size of the Box3d structure.
         /// </summary>
-        public Vector3d Size
+        public Vector3d CenteredSize
         {
             get => Max - Min;
             set
@@ -118,8 +118,8 @@ namespace OpenTK.Mathematics
         /// </summary>
         public Vector3d HalfSize
         {
-            get => Size / 2;
-            set => Size = value * 2;
+            get => CenteredSize / 2;
+            set => CenteredSize = value * 2;
         }
 
         /// <summary>
@@ -130,6 +130,364 @@ namespace OpenTK.Mathematics
             get => HalfSize + _min;
             set => Translate(value - Center);
         }
+
+        // --
+
+        /// <summary>
+        /// Gets or sets the width of the box.
+        /// </summary>
+        public double Width
+        {
+            get => _max.X - _min.X;
+            set => _max.X = _min.X + value;
+        }
+
+        /// <summary>
+        /// Gets or sets the height of the box.
+        /// </summary>
+        public double Height
+        {
+            get => _max.Y - _min.Y;
+            set => _max.Y = _min.Y + value;
+        }
+
+        /// <summary>
+        /// Gets or sets the depth of the box.
+        /// </summary>
+        public double Depth
+        {
+            get => _max.Z - _min.Z;
+            set => _max.Z = _min.Z + value;
+        }
+
+        /// <summary>
+        /// Gets or sets the left location of the box.
+        /// </summary>
+        public double Left
+        {
+            get => _min.X;
+            set => _min.X = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the top location of the box.
+        /// </summary>
+        public double Top
+        {
+            get => _min.Y;
+            set => _min.Y = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the right location of the box.
+        /// </summary>
+        public double Right
+        {
+            get => _max.X;
+            set => _max.X = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the bottom location of the box.
+        /// </summary>
+        public double Bottom
+        {
+            get => _max.Y;
+            set => _max.Y = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the front location of the box.
+        /// </summary>
+        public double Front
+        {
+            get => _min.Z;
+            set => _min.Z = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the back location of the box.
+        /// </summary>
+        public double Back
+        {
+            get => _max.Z;
+            set => _max.Z = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the X location of the box.
+        /// </summary>
+        public double X
+        {
+            get => _min.X;
+            set => _min.X = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the Y location of the box.
+        /// </summary>
+        public double Y
+        {
+            get => _min.Y;
+            set => _min.Y = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the Z location of the box.
+        /// </summary>
+        public double Z
+        {
+            get => _min.Z;
+            set => _min.Z = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the horizontal size.
+        /// </summary>
+        public double SizeX
+        {
+            get => _max.X - _min.X;
+            set => _max.X = _min.X + value;
+        }
+
+        /// <summary>
+        /// Gets or sets the vertical size.
+        /// </summary>
+        public double SizeY
+        {
+            get => _max.Y - _min.Y;
+            set => _max.Y = _min.Y + value;
+        }
+
+        /// <summary>
+        /// Gets or sets the vertical size.
+        /// </summary>
+        public double SizeZ
+        {
+            get => _max.Z - _min.Z;
+            set => _max.Z = _min.Z + value;
+        }
+
+        /// <summary>
+        /// Gets or sets the size of the box.
+        /// </summary>
+        public Vector3d Size
+        {
+            get => new Vector3d(_max.X - _min.X, _max.Y - _min.Y, _max.Z - _min.Z);
+            set
+            {
+                _max.X = _min.X + value.X;
+                _max.Y = _min.Y + value.Y;
+                _max.Z = _min.Z + value.Z;
+            }
+        }
+
+        /// <summary>
+        /// Gets the location of the box.
+        /// </summary>
+        public Vector3d Location => _min;
+
+        /// <summary>
+        /// Gets a value indicating whether all values are zero.
+        /// </summary>
+        public bool IsZero => _min.X == 0 && _min.Y == 0 && _min.Z == 0
+                           && _max.X == 0 && _max.Y == 0 && _max.Z == 0;
+
+        /// <summary>
+        /// Gets a box with all components zero.
+        /// </summary>
+        public static readonly Box3d Zero = new Box3d(0, 0, 0, 0, 0, 0);
+
+        /// <summary>
+        /// Gets a box with a location 0,0,9 with the a size of 1.
+        /// </summary>
+        public static readonly Box3d UnitSquare = new Box3d(0, 0, 0, 1, 1, 1);
+
+        /// <summary>
+        /// Creates a box.
+        /// </summary>
+        /// <param name="location">The location of the box.</param>
+        /// <param name="size">The size of the box.</param>
+        /// <returns>A box.</returns>
+        public static Box3d FromSize(Vector3d location, Vector3d size)
+        {
+            return new Box3d(location, location + size);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Box3"/> struct.
+        /// </summary>
+        /// <param name="min">The minimum point on the XY plane this box encloses.</param>
+        /// <param name="max">The maximum point on the XY plane this box encloses.</param>
+        /// <returns>A box.</returns>
+        public static Box3d FromPositions(Vector3d min, Vector3d max)
+        {
+            return new Box3d(min, max);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Box3d"/> struct.
+        /// </summary>
+        /// <param name="minX">The minimum X value to be enclosed.</param>
+        /// <param name="minY">The minimum Y value to be enclosed.</param>
+        /// <param name="minZ">The minimum Z value to be enclosed.</param>
+        /// <param name="maxX">The maximum X value to be enclosed.</param>
+        /// <param name="maxY">The maximum Y value to be enclosed.</param>
+        /// <param name="maxZ">The maximum Z value to be enclosed.</param>
+        /// <returns>A box.</returns>
+        public static Box3d FromPositions(double minX, double minY, double minZ, double maxX, double maxY, double maxZ)
+        {
+            return new Box3d(minX, minY, minZ, maxX, maxY, maxZ);
+        }
+
+        /// <summary>
+        /// Replaces this Box with the intersection of itself and the specified Box.
+        /// </summary>
+        /// <param name="other">The Box with which to intersect.</param>
+        public void Intersect(Box3d other)
+        {
+            Box3d result = Intersect(other, this);
+
+            X = result.X;
+            Y = result.Y;
+            Z = result.Z;
+            Width = result.Width;
+            Height = result.Height;
+            Depth = result.Depth;
+        }
+
+        /// <summary>
+        /// Returns the intersection of two Boxes.
+        /// </summary>
+        /// <param name="a">The first box.</param>
+        /// <param name="b">The second box.</param>
+        /// <returns>The intersection of two Boxes.</returns>
+        public static Box3d Intersect(Box3d a, Box3d b)
+        {
+            double minX = a._min.X > b._min.X ? a._min.X : b._min.X;
+            double minY = a._min.Y > b._min.Y ? a._min.Y : b._min.Y;
+            double minZ = a._min.Z > b._min.Z ? a._min.Z : b._min.Z;
+            double maxX = a._max.X < b._max.X ? a._max.X : b._max.X;
+            double maxY = a._max.Y < b._max.Y ? a._max.Y : b._max.Y;
+            double maxZ = a._max.Z < b._max.Z ? a._max.Z : b._max.Z;
+
+            if (maxX >= minX && maxY >= minY && maxZ >= minZ)
+            {
+                return new Box3d(minX, minY, minZ, maxX, maxY, maxZ);
+            }
+
+            return Zero;
+        }
+
+        /// <summary>
+        /// Returns the intersection of itself and the specified Box.
+        /// </summary>
+        /// <param name="other">The Box with which to intersect.</param>
+        /// <returns>The intersection of itself and the specified Box.</returns>
+        public Box3d Intersected(Box3d other)
+        {
+            return Intersect(other, this);
+        }
+
+        /// <summary>
+        /// Determines if this Box intersects with another Box.
+        /// </summary>
+        /// <param name="other">The Box to test.</param>
+        /// <returns>This method returns true if there is any intersection, otherwise false.</returns>
+        public bool IntersectsWith(Box3d other)
+        {
+            return other._min.X < _max.X
+                && _min.X < other._max.X
+                && other._min.Y < _max.Y
+                && _min.Y < other._max.Y
+                && other._min.Z < _max.Z
+                && _min.Z < other._max.Z;
+        }
+
+        /// <summary>
+        /// Determines if this Box intersects or touches with another Box.
+        /// </summary>
+        /// <param name="other">The Box to test.</param>
+        /// <returns>This method returns true if there is any intersection or touches, otherwise false.</returns>
+        public bool TouchWith(Box3d other)
+        {
+            return other._min.X <= _max.X
+                && _min.X <= other._max.X
+                && other._min.Y <= _max.Y
+                && _min.Y <= other._max.Y
+                && other._min.Z <= _max.Z
+                && _min.Z <= other._max.Z;
+        }
+
+        /// <summary>
+        /// Gets a Box structure that contains the union of two Box structures.
+        /// </summary>
+        /// <param name="a">A Box to union.</param>
+        /// <param name="b">a box to union.</param>
+        /// <returns>A Box structure that bounds the union of the two Box structures.</returns>
+        public static Box3d Union(Box3d a, Box3d b)
+        {
+            double minX = a._min.X < b._min.X ? a._min.X : b._min.X;
+            double minY = a._min.Y < b._min.Y ? a._min.Y : b._min.Y;
+            double minZ = a._min.Z < b._min.Z ? a._min.Z : b._min.Z;
+            double maxX = a._max.X > b._max.X ? a._max.X : b._max.X;
+            double maxY = a._max.Y > b._max.Y ? a._max.Y : b._max.Y;
+            double maxZ = a._max.Z > b._max.Z ? a._max.Z : b._max.Z;
+
+            return new Box3d(minX, minY, minZ, maxX, maxY, maxZ);
+        }
+
+        /// <summary>
+        /// Gets a Box structure that contains rounded integers.
+        /// </summary>
+        /// <param name="value">A Box to round.</param>
+        /// <returns>A Box structure that contains rounded integers.</returns>
+        public static Box3i Round(Box3d value)
+        {
+            return new Box3i(
+                (int)MathHelper.Round(value.Min.X),
+                (int)MathHelper.Round(value.Min.Y),
+                (int)MathHelper.Round(value.Min.Z),
+                (int)MathHelper.Round(value.Max.X),
+                (int)MathHelper.Round(value.Max.Y),
+                (int)MathHelper.Round(value.Max.Z));
+        }
+
+        /// <summary>
+        /// Gets a Box structure that contains rounded up integers.
+        /// </summary>
+        /// <param name="value">A Box to round.</param>
+        /// <returns>A Box structure that contains rounded up integers.</returns>
+        public static Box3i Ceiling(Box3d value)
+        {
+            int x = (int)MathHelper.Ceiling(value._min.X);
+            int y = (int)MathHelper.Ceiling(value._min.Y);
+            int z = (int)MathHelper.Ceiling(value._min.Z);
+            int sizeX = (int)MathHelper.Ceiling(value.Width);
+            int sizeY = (int)MathHelper.Ceiling(value.Height);
+            int sizeZ = (int)MathHelper.Ceiling(value.Depth);
+
+            return new Box3i(x, y, z, x + sizeX, y + sizeY, z + sizeZ);
+        }
+
+        /// <summary>
+        /// Gets a Box structure that contains rounded down integers.
+        /// </summary>
+        /// <param name="value">A Box to round.</param>
+        /// <returns>A Box structure that contains rounded down integers.</returns>
+        public static Box3i Floor(Box3d value)
+        {
+            int x = (int)MathHelper.Floor(value._min.X);
+            int y = (int)MathHelper.Floor(value._min.Y);
+            int z = (int)MathHelper.Floor(value._min.Z);
+            int sizeX = (int)MathHelper.Floor(value.Width);
+            int sizeY = (int)MathHelper.Floor(value.Height);
+            int sizeZ = (int)MathHelper.Floor(value.Depth);
+
+            return new Box3i(x, y, z, x + sizeX, y + sizeY, z + sizeZ);
+        }
+
+        // --
 
         /// <summary>
         /// Returns whether the box contains the specified point (borders inclusive).

--- a/src/OpenTK.Mathematics/Geometry/Box3d.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box3d.cs
@@ -290,13 +290,13 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Gets a value indicating whether all values are zero.
         /// </summary>
-        public bool IsZero => _min.X == 0 && _min.Y == 0 && _min.Z == 0
+        public bool IsEmpty => _min.X == 0 && _min.Y == 0 && _min.Z == 0
                            && _max.X == 0 && _max.Y == 0 && _max.Z == 0;
 
         /// <summary>
         /// Gets a box with all components zero.
         /// </summary>
-        public static readonly Box3d Zero = new Box3d(0, 0, 0, 0, 0, 0);
+        public static readonly Box3d Empty = new Box3d(0, 0, 0, 0, 0, 0);
 
         /// <summary>
         /// Gets a box with a location 0,0,9 with the a size of 1.
@@ -376,7 +376,7 @@ namespace OpenTK.Mathematics
                 return new Box3d(minX, minY, minZ, maxX, maxY, maxZ);
             }
 
-            return Zero;
+            return Empty;
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Geometry/Box3i.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box3i.cs
@@ -289,7 +289,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Gets a value indicating whether all values are zero.
         /// </summary>
-        public bool IsEmpty => _min.X == 0 && _min.Y == 0 && _min.Z == 0
+        public bool IsZero => _min.X == 0 && _min.Y == 0 && _min.Z == 0
                            && _max.X == 0 && _max.Y == 0 && _max.Z == 0;
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Geometry/Box3i.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box3i.cs
@@ -289,13 +289,13 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Gets a value indicating whether all values are zero.
         /// </summary>
-        public bool IsZero => _min.X == 0 && _min.Y == 0 && _min.Z == 0
+        public bool IsEmpty => _min.X == 0 && _min.Y == 0 && _min.Z == 0
                            && _max.X == 0 && _max.Y == 0 && _max.Z == 0;
 
         /// <summary>
         /// Gets a box with all components zero.
         /// </summary>
-        public static readonly Box3i Zero = new Box3i(0, 0, 0, 0, 0, 0);
+        public static readonly Box3i Empty = new Box3i(0, 0, 0, 0, 0, 0);
 
         /// <summary>
         /// Gets a box with a location 0,0,9 with the a size of 1.
@@ -375,7 +375,7 @@ namespace OpenTK.Mathematics
                 return new Box3i(minX, minY, minZ, maxX, maxY, maxZ);
             }
 
-            return Zero;
+            return Empty;
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Geometry/Box3i.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box3i.cs
@@ -102,7 +102,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Gets a vector describing the size of the Box3i structure.
         /// </summary>
-        public Vector3i Size
+        public Vector3i CenteredSize
         {
             get => Max - Min;
         }
@@ -112,7 +112,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public Vector3i HalfSize
         {
-            get => Size / 2;
+            get => CenteredSize / 2;
             set
             {
                 Vector3i center = new Vector3i((int)Center.X, (int)Center.Y, (int)Center.Z);
@@ -129,6 +129,314 @@ namespace OpenTK.Mathematics
         {
             get => ((_min + _max).ToVector3() * 0.5f) + _min.ToVector3();
         }
+
+        // --
+
+        /// <summary>
+        /// Gets or sets the width of the box.
+        /// </summary>
+        public int Width
+        {
+            get => _max.X - _min.X;
+            set => _max.X = _min.X + value;
+        }
+
+        /// <summary>
+        /// Gets or sets the height of the box.
+        /// </summary>
+        public int Height
+        {
+            get => _max.Y - _min.Y;
+            set => _max.Y = _min.Y + value;
+        }
+
+        /// <summary>
+        /// Gets or sets the depth of the box.
+        /// </summary>
+        public int Depth
+        {
+            get => _max.Z - _min.Z;
+            set => _max.Z = _min.Z + value;
+        }
+
+        /// <summary>
+        /// Gets or sets the left location of the box.
+        /// </summary>
+        public int Left
+        {
+            get => _min.X;
+            set => _min.X = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the top location of the box.
+        /// </summary>
+        public int Top
+        {
+            get => _min.Y;
+            set => _min.Y = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the right location of the box.
+        /// </summary>
+        public int Right
+        {
+            get => _max.X;
+            set => _max.X = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the bottom location of the box.
+        /// </summary>
+        public int Bottom
+        {
+            get => _max.Y;
+            set => _max.Y = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the front location of the box.
+        /// </summary>
+        public int Front
+        {
+            get => _min.Z;
+            set => _min.Z = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the back location of the box.
+        /// </summary>
+        public int Back
+        {
+            get => _max.Z;
+            set => _max.Z = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the X location of the box.
+        /// </summary>
+        public int X
+        {
+            get => _min.X;
+            set => _min.X = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the Y location of the box.
+        /// </summary>
+        public int Y
+        {
+            get => _min.Y;
+            set => _min.Y = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the Z location of the box.
+        /// </summary>
+        public int Z
+        {
+            get => _min.Z;
+            set => _min.Z = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the horizontal size.
+        /// </summary>
+        public int SizeX
+        {
+            get => _max.X - _min.X;
+            set => _max.X = _min.X + value;
+        }
+
+        /// <summary>
+        /// Gets or sets the vertical size.
+        /// </summary>
+        public int SizeY
+        {
+            get => _max.Y - _min.Y;
+            set => _max.Y = _min.Y + value;
+        }
+
+        /// <summary>
+        /// Gets or sets the vertical size.
+        /// </summary>
+        public int SizeZ
+        {
+            get => _max.Z - _min.Z;
+            set => _max.Z = _min.Z + value;
+        }
+
+        /// <summary>
+        /// Gets or sets the size of the box.
+        /// </summary>
+        public Vector3i Size
+        {
+            get => new Vector3i(_max.X - _min.X, _max.Y - _min.Y, _max.Z - _min.Z);
+            set
+            {
+                _max.X = _min.X + value.X;
+                _max.Y = _min.Y + value.Y;
+                _max.Z = _min.Z + value.Z;
+            }
+        }
+
+        /// <summary>
+        /// Gets the location of the box.
+        /// </summary>
+        public Vector3i Location => _min;
+
+        /// <summary>
+        /// Gets a value indicating whether all values are zero.
+        /// </summary>
+        public bool IsZero => _min.X == 0 && _min.Y == 0 && _min.Z == 0
+                           && _max.X == 0 && _max.Y == 0 && _max.Z == 0;
+
+        /// <summary>
+        /// Gets a box with all components zero.
+        /// </summary>
+        public static readonly Box3i Zero = new Box3i(0, 0, 0, 0, 0, 0);
+
+        /// <summary>
+        /// Gets a box with a location 0,0,9 with the a size of 1.
+        /// </summary>
+        public static readonly Box3i UnitSquare = new Box3i(0, 0, 0, 1, 1, 1);
+
+        /// <summary>
+        /// Creates a box.
+        /// </summary>
+        /// <param name="location">The location of the box.</param>
+        /// <param name="size">The size of the box.</param>
+        /// <returns>A box.</returns>
+        public static Box3i FromSize(Vector3i location, Vector3i size)
+        {
+            return new Box3i(location, location + size);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Box3"/> struct.
+        /// </summary>
+        /// <param name="min">The minimum point on the XY plane this box encloses.</param>
+        /// <param name="max">The maximum point on the XY plane this box encloses.</param>
+        /// <returns>A box.</returns>
+        public static Box3i FromPositions(Vector3i min, Vector3i max)
+        {
+            return new Box3i(min, max);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Box3i"/> struct.
+        /// </summary>
+        /// <param name="minX">The minimum X value to be enclosed.</param>
+        /// <param name="minY">The minimum Y value to be enclosed.</param>
+        /// <param name="minZ">The minimum Z value to be enclosed.</param>
+        /// <param name="maxX">The maximum X value to be enclosed.</param>
+        /// <param name="maxY">The maximum Y value to be enclosed.</param>
+        /// <param name="maxZ">The maximum Z value to be enclosed.</param>
+        /// <returns>A box.</returns>
+        public static Box3i FromPositions(int minX, int minY, int minZ, int maxX, int maxY, int maxZ)
+        {
+            return new Box3i(minX, minY, minZ, maxX, maxY, maxZ);
+        }
+
+        /// <summary>
+        /// Replaces this Box with the intersection of itself and the specified Box.
+        /// </summary>
+        /// <param name="other">The Box with which to intersect.</param>
+        public void Intersect(Box3i other)
+        {
+            Box3i result = Intersect(other, this);
+
+            X = result.X;
+            Y = result.Y;
+            Z = result.Z;
+            Width = result.Width;
+            Height = result.Height;
+            Depth = result.Depth;
+        }
+
+        /// <summary>
+        /// Returns the intersection of two Boxes.
+        /// </summary>
+        /// <param name="a">The first box.</param>
+        /// <param name="b">The second box.</param>
+        /// <returns>The intersection of two Boxes.</returns>
+        public static Box3i Intersect(Box3i a, Box3i b)
+        {
+            int minX = a._min.X > b._min.X ? a._min.X : b._min.X;
+            int minY = a._min.Y > b._min.Y ? a._min.Y : b._min.Y;
+            int minZ = a._min.Z > b._min.Z ? a._min.Z : b._min.Z;
+            int maxX = a._max.X < b._max.X ? a._max.X : b._max.X;
+            int maxY = a._max.Y < b._max.Y ? a._max.Y : b._max.Y;
+            int maxZ = a._max.Z < b._max.Z ? a._max.Z : b._max.Z;
+
+            if (maxX >= minX && maxY >= minY && maxZ >= minZ)
+            {
+                return new Box3i(minX, minY, minZ, maxX, maxY, maxZ);
+            }
+
+            return Zero;
+        }
+
+        /// <summary>
+        /// Returns the intersection of itself and the specified Box.
+        /// </summary>
+        /// <param name="other">The Box with which to intersect.</param>
+        /// <returns>The intersection of itself and the specified Box.</returns>
+        public Box3i Intersected(Box3i other)
+        {
+            return Intersect(other, this);
+        }
+
+        /// <summary>
+        /// Determines if this Box intersects with another Box.
+        /// </summary>
+        /// <param name="other">The Box to test.</param>
+        /// <returns>This method returns true if there is any intersection, otherwise false.</returns>
+        public bool IntersectsWith(Box3i other)
+        {
+            return other._min.X < _max.X
+                && _min.X < other._max.X
+                && other._min.Y < _max.Y
+                && _min.Y < other._max.Y
+                && other._min.Z < _max.Z
+                && _min.Z < other._max.Z;
+        }
+
+        /// <summary>
+        /// Determines if this Box intersects or touches with another Box.
+        /// </summary>
+        /// <param name="other">The Box to test.</param>
+        /// <returns>This method returns true if there is any intersection or touches, otherwise false.</returns>
+        public bool TouchWith(Box3i other)
+        {
+            return other._min.X <= _max.X
+                && _min.X <= other._max.X
+                && other._min.Y <= _max.Y
+                && _min.Y <= other._max.Y
+                && other._min.Z <= _max.Z
+                && _min.Z <= other._max.Z;
+        }
+
+        /// <summary>
+        /// Gets a Box structure that contains the union of two Box structures.
+        /// </summary>
+        /// <param name="a">A Box to union.</param>
+        /// <param name="b">a box to union.</param>
+        /// <returns>A Box structure that bounds the union of the two Box structures.</returns>
+        public static Box3i Union(Box3i a, Box3i b)
+        {
+            int minX = a._min.X < b._min.X ? a._min.X : b._min.X;
+            int minY = a._min.Y < b._min.Y ? a._min.Y : b._min.Y;
+            int minZ = a._min.Z < b._min.Z ? a._min.Z : b._min.Z;
+            int maxX = a._max.X > b._max.X ? a._max.X : b._max.X;
+            int maxY = a._max.Y > b._max.Y ? a._max.Y : b._max.Y;
+            int maxZ = a._max.Z > b._max.Z ? a._max.Z : b._max.Z;
+
+            return new Box3i(minX, minY, minZ, maxX, maxY, maxZ);
+        }
+
+        // --
 
         /// <summary>
         /// Returns whether the box contains the specified point (borders inclusive).


### PR DESCRIPTION
### Purpose of this PR

This cherry picks the box changes from #1037 into OpenTK 5 so that we can revert them in OpenTK 4 and get OpenTK 4.7 released.

### Testing status

The implementation has the same testing status as in #1037, though the cherry pick might have messed something up.
Worth testing some of it again.
