### PR TITLE
fix type enum in VertexArrayAttrib*Format

### DIFF
--- a/src/Generator.Bind/Specifications/GL2/GL/4.5/ARB_direct_state_access.xml
+++ b/src/Generator.Bind/Specifications/GL2/GL/4.5/ARB_direct_state_access.xml
@@ -220,9 +220,6 @@
     <function name="VertexArrayAttribFormat">
       <param name="type"><type>VertexAttribType</type></param>
     </function>
-    <function name="VertexArrayAttribIFormat">
-      <param name="type"><type>VertexAttribIntegerType</type></param>
-    </function>
 
   </replace>
 

--- a/src/Generator.Bind/Specifications/GL2/GL/4.5/ARB_direct_state_access.xml
+++ b/src/Generator.Bind/Specifications/GL2/GL/4.5/ARB_direct_state_access.xml
@@ -221,7 +221,7 @@
       <param name="type"><type>VertexAttribType</type></param>
     </function>
     <function name="VertexArrayAttribIFormat">
-      <param name="type"><type>VertexAttribType</type></param>
+      <param name="type"><type>VertexAttribIntegerType</type></param>
     </function>
 
   </replace>

--- a/src/Generator.Bind/Specifications/GL2/overrides.xml
+++ b/src/Generator.Bind/Specifications/GL2/overrides.xml
@@ -1729,14 +1729,19 @@
     </function>
   </replace>
 
-  <!-- For backwards compatibility, see https://github.com/opentk/opentk/pull/1438#issuecomment-1115895014 -->
   <overload name="gl|glcore">
+    <!-- For backwards compatibility, see https://github.com/opentk/opentk/pull/1431#issuecomment-1115467424 -->
+    <function name="MultiDrawElementsIndirectCount" extension="Core">
+      <param name="type">
+        <type>All</type>
+      </param>
+    </function>
+    <!-- For backwards compatibility, see https://github.com/opentk/opentk/pull/1438#issuecomment-1115895014 -->
     <function name="VertexArrayAttribIFormat" extension="Core">
       <param name="type">
         <type>VertexAttribType</type>
       </param>
     </function>
-
     <function name="VertexArrayAttribLFormat" extension="Core">
       <param name="type">
         <type>VertexAttribType</type>

--- a/src/Generator.Bind/Specifications/GL2/overrides.xml
+++ b/src/Generator.Bind/Specifications/GL2/overrides.xml
@@ -1729,6 +1729,21 @@
     </function>
   </replace>
 
+  <!-- For backwards compatibility, see https://github.com/opentk/opentk/pull/1438#issuecomment-1115895014 -->
+  <overload name="gl|glcore">
+    <function name="VertexArrayAttribIFormat" extension="Core">
+      <param name="type">
+        <type>VertexAttribType</type>
+      </param>
+    </function>
+
+    <function name="VertexArrayAttribLFormat" extension="Core">
+      <param name="type">
+        <type>VertexAttribType</type>
+      </param>
+    </function>
+  </overload>
+
   <overload name="gl">
     <!-- generated from apitest -->
     <function name="TessellationMode" extension="Amd" obsolete="Use AmdVertexShaderTessellator overload instead">

--- a/src/Generator.Bind/Specifications/GL2/signatures.xml
+++ b/src/Generator.Bind/Specifications/GL2/signatures.xml
@@ -21519,7 +21519,7 @@
       <param name="vaobj" type="GLuint" flow="in" />
       <param name="attribindex" type="GLuint" flow="in" />
       <param name="size" type="GLint" flow="in" />
-      <param name="type" type="VertexAttribType" flow="in" />
+      <param name="type" type="VertexAttribIntegerType" flow="in" />
       <param name="relativeoffset" type="GLuint" flow="in" />
       <returns type="void" />
     </function>
@@ -21527,7 +21527,7 @@
       <param name="vaobj" type="GLuint" flow="in" />
       <param name="attribindex" type="GLuint" flow="in" />
       <param name="size" type="GLint" flow="in" />
-      <param name="type" type="VertexAttribType" flow="in" />
+      <param name="type" type="VertexAttribDoubleType" flow="in" />
       <param name="relativeoffset" type="GLuint" flow="in" />
       <returns type="void" />
     </function>
@@ -31520,7 +31520,7 @@
       <param name="vaobj" type="GLuint" flow="in" />
       <param name="attribindex" type="GLuint" flow="in" />
       <param name="size" type="GLint" flow="in" />
-      <param name="type" type="VertexAttribType" flow="in" />
+      <param name="type" type="VertexAttribIntegerType" flow="in" />
       <param name="relativeoffset" type="GLuint" flow="in" />
       <returns type="void" />
     </function>
@@ -31528,7 +31528,7 @@
       <param name="vaobj" type="GLuint" flow="in" />
       <param name="attribindex" type="GLuint" flow="in" />
       <param name="size" type="GLint" flow="in" />
-      <param name="type" type="VertexAttribType" flow="in" />
+      <param name="type" type="VertexAttribDoubleType" flow="in" />
       <param name="relativeoffset" type="GLuint" flow="in" />
       <returns type="void" />
     </function>
@@ -43249,7 +43249,7 @@
       <param name="vaobj" type="GLuint" flow="in" />
       <param name="attribindex" type="GLuint" flow="in" />
       <param name="size" type="GLint" flow="in" />
-      <param name="type" type="VertexAttribType" flow="in" />
+      <param name="type" type="VertexAttribIntegerType" flow="in" />
       <param name="relativeoffset" type="GLuint" flow="in" />
       <returns type="void" />
     </function>
@@ -43257,7 +43257,7 @@
       <param name="vaobj" type="GLuint" flow="in" />
       <param name="attribindex" type="GLuint" flow="in" />
       <param name="size" type="GLint" flow="in" />
-      <param name="type" type="VertexAttribType" flow="in" />
+      <param name="type" type="VertexAttribDoubleType" flow="in" />
       <param name="relativeoffset" type="GLuint" flow="in" />
       <returns type="void" />
     </function>
@@ -49742,7 +49742,7 @@
       <param name="vaobj" type="GLuint" flow="in" />
       <param name="attribindex" type="GLuint" flow="in" />
       <param name="size" type="GLint" flow="in" />
-      <param name="type" type="VertexAttribType" flow="in" />
+      <param name="type" type="VertexAttribIntegerType" flow="in" />
       <param name="relativeoffset" type="GLuint" flow="in" />
       <returns type="void" />
     </function>
@@ -49750,7 +49750,7 @@
       <param name="vaobj" type="GLuint" flow="in" />
       <param name="attribindex" type="GLuint" flow="in" />
       <param name="size" type="GLint" flow="in" />
-      <param name="type" type="VertexAttribType" flow="in" />
+      <param name="type" type="VertexAttribDoubleType" flow="in" />
       <param name="relativeoffset" type="GLuint" flow="in" />
       <returns type="void" />
     </function>


### PR DESCRIPTION
### Purpose of this PR

Makes the functions `VertexArrayAttribIFormat` and `VertexArrayAttribLFormat` take in `VertexAttribIntegerType` and `VertexAttribDoubleType` respectivly as the type parameter. This PR is related to #1399.

### Testing status

Run the generator with expected results.

### Comments

This PR modifies existing functions instead of adding additional overloads.
Do we want to add overloads instead to avoid breaking changes?
So one that takes `VertexAttribType` and one for `VertexAttribIntegerType`/`VertexAttribDoubleType`.
(`VertexAttribType` is superset of the other).

