### PR TITLE
Fixed small typo in Box3i.Contains(Vector3i)

### DIFF
--- a/src/OpenTK.Mathematics/Geometry/Box3i.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box3i.cs
@@ -120,7 +120,7 @@ namespace OpenTK.Mathematics
         public bool Contains(Vector3i point)
         {
             return _min.X < point.X && point.X < _max.X &&
-                   _min.Y < point.Z && point.Y < _max.Y &&
+                   _min.Y < point.Y && point.Y < _max.Y &&
                    _min.Z < point.Z && point.Z < _max.Z;
         }
 


### PR DESCRIPTION
### Purpose of this PR

Just a one letter bugfix I noticed when using Box3i.Contains(Vector3i), this time creating the PR myself instead of just an issue :)
Hope it's ok to not follow the Early Pull Reqeust approach for just one letter.
