### PR TITLE
Adds IsButtonPressed and IsButtonReleased to JoystickState.

### DIFF
--- a/src/OpenTK.Windowing.GraphicsLibraryFramework/Input/JoystickState.cs
+++ b/src/OpenTK.Windowing.GraphicsLibraryFramework/Input/JoystickState.cs
@@ -135,6 +135,34 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
             return _buttonsPrevious[index];
         }
 
+        /// <summary>
+        /// Gets a <see cref="bool"/> describing whether the specified button is down in the current frame but was up in the previous frame.
+        /// </summary>
+        /// <remarks>
+        /// "Frame" refers to invocations of <see cref="NativeWindow.ProcessEvents()"/> here.
+        /// </remarks>
+        /// <param name="index">The index of the button.</param>
+        /// <returns>True if the button is down in this frame, but not the last frame.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool IsButtonPressed(int index)
+        {
+            return IsButtonDown(index) && !WasButtonDown(index);
+        }
+
+        /// <summary>
+        /// Gets a <see cref="bool"/> describing whether the specified button is up in the current frame but was down in the previous frame.
+        /// </summary>
+        /// <remarks>
+        /// "Frame" refers to invocations of <see cref="NativeWindow.ProcessEvents()"/> here.
+        /// </remarks>
+        /// <param name="index">The index of the button.</param>
+        /// <returns>True if the button is up in this frame, but down the last frame.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool IsButtonReleased(int index)
+        {
+            return !IsButtonDown(index) && WasButtonDown(index);
+        }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void SetButtonDown(int index, bool value)
         {


### PR DESCRIPTION
### Purpose of this PR

Adds the two methods `IsButtonPressed` and `IsButtonReleased` to `JoystickState`. They were available for `MouseState` and `KeyboardState` but not for `JoystickState`, which might be unexpected for users of the library.

### Testing status

I tested both methods manually and locally using a virtual joystick.

### Comments

I was not sure whether to implement the new methods using the available methods (`IsButtonDown`, `WasButtonDown`) or by accessing `_buttons` and `_buttonsPrevious` directly. I opted for using the available methods since I think this is more maintainable and shouldn't have any performance overhead since all four methods are aggressively inlined. I'm open for discussing this and being educated, though.