### PR TITLE
Uniformize vectors constructors

### DIFF
--- a/src/OpenTK.Mathematics/Vector/Vector2.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2.cs
@@ -62,8 +62,8 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector2"/> struct.
         /// </summary>
-        /// <param name="x">The x coordinate of the net Vector2.</param>
-        /// <param name="y">The y coordinate of the net Vector2.</param>
+        /// <param name="x">The x component of the Vector2.</param>
+        /// <param name="y">The y component of the Vector2.</param>
         public Vector2(float x, float y)
         {
             X = x;

--- a/src/OpenTK.Mathematics/Vector/Vector2d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2d.cs
@@ -94,8 +94,8 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector2d"/> struct.
         /// </summary>
-        /// <param name="x">The X coordinate.</param>
-        /// <param name="y">The Y coordinate.</param>
+        /// <param name="x">The x component of the Vector2d.</param>
+        /// <param name="y">The y component of the Vector2d.</param>
         public Vector2d(double x, double y)
         {
             X = x;

--- a/src/OpenTK.Mathematics/Vector/Vector2h.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2h.cs
@@ -71,8 +71,8 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector2h"/> struct.
         /// </summary>
-        /// <param name="x">The X component of the vector.</param>
-        /// <param name="y">The Y component of the vector.</param>
+        /// <param name="x">The x component of the Vector2h.</param>
+        /// <param name="y">The y component of the Vector2h.</param>
         public Vector2h(Half x, Half y)
         {
             X = x;
@@ -82,52 +82,12 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector2h"/> struct.
         /// </summary>
-        /// <param name="x">The X component of the vector.</param>
-        /// <param name="y">The Y component of the vector.</param>
+        /// <param name="x">The x component of the Vector2h.</param>
+        /// <param name="y">The y component of the Vector2h.</param>
         public Vector2h(float x, float y)
         {
             X = (Half)x;
             Y = (Half)y;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector2h"/> struct.
-        /// </summary>
-        /// <param name="v">The <see cref="Vector2"/> to convert.</param>
-        public Vector2h(Vector2 v)
-        {
-            X = (Half)v.X;
-            Y = (Half)v.Y;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector2h"/> struct.
-        /// </summary>
-        /// <param name="v">The <see cref="Vector2"/> to convert.</param>
-        public Vector2h(in Vector2 v)
-        {
-            X = (Half)v.X;
-            Y = (Half)v.Y;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector2h"/> struct.
-        /// </summary>
-        /// <param name="v">The <see cref="Vector2d"/> to convert.</param>
-        public Vector2h(Vector2d v)
-        {
-            X = (Half)v.X;
-            Y = (Half)v.Y;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector2h"/> struct.
-        /// </summary>
-        /// <param name="v">The <see cref="Vector2d"/> to convert.</param>
-        public Vector2h(in Vector2d v)
-        {
-            X = (Half)v.X;
-            Y = (Half)v.Y;
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Vector/Vector2i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2i.cs
@@ -49,8 +49,8 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector2i"/> struct.
         /// </summary>
-        /// <param name="x">The X component of the Vector2i.</param>
-        /// <param name="y">The Y component of the Vector2i.</param>
+        /// <param name="x">The x component of the Vector2i.</param>
+        /// <param name="y">The y component of the Vector2i.</param>
         public Vector2i(int x, int y)
         {
             X = x;

--- a/src/OpenTK.Mathematics/Vector/Vector3.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3.cs
@@ -83,23 +83,11 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="xy">The x and y components of the Vector3.</param>
         /// <param name="z">The z component of the Vector3.</param>
-        public Vector3(Vector2 xy, float z)
+        public Vector3(Vector2 xy, float z = default)
         {
             X = xy.X;
             Y = xy.Y;
             Z = z;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector3"/> struct.
-        /// </summary>
-        /// <param name="x">The x component of the Vector3.</param>
-        /// <param name="yz">The y and z components of the Vector3.</param>
-        public Vector3(float x, Vector2 yz)
-        {
-            X = x;
-            Y = yz.X;
-            Z = yz.Y;
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Vector/Vector3.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3.cs
@@ -81,34 +81,25 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector3"/> struct.
         /// </summary>
-        /// <param name="v">The Vector2 to copy components from.</param>
-        public Vector3(Vector2 v)
+        /// <param name="xy">The x and y components of the Vector3.</param>
+        /// <param name="z">The z component of the Vector3.</param>
+        public Vector3(Vector2 xy, float z)
         {
-            X = v.X;
-            Y = v.Y;
-            Z = 0.0f;
+            X = xy.X;
+            Y = xy.Y;
+            Z = z;
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector3"/> struct.
         /// </summary>
-        /// <param name="v">The Vector3 to copy components from.</param>
-        public Vector3(Vector3 v)
+        /// <param name="x">The x component of the Vector3.</param>
+        /// <param name="yz">The y and z components of the Vector3.</param>
+        public Vector3(float x, Vector2 yz)
         {
-            X = v.X;
-            Y = v.Y;
-            Z = v.Z;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector3"/> struct.
-        /// </summary>
-        /// <param name="v">The Vector4 to copy components from.</param>
-        public Vector3(Vector4 v)
-        {
-            X = v.X;
-            Y = v.Y;
-            Z = v.Z;
+            X = x;
+            Y = yz.X;
+            Z = yz.Y;
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Vector/Vector3d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3d.cs
@@ -65,9 +65,9 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector3d"/> struct.
         /// </summary>
-        /// <param name="x">The x component of the Vector3.</param>
-        /// <param name="y">The y component of the Vector3.</param>
-        /// <param name="z">The z component of the Vector3.</param>
+        /// <param name="x">The x component of the Vector3d.</param>
+        /// <param name="y">The y component of the Vector3d.</param>
+        /// <param name="z">The z component of the Vector3d.</param>
         public Vector3d(double x, double y, double z)
         {
             X = x;
@@ -78,34 +78,25 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector3d"/> struct.
         /// </summary>
-        /// <param name="v">The Vector2d to copy components from.</param>
-        public Vector3d(Vector2d v)
+        /// <param name="xy">The x and y components of the Vector3d.</param>
+        /// <param name="z">The z component of the Vector3d.</param>
+        public Vector3d(Vector2d xy, double z)
         {
-            X = v.X;
-            Y = v.Y;
-            Z = 0.0f;
+            X = xy.X;
+            Y = xy.Y;
+            Z = z;
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector3d"/> struct.
         /// </summary>
-        /// <param name="v">The Vector3d to copy components from.</param>
-        public Vector3d(Vector3d v)
+        /// <param name="x">The x component of the Vector3d.</param>
+        /// <param name="yz">The y and z components of the Vector3d.</param>
+        public Vector3d(double x, Vector2d yz)
         {
-            X = v.X;
-            Y = v.Y;
-            Z = v.Z;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector3d"/> struct.
-        /// </summary>
-        /// <param name="v">The Vector4d to copy components from.</param>
-        public Vector3d(Vector4d v)
-        {
-            X = v.X;
-            Y = v.Y;
-            Z = v.Z;
+            X = x;
+            Y = yz.X;
+            Z = yz.Y;
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Vector/Vector3d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3d.cs
@@ -80,23 +80,11 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="xy">The x and y components of the Vector3d.</param>
         /// <param name="z">The z component of the Vector3d.</param>
-        public Vector3d(Vector2d xy, double z)
+        public Vector3d(Vector2d xy, double z = default)
         {
             X = xy.X;
             Y = xy.Y;
             Z = z;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector3d"/> struct.
-        /// </summary>
-        /// <param name="x">The x component of the Vector3d.</param>
-        /// <param name="yz">The y and z components of the Vector3d.</param>
-        public Vector3d(double x, Vector2d yz)
-        {
-            X = x;
-            Y = yz.X;
-            Z = yz.Y;
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Vector/Vector3h.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3h.cs
@@ -78,9 +78,9 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector3h"/> struct.
         /// </summary>
-        /// <param name="x">The X component of the vector.</param>
-        /// <param name="y">The Y component of the vector.</param>
-        /// <param name="z">The Z component of the vector.</param>
+        /// <param name="x">The x component of the Vector3h.</param>
+        /// <param name="y">The y component of the Vector3h.</param>
+        /// <param name="z">The z component of the Vector3h.</param>
         public Vector3h(Half x, Half y, Half z)
         {
             X = x;
@@ -92,9 +92,9 @@ namespace OpenTK.Mathematics
         /// Initializes a new instance of the <see cref="Vector3h"/> struct.
         /// The new Half3 instance will convert the 3 parameters into 16-bit half-precision floating-point.
         /// </summary>
-        /// <param name="x">The X component of the vector.</param>
-        /// <param name="y">The Y component of the vector.</param>
-        /// <param name="z">The Z component of the vector.</param>
+        /// <param name="x">The x component of the Vector3h.</param>
+        /// <param name="y">The y component of the Vector3h.</param>
+        /// <param name="z">The z component of the Vector3h.</param>
         public Vector3h(float x, float y, float z)
         {
             X = (Half)x;
@@ -105,45 +105,49 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector3h"/> struct.
         /// </summary>
-        /// <param name="v">The <see cref="Vector3"/> to convert.</param>
-        public Vector3h(Vector3 v)
+        /// <param name="xy">The x and y components of the Vector3h.</param>
+        /// <param name="z">The z component of the Vector3h.</param>
+        public Vector3h(Vector2h xy, float z)
         {
-            X = (Half)v.X;
-            Y = (Half)v.Y;
-            Z = (Half)v.Z;
+            X = xy.X;
+            Y = xy.Y;
+            Z = (Half)z;
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector3h"/> struct.
         /// </summary>
-        /// <param name="v">The <see cref="Vector3"/> to convert.</param>
-        public Vector3h(in Vector3 v)
+        /// <param name="xy">The x and y components of the Vector3h.</param>
+        /// <param name="z">The z component of the Vector3h.</param>
+        public Vector3h(Vector2h xy, Half z)
         {
-            X = (Half)v.X;
-            Y = (Half)v.Y;
-            Z = (Half)v.Z;
+            X = xy.X;
+            Y = xy.Y;
+            Z = z;
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector3h"/> struct.
         /// </summary>
-        /// <param name="v">The <see cref="Vector3d"/> to convert.</param>
-        public Vector3h(Vector3d v)
+        /// <param name="x">The x component of the Vector3h.</param>
+        /// <param name="yz">The y and z components of the Vector3h.</param>
+        public Vector3h(float x, Vector2h yz)
         {
-            X = (Half)v.X;
-            Y = (Half)v.Y;
-            Z = (Half)v.Z;
+            X = (Half)x;
+            Y = yz.X;
+            Z = yz.Y;
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector3h"/> struct.
         /// </summary>
-        /// <param name="v">The <see cref="Vector3d"/> to convert.</param>
-        public Vector3h(in Vector3d v)
+        /// <param name="x">The x component of the Vector3h.</param>
+        /// <param name="yz">The y and z components of the Vector3h.</param>
+        public Vector3h(Half x, Vector2h yz)
         {
-            X = (Half)v.X;
-            Y = (Half)v.Y;
-            Z = (Half)v.Z;
+            X = x;
+            Y = yz.X;
+            Z = yz.Y;
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Vector/Vector3h.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3h.cs
@@ -107,7 +107,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="xy">The x and y components of the Vector3h.</param>
         /// <param name="z">The z component of the Vector3h.</param>
-        public Vector3h(Vector2h xy, float z)
+        public Vector3h(Vector2h xy, float z = default)
         {
             X = xy.X;
             Y = xy.Y;
@@ -119,35 +119,11 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="xy">The x and y components of the Vector3h.</param>
         /// <param name="z">The z component of the Vector3h.</param>
-        public Vector3h(Vector2h xy, Half z)
+        public Vector3h(Vector2h xy, Half z = default)
         {
             X = xy.X;
             Y = xy.Y;
             Z = z;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector3h"/> struct.
-        /// </summary>
-        /// <param name="x">The x component of the Vector3h.</param>
-        /// <param name="yz">The y and z components of the Vector3h.</param>
-        public Vector3h(float x, Vector2h yz)
-        {
-            X = (Half)x;
-            Y = yz.X;
-            Z = yz.Y;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector3h"/> struct.
-        /// </summary>
-        /// <param name="x">The x component of the Vector3h.</param>
-        /// <param name="yz">The y and z components of the Vector3h.</param>
-        public Vector3h(Half x, Vector2h yz)
-        {
-            X = x;
-            Y = yz.X;
-            Z = yz.Y;
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Vector/Vector3i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3i.cs
@@ -55,9 +55,9 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector3i"/> struct.
         /// </summary>
-        /// <param name="x">The x component of the Vector3.</param>
-        /// <param name="y">The y component of the Vector3.</param>
-        /// <param name="z">The z component of the Vector3.</param>
+        /// <param name="x">The x component of the Vector3i.</param>
+        /// <param name="y">The y component of the Vector3i.</param>
+        /// <param name="z">The z component of the Vector3i.</param>
         public Vector3i(int x, int y, int z)
         {
             X = x;
@@ -68,24 +68,25 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector3i"/> struct.
         /// </summary>
-        /// <param name="v">The <see cref="Vector2i"/> to copy components from.</param>
-        public Vector3i(Vector2i v)
+        /// <param name="xy">The x and y components of the Vector3i.</param>
+        /// <param name="z">The z component of the Vector3i.</param>
+        public Vector3i(Vector2i xy, int z)
         {
-            X = v.X;
-            Y = v.Y;
-            Z = 0;
+            X = xy.X;
+            Y = xy.Y;
+            Z = z;
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector3i"/> struct.
         /// </summary>
-        /// <param name="v">The <see cref="Vector2i"/> to copy components from.</param>
-        /// <param name="z">The z component of the new Vector3.</param>
-        public Vector3i(Vector2i v, int z)
+        /// <param name="x">The x component of the Vector3i.</param>
+        /// <param name="yz">The y and z components of the Vector3i.</param>
+        public Vector3i(int x, Vector2i yz)
         {
-            X = v.X;
-            Y = v.Y;
-            Z = z;
+            X = x;
+            Y = yz.X;
+            Z = yz.Y;
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Vector/Vector3i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3i.cs
@@ -70,23 +70,11 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="xy">The x and y components of the Vector3i.</param>
         /// <param name="z">The z component of the Vector3i.</param>
-        public Vector3i(Vector2i xy, int z)
+        public Vector3i(Vector2i xy, int z = default)
         {
             X = xy.X;
             Y = xy.Y;
             Z = z;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector3i"/> struct.
-        /// </summary>
-        /// <param name="x">The x component of the Vector3i.</param>
-        /// <param name="yz">The y and z components of the Vector3i.</param>
-        public Vector3i(int x, Vector2i yz)
-        {
-            X = x;
-            Y = yz.X;
-            Z = yz.Y;
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Vector/Vector4.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4.cs
@@ -137,7 +137,7 @@ namespace OpenTK.Mathematics
         /// <param name="xy">The x and y components of the Vector4.</param>
         /// <param name="z">The z component of the Vector4.</param>
         /// <param name="w">The w component of the Vector4.</param>
-        public Vector4(Vector2 xy, float z, float w)
+        public Vector4(Vector2 xy, float z = default, float w = default)
         {
             X = xy.X;
             Y = xy.Y;
@@ -148,68 +148,14 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector4"/> struct.
         /// </summary>
-        /// <param name="x">The x component of the Vector4.</param>
-        /// <param name="yz">The y and z components of the Vector4.</param>
-        /// <param name="w">The w component of the Vector4.</param>
-        public Vector4(float x, Vector2 yz, float w)
-        {
-            X = x;
-            Y = yz.X;
-            Z = yz.Y;
-            W = w;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector4"/> struct.
-        /// </summary>
-        /// <param name="x">The x component of the Vector4.</param>
-        /// <param name="y">The y component of the Vector4.</param>
-        /// <param name="zw">The z and w components of the Vector4.</param>
-        public Vector4(float x, float y, Vector2 zw)
-        {
-            X = x;
-            Y = y;
-            Z = zw.X;
-            W = zw.Y;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector4"/> struct.
-        /// </summary>
-        /// <param name="xy">The x and y components of the Vector4.</param>
-        /// <param name="zw">The z and w components of the Vector4.</param>
-        public Vector4(Vector2 xy, Vector2 zw)
-        {
-            X = xy.X;
-            Y = xy.Y;
-            Z = zw.X;
-            W = zw.Y;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector4"/> struct.
-        /// </summary>
         /// <param name="xyz">The x, y and z components of the Vector4.</param>
         /// <param name="w">The w component of the Vector4.</param>
-        public Vector4(Vector3 xyz, float w)
+        public Vector4(Vector3 xyz, float w = default)
         {
             X = xyz.X;
             Y = xyz.Y;
             Z = xyz.Z;
             W = w;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector4"/> struct.
-        /// </summary>
-        /// <param name="x">The x component of the Vector4.</param>
-        /// <param name="yzw">The y, z and w components of the Vector4.</param>
-        public Vector4(float x, Vector3 yzw)
-        {
-            X = x;
-            Y = yzw.X;
-            Z = yzw.Y;
-            W = yzw.Z;
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Vector/Vector4.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4.cs
@@ -1966,31 +1966,6 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
-        /// Returns a pointer to the first element of the specified instance.
-        /// </summary>
-        /// <param name="v">The instance.</param>
-        /// <returns>A pointer to the first element of v.</returns>
-        [Pure]
-        public static unsafe explicit operator float*(Vector4 v)
-        {
-            return &v.X;
-        }
-
-        /// <summary>
-        /// Returns a pointer to the first element of the specified instance.
-        /// </summary>
-        /// <param name="v">The instance.</param>
-        /// <returns>A pointer to the first element of v.</returns>
-        [Pure]
-        public static explicit operator IntPtr(Vector4 v)
-        {
-            unsafe
-            {
-                return (IntPtr)(&v.X);
-            }
-        }
-
-        /// <summary>
         /// Converts OpenTK.Vector4 to OpenTK.Vector4d.
         /// </summary>
         /// <param name="vec">The Vector4 to convert.</param>

--- a/src/OpenTK.Mathematics/Vector/Vector4.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4.cs
@@ -134,53 +134,82 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector4"/> struct.
         /// </summary>
-        /// <param name="v">The Vector2 to copy components from.</param>
-        public Vector4(Vector2 v)
+        /// <param name="xy">The x and y components of the Vector4.</param>
+        /// <param name="z">The z component of the Vector4.</param>
+        /// <param name="w">The w component of the Vector4.</param>
+        public Vector4(Vector2 xy, float z, float w)
         {
-            X = v.X;
-            Y = v.Y;
-            Z = 0.0f;
-            W = 0.0f;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector4"/> struct.
-        /// </summary>
-        /// <param name="v">The Vector3 to copy components from.</param>
-        /// <remarks>
-        ///  .<seealso cref="Vector4(Vector3, float)"/>
-        /// </remarks>
-        public Vector4(Vector3 v)
-        {
-            X = v.X;
-            Y = v.Y;
-            Z = v.Z;
-            W = 0.0f;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector4"/> struct.
-        /// </summary>
-        /// <param name="v">The Vector3 to copy components from.</param>
-        /// <param name="w">The w component of the new Vector4.</param>
-        public Vector4(Vector3 v, float w)
-        {
-            X = v.X;
-            Y = v.Y;
-            Z = v.Z;
+            X = xy.X;
+            Y = xy.Y;
+            Z = z;
             W = w;
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector4"/> struct.
         /// </summary>
-        /// <param name="v">The Vector4 to copy components from.</param>
-        public Vector4(Vector4 v)
+        /// <param name="x">The x component of the Vector4.</param>
+        /// <param name="yz">The y and z components of the Vector4.</param>
+        /// <param name="w">The w component of the Vector4.</param>
+        public Vector4(float x, Vector2 yz, float w)
         {
-            X = v.X;
-            Y = v.Y;
-            Z = v.Z;
-            W = v.W;
+            X = x;
+            Y = yz.X;
+            Z = yz.Y;
+            W = w;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector4"/> struct.
+        /// </summary>
+        /// <param name="x">The x component of the Vector4.</param>
+        /// <param name="y">The y component of the Vector4.</param>
+        /// <param name="zw">The z and w components of the Vector4.</param>
+        public Vector4(float x, float y, Vector2 zw)
+        {
+            X = x;
+            Y = y;
+            Z = zw.X;
+            W = zw.Y;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector4"/> struct.
+        /// </summary>
+        /// <param name="xy">The x and y components of the Vector4.</param>
+        /// <param name="zw">The z and w components of the Vector4.</param>
+        public Vector4(Vector2 xy, Vector2 zw)
+        {
+            X = xy.X;
+            Y = xy.Y;
+            Z = zw.X;
+            W = zw.Y;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector4"/> struct.
+        /// </summary>
+        /// <param name="xyz">The x, y and z components of the Vector4.</param>
+        /// <param name="w">The w component of the Vector4.</param>
+        public Vector4(Vector3 xyz, float w)
+        {
+            X = xyz.X;
+            Y = xyz.Y;
+            Z = xyz.Z;
+            W = w;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector4"/> struct.
+        /// </summary>
+        /// <param name="x">The x component of the Vector4.</param>
+        /// <param name="yzw">The y, z and w components of the Vector4.</param>
+        public Vector4(float x, Vector3 yzw)
+        {
+            X = x;
+            Y = yzw.X;
+            Z = yzw.Y;
+            W = yzw.Z;
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Vector/Vector4d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4d.cs
@@ -137,7 +137,7 @@ namespace OpenTK.Mathematics
         /// <param name="xy">The x and y components of the Vector4d.</param>
         /// <param name="z">The z component of the Vector4d.</param>
         /// <param name="w">The w component of the Vector4d.</param>
-        public Vector4d(Vector2d xy, double z, double w)
+        public Vector4d(Vector2d xy, double z = default, double w = default)
         {
             X = xy.X;
             Y = xy.Y;
@@ -148,68 +148,14 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector4d"/> struct.
         /// </summary>
-        /// <param name="x">The x component of the Vector4d.</param>
-        /// <param name="yz">The y and z components of the Vector4d.</param>
-        /// <param name="w">The w component of the Vector4d.</param>
-        public Vector4d(double x, Vector2d yz, double w)
-        {
-            X = x;
-            Y = yz.X;
-            Z = yz.Y;
-            W = w;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector4d"/> struct.
-        /// </summary>
-        /// <param name="x">The x component of the Vector4d.</param>
-        /// <param name="y">The y component of the Vector4d.</param>
-        /// <param name="zw">The z and w components of the Vector4d.</param>
-        public Vector4d(double x, double y, Vector2d zw)
-        {
-            X = x;
-            Y = y;
-            Z = zw.X;
-            W = zw.Y;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector4d"/> struct.
-        /// </summary>
-        /// <param name="xy">The x and y components of the Vector4d.</param>
-        /// <param name="zw">The z and w components of the Vector4d.</param>
-        public Vector4d(Vector2d xy, Vector2d zw)
-        {
-            X = xy.X;
-            Y = xy.Y;
-            Z = zw.X;
-            W = zw.Y;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector4d"/> struct.
-        /// </summary>
         /// <param name="xyz">The x, y and z components of the Vector4d.</param>
         /// <param name="w">The w component of the Vector4d.</param>
-        public Vector4d(Vector3d xyz, double w)
+        public Vector4d(Vector3d xyz, double w = default)
         {
             X = xyz.X;
             Y = xyz.Y;
             Z = xyz.Z;
             W = w;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector4d"/> struct.
-        /// </summary>
-        /// <param name="x">The x component of the Vector4d.</param>
-        /// <param name="yzw">The y, z and w components of the Vector4d.</param>
-        public Vector4d(double x, Vector3d yzw)
-        {
-            X = x;
-            Y = yzw.X;
-            Z = yzw.Y;
-            W = yzw.Z;
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Vector/Vector4d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4d.cs
@@ -1961,31 +1961,6 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
-        /// Returns a pointer to the first element of the specified instance.
-        /// </summary>
-        /// <param name="v">The instance.</param>
-        /// <returns>A pointer to the first element of v.</returns>
-        [Pure]
-        public static unsafe explicit operator double*(Vector4d v)
-        {
-            return &v.X;
-        }
-
-        /// <summary>
-        /// Returns a pointer to the first element of the specified instance.
-        /// </summary>
-        /// <param name="v">The instance.</param>
-        /// <returns>A pointer to the first element of v.</returns>
-        [Pure]
-        public static explicit operator IntPtr(Vector4d v)
-        {
-            unsafe
-            {
-                return (IntPtr)(&v.X);
-            }
-        }
-
-        /// <summary>
         /// Converts OpenTK.Vector4d to OpenTK.Vector4.
         /// </summary>
         /// <param name="vec">The Vector4d to convert.</param>

--- a/src/OpenTK.Mathematics/Vector/Vector4d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4d.cs
@@ -134,53 +134,82 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector4d"/> struct.
         /// </summary>
-        /// <param name="v">The Vector2d to copy components from.</param>
-        public Vector4d(Vector2d v)
+        /// <param name="xy">The x and y components of the Vector4d.</param>
+        /// <param name="z">The z component of the Vector4d.</param>
+        /// <param name="w">The w component of the Vector4d.</param>
+        public Vector4d(Vector2d xy, double z, double w)
         {
-            X = v.X;
-            Y = v.Y;
-            Z = 0.0f;
-            W = 0.0f;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector4d"/> struct.
-        /// </summary>
-        /// <param name="v">The Vector3d to copy components from.</param>
-        /// <remarks>
-        /// <seealso cref="Vector4d(Vector3d, double)"/>.
-        /// </remarks>
-        public Vector4d(Vector3d v)
-        {
-            X = v.X;
-            Y = v.Y;
-            Z = v.Z;
-            W = 0.0f;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector4d"/> struct.
-        /// </summary>
-        /// <param name="v">The Vector3d to copy components from.</param>
-        /// <param name="w">The w component of the new Vector4.</param>
-        public Vector4d(Vector3d v, double w)
-        {
-            X = v.X;
-            Y = v.Y;
-            Z = v.Z;
+            X = xy.X;
+            Y = xy.Y;
+            Z = z;
             W = w;
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector4d"/> struct.
         /// </summary>
-        /// <param name="v">The Vector4d to copy components from.</param>
-        public Vector4d(Vector4d v)
+        /// <param name="x">The x component of the Vector4d.</param>
+        /// <param name="yz">The y and z components of the Vector4d.</param>
+        /// <param name="w">The w component of the Vector4d.</param>
+        public Vector4d(double x, Vector2d yz, double w)
         {
-            X = v.X;
-            Y = v.Y;
-            Z = v.Z;
-            W = v.W;
+            X = x;
+            Y = yz.X;
+            Z = yz.Y;
+            W = w;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector4d"/> struct.
+        /// </summary>
+        /// <param name="x">The x component of the Vector4d.</param>
+        /// <param name="y">The y component of the Vector4d.</param>
+        /// <param name="zw">The z and w components of the Vector4d.</param>
+        public Vector4d(double x, double y, Vector2d zw)
+        {
+            X = x;
+            Y = y;
+            Z = zw.X;
+            W = zw.Y;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector4d"/> struct.
+        /// </summary>
+        /// <param name="xy">The x and y components of the Vector4d.</param>
+        /// <param name="zw">The z and w components of the Vector4d.</param>
+        public Vector4d(Vector2d xy, Vector2d zw)
+        {
+            X = xy.X;
+            Y = xy.Y;
+            Z = zw.X;
+            W = zw.Y;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector4d"/> struct.
+        /// </summary>
+        /// <param name="xyz">The x, y and z components of the Vector4d.</param>
+        /// <param name="w">The w component of the Vector4d.</param>
+        public Vector4d(Vector3d xyz, double w)
+        {
+            X = xyz.X;
+            Y = xyz.Y;
+            Z = xyz.Z;
+            W = w;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector4d"/> struct.
+        /// </summary>
+        /// <param name="x">The x component of the Vector4d.</param>
+        /// <param name="yzw">The y, z and w components of the Vector4d.</param>
+        public Vector4d(double x, Vector3d yzw)
+        {
+            X = x;
+            Y = yzw.X;
+            Z = yzw.Y;
+            W = yzw.Z;
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Vector/Vector4h.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4h.cs
@@ -123,7 +123,7 @@ namespace OpenTK.Mathematics
         /// <param name="xy">The x and y components of the Vector4h.</param>
         /// <param name="z">The z component of the Vector4h.</param>
         /// <param name="w">The w component of the Vector4h.</param>
-        public Vector4h(Vector2h xy, float z, float w)
+        public Vector4h(Vector2h xy, float z = default, float w = default)
         {
             X = xy.X;
             Y = xy.Y;
@@ -137,7 +137,7 @@ namespace OpenTK.Mathematics
         /// <param name="xy">The x and y components of the Vector4h.</param>
         /// <param name="z">The z component of the Vector4h.</param>
         /// <param name="w">The w component of the Vector4h.</param>
-        public Vector4h(Vector2h xy, Half z, Half w)
+        public Vector4h(Vector2h xy, Half z = default, Half w = default)
         {
             X = xy.X;
             Y = xy.Y;
@@ -148,78 +148,9 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector4h"/> struct.
         /// </summary>
-        /// <param name="x">The x component of the Vector4h.</param>
-        /// <param name="yz">The y and z components of the Vector4h.</param>
-        /// <param name="w">The w component of the Vector4h.</param>
-        public Vector4h(float x, Vector2h yz, float w)
-        {
-            X = (Half)x;
-            Y = yz.X;
-            Z = yz.Y;
-            W = (Half)w;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector4h"/> struct.
-        /// </summary>
-        /// <param name="x">The x component of the Vector4h.</param>
-        /// <param name="yz">The y and z components of the Vector4h.</param>
-        /// <param name="w">The w component of the Vector4h.</param>
-        public Vector4h(Half x, Vector2h yz, Half w)
-        {
-            X = x;
-            Y = yz.X;
-            Z = yz.Y;
-            W = w;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector4h"/> struct.
-        /// </summary>
-        /// <param name="x">The x component of the Vector4h.</param>
-        /// <param name="y">The y component of the Vector4h.</param>
-        /// <param name="zw">The z and w components of the Vector4h.</param>
-        public Vector4h(float x, float y, Vector2h zw)
-        {
-            X = (Half)x;
-            Y = (Half)y;
-            Z = zw.X;
-            W = zw.Y;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector4h"/> struct.
-        /// </summary>
-        /// <param name="x">The x component of the Vector4h.</param>
-        /// <param name="y">The y component of the Vector4h.</param>
-        /// <param name="zw">The z and w components of the Vector4h.</param>
-        public Vector4h(Half x, Half y, Vector2h zw)
-        {
-            X = x;
-            Y = y;
-            Z = zw.X;
-            W = zw.Y;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector4h"/> struct.
-        /// </summary>
-        /// <param name="xy">The x and y components of the Vector4h.</param>
-        /// <param name="zw">The z and w components of the Vector4h.</param>
-        public Vector4h(Vector2h xy, Vector2h zw)
-        {
-            X = xy.X;
-            Y = xy.Y;
-            Z = zw.X;
-            W = zw.Y;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector4h"/> struct.
-        /// </summary>
         /// <param name="xyz">The x, y and z components of the Vector4h.</param>
         /// <param name="w">The w component of the Vector4h.</param>
-        public Vector4h(Vector3h xyz, float w)
+        public Vector4h(Vector3h xyz, float w = default)
         {
             X = xyz.X;
             Y = xyz.Y;
@@ -232,38 +163,12 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="xyz">The x, y and z components of the Vector4h.</param>
         /// <param name="w">The w component of the Vector4h.</param>
-        public Vector4h(Vector3h xyz, Half w)
+        public Vector4h(Vector3h xyz, Half w = default)
         {
             X = xyz.X;
             Y = xyz.Y;
             Z = xyz.Z;
             W = w;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector4h"/> struct.
-        /// </summary>
-        /// <param name="x">The x component of the Vector4h.</param>
-        /// <param name="yzw">The y, z and w components of the Vector4h.</param>
-        public Vector4h(float x, Vector3h yzw)
-        {
-            X = (Half)x;
-            Y = yzw.X;
-            Z = yzw.Y;
-            W = yzw.Z;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector4h"/> struct.
-        /// </summary>
-        /// <param name="x">The x component of the Vector4h.</param>
-        /// <param name="yzw">The y, z and w components of the Vector4h.</param>
-        public Vector4h(Half x, Vector3h yzw)
-        {
-            X = x;
-            Y = yzw.X;
-            Z = yzw.Y;
-            W = yzw.Z;
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Vector/Vector4h.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4h.cs
@@ -90,10 +90,10 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector4h"/> struct.
         /// </summary>
-        /// <param name="x">The X component of the vector.</param>
-        /// <param name="y">The Y component of the vector.</param>
-        /// <param name="z">The Z component of the vector.</param>
-        /// <param name="w">The W component of the vector.</param>
+        /// <param name="x">The x component of the Vector4h.</param>
+        /// <param name="y">The y component of the Vector4h.</param>
+        /// <param name="z">The z component of the Vector4h.</param>
+        /// <param name="w">The w component of the Vector4h.</param>
         public Vector4h(Half x, Half y, Half z, Half w)
         {
             X = x;
@@ -105,10 +105,10 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector4h"/> struct.
         /// </summary>
-        /// <param name="x">The X component of the vector.</param>
-        /// <param name="y">The Y component of the vector.</param>
-        /// <param name="z">The Z component of the vector.</param>
-        /// <param name="w">The W component of the vector.</param>
+        /// <param name="x">The x component of the Vector4h.</param>
+        /// <param name="y">The y component of the Vector4h.</param>
+        /// <param name="z">The z component of the Vector4h.</param>
+        /// <param name="w">The w component of the Vector4h.</param>
         public Vector4h(float x, float y, float z, float w)
         {
             X = (Half)x;
@@ -120,49 +120,150 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector4h"/> struct.
         /// </summary>
-        /// <param name="v">The <see cref="Vector4"/> to convert.</param>
-        public Vector4h(Vector4 v)
+        /// <param name="xy">The x and y components of the Vector4h.</param>
+        /// <param name="z">The z component of the Vector4h.</param>
+        /// <param name="w">The w component of the Vector4h.</param>
+        public Vector4h(Vector2h xy, float z, float w)
         {
-            X = (Half)v.X;
-            Y = (Half)v.Y;
-            Z = (Half)v.Z;
-            W = (Half)v.W;
+            X = xy.X;
+            Y = xy.Y;
+            Z = (Half)z;
+            W = (Half)w;
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector4h"/> struct.
         /// </summary>
-        /// <param name="v">The <see cref="Vector4"/> to convert.</param>
-        public Vector4h(in Vector4 v)
+        /// <param name="xy">The x and y components of the Vector4h.</param>
+        /// <param name="z">The z component of the Vector4h.</param>
+        /// <param name="w">The w component of the Vector4h.</param>
+        public Vector4h(Vector2h xy, Half z, Half w)
         {
-            X = (Half)v.X;
-            Y = (Half)v.Y;
-            Z = (Half)v.Z;
-            W = (Half)v.W;
+            X = xy.X;
+            Y = xy.Y;
+            Z = z;
+            W = w;
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector4h"/> struct.
         /// </summary>
-        /// <param name="v">The <see cref="Vector4d"/> to convert.</param>
-        public Vector4h(Vector4d v)
+        /// <param name="x">The x component of the Vector4h.</param>
+        /// <param name="yz">The y and z components of the Vector4h.</param>
+        /// <param name="w">The w component of the Vector4h.</param>
+        public Vector4h(float x, Vector2h yz, float w)
         {
-            X = (Half)v.X;
-            Y = (Half)v.Y;
-            Z = (Half)v.Z;
-            W = (Half)v.W;
+            X = (Half)x;
+            Y = yz.X;
+            Z = yz.Y;
+            W = (Half)w;
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector4h"/> struct.
         /// </summary>
-        /// <param name="v">The <see cref="Vector4d"/> to convert.</param>
-        public Vector4h(in Vector4d v)
+        /// <param name="x">The x component of the Vector4h.</param>
+        /// <param name="yz">The y and z components of the Vector4h.</param>
+        /// <param name="w">The w component of the Vector4h.</param>
+        public Vector4h(Half x, Vector2h yz, Half w)
         {
-            X = (Half)v.X;
-            Y = (Half)v.Y;
-            Z = (Half)v.Z;
-            W = (Half)v.W;
+            X = x;
+            Y = yz.X;
+            Z = yz.Y;
+            W = w;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector4h"/> struct.
+        /// </summary>
+        /// <param name="x">The x component of the Vector4h.</param>
+        /// <param name="y">The y component of the Vector4h.</param>
+        /// <param name="zw">The z and w components of the Vector4h.</param>
+        public Vector4h(float x, float y, Vector2h zw)
+        {
+            X = (Half)x;
+            Y = (Half)y;
+            Z = zw.X;
+            W = zw.Y;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector4h"/> struct.
+        /// </summary>
+        /// <param name="x">The x component of the Vector4h.</param>
+        /// <param name="y">The y component of the Vector4h.</param>
+        /// <param name="zw">The z and w components of the Vector4h.</param>
+        public Vector4h(Half x, Half y, Vector2h zw)
+        {
+            X = x;
+            Y = y;
+            Z = zw.X;
+            W = zw.Y;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector4h"/> struct.
+        /// </summary>
+        /// <param name="xy">The x and y components of the Vector4h.</param>
+        /// <param name="zw">The z and w components of the Vector4h.</param>
+        public Vector4h(Vector2h xy, Vector2h zw)
+        {
+            X = xy.X;
+            Y = xy.Y;
+            Z = zw.X;
+            W = zw.Y;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector4h"/> struct.
+        /// </summary>
+        /// <param name="xyz">The x, y and z components of the Vector4h.</param>
+        /// <param name="w">The w component of the Vector4h.</param>
+        public Vector4h(Vector3h xyz, float w)
+        {
+            X = xyz.X;
+            Y = xyz.Y;
+            Z = xyz.Z;
+            W = (Half)w;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector4h"/> struct.
+        /// </summary>
+        /// <param name="xyz">The x, y and z components of the Vector4h.</param>
+        /// <param name="w">The w component of the Vector4h.</param>
+        public Vector4h(Vector3h xyz, Half w)
+        {
+            X = xyz.X;
+            Y = xyz.Y;
+            Z = xyz.Z;
+            W = w;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector4h"/> struct.
+        /// </summary>
+        /// <param name="x">The x component of the Vector4h.</param>
+        /// <param name="yzw">The y, z and w components of the Vector4h.</param>
+        public Vector4h(float x, Vector3h yzw)
+        {
+            X = (Half)x;
+            Y = yzw.X;
+            Z = yzw.Y;
+            W = yzw.Z;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector4h"/> struct.
+        /// </summary>
+        /// <param name="x">The x component of the Vector4h.</param>
+        /// <param name="yzw">The y, z and w components of the Vector4h.</param>
+        public Vector4h(Half x, Vector3h yzw)
+        {
+            X = x;
+            Y = yzw.X;
+            Z = yzw.Y;
+            W = yzw.Z;
         }
 
         /// <summary>
@@ -1144,25 +1245,28 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
-        /// Converts OpenTK.Vector4 to OpenTK.Half4.
+        /// Returns a pointer to the first element of the specified instance.
         /// </summary>
-        /// <param name="v4f">The Vector4 to convert.</param>
-        /// <returns>The resulting Half vector.</returns>
+        /// <param name="v">The instance.</param>
+        /// <returns>A pointer to the first element of v.</returns>
         [Pure]
-        public static explicit operator Vector4h(Vector4 v4f)
+        public static unsafe explicit operator Half*(Vector4h v)
         {
-            return new Vector4h(v4f);
+            return &v.X;
         }
 
         /// <summary>
-        /// Converts OpenTK.Vector4d to OpenTK.Half4.
+        /// Returns a pointer to the first element of the specified instance.
         /// </summary>
-        /// <param name="v4d">The Vector4d to convert.</param>
-        /// <returns>The resulting Half vector.</returns>
+        /// <param name="v">The instance.</param>
+        /// <returns>A pointer to the first element of v.</returns>
         [Pure]
-        public static explicit operator Vector4h(Vector4d v4d)
+        public static explicit operator IntPtr(Vector4h v)
         {
-            return new Vector4h(v4d);
+            unsafe
+            {
+                return (IntPtr)(&v.X);
+            }
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Vector/Vector4h.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4h.cs
@@ -1150,31 +1150,6 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
-        /// Returns a pointer to the first element of the specified instance.
-        /// </summary>
-        /// <param name="v">The instance.</param>
-        /// <returns>A pointer to the first element of v.</returns>
-        [Pure]
-        public static unsafe explicit operator Half*(Vector4h v)
-        {
-            return &v.X;
-        }
-
-        /// <summary>
-        /// Returns a pointer to the first element of the specified instance.
-        /// </summary>
-        /// <param name="v">The instance.</param>
-        /// <returns>A pointer to the first element of v.</returns>
-        [Pure]
-        public static explicit operator IntPtr(Vector4h v)
-        {
-            unsafe
-            {
-                return (IntPtr)(&v.X);
-            }
-        }
-
-        /// <summary>
         /// Converts OpenTK.Vector4h to OpenTK.Vector4.
         /// </summary>
         /// <param name="vec">The Vector4h to convert.</param>

--- a/src/OpenTK.Mathematics/Vector/Vector4i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4i.cs
@@ -76,51 +76,82 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector4i"/> struct.
         /// </summary>
-        /// <param name="v">The <see cref="Vector2i"/> to copy components from.</param>
-        public Vector4i(Vector2i v)
+        /// <param name="xy">The x and y components of the Vector4i.</param>
+        /// <param name="z">The z component of the Vector4i.</param>
+        /// <param name="w">The w component of the Vector4i.</param>
+        public Vector4i(Vector2i xy, int z, int w)
         {
-            X = v.X;
-            Y = v.Y;
-            Z = 0;
-            W = 0;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector4i"/> struct.
-        /// </summary>
-        /// <param name="v1">The <see cref="Vector2i"/> to get the X and Y components for the Vector4.</param>
-        /// <param name="v2">The <see cref="Vector2i"/> to get the Z and W components for the Vector4.</param>
-        public Vector4i(Vector2i v1, Vector2i v2)
-        {
-            X = v1.X;
-            Y = v1.Y;
-            Z = v2.X;
-            W = v2.Y;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector4i"/> struct.
-        /// </summary>
-        /// <param name="v">The <see cref="Vector3i"/> to copy components from.</param>
-        public Vector4i(Vector3i v)
-        {
-            X = v.X;
-            Y = v.Y;
-            Z = v.Z;
-            W = 0;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector4i"/> struct.
-        /// </summary>
-        /// <param name="v">The <see cref="Vector3i"/> to copy components from.</param>
-        /// <param name="w">The w component of the new Vector4.</param>
-        public Vector4i(Vector3i v, int w)
-        {
-            X = v.X;
-            Y = v.Y;
-            Z = v.Z;
+            X = xy.X;
+            Y = xy.Y;
+            Z = z;
             W = w;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector4i"/> struct.
+        /// </summary>
+        /// <param name="x">The x component of the Vector4i.</param>
+        /// <param name="yz">The y and z components of the Vector4i.</param>
+        /// <param name="w">The w component of the Vector4i.</param>
+        public Vector4i(int x, Vector2i yz, int w)
+        {
+            X = x;
+            Y = yz.X;
+            Z = yz.Y;
+            W = w;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector4i"/> struct.
+        /// </summary>
+        /// <param name="x">The x component of the Vector4i.</param>
+        /// <param name="y">The y component of the Vector4i.</param>
+        /// <param name="zw">The z and w components of the Vector4i.</param>
+        public Vector4i(int x, int y, Vector2i zw)
+        {
+            X = x;
+            Y = y;
+            Z = zw.X;
+            W = zw.Y;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector4i"/> struct.
+        /// </summary>
+        /// <param name="xy">The x and y components of the Vector4i.</param>
+        /// <param name="zw">The z and w components of the Vector4i.</param>
+        public Vector4i(Vector2i xy, Vector2i zw)
+        {
+            X = xy.X;
+            Y = xy.Y;
+            Z = zw.X;
+            W = zw.Y;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector4i"/> struct.
+        /// </summary>
+        /// <param name="xyz">The x, y and z components of the Vector4i.</param>
+        /// <param name="w">The w component of the Vector4i.</param>
+        public Vector4i(Vector3i xyz, int w)
+        {
+            X = xyz.X;
+            Y = xyz.Y;
+            Z = xyz.Z;
+            W = w;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector4i"/> struct.
+        /// </summary>
+        /// <param name="x">The x component of the Vector4i.</param>
+        /// <param name="yzw">The y, z and w components of the Vector4i.</param>
+        public Vector4i(int x, Vector3i yzw)
+        {
+            X = x;
+            Y = yzw.X;
+            Z = yzw.Y;
+            W = yzw.Z;
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Vector/Vector4i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4i.cs
@@ -79,7 +79,7 @@ namespace OpenTK.Mathematics
         /// <param name="xy">The x and y components of the Vector4i.</param>
         /// <param name="z">The z component of the Vector4i.</param>
         /// <param name="w">The w component of the Vector4i.</param>
-        public Vector4i(Vector2i xy, int z, int w)
+        public Vector4i(Vector2i xy, int z = default, int w = default)
         {
             X = xy.X;
             Y = xy.Y;
@@ -90,68 +90,14 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector4i"/> struct.
         /// </summary>
-        /// <param name="x">The x component of the Vector4i.</param>
-        /// <param name="yz">The y and z components of the Vector4i.</param>
-        /// <param name="w">The w component of the Vector4i.</param>
-        public Vector4i(int x, Vector2i yz, int w)
-        {
-            X = x;
-            Y = yz.X;
-            Z = yz.Y;
-            W = w;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector4i"/> struct.
-        /// </summary>
-        /// <param name="x">The x component of the Vector4i.</param>
-        /// <param name="y">The y component of the Vector4i.</param>
-        /// <param name="zw">The z and w components of the Vector4i.</param>
-        public Vector4i(int x, int y, Vector2i zw)
-        {
-            X = x;
-            Y = y;
-            Z = zw.X;
-            W = zw.Y;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector4i"/> struct.
-        /// </summary>
-        /// <param name="xy">The x and y components of the Vector4i.</param>
-        /// <param name="zw">The z and w components of the Vector4i.</param>
-        public Vector4i(Vector2i xy, Vector2i zw)
-        {
-            X = xy.X;
-            Y = xy.Y;
-            Z = zw.X;
-            W = zw.Y;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector4i"/> struct.
-        /// </summary>
         /// <param name="xyz">The x, y and z components of the Vector4i.</param>
         /// <param name="w">The w component of the Vector4i.</param>
-        public Vector4i(Vector3i xyz, int w)
+        public Vector4i(Vector3i xyz, int w = default)
         {
             X = xyz.X;
             Y = xyz.Y;
             Z = xyz.Z;
             W = w;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector4i"/> struct.
-        /// </summary>
-        /// <param name="x">The x component of the Vector4i.</param>
-        /// <param name="yzw">The y, z and w components of the Vector4i.</param>
-        public Vector4i(int x, Vector3i yzw)
-        {
-            X = x;
-            Y = yzw.X;
-            Z = yzw.Y;
-            W = yzw.Z;
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Vector/Vector4i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4i.cs
@@ -1572,31 +1572,6 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
-        /// Returns a pointer to the first element of the specified instance.
-        /// </summary>
-        /// <param name="v">The instance.</param>
-        /// <returns>A pointer to the first element of v.</returns>
-        [Pure]
-        public static unsafe explicit operator int*(Vector4i v)
-        {
-            return &v.X;
-        }
-
-        /// <summary>
-        /// Returns a pointer to the first element of the specified instance.
-        /// </summary>
-        /// <param name="v">The instance.</param>
-        /// <returns>A pointer to the first element of v.</returns>
-        [Pure]
-        public static explicit operator IntPtr(Vector4i v)
-        {
-            unsafe
-            {
-                return (IntPtr)(&v.X);
-            }
-        }
-
-        /// <summary>
         /// Converts OpenTK.Vector4i to OpenTK.Vector4.
         /// </summary>
         /// <param name="vec">The Vector4i to convert.</param>

--- a/tests/OpenTK.Tests/Vector2Tests.fs
+++ b/tests/OpenTK.Tests/Vector2Tests.fs
@@ -13,14 +13,16 @@ module Vector2 =
     module Constructors =
         //
         [<Property>]
-        let ``Single value constructor sets all components to the same value`` (f : float32) =
-            let v = Vector2(f)
-            Assert.Equal(f,v.X)
-            Assert.Equal(f,v.Y)
+        let ``(float) constructor sets all components to the same value`` (value : float32) =
+            let v = Vector2(value)
+            
+            Assert.Equal(value, v.X)
+            Assert.Equal(value, v.Y)
 
         [<Property>]
-        let ``Two value constructor sets all components correctly`` (x,y) =
+        let ``(float, float) constructor sets all components correctly`` (x : float32, y : float32) =
             let v = Vector2(x,y)
+            
             Assert.Equal(x,v.X)
             Assert.Equal(y,v.Y)
 

--- a/tests/OpenTK.Tests/Vector3Tests.fs
+++ b/tests/OpenTK.Tests/Vector3Tests.fs
@@ -13,58 +13,38 @@ module Vector3 =
     module Constructors =
         //
         [<Property>]
-        let ``Triple value constructor sets all components to the correct values`` (a, b, c) =
-            let v = Vector3(a, b, c)
+        let ``(float, float, float) constructor sets all components to the correct values`` (x : float32, y : float32, z : float32) =
+            let v = Vector3(x, y, z)
 
-            Assert.Equal(a, v.X)
-            Assert.Equal(b, v.Y)
-            Assert.Equal(c, v.Z)
-
-        [<Property>]
-        let ``Single value constructor sets all components to the correct values`` (a : float32) =
-            let v = Vector3(a)
-
-            Assert.Equal(a, v.X)
-            Assert.Equal(a, v.Y)
-            Assert.Equal(a, v.Z)
+            Assert.Equal(x, v.X)
+            Assert.Equal(y, v.Y)
+            Assert.Equal(z, v.Z)
 
         [<Property>]
-        let ``Vector2 value constructor sets all components to the correct values`` (a, b) =
-            let v1 = Vector2(a, b)
-            let v2 = Vector3(v1)
+        let ``(float) constructor sets all components to the correct values`` (value : float32) =
+            let v = Vector3(value)
 
-            Assert.Equal(v1.X, v2.X)
-            Assert.Equal(v1.Y, v2.Y)
-
-            Assert.Equal(a, v2.X)
-            Assert.Equal(b, v2.Y)
-            Assert.Equal(0.0f, v2.Z)
+            Assert.Equal(value, v.X)
+            Assert.Equal(value, v.Y)
+            Assert.Equal(value, v.Z)
 
         [<Property>]
-        let ``Vector3 value constructor sets all components to the correct values`` (a, b, c) =
-            let v1 = Vector3(a, b, c)
-            let v2 = Vector3(v1)
+        let ``(Vector2, float) constructor sets all components to the correct values`` (x : float32, y : float32, z : float32) =
+            let v1 = Vector2(x, y)
+            let v2 = Vector3(v1, z)
 
-            Assert.Equal(v1.X, v2.X)
-            Assert.Equal(v1.Y, v2.Y)
-            Assert.Equal(v1.Z, v2.Z)
-
-            Assert.Equal(a, v2.X)
-            Assert.Equal(b, v2.Y)
-            Assert.Equal(c, v2.Z)
+            Assert.Equal(x, v2.X)
+            Assert.Equal(y, v2.Y)
+            Assert.Equal(z, v2.Z)
 
         [<Property>]
-        let ``Vector4 value constructor sets all components to the correct values`` (a, b, c, d) =
-            let v1 = Vector4(a, b, c, d)
-            let v2 = Vector3(v1)
+        let ``(float, Vector2) constructor sets all components to the correct values`` (x : float32, y : float32, z : float32) =
+            let v1 = Vector2(y, z)
+            let v2 = Vector3(x, v1)
 
-            Assert.Equal(v1.X, v2.X)
-            Assert.Equal(v1.Y, v2.Y)
-            Assert.Equal(v1.Z, v2.Z)
-
-            Assert.Equal(a, v2.X)
-            Assert.Equal(b, v2.Y)
-            Assert.Equal(c, v2.Z)
+            Assert.Equal(x, v2.X)
+            Assert.Equal(y, v2.Y)
+            Assert.Equal(z, v2.Z)
 
     [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Indexing =

--- a/tests/OpenTK.Tests/Vector3Tests.fs
+++ b/tests/OpenTK.Tests/Vector3Tests.fs
@@ -31,20 +31,18 @@ module Vector3 =
         [<Property>]
         let ``(Vector2, float) constructor sets all components to the correct values`` (x : float32, y : float32, z : float32) =
             let v1 = Vector2(x, y)
-            let v2 = Vector3(v1, z)
+
+            let v2 = Vector3(v1)
 
             Assert.Equal(x, v2.X)
             Assert.Equal(y, v2.Y)
-            Assert.Equal(z, v2.Z)
+            Assert.Equal(0.0f, v2.Z)
 
-        [<Property>]
-        let ``(float, Vector2) constructor sets all components to the correct values`` (x : float32, y : float32, z : float32) =
-            let v1 = Vector2(y, z)
-            let v2 = Vector3(x, v1)
+            let v3 = Vector3(v1, z)
 
-            Assert.Equal(x, v2.X)
-            Assert.Equal(y, v2.Y)
-            Assert.Equal(z, v2.Z)
+            Assert.Equal(x, v3.X)
+            Assert.Equal(y, v3.Y)
+            Assert.Equal(z, v3.Z)
 
     [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Indexing =

--- a/tests/OpenTK.Tests/Vector4Tests.fs
+++ b/tests/OpenTK.Tests/Vector4Tests.fs
@@ -33,63 +33,45 @@ module Vector4 =
         [<Property>]
         let ``(Vector2, float, float) constructor sets all components to the correct values`` (x : float32, y : float32, z : float32, w : float32) =
             let v1 = Vector2(x, y)
-            let v2 = Vector4(v1, z, w)
+
+            let v2 = Vector4(v1)
+
+            Assert.Equal(x, v2.X)
+            Assert.Equal(y, v2.Y)
+            Assert.Equal(0.0f, v2.Z)
+            Assert.Equal(0.0f, v2.W)
+
+            let v3 = Vector4(v1, z)
+
+            Assert.Equal(x, v3.X)
+            Assert.Equal(y, v3.Y)
+            Assert.Equal(z, v3.Z)
+            Assert.Equal(0.0f, v3.W)
+
+            let v4 = Vector4(v1, z, w)
+
+            Assert.Equal(x, v4.X)
+            Assert.Equal(y, v4.Y)
+            Assert.Equal(z, v4.Z)
+            Assert.Equal(w, v4.W)
+
+        [<Property>]
+        let ``(Vector3, float) constructor sets all components to the correct values`` (x : float32, y : float32, z : float32, w : float32) =
+            let v1 = Vector3(x, y, z)
+
+            let v2 = Vector4(v1)
 
             Assert.Equal(x, v2.X)
             Assert.Equal(y, v2.Y)
             Assert.Equal(z, v2.Z)
-            Assert.Equal(w, v2.W)
+            Assert.Equal(0.0f, v2.W)
 
-        [<Property>]
-        let ``(float, Vector2, float) constructor sets all components to the correct values`` (x : float32, y : float32, z : float32, w : float32) =
-            let v1 = Vector2(y, z)
-            let v2 = Vector4(x, v1, w)
-
-            Assert.Equal(x, v2.X)
-            Assert.Equal(y, v2.Y)
-            Assert.Equal(z, v2.Z)
-            Assert.Equal(w, v2.W)
-
-        [<Property>]
-        let ``(float, float, Vector2) constructor sets all components to the correct values`` (x : float32, y : float32, z : float32, w : float32) =
-            let v1 = Vector2(z, w)
-            let v2 = Vector4(x, y, v1)
-
-            Assert.Equal(x, v2.X)
-            Assert.Equal(y, v2.Y)
-            Assert.Equal(z, v2.Z)
-            Assert.Equal(w, v2.W)
-
-        [<Property>]
-        let ``(Vector2, Vector2) constructor sets all components to the correct values`` (x : float32, y : float32, z : float32, w : float32) =
-            let v1 = Vector2(x, y)
-            let v2 = Vector2(z, w)
-            let v3 = Vector4(v1, v2)
+            let v3 = Vector4(v1, w)
 
             Assert.Equal(x, v3.X)
             Assert.Equal(y, v3.Y)
             Assert.Equal(z, v3.Z)
             Assert.Equal(w, v3.W)
-
-        [<Property>]
-        let ``(Vector3, float) constructor sets all components to the correct values`` (x : float32, y : float32, z : float32, w : float32) =
-            let v1 = Vector3(x, y, z)
-            let v2 = Vector4(v1, w)
-
-            Assert.Equal(x, v2.X)
-            Assert.Equal(y, v2.Y)
-            Assert.Equal(z, v2.Z)
-            Assert.Equal(w, v2.W)
-
-        [<Property>]
-        let ``(float, Vector3) constructor sets all components to the correct values`` (x : float32, y : float32, z : float32, w : float32) =
-            let v1 = Vector3(y, z, w)
-            let v2 = Vector4(x, v1)
-
-            Assert.Equal(x, v2.X)
-            Assert.Equal(y, v2.Y)
-            Assert.Equal(z, v2.Z)
-            Assert.Equal(w, v2.W)
 
     [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
     module Indexing =

--- a/tests/OpenTK.Tests/Vector4Tests.fs
+++ b/tests/OpenTK.Tests/Vector4Tests.fs
@@ -13,7 +13,7 @@ module Vector4 =
     module Constructors =
         //
         [<Property>]
-        let ``Triple value constructor sets all components to the correct values`` (x, y, z, w) =
+        let ``(float, float, float, float) constructor sets all components to the correct values`` (x : float32, y : float32, z : float32, w : float32) =
             let v = Vector4(x, y, z, w)
 
             Assert.Equal(x, v.X)
@@ -22,49 +22,18 @@ module Vector4 =
             Assert.Equal(w, v.W)
 
         [<Property>]
-        let ``Single value constructor sets all components to the correct values`` (a : float32) =
-            let v = Vector4(a)
+        let ``(float) value constructor sets all components to the correct values`` (value : float32) =
+            let v = Vector4(value)
 
-            Assert.Equal(a, v.X)
-            Assert.Equal(a, v.Y)
-            Assert.Equal(a, v.Z)
-            Assert.Equal(a, v.W)
+            Assert.Equal(value, v.X)
+            Assert.Equal(value, v.Y)
+            Assert.Equal(value, v.Z)
+            Assert.Equal(value, v.W)
 
         [<Property>]
-        let ``Vector2 value constructor sets all components to the correct values`` (x, y) =
+        let ``(Vector2, float, float) constructor sets all components to the correct values`` (x : float32, y : float32, z : float32, w : float32) =
             let v1 = Vector2(x, y)
-            let v2 = Vector4(v1)
-
-            Assert.Equal(v1.X, v2.X)
-            Assert.Equal(v1.Y, v2.Y)
-
-            Assert.Equal(x, v2.X)
-            Assert.Equal(y, v2.Y)
-            Assert.Equal(0.0f, v2.Z)
-            Assert.Equal(0.0f, v2.W)
-
-        [<Property>]
-        let ``Vector3 value constructor sets all components to the correct values`` (x, y, z) =
-            let v1 = Vector3(x, y, z)
-            let v2 = Vector4(v1)
-
-            Assert.Equal(v1.X, v2.X)
-            Assert.Equal(v1.Y, v2.Y)
-            Assert.Equal(v1.Z, v2.Z)
-
-            Assert.Equal(x, v2.X)
-            Assert.Equal(y, v2.Y)
-            Assert.Equal(z, v2.Z)
-            Assert.Equal(0.0f, v2.W)
-
-        [<Property>]
-        let ``Vector3 value and scalar constructor sets all components to the correct values`` (x, y, z, w) =
-            let v1 = Vector3(x, y, z)
-            let v2 = Vector4(v1, w)
-
-            Assert.Equal(v1.X, v2.X)
-            Assert.Equal(v1.Y, v2.Y)
-            Assert.Equal(v1.Z, v2.Z)
+            let v2 = Vector4(v1, z, w)
 
             Assert.Equal(x, v2.X)
             Assert.Equal(y, v2.Y)
@@ -72,14 +41,50 @@ module Vector4 =
             Assert.Equal(w, v2.W)
 
         [<Property>]
-        let ``Vector4 value constructor sets all components to the correct values`` (x, y, z, w) =
-            let v1 = Vector4(x, y, z, w)
-            let v2 = Vector4(v1)
+        let ``(float, Vector2, float) constructor sets all components to the correct values`` (x : float32, y : float32, z : float32, w : float32) =
+            let v1 = Vector2(y, z)
+            let v2 = Vector4(x, v1, w)
 
-            Assert.Equal(v1.X, v2.X)
-            Assert.Equal(v1.Y, v2.Y)
-            Assert.Equal(v1.Z, v2.Z)
-            Assert.Equal(v1.W, v2.W)
+            Assert.Equal(x, v2.X)
+            Assert.Equal(y, v2.Y)
+            Assert.Equal(z, v2.Z)
+            Assert.Equal(w, v2.W)
+
+        [<Property>]
+        let ``(float, float, Vector2) constructor sets all components to the correct values`` (x : float32, y : float32, z : float32, w : float32) =
+            let v1 = Vector2(z, w)
+            let v2 = Vector4(x, y, v1)
+
+            Assert.Equal(x, v2.X)
+            Assert.Equal(y, v2.Y)
+            Assert.Equal(z, v2.Z)
+            Assert.Equal(w, v2.W)
+
+        [<Property>]
+        let ``(Vector2, Vector2) constructor sets all components to the correct values`` (x : float32, y : float32, z : float32, w : float32) =
+            let v1 = Vector2(x, y)
+            let v2 = Vector2(z, w)
+            let v3 = Vector4(v1, v2)
+
+            Assert.Equal(x, v3.X)
+            Assert.Equal(y, v3.Y)
+            Assert.Equal(z, v3.Z)
+            Assert.Equal(w, v3.W)
+
+        [<Property>]
+        let ``(Vector3, float) constructor sets all components to the correct values`` (x : float32, y : float32, z : float32, w : float32) =
+            let v1 = Vector3(x, y, z)
+            let v2 = Vector4(v1, w)
+
+            Assert.Equal(x, v2.X)
+            Assert.Equal(y, v2.Y)
+            Assert.Equal(z, v2.Z)
+            Assert.Equal(w, v2.W)
+
+        [<Property>]
+        let ``(float, Vector3) constructor sets all components to the correct values`` (x : float32, y : float32, z : float32, w : float32) =
+            let v1 = Vector3(y, z, w)
+            let v2 = Vector4(x, v1)
 
             Assert.Equal(x, v2.X)
             Assert.Equal(y, v2.Y)


### PR DESCRIPTION
**Recreated from #1418 onto 5.0**

### Purpose of this PR

Currently, there are inconsistencies between vectors constructors.

Some examples:

Vector4 can be constructed from a Vector3 and a W component:
`public Vector4(Vector3 v, float w)`
But Vector3 cannot be constructed from a Vector2 and a Z comonent.

Vector3 can be constructed from a Vector4:
`public Vector3(Vector4 v)`
But Vector2 cannot be constructed from a Vector3 or a Vector4.

Vector4 has two constructors:
`public Vector4(Vector3 v)`
`public Vector4(Vector3 v, float w)`
That could be merged into one:
`public Vector4(Vector3 v, float w = 0.0f)`
(I am note sure if having optional parameters in vectors constructors is a good idea though)

This PR uniformizes these constructores to support constructing any vector type from all other vector types.

### Testing status

Current constructors are already tested (see Vector2Tests.fs, Vector3Tests.fs and Vector4Tests.fs).
These tests should be extended to support the added and refactored constructors.

EDIT: Tests have been adapted.