### PR TITLE
Added component-wise division operator to vector types.

### DIFF
--- a/src/OpenTK.Mathematics/Vector/Vector2.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2.cs
@@ -947,6 +947,20 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
+        /// Component-wise division between the specified instance by a scale vector.
+        /// </summary>
+        /// <param name="vec">Left operand.</param>
+        /// <param name="scale">Right operand.</param>
+        /// <returns>Result of the division.</returns>
+        [Pure]
+        public static Vector2 operator /(Vector2 vec, Vector2 scale)
+        {
+            vec.X /= scale.X;
+            vec.Y /= scale.Y;
+            return vec;
+        }
+
+        /// <summary>
         /// Compares the specified instances for equality.
         /// </summary>
         /// <param name="left">Left operand.</param>

--- a/src/OpenTK.Mathematics/Vector/Vector2d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2d.cs
@@ -898,6 +898,20 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
+        /// Component-wise division between the specified instance by a scale vector.
+        /// </summary>
+        /// <param name="vec">Left operand.</param>
+        /// <param name="scale">Right operand.</param>
+        /// <returns>Result of the division.</returns>
+        [Pure]
+        public static Vector2d operator /(Vector2d vec, Vector2d scale)
+        {
+            vec.X /= scale.X;
+            vec.Y /= scale.Y;
+            return vec;
+        }
+
+        /// <summary>
         /// Compares two instances for equality.
         /// </summary>
         /// <param name="left">The left instance.</param>

--- a/src/OpenTK.Mathematics/Vector/Vector2i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2i.cs
@@ -503,6 +503,20 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
+        /// Component-wise division between the specified instance by a scale vector.
+        /// </summary>
+        /// <param name="vec">Left operand.</param>
+        /// <param name="scale">Right operand.</param>
+        /// <returns>Result of the division.</returns>
+        [Pure]
+        public static Vector2i operator /(Vector2i vec, Vector2i scale)
+        {
+            vec.X /= scale.X;
+            vec.Y /= scale.Y;
+            return vec;
+        }
+
+        /// <summary>
         /// Compares the specified instances for equality.
         /// </summary>
         /// <param name="left">Left operand.</param>

--- a/src/OpenTK.Mathematics/Vector/Vector3.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3.cs
@@ -1503,6 +1503,21 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
+        /// Component-wise division between the specified instance by a scale vector.
+        /// </summary>
+        /// <param name="vec">Left operand.</param>
+        /// <param name="scale">Right operand.</param>
+        /// <returns>Result of the division.</returns>
+        [Pure]
+        public static Vector3 operator /(Vector3 vec, Vector3 scale)
+        {
+            vec.X /= scale.X;
+            vec.Y /= scale.Y;
+            vec.Z /= scale.Z;
+            return vec;
+        }
+
+        /// <summary>
         /// Compares two instances for equality.
         /// </summary>
         /// <param name="left">The first instance.</param>

--- a/src/OpenTK.Mathematics/Vector/Vector3d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3d.cs
@@ -1369,6 +1369,21 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
+        /// Component-wise division between the specified instance by a scale vector.
+        /// </summary>
+        /// <param name="vec">Left operand.</param>
+        /// <param name="scale">Right operand.</param>
+        /// <returns>Result of the division.</returns>
+        [Pure]
+        public static Vector3d operator /(Vector3d vec, Vector3d scale)
+        {
+            vec.X /= scale.X;
+            vec.Y /= scale.Y;
+            vec.Z /= scale.Z;
+            return vec;
+        }
+
+        /// <summary>
         /// Compares two instances for equality.
         /// </summary>
         /// <param name="left">The first instance.</param>

--- a/src/OpenTK.Mathematics/Vector/Vector3i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3i.cs
@@ -696,6 +696,21 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
+        /// Component-wise division between the specified instance by a scale vector.
+        /// </summary>
+        /// <param name="vec">Left operand.</param>
+        /// <param name="scale">Right operand.</param>
+        /// <returns>Result of the division.</returns>
+        [Pure]
+        public static Vector3i operator /(Vector3i vec, Vector3i scale)
+        {
+            vec.X /= scale.X;
+            vec.Y /= scale.Y;
+            vec.Z /= scale.Z;
+            return vec;
+        }
+
+        /// <summary>
         /// Compares two instances for equality.
         /// </summary>
         /// <param name="left">The first instance.</param>

--- a/src/OpenTK.Mathematics/Vector/Vector4.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4.cs
@@ -1969,6 +1969,22 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
+        /// Component-wise division between the specified instance by a scale vector.
+        /// </summary>
+        /// <param name="vec">Left operand.</param>
+        /// <param name="scale">Right operand.</param>
+        /// <returns>Result of the division.</returns>
+        [Pure]
+        public static Vector4 operator /(Vector4 vec, Vector4 scale)
+        {
+            vec.X /= scale.X;
+            vec.Y /= scale.Y;
+            vec.Z /= scale.Z;
+            vec.W /= scale.W;
+            return vec;
+        }
+
+        /// <summary>
         /// Compares two instances for equality.
         /// </summary>
         /// <param name="left">The first instance.</param>

--- a/src/OpenTK.Mathematics/Vector/Vector4d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4d.cs
@@ -1964,6 +1964,22 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
+        /// Component-wise division between the specified instance by a scale vector.
+        /// </summary>
+        /// <param name="vec">Left operand.</param>
+        /// <param name="scale">Right operand.</param>
+        /// <returns>Result of the division.</returns>
+        [Pure]
+        public static Vector4d operator /(Vector4d vec, Vector4d scale)
+        {
+            vec.X /= scale.X;
+            vec.Y /= scale.Y;
+            vec.Z /= scale.Z;
+            vec.W /= scale.W;
+            return vec;
+        }
+
+        /// <summary>
         /// Compares two instances for equality.
         /// </summary>
         /// <param name="left">The first instance.</param>

--- a/src/OpenTK.Mathematics/Vector/Vector4i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4i.cs
@@ -1576,6 +1576,22 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
+        /// Component-wise division between the specified instance by a scale vector.
+        /// </summary>
+        /// <param name="vec">Left operand.</param>
+        /// <param name="scale">Right operand.</param>
+        /// <returns>Result of the division.</returns>
+        [Pure]
+        public static Vector4i operator /(Vector4i vec, Vector4i scale)
+        {
+            vec.X /= scale.X;
+            vec.Y /= scale.Y;
+            vec.Z /= scale.Z;
+            vec.W /= scale.W;
+            return vec;
+        }
+
+        /// <summary>
         /// Compares two instances for equality.
         /// </summary>
         /// <param name="left">The first instance.</param>


### PR DESCRIPTION
### Purpose of this PR

Adds component-wise operators to all vector types (excluding `Half` vectors).
Fixes #1385 

### Testing status

Manually tested.