### PR TITLE
Fixed ComponentMin returning wrong result

### DIFF
--- a/src/OpenTK.Mathematics/Vector/Vector3i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3i.cs
@@ -345,7 +345,7 @@ namespace OpenTK.Mathematics
             result.X = Math.Min(a.X, b.X);
             result.Y = Math.Min(a.Y, b.Y);
             result.Z = Math.Min(a.Z, b.Z);
-            return a;
+            return result;
         }
 
         /// <summary>


### PR DESCRIPTION
There is a type-o in ComponentMin. Instead of returning the calculated result, it returns one of the parameters.