### PR TITLE
Add proper check for initializing GLFW from the main thread.

### DIFF
--- a/src/OpenTK.Windowing.Desktop/GLFWProvider.cs
+++ b/src/OpenTK.Windowing.Desktop/GLFWProvider.cs
@@ -30,13 +30,29 @@ namespace OpenTK.Windowing.Desktop
 
         /// <summary>
         /// Gets a value indicating whether the <see cref="Thread.CurrentThread"/> is the same as the GLFW main thread.
+        /// If <see cref="CheckForMainThread"/> is false this function will always return true.
         /// </summary>
-        public static bool IsOnMainThread => _mainThread?.ManagedThreadId == Thread.CurrentThread.ManagedThreadId;
+        public static bool IsOnMainThread
+        {
+            get
+            {
+                if (CheckForMainThread == false)
+                {
+                    return true;
+                }
+                else
+                {
+                    return _mainThread?.ManagedThreadId == Thread.CurrentThread.ManagedThreadId;
+                }
+            }
+        }
 
         /// <summary>
         /// Whether or not to check that GLFW is initialzed on the main thread.
         /// </summary>
         public static bool CheckForMainThread { get; set; } = true;
+
+        private static bool Initialized = false;
 
         /// <summary>
         /// Makes sure GLFW is intialized.
@@ -73,8 +89,12 @@ namespace OpenTK.Windowing.Desktop
                 }
             }
 
-            GLFW.Init();
-            GLFW.SetErrorCallback(ErrorCallback);
+            if (Initialized == false)
+            {
+                GLFW.Init();
+                GLFW.SetErrorCallback(ErrorCallback);
+                Initialized = true;
+            }
         }
     }
 }

--- a/src/OpenTK.Windowing.Desktop/GLFWProvider.cs
+++ b/src/OpenTK.Windowing.Desktop/GLFWProvider.cs
@@ -8,6 +8,8 @@
 //
 
 using System;
+using System.Diagnostics;
+using System.Reflection;
 using System.Threading;
 using OpenTK.Windowing.GraphicsLibraryFramework;
 
@@ -16,7 +18,7 @@ namespace OpenTK.Windowing.Desktop
     /// <summary>
     /// Singleton providing easy GLFW implementation access.
     /// </summary>
