### PR TITLE
Renamed Inflate to Union and added new Inflated implementation

### DIFF
--- a/src/OpenTK.Mathematics/Geometry/Box2.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box2.cs
@@ -230,6 +230,30 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
+        /// Inflates this Box2 by the given size in all directions. A negative size will shrink the box to a maximum of -HalfSize.
+        /// </summary>
+        /// <param name="size">The size to inflate by.</param>
+        public void Inflate(Vector2 size)
+        {
+            size = Vector2.ComponentMax(size, -HalfSize);
+            _min -= size;
+            _max += size;
+        }
+
+        /// <summary>
+        /// Inflates this Box2 by the given size in all directions. A negative size will shrink the box to a maximum of -HalfSize.
+        /// </summary>
+        /// <param name="size">The size to inflate by.</param>
+        /// <returns>The inflated box.</returns>
+        public Box2 Inflated(Vector2 size)
+        {
+            // create a local copy of this box
+            Box2 box = this;
+            box.Inflate(size);
+            return box;
+        }
+
+        /// <summary>
         /// Inflate this Box2 to encapsulate a given point.
         /// </summary>
         /// <param name="point">The point to query.</param>

--- a/src/OpenTK.Mathematics/Geometry/Box2.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box2.cs
@@ -233,10 +233,20 @@ namespace OpenTK.Mathematics
         /// Inflate this Box2 to encapsulate a given point.
         /// </summary>
         /// <param name="point">The point to query.</param>
-        public void Inflate(Vector2 point)
+        public void Union(Vector2 point)
         {
             _min = Vector2.ComponentMin(_min, point);
             _max = Vector2.ComponentMax(_max, point);
+        }
+
+        /// <summary>
+        /// Inflate this Box2 to encapsulate a given box.
+        /// </summary>
+        /// <param name="other">The box to query.</param>
+        public void Union(Box2 other)
+        {
+            _min = Vector2.ComponentMin(_min, other._min);
+            _max = Vector2.ComponentMax(_max, other._max);
         }
 
         /// <summary>
@@ -245,11 +255,25 @@ namespace OpenTK.Mathematics
         /// <param name="point">The point to query.</param>
         /// <returns>The inflated box.</returns>
         [Pure]
-        public Box2 Inflated(Vector2 point)
+        public Box2 Unioned(Vector2 point)
         {
             // create a local copy of this box
             Box2 box = this;
-            box.Inflate(point);
+            box.Union(point);
+            return box;
+        }
+
+        /// <summary>
+        /// Inflate this Box2 to encapsulate a given box.
+        /// </summary>
+        /// <param name="other">The box to query.</param>
+        /// <returns>The inflated box.</returns>
+        [Pure]
+        public Box2 Unioned(Box2 other)
+        {
+            // create a local copy of this box
+            Box2 box = this;
+            box.Union(other);
             return box;
         }
 

--- a/src/OpenTK.Mathematics/Geometry/Box2d.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box2d.cs
@@ -230,6 +230,30 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
+        /// Inflates this Box2d by the given size in all directions. A negative size will shrink the box to a maximum of -HalfSize.
+        /// </summary>
+        /// <param name="size">The size to inflate by.</param>
+        public void Inflate(Vector2d size)
+        {
+            size = Vector2d.ComponentMax(size, -HalfSize);
+            _min -= size;
+            _max += size;
+        }
+
+        /// <summary>
+        /// Inflates this Box2d by the given size in all directions. A negative size will shrink the box to a maximum of -HalfSize.
+        /// </summary>
+        /// <param name="size">The size to inflate by.</param>
+        /// <returns>The inflated box.</returns>
+        public Box2d Inflated(Vector2d size)
+        {
+            // create a local copy of this box
+            Box2d box = this;
+            box.Inflate(size);
+            return box;
+        }
+
+        /// <summary>
         /// Inflate this Box2d to encapsulate a given point.
         /// </summary>
         /// <param name="point">The point to query.</param>

--- a/src/OpenTK.Mathematics/Geometry/Box2d.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box2d.cs
@@ -233,10 +233,20 @@ namespace OpenTK.Mathematics
         /// Inflate this Box2d to encapsulate a given point.
         /// </summary>
         /// <param name="point">The point to query.</param>
