### PR TITLE
Smaller version of #1430 for 4.7.2

### DIFF
--- a/LocalTest/Program.cs
+++ b/LocalTest/Program.cs
@@ -2,6 +2,7 @@
 using OpenTK.Mathematics;
 using OpenTK.Windowing.Common;
 using OpenTK.Windowing.Desktop;
+using OpenTK.Windowing.GraphicsLibraryFramework;
 using System;
 using System.Diagnostics;
 
@@ -13,6 +14,8 @@ namespace LocalTest
         {
             GameWindowSettings gwSettings = new GameWindowSettings()
             {
+                //UpdateFrequency = 10,
+                //RenderFrequency = 10,
             };
 
             NativeWindowSettings nwSettings = new NativeWindowSettings()
@@ -56,6 +59,13 @@ namespace LocalTest
             GL.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit);
 
             SwapBuffers();
+        }
+
+        protected override void OnUpdateFrame(FrameEventArgs args)
+        {
+            base.OnUpdateFrame(args);
+
+
         }
     }
 }

--- a/src/OpenTK.Windowing.Desktop/GameWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/GameWindow.cs
@@ -229,7 +229,6 @@ namespace OpenTK.Windowing.Desktop
             _watchUpdate.Start();
             while (GLFW.WindowShouldClose(WindowPtr) == false)
             {
-                ProcessEvents();
                 DispatchUpdateFrame();
 
                 if (!IsMultiThreaded)
@@ -264,9 +263,14 @@ namespace OpenTK.Windowing.Desktop
 
             while (elapsed > 0 && elapsed + _updateEpsilon >= updatePeriod)
             {
+                ProcessWindowEvents(IsEventDriven);
+
                 _watchUpdate.Restart();
                 UpdateTime = elapsed;
                 OnUpdateFrame(new FrameEventArgs(elapsed));
+
+                // Update input state for next frame
+                ProcessInputEvents();
 
                 // Calculate difference (positive or negative) between
                 // actual elapsed time and target elapsed time. We must

--- a/src/OpenTK.Windowing.Desktop/GameWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/GameWindow.cs
@@ -263,14 +263,14 @@ namespace OpenTK.Windowing.Desktop
 
             while (elapsed > 0 && elapsed + _updateEpsilon >= updatePeriod)
             {
+                // Update input state for next frame
+                ProcessInputEvents();
+                // Handle events for this frame
                 ProcessWindowEvents(IsEventDriven);
 
                 _watchUpdate.Restart();
                 UpdateTime = elapsed;
                 OnUpdateFrame(new FrameEventArgs(elapsed));
-
-                // Update input state for next frame
-                ProcessInputEvents();
 
                 // Calculate difference (positive or negative) between
                 // actual elapsed time and target elapsed time. We must

--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -1395,6 +1395,7 @@ namespace OpenTK.Windowing.Desktop
         /// <summary>
         /// Processes pending window events, either by calling <see cref="GLFW.WaitEvents"/> or <see cref="GLFW.PollEvents"/> depending on if <paramref name="waitForEvents"/> is set to true or not.
         /// </summary>
+        /// <remarks>This function should only be called from the main thread.</remarks>
         /// <param name="waitForEvents">Whether to call <see cref="GLFW.WaitEvents()"/> or <see cref="GLFW.PollEvents()"/>.</param>
         public static void ProcessWindowEvents(bool waitForEvents)
         {

--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -37,7 +37,7 @@ namespace OpenTK.Windowing.Desktop
         private Vector2 _lastReportedMousePos;
 
         // Stores exceptions thrown in callbacks so that we can rethrow them after ProcessEvents().
-        private List<ExceptionDispatchInfo> _callbackExceptions = new List<ExceptionDispatchInfo>();
+        private static List<ExceptionDispatchInfo> _callbackExceptions = new List<ExceptionDispatchInfo>();
 
         // GLFW cursor we assigned to the window.
         // Null if the cursor is default.
@@ -1383,11 +1383,21 @@ namespace OpenTK.Windowing.Desktop
         /// <summary>
         /// Processes pending window events.
         /// </summary>
+        [Obsolete("This function wrongly implies that only events from this window are processed, while in fact events for all windows are processed. Use NativeWindow.ProcessWindowEvents() instead.")]
         public virtual void ProcessEvents()
         {
             ProcessInputEvents();
 
-            if (IsEventDriven)
+            ProcessWindowEvents(IsEventDriven);
+        }
+
+        /// <summary>
+        /// Processes pending window events, either by calling <see cref="GLFW.WaitEvents"/> or <see cref="GLFW.PollEvents"/> depending on if <paramref name="waitForEvents"/> is set to true or not.
+        /// </summary>
+        /// <param name="waitForEvents">Whether to call <see cref="GLFW.WaitEvents()"/> or <see cref="GLFW.PollEvents()"/>.</param>
+        public static void ProcessWindowEvents(bool waitForEvents)
+        {
+            if (waitForEvents)
             {
                 GLFW.WaitEvents();
             }
@@ -1399,7 +1409,7 @@ namespace OpenTK.Windowing.Desktop
             RethrowCallbackExceptionsIfNeeded();
         }
 
-        private void RethrowCallbackExceptionsIfNeeded()
+        private static void RethrowCallbackExceptionsIfNeeded()
         {
             if (_callbackExceptions.Count == 1)
             {

--- a/src/OpenTK.Windowing.GraphicsLibraryFramework/Input/MouseState.cs
+++ b/src/OpenTK.Windowing.GraphicsLibraryFramework/Input/MouseState.cs
@@ -92,16 +92,6 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
         }
 
         /// <summary>
-        /// Gets a <see cref="bool" /> indicating whether this button is down.
-        /// </summary>
-        /// <param name="button">The <see cref="MouseButton" /> to check.</param>
-        /// <returns><c>true</c> if the <paramref name="button"/> is down, otherwise <c>false</c>.</returns>
-        public bool IsButtonDown(MouseButton button)
-        {
-            return _buttons[(int)button];
-        }
-
-        /// <summary>
         /// Gets an integer representing the absolute x position of the pointer, in window pixel coordinates.
         /// </summary>
         public float X => Position.X;
@@ -166,6 +156,16 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
         }
 
         /// <summary>
+        /// Gets a <see cref="bool" /> indicating whether this button is down.
+        /// </summary>
+        /// <param name="button">The <see cref="MouseButton" /> to check.</param>
+        /// <returns><c>true</c> if the <paramref name="button"/> is down, otherwise <c>false</c>.</returns>
+        public bool IsButtonDown(MouseButton button)
+        {
+            return _buttons[(int)button];
+        }
+
+        /// <summary>
         /// Gets a <see cref="bool" /> indicating whether this button was down in the previous frame.
         /// </summary>
         /// <param name="button">The <see cref="MouseButton" /> to check.</param>
@@ -173,6 +173,32 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
         public bool WasButtonDown(MouseButton button)
         {
             return _buttonsPrevious[(int)button];
+        }
+
+        /// <summary>
+        /// Gets whether the specified mouse button is pressed in the current frame but released in the previous frame.
+        /// </summary>
+        /// <remarks>
+        ///     "Frame" refers to invocations of <see cref="NativeWindow.ProcessEvents()"/> (<see cref="NativeWindow.ProcessInputEvents()"/> more precisely) here.
+        /// </remarks>
+        /// <param name="button">The <see cref="MouseButton">mouse button</see> to check.</param>
+        /// <returns>True if the mouse button is pressed in this frame, but not the last frame.</returns>
+        public bool IsButtonPressed(MouseButton button)
+        {
+            return _buttons[(int)button] && !_buttonsPrevious[(int)button];
+        }
+
+        /// <summary>
+        /// Gets whether the specified mouse button is released in the current frame but pressed in the previous frame.
+        /// </summary>
+        /// <remarks>
+        /// "Frame" refers to invocations of <see cref="NativeWindow.ProcessEvents()"/> (<see cref="NativeWindow.ProcessInputEvents()"/> more precisely) here.
+        /// </remarks>
+        /// <param name="button">The <see cref="MouseButton">mouse button</see> to check.</param>
+        /// <returns>True if the mouse button is released in this frame, but pressed the last frame.</returns>
+        public bool IsButtonReleased(MouseButton button)
+        {
+            return !_buttons[(int)button] && _buttonsPrevious[(int)button];
         }
 
         /// <summary>


### PR DESCRIPTION
### Purpose of this PR

Make a smaller version of #1430 that isn't that much of an all-encompassing change as #1430 is.
This instead aims to be fix the problem in #1410 without changing too much of the current implementation.

This PR currently introduces a change where limiting both the update rate and the rendering rate will pin one core to 100% usage which is because the update loop no longer polling for event every update. This could be fixed by adding a sleep somewhere that is the min of the time to the next update and the time to the new render.

This PR will change the update order of events, which is not really ideal but it should keep the noticeable changes to a minimum as events are still processed before UpdateFrame is a called, and input is update before that.

This PR also has the benefit of solving a problem with multiple windows where calling `window.ProcessEvents()` would update the input state for that window and then later process events for all windows, which would update input values for windows which hadn't had their input state updated yet. This PR for updating the window state of all windows and then calling `NativeWindow.ProcessWindowEvents` to handle events for all windows.

### Testing status

Tested using the local project, and it seems to work fine for mouse button presses.

More testing is needed to determine if this change breaks projects using `4.7.1`.