### PR TITLE
Fix input updating too fast when limiting update rate

### DIFF
--- a/LocalTest/LocalTest.csproj
+++ b/LocalTest/LocalTest.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>net5.0</TargetFramework>
     <ApplicationIcon />
     <StartupObject />
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LocalTest/Program.cs
+++ b/LocalTest/Program.cs
@@ -2,6 +2,7 @@
 using OpenTK.Mathematics;
 using OpenTK.Windowing.Common;
 using OpenTK.Windowing.Desktop;
+using OpenTK.Windowing.GraphicsLibraryFramework;
 using System;
 using System.Diagnostics;
 
@@ -13,6 +14,8 @@ namespace LocalTest
         {
             GameWindowSettings gwSettings = new GameWindowSettings()
             {
+                RenderFrequency = 0,
+                UpdateFrequency = 0,
             };
 
             NativeWindowSettings nwSettings = new NativeWindowSettings()
@@ -56,6 +59,13 @@ namespace LocalTest
             GL.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit);
 
             SwapBuffers();
+        }
+        
+        protected override void OnUpdateFrame(FrameEventArgs args)
+        {
+            base.OnUpdateFrame(args);
+
+
         }
     }
 }

--- a/LocalTest/Program.cs
+++ b/LocalTest/Program.cs
@@ -65,11 +65,6 @@ namespace LocalTest
         {
             base.OnUpdateFrame(args);
 
-            if (MouseState.IsButtonDown(MouseButton.Left) &&
-                MouseState.WasButtonDown(MouseButton.Left) == false)
-            {
-                Console.WriteLine("Pressed!");
-            }
         }
     }
 }

--- a/LocalTest/Program.cs
+++ b/LocalTest/Program.cs
@@ -65,7 +65,11 @@ namespace LocalTest
         {
             base.OnUpdateFrame(args);
 
-
+            if (MouseState.IsButtonDown(MouseButton.Left) &&
+                MouseState.WasButtonDown(MouseButton.Left) == false)
+            {
+                Console.WriteLine("Pressed!");
+            }
         }
     }
 }

