### PR TITLE
Actually update OpenTK.glfw.redist nuget package we are using...

### DIFF
--- a/src/OpenTK.Windowing.GraphicsLibraryFramework/paket
+++ b/src/OpenTK.Windowing.GraphicsLibraryFramework/paket
@@ -5,7 +5,7 @@ description
 dependencies
     framework: netcoreapp3.1
         OpenTK.Core ~> #VERSION#
-        OpenTK.redist.glfw ~> 3.3.0-pre20200830200122
+        OpenTK.redist.glfw ~> 3.3.5.18
 files
     bin\Release\netcoreapp3.1\OpenTK.Windowing.GraphicsLibraryFramework.dll ==> lib\netcoreapp3.1
     bin\Release\netcoreapp3.1\OpenTK.Windowing.GraphicsLibraryFramework.xml ==> lib\netcoreapp3.1


### PR DESCRIPTION
### Purpose of this PR

#1344 tried updating GLFW to the newest version, but just changing the .csproj file is apparently not enough as we are building our nuget packages through paket. So this PR changes the paket file so that the dependency for the nuget package is correctly updated.

### Testing status

Built the nuget packages locally and checked that their dependencies are correct.