-    internal static class GLFWProvider
+    public static class GLFWProvider
     {
         private static readonly GLFWCallbacks.ErrorCallback ErrorCallback =
             (errorCode, description) => throw new GLFWException(description, errorCode);
@@ -29,16 +31,48 @@ namespace OpenTK.Windowing.Desktop
         /// <summary>
         /// Gets a value indicating whether the <see cref="Thread.CurrentThread"/> is the same as the GLFW main thread.
         /// </summary>
-        public static bool IsOnMainThread => _mainThread == Thread.CurrentThread;
+        public static bool IsOnMainThread => _mainThread?.ManagedThreadId == Thread.CurrentThread.ManagedThreadId;
 
+        /// <summary>
+        /// Whether or not to check that GLFW is initialzed on the main thread.
+        /// </summary>
+        public static bool CheckForMainThread { get; set; } = true;
+
+        /// <summary>
+        /// Makes sure GLFW is intialized.
+        /// </summary>
+        /// <exception cref="GLFWException">If this function is not called from the main thread and <see cref="CheckForMainThread"/> is true.</exception>
         public static void EnsureInitialized()
         {
-            if (_mainThread != null)
+            if (CheckForMainThread)
             {
-                return;
+                if (_mainThread == null)
+                {
+                    if (Thread.CurrentThread.IsBackground == false &&
+                        Thread.CurrentThread.IsThreadPoolThread == false &&
+                        Thread.CurrentThread.IsAlive)
+                    {
+                        MethodInfo correctEntryMethod = Assembly.GetEntryAssembly().EntryPoint;
+                        StackTrace trace = new StackTrace();
+                        StackFrame[] frames = trace.GetFrames();
+                        for (int i = frames.Length - 1; i >= 0; i--)
+                        {
+                            MethodBase method = frames[i].GetMethod();
+                            if (correctEntryMethod == method)
+                            {
+                                _mainThread = Thread.CurrentThread;
+                                break;
+                            }
+                        }
+                    }
+                }
+
+                if (_mainThread?.ManagedThreadId != Thread.CurrentThread.ManagedThreadId)
+                {
+                    throw new GLFWException("GLFW can only be called from the main thread!");
+                }
             }
 
-            _mainThread = Thread.CurrentThread;
             GLFW.Init();
             GLFW.SetErrorCallback(ErrorCallback);
         }

--- a/src/OpenTK.Windowing.Desktop/GLFWProvider.cs
+++ b/src/OpenTK.Windowing.Desktop/GLFWProvider.cs
@@ -32,20 +32,7 @@ namespace OpenTK.Windowing.Desktop
         /// Gets a value indicating whether the <see cref="Thread.CurrentThread"/> is the same as the GLFW main thread.
         /// If <see cref="CheckForMainThread"/> is false this function will always return true.
         /// </summary>
-        public static bool IsOnMainThread
-        {
-            get
-            {
-                if (CheckForMainThread == false)
-                {
-                    return true;
-                }
-                else
-                {
-                    return _mainThread?.ManagedThreadId == Thread.CurrentThread.ManagedThreadId;
-                }
-            }
-        }
+        public static bool IsOnMainThread => CheckForMainThread == false || _mainThread == Thread.CurrentThread;
 
         /// <summary>
         /// Whether or not to check that GLFW is initialzed on the main thread.

--- a/src/OpenTK.Windowing.Desktop/Joysticks.cs
+++ b/src/OpenTK.Windowing.Desktop/Joysticks.cs
@@ -13,11 +13,6 @@ namespace OpenTK.Windowing.Desktop
         {
             GLFWProvider.EnsureInitialized();
 
-            if (!GLFWProvider.IsOnMainThread)
-            {
-                throw new InvalidOperationException("Only GLFW main thread can access this class.");
-            }
-
             _joystickCallback = (id, state) => JoystickCallback(id, state);
 
             GLFW.SetJoystickCallback(_joystickCallback);

--- a/src/OpenTK.Windowing.Desktop/MonitorInfo.cs
+++ b/src/OpenTK.Windowing.Desktop/MonitorInfo.cs
@@ -128,10 +128,7 @@ namespace OpenTK.Windowing.Desktop
         /// <param name="handle">An opaque handle to a monitor.</param>
         internal MonitorInfo(MonitorHandle handle)
         {
-            if (!GLFWProvider.IsOnMainThread)
-            {
-                throw new NotSupportedException("Only the GLFW thread can construct this object.");
-            }
+            GLFWProvider.EnsureInitialized();
 
             if (handle.Pointer == IntPtr.Zero)
             {

--- a/src/OpenTK.Windowing.Desktop/Monitors.cs
+++ b/src/OpenTK.Windowing.Desktop/Monitors.cs
@@ -26,11 +26,6 @@ namespace OpenTK.Windowing.Desktop
         {
             GLFWProvider.EnsureInitialized();
 
-            if (!GLFWProvider.IsOnMainThread)
-            {
-                throw new InvalidOperationException("Only GLFW main thread can access this class.");
-            }
-
             _monitorCallback = MonitorCallback;
             GLFW.SetMonitorCallback(_monitorCallback);
         }

--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -665,10 +665,6 @@ namespace OpenTK.Windowing.Desktop
         public unsafe NativeWindow(NativeWindowSettings settings)
         {
             GLFWProvider.EnsureInitialized();
-            if (!GLFWProvider.IsOnMainThread)
-            {
-                throw new GLFWException("Can only create windows on the Glfw main thread (the thread that calls Main).");
-            }
 
             _title = settings.Title;
 


### PR DESCRIPTION
### Purpose of this PR

Fixes #961 
Relates to #1206

### Testing status

Tested using the local project. Both running from the main thread and from a secondary thread (with both `CheckForMainThread=true` and `CheckForMainThread=false`).
