### PR TITLE
Dropping remaining epsilon when update frames are too far behind;

### DIFF
--- a/src/OpenTK.Windowing.Desktop/GameWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/GameWindow.cs
@@ -287,6 +287,7 @@ namespace OpenTK.Windowing.Desktop
                 {
                     // If UpdateFrame consistently takes longer than TargetUpdateFrame
                     // stop raising events to avoid hanging inside the UpdateFrame loop.
+                    _updateEpsilon = 0;
                     break;
                 }
 


### PR DESCRIPTION
### Purpose of this PR

* Addresses #1434
* Removes what is effectively the backlogged duration for executing update frames when the update loop is running too slowly
* Affects GameWindow in Desktop project
* Based on `4.7.1` tag since the issue was labelled for `4.7.2` milestone

### Testing status

* Tested as described in the linked issue using the LocalTest project. Dragging the window in Windows 10 seems to cause the known issue reliably.
* https://gist.github.com/daerogami/f3eb28df2e497c35ff577cb053ae1c55
* When dragging the window, the lingering higher updates per-second logged to the console indicate the epsilon that never decrements because the update loop escapes every time.

### Comments

* I have some rename suggestions because `elapsed` and `updateEpsilon` are too terse when trying to read this code. I have omitted them to avoid making this PR touch things it doesn't need to.
* `elapsed` could be written out as `elapsedSinceLastUpdate` since we have other durations that we should help disambiguate
* `updateEpsilon` would be better written with respect to what its used for, `updateDurationRemaining` works for me.
