### PR TITLE
Added sRGB setting in NativeWindowSettings

### DIFF
--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -751,6 +751,8 @@ namespace OpenTK.Windowing.Desktop
 
             GLFW.WindowHint(WindowHintInt.Samples, settings.NumberOfSamples);
 
+            GLFW.WindowHint(WindowHintBool.SrgbCapable, settings.SrgbCapable);
+
             // We do the work to set the hint bits outside of the CreateWindow conditional
             // so that the window will get the correct fullscreen red/green/blue bits stored
             // in its hidden fields regardless of how it gets created.  (The extra curly

--- a/src/OpenTK.Windowing.Desktop/NativeWindowSettings.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindowSettings.cs
@@ -246,5 +246,10 @@ namespace OpenTK.Windowing.Desktop
         /// Default value is 8.
         /// </remarks>
         public int? AlphaBits { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the backbuffer should be sRGB capable.
+        /// </summary>
+        public bool SrgbCapable { get; set; }
     }
 }


### PR DESCRIPTION
### Purpose of this PR

Fixes #1421 

### Testing status

Tested locally, though even with `SrgbCapable = false` I was able to enable sRGB with `GL.Enable(EnableCap.FramebufferSrgb)`, so I'm not sure if this would work on other platforms.
