### PR TITLE
Fixed ReadOnlySpan<int> overload in OpenAL loop points extension

### DIFF
--- a/src/OpenAL/OpenTK.OpenAL/Extensions/SOFT.LoopPoints/LoopPoints.cs
+++ b/src/OpenAL/OpenTK.OpenAL/Extensions/SOFT.LoopPoints/LoopPoints.cs
@@ -34,8 +34,10 @@ namespace OpenTK.Audio.OpenAL.Extensions.SOFT.LoopPoints
         [DllImport(AL.Lib, EntryPoint = "alBufferiv", ExactSpelling = true, CallingConvention = AL.ALCallingConvention)]
         public static extern void Buffer(int buffer, BufferLoopPoint param, ref int values);
 
-        [DllImport(AL.Lib, EntryPoint = "alBufferiv", ExactSpelling = true, CallingConvention = AL.ALCallingConvention)]
-        public static extern void Buffer(int buffer, BufferLoopPoint param, ReadOnlySpan<int> values);
+        public static unsafe void Buffer(int buffer, BufferLoopPoint param, ReadOnlySpan<int> values)
+        {
+            Buffer(buffer, param, ref MemoryMarshal.GetReference(values));
+        }
 
         public static void Buffer(int buffer, BufferLoopPoint param, int start, int end)
         {


### PR DESCRIPTION
### Purpose of this PR

Changes the `ReadOnlySpan<int>` overload to no longer marshal the span directly.

### Testing status

Not tested.