### PR TITLE
Fixed Generator.Converter to be able to handle the new enum group format in gl.xml

### DIFF
--- a/src/Generator.Bind/Specifications/GL2/overrides.xml
+++ b/src/Generator.Bind/Specifications/GL2/overrides.xml
@@ -5540,7 +5540,7 @@
     <function name="GetTranslatedShaderSource" extension="ANGLE">
       <param name="length" legacyArrayParameter="true" />
       <param name="source">
-        <count>bufsize</count>
+        <count>bufSize</count>
       </param>
     </function>
     <function name="GetProgramBinary" extension="OES">

--- a/src/Generator.Bind/Specifications/GL2/signatures.xml
+++ b/src/Generator.Bind/Specifications/GL2/signatures.xml
@@ -62277,7 +62277,7 @@
     </function>
     <function name="GetTranslatedShaderSourceANGLE" category="ANGLE_translated_shader_source" extension="ANGLE">
       <param name="shader" type="GLuint" flow="in" />
-      <param name="bufsize" type="GLsizei" flow="in" />
+      <param name="bufSize" type="GLsizei" flow="in" />
       <param name="length" type="GLsizei *" flow="out" count="1" />
       <param name="source" type="GLchar *" flow="out" />
       <returns type="void" />


### PR DESCRIPTION
### Purpose of this PR

Khronos OpenGL-Registry `gl.xml` has changed how it handles enum groups, `Generator.Converter` has not been updated since before that change so this PR modifies `Generator.Converter` so that it still groups enums correctly.

### Testing status

Has been locally tested to see that it produces enum groups.
It's hard to compare if it generates identical enum groups as the groups have changed in `gl.xml`, as well as the order of enums and such. And I do not know the last version of `gl.xml` used to generate the bindings so I cannot compare what has changed in respect to that.

### Comments

This doesn't actually run the `Generator.Converter` project and does not update any of the specification files in the OpenTK repo. This is just so that the possibility of running `Generator.Converter` is there, which might be used to update the bindings in the fututre.

This might be interesting to backport to OpenTK 3 too, if we ever want to update the OpenGL spec used there.