### PR TITLE
Fixed filepath and use of deprecated syntanx in batch file

### DIFF
--- a/update-bindings.bat
+++ b/update-bindings.bat
@@ -1,2 +1,2 @@
-dotnet run -f netcoreapp31 -p "src/Generators/Generator.Bind/Generator.Bind.csproj" %*
+dotnet run -f netcoreapp3.1 --project "src/Generator.Bind/Generator.Bind.csproj" %*
 pause

--- a/update-specifications.bat
+++ b/update-specifications.bat
@@ -1,2 +1,2 @@
-dotnet run -f netcoreapp31 -p "src/Generators/Generator.Converter/Generator.Convert.csproj" -i https://raw.githubusercontent.com/KhronosGroup/OpenGL-Registry/master/xml/gl.xml -o src/Generators/Generator.Bind/Specifications/OpenGL/signatures.xml --prefix gl
+dotnet run -f netcoreapp3.1 --project "src/Generator.Converter/Generator.Convert.csproj" -i https://raw.githubusercontent.com/KhronosGroup/OpenGL-Registry/master/xml/gl.xml -o src/Generator.Bind/Specifications/GL2/signatures.xml --prefix gl
 pause


### PR DESCRIPTION
### Purpose of this PR

This PR fixes two batch scripts to generated all of the bindings.
I was trying to run them because of #1398 and it said that "-p" is deprecated. I also updated the file paths and changed
`netcoreapp31` to `netcoreapp3.1`. Without all of these changes the scripts wouldn't properly execute in dotnet 6.

### Testing status

They both run fine on dotnet 6.