--- a/src/OpenTK.Windowing.Desktop/GameWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/GameWindow.cs
@@ -230,7 +230,7 @@ namespace OpenTK.Windowing.Desktop
             while (GLFW.WindowShouldClose(WindowPtr) == false)
             {
                 // Process events, this will be called continuously while waiting to dispatch render and update frames.
-                ProcessEventsNoInput();
+                ProcessEventsNoInput(IsEventDriven);
                 DispatchUpdateFrame();
 
                 if (!IsMultiThreaded)

--- a/src/OpenTK.Windowing.Desktop/GameWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/GameWindow.cs
@@ -229,7 +229,9 @@ namespace OpenTK.Windowing.Desktop
             _watchUpdate.Start();
             while (GLFW.WindowShouldClose(WindowPtr) == false)
             {
-                ProcessEvents();
+                // Update input state for this frame.
+                // We will continually poll for events while waiting to dispatch update frame.
+                ProcessInputEvents();
                 DispatchUpdateFrame();
 
                 if (!IsMultiThreaded)
@@ -264,6 +266,8 @@ namespace OpenTK.Windowing.Desktop
 
             while (elapsed > 0 && elapsed + _updateEpsilon >= updatePeriod)
             {
+                ProcessEventsNoInput();
+
                 _watchUpdate.Restart();
                 UpdateTime = elapsed;
                 OnUpdateFrame(new FrameEventArgs(elapsed));

--- a/src/OpenTK.Windowing.Desktop/GameWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/GameWindow.cs
@@ -229,9 +229,8 @@ namespace OpenTK.Windowing.Desktop
             _watchUpdate.Start();
             while (GLFW.WindowShouldClose(WindowPtr) == false)
             {
-                // Update input state for this frame.
-                // We will continually poll for events while waiting to dispatch update frame.
-                ProcessInputEvents();
+                // Process events, this will be called continuously while waiting to dispatch render and update frames.
+                ProcessEventsNoInput();
                 DispatchUpdateFrame();
 
                 if (!IsMultiThreaded)
@@ -266,11 +265,12 @@ namespace OpenTK.Windowing.Desktop
 
             while (elapsed > 0 && elapsed + _updateEpsilon >= updatePeriod)
             {
-                ProcessEventsNoInput();
-
                 _watchUpdate.Restart();
                 UpdateTime = elapsed;
                 OnUpdateFrame(new FrameEventArgs(elapsed));
+
+                // Prepare input for the next update.
+                ProcessInputEvents();
 
                 // Calculate difference (positive or negative) between
                 // actual elapsed time and target elapsed time. We must

--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -1440,7 +1440,7 @@ namespace OpenTK.Windowing.Desktop
         /// </summary>
         public unsafe void ProcessInputEvents()
         {
-            MouseState.Update();
+            MouseState.Update(WindowPtr);
             KeyboardState.Update();
 
             GLFW.GetCursorPos(WindowPtr, out var x, out var y);
@@ -1454,6 +1454,44 @@ namespace OpenTK.Windowing.Desktop
                 }
 
                 _joystickStates[i].Update();
+            }
+        }
+
+        public unsafe void UpdateInput()
+        {
+            MouseState.Update(WindowPtr);
+            KeyboardState.Update();
+
+            GLFW.GetCursorPos(WindowPtr, out var x, out var y);
+            MouseState.Position = new Vector2((float)x, (float)y);
+
+            for (var i = 0; i < _joystickStates.Length; i++)
+            {
+                if (_joystickStates[i] == null)
+                {
+                    continue;
+                }
+
+                _joystickStates[i].Update();
+            }
+        }
+
+        public unsafe void NewInputFrame()
+        {
+            MouseState.NewFrame();
+            KeyboardState.NewFrame();
+
+            GLFW.GetCursorPos(WindowPtr, out var x, out var y);
+            MouseState.Position = new Vector2((float)x, (float)y);
+
+            for (var i = 0; i < _joystickStates.Length; i++)
+            {
+                if (_joystickStates[i] == null)
+                {
+                    continue;
+                }
+
+                _joystickStates[i].NewFrame();
             }
         }
 

--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -37,7 +37,7 @@ namespace OpenTK.Windowing.Desktop
         private Vector2 _lastReportedMousePos;
 
         // Stores exceptions thrown in callbacks so that we can rethrow them after ProcessEvents().
-        private List<ExceptionDispatchInfo> _callbackExceptions = new List<ExceptionDispatchInfo>();
+        private static List<ExceptionDispatchInfo> _callbackExceptions = new List<ExceptionDispatchInfo>();
 
         // GLFW cursor we assigned to the window.
         // Null if the cursor is default.
@@ -1391,24 +1391,16 @@ namespace OpenTK.Windowing.Desktop
         {
             ProcessInputEvents();
 
-            if (IsEventDriven)
-            {
-                GLFW.WaitEvents();
-            }
-            else
-            {
-                GLFW.PollEvents();
-            }
-
-            RethrowCallbackExceptionsIfNeeded();
+            ProcessEventsNoInput(IsEventDriven);
         }
 
         /// <summary>
         /// Processes pending window events without a call to <see cref="ProcessInputEvents()"/>.
         /// </summary>
-        public virtual void ProcessEventsNoInput()
+        /// <param name="isEventDriven">Wheather to call <see cref="GLFW.WaitEvents()"/> or <see cref="GLFW.PollEvents()"/>.</param>
+        public static void ProcessEventsNoInput(bool isEventDriven)
         {
-            if (IsEventDriven)
+            if (isEventDriven)
             {
                 GLFW.WaitEvents();
             }
@@ -1420,7 +1412,7 @@ namespace OpenTK.Windowing.Desktop
             RethrowCallbackExceptionsIfNeeded();
         }
 
-        private void RethrowCallbackExceptionsIfNeeded()
+        private static void RethrowCallbackExceptionsIfNeeded()
         {
             if (_callbackExceptions.Count == 1)
             {

--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -1403,6 +1403,23 @@ namespace OpenTK.Windowing.Desktop
             RethrowCallbackExceptionsIfNeeded();
         }
 
+        /// <summary>
+        /// Processes pending window events without a call to <see cref="ProcessInputEvents()"/>.
+        /// </summary>
+        public virtual void ProcessEventsNoInput()
+        {
+            if (IsEventDriven)
+            {
+                GLFW.WaitEvents();
+            }
+            else
+            {
+                GLFW.PollEvents();
+            }
+
+            RethrowCallbackExceptionsIfNeeded();
+        }
+
         private void RethrowCallbackExceptionsIfNeeded()
         {
             if (_callbackExceptions.Count == 1)

--- a/src/OpenTK.Windowing.GraphicsLibraryFramework/GLFW.cs
+++ b/src/OpenTK.Windowing.GraphicsLibraryFramework/GLFW.cs
@@ -2034,22 +2034,16 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
         /// Possible errors include <see cref="ErrorCode.NotInitialized"/>, <see cref="ErrorCode.InvalidEnum"/> and <see cref="ErrorCode.PlatformError"/>.
         /// </para>
         /// </remarks>
-        public static unsafe JoystickInputAction[] GetJoystickButtons(int jid)
+        public static unsafe Span<JoystickInputAction> GetJoystickButtons(int jid)
         {
             var ptr = GetJoystickButtonsRaw(jid, out var count);
 
             if (ptr == null)
             {
-                return null;
+                return Span<JoystickInputAction>.Empty;
             }
 
-            var array = new JoystickInputAction[count];
-            for (var i = 0; i < count; i++)
-            {
-                array[i] = ptr[i];
-            }
-
-            return array;
+            return new Span<JoystickInputAction>(ptr, count);
         }
 
         /// <summary>
@@ -2186,22 +2180,16 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
         /// Possible errors include <see cref="ErrorCode.NotInitialized"/>, <see cref="ErrorCode.InvalidEnum"/> and <see cref="ErrorCode.PlatformError"/>.
         /// </para>
         /// </remarks>
-        public static unsafe JoystickHats[] GetJoystickHats(int jid)
+        public static unsafe Span<JoystickHats> GetJoystickHats(int jid)
         {
             var ptr = GetJoystickHatsRaw(jid, out var count);
 
             if (ptr == null)
             {
-                return null;
+                return Span<JoystickHats>.Empty;
             }
 
-            var array = new JoystickHats[count];
-            for (var i = 0; i < count; i++)
-            {
-                array[i] = ptr[i];
-            }
-
-            return array;
+            return new Span<JoystickHats>(ptr, count);
         }
 
         /// <summary>

--- a/src/OpenTK.Windowing.GraphicsLibraryFramework/Input/JoystickState.cs
+++ b/src/OpenTK.Windowing.GraphicsLibraryFramework/Input/JoystickState.cs
@@ -201,41 +201,27 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
 
         internal unsafe void Update()
         {
-            UpdateHats();
-
-            UpdateAxes();
-
-            UpdateButtons();
-        }
-
-        private unsafe void UpdateButtons()
-        {
-            Utils.Swap(ref _buttons, ref _buttonsPrevious);
-
-            var b = GLFW.GetJoystickButtonsRaw(Id, out int count);
-            for (var j = 0; j < count; j++)
+            var hats = GLFW.GetJoystickHats(Id);
+            for (var j = 0; j < hats.Length; j++)
             {
-                SetButtonDown(j, b[j] == JoystickInputAction.Press);
+                SetHat(j, (Hat)hats[j]);
             }
-        }
-
-        private void UpdateAxes()
-        {
-            Utils.Swap(ref _axes, ref _axesPrevious);
 
             var axes = GLFW.GetJoystickAxes(Id);
             SetAxes(axes);
+
+            var buttons = GLFW.GetJoystickButtons(Id);
+            for (var j = 0; j < buttons.Length; j++)
+            {
+                SetButtonDown(j, buttons[j] == JoystickInputAction.Press);
+            }
         }
 
-        private unsafe void UpdateHats()
+        internal unsafe void NewFrame()
         {
             Utils.Swap(ref _hats, ref _hatsPrevious);
-
-            var h = GLFW.GetJoystickHatsRaw(Id, out int count);
-            for (var j = 0; j < count; j++)
-            {
-                SetHat(j, (Hat)h[j]);
-            }
+            Utils.Swap(ref _axes, ref _axesPrevious);
+            Utils.Swap(ref _buttons, ref _buttonsPrevious);
         }
 
         /// <summary>

--- a/src/OpenTK.Windowing.GraphicsLibraryFramework/Input/JoystickState.cs
+++ b/src/OpenTK.Windowing.GraphicsLibraryFramework/Input/JoystickState.cs
@@ -92,6 +92,7 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
         /// </summary>
         /// <param name="index">The index of the hat to check.</param>
         /// <returns>A <see cref="Hat"/> describing the hat state.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Hat GetHat(int index)
         {
             return _hats[index];
@@ -102,6 +103,7 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
         /// </summary>
         /// <param name="index">The index of the hat to check.</param>
         /// <returns>A <see cref="Hat"/> describing the hat state.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Hat GetHatPrevious(int index)
         {
             return _hatsPrevious[index];
@@ -146,6 +148,7 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
         /// </summary>
         /// <param name="index">The index of the Axis to check.</param>
         /// <returns>A <see cref="float"/> between -1 and 1 describing the position of the axis.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public float GetAxis(int index)
         {
             return _axes[index];
@@ -156,6 +159,7 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
         /// </summary>
         /// <param name="index">The index of the Axis to check.</param>
         /// <returns>A <see cref="float"/> between -1 and 1 describing the position of the axis.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public float GetAxisPrevious(int index)
         {
             return _axesPrevious[index];
@@ -215,7 +219,6 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
             }
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void UpdateAxes()
         {
             Utils.Swap(ref _axes, ref _axesPrevious);

--- a/src/OpenTK.Windowing.GraphicsLibraryFramework/Input/KeyboardState.cs
+++ b/src/OpenTK.Windowing.GraphicsLibraryFramework/Input/KeyboardState.cs
@@ -100,6 +100,10 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
 
         internal void Update()
         {
+        }
+
+        internal void NewFrame()
+        {
             _keysPrevious.SetAll(false);
             _keysPrevious.Or(_keys);
         }

--- a/src/OpenTK.Windowing.GraphicsLibraryFramework/Input/KeyboardState.cs
+++ b/src/OpenTK.Windowing.GraphicsLibraryFramework/Input/KeyboardState.cs
@@ -125,10 +125,10 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
         }
 
         /// <summary>
-        ///     Gets whether the specified key is pressed in the current frame but released in the previous frame.
+        /// Gets whether the specified key is pressed in the current frame but released in the previous frame.
         /// </summary>
         /// <remarks>
-        ///     "Frame" refers to invocations of <see cref="NativeWindow.ProcessEvents()"/> here.
+        /// "Frame" refers to invocations of <see cref="NativeWindow.ProcessEvents()"/> (<see cref="NativeWindow.ProcessInputEvents()"/> more precisely) here.
         /// </remarks>
         /// <param name="key">The <see cref="Keys">key</see> to check.</param>
         /// <returns>True if the key is pressed in this frame, but not the last frame.</returns>
@@ -138,10 +138,10 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
         }
 
         /// <summary>
-        ///     Gets whether the specified key is released in the current frame but pressed in the previous frame.
+        /// Gets whether the specified key is released in the current frame but pressed in the previous frame.
         /// </summary>
         /// <remarks>
-        ///     "Frame" refers to invocations of <see cref="NativeWindow.ProcessEvents()"/> here.
+        /// "Frame" refers to invocations of <see cref="NativeWindow.ProcessEvents()"/> (<see cref="NativeWindow.ProcessInputEvents()"/> more precisely) here.
         /// </remarks>
         /// <param name="key">The <see cref="Keys">key</see> to check.</param>
         /// <returns>True if the key is released in this frame, but pressed the last frame.</returns>

--- a/src/OpenTK.Windowing.GraphicsLibraryFramework/Input/MouseState.cs
+++ b/src/OpenTK.Windowing.GraphicsLibraryFramework/Input/MouseState.cs
@@ -146,7 +146,13 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
             return $"[X={X}, Y={Y}, Buttons={b}]";
         }
 
-        internal void Update()
+        internal unsafe void Update(Window* windowPtr)
+        {
+            GLFW.GetCursorPos(windowPtr, out var x, out var y);
+            Position = new Vector2((float)x, (float)y);
+        }
+
+        internal void NewFrame()
         {
             _buttonsPrevious.SetAll(false);
             _buttonsPrevious.Or(_buttons);

--- a/src/OpenTK.Windowing.GraphicsLibraryFramework/Input/MouseState.cs
+++ b/src/OpenTK.Windowing.GraphicsLibraryFramework/Input/MouseState.cs
@@ -92,16 +92,6 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
         }
 
         /// <summary>
-        /// Gets a <see cref="bool" /> indicating whether this button is down.
-        /// </summary>
-        /// <param name="button">The <see cref="MouseButton" /> to check.</param>
-        /// <returns><c>true</c> if the <paramref name="button"/> is down, otherwise <c>false</c>.</returns>
-        public bool IsButtonDown(MouseButton button)
-        {
-            return _buttons[(int)button];
-        }
-
-        /// <summary>
         /// Gets an integer representing the absolute x position of the pointer, in window pixel coordinates.
         /// </summary>
         public float X => Position.X;
@@ -166,6 +156,16 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
         }
 
         /// <summary>
+        /// Gets a <see cref="bool" /> indicating whether this button is down.
+        /// </summary>
+        /// <param name="button">The <see cref="MouseButton" /> to check.</param>
+        /// <returns><c>true</c> if the <paramref name="button"/> is down, otherwise <c>false</c>.</returns>
+        public bool IsButtonDown(MouseButton button)
+        {
+            return _buttons[(int)button];
+        }
+
+        /// <summary>
         /// Gets a <see cref="bool" /> indicating whether this button was down in the previous frame.
         /// </summary>
         /// <param name="button">The <see cref="MouseButton" /> to check.</param>
@@ -173,6 +173,32 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
         public bool WasButtonDown(MouseButton button)
         {
             return _buttonsPrevious[(int)button];
+        }
+
+        /// <summary>
+        /// Gets whether the specified mouse button is pressed in the current frame but released in the previous frame.
+        /// </summary>
+        /// <remarks>
+        ///     "Frame" refers to invocations of <see cref="NativeWindow.ProcessEvents()"/> (<see cref="NativeWindow.ProcessInputEvents()"/> more precisely) here.
+        /// </remarks>
+        /// <param name="button">The <see cref="MouseButton">mouse button</see> to check.</param>
+        /// <returns>True if the mouse button is pressed in this frame, but not the last frame.</returns>
+        public bool IsButtonPressed(MouseButton button)
+        {
+            return _buttons[(int)button] && !_buttonsPrevious[(int)button];
+        }
+
+        /// <summary>
+        /// Gets whether the specified mouse button is released in the current frame but pressed in the previous frame.
+        /// </summary>
+        /// <remarks>
+        /// "Frame" refers to invocations of <see cref="NativeWindow.ProcessEvents()"/> (<see cref="NativeWindow.ProcessInputEvents()"/> more precisely) here.
+        /// </remarks>
+        /// <param name="button">The <see cref="MouseButton">mouse button</see> to check.</param>
+        /// <returns>True if the mouse button is released in this frame, but pressed the last frame.</returns>
+        public bool IsButtonReleased(MouseButton button)
+        {
+            return !_buttons[(int)button] && _buttonsPrevious[(int)button];
         }
 
         /// <summary>


### PR DESCRIPTION
### Purpose of this PR

Fixes #1410
Changes so input state is only updated (current input becoming last frames input) once per update frame instead of being swapped as fast as possible while waiting for updates.
This is not a perfect fix as fast mouse clicks and similar can get set and unset in the same frame.
There could be merit in making a separate `TimesPressed()` api or something that can tell you how many times a button is pressed within a frame.

### Testing status

This is not yet tested.