### PR TITLE
Fix cpu usage when limiting update and render frequencies at the same time

### DIFF
--- a/src/OpenTK.Windowing.Desktop/GameWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/GameWindow.cs
@@ -241,7 +241,6 @@ namespace OpenTK.Windowing.Desktop
 
                 if (sleepTime > 0)
                 {
-                    Console.WriteLine(sleepTime * 1000);
                     Thread.Sleep((int)Math.Floor(sleepTime * 1000));
                 }
             }


### PR DESCRIPTION
### Purpose of this PR

#1436 changed how the run loop works, making cpu usage go to 100% if both update and render frequency are limited. This PR fixes this by introducing a sleep.

### Testing status

Tested using the local test project. Seems to be working well.