-        public void Inflate(Vector2d point)
+        public void Union(Vector2d point)
         {
             _min = Vector2d.ComponentMin(_min, point);
             _max = Vector2d.ComponentMax(_max, point);
+        }
+
+        /// <summary>
+        /// Inflate this Box2d to encapsulate a given box.
+        /// </summary>
+        /// <param name="other">The box to query.</param>
+        public void Union(Box2d other)
+        {
+            _min = Vector2d.ComponentMin(_min, other._min);
+            _max = Vector2d.ComponentMax(_max, other._max);
         }
 
         /// <summary>
@@ -245,11 +255,25 @@ namespace OpenTK.Mathematics
         /// <param name="point">The point to query.</param>
         /// <returns>The inflated box.</returns>
         [Pure]
-        public Box2d Inflated(Vector2d point)
+        public Box2d Unioned(Vector2d point)
         {
             // create a local copy of this box
             Box2d box = this;
-            box.Inflate(point);
+            box.Union(point);
+            return box;
+        }
+
+        /// <summary>
+        /// Inflate this Box2d to encapsulate a given box.
+        /// </summary>
+        /// <param name="other">The box to query.</param>
+        /// <returns>The inflated box.</returns>
+        [Pure]
+        public Box2d Unioned(Box2d other)
+        {
+            // create a local copy of this box
+            Box2d box = this;
+            box.Union(other);
             return box;
         }
 

--- a/src/OpenTK.Mathematics/Geometry/Box2i.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box2i.cs
@@ -246,10 +246,20 @@ namespace OpenTK.Mathematics
         /// Inflate this Box2i to encapsulate a given point.
         /// </summary>
         /// <param name="point">The point to query.</param>
-        public void Inflate(Vector2i point)
+        public void Union(Vector2i point)
         {
             _min = Vector2i.ComponentMin(_min, point);
             _max = Vector2i.ComponentMax(_max, point);
+        }
+
+        /// <summary>
+        /// Inflate this Box2i to encapsulate a given box.
+        /// </summary>
+        /// <param name="other">The box to query.</param>
+        public void Union(Box2i other)
+        {
+            _min = Vector2i.ComponentMin(_min, other._min);
+            _max = Vector2i.ComponentMax(_max, other._max);
         }
 
         /// <summary>
@@ -258,11 +268,25 @@ namespace OpenTK.Mathematics
         /// <param name="point">The point to query.</param>
         /// <returns>The inflated box.</returns>
         [Pure]
-        public Box2i Inflated(Vector2i point)
+        public Box2i Unioned(Vector2i point)
         {
             // create a local copy of this box
             Box2i box = this;
-            box.Inflate(point);
+            box.Union(point);
+            return box;
+        }
+
+        /// <summary>
+        /// Inflate this Box2i to encapsulate a given box.
+        /// </summary>
+        /// <param name="other">The box to query.</param>
+        /// <returns>The inflated box.</returns>
+        [Pure]
+        public Box2i Unioned(Box2i other)
+        {
+            // create a local copy of this box
+            Box2i box = this;
+            box.Union(other);
             return box;
         }
 

--- a/src/OpenTK.Mathematics/Geometry/Box2i.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box2i.cs
@@ -243,6 +243,30 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
+        /// Inflates this Box2i by the given size in all directions. A negative size will shrink the box to a maximum of -HalfSize.
+        /// </summary>
+        /// <param name="size">The size to inflate by.</param>
+        public void Inflate(Vector2i size)
+        {
+            size = Vector2i.ComponentMax(size, -HalfSize);
+            _min -= size;
+            _max += size;
+        }
+
+        /// <summary>
+        /// Inflates this Box2i by the given size in all directions. A negative size will shrink the box to a maximum of -HalfSize.
+        /// </summary>
+        /// <param name="size">The size to inflate by.</param>
+        /// <returns>The inflated box.</returns>
+        public Box2i Inflated(Vector2i size)
+        {
+            // create a local copy of this box
+            Box2i box = this;
+            box.Inflate(size);
+            return box;
+        }
+
+        /// <summary>
         /// Inflate this Box2i to encapsulate a given point.
         /// </summary>
         /// <param name="point">The point to query.</param>

