### PR TITLE
Expose ProcessInputEvents() to allow for proper multi-window setups

### DIFF
--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -1423,7 +1423,11 @@ namespace OpenTK.Windowing.Desktop
             }
         }
 
-        private unsafe void ProcessInputEvents()
+        /// <summary>
+        /// Updates the input state in preparation for a call to <see cref="GLFW.PollEvents"/> or <see cref="GLFW.WaitEvents"/>.
+        /// Do not call this function if you are calling <see cref="ProcessEvents()"/> or if you are running the window using <see cref="GameWindow.Run()"/>.
+        /// </summary>
+        public unsafe void ProcessInputEvents()
         {
             MouseState.Update();
             KeyboardState.Update();


### PR DESCRIPTION
### Purpose of this PR

Exposes `ProcessInputEvents` so that multi-window setups can have working input, see #1415 .

### Testing status

This is not tested to actually work with multiple windows.