### PR TITLE
Added missing One and Zero in Vector3i

### DIFF
--- a/src/OpenTK.Mathematics/Vector/Vector2.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2.cs
@@ -190,7 +190,7 @@ namespace OpenTK.Mathematics
         public static readonly Vector2 UnitY = new Vector2(0, 1);
 
         /// <summary>
-        /// Defines a zero-length Vector2.
+        /// Defines an instance with all components set to 0.
         /// </summary>
         public static readonly Vector2 Zero = new Vector2(0, 0);
 

--- a/src/OpenTK.Mathematics/Vector/Vector2d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2d.cs
@@ -57,7 +57,7 @@ namespace OpenTK.Mathematics
         public static readonly Vector2d UnitY = new Vector2d(0, 1);
 
         /// <summary>
-        /// Defines a zero-length Vector2d.
+        /// Defines an instance with all components set to 0.
         /// </summary>
         public static readonly Vector2d Zero = new Vector2d(0, 0);
 

--- a/src/OpenTK.Mathematics/Vector/Vector2i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2i.cs
@@ -127,7 +127,7 @@ namespace OpenTK.Mathematics
         public static readonly Vector2i UnitY = new Vector2i(0, 1);
 
         /// <summary>
-        /// Defines a zero-length <see cref="Vector2i"/>.
+        /// Defines an instance with all components set to 0.
         /// </summary>
         public static readonly Vector2i Zero = new Vector2i(0, 0);
 

--- a/src/OpenTK.Mathematics/Vector/Vector3.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3.cs
@@ -237,7 +237,7 @@ namespace OpenTK.Mathematics
         public static readonly Vector3 UnitZ = new Vector3(0, 0, 1);
 
         /// <summary>
-        /// Defines a zero-length Vector3.
+        /// Defines an instance with all components set to 0.
         /// </summary>
         public static readonly Vector3 Zero = new Vector3(0, 0, 0);
 

--- a/src/OpenTK.Mathematics/Vector/Vector3d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3d.cs
@@ -234,7 +234,7 @@ namespace OpenTK.Mathematics
         public static readonly Vector3d UnitZ = new Vector3d(0, 0, 1);
 
         /// <summary>
-        /// Defines a zero-length Vector3.
+        /// Defines an instance with all components set to 0.
         /// </summary>
         public static readonly Vector3d Zero = new Vector3d(0, 0, 0);
 

--- a/src/OpenTK.Mathematics/Vector/Vector3i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3i.cs
@@ -162,6 +162,16 @@ namespace OpenTK.Mathematics
         public static readonly Vector3i UnitZ = new Vector3i(0, 0, 1);
 
         /// <summary>
+        /// Defines an instance with all components set to 0.
+        /// </summary>
+        public static readonly Vector3i Zero = new Vector3i(0, 0, 0);
+
+        /// <summary>
+        /// Defines an instance with all components set to 1.
+        /// </summary>
+        public static readonly Vector3i One = new Vector3i(1, 1, 1);
+
+        /// <summary>
         /// Defines the size of the Vector3i struct in bytes.
         /// </summary>
         public static readonly int SizeInBytes = Unsafe.SizeOf<Vector3i>();

--- a/src/OpenTK.Mathematics/Vector/Vector4.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4.cs
@@ -80,7 +80,7 @@ namespace OpenTK.Mathematics
         public static readonly Vector4 UnitW = new Vector4(0, 0, 0, 1);
 
         /// <summary>
-        /// Defines a zero-length Vector4.
+        /// Defines an instance with all components set to 0.
         /// </summary>
         public static readonly Vector4 Zero = new Vector4(0, 0, 0, 0);
 

--- a/src/OpenTK.Mathematics/Vector/Vector4d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4d.cs
@@ -80,7 +80,7 @@ namespace OpenTK.Mathematics
         public static readonly Vector4d UnitW = new Vector4d(0, 0, 0, 1);
 
         /// <summary>
-        /// Defines a zero-length Vector4d.
+        /// Defines an instance with all components set to 0.
         /// </summary>
         public static readonly Vector4d Zero = new Vector4d(0, 0, 0, 0);
 

--- a/src/OpenTK.Mathematics/Vector/Vector4i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4i.cs
@@ -211,7 +211,7 @@ namespace OpenTK.Mathematics
         public static readonly Vector4i UnitW = new Vector4i(0, 0, 0, 1);
 
         /// <summary>
-        /// Defines a zero-length <see cref="Vector4i"/>.
+        /// Defines an instance with all components set to 0.
         /// </summary>
         public static readonly Vector4i Zero = new Vector4i(0, 0, 0, 0);
 


### PR DESCRIPTION
### Purpose of this PR

Adds missing `One` and `Zero` constants to `Vector3i`.
Fixes #1384 

### Testing status

No need for testing.