--- a/src/OpenTK.Mathematics/Geometry/Box3.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box3.cs
@@ -245,13 +245,37 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
+        /// Inflate this Box3 to encapsulate a given box.
+        /// </summary>
+        /// <param name="other">The box to query.</param>
+        public void Union(Box3 other)
+        {
+            _min = Vector3.ComponentMin(_min, other._min);
+            _max = Vector3.ComponentMax(_max, other._max);
+        }
+
+        /// <summary>
         /// Inflate this Box3 to encapsulate a given point.
         /// </summary>
         /// <param name="point">The point to query.</param>
-        public void Inflate(Vector3 point)
+        public void Union(Vector3 point)
         {
             _min = Vector3.ComponentMin(_min, point);
             _max = Vector3.ComponentMax(_max, point);
+        }
+
+        /// <summary>
+        /// Inflate this Box3 to encapsulate a given box.
+        /// </summary>
+        /// <param name="other">The box to query.</param>
+        /// <returns>The inflated box.</returns>
+        [Pure]
+        public Box3 Unioned(Box3 other)
+        {
+            // create a local copy of this box
+            Box3 box = this;
+            box.Union(other);
+            return box;
         }
 
         /// <summary>
@@ -260,11 +284,11 @@ namespace OpenTK.Mathematics
         /// <param name="point">The point to query.</param>
         /// <returns>The inflated box.</returns>
         [Pure]
-        public Box3 Inflated(Vector3 point)
+        public Box3 Unioned(Vector3 point)
         {
             // create a local copy of this box
             Box3 box = this;
-            box.Inflate(point);
+            box.Union(point);
             return box;
         }
 

--- a/src/OpenTK.Mathematics/Geometry/Box3.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box3.cs
@@ -245,6 +245,30 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
+        /// Inflates this Box3 by the given size in all directions. A negative size will shrink the box to a maximum of -HalfSize.
+        /// </summary>
+        /// <param name="size">The size to inflate by.</param>
+        public void Inflate(Vector3 size)
+        {
+            size = Vector3.ComponentMax(size, -HalfSize);
+            _min -= size;
+            _max += size;
+        }
+
+        /// <summary>
+        /// Inflates this Box3 by the given size in all directions. A negative size will shrink the box to a maximum of -HalfSize.
+        /// </summary>
+        /// <param name="size">The size to inflate by.</param>
+        /// <returns>The inflated box.</returns>
+        public Box3 Inflated(Vector3 size)
+        {
+            // create a local copy of this box
+            Box3 box = this;
+            box.Inflate(size);
+            return box;
+        }
+
+        /// <summary>
         /// Inflate this Box3 to encapsulate a given box.
         /// </summary>
         /// <param name="other">The box to query.</param>

--- a/src/OpenTK.Mathematics/Geometry/Box3d.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box3d.cs
@@ -248,10 +248,20 @@ namespace OpenTK.Mathematics
         /// Inflate this Box3d to encapsulate a given point.
         /// </summary>
         /// <param name="point">The point to query.</param>
-        public void Inflate(Vector3d point)
+        public void Union(Vector3d point)
         {
             _min = Vector3d.ComponentMin(_min, point);
             _max = Vector3d.ComponentMax(_max, point);
+        }
+
+        /// <summary>
+        /// Inflate this Box3d to encapsulate a given box.
+        /// </summary>
+        /// <param name="other">The box to query.</param>
+        public void Union(Box3d other)
+        {
+            _min = Vector3d.ComponentMin(_min, other._min);
+            _max = Vector3d.ComponentMax(_max, other._max);
         }
 
         /// <summary>
@@ -260,11 +270,25 @@ namespace OpenTK.Mathematics
         /// <param name="point">The point to query.</param>
         /// <returns>The inflated box.</returns>
         [Pure]
-        public Box3d Inflated(Vector3d point)
+        public Box3d Unioned(Vector3d point)
         {
             // create a local copy of this box
             Box3d box = this;
-            box.Inflate(point);
+            box.Union(point);
+            return box;
+        }
+
+        /// <summary>
+        /// Inflate this Box3d to encapsulate a given box.
+        /// </summary>
+        /// <param name="other">The box to query.</param>
+        /// <returns>The inflated box.</returns>
+        [Pure]
+        public Box3d Unioned(Box3d other)
+        {
+            // create a local copy of this box
+            Box3d box = this;
+            box.Union(other);
             return box;
         }
 

--- a/src/OpenTK.Mathematics/Geometry/Box3d.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box3d.cs
@@ -245,6 +245,30 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
+        /// Inflates this Box3d by the given size in all directions. A negative size will shrink the box to a maximum of -HalfSize.
+        /// </summary>
+        /// <param name="size">The size to inflate by.</param>
+        public void Inflate(Vector3d size)
+        {
+            size = Vector3d.ComponentMax(size, -HalfSize);
+            _min -= size;
+            _max += size;
+        }
+
+        /// <summary>
+        /// Inflates this Box3d by the given size in all directions. A negative size will shrink the box to a maximum of -HalfSize.
+        /// </summary>
+        /// <param name="size">The size to inflate by.</param>
+        /// <returns>The inflated box.</returns>
+        public Box3d Inflated(Vector3d size)
+        {
+            // create a local copy of this box
+            Box3d box = this;
+            box.Inflate(size);
+            return box;
+        }
+
+        /// <summary>
         /// Inflate this Box3d to encapsulate a given point.
         /// </summary>
         /// <param name="point">The point to query.</param>

--- a/src/OpenTK.Mathematics/Geometry/Box3i.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box3i.cs
@@ -229,6 +229,30 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
+        /// Inflates this Box3i by the given size in all directions. A negative size will shrink the box to a maximum of -HalfSize.
+        /// </summary>
+        /// <param name="size">The size to inflate by.</param>
+        public void Inflate(Vector3i size)
+        {
+            size = Vector3i.ComponentMax(size, -HalfSize);
+            _min -= size;
+            _max += size;
+        }
+
+        /// <summary>
+        /// Inflates this Box3i by the given size in all directions. A negative size will shrink the box to a maximum of -HalfSize.
+        /// </summary>
+        /// <param name="size">The size to inflate by.</param>
+        /// <returns>The inflated box.</returns>
+        public Box3i Inflated(Vector3i size)
+        {
+            // create a local copy of this box
+            Box3i box = this;
+            box.Inflate(size);
+            return box;
+        }
+
+        /// <summary>
         /// Inflate this Box3i to encapsulate a given point.
         /// </summary>
         /// <param name="point">The point to query.</param>

--- a/src/OpenTK.Mathematics/Geometry/Box3i.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box3i.cs
@@ -9,6 +9,7 @@
 
 using System;
 using System.Diagnostics.Contracts;
+using System.Drawing;
 using System.Globalization;
 using System.Runtime.InteropServices;
 
@@ -231,10 +232,20 @@ namespace OpenTK.Mathematics
         /// Inflate this Box3i to encapsulate a given point.
         /// </summary>
         /// <param name="point">The point to query.</param>
-        public void Inflate(Vector3i point)
+        public void Union(Vector3i point)
         {
             _min = Vector3i.ComponentMin(_min, point);
             _max = Vector3i.ComponentMax(_max, point);
+        }
+
+        /// <summary>
+        /// Inflate this Box3i to encapsulate a given Box.
+        /// </summary>
+        /// <param name="other">The box to include.</param>
+        public void Union(Box3i other)
+        {
+            _min = Vector3i.ComponentMin(_min, other._min);
+            _max = Vector3i.ComponentMax(_max, other._max);
         }
 
         /// <summary>
@@ -243,11 +254,25 @@ namespace OpenTK.Mathematics
         /// <param name="point">The point to query.</param>
         /// <returns>The inflated box.</returns>
         [Pure]
-        public Box3i Inflated(Vector3i point)
+        public Box3i Unioned(Vector3i point)
         {
             // create a local copy of this box
             Box3i box = this;
-            box.Inflate(point);
+            box.Union(point);
+            return box;
+        }
+
+        /// <summary>
+        /// Inflate this Box3i to encapsulate a given Box.
+        /// </summary>
+        /// <param name="other">The box to include.</param>
+        /// <returns>The inflated box.</returns>
+        [Pure]
+        public Box3i Unioned(Box3i other)
+        {
+            // create a local copy of this box
+            Box3i box = this;
+            box.Union(other);
             return box;
         }
 

--- a/tests/OpenTK.Tests/Box2Tests.fs
+++ b/tests/OpenTK.Tests/Box2Tests.fs
@@ -155,26 +155,39 @@ module Box2 =
             Assert.Equal(b, b1.Translated(v1))
             
     [<Properties(Arbitrary = [|typeof<OpenTKGen>|])>]
-    module Inflate =
+    module Union =
         [<Property>]
         let ``After inflating a box the point should be either on the edge of the box or the box shouldn't change size`` (b1 : Box2, v1 : Vector2) =
             let v2 = b1.Size
             
-            b1.Inflate(v1)
+            b1.Union(v1)
             
             Assert.True(b1.DistanceToNearestEdge(v1) = (float32)0 || v2 = b1.Size)
         
         [<Property>]
         let ``After inflating the point should be enclosed in the box`` (b1 : Box2, v1 : Vector2) =
-            Assert.True(b1.Inflated(v1).Contains(v1, true))
+            Assert.True(b1.Unioned(v1).Contains(v1, true))
+            
+        [<Property>]
+        let ``After inflating both boxes should be enclosed in the box`` (b1 : Box2, b2 : Box2) =
+            Assert.True(b1.Unioned(b2).Contains(b1))
+            Assert.True(b1.Unioned(b2).Contains(b2))
 
         [<Property>]
-        let ``Box2.Inflate is equivalent to Box2.Inflated`` (b1 : Box2, v1 : Vector2) =
+        let ``Box2.Inflate(Vector2) is equivalent to Box2.Inflated(Vector2)`` (b1 : Box2, v1 : Vector2) =
             let mutable b = b1
             
-            b.Inflate(v1)
+            b.Union(v1)
             
-            Assert.Equal(b, b1.Inflated(v1))
+            Assert.Equal(b, b1.Unioned(v1))
+
+        [<Property>]
+        let ``Box2.Inflate(Box2) is equivalent to Box2.Inflated(Box2)`` (b1 : Box2, b2 : Box2) =
+            let mutable b = b1
+            
+            b.Union(b2)
+            
+            Assert.Equal(b, b1.Unioned(b2))
         
     [<Properties(Arbitrary = [|typeof<OpenTKGen>|])>]
     module Center =

--- a/tests/OpenTK.Tests/Box2Tests.fs
+++ b/tests/OpenTK.Tests/Box2Tests.fs
@@ -155,6 +155,16 @@ module Box2 =
             Assert.Equal(b, b1.Translated(v1))
             
     [<Properties(Arbitrary = [|typeof<OpenTKGen>|])>]
+    module Inflate =
+        [<Property>]
+        let ``Box2.Inflate is equivalent to Box2.Inflated`` (b1 : Box2, v1 : Vector2) =
+            let mutable b = b1
+            
+            b.Inflate(v1)
+            
+            Assert.Equal(b, b1.Inflated(v1))
+
+    [<Properties(Arbitrary = [|typeof<OpenTKGen>|])>]
     module Union =
         [<Property>]
         let ``After inflating a box the point should be either on the edge of the box or the box shouldn't change size`` (b1 : Box2, v1 : Vector2) =
@@ -174,7 +184,7 @@ module Box2 =
             Assert.True(b1.Unioned(b2).Contains(b2))
 
         [<Property>]
-        let ``Box2.Inflate(Vector2) is equivalent to Box2.Inflated(Vector2)`` (b1 : Box2, v1 : Vector2) =
+        let ``Box2.Union(Vector2) is equivalent to Box2.Unioned(Vector2)`` (b1 : Box2, v1 : Vector2) =
             let mutable b = b1
             
             b.Union(v1)
@@ -182,7 +192,7 @@ module Box2 =
             Assert.Equal(b, b1.Unioned(v1))
 
         [<Property>]
-        let ``Box2.Inflate(Box2) is equivalent to Box2.Inflated(Box2)`` (b1 : Box2, b2 : Box2) =
+        let ``Box2.Union(Box2) is equivalent to Box2.Unioned(Box2)`` (b1 : Box2, b2 : Box2) =
             let mutable b = b1
             
             b.Union(b2)

--- a/tests/OpenTK.Tests/Box3Tests.fs
+++ b/tests/OpenTK.Tests/Box3Tests.fs
@@ -157,6 +157,16 @@ module Box3 =
             Assert.Equal(b, b1.Translated(v1))
             
     [<Properties(Arbitrary = [|typeof<OpenTKGen>|])>]
+    module Inflate =
+        [<Property>]
+        let ``Box3.Inflate is equivalent to Box3.Inflated`` (b1 : Box3, v1 : Vector3) =
+            let mutable b = b1
+            
+            b.Inflate(v1)
+            
+            Assert.Equal(b, b1.Inflated(v1))
+
+    [<Properties(Arbitrary = [|typeof<OpenTKGen>|])>]
     module Union =
         [<Property>]
         let ``After inflating a box the point should be either on the edge of the box or the box shouldn't change size`` (b1 : Box3, v1 : Vector3) =

--- a/tests/OpenTK.Tests/Box3Tests.fs
+++ b/tests/OpenTK.Tests/Box3Tests.fs
@@ -157,26 +157,39 @@ module Box3 =
             Assert.Equal(b, b1.Translated(v1))
             
     [<Properties(Arbitrary = [|typeof<OpenTKGen>|])>]
-    module Inflate =
+    module Union =
         [<Property>]
         let ``After inflating a box the point should be either on the edge of the box or the box shouldn't change size`` (b1 : Box3, v1 : Vector3) =
             let v2 = b1.Size
             
-            b1.Inflate(v1)
+            b1.Union(v1)
             
             Assert.True(b1.DistanceToNearestEdge(v1) = (float32)0 || v2 = b1.Size)
         
         [<Property>]
         let ``After inflating the point should be enclosed in the box`` (b1 : Box3, v1 : Vector3) =
-            Assert.True(b1.Inflated(v1).Contains(v1, true))
+            Assert.True(b1.Unioned(v1).Contains(v1, true))
+        
+        [<Property>]
+        let ``After inflating both boxes should be enclosed in the box`` (b1 : Box3, b2 : Box3) =
+            Assert.True(b1.Unioned(b2).Contains(b1))
+            Assert.True(b1.Unioned(b2).Contains(b2))
 
         [<Property>]
-        let ``Box3.Inflate is equivalent to Box3.Inflated`` (b1 : Box3, v1 : Vector3) =
+        let ``Box3.Union(Vector3) is equivalent to Box3.Unioned(Vector3)`` (b1 : Box3, v1 : Vector3) =
             let mutable b = b1
             
-            b.Inflate(v1)
+            b.Union(v1)
             
-            Assert.Equal(b, b1.Inflated(v1))
+            Assert.Equal(b, b1.Unioned(v1))
+
+        [<Property>]
+        let ``Box3.Union(Box3) is equivalent to Box3.Unioned(Box3)`` (b1 : Box3, b2 : Box3) =
+            let mutable b = b1
+            
+            b.Union(b2)
+            
+            Assert.Equal(b, b1.Unioned(b2))
         
     [<Properties(Arbitrary = [|typeof<OpenTKGen>|])>]
     module Center =


### PR DESCRIPTION
### Purpose of this PR

- Box.Inflate now has same behavior as System.Drawing's Rectangle.Inflate (extends by a size on all sides)
- Old behavior renamed to Union (grow box to include a point)
- Add Union(Box) to create a box that encapsulates both boxes

### Testing status

- Tests where updated and added accordingly, all passes
- Done some manual testing, mostly from my framework moving from RectangleF to Box2

### Comments

Terminology between Box structs and System.Drawing.Rectangle structs are divergent. `Box.Inflate` currently enlarges a rectangle to include a point. However, Rectangle.Inflate actually extends the size of the rectangle uniformly in all directions. I believe this is a lot more consistent with the term `Inflate`.

In this PR, the old `Inflate` behavior was moved to `Union` and `Inflate` now has the same behavior as `Rectangle`.

I know this was discussed in https://github.com/opentk/opentk/pull/1037 but I truely believe we should keep it in line with System.Drawing. Union makes more sense when you think of two boxes, why not also for a box and a point? Adding to that, What would you call inflating a box otherwise?

The only thing that bothers me is the change in API and the breaking change that this brings. That said, I still went ahead and made the change because I consider it `[...] correcting the behaviour to an expected result.`
