### PR TITLE
Updated OpenTK.redist.glfw package

### DIFF
--- a/src/OpenTK.Windowing.GraphicsLibraryFramework/OpenTK.Windowing.GraphicsLibraryFramework.csproj
+++ b/src/OpenTK.Windowing.GraphicsLibraryFramework/OpenTK.Windowing.GraphicsLibraryFramework.csproj
@@ -18,7 +18,7 @@
         <PrivateAssets>all</PrivateAssets>
       </PackageReference>
       <PackageReference Condition="'$(TargetFramework)' == 'net472'" Include="System.Memory" Version="4.5" />
-      <PackageReference Include="OpenTK.redist.glfw" Version="3.3.5.18" />
+      <PackageReference Include="OpenTK.redist.glfw" Version="3.3.7.25" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/OpenTK.Windowing.GraphicsLibraryFramework/paket
+++ b/src/OpenTK.Windowing.GraphicsLibraryFramework/paket
@@ -5,7 +5,7 @@ description
 dependencies
     framework: netcoreapp3.1
         OpenTK.Core ~> #VERSION#
-        OpenTK.redist.glfw ~> 3.3.5.18
+        OpenTK.redist.glfw => 3.3.7.25
 files
     bin\Release\netcoreapp3.1\OpenTK.Windowing.GraphicsLibraryFramework.dll ==> lib\netcoreapp3.1
     bin\Release\netcoreapp3.1\OpenTK.Windowing.GraphicsLibraryFramework.xml ==> lib\netcoreapp3.1


### PR DESCRIPTION
### Purpose of this PR

Updates `OpenTK.redist.glfw` package to glfw 3.3.7.
This should fix #1363 and #1414 .

This relates to #1404.

### Testing status

Tested using the local package, and `Console.WriteLine(GLFW.GetVersionString());` prints out 3.3.7 correctly.