### PR TITLE
Add backwards compatibility overloads for MultiDrawElementsIndirectCount

### DIFF
--- a/src/Generator.Bind/Specifications/GL2/overrides.xml
+++ b/src/Generator.Bind/Specifications/GL2/overrides.xml
@@ -1729,6 +1729,15 @@
     </function>
   </replace>
 
+  <!-- For backwards compatibility, see https://github.com/opentk/opentk/pull/1431#issuecomment-1115467424 -->
+  <overload name="gl|glcore">
+    <function name="MultiDrawElementsIndirectCount" extension="Core">
+      <param name="type">
+        <type>All</type>
+      </param>
+    </function>
+  </overload>
+
   <overload name="gl">
     <!-- generated from apitest -->
     <function name="TessellationMode" extension="Amd" obsolete="Use AmdVertexShaderTessellator overload instead">


### PR DESCRIPTION
### Purpose of this PR

Makes the changes in #1431 backwards compatible.
See https://github.com/opentk/opentk/pull/1431#issuecomment-1115467424

### Testing status

The bindings are run on this and it does indeed produce both an `All` and `DrawElementsType` overload.