### PR TITLE
[5.0] Proper depluralization of GenQueries

### DIFF
--- a/src/Generator/Process/Overloaders.cs
+++ b/src/Generator/Process/Overloaders.cs
@@ -672,11 +672,21 @@ namespace Generator.Process
 
     public class GenCreateAndDeleteOverloader : IOverloader
     {
+        public static readonly string[] Prefixes = new string[] { "Gen", "Create", "Delete" };
+
         // Atm only Queries/Query needs this renaming
         // - 2022-06-27
         public static Dictionary<string, string> pluralNameToSingularName = new Dictionary<string, string>()
         {
             { "Queries", "Query" },
+            { "TransformFeedbacks", "TransformFeedback" },
+            { "VertexArrays", "VertexArray" },
+            { "Textures", "Texture" },
+            { "Samplers", "Sampler" },
+            { "Renderbuffers", "Renderbuffer" },
+            { "ProgramPipelines", "ProgramPipeline" },
+            { "Framebuffers", "Framebuffer" },
+            { "Buffers", "Buffer" },
         };
 
         public static Dictionary<string, string> parameterNamesToChange = new Dictionary<string, string>()
@@ -716,8 +726,6 @@ namespace Generator.Process
                 return false;
             }
 
-            string[] Prefixes = new string[] { "Gen", "Create", "Delete" };
-
             string? namePrefix = null;
             string? nameWithoutPrefix = null;
             foreach (var prefix in Prefixes)
@@ -740,7 +748,8 @@ namespace Generator.Process
             else
             {
                 // If the name didn't have a custom singular name, we just remove the trailing 's'
-                newName = NameMangler.RemoveEnd(nativeName, "s");
+                newName = nativeName;
+                Logger.Warning($"Function '{nativeName}' ({nameWithoutPrefix}) {nameWithoutPrefix[..^1]} needs a depluralized name.");
             }
 
             int lengthParameterIndex = -1;

--- a/src/Generator/Utility/NameMangler.cs
+++ b/src/Generator/Utility/NameMangler.cs
@@ -12,6 +12,14 @@ namespace Generator.Utility
             return str[start.Length..];
         }
 
+        public static string RemoveEnd(string str, string end)
+        {
+            if (!str.EndsWith(end))
+                throw new System.Exception($"'{str}' dosen't end with '{end}'");
+
+            return str[0..^end.Length];
+        }
+
         public static string MangleFunctionName(string name)
         {
             // Remove the "gl" prefix.

--- a/src/OpenTK.Graphics/OpenGL/Compatibility/GL.Overloads.cs
+++ b/src/OpenTK.Graphics/OpenGL/Compatibility/GL.Overloads.cs
@@ -3578,10 +3578,10 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="DeleteTextures"/>
-        public static unsafe void DeleteTexture(in TextureHandle textures)
+        public static unsafe void DeleteTexture(in TextureHandle texture)
         {
             int n = 1;
-            fixed(TextureHandle* textures_handle = &textures)
+            fixed(TextureHandle* textures_handle = &texture)
             {
                 DeleteTextures(n, textures_handle);
             }
@@ -3615,9 +3615,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <inheritdoc cref="GenTextures"/>
         public static unsafe TextureHandle GenTexture()
         {
-            TextureHandle textures;
+            TextureHandle texture;
             int n = 1;
-            Unsafe.SkipInit(out textures);
+            Unsafe.SkipInit(out texture);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -3626,15 +3626,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            TextureHandle* textures_handle = (TextureHandle*)Unsafe.AsPointer(ref textures);
+            TextureHandle* textures_handle = (TextureHandle*)Unsafe.AsPointer(ref texture);
             GenTextures(n, textures_handle);
-            return textures;
+            return texture;
         }
         /// <inheritdoc cref="GenTextures"/>
-        public static unsafe void GenTexture(out TextureHandle textures)
+        public static unsafe void GenTexture(out TextureHandle texture)
         {
             int n = 1;
-            Unsafe.SkipInit(out textures);
+            Unsafe.SkipInit(out texture);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -3643,7 +3643,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            TextureHandle* textures_handle = (TextureHandle*)Unsafe.AsPointer(ref textures);
+            TextureHandle* textures_handle = (TextureHandle*)Unsafe.AsPointer(ref texture);
             GenTextures(n, textures_handle);
         }
         /// <inheritdoc cref="GenTextures"/>
@@ -5453,11 +5453,11 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GenQueries"/>
-        public static unsafe QueryHandle GenQuerie()
+        public static unsafe QueryHandle GenQuery()
         {
-            QueryHandle ids;
+            QueryHandle id;
             int n = 1;
-            Unsafe.SkipInit(out ids);
+            Unsafe.SkipInit(out id);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -5466,15 +5466,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            QueryHandle* ids_handle = (QueryHandle*)Unsafe.AsPointer(ref ids);
+            QueryHandle* ids_handle = (QueryHandle*)Unsafe.AsPointer(ref id);
             GenQueries(n, ids_handle);
-            return ids;
+            return id;
         }
         /// <inheritdoc cref="GenQueries"/>
-        public static unsafe void GenQuerie(out QueryHandle ids)
+        public static unsafe void GenQuery(out QueryHandle id)
         {
             int n = 1;
-            Unsafe.SkipInit(out ids);
+            Unsafe.SkipInit(out id);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -5483,7 +5483,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            QueryHandle* ids_handle = (QueryHandle*)Unsafe.AsPointer(ref ids);
+            QueryHandle* ids_handle = (QueryHandle*)Unsafe.AsPointer(ref id);
             GenQueries(n, ids_handle);
         }
         /// <inheritdoc cref="GenQueries"/>
@@ -5513,10 +5513,10 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="DeleteQueries"/>
-        public static unsafe void DeleteQuerie(in QueryHandle ids)
+        public static unsafe void DeleteQuery(in QueryHandle id)
         {
             int n = 1;
-            fixed(QueryHandle* ids_handle = &ids)
+            fixed(QueryHandle* ids_handle = &id)
             {
                 DeleteQueries(n, ids_handle);
             }
@@ -5620,10 +5620,10 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="DeleteBuffers"/>
-        public static unsafe void DeleteBuffer(in BufferHandle buffers)
+        public static unsafe void DeleteBuffer(in BufferHandle buffer)
         {
             int n = 1;
-            fixed(BufferHandle* buffers_handle = &buffers)
+            fixed(BufferHandle* buffers_handle = &buffer)
             {
                 DeleteBuffers(n, buffers_handle);
             }
@@ -5657,9 +5657,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <inheritdoc cref="GenBuffers"/>
         public static unsafe BufferHandle GenBuffer()
         {
-            BufferHandle buffers;
+            BufferHandle buffer;
             int n = 1;
-            Unsafe.SkipInit(out buffers);
+            Unsafe.SkipInit(out buffer);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -5668,15 +5668,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            BufferHandle* buffers_handle = (BufferHandle*)Unsafe.AsPointer(ref buffers);
+            BufferHandle* buffers_handle = (BufferHandle*)Unsafe.AsPointer(ref buffer);
             GenBuffers(n, buffers_handle);
-            return buffers;
+            return buffer;
         }
         /// <inheritdoc cref="GenBuffers"/>
-        public static unsafe void GenBuffer(out BufferHandle buffers)
+        public static unsafe void GenBuffer(out BufferHandle buffer)
         {
             int n = 1;
-            Unsafe.SkipInit(out buffers);
+            Unsafe.SkipInit(out buffer);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -5685,7 +5685,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            BufferHandle* buffers_handle = (BufferHandle*)Unsafe.AsPointer(ref buffers);
+            BufferHandle* buffers_handle = (BufferHandle*)Unsafe.AsPointer(ref buffer);
             GenBuffers(n, buffers_handle);
         }
         /// <inheritdoc cref="GenBuffers"/>
@@ -8458,10 +8458,10 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             return returnValue_str;
         }
         /// <inheritdoc cref="DeleteRenderbuffers"/>
-        public static unsafe void DeleteRenderbuffer(in RenderbufferHandle renderbuffers)
+        public static unsafe void DeleteRenderbuffer(in RenderbufferHandle renderbuffer)
         {
             int n = 1;
-            fixed(RenderbufferHandle* renderbuffers_handle = &renderbuffers)
+            fixed(RenderbufferHandle* renderbuffers_handle = &renderbuffer)
             {
                 DeleteRenderbuffers(n, renderbuffers_handle);
             }
@@ -8495,9 +8495,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <inheritdoc cref="GenRenderbuffers"/>
         public static unsafe RenderbufferHandle GenRenderbuffer()
         {
-            RenderbufferHandle renderbuffers;
+            RenderbufferHandle renderbuffer;
             int n = 1;
-            Unsafe.SkipInit(out renderbuffers);
+            Unsafe.SkipInit(out renderbuffer);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -8506,15 +8506,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            RenderbufferHandle* renderbuffers_handle = (RenderbufferHandle*)Unsafe.AsPointer(ref renderbuffers);
+            RenderbufferHandle* renderbuffers_handle = (RenderbufferHandle*)Unsafe.AsPointer(ref renderbuffer);
             GenRenderbuffers(n, renderbuffers_handle);
-            return renderbuffers;
+            return renderbuffer;
         }
         /// <inheritdoc cref="GenRenderbuffers"/>
-        public static unsafe void GenRenderbuffer(out RenderbufferHandle renderbuffers)
+        public static unsafe void GenRenderbuffer(out RenderbufferHandle renderbuffer)
         {
             int n = 1;
-            Unsafe.SkipInit(out renderbuffers);
+            Unsafe.SkipInit(out renderbuffer);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -8523,7 +8523,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            RenderbufferHandle* renderbuffers_handle = (RenderbufferHandle*)Unsafe.AsPointer(ref renderbuffers);
+            RenderbufferHandle* renderbuffers_handle = (RenderbufferHandle*)Unsafe.AsPointer(ref renderbuffer);
             GenRenderbuffers(n, renderbuffers_handle);
         }
         /// <inheritdoc cref="GenRenderbuffers"/>
@@ -8577,10 +8577,10 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="DeleteFramebuffers"/>
-        public static unsafe void DeleteFramebuffer(in FramebufferHandle framebuffers)
+        public static unsafe void DeleteFramebuffer(in FramebufferHandle framebuffer)
         {
             int n = 1;
-            fixed(FramebufferHandle* framebuffers_handle = &framebuffers)
+            fixed(FramebufferHandle* framebuffers_handle = &framebuffer)
             {
                 DeleteFramebuffers(n, framebuffers_handle);
             }
@@ -8614,9 +8614,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <inheritdoc cref="GenFramebuffers"/>
         public static unsafe FramebufferHandle GenFramebuffer()
         {
-            FramebufferHandle framebuffers;
+            FramebufferHandle framebuffer;
             int n = 1;
-            Unsafe.SkipInit(out framebuffers);
+            Unsafe.SkipInit(out framebuffer);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -8625,15 +8625,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            FramebufferHandle* framebuffers_handle = (FramebufferHandle*)Unsafe.AsPointer(ref framebuffers);
+            FramebufferHandle* framebuffers_handle = (FramebufferHandle*)Unsafe.AsPointer(ref framebuffer);
             GenFramebuffers(n, framebuffers_handle);
-            return framebuffers;
+            return framebuffer;
         }
         /// <inheritdoc cref="GenFramebuffers"/>
-        public static unsafe void GenFramebuffer(out FramebufferHandle framebuffers)
+        public static unsafe void GenFramebuffer(out FramebufferHandle framebuffer)
         {
             int n = 1;
-            Unsafe.SkipInit(out framebuffers);
+            Unsafe.SkipInit(out framebuffer);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -8642,7 +8642,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            FramebufferHandle* framebuffers_handle = (FramebufferHandle*)Unsafe.AsPointer(ref framebuffers);
+            FramebufferHandle* framebuffers_handle = (FramebufferHandle*)Unsafe.AsPointer(ref framebuffer);
             GenFramebuffers(n, framebuffers_handle);
         }
         /// <inheritdoc cref="GenFramebuffers"/>
@@ -8696,10 +8696,10 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="DeleteVertexArrays"/>
-        public static unsafe void DeleteVertexArray(in VertexArrayHandle arrays)
+        public static unsafe void DeleteVertexArray(in VertexArrayHandle array)
         {
             int n = 1;
-            fixed(VertexArrayHandle* arrays_handle = &arrays)
+            fixed(VertexArrayHandle* arrays_handle = &array)
             {
                 DeleteVertexArrays(n, arrays_handle);
             }
@@ -8733,9 +8733,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <inheritdoc cref="GenVertexArrays"/>
         public static unsafe VertexArrayHandle GenVertexArray()
         {
-            VertexArrayHandle arrays;
+            VertexArrayHandle array;
             int n = 1;
-            Unsafe.SkipInit(out arrays);
+            Unsafe.SkipInit(out array);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -8744,15 +8744,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            VertexArrayHandle* arrays_handle = (VertexArrayHandle*)Unsafe.AsPointer(ref arrays);
+            VertexArrayHandle* arrays_handle = (VertexArrayHandle*)Unsafe.AsPointer(ref array);
             GenVertexArrays(n, arrays_handle);
-            return arrays;
+            return array;
         }
         /// <inheritdoc cref="GenVertexArrays"/>
-        public static unsafe void GenVertexArray(out VertexArrayHandle arrays)
+        public static unsafe void GenVertexArray(out VertexArrayHandle array)
         {
             int n = 1;
-            Unsafe.SkipInit(out arrays);
+            Unsafe.SkipInit(out array);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -8761,7 +8761,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            VertexArrayHandle* arrays_handle = (VertexArrayHandle*)Unsafe.AsPointer(ref arrays);
+            VertexArrayHandle* arrays_handle = (VertexArrayHandle*)Unsafe.AsPointer(ref array);
             GenVertexArrays(n, arrays_handle);
         }
         /// <inheritdoc cref="GenVertexArrays"/>
@@ -9239,9 +9239,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <inheritdoc cref="GenSamplers"/>
         public static unsafe SamplerHandle GenSampler()
         {
-            SamplerHandle samplers;
+            SamplerHandle sampler;
             int count = 1;
-            Unsafe.SkipInit(out samplers);
+            Unsafe.SkipInit(out sampler);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -9250,15 +9250,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            SamplerHandle* samplers_handle = (SamplerHandle*)Unsafe.AsPointer(ref samplers);
+            SamplerHandle* samplers_handle = (SamplerHandle*)Unsafe.AsPointer(ref sampler);
             GenSamplers(count, samplers_handle);
-            return samplers;
+            return sampler;
         }
         /// <inheritdoc cref="GenSamplers"/>
-        public static unsafe void GenSampler(out SamplerHandle samplers)
+        public static unsafe void GenSampler(out SamplerHandle sampler)
         {
             int count = 1;
-            Unsafe.SkipInit(out samplers);
+            Unsafe.SkipInit(out sampler);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -9267,7 +9267,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            SamplerHandle* samplers_handle = (SamplerHandle*)Unsafe.AsPointer(ref samplers);
+            SamplerHandle* samplers_handle = (SamplerHandle*)Unsafe.AsPointer(ref sampler);
             GenSamplers(count, samplers_handle);
         }
         /// <inheritdoc cref="GenSamplers"/>
@@ -9297,10 +9297,10 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="DeleteSamplers"/>
-        public static unsafe void DeleteSampler(in SamplerHandle samplers)
+        public static unsafe void DeleteSampler(in SamplerHandle sampler)
         {
             int count = 1;
-            fixed(SamplerHandle* samplers_handle = &samplers)
+            fixed(SamplerHandle* samplers_handle = &sampler)
             {
                 DeleteSamplers(count, samplers_handle);
             }
@@ -10793,10 +10793,10 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="DeleteTransformFeedbacks"/>
-        public static unsafe void DeleteTransformFeedback(in TransformFeedbackHandle ids)
+        public static unsafe void DeleteTransformFeedback(in TransformFeedbackHandle id)
         {
             int n = 1;
-            fixed(TransformFeedbackHandle* ids_handle = &ids)
+            fixed(TransformFeedbackHandle* ids_handle = &id)
             {
                 DeleteTransformFeedbacks(n, ids_handle);
             }
@@ -10830,9 +10830,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <inheritdoc cref="GenTransformFeedbacks"/>
         public static unsafe TransformFeedbackHandle GenTransformFeedback()
         {
-            TransformFeedbackHandle ids;
+            TransformFeedbackHandle id;
             int n = 1;
-            Unsafe.SkipInit(out ids);
+            Unsafe.SkipInit(out id);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -10841,15 +10841,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            TransformFeedbackHandle* ids_handle = (TransformFeedbackHandle*)Unsafe.AsPointer(ref ids);
+            TransformFeedbackHandle* ids_handle = (TransformFeedbackHandle*)Unsafe.AsPointer(ref id);
             GenTransformFeedbacks(n, ids_handle);
-            return ids;
+            return id;
         }
         /// <inheritdoc cref="GenTransformFeedbacks"/>
-        public static unsafe void GenTransformFeedback(out TransformFeedbackHandle ids)
+        public static unsafe void GenTransformFeedback(out TransformFeedbackHandle id)
         {
             int n = 1;
-            Unsafe.SkipInit(out ids);
+            Unsafe.SkipInit(out id);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -10858,7 +10858,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            TransformFeedbackHandle* ids_handle = (TransformFeedbackHandle*)Unsafe.AsPointer(ref ids);
+            TransformFeedbackHandle* ids_handle = (TransformFeedbackHandle*)Unsafe.AsPointer(ref id);
             GenTransformFeedbacks(n, ids_handle);
         }
         /// <inheritdoc cref="GenTransformFeedbacks"/>
@@ -11129,10 +11129,10 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             return returnValue;
         }
         /// <inheritdoc cref="DeleteProgramPipelines"/>
-        public static unsafe void DeleteProgramPipeline(in ProgramPipelineHandle pipelines)
+        public static unsafe void DeleteProgramPipeline(in ProgramPipelineHandle pipeline)
         {
             int n = 1;
-            fixed(ProgramPipelineHandle* pipelines_handle = &pipelines)
+            fixed(ProgramPipelineHandle* pipelines_handle = &pipeline)
             {
                 DeleteProgramPipelines(n, pipelines_handle);
             }
@@ -11166,9 +11166,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <inheritdoc cref="GenProgramPipelines"/>
         public static unsafe ProgramPipelineHandle GenProgramPipeline()
         {
-            ProgramPipelineHandle pipelines;
+            ProgramPipelineHandle pipeline;
             int n = 1;
-            Unsafe.SkipInit(out pipelines);
+            Unsafe.SkipInit(out pipeline);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -11177,15 +11177,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            ProgramPipelineHandle* pipelines_handle = (ProgramPipelineHandle*)Unsafe.AsPointer(ref pipelines);
+            ProgramPipelineHandle* pipelines_handle = (ProgramPipelineHandle*)Unsafe.AsPointer(ref pipeline);
             GenProgramPipelines(n, pipelines_handle);
-            return pipelines;
+            return pipeline;
         }
         /// <inheritdoc cref="GenProgramPipelines"/>
-        public static unsafe void GenProgramPipeline(out ProgramPipelineHandle pipelines)
+        public static unsafe void GenProgramPipeline(out ProgramPipelineHandle pipeline)
         {
             int n = 1;
-            Unsafe.SkipInit(out pipelines);
+            Unsafe.SkipInit(out pipeline);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -11194,7 +11194,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            ProgramPipelineHandle* pipelines_handle = (ProgramPipelineHandle*)Unsafe.AsPointer(ref pipelines);
+            ProgramPipelineHandle* pipelines_handle = (ProgramPipelineHandle*)Unsafe.AsPointer(ref pipeline);
             GenProgramPipelines(n, pipelines_handle);
         }
         /// <inheritdoc cref="GenProgramPipelines"/>
@@ -13769,9 +13769,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <inheritdoc cref="CreateTransformFeedbacks"/>
         public static unsafe TransformFeedbackHandle CreateTransformFeedback()
         {
-            TransformFeedbackHandle ids;
+            TransformFeedbackHandle id;
             int n = 1;
-            Unsafe.SkipInit(out ids);
+            Unsafe.SkipInit(out id);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -13780,15 +13780,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            TransformFeedbackHandle* ids_handle = (TransformFeedbackHandle*)Unsafe.AsPointer(ref ids);
+            TransformFeedbackHandle* ids_handle = (TransformFeedbackHandle*)Unsafe.AsPointer(ref id);
             CreateTransformFeedbacks(n, ids_handle);
-            return ids;
+            return id;
         }
         /// <inheritdoc cref="CreateTransformFeedbacks"/>
-        public static unsafe void CreateTransformFeedback(out TransformFeedbackHandle ids)
+        public static unsafe void CreateTransformFeedback(out TransformFeedbackHandle id)
         {
             int n = 1;
-            Unsafe.SkipInit(out ids);
+            Unsafe.SkipInit(out id);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -13797,7 +13797,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            TransformFeedbackHandle* ids_handle = (TransformFeedbackHandle*)Unsafe.AsPointer(ref ids);
+            TransformFeedbackHandle* ids_handle = (TransformFeedbackHandle*)Unsafe.AsPointer(ref id);
             CreateTransformFeedbacks(n, ids_handle);
         }
         /// <inheritdoc cref="CreateTransformFeedbacks"/>
@@ -13853,9 +13853,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <inheritdoc cref="CreateBuffers"/>
         public static unsafe BufferHandle CreateBuffer()
         {
-            BufferHandle buffers;
+            BufferHandle buffer;
             int n = 1;
-            Unsafe.SkipInit(out buffers);
+            Unsafe.SkipInit(out buffer);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -13864,15 +13864,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            BufferHandle* buffers_handle = (BufferHandle*)Unsafe.AsPointer(ref buffers);
+            BufferHandle* buffers_handle = (BufferHandle*)Unsafe.AsPointer(ref buffer);
             CreateBuffers(n, buffers_handle);
-            return buffers;
+            return buffer;
         }
         /// <inheritdoc cref="CreateBuffers"/>
-        public static unsafe void CreateBuffer(out BufferHandle buffers)
+        public static unsafe void CreateBuffer(out BufferHandle buffer)
         {
             int n = 1;
-            Unsafe.SkipInit(out buffers);
+            Unsafe.SkipInit(out buffer);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -13881,7 +13881,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            BufferHandle* buffers_handle = (BufferHandle*)Unsafe.AsPointer(ref buffers);
+            BufferHandle* buffers_handle = (BufferHandle*)Unsafe.AsPointer(ref buffer);
             CreateBuffers(n, buffers_handle);
         }
         /// <inheritdoc cref="CreateBuffers"/>
@@ -14062,9 +14062,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <inheritdoc cref="CreateFramebuffers"/>
         public static unsafe FramebufferHandle CreateFramebuffer()
         {
-            FramebufferHandle framebuffers;
+            FramebufferHandle framebuffer;
             int n = 1;
-            Unsafe.SkipInit(out framebuffers);
+            Unsafe.SkipInit(out framebuffer);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -14073,15 +14073,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            FramebufferHandle* framebuffers_handle = (FramebufferHandle*)Unsafe.AsPointer(ref framebuffers);
+            FramebufferHandle* framebuffers_handle = (FramebufferHandle*)Unsafe.AsPointer(ref framebuffer);
             CreateFramebuffers(n, framebuffers_handle);
-            return framebuffers;
+            return framebuffer;
         }
         /// <inheritdoc cref="CreateFramebuffers"/>
-        public static unsafe void CreateFramebuffer(out FramebufferHandle framebuffers)
+        public static unsafe void CreateFramebuffer(out FramebufferHandle framebuffer)
         {
             int n = 1;
-            Unsafe.SkipInit(out framebuffers);
+            Unsafe.SkipInit(out framebuffer);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -14090,7 +14090,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            FramebufferHandle* framebuffers_handle = (FramebufferHandle*)Unsafe.AsPointer(ref framebuffers);
+            FramebufferHandle* framebuffers_handle = (FramebufferHandle*)Unsafe.AsPointer(ref framebuffer);
             CreateFramebuffers(n, framebuffers_handle);
         }
         /// <inheritdoc cref="CreateFramebuffers"/>
@@ -14191,9 +14191,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <inheritdoc cref="CreateRenderbuffers"/>
         public static unsafe RenderbufferHandle CreateRenderbuffer()
         {
-            RenderbufferHandle renderbuffers;
+            RenderbufferHandle renderbuffer;
             int n = 1;
-            Unsafe.SkipInit(out renderbuffers);
+            Unsafe.SkipInit(out renderbuffer);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -14202,15 +14202,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            RenderbufferHandle* renderbuffers_handle = (RenderbufferHandle*)Unsafe.AsPointer(ref renderbuffers);
+            RenderbufferHandle* renderbuffers_handle = (RenderbufferHandle*)Unsafe.AsPointer(ref renderbuffer);
             CreateRenderbuffers(n, renderbuffers_handle);
-            return renderbuffers;
+            return renderbuffer;
         }
         /// <inheritdoc cref="CreateRenderbuffers"/>
-        public static unsafe void CreateRenderbuffer(out RenderbufferHandle renderbuffers)
+        public static unsafe void CreateRenderbuffer(out RenderbufferHandle renderbuffer)
         {
             int n = 1;
-            Unsafe.SkipInit(out renderbuffers);
+            Unsafe.SkipInit(out renderbuffer);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -14219,7 +14219,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            RenderbufferHandle* renderbuffers_handle = (RenderbufferHandle*)Unsafe.AsPointer(ref renderbuffers);
+            RenderbufferHandle* renderbuffers_handle = (RenderbufferHandle*)Unsafe.AsPointer(ref renderbuffer);
             CreateRenderbuffers(n, renderbuffers_handle);
         }
         /// <inheritdoc cref="CreateRenderbuffers"/>
@@ -14259,9 +14259,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <inheritdoc cref="CreateTextures"/>
         public static unsafe TextureHandle CreateTexture(TextureTarget target)
         {
-            TextureHandle textures;
+            TextureHandle texture;
             int n = 1;
-            Unsafe.SkipInit(out textures);
+            Unsafe.SkipInit(out texture);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -14270,15 +14270,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            TextureHandle* textures_handle = (TextureHandle*)Unsafe.AsPointer(ref textures);
+            TextureHandle* textures_handle = (TextureHandle*)Unsafe.AsPointer(ref texture);
             CreateTextures(target, n, textures_handle);
-            return textures;
+            return texture;
         }
         /// <inheritdoc cref="CreateTextures"/>
-        public static unsafe void CreateTexture(TextureTarget target, out TextureHandle textures)
+        public static unsafe void CreateTexture(TextureTarget target, out TextureHandle texture)
         {
             int n = 1;
-            Unsafe.SkipInit(out textures);
+            Unsafe.SkipInit(out texture);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -14287,7 +14287,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            TextureHandle* textures_handle = (TextureHandle*)Unsafe.AsPointer(ref textures);
+            TextureHandle* textures_handle = (TextureHandle*)Unsafe.AsPointer(ref texture);
             CreateTextures(target, n, textures_handle);
         }
         /// <inheritdoc cref="CreateTextures"/>
@@ -14531,9 +14531,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <inheritdoc cref="CreateVertexArrays"/>
         public static unsafe VertexArrayHandle CreateVertexArray()
         {
-            VertexArrayHandle arrays;
+            VertexArrayHandle array;
             int n = 1;
-            Unsafe.SkipInit(out arrays);
+            Unsafe.SkipInit(out array);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -14542,15 +14542,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            VertexArrayHandle* arrays_handle = (VertexArrayHandle*)Unsafe.AsPointer(ref arrays);
+            VertexArrayHandle* arrays_handle = (VertexArrayHandle*)Unsafe.AsPointer(ref array);
             CreateVertexArrays(n, arrays_handle);
-            return arrays;
+            return array;
         }
         /// <inheritdoc cref="CreateVertexArrays"/>
-        public static unsafe void CreateVertexArray(out VertexArrayHandle arrays)
+        public static unsafe void CreateVertexArray(out VertexArrayHandle array)
         {
             int n = 1;
-            Unsafe.SkipInit(out arrays);
+            Unsafe.SkipInit(out array);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -14559,7 +14559,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            VertexArrayHandle* arrays_handle = (VertexArrayHandle*)Unsafe.AsPointer(ref arrays);
+            VertexArrayHandle* arrays_handle = (VertexArrayHandle*)Unsafe.AsPointer(ref array);
             CreateVertexArrays(n, arrays_handle);
         }
         /// <inheritdoc cref="CreateVertexArrays"/>
@@ -14631,9 +14631,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <inheritdoc cref="CreateSamplers"/>
         public static unsafe SamplerHandle CreateSampler()
         {
-            SamplerHandle samplers;
+            SamplerHandle sampler;
             int n = 1;
-            Unsafe.SkipInit(out samplers);
+            Unsafe.SkipInit(out sampler);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -14642,15 +14642,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            SamplerHandle* samplers_handle = (SamplerHandle*)Unsafe.AsPointer(ref samplers);
+            SamplerHandle* samplers_handle = (SamplerHandle*)Unsafe.AsPointer(ref sampler);
             CreateSamplers(n, samplers_handle);
-            return samplers;
+            return sampler;
         }
         /// <inheritdoc cref="CreateSamplers"/>
-        public static unsafe void CreateSampler(out SamplerHandle samplers)
+        public static unsafe void CreateSampler(out SamplerHandle sampler)
         {
             int n = 1;
-            Unsafe.SkipInit(out samplers);
+            Unsafe.SkipInit(out sampler);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -14659,7 +14659,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            SamplerHandle* samplers_handle = (SamplerHandle*)Unsafe.AsPointer(ref samplers);
+            SamplerHandle* samplers_handle = (SamplerHandle*)Unsafe.AsPointer(ref sampler);
             CreateSamplers(n, samplers_handle);
         }
         /// <inheritdoc cref="CreateSamplers"/>
@@ -14691,9 +14691,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <inheritdoc cref="CreateProgramPipelines"/>
         public static unsafe ProgramPipelineHandle CreateProgramPipeline()
         {
-            ProgramPipelineHandle pipelines;
+            ProgramPipelineHandle pipeline;
             int n = 1;
-            Unsafe.SkipInit(out pipelines);
+            Unsafe.SkipInit(out pipeline);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -14702,15 +14702,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            ProgramPipelineHandle* pipelines_handle = (ProgramPipelineHandle*)Unsafe.AsPointer(ref pipelines);
+            ProgramPipelineHandle* pipelines_handle = (ProgramPipelineHandle*)Unsafe.AsPointer(ref pipeline);
             CreateProgramPipelines(n, pipelines_handle);
-            return pipelines;
+            return pipeline;
         }
         /// <inheritdoc cref="CreateProgramPipelines"/>
-        public static unsafe void CreateProgramPipeline(out ProgramPipelineHandle pipelines)
+        public static unsafe void CreateProgramPipeline(out ProgramPipelineHandle pipeline)
         {
             int n = 1;
-            Unsafe.SkipInit(out pipelines);
+            Unsafe.SkipInit(out pipeline);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -14719,7 +14719,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            ProgramPipelineHandle* pipelines_handle = (ProgramPipelineHandle*)Unsafe.AsPointer(ref pipelines);
+            ProgramPipelineHandle* pipelines_handle = (ProgramPipelineHandle*)Unsafe.AsPointer(ref pipeline);
             CreateProgramPipelines(n, pipelines_handle);
         }
         /// <inheritdoc cref="CreateProgramPipelines"/>
@@ -14749,11 +14749,11 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="CreateQueries"/>
-        public static unsafe QueryHandle CreateQuerie(QueryTarget target)
+        public static unsafe QueryHandle CreateQuery(QueryTarget target)
         {
-            QueryHandle ids;
+            QueryHandle id;
             int n = 1;
-            Unsafe.SkipInit(out ids);
+            Unsafe.SkipInit(out id);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -14762,15 +14762,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            QueryHandle* ids_handle = (QueryHandle*)Unsafe.AsPointer(ref ids);
+            QueryHandle* ids_handle = (QueryHandle*)Unsafe.AsPointer(ref id);
             CreateQueries(target, n, ids_handle);
-            return ids;
+            return id;
         }
         /// <inheritdoc cref="CreateQueries"/>
-        public static unsafe void CreateQuerie(QueryTarget target, out QueryHandle ids)
+        public static unsafe void CreateQuery(QueryTarget target, out QueryHandle id)
         {
             int n = 1;
-            Unsafe.SkipInit(out ids);
+            Unsafe.SkipInit(out id);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -14779,7 +14779,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            QueryHandle* ids_handle = (QueryHandle*)Unsafe.AsPointer(ref ids);
+            QueryHandle* ids_handle = (QueryHandle*)Unsafe.AsPointer(ref id);
             CreateQueries(target, n, ids_handle);
         }
         /// <inheritdoc cref="CreateQueries"/>
@@ -17494,9 +17494,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <inheritdoc cref="CreateTransformFeedbacks"/>
             public static unsafe TransformFeedbackHandle CreateTransformFeedback()
             {
-                TransformFeedbackHandle ids;
+                TransformFeedbackHandle id;
                 int n = 1;
-                Unsafe.SkipInit(out ids);
+                Unsafe.SkipInit(out id);
                 // FIXME: This could be a problem for the overloads that take an out parameter
                 // as this parameter could *potentially* move while inside of this function
                 // which would mean that the new value never gets written to the out parameter.
@@ -17505,15 +17505,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                TransformFeedbackHandle* ids_handle = (TransformFeedbackHandle*)Unsafe.AsPointer(ref ids);
+                TransformFeedbackHandle* ids_handle = (TransformFeedbackHandle*)Unsafe.AsPointer(ref id);
                 CreateTransformFeedbacks(n, ids_handle);
-                return ids;
+                return id;
             }
             /// <inheritdoc cref="CreateTransformFeedbacks"/>
-            public static unsafe void CreateTransformFeedback(out TransformFeedbackHandle ids)
+            public static unsafe void CreateTransformFeedback(out TransformFeedbackHandle id)
             {
                 int n = 1;
-                Unsafe.SkipInit(out ids);
+                Unsafe.SkipInit(out id);
                 // FIXME: This could be a problem for the overloads that take an out parameter
                 // as this parameter could *potentially* move while inside of this function
                 // which would mean that the new value never gets written to the out parameter.
@@ -17522,7 +17522,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                TransformFeedbackHandle* ids_handle = (TransformFeedbackHandle*)Unsafe.AsPointer(ref ids);
+                TransformFeedbackHandle* ids_handle = (TransformFeedbackHandle*)Unsafe.AsPointer(ref id);
                 CreateTransformFeedbacks(n, ids_handle);
             }
             /// <inheritdoc cref="CreateTransformFeedbacks"/>
@@ -17578,9 +17578,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <inheritdoc cref="CreateBuffers"/>
             public static unsafe BufferHandle CreateBuffer()
             {
-                BufferHandle buffers;
+                BufferHandle buffer;
                 int n = 1;
-                Unsafe.SkipInit(out buffers);
+                Unsafe.SkipInit(out buffer);
                 // FIXME: This could be a problem for the overloads that take an out parameter
                 // as this parameter could *potentially* move while inside of this function
                 // which would mean that the new value never gets written to the out parameter.
@@ -17589,15 +17589,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                BufferHandle* buffers_handle = (BufferHandle*)Unsafe.AsPointer(ref buffers);
+                BufferHandle* buffers_handle = (BufferHandle*)Unsafe.AsPointer(ref buffer);
                 CreateBuffers(n, buffers_handle);
-                return buffers;
+                return buffer;
             }
             /// <inheritdoc cref="CreateBuffers"/>
-            public static unsafe void CreateBuffer(out BufferHandle buffers)
+            public static unsafe void CreateBuffer(out BufferHandle buffer)
             {
                 int n = 1;
-                Unsafe.SkipInit(out buffers);
+                Unsafe.SkipInit(out buffer);
                 // FIXME: This could be a problem for the overloads that take an out parameter
                 // as this parameter could *potentially* move while inside of this function
                 // which would mean that the new value never gets written to the out parameter.
@@ -17606,7 +17606,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                BufferHandle* buffers_handle = (BufferHandle*)Unsafe.AsPointer(ref buffers);
+                BufferHandle* buffers_handle = (BufferHandle*)Unsafe.AsPointer(ref buffer);
                 CreateBuffers(n, buffers_handle);
             }
             /// <inheritdoc cref="CreateBuffers"/>
@@ -17787,9 +17787,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <inheritdoc cref="CreateFramebuffers"/>
             public static unsafe FramebufferHandle CreateFramebuffer()
             {
-                FramebufferHandle framebuffers;
+                FramebufferHandle framebuffer;
                 int n = 1;
-                Unsafe.SkipInit(out framebuffers);
+                Unsafe.SkipInit(out framebuffer);
                 // FIXME: This could be a problem for the overloads that take an out parameter
                 // as this parameter could *potentially* move while inside of this function
                 // which would mean that the new value never gets written to the out parameter.
@@ -17798,15 +17798,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                FramebufferHandle* framebuffers_handle = (FramebufferHandle*)Unsafe.AsPointer(ref framebuffers);
+                FramebufferHandle* framebuffers_handle = (FramebufferHandle*)Unsafe.AsPointer(ref framebuffer);
                 CreateFramebuffers(n, framebuffers_handle);
-                return framebuffers;
+                return framebuffer;
             }
             /// <inheritdoc cref="CreateFramebuffers"/>
-            public static unsafe void CreateFramebuffer(out FramebufferHandle framebuffers)
+            public static unsafe void CreateFramebuffer(out FramebufferHandle framebuffer)
             {
                 int n = 1;
-                Unsafe.SkipInit(out framebuffers);
+                Unsafe.SkipInit(out framebuffer);
                 // FIXME: This could be a problem for the overloads that take an out parameter
                 // as this parameter could *potentially* move while inside of this function
                 // which would mean that the new value never gets written to the out parameter.
@@ -17815,7 +17815,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                FramebufferHandle* framebuffers_handle = (FramebufferHandle*)Unsafe.AsPointer(ref framebuffers);
+                FramebufferHandle* framebuffers_handle = (FramebufferHandle*)Unsafe.AsPointer(ref framebuffer);
                 CreateFramebuffers(n, framebuffers_handle);
             }
             /// <inheritdoc cref="CreateFramebuffers"/>
@@ -17916,9 +17916,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <inheritdoc cref="CreateRenderbuffers"/>
             public static unsafe RenderbufferHandle CreateRenderbuffer()
             {
-                RenderbufferHandle renderbuffers;
+                RenderbufferHandle renderbuffer;
                 int n = 1;
-                Unsafe.SkipInit(out renderbuffers);
+                Unsafe.SkipInit(out renderbuffer);
                 // FIXME: This could be a problem for the overloads that take an out parameter
                 // as this parameter could *potentially* move while inside of this function
                 // which would mean that the new value never gets written to the out parameter.
@@ -17927,15 +17927,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                RenderbufferHandle* renderbuffers_handle = (RenderbufferHandle*)Unsafe.AsPointer(ref renderbuffers);
+                RenderbufferHandle* renderbuffers_handle = (RenderbufferHandle*)Unsafe.AsPointer(ref renderbuffer);
                 CreateRenderbuffers(n, renderbuffers_handle);
-                return renderbuffers;
+                return renderbuffer;
             }
             /// <inheritdoc cref="CreateRenderbuffers"/>
-            public static unsafe void CreateRenderbuffer(out RenderbufferHandle renderbuffers)
+            public static unsafe void CreateRenderbuffer(out RenderbufferHandle renderbuffer)
             {
                 int n = 1;
-                Unsafe.SkipInit(out renderbuffers);
+                Unsafe.SkipInit(out renderbuffer);
                 // FIXME: This could be a problem for the overloads that take an out parameter
                 // as this parameter could *potentially* move while inside of this function
                 // which would mean that the new value never gets written to the out parameter.
@@ -17944,7 +17944,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                RenderbufferHandle* renderbuffers_handle = (RenderbufferHandle*)Unsafe.AsPointer(ref renderbuffers);
+                RenderbufferHandle* renderbuffers_handle = (RenderbufferHandle*)Unsafe.AsPointer(ref renderbuffer);
                 CreateRenderbuffers(n, renderbuffers_handle);
             }
             /// <inheritdoc cref="CreateRenderbuffers"/>
@@ -17984,9 +17984,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <inheritdoc cref="CreateTextures"/>
             public static unsafe TextureHandle CreateTexture(TextureTarget target)
             {
-                TextureHandle textures;
+                TextureHandle texture;
                 int n = 1;
-                Unsafe.SkipInit(out textures);
+                Unsafe.SkipInit(out texture);
                 // FIXME: This could be a problem for the overloads that take an out parameter
                 // as this parameter could *potentially* move while inside of this function
                 // which would mean that the new value never gets written to the out parameter.
@@ -17995,15 +17995,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                TextureHandle* textures_handle = (TextureHandle*)Unsafe.AsPointer(ref textures);
+                TextureHandle* textures_handle = (TextureHandle*)Unsafe.AsPointer(ref texture);
                 CreateTextures(target, n, textures_handle);
-                return textures;
+                return texture;
             }
             /// <inheritdoc cref="CreateTextures"/>
-            public static unsafe void CreateTexture(TextureTarget target, out TextureHandle textures)
+            public static unsafe void CreateTexture(TextureTarget target, out TextureHandle texture)
             {
                 int n = 1;
-                Unsafe.SkipInit(out textures);
+                Unsafe.SkipInit(out texture);
                 // FIXME: This could be a problem for the overloads that take an out parameter
                 // as this parameter could *potentially* move while inside of this function
                 // which would mean that the new value never gets written to the out parameter.
@@ -18012,7 +18012,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                TextureHandle* textures_handle = (TextureHandle*)Unsafe.AsPointer(ref textures);
+                TextureHandle* textures_handle = (TextureHandle*)Unsafe.AsPointer(ref texture);
                 CreateTextures(target, n, textures_handle);
             }
             /// <inheritdoc cref="CreateTextures"/>
@@ -18256,9 +18256,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <inheritdoc cref="CreateVertexArrays"/>
             public static unsafe VertexArrayHandle CreateVertexArray()
             {
-                VertexArrayHandle arrays;
+                VertexArrayHandle array;
                 int n = 1;
-                Unsafe.SkipInit(out arrays);
+                Unsafe.SkipInit(out array);
                 // FIXME: This could be a problem for the overloads that take an out parameter
                 // as this parameter could *potentially* move while inside of this function
                 // which would mean that the new value never gets written to the out parameter.
@@ -18267,15 +18267,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                VertexArrayHandle* arrays_handle = (VertexArrayHandle*)Unsafe.AsPointer(ref arrays);
+                VertexArrayHandle* arrays_handle = (VertexArrayHandle*)Unsafe.AsPointer(ref array);
                 CreateVertexArrays(n, arrays_handle);
-                return arrays;
+                return array;
             }
             /// <inheritdoc cref="CreateVertexArrays"/>
-            public static unsafe void CreateVertexArray(out VertexArrayHandle arrays)
+            public static unsafe void CreateVertexArray(out VertexArrayHandle array)
             {
                 int n = 1;
-                Unsafe.SkipInit(out arrays);
+                Unsafe.SkipInit(out array);
                 // FIXME: This could be a problem for the overloads that take an out parameter
                 // as this parameter could *potentially* move while inside of this function
                 // which would mean that the new value never gets written to the out parameter.
@@ -18284,7 +18284,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                VertexArrayHandle* arrays_handle = (VertexArrayHandle*)Unsafe.AsPointer(ref arrays);
+                VertexArrayHandle* arrays_handle = (VertexArrayHandle*)Unsafe.AsPointer(ref array);
                 CreateVertexArrays(n, arrays_handle);
             }
             /// <inheritdoc cref="CreateVertexArrays"/>
@@ -18356,9 +18356,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <inheritdoc cref="CreateSamplers"/>
             public static unsafe SamplerHandle CreateSampler()
             {
-                SamplerHandle samplers;
+                SamplerHandle sampler;
                 int n = 1;
-                Unsafe.SkipInit(out samplers);
+                Unsafe.SkipInit(out sampler);
                 // FIXME: This could be a problem for the overloads that take an out parameter
                 // as this parameter could *potentially* move while inside of this function
                 // which would mean that the new value never gets written to the out parameter.
@@ -18367,15 +18367,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                SamplerHandle* samplers_handle = (SamplerHandle*)Unsafe.AsPointer(ref samplers);
+                SamplerHandle* samplers_handle = (SamplerHandle*)Unsafe.AsPointer(ref sampler);
                 CreateSamplers(n, samplers_handle);
-                return samplers;
+                return sampler;
             }
             /// <inheritdoc cref="CreateSamplers"/>
-            public static unsafe void CreateSampler(out SamplerHandle samplers)
+            public static unsafe void CreateSampler(out SamplerHandle sampler)
             {
                 int n = 1;
-                Unsafe.SkipInit(out samplers);
+                Unsafe.SkipInit(out sampler);
                 // FIXME: This could be a problem for the overloads that take an out parameter
                 // as this parameter could *potentially* move while inside of this function
                 // which would mean that the new value never gets written to the out parameter.
@@ -18384,7 +18384,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                SamplerHandle* samplers_handle = (SamplerHandle*)Unsafe.AsPointer(ref samplers);
+                SamplerHandle* samplers_handle = (SamplerHandle*)Unsafe.AsPointer(ref sampler);
                 CreateSamplers(n, samplers_handle);
             }
             /// <inheritdoc cref="CreateSamplers"/>
@@ -18416,9 +18416,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <inheritdoc cref="CreateProgramPipelines"/>
             public static unsafe ProgramPipelineHandle CreateProgramPipeline()
             {
-                ProgramPipelineHandle pipelines;
+                ProgramPipelineHandle pipeline;
                 int n = 1;
-                Unsafe.SkipInit(out pipelines);
+                Unsafe.SkipInit(out pipeline);
                 // FIXME: This could be a problem for the overloads that take an out parameter
                 // as this parameter could *potentially* move while inside of this function
                 // which would mean that the new value never gets written to the out parameter.
@@ -18427,15 +18427,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                ProgramPipelineHandle* pipelines_handle = (ProgramPipelineHandle*)Unsafe.AsPointer(ref pipelines);
+                ProgramPipelineHandle* pipelines_handle = (ProgramPipelineHandle*)Unsafe.AsPointer(ref pipeline);
                 CreateProgramPipelines(n, pipelines_handle);
-                return pipelines;
+                return pipeline;
             }
             /// <inheritdoc cref="CreateProgramPipelines"/>
-            public static unsafe void CreateProgramPipeline(out ProgramPipelineHandle pipelines)
+            public static unsafe void CreateProgramPipeline(out ProgramPipelineHandle pipeline)
             {
                 int n = 1;
-                Unsafe.SkipInit(out pipelines);
+                Unsafe.SkipInit(out pipeline);
                 // FIXME: This could be a problem for the overloads that take an out parameter
                 // as this parameter could *potentially* move while inside of this function
                 // which would mean that the new value never gets written to the out parameter.
@@ -18444,7 +18444,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                ProgramPipelineHandle* pipelines_handle = (ProgramPipelineHandle*)Unsafe.AsPointer(ref pipelines);
+                ProgramPipelineHandle* pipelines_handle = (ProgramPipelineHandle*)Unsafe.AsPointer(ref pipeline);
                 CreateProgramPipelines(n, pipelines_handle);
             }
             /// <inheritdoc cref="CreateProgramPipelines"/>
@@ -18474,11 +18474,11 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="CreateQueries"/>
-            public static unsafe QueryHandle CreateQuerie(QueryTarget target)
+            public static unsafe QueryHandle CreateQuery(QueryTarget target)
             {
-                QueryHandle ids;
+                QueryHandle id;
                 int n = 1;
-                Unsafe.SkipInit(out ids);
+                Unsafe.SkipInit(out id);
                 // FIXME: This could be a problem for the overloads that take an out parameter
                 // as this parameter could *potentially* move while inside of this function
                 // which would mean that the new value never gets written to the out parameter.
@@ -18487,15 +18487,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                QueryHandle* ids_handle = (QueryHandle*)Unsafe.AsPointer(ref ids);
+                QueryHandle* ids_handle = (QueryHandle*)Unsafe.AsPointer(ref id);
                 CreateQueries(target, n, ids_handle);
-                return ids;
+                return id;
             }
             /// <inheritdoc cref="CreateQueries"/>
-            public static unsafe void CreateQuerie(QueryTarget target, out QueryHandle ids)
+            public static unsafe void CreateQuery(QueryTarget target, out QueryHandle id)
             {
                 int n = 1;
-                Unsafe.SkipInit(out ids);
+                Unsafe.SkipInit(out id);
                 // FIXME: This could be a problem for the overloads that take an out parameter
                 // as this parameter could *potentially* move while inside of this function
                 // which would mean that the new value never gets written to the out parameter.
@@ -18504,7 +18504,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                QueryHandle* ids_handle = (QueryHandle*)Unsafe.AsPointer(ref ids);
+                QueryHandle* ids_handle = (QueryHandle*)Unsafe.AsPointer(ref id);
                 CreateQueries(target, n, ids_handle);
             }
             /// <inheritdoc cref="CreateQueries"/>
@@ -19025,10 +19025,10 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="DeleteRenderbuffers"/>
-            public static unsafe void DeleteRenderbuffer(in RenderbufferHandle renderbuffers)
+            public static unsafe void DeleteRenderbuffer(in RenderbufferHandle renderbuffer)
             {
                 int n = 1;
-                fixed(RenderbufferHandle* renderbuffers_handle = &renderbuffers)
+                fixed(RenderbufferHandle* renderbuffers_handle = &renderbuffer)
                 {
                     DeleteRenderbuffers(n, renderbuffers_handle);
                 }
@@ -19062,9 +19062,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <inheritdoc cref="GenRenderbuffers"/>
             public static unsafe RenderbufferHandle GenRenderbuffer()
             {
-                RenderbufferHandle renderbuffers;
+                RenderbufferHandle renderbuffer;
                 int n = 1;
-                Unsafe.SkipInit(out renderbuffers);
+                Unsafe.SkipInit(out renderbuffer);
                 // FIXME: This could be a problem for the overloads that take an out parameter
                 // as this parameter could *potentially* move while inside of this function
                 // which would mean that the new value never gets written to the out parameter.
@@ -19073,15 +19073,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                RenderbufferHandle* renderbuffers_handle = (RenderbufferHandle*)Unsafe.AsPointer(ref renderbuffers);
+                RenderbufferHandle* renderbuffers_handle = (RenderbufferHandle*)Unsafe.AsPointer(ref renderbuffer);
                 GenRenderbuffers(n, renderbuffers_handle);
-                return renderbuffers;
+                return renderbuffer;
             }
             /// <inheritdoc cref="GenRenderbuffers"/>
-            public static unsafe void GenRenderbuffer(out RenderbufferHandle renderbuffers)
+            public static unsafe void GenRenderbuffer(out RenderbufferHandle renderbuffer)
             {
                 int n = 1;
-                Unsafe.SkipInit(out renderbuffers);
+                Unsafe.SkipInit(out renderbuffer);
                 // FIXME: This could be a problem for the overloads that take an out parameter
                 // as this parameter could *potentially* move while inside of this function
                 // which would mean that the new value never gets written to the out parameter.
@@ -19090,7 +19090,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                RenderbufferHandle* renderbuffers_handle = (RenderbufferHandle*)Unsafe.AsPointer(ref renderbuffers);
+                RenderbufferHandle* renderbuffers_handle = (RenderbufferHandle*)Unsafe.AsPointer(ref renderbuffer);
                 GenRenderbuffers(n, renderbuffers_handle);
             }
             /// <inheritdoc cref="GenRenderbuffers"/>
@@ -19144,10 +19144,10 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="DeleteFramebuffers"/>
-            public static unsafe void DeleteFramebuffer(in FramebufferHandle framebuffers)
+            public static unsafe void DeleteFramebuffer(in FramebufferHandle framebuffer)
             {
                 int n = 1;
-                fixed(FramebufferHandle* framebuffers_handle = &framebuffers)
+                fixed(FramebufferHandle* framebuffers_handle = &framebuffer)
                 {
                     DeleteFramebuffers(n, framebuffers_handle);
                 }
@@ -19181,9 +19181,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <inheritdoc cref="GenFramebuffers"/>
             public static unsafe FramebufferHandle GenFramebuffer()
             {
-                FramebufferHandle framebuffers;
+                FramebufferHandle framebuffer;
                 int n = 1;
-                Unsafe.SkipInit(out framebuffers);
+                Unsafe.SkipInit(out framebuffer);
                 // FIXME: This could be a problem for the overloads that take an out parameter
                 // as this parameter could *potentially* move while inside of this function
                 // which would mean that the new value never gets written to the out parameter.
@@ -19192,15 +19192,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                FramebufferHandle* framebuffers_handle = (FramebufferHandle*)Unsafe.AsPointer(ref framebuffers);
+                FramebufferHandle* framebuffers_handle = (FramebufferHandle*)Unsafe.AsPointer(ref framebuffer);
                 GenFramebuffers(n, framebuffers_handle);
-                return framebuffers;
+                return framebuffer;
             }
             /// <inheritdoc cref="GenFramebuffers"/>
-            public static unsafe void GenFramebuffer(out FramebufferHandle framebuffers)
+            public static unsafe void GenFramebuffer(out FramebufferHandle framebuffer)
             {
                 int n = 1;
-                Unsafe.SkipInit(out framebuffers);
+                Unsafe.SkipInit(out framebuffer);
                 // FIXME: This could be a problem for the overloads that take an out parameter
                 // as this parameter could *potentially* move while inside of this function
                 // which would mean that the new value never gets written to the out parameter.
@@ -19209,7 +19209,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                FramebufferHandle* framebuffers_handle = (FramebufferHandle*)Unsafe.AsPointer(ref framebuffers);
+                FramebufferHandle* framebuffers_handle = (FramebufferHandle*)Unsafe.AsPointer(ref framebuffer);
                 GenFramebuffers(n, framebuffers_handle);
             }
             /// <inheritdoc cref="GenFramebuffers"/>
@@ -22828,9 +22828,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <inheritdoc cref="GenSamplers"/>
             public static unsafe SamplerHandle GenSampler()
             {
-                SamplerHandle samplers;
+                SamplerHandle sampler;
                 int count = 1;
-                Unsafe.SkipInit(out samplers);
+                Unsafe.SkipInit(out sampler);
                 // FIXME: This could be a problem for the overloads that take an out parameter
                 // as this parameter could *potentially* move while inside of this function
                 // which would mean that the new value never gets written to the out parameter.
@@ -22839,15 +22839,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                SamplerHandle* samplers_handle = (SamplerHandle*)Unsafe.AsPointer(ref samplers);
+                SamplerHandle* samplers_handle = (SamplerHandle*)Unsafe.AsPointer(ref sampler);
                 GenSamplers(count, samplers_handle);
-                return samplers;
+                return sampler;
             }
             /// <inheritdoc cref="GenSamplers"/>
-            public static unsafe void GenSampler(out SamplerHandle samplers)
+            public static unsafe void GenSampler(out SamplerHandle sampler)
             {
                 int count = 1;
-                Unsafe.SkipInit(out samplers);
+                Unsafe.SkipInit(out sampler);
                 // FIXME: This could be a problem for the overloads that take an out parameter
                 // as this parameter could *potentially* move while inside of this function
                 // which would mean that the new value never gets written to the out parameter.
@@ -22856,7 +22856,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                SamplerHandle* samplers_handle = (SamplerHandle*)Unsafe.AsPointer(ref samplers);
+                SamplerHandle* samplers_handle = (SamplerHandle*)Unsafe.AsPointer(ref sampler);
                 GenSamplers(count, samplers_handle);
             }
             /// <inheritdoc cref="GenSamplers"/>
@@ -22886,10 +22886,10 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="DeleteSamplers"/>
-            public static unsafe void DeleteSampler(in SamplerHandle samplers)
+            public static unsafe void DeleteSampler(in SamplerHandle sampler)
             {
                 int count = 1;
-                fixed(SamplerHandle* samplers_handle = &samplers)
+                fixed(SamplerHandle* samplers_handle = &sampler)
                 {
                     DeleteSamplers(count, samplers_handle);
                 }
@@ -23120,10 +23120,10 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return returnValue;
             }
             /// <inheritdoc cref="DeleteProgramPipelines"/>
-            public static unsafe void DeleteProgramPipeline(in ProgramPipelineHandle pipelines)
+            public static unsafe void DeleteProgramPipeline(in ProgramPipelineHandle pipeline)
             {
                 int n = 1;
-                fixed(ProgramPipelineHandle* pipelines_handle = &pipelines)
+                fixed(ProgramPipelineHandle* pipelines_handle = &pipeline)
                 {
                     DeleteProgramPipelines(n, pipelines_handle);
                 }
@@ -23157,9 +23157,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <inheritdoc cref="GenProgramPipelines"/>
             public static unsafe ProgramPipelineHandle GenProgramPipeline()
             {
-                ProgramPipelineHandle pipelines;
+                ProgramPipelineHandle pipeline;
                 int n = 1;
-                Unsafe.SkipInit(out pipelines);
+                Unsafe.SkipInit(out pipeline);
                 // FIXME: This could be a problem for the overloads that take an out parameter
                 // as this parameter could *potentially* move while inside of this function
                 // which would mean that the new value never gets written to the out parameter.
@@ -23168,15 +23168,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                ProgramPipelineHandle* pipelines_handle = (ProgramPipelineHandle*)Unsafe.AsPointer(ref pipelines);
+                ProgramPipelineHandle* pipelines_handle = (ProgramPipelineHandle*)Unsafe.AsPointer(ref pipeline);
                 GenProgramPipelines(n, pipelines_handle);
-                return pipelines;
+                return pipeline;
             }
             /// <inheritdoc cref="GenProgramPipelines"/>
-            public static unsafe void GenProgramPipeline(out ProgramPipelineHandle pipelines)
+            public static unsafe void GenProgramPipeline(out ProgramPipelineHandle pipeline)
             {
                 int n = 1;
-                Unsafe.SkipInit(out pipelines);
+                Unsafe.SkipInit(out pipeline);
                 // FIXME: This could be a problem for the overloads that take an out parameter
                 // as this parameter could *potentially* move while inside of this function
                 // which would mean that the new value never gets written to the out parameter.
@@ -23185,7 +23185,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                ProgramPipelineHandle* pipelines_handle = (ProgramPipelineHandle*)Unsafe.AsPointer(ref pipelines);
+                ProgramPipelineHandle* pipelines_handle = (ProgramPipelineHandle*)Unsafe.AsPointer(ref pipeline);
                 GenProgramPipelines(n, pipelines_handle);
             }
             /// <inheritdoc cref="GenProgramPipelines"/>
@@ -25901,10 +25901,10 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="DeleteTransformFeedbacks"/>
-            public static unsafe void DeleteTransformFeedback(in TransformFeedbackHandle ids)
+            public static unsafe void DeleteTransformFeedback(in TransformFeedbackHandle id)
             {
                 int n = 1;
-                fixed(TransformFeedbackHandle* ids_handle = &ids)
+                fixed(TransformFeedbackHandle* ids_handle = &id)
                 {
                     DeleteTransformFeedbacks(n, ids_handle);
                 }
@@ -25938,9 +25938,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <inheritdoc cref="GenTransformFeedbacks"/>
             public static unsafe TransformFeedbackHandle GenTransformFeedback()
             {
-                TransformFeedbackHandle ids;
+                TransformFeedbackHandle id;
                 int n = 1;
-                Unsafe.SkipInit(out ids);
+                Unsafe.SkipInit(out id);
                 // FIXME: This could be a problem for the overloads that take an out parameter
                 // as this parameter could *potentially* move while inside of this function
                 // which would mean that the new value never gets written to the out parameter.
@@ -25949,15 +25949,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                TransformFeedbackHandle* ids_handle = (TransformFeedbackHandle*)Unsafe.AsPointer(ref ids);
+                TransformFeedbackHandle* ids_handle = (TransformFeedbackHandle*)Unsafe.AsPointer(ref id);
                 GenTransformFeedbacks(n, ids_handle);
-                return ids;
+                return id;
             }
             /// <inheritdoc cref="GenTransformFeedbacks"/>
-            public static unsafe void GenTransformFeedback(out TransformFeedbackHandle ids)
+            public static unsafe void GenTransformFeedback(out TransformFeedbackHandle id)
             {
                 int n = 1;
-                Unsafe.SkipInit(out ids);
+                Unsafe.SkipInit(out id);
                 // FIXME: This could be a problem for the overloads that take an out parameter
                 // as this parameter could *potentially* move while inside of this function
                 // which would mean that the new value never gets written to the out parameter.
@@ -25966,7 +25966,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                TransformFeedbackHandle* ids_handle = (TransformFeedbackHandle*)Unsafe.AsPointer(ref ids);
+                TransformFeedbackHandle* ids_handle = (TransformFeedbackHandle*)Unsafe.AsPointer(ref id);
                 GenTransformFeedbacks(n, ids_handle);
             }
             /// <inheritdoc cref="GenTransformFeedbacks"/>
@@ -26374,10 +26374,10 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="DeleteVertexArrays"/>
-            public static unsafe void DeleteVertexArray(in VertexArrayHandle arrays)
+            public static unsafe void DeleteVertexArray(in VertexArrayHandle array)
             {
                 int n = 1;
-                fixed(VertexArrayHandle* arrays_handle = &arrays)
+                fixed(VertexArrayHandle* arrays_handle = &array)
                 {
                     DeleteVertexArrays(n, arrays_handle);
                 }
@@ -26411,9 +26411,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <inheritdoc cref="GenVertexArrays"/>
             public static unsafe VertexArrayHandle GenVertexArray()
             {
-                VertexArrayHandle arrays;
+                VertexArrayHandle array;
                 int n = 1;
-                Unsafe.SkipInit(out arrays);
+                Unsafe.SkipInit(out array);
                 // FIXME: This could be a problem for the overloads that take an out parameter
                 // as this parameter could *potentially* move while inside of this function
                 // which would mean that the new value never gets written to the out parameter.
@@ -26422,15 +26422,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                VertexArrayHandle* arrays_handle = (VertexArrayHandle*)Unsafe.AsPointer(ref arrays);
+                VertexArrayHandle* arrays_handle = (VertexArrayHandle*)Unsafe.AsPointer(ref array);
                 GenVertexArrays(n, arrays_handle);
-                return arrays;
+                return array;
             }
             /// <inheritdoc cref="GenVertexArrays"/>
-            public static unsafe void GenVertexArray(out VertexArrayHandle arrays)
+            public static unsafe void GenVertexArray(out VertexArrayHandle array)
             {
                 int n = 1;
-                Unsafe.SkipInit(out arrays);
+                Unsafe.SkipInit(out array);
                 // FIXME: This could be a problem for the overloads that take an out parameter
                 // as this parameter could *potentially* move while inside of this function
                 // which would mean that the new value never gets written to the out parameter.
@@ -26439,7 +26439,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                VertexArrayHandle* arrays_handle = (VertexArrayHandle*)Unsafe.AsPointer(ref arrays);
+                VertexArrayHandle* arrays_handle = (VertexArrayHandle*)Unsafe.AsPointer(ref array);
                 GenVertexArrays(n, arrays_handle);
             }
             /// <inheritdoc cref="GenVertexArrays"/>

--- a/src/OpenTK.Graphics/OpenGL/GL.Overloads.cs
+++ b/src/OpenTK.Graphics/OpenGL/GL.Overloads.cs
@@ -478,10 +478,10 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="DeleteTextures"/>
-        public static unsafe void DeleteTexture(in TextureHandle textures)
+        public static unsafe void DeleteTexture(in TextureHandle texture)
         {
             int n = 1;
-            fixed(TextureHandle* textures_handle = &textures)
+            fixed(TextureHandle* textures_handle = &texture)
             {
                 DeleteTextures(n, textures_handle);
             }
@@ -515,9 +515,9 @@ namespace OpenTK.Graphics.OpenGL
         /// <inheritdoc cref="GenTextures"/>
         public static unsafe TextureHandle GenTexture()
         {
-            TextureHandle textures;
+            TextureHandle texture;
             int n = 1;
-            Unsafe.SkipInit(out textures);
+            Unsafe.SkipInit(out texture);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -526,15 +526,15 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            TextureHandle* textures_handle = (TextureHandle*)Unsafe.AsPointer(ref textures);
+            TextureHandle* textures_handle = (TextureHandle*)Unsafe.AsPointer(ref texture);
             GenTextures(n, textures_handle);
-            return textures;
+            return texture;
         }
         /// <inheritdoc cref="GenTextures"/>
-        public static unsafe void GenTexture(out TextureHandle textures)
+        public static unsafe void GenTexture(out TextureHandle texture)
         {
             int n = 1;
-            Unsafe.SkipInit(out textures);
+            Unsafe.SkipInit(out texture);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -543,7 +543,7 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            TextureHandle* textures_handle = (TextureHandle*)Unsafe.AsPointer(ref textures);
+            TextureHandle* textures_handle = (TextureHandle*)Unsafe.AsPointer(ref texture);
             GenTextures(n, textures_handle);
         }
         /// <inheritdoc cref="GenTextures"/>
@@ -997,11 +997,11 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GenQueries"/>
-        public static unsafe QueryHandle GenQuerie()
+        public static unsafe QueryHandle GenQuery()
         {
-            QueryHandle ids;
+            QueryHandle id;
             int n = 1;
-            Unsafe.SkipInit(out ids);
+            Unsafe.SkipInit(out id);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -1010,15 +1010,15 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            QueryHandle* ids_handle = (QueryHandle*)Unsafe.AsPointer(ref ids);
+            QueryHandle* ids_handle = (QueryHandle*)Unsafe.AsPointer(ref id);
             GenQueries(n, ids_handle);
-            return ids;
+            return id;
         }
         /// <inheritdoc cref="GenQueries"/>
-        public static unsafe void GenQuerie(out QueryHandle ids)
+        public static unsafe void GenQuery(out QueryHandle id)
         {
             int n = 1;
-            Unsafe.SkipInit(out ids);
+            Unsafe.SkipInit(out id);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -1027,7 +1027,7 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            QueryHandle* ids_handle = (QueryHandle*)Unsafe.AsPointer(ref ids);
+            QueryHandle* ids_handle = (QueryHandle*)Unsafe.AsPointer(ref id);
             GenQueries(n, ids_handle);
         }
         /// <inheritdoc cref="GenQueries"/>
@@ -1057,10 +1057,10 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="DeleteQueries"/>
-        public static unsafe void DeleteQuerie(in QueryHandle ids)
+        public static unsafe void DeleteQuery(in QueryHandle id)
         {
             int n = 1;
-            fixed(QueryHandle* ids_handle = &ids)
+            fixed(QueryHandle* ids_handle = &id)
             {
                 DeleteQueries(n, ids_handle);
             }
@@ -1164,10 +1164,10 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="DeleteBuffers"/>
-        public static unsafe void DeleteBuffer(in BufferHandle buffers)
+        public static unsafe void DeleteBuffer(in BufferHandle buffer)
         {
             int n = 1;
-            fixed(BufferHandle* buffers_handle = &buffers)
+            fixed(BufferHandle* buffers_handle = &buffer)
             {
                 DeleteBuffers(n, buffers_handle);
             }
@@ -1201,9 +1201,9 @@ namespace OpenTK.Graphics.OpenGL
         /// <inheritdoc cref="GenBuffers"/>
         public static unsafe BufferHandle GenBuffer()
         {
-            BufferHandle buffers;
+            BufferHandle buffer;
             int n = 1;
-            Unsafe.SkipInit(out buffers);
+            Unsafe.SkipInit(out buffer);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -1212,15 +1212,15 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            BufferHandle* buffers_handle = (BufferHandle*)Unsafe.AsPointer(ref buffers);
+            BufferHandle* buffers_handle = (BufferHandle*)Unsafe.AsPointer(ref buffer);
             GenBuffers(n, buffers_handle);
-            return buffers;
+            return buffer;
         }
         /// <inheritdoc cref="GenBuffers"/>
-        public static unsafe void GenBuffer(out BufferHandle buffers)
+        public static unsafe void GenBuffer(out BufferHandle buffer)
         {
             int n = 1;
-            Unsafe.SkipInit(out buffers);
+            Unsafe.SkipInit(out buffer);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -1229,7 +1229,7 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            BufferHandle* buffers_handle = (BufferHandle*)Unsafe.AsPointer(ref buffers);
+            BufferHandle* buffers_handle = (BufferHandle*)Unsafe.AsPointer(ref buffer);
             GenBuffers(n, buffers_handle);
         }
         /// <inheritdoc cref="GenBuffers"/>
@@ -4002,10 +4002,10 @@ namespace OpenTK.Graphics.OpenGL
             return returnValue_str;
         }
         /// <inheritdoc cref="DeleteRenderbuffers"/>
-        public static unsafe void DeleteRenderbuffer(in RenderbufferHandle renderbuffers)
+        public static unsafe void DeleteRenderbuffer(in RenderbufferHandle renderbuffer)
         {
             int n = 1;
-            fixed(RenderbufferHandle* renderbuffers_handle = &renderbuffers)
+            fixed(RenderbufferHandle* renderbuffers_handle = &renderbuffer)
             {
                 DeleteRenderbuffers(n, renderbuffers_handle);
             }
@@ -4039,9 +4039,9 @@ namespace OpenTK.Graphics.OpenGL
         /// <inheritdoc cref="GenRenderbuffers"/>
         public static unsafe RenderbufferHandle GenRenderbuffer()
         {
-            RenderbufferHandle renderbuffers;
+            RenderbufferHandle renderbuffer;
             int n = 1;
-            Unsafe.SkipInit(out renderbuffers);
+            Unsafe.SkipInit(out renderbuffer);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -4050,15 +4050,15 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            RenderbufferHandle* renderbuffers_handle = (RenderbufferHandle*)Unsafe.AsPointer(ref renderbuffers);
+            RenderbufferHandle* renderbuffers_handle = (RenderbufferHandle*)Unsafe.AsPointer(ref renderbuffer);
             GenRenderbuffers(n, renderbuffers_handle);
-            return renderbuffers;
+            return renderbuffer;
         }
         /// <inheritdoc cref="GenRenderbuffers"/>
-        public static unsafe void GenRenderbuffer(out RenderbufferHandle renderbuffers)
+        public static unsafe void GenRenderbuffer(out RenderbufferHandle renderbuffer)
         {
             int n = 1;
-            Unsafe.SkipInit(out renderbuffers);
+            Unsafe.SkipInit(out renderbuffer);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -4067,7 +4067,7 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            RenderbufferHandle* renderbuffers_handle = (RenderbufferHandle*)Unsafe.AsPointer(ref renderbuffers);
+            RenderbufferHandle* renderbuffers_handle = (RenderbufferHandle*)Unsafe.AsPointer(ref renderbuffer);
             GenRenderbuffers(n, renderbuffers_handle);
         }
         /// <inheritdoc cref="GenRenderbuffers"/>
@@ -4121,10 +4121,10 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="DeleteFramebuffers"/>
-        public static unsafe void DeleteFramebuffer(in FramebufferHandle framebuffers)
+        public static unsafe void DeleteFramebuffer(in FramebufferHandle framebuffer)
         {
             int n = 1;
-            fixed(FramebufferHandle* framebuffers_handle = &framebuffers)
+            fixed(FramebufferHandle* framebuffers_handle = &framebuffer)
             {
                 DeleteFramebuffers(n, framebuffers_handle);
             }
@@ -4158,9 +4158,9 @@ namespace OpenTK.Graphics.OpenGL
         /// <inheritdoc cref="GenFramebuffers"/>
         public static unsafe FramebufferHandle GenFramebuffer()
         {
-            FramebufferHandle framebuffers;
+            FramebufferHandle framebuffer;
             int n = 1;
-            Unsafe.SkipInit(out framebuffers);
+            Unsafe.SkipInit(out framebuffer);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -4169,15 +4169,15 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            FramebufferHandle* framebuffers_handle = (FramebufferHandle*)Unsafe.AsPointer(ref framebuffers);
+            FramebufferHandle* framebuffers_handle = (FramebufferHandle*)Unsafe.AsPointer(ref framebuffer);
             GenFramebuffers(n, framebuffers_handle);
-            return framebuffers;
+            return framebuffer;
         }
         /// <inheritdoc cref="GenFramebuffers"/>
-        public static unsafe void GenFramebuffer(out FramebufferHandle framebuffers)
+        public static unsafe void GenFramebuffer(out FramebufferHandle framebuffer)
         {
             int n = 1;
-            Unsafe.SkipInit(out framebuffers);
+            Unsafe.SkipInit(out framebuffer);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -4186,7 +4186,7 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            FramebufferHandle* framebuffers_handle = (FramebufferHandle*)Unsafe.AsPointer(ref framebuffers);
+            FramebufferHandle* framebuffers_handle = (FramebufferHandle*)Unsafe.AsPointer(ref framebuffer);
             GenFramebuffers(n, framebuffers_handle);
         }
         /// <inheritdoc cref="GenFramebuffers"/>
@@ -4240,10 +4240,10 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="DeleteVertexArrays"/>
-        public static unsafe void DeleteVertexArray(in VertexArrayHandle arrays)
+        public static unsafe void DeleteVertexArray(in VertexArrayHandle array)
         {
             int n = 1;
-            fixed(VertexArrayHandle* arrays_handle = &arrays)
+            fixed(VertexArrayHandle* arrays_handle = &array)
             {
                 DeleteVertexArrays(n, arrays_handle);
             }
@@ -4277,9 +4277,9 @@ namespace OpenTK.Graphics.OpenGL
         /// <inheritdoc cref="GenVertexArrays"/>
         public static unsafe VertexArrayHandle GenVertexArray()
         {
-            VertexArrayHandle arrays;
+            VertexArrayHandle array;
             int n = 1;
-            Unsafe.SkipInit(out arrays);
+            Unsafe.SkipInit(out array);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -4288,15 +4288,15 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            VertexArrayHandle* arrays_handle = (VertexArrayHandle*)Unsafe.AsPointer(ref arrays);
+            VertexArrayHandle* arrays_handle = (VertexArrayHandle*)Unsafe.AsPointer(ref array);
             GenVertexArrays(n, arrays_handle);
-            return arrays;
+            return array;
         }
         /// <inheritdoc cref="GenVertexArrays"/>
-        public static unsafe void GenVertexArray(out VertexArrayHandle arrays)
+        public static unsafe void GenVertexArray(out VertexArrayHandle array)
         {
             int n = 1;
-            Unsafe.SkipInit(out arrays);
+            Unsafe.SkipInit(out array);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -4305,7 +4305,7 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            VertexArrayHandle* arrays_handle = (VertexArrayHandle*)Unsafe.AsPointer(ref arrays);
+            VertexArrayHandle* arrays_handle = (VertexArrayHandle*)Unsafe.AsPointer(ref array);
             GenVertexArrays(n, arrays_handle);
         }
         /// <inheritdoc cref="GenVertexArrays"/>
@@ -4783,9 +4783,9 @@ namespace OpenTK.Graphics.OpenGL
         /// <inheritdoc cref="GenSamplers"/>
         public static unsafe SamplerHandle GenSampler()
         {
-            SamplerHandle samplers;
+            SamplerHandle sampler;
             int count = 1;
-            Unsafe.SkipInit(out samplers);
+            Unsafe.SkipInit(out sampler);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -4794,15 +4794,15 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            SamplerHandle* samplers_handle = (SamplerHandle*)Unsafe.AsPointer(ref samplers);
+            SamplerHandle* samplers_handle = (SamplerHandle*)Unsafe.AsPointer(ref sampler);
             GenSamplers(count, samplers_handle);
-            return samplers;
+            return sampler;
         }
         /// <inheritdoc cref="GenSamplers"/>
-        public static unsafe void GenSampler(out SamplerHandle samplers)
+        public static unsafe void GenSampler(out SamplerHandle sampler)
         {
             int count = 1;
-            Unsafe.SkipInit(out samplers);
+            Unsafe.SkipInit(out sampler);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -4811,7 +4811,7 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            SamplerHandle* samplers_handle = (SamplerHandle*)Unsafe.AsPointer(ref samplers);
+            SamplerHandle* samplers_handle = (SamplerHandle*)Unsafe.AsPointer(ref sampler);
             GenSamplers(count, samplers_handle);
         }
         /// <inheritdoc cref="GenSamplers"/>
@@ -4841,10 +4841,10 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="DeleteSamplers"/>
-        public static unsafe void DeleteSampler(in SamplerHandle samplers)
+        public static unsafe void DeleteSampler(in SamplerHandle sampler)
         {
             int count = 1;
-            fixed(SamplerHandle* samplers_handle = &samplers)
+            fixed(SamplerHandle* samplers_handle = &sampler)
             {
                 DeleteSamplers(count, samplers_handle);
             }
@@ -5977,10 +5977,10 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="DeleteTransformFeedbacks"/>
-        public static unsafe void DeleteTransformFeedback(in TransformFeedbackHandle ids)
+        public static unsafe void DeleteTransformFeedback(in TransformFeedbackHandle id)
         {
             int n = 1;
-            fixed(TransformFeedbackHandle* ids_handle = &ids)
+            fixed(TransformFeedbackHandle* ids_handle = &id)
             {
                 DeleteTransformFeedbacks(n, ids_handle);
             }
@@ -6014,9 +6014,9 @@ namespace OpenTK.Graphics.OpenGL
         /// <inheritdoc cref="GenTransformFeedbacks"/>
         public static unsafe TransformFeedbackHandle GenTransformFeedback()
         {
-            TransformFeedbackHandle ids;
+            TransformFeedbackHandle id;
             int n = 1;
-            Unsafe.SkipInit(out ids);
+            Unsafe.SkipInit(out id);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -6025,15 +6025,15 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            TransformFeedbackHandle* ids_handle = (TransformFeedbackHandle*)Unsafe.AsPointer(ref ids);
+            TransformFeedbackHandle* ids_handle = (TransformFeedbackHandle*)Unsafe.AsPointer(ref id);
             GenTransformFeedbacks(n, ids_handle);
-            return ids;
+            return id;
         }
         /// <inheritdoc cref="GenTransformFeedbacks"/>
-        public static unsafe void GenTransformFeedback(out TransformFeedbackHandle ids)
+        public static unsafe void GenTransformFeedback(out TransformFeedbackHandle id)
         {
             int n = 1;
-            Unsafe.SkipInit(out ids);
+            Unsafe.SkipInit(out id);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -6042,7 +6042,7 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            TransformFeedbackHandle* ids_handle = (TransformFeedbackHandle*)Unsafe.AsPointer(ref ids);
+            TransformFeedbackHandle* ids_handle = (TransformFeedbackHandle*)Unsafe.AsPointer(ref id);
             GenTransformFeedbacks(n, ids_handle);
         }
         /// <inheritdoc cref="GenTransformFeedbacks"/>
@@ -6313,10 +6313,10 @@ namespace OpenTK.Graphics.OpenGL
             return returnValue;
         }
         /// <inheritdoc cref="DeleteProgramPipelines"/>
-        public static unsafe void DeleteProgramPipeline(in ProgramPipelineHandle pipelines)
+        public static unsafe void DeleteProgramPipeline(in ProgramPipelineHandle pipeline)
         {
             int n = 1;
-            fixed(ProgramPipelineHandle* pipelines_handle = &pipelines)
+            fixed(ProgramPipelineHandle* pipelines_handle = &pipeline)
             {
                 DeleteProgramPipelines(n, pipelines_handle);
             }
@@ -6350,9 +6350,9 @@ namespace OpenTK.Graphics.OpenGL
         /// <inheritdoc cref="GenProgramPipelines"/>
         public static unsafe ProgramPipelineHandle GenProgramPipeline()
         {
-            ProgramPipelineHandle pipelines;
+            ProgramPipelineHandle pipeline;
             int n = 1;
-            Unsafe.SkipInit(out pipelines);
+            Unsafe.SkipInit(out pipeline);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -6361,15 +6361,15 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            ProgramPipelineHandle* pipelines_handle = (ProgramPipelineHandle*)Unsafe.AsPointer(ref pipelines);
+            ProgramPipelineHandle* pipelines_handle = (ProgramPipelineHandle*)Unsafe.AsPointer(ref pipeline);
             GenProgramPipelines(n, pipelines_handle);
-            return pipelines;
+            return pipeline;
         }
         /// <inheritdoc cref="GenProgramPipelines"/>
-        public static unsafe void GenProgramPipeline(out ProgramPipelineHandle pipelines)
+        public static unsafe void GenProgramPipeline(out ProgramPipelineHandle pipeline)
         {
             int n = 1;
-            Unsafe.SkipInit(out pipelines);
+            Unsafe.SkipInit(out pipeline);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -6378,7 +6378,7 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            ProgramPipelineHandle* pipelines_handle = (ProgramPipelineHandle*)Unsafe.AsPointer(ref pipelines);
+            ProgramPipelineHandle* pipelines_handle = (ProgramPipelineHandle*)Unsafe.AsPointer(ref pipeline);
             GenProgramPipelines(n, pipelines_handle);
         }
         /// <inheritdoc cref="GenProgramPipelines"/>
@@ -8953,9 +8953,9 @@ namespace OpenTK.Graphics.OpenGL
         /// <inheritdoc cref="CreateTransformFeedbacks"/>
         public static unsafe TransformFeedbackHandle CreateTransformFeedback()
         {
-            TransformFeedbackHandle ids;
+            TransformFeedbackHandle id;
             int n = 1;
-            Unsafe.SkipInit(out ids);
+            Unsafe.SkipInit(out id);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -8964,15 +8964,15 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            TransformFeedbackHandle* ids_handle = (TransformFeedbackHandle*)Unsafe.AsPointer(ref ids);
+            TransformFeedbackHandle* ids_handle = (TransformFeedbackHandle*)Unsafe.AsPointer(ref id);
             CreateTransformFeedbacks(n, ids_handle);
-            return ids;
+            return id;
         }
         /// <inheritdoc cref="CreateTransformFeedbacks"/>
-        public static unsafe void CreateTransformFeedback(out TransformFeedbackHandle ids)
+        public static unsafe void CreateTransformFeedback(out TransformFeedbackHandle id)
         {
             int n = 1;
-            Unsafe.SkipInit(out ids);
+            Unsafe.SkipInit(out id);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -8981,7 +8981,7 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            TransformFeedbackHandle* ids_handle = (TransformFeedbackHandle*)Unsafe.AsPointer(ref ids);
+            TransformFeedbackHandle* ids_handle = (TransformFeedbackHandle*)Unsafe.AsPointer(ref id);
             CreateTransformFeedbacks(n, ids_handle);
         }
         /// <inheritdoc cref="CreateTransformFeedbacks"/>
@@ -9037,9 +9037,9 @@ namespace OpenTK.Graphics.OpenGL
         /// <inheritdoc cref="CreateBuffers"/>
         public static unsafe BufferHandle CreateBuffer()
         {
-            BufferHandle buffers;
+            BufferHandle buffer;
             int n = 1;
-            Unsafe.SkipInit(out buffers);
+            Unsafe.SkipInit(out buffer);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -9048,15 +9048,15 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            BufferHandle* buffers_handle = (BufferHandle*)Unsafe.AsPointer(ref buffers);
+            BufferHandle* buffers_handle = (BufferHandle*)Unsafe.AsPointer(ref buffer);
             CreateBuffers(n, buffers_handle);
-            return buffers;
+            return buffer;
         }
         /// <inheritdoc cref="CreateBuffers"/>
-        public static unsafe void CreateBuffer(out BufferHandle buffers)
+        public static unsafe void CreateBuffer(out BufferHandle buffer)
         {
             int n = 1;
-            Unsafe.SkipInit(out buffers);
+            Unsafe.SkipInit(out buffer);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -9065,7 +9065,7 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            BufferHandle* buffers_handle = (BufferHandle*)Unsafe.AsPointer(ref buffers);
+            BufferHandle* buffers_handle = (BufferHandle*)Unsafe.AsPointer(ref buffer);
             CreateBuffers(n, buffers_handle);
         }
         /// <inheritdoc cref="CreateBuffers"/>
@@ -9246,9 +9246,9 @@ namespace OpenTK.Graphics.OpenGL
         /// <inheritdoc cref="CreateFramebuffers"/>
         public static unsafe FramebufferHandle CreateFramebuffer()
         {
-            FramebufferHandle framebuffers;
+            FramebufferHandle framebuffer;
             int n = 1;
-            Unsafe.SkipInit(out framebuffers);
+            Unsafe.SkipInit(out framebuffer);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -9257,15 +9257,15 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            FramebufferHandle* framebuffers_handle = (FramebufferHandle*)Unsafe.AsPointer(ref framebuffers);
+            FramebufferHandle* framebuffers_handle = (FramebufferHandle*)Unsafe.AsPointer(ref framebuffer);
             CreateFramebuffers(n, framebuffers_handle);
-            return framebuffers;
+            return framebuffer;
         }
         /// <inheritdoc cref="CreateFramebuffers"/>
-        public static unsafe void CreateFramebuffer(out FramebufferHandle framebuffers)
+        public static unsafe void CreateFramebuffer(out FramebufferHandle framebuffer)
         {
             int n = 1;
-            Unsafe.SkipInit(out framebuffers);
+            Unsafe.SkipInit(out framebuffer);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -9274,7 +9274,7 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            FramebufferHandle* framebuffers_handle = (FramebufferHandle*)Unsafe.AsPointer(ref framebuffers);
+            FramebufferHandle* framebuffers_handle = (FramebufferHandle*)Unsafe.AsPointer(ref framebuffer);
             CreateFramebuffers(n, framebuffers_handle);
         }
         /// <inheritdoc cref="CreateFramebuffers"/>
@@ -9375,9 +9375,9 @@ namespace OpenTK.Graphics.OpenGL
         /// <inheritdoc cref="CreateRenderbuffers"/>
         public static unsafe RenderbufferHandle CreateRenderbuffer()
         {
-            RenderbufferHandle renderbuffers;
+            RenderbufferHandle renderbuffer;
             int n = 1;
-            Unsafe.SkipInit(out renderbuffers);
+            Unsafe.SkipInit(out renderbuffer);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -9386,15 +9386,15 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            RenderbufferHandle* renderbuffers_handle = (RenderbufferHandle*)Unsafe.AsPointer(ref renderbuffers);
+            RenderbufferHandle* renderbuffers_handle = (RenderbufferHandle*)Unsafe.AsPointer(ref renderbuffer);
             CreateRenderbuffers(n, renderbuffers_handle);
-            return renderbuffers;
+            return renderbuffer;
         }
         /// <inheritdoc cref="CreateRenderbuffers"/>
-        public static unsafe void CreateRenderbuffer(out RenderbufferHandle renderbuffers)
+        public static unsafe void CreateRenderbuffer(out RenderbufferHandle renderbuffer)
         {
             int n = 1;
-            Unsafe.SkipInit(out renderbuffers);
+            Unsafe.SkipInit(out renderbuffer);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -9403,7 +9403,7 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            RenderbufferHandle* renderbuffers_handle = (RenderbufferHandle*)Unsafe.AsPointer(ref renderbuffers);
+            RenderbufferHandle* renderbuffers_handle = (RenderbufferHandle*)Unsafe.AsPointer(ref renderbuffer);
             CreateRenderbuffers(n, renderbuffers_handle);
         }
         /// <inheritdoc cref="CreateRenderbuffers"/>
@@ -9443,9 +9443,9 @@ namespace OpenTK.Graphics.OpenGL
         /// <inheritdoc cref="CreateTextures"/>
         public static unsafe TextureHandle CreateTexture(TextureTarget target)
         {
-            TextureHandle textures;
+            TextureHandle texture;
             int n = 1;
-            Unsafe.SkipInit(out textures);
+            Unsafe.SkipInit(out texture);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -9454,15 +9454,15 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            TextureHandle* textures_handle = (TextureHandle*)Unsafe.AsPointer(ref textures);
+            TextureHandle* textures_handle = (TextureHandle*)Unsafe.AsPointer(ref texture);
             CreateTextures(target, n, textures_handle);
-            return textures;
+            return texture;
         }
         /// <inheritdoc cref="CreateTextures"/>
-        public static unsafe void CreateTexture(TextureTarget target, out TextureHandle textures)
+        public static unsafe void CreateTexture(TextureTarget target, out TextureHandle texture)
         {
             int n = 1;
-            Unsafe.SkipInit(out textures);
+            Unsafe.SkipInit(out texture);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -9471,7 +9471,7 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            TextureHandle* textures_handle = (TextureHandle*)Unsafe.AsPointer(ref textures);
+            TextureHandle* textures_handle = (TextureHandle*)Unsafe.AsPointer(ref texture);
             CreateTextures(target, n, textures_handle);
         }
         /// <inheritdoc cref="CreateTextures"/>
@@ -9715,9 +9715,9 @@ namespace OpenTK.Graphics.OpenGL
         /// <inheritdoc cref="CreateVertexArrays"/>
         public static unsafe VertexArrayHandle CreateVertexArray()
         {
-            VertexArrayHandle arrays;
+            VertexArrayHandle array;
             int n = 1;
-            Unsafe.SkipInit(out arrays);
+            Unsafe.SkipInit(out array);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -9726,15 +9726,15 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            VertexArrayHandle* arrays_handle = (VertexArrayHandle*)Unsafe.AsPointer(ref arrays);
+            VertexArrayHandle* arrays_handle = (VertexArrayHandle*)Unsafe.AsPointer(ref array);
             CreateVertexArrays(n, arrays_handle);
-            return arrays;
+            return array;
         }
         /// <inheritdoc cref="CreateVertexArrays"/>
-        public static unsafe void CreateVertexArray(out VertexArrayHandle arrays)
+        public static unsafe void CreateVertexArray(out VertexArrayHandle array)
         {
             int n = 1;
-            Unsafe.SkipInit(out arrays);
+            Unsafe.SkipInit(out array);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -9743,7 +9743,7 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            VertexArrayHandle* arrays_handle = (VertexArrayHandle*)Unsafe.AsPointer(ref arrays);
+            VertexArrayHandle* arrays_handle = (VertexArrayHandle*)Unsafe.AsPointer(ref array);
             CreateVertexArrays(n, arrays_handle);
         }
         /// <inheritdoc cref="CreateVertexArrays"/>
@@ -9815,9 +9815,9 @@ namespace OpenTK.Graphics.OpenGL
         /// <inheritdoc cref="CreateSamplers"/>
         public static unsafe SamplerHandle CreateSampler()
         {
-            SamplerHandle samplers;
+            SamplerHandle sampler;
             int n = 1;
-            Unsafe.SkipInit(out samplers);
+            Unsafe.SkipInit(out sampler);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -9826,15 +9826,15 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            SamplerHandle* samplers_handle = (SamplerHandle*)Unsafe.AsPointer(ref samplers);
+            SamplerHandle* samplers_handle = (SamplerHandle*)Unsafe.AsPointer(ref sampler);
             CreateSamplers(n, samplers_handle);
-            return samplers;
+            return sampler;
         }
         /// <inheritdoc cref="CreateSamplers"/>
-        public static unsafe void CreateSampler(out SamplerHandle samplers)
+        public static unsafe void CreateSampler(out SamplerHandle sampler)
         {
             int n = 1;
-            Unsafe.SkipInit(out samplers);
+            Unsafe.SkipInit(out sampler);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -9843,7 +9843,7 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            SamplerHandle* samplers_handle = (SamplerHandle*)Unsafe.AsPointer(ref samplers);
+            SamplerHandle* samplers_handle = (SamplerHandle*)Unsafe.AsPointer(ref sampler);
             CreateSamplers(n, samplers_handle);
         }
         /// <inheritdoc cref="CreateSamplers"/>
@@ -9875,9 +9875,9 @@ namespace OpenTK.Graphics.OpenGL
         /// <inheritdoc cref="CreateProgramPipelines"/>
         public static unsafe ProgramPipelineHandle CreateProgramPipeline()
         {
-            ProgramPipelineHandle pipelines;
+            ProgramPipelineHandle pipeline;
             int n = 1;
-            Unsafe.SkipInit(out pipelines);
+            Unsafe.SkipInit(out pipeline);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -9886,15 +9886,15 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            ProgramPipelineHandle* pipelines_handle = (ProgramPipelineHandle*)Unsafe.AsPointer(ref pipelines);
+            ProgramPipelineHandle* pipelines_handle = (ProgramPipelineHandle*)Unsafe.AsPointer(ref pipeline);
             CreateProgramPipelines(n, pipelines_handle);
-            return pipelines;
+            return pipeline;
         }
         /// <inheritdoc cref="CreateProgramPipelines"/>
-        public static unsafe void CreateProgramPipeline(out ProgramPipelineHandle pipelines)
+        public static unsafe void CreateProgramPipeline(out ProgramPipelineHandle pipeline)
         {
             int n = 1;
-            Unsafe.SkipInit(out pipelines);
+            Unsafe.SkipInit(out pipeline);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -9903,7 +9903,7 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            ProgramPipelineHandle* pipelines_handle = (ProgramPipelineHandle*)Unsafe.AsPointer(ref pipelines);
+            ProgramPipelineHandle* pipelines_handle = (ProgramPipelineHandle*)Unsafe.AsPointer(ref pipeline);
             CreateProgramPipelines(n, pipelines_handle);
         }
         /// <inheritdoc cref="CreateProgramPipelines"/>
@@ -9933,11 +9933,11 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="CreateQueries"/>
-        public static unsafe QueryHandle CreateQuerie(QueryTarget target)
+        public static unsafe QueryHandle CreateQuery(QueryTarget target)
         {
-            QueryHandle ids;
+            QueryHandle id;
             int n = 1;
-            Unsafe.SkipInit(out ids);
+            Unsafe.SkipInit(out id);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -9946,15 +9946,15 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            QueryHandle* ids_handle = (QueryHandle*)Unsafe.AsPointer(ref ids);
+            QueryHandle* ids_handle = (QueryHandle*)Unsafe.AsPointer(ref id);
             CreateQueries(target, n, ids_handle);
-            return ids;
+            return id;
         }
         /// <inheritdoc cref="CreateQueries"/>
-        public static unsafe void CreateQuerie(QueryTarget target, out QueryHandle ids)
+        public static unsafe void CreateQuery(QueryTarget target, out QueryHandle id)
         {
             int n = 1;
-            Unsafe.SkipInit(out ids);
+            Unsafe.SkipInit(out id);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -9963,7 +9963,7 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            QueryHandle* ids_handle = (QueryHandle*)Unsafe.AsPointer(ref ids);
+            QueryHandle* ids_handle = (QueryHandle*)Unsafe.AsPointer(ref id);
             CreateQueries(target, n, ids_handle);
         }
         /// <inheritdoc cref="CreateQueries"/>
@@ -12365,9 +12365,9 @@ namespace OpenTK.Graphics.OpenGL
             /// <inheritdoc cref="CreateTransformFeedbacks"/>
             public static unsafe TransformFeedbackHandle CreateTransformFeedback()
             {
-                TransformFeedbackHandle ids;
+                TransformFeedbackHandle id;
                 int n = 1;
-                Unsafe.SkipInit(out ids);
+                Unsafe.SkipInit(out id);
                 // FIXME: This could be a problem for the overloads that take an out parameter
                 // as this parameter could *potentially* move while inside of this function
                 // which would mean that the new value never gets written to the out parameter.
@@ -12376,15 +12376,15 @@ namespace OpenTK.Graphics.OpenGL
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                TransformFeedbackHandle* ids_handle = (TransformFeedbackHandle*)Unsafe.AsPointer(ref ids);
+                TransformFeedbackHandle* ids_handle = (TransformFeedbackHandle*)Unsafe.AsPointer(ref id);
                 CreateTransformFeedbacks(n, ids_handle);
-                return ids;
+                return id;
             }
             /// <inheritdoc cref="CreateTransformFeedbacks"/>
-            public static unsafe void CreateTransformFeedback(out TransformFeedbackHandle ids)
+            public static unsafe void CreateTransformFeedback(out TransformFeedbackHandle id)
             {
                 int n = 1;
-                Unsafe.SkipInit(out ids);
+                Unsafe.SkipInit(out id);
                 // FIXME: This could be a problem for the overloads that take an out parameter
                 // as this parameter could *potentially* move while inside of this function
                 // which would mean that the new value never gets written to the out parameter.
@@ -12393,7 +12393,7 @@ namespace OpenTK.Graphics.OpenGL
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                TransformFeedbackHandle* ids_handle = (TransformFeedbackHandle*)Unsafe.AsPointer(ref ids);
+                TransformFeedbackHandle* ids_handle = (TransformFeedbackHandle*)Unsafe.AsPointer(ref id);
                 CreateTransformFeedbacks(n, ids_handle);
             }
             /// <inheritdoc cref="CreateTransformFeedbacks"/>
@@ -12449,9 +12449,9 @@ namespace OpenTK.Graphics.OpenGL
             /// <inheritdoc cref="CreateBuffers"/>
             public static unsafe BufferHandle CreateBuffer()
             {
-                BufferHandle buffers;
+                BufferHandle buffer;
                 int n = 1;
-                Unsafe.SkipInit(out buffers);
+                Unsafe.SkipInit(out buffer);
                 // FIXME: This could be a problem for the overloads that take an out parameter
                 // as this parameter could *potentially* move while inside of this function
                 // which would mean that the new value never gets written to the out parameter.
@@ -12460,15 +12460,15 @@ namespace OpenTK.Graphics.OpenGL
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                BufferHandle* buffers_handle = (BufferHandle*)Unsafe.AsPointer(ref buffers);
+                BufferHandle* buffers_handle = (BufferHandle*)Unsafe.AsPointer(ref buffer);
                 CreateBuffers(n, buffers_handle);
-                return buffers;
+                return buffer;
             }
             /// <inheritdoc cref="CreateBuffers"/>
-            public static unsafe void CreateBuffer(out BufferHandle buffers)
+            public static unsafe void CreateBuffer(out BufferHandle buffer)
             {
                 int n = 1;
-                Unsafe.SkipInit(out buffers);
+                Unsafe.SkipInit(out buffer);
                 // FIXME: This could be a problem for the overloads that take an out parameter
                 // as this parameter could *potentially* move while inside of this function
                 // which would mean that the new value never gets written to the out parameter.
@@ -12477,7 +12477,7 @@ namespace OpenTK.Graphics.OpenGL
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                BufferHandle* buffers_handle = (BufferHandle*)Unsafe.AsPointer(ref buffers);
+                BufferHandle* buffers_handle = (BufferHandle*)Unsafe.AsPointer(ref buffer);
                 CreateBuffers(n, buffers_handle);
             }
             /// <inheritdoc cref="CreateBuffers"/>
@@ -12658,9 +12658,9 @@ namespace OpenTK.Graphics.OpenGL
             /// <inheritdoc cref="CreateFramebuffers"/>
             public static unsafe FramebufferHandle CreateFramebuffer()
             {
-                FramebufferHandle framebuffers;
+                FramebufferHandle framebuffer;
                 int n = 1;
-                Unsafe.SkipInit(out framebuffers);
+                Unsafe.SkipInit(out framebuffer);
                 // FIXME: This could be a problem for the overloads that take an out parameter
                 // as this parameter could *potentially* move while inside of this function
                 // which would mean that the new value never gets written to the out parameter.
@@ -12669,15 +12669,15 @@ namespace OpenTK.Graphics.OpenGL
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                FramebufferHandle* framebuffers_handle = (FramebufferHandle*)Unsafe.AsPointer(ref framebuffers);
+                FramebufferHandle* framebuffers_handle = (FramebufferHandle*)Unsafe.AsPointer(ref framebuffer);
                 CreateFramebuffers(n, framebuffers_handle);
-                return framebuffers;
+                return framebuffer;
             }
             /// <inheritdoc cref="CreateFramebuffers"/>
-            public static unsafe void CreateFramebuffer(out FramebufferHandle framebuffers)
+            public static unsafe void CreateFramebuffer(out FramebufferHandle framebuffer)
             {
                 int n = 1;
-                Unsafe.SkipInit(out framebuffers);
+                Unsafe.SkipInit(out framebuffer);
                 // FIXME: This could be a problem for the overloads that take an out parameter
                 // as this parameter could *potentially* move while inside of this function
                 // which would mean that the new value never gets written to the out parameter.
@@ -12686,7 +12686,7 @@ namespace OpenTK.Graphics.OpenGL
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                FramebufferHandle* framebuffers_handle = (FramebufferHandle*)Unsafe.AsPointer(ref framebuffers);
+                FramebufferHandle* framebuffers_handle = (FramebufferHandle*)Unsafe.AsPointer(ref framebuffer);
                 CreateFramebuffers(n, framebuffers_handle);
             }
             /// <inheritdoc cref="CreateFramebuffers"/>
@@ -12787,9 +12787,9 @@ namespace OpenTK.Graphics.OpenGL
             /// <inheritdoc cref="CreateRenderbuffers"/>
             public static unsafe RenderbufferHandle CreateRenderbuffer()
             {
-                RenderbufferHandle renderbuffers;
+                RenderbufferHandle renderbuffer;
                 int n = 1;
-                Unsafe.SkipInit(out renderbuffers);
+                Unsafe.SkipInit(out renderbuffer);
                 // FIXME: This could be a problem for the overloads that take an out parameter
                 // as this parameter could *potentially* move while inside of this function
                 // which would mean that the new value never gets written to the out parameter.
@@ -12798,15 +12798,15 @@ namespace OpenTK.Graphics.OpenGL
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                RenderbufferHandle* renderbuffers_handle = (RenderbufferHandle*)Unsafe.AsPointer(ref renderbuffers);
+                RenderbufferHandle* renderbuffers_handle = (RenderbufferHandle*)Unsafe.AsPointer(ref renderbuffer);
                 CreateRenderbuffers(n, renderbuffers_handle);
-                return renderbuffers;
+                return renderbuffer;
             }
             /// <inheritdoc cref="CreateRenderbuffers"/>
-            public static unsafe void CreateRenderbuffer(out RenderbufferHandle renderbuffers)
+            public static unsafe void CreateRenderbuffer(out RenderbufferHandle renderbuffer)
             {
                 int n = 1;
-                Unsafe.SkipInit(out renderbuffers);
+                Unsafe.SkipInit(out renderbuffer);
                 // FIXME: This could be a problem for the overloads that take an out parameter
                 // as this parameter could *potentially* move while inside of this function
                 // which would mean that the new value never gets written to the out parameter.
@@ -12815,7 +12815,7 @@ namespace OpenTK.Graphics.OpenGL
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                RenderbufferHandle* renderbuffers_handle = (RenderbufferHandle*)Unsafe.AsPointer(ref renderbuffers);
+                RenderbufferHandle* renderbuffers_handle = (RenderbufferHandle*)Unsafe.AsPointer(ref renderbuffer);
                 CreateRenderbuffers(n, renderbuffers_handle);
             }
             /// <inheritdoc cref="CreateRenderbuffers"/>
@@ -12855,9 +12855,9 @@ namespace OpenTK.Graphics.OpenGL
             /// <inheritdoc cref="CreateTextures"/>
             public static unsafe TextureHandle CreateTexture(TextureTarget target)
             {
-                TextureHandle textures;
+                TextureHandle texture;
                 int n = 1;
-                Unsafe.SkipInit(out textures);
+                Unsafe.SkipInit(out texture);
                 // FIXME: This could be a problem for the overloads that take an out parameter
                 // as this parameter could *potentially* move while inside of this function
                 // which would mean that the new value never gets written to the out parameter.
@@ -12866,15 +12866,15 @@ namespace OpenTK.Graphics.OpenGL
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                TextureHandle* textures_handle = (TextureHandle*)Unsafe.AsPointer(ref textures);
+                TextureHandle* textures_handle = (TextureHandle*)Unsafe.AsPointer(ref texture);
                 CreateTextures(target, n, textures_handle);
-                return textures;
+                return texture;
             }
             /// <inheritdoc cref="CreateTextures"/>
-            public static unsafe void CreateTexture(TextureTarget target, out TextureHandle textures)
+            public static unsafe void CreateTexture(TextureTarget target, out TextureHandle texture)
             {
                 int n = 1;
-                Unsafe.SkipInit(out textures);
+                Unsafe.SkipInit(out texture);
                 // FIXME: This could be a problem for the overloads that take an out parameter
                 // as this parameter could *potentially* move while inside of this function
                 // which would mean that the new value never gets written to the out parameter.
@@ -12883,7 +12883,7 @@ namespace OpenTK.Graphics.OpenGL
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                TextureHandle* textures_handle = (TextureHandle*)Unsafe.AsPointer(ref textures);
+                TextureHandle* textures_handle = (TextureHandle*)Unsafe.AsPointer(ref texture);
                 CreateTextures(target, n, textures_handle);
             }
             /// <inheritdoc cref="CreateTextures"/>
@@ -13127,9 +13127,9 @@ namespace OpenTK.Graphics.OpenGL
             /// <inheritdoc cref="CreateVertexArrays"/>
             public static unsafe VertexArrayHandle CreateVertexArray()
             {
-                VertexArrayHandle arrays;
+                VertexArrayHandle array;
                 int n = 1;
-                Unsafe.SkipInit(out arrays);
+                Unsafe.SkipInit(out array);
                 // FIXME: This could be a problem for the overloads that take an out parameter
                 // as this parameter could *potentially* move while inside of this function
                 // which would mean that the new value never gets written to the out parameter.
@@ -13138,15 +13138,15 @@ namespace OpenTK.Graphics.OpenGL
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                VertexArrayHandle* arrays_handle = (VertexArrayHandle*)Unsafe.AsPointer(ref arrays);
+                VertexArrayHandle* arrays_handle = (VertexArrayHandle*)Unsafe.AsPointer(ref array);
                 CreateVertexArrays(n, arrays_handle);
-                return arrays;
+                return array;
             }
             /// <inheritdoc cref="CreateVertexArrays"/>
-            public static unsafe void CreateVertexArray(out VertexArrayHandle arrays)
+            public static unsafe void CreateVertexArray(out VertexArrayHandle array)
             {
                 int n = 1;
-                Unsafe.SkipInit(out arrays);
+                Unsafe.SkipInit(out array);
                 // FIXME: This could be a problem for the overloads that take an out parameter
                 // as this parameter could *potentially* move while inside of this function
                 // which would mean that the new value never gets written to the out parameter.
@@ -13155,7 +13155,7 @@ namespace OpenTK.Graphics.OpenGL
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                VertexArrayHandle* arrays_handle = (VertexArrayHandle*)Unsafe.AsPointer(ref arrays);
+                VertexArrayHandle* arrays_handle = (VertexArrayHandle*)Unsafe.AsPointer(ref array);
                 CreateVertexArrays(n, arrays_handle);
             }
             /// <inheritdoc cref="CreateVertexArrays"/>
@@ -13227,9 +13227,9 @@ namespace OpenTK.Graphics.OpenGL
             /// <inheritdoc cref="CreateSamplers"/>
             public static unsafe SamplerHandle CreateSampler()
             {
-                SamplerHandle samplers;
+                SamplerHandle sampler;
                 int n = 1;
-                Unsafe.SkipInit(out samplers);
+                Unsafe.SkipInit(out sampler);
                 // FIXME: This could be a problem for the overloads that take an out parameter
                 // as this parameter could *potentially* move while inside of this function
                 // which would mean that the new value never gets written to the out parameter.
@@ -13238,15 +13238,15 @@ namespace OpenTK.Graphics.OpenGL
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                SamplerHandle* samplers_handle = (SamplerHandle*)Unsafe.AsPointer(ref samplers);
+                SamplerHandle* samplers_handle = (SamplerHandle*)Unsafe.AsPointer(ref sampler);
                 CreateSamplers(n, samplers_handle);
-                return samplers;
+                return sampler;
             }
             /// <inheritdoc cref="CreateSamplers"/>
-            public static unsafe void CreateSampler(out SamplerHandle samplers)
+            public static unsafe void CreateSampler(out SamplerHandle sampler)
             {
                 int n = 1;
-                Unsafe.SkipInit(out samplers);
+                Unsafe.SkipInit(out sampler);
                 // FIXME: This could be a problem for the overloads that take an out parameter
                 // as this parameter could *potentially* move while inside of this function
                 // which would mean that the new value never gets written to the out parameter.
@@ -13255,7 +13255,7 @@ namespace OpenTK.Graphics.OpenGL
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                SamplerHandle* samplers_handle = (SamplerHandle*)Unsafe.AsPointer(ref samplers);
+                SamplerHandle* samplers_handle = (SamplerHandle*)Unsafe.AsPointer(ref sampler);
                 CreateSamplers(n, samplers_handle);
             }
             /// <inheritdoc cref="CreateSamplers"/>
@@ -13287,9 +13287,9 @@ namespace OpenTK.Graphics.OpenGL
             /// <inheritdoc cref="CreateProgramPipelines"/>
             public static unsafe ProgramPipelineHandle CreateProgramPipeline()
             {
-                ProgramPipelineHandle pipelines;
+                ProgramPipelineHandle pipeline;
                 int n = 1;
-                Unsafe.SkipInit(out pipelines);
+                Unsafe.SkipInit(out pipeline);
                 // FIXME: This could be a problem for the overloads that take an out parameter
                 // as this parameter could *potentially* move while inside of this function
                 // which would mean that the new value never gets written to the out parameter.
@@ -13298,15 +13298,15 @@ namespace OpenTK.Graphics.OpenGL
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                ProgramPipelineHandle* pipelines_handle = (ProgramPipelineHandle*)Unsafe.AsPointer(ref pipelines);
+                ProgramPipelineHandle* pipelines_handle = (ProgramPipelineHandle*)Unsafe.AsPointer(ref pipeline);
                 CreateProgramPipelines(n, pipelines_handle);
-                return pipelines;
+                return pipeline;
             }
             /// <inheritdoc cref="CreateProgramPipelines"/>
-            public static unsafe void CreateProgramPipeline(out ProgramPipelineHandle pipelines)
+            public static unsafe void CreateProgramPipeline(out ProgramPipelineHandle pipeline)
             {
                 int n = 1;
-                Unsafe.SkipInit(out pipelines);
+                Unsafe.SkipInit(out pipeline);
                 // FIXME: This could be a problem for the overloads that take an out parameter
                 // as this parameter could *potentially* move while inside of this function
                 // which would mean that the new value never gets written to the out parameter.
@@ -13315,7 +13315,7 @@ namespace OpenTK.Graphics.OpenGL
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                ProgramPipelineHandle* pipelines_handle = (ProgramPipelineHandle*)Unsafe.AsPointer(ref pipelines);
+                ProgramPipelineHandle* pipelines_handle = (ProgramPipelineHandle*)Unsafe.AsPointer(ref pipeline);
                 CreateProgramPipelines(n, pipelines_handle);
             }
             /// <inheritdoc cref="CreateProgramPipelines"/>
@@ -13345,11 +13345,11 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="CreateQueries"/>
-            public static unsafe QueryHandle CreateQuerie(QueryTarget target)
+            public static unsafe QueryHandle CreateQuery(QueryTarget target)
             {
-                QueryHandle ids;
+                QueryHandle id;
                 int n = 1;
-                Unsafe.SkipInit(out ids);
+                Unsafe.SkipInit(out id);
                 // FIXME: This could be a problem for the overloads that take an out parameter
                 // as this parameter could *potentially* move while inside of this function
                 // which would mean that the new value never gets written to the out parameter.
@@ -13358,15 +13358,15 @@ namespace OpenTK.Graphics.OpenGL
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                QueryHandle* ids_handle = (QueryHandle*)Unsafe.AsPointer(ref ids);
+                QueryHandle* ids_handle = (QueryHandle*)Unsafe.AsPointer(ref id);
                 CreateQueries(target, n, ids_handle);
-                return ids;
+                return id;
             }
             /// <inheritdoc cref="CreateQueries"/>
-            public static unsafe void CreateQuerie(QueryTarget target, out QueryHandle ids)
+            public static unsafe void CreateQuery(QueryTarget target, out QueryHandle id)
             {
                 int n = 1;
-                Unsafe.SkipInit(out ids);
+                Unsafe.SkipInit(out id);
                 // FIXME: This could be a problem for the overloads that take an out parameter
                 // as this parameter could *potentially* move while inside of this function
                 // which would mean that the new value never gets written to the out parameter.
@@ -13375,7 +13375,7 @@ namespace OpenTK.Graphics.OpenGL
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                QueryHandle* ids_handle = (QueryHandle*)Unsafe.AsPointer(ref ids);
+                QueryHandle* ids_handle = (QueryHandle*)Unsafe.AsPointer(ref id);
                 CreateQueries(target, n, ids_handle);
             }
             /// <inheritdoc cref="CreateQueries"/>
@@ -13896,10 +13896,10 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="DeleteRenderbuffers"/>
-            public static unsafe void DeleteRenderbuffer(in RenderbufferHandle renderbuffers)
+            public static unsafe void DeleteRenderbuffer(in RenderbufferHandle renderbuffer)
             {
                 int n = 1;
-                fixed(RenderbufferHandle* renderbuffers_handle = &renderbuffers)
+                fixed(RenderbufferHandle* renderbuffers_handle = &renderbuffer)
                 {
                     DeleteRenderbuffers(n, renderbuffers_handle);
                 }
@@ -13933,9 +13933,9 @@ namespace OpenTK.Graphics.OpenGL
             /// <inheritdoc cref="GenRenderbuffers"/>
             public static unsafe RenderbufferHandle GenRenderbuffer()
             {
-                RenderbufferHandle renderbuffers;
+                RenderbufferHandle renderbuffer;
                 int n = 1;
-                Unsafe.SkipInit(out renderbuffers);
+                Unsafe.SkipInit(out renderbuffer);
                 // FIXME: This could be a problem for the overloads that take an out parameter
                 // as this parameter could *potentially* move while inside of this function
                 // which would mean that the new value never gets written to the out parameter.
@@ -13944,15 +13944,15 @@ namespace OpenTK.Graphics.OpenGL
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                RenderbufferHandle* renderbuffers_handle = (RenderbufferHandle*)Unsafe.AsPointer(ref renderbuffers);
+                RenderbufferHandle* renderbuffers_handle = (RenderbufferHandle*)Unsafe.AsPointer(ref renderbuffer);
                 GenRenderbuffers(n, renderbuffers_handle);
-                return renderbuffers;
+                return renderbuffer;
             }
             /// <inheritdoc cref="GenRenderbuffers"/>
-            public static unsafe void GenRenderbuffer(out RenderbufferHandle renderbuffers)
+            public static unsafe void GenRenderbuffer(out RenderbufferHandle renderbuffer)
             {
                 int n = 1;
-                Unsafe.SkipInit(out renderbuffers);
+                Unsafe.SkipInit(out renderbuffer);
                 // FIXME: This could be a problem for the overloads that take an out parameter
                 // as this parameter could *potentially* move while inside of this function
                 // which would mean that the new value never gets written to the out parameter.
@@ -13961,7 +13961,7 @@ namespace OpenTK.Graphics.OpenGL
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                RenderbufferHandle* renderbuffers_handle = (RenderbufferHandle*)Unsafe.AsPointer(ref renderbuffers);
+                RenderbufferHandle* renderbuffers_handle = (RenderbufferHandle*)Unsafe.AsPointer(ref renderbuffer);
                 GenRenderbuffers(n, renderbuffers_handle);
             }
             /// <inheritdoc cref="GenRenderbuffers"/>
@@ -14015,10 +14015,10 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="DeleteFramebuffers"/>
-            public static unsafe void DeleteFramebuffer(in FramebufferHandle framebuffers)
+            public static unsafe void DeleteFramebuffer(in FramebufferHandle framebuffer)
             {
                 int n = 1;
-                fixed(FramebufferHandle* framebuffers_handle = &framebuffers)
+                fixed(FramebufferHandle* framebuffers_handle = &framebuffer)
                 {
                     DeleteFramebuffers(n, framebuffers_handle);
                 }
@@ -14052,9 +14052,9 @@ namespace OpenTK.Graphics.OpenGL
             /// <inheritdoc cref="GenFramebuffers"/>
             public static unsafe FramebufferHandle GenFramebuffer()
             {
-                FramebufferHandle framebuffers;
+                FramebufferHandle framebuffer;
                 int n = 1;
-                Unsafe.SkipInit(out framebuffers);
+                Unsafe.SkipInit(out framebuffer);
                 // FIXME: This could be a problem for the overloads that take an out parameter
                 // as this parameter could *potentially* move while inside of this function
                 // which would mean that the new value never gets written to the out parameter.
@@ -14063,15 +14063,15 @@ namespace OpenTK.Graphics.OpenGL
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                FramebufferHandle* framebuffers_handle = (FramebufferHandle*)Unsafe.AsPointer(ref framebuffers);
+                FramebufferHandle* framebuffers_handle = (FramebufferHandle*)Unsafe.AsPointer(ref framebuffer);
                 GenFramebuffers(n, framebuffers_handle);
-                return framebuffers;
+                return framebuffer;
             }
             /// <inheritdoc cref="GenFramebuffers"/>
-            public static unsafe void GenFramebuffer(out FramebufferHandle framebuffers)
+            public static unsafe void GenFramebuffer(out FramebufferHandle framebuffer)
             {
                 int n = 1;
-                Unsafe.SkipInit(out framebuffers);
+                Unsafe.SkipInit(out framebuffer);
                 // FIXME: This could be a problem for the overloads that take an out parameter
                 // as this parameter could *potentially* move while inside of this function
                 // which would mean that the new value never gets written to the out parameter.
@@ -14080,7 +14080,7 @@ namespace OpenTK.Graphics.OpenGL
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                FramebufferHandle* framebuffers_handle = (FramebufferHandle*)Unsafe.AsPointer(ref framebuffers);
+                FramebufferHandle* framebuffers_handle = (FramebufferHandle*)Unsafe.AsPointer(ref framebuffer);
                 GenFramebuffers(n, framebuffers_handle);
             }
             /// <inheritdoc cref="GenFramebuffers"/>
@@ -16639,9 +16639,9 @@ namespace OpenTK.Graphics.OpenGL
             /// <inheritdoc cref="GenSamplers"/>
             public static unsafe SamplerHandle GenSampler()
             {
-                SamplerHandle samplers;
+                SamplerHandle sampler;
                 int count = 1;
-                Unsafe.SkipInit(out samplers);
+                Unsafe.SkipInit(out sampler);
                 // FIXME: This could be a problem for the overloads that take an out parameter
                 // as this parameter could *potentially* move while inside of this function
                 // which would mean that the new value never gets written to the out parameter.
@@ -16650,15 +16650,15 @@ namespace OpenTK.Graphics.OpenGL
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                SamplerHandle* samplers_handle = (SamplerHandle*)Unsafe.AsPointer(ref samplers);
+                SamplerHandle* samplers_handle = (SamplerHandle*)Unsafe.AsPointer(ref sampler);
                 GenSamplers(count, samplers_handle);
-                return samplers;
+                return sampler;
             }
             /// <inheritdoc cref="GenSamplers"/>
-            public static unsafe void GenSampler(out SamplerHandle samplers)
+            public static unsafe void GenSampler(out SamplerHandle sampler)
             {
                 int count = 1;
-                Unsafe.SkipInit(out samplers);
+                Unsafe.SkipInit(out sampler);
                 // FIXME: This could be a problem for the overloads that take an out parameter
                 // as this parameter could *potentially* move while inside of this function
                 // which would mean that the new value never gets written to the out parameter.
@@ -16667,7 +16667,7 @@ namespace OpenTK.Graphics.OpenGL
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                SamplerHandle* samplers_handle = (SamplerHandle*)Unsafe.AsPointer(ref samplers);
+                SamplerHandle* samplers_handle = (SamplerHandle*)Unsafe.AsPointer(ref sampler);
                 GenSamplers(count, samplers_handle);
             }
             /// <inheritdoc cref="GenSamplers"/>
@@ -16697,10 +16697,10 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="DeleteSamplers"/>
-            public static unsafe void DeleteSampler(in SamplerHandle samplers)
+            public static unsafe void DeleteSampler(in SamplerHandle sampler)
             {
                 int count = 1;
-                fixed(SamplerHandle* samplers_handle = &samplers)
+                fixed(SamplerHandle* samplers_handle = &sampler)
                 {
                     DeleteSamplers(count, samplers_handle);
                 }
@@ -16931,10 +16931,10 @@ namespace OpenTK.Graphics.OpenGL
                 return returnValue;
             }
             /// <inheritdoc cref="DeleteProgramPipelines"/>
-            public static unsafe void DeleteProgramPipeline(in ProgramPipelineHandle pipelines)
+            public static unsafe void DeleteProgramPipeline(in ProgramPipelineHandle pipeline)
             {
                 int n = 1;
-                fixed(ProgramPipelineHandle* pipelines_handle = &pipelines)
+                fixed(ProgramPipelineHandle* pipelines_handle = &pipeline)
                 {
                     DeleteProgramPipelines(n, pipelines_handle);
                 }
@@ -16968,9 +16968,9 @@ namespace OpenTK.Graphics.OpenGL
             /// <inheritdoc cref="GenProgramPipelines"/>
             public static unsafe ProgramPipelineHandle GenProgramPipeline()
             {
-                ProgramPipelineHandle pipelines;
+                ProgramPipelineHandle pipeline;
                 int n = 1;
-                Unsafe.SkipInit(out pipelines);
+                Unsafe.SkipInit(out pipeline);
                 // FIXME: This could be a problem for the overloads that take an out parameter
                 // as this parameter could *potentially* move while inside of this function
                 // which would mean that the new value never gets written to the out parameter.
@@ -16979,15 +16979,15 @@ namespace OpenTK.Graphics.OpenGL
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                ProgramPipelineHandle* pipelines_handle = (ProgramPipelineHandle*)Unsafe.AsPointer(ref pipelines);
+                ProgramPipelineHandle* pipelines_handle = (ProgramPipelineHandle*)Unsafe.AsPointer(ref pipeline);
                 GenProgramPipelines(n, pipelines_handle);
-                return pipelines;
+                return pipeline;
             }
             /// <inheritdoc cref="GenProgramPipelines"/>
-            public static unsafe void GenProgramPipeline(out ProgramPipelineHandle pipelines)
+            public static unsafe void GenProgramPipeline(out ProgramPipelineHandle pipeline)
             {
                 int n = 1;
-                Unsafe.SkipInit(out pipelines);
+                Unsafe.SkipInit(out pipeline);
                 // FIXME: This could be a problem for the overloads that take an out parameter
                 // as this parameter could *potentially* move while inside of this function
                 // which would mean that the new value never gets written to the out parameter.
@@ -16996,7 +16996,7 @@ namespace OpenTK.Graphics.OpenGL
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                ProgramPipelineHandle* pipelines_handle = (ProgramPipelineHandle*)Unsafe.AsPointer(ref pipelines);
+                ProgramPipelineHandle* pipelines_handle = (ProgramPipelineHandle*)Unsafe.AsPointer(ref pipeline);
                 GenProgramPipelines(n, pipelines_handle);
             }
             /// <inheritdoc cref="GenProgramPipelines"/>
@@ -19712,10 +19712,10 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="DeleteTransformFeedbacks"/>
-            public static unsafe void DeleteTransformFeedback(in TransformFeedbackHandle ids)
+            public static unsafe void DeleteTransformFeedback(in TransformFeedbackHandle id)
             {
                 int n = 1;
-                fixed(TransformFeedbackHandle* ids_handle = &ids)
+                fixed(TransformFeedbackHandle* ids_handle = &id)
                 {
                     DeleteTransformFeedbacks(n, ids_handle);
                 }
@@ -19749,9 +19749,9 @@ namespace OpenTK.Graphics.OpenGL
             /// <inheritdoc cref="GenTransformFeedbacks"/>
             public static unsafe TransformFeedbackHandle GenTransformFeedback()
             {
-                TransformFeedbackHandle ids;
+                TransformFeedbackHandle id;
                 int n = 1;
-                Unsafe.SkipInit(out ids);
+                Unsafe.SkipInit(out id);
                 // FIXME: This could be a problem for the overloads that take an out parameter
                 // as this parameter could *potentially* move while inside of this function
                 // which would mean that the new value never gets written to the out parameter.
@@ -19760,15 +19760,15 @@ namespace OpenTK.Graphics.OpenGL
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                TransformFeedbackHandle* ids_handle = (TransformFeedbackHandle*)Unsafe.AsPointer(ref ids);
+                TransformFeedbackHandle* ids_handle = (TransformFeedbackHandle*)Unsafe.AsPointer(ref id);
                 GenTransformFeedbacks(n, ids_handle);
-                return ids;
+                return id;
             }
             /// <inheritdoc cref="GenTransformFeedbacks"/>
-            public static unsafe void GenTransformFeedback(out TransformFeedbackHandle ids)
+            public static unsafe void GenTransformFeedback(out TransformFeedbackHandle id)
             {
                 int n = 1;
-                Unsafe.SkipInit(out ids);
+                Unsafe.SkipInit(out id);
                 // FIXME: This could be a problem for the overloads that take an out parameter
                 // as this parameter could *potentially* move while inside of this function
                 // which would mean that the new value never gets written to the out parameter.
@@ -19777,7 +19777,7 @@ namespace OpenTK.Graphics.OpenGL
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                TransformFeedbackHandle* ids_handle = (TransformFeedbackHandle*)Unsafe.AsPointer(ref ids);
+                TransformFeedbackHandle* ids_handle = (TransformFeedbackHandle*)Unsafe.AsPointer(ref id);
                 GenTransformFeedbacks(n, ids_handle);
             }
             /// <inheritdoc cref="GenTransformFeedbacks"/>
@@ -20185,10 +20185,10 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="DeleteVertexArrays"/>
-            public static unsafe void DeleteVertexArray(in VertexArrayHandle arrays)
+            public static unsafe void DeleteVertexArray(in VertexArrayHandle array)
             {
                 int n = 1;
-                fixed(VertexArrayHandle* arrays_handle = &arrays)
+                fixed(VertexArrayHandle* arrays_handle = &array)
                 {
                     DeleteVertexArrays(n, arrays_handle);
                 }
@@ -20222,9 +20222,9 @@ namespace OpenTK.Graphics.OpenGL
             /// <inheritdoc cref="GenVertexArrays"/>
             public static unsafe VertexArrayHandle GenVertexArray()
             {
-                VertexArrayHandle arrays;
+                VertexArrayHandle array;
                 int n = 1;
-                Unsafe.SkipInit(out arrays);
+                Unsafe.SkipInit(out array);
                 // FIXME: This could be a problem for the overloads that take an out parameter
                 // as this parameter could *potentially* move while inside of this function
                 // which would mean that the new value never gets written to the out parameter.
@@ -20233,15 +20233,15 @@ namespace OpenTK.Graphics.OpenGL
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                VertexArrayHandle* arrays_handle = (VertexArrayHandle*)Unsafe.AsPointer(ref arrays);
+                VertexArrayHandle* arrays_handle = (VertexArrayHandle*)Unsafe.AsPointer(ref array);
                 GenVertexArrays(n, arrays_handle);
-                return arrays;
+                return array;
             }
             /// <inheritdoc cref="GenVertexArrays"/>
-            public static unsafe void GenVertexArray(out VertexArrayHandle arrays)
+            public static unsafe void GenVertexArray(out VertexArrayHandle array)
             {
                 int n = 1;
-                Unsafe.SkipInit(out arrays);
+                Unsafe.SkipInit(out array);
                 // FIXME: This could be a problem for the overloads that take an out parameter
                 // as this parameter could *potentially* move while inside of this function
                 // which would mean that the new value never gets written to the out parameter.
@@ -20250,7 +20250,7 @@ namespace OpenTK.Graphics.OpenGL
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                VertexArrayHandle* arrays_handle = (VertexArrayHandle*)Unsafe.AsPointer(ref arrays);
+                VertexArrayHandle* arrays_handle = (VertexArrayHandle*)Unsafe.AsPointer(ref array);
                 GenVertexArrays(n, arrays_handle);
             }
             /// <inheritdoc cref="GenVertexArrays"/>

--- a/src/OpenTK.Graphics/OpenGLES1/GL.Overloads.cs
+++ b/src/OpenTK.Graphics/OpenGLES1/GL.Overloads.cs
@@ -605,10 +605,10 @@ namespace OpenTK.Graphics.OpenGLES1
             }
         }
         /// <inheritdoc cref="DeleteBuffers"/>
-        public static unsafe void DeleteBuffer(in BufferHandle buffers)
+        public static unsafe void DeleteBuffer(in BufferHandle buffer)
         {
             int n = 1;
-            fixed(BufferHandle* buffers_handle = &buffers)
+            fixed(BufferHandle* buffers_handle = &buffer)
             {
                 DeleteBuffers(n, buffers_handle);
             }
@@ -640,10 +640,10 @@ namespace OpenTK.Graphics.OpenGLES1
             }
         }
         /// <inheritdoc cref="DeleteTextures"/>
-        public static unsafe void DeleteTexture(in TextureHandle textures)
+        public static unsafe void DeleteTexture(in TextureHandle texture)
         {
             int n = 1;
-            fixed(TextureHandle* textures_handle = &textures)
+            fixed(TextureHandle* textures_handle = &texture)
             {
                 DeleteTextures(n, textures_handle);
             }
@@ -785,9 +785,9 @@ namespace OpenTK.Graphics.OpenGLES1
         /// <inheritdoc cref="GenBuffers"/>
         public static unsafe BufferHandle GenBuffer()
         {
-            BufferHandle buffers;
+            BufferHandle buffer;
             int n = 1;
-            Unsafe.SkipInit(out buffers);
+            Unsafe.SkipInit(out buffer);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -796,15 +796,15 @@ namespace OpenTK.Graphics.OpenGLES1
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            BufferHandle* buffers_handle = (BufferHandle*)Unsafe.AsPointer(ref buffers);
+            BufferHandle* buffers_handle = (BufferHandle*)Unsafe.AsPointer(ref buffer);
             GenBuffers(n, buffers_handle);
-            return buffers;
+            return buffer;
         }
         /// <inheritdoc cref="GenBuffers"/>
-        public static unsafe void GenBuffer(out BufferHandle buffers)
+        public static unsafe void GenBuffer(out BufferHandle buffer)
         {
             int n = 1;
-            Unsafe.SkipInit(out buffers);
+            Unsafe.SkipInit(out buffer);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -813,7 +813,7 @@ namespace OpenTK.Graphics.OpenGLES1
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            BufferHandle* buffers_handle = (BufferHandle*)Unsafe.AsPointer(ref buffers);
+            BufferHandle* buffers_handle = (BufferHandle*)Unsafe.AsPointer(ref buffer);
             GenBuffers(n, buffers_handle);
         }
         /// <inheritdoc cref="GenBuffers"/>
@@ -845,9 +845,9 @@ namespace OpenTK.Graphics.OpenGLES1
         /// <inheritdoc cref="GenTextures"/>
         public static unsafe TextureHandle GenTexture()
         {
-            TextureHandle textures;
+            TextureHandle texture;
             int n = 1;
-            Unsafe.SkipInit(out textures);
+            Unsafe.SkipInit(out texture);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -856,15 +856,15 @@ namespace OpenTK.Graphics.OpenGLES1
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            TextureHandle* textures_handle = (TextureHandle*)Unsafe.AsPointer(ref textures);
+            TextureHandle* textures_handle = (TextureHandle*)Unsafe.AsPointer(ref texture);
             GenTextures(n, textures_handle);
-            return textures;
+            return texture;
         }
         /// <inheritdoc cref="GenTextures"/>
-        public static unsafe void GenTexture(out TextureHandle textures)
+        public static unsafe void GenTexture(out TextureHandle texture)
         {
             int n = 1;
-            Unsafe.SkipInit(out textures);
+            Unsafe.SkipInit(out texture);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -873,7 +873,7 @@ namespace OpenTK.Graphics.OpenGLES1
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            TextureHandle* textures_handle = (TextureHandle*)Unsafe.AsPointer(ref textures);
+            TextureHandle* textures_handle = (TextureHandle*)Unsafe.AsPointer(ref texture);
             GenTextures(n, textures_handle);
         }
         /// <inheritdoc cref="GenTextures"/>

--- a/src/OpenTK.Graphics/OpenGLES3/GL.Overloads.cs
+++ b/src/OpenTK.Graphics/OpenGLES3/GL.Overloads.cs
@@ -166,10 +166,10 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="DeleteBuffers"/>
-        public static unsafe void DeleteBuffer(in BufferHandle buffers)
+        public static unsafe void DeleteBuffer(in BufferHandle buffer)
         {
             int n = 1;
-            fixed(BufferHandle* buffers_handle = &buffers)
+            fixed(BufferHandle* buffers_handle = &buffer)
             {
                 DeleteBuffers(n, buffers_handle);
             }
@@ -201,10 +201,10 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="DeleteFramebuffers"/>
-        public static unsafe void DeleteFramebuffer(in FramebufferHandle framebuffers)
+        public static unsafe void DeleteFramebuffer(in FramebufferHandle framebuffer)
         {
             int n = 1;
-            fixed(FramebufferHandle* framebuffers_handle = &framebuffers)
+            fixed(FramebufferHandle* framebuffers_handle = &framebuffer)
             {
                 DeleteFramebuffers(n, framebuffers_handle);
             }
@@ -236,10 +236,10 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="DeleteRenderbuffers"/>
-        public static unsafe void DeleteRenderbuffer(in RenderbufferHandle renderbuffers)
+        public static unsafe void DeleteRenderbuffer(in RenderbufferHandle renderbuffer)
         {
             int n = 1;
-            fixed(RenderbufferHandle* renderbuffers_handle = &renderbuffers)
+            fixed(RenderbufferHandle* renderbuffers_handle = &renderbuffer)
             {
                 DeleteRenderbuffers(n, renderbuffers_handle);
             }
@@ -271,10 +271,10 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="DeleteTextures"/>
-        public static unsafe void DeleteTexture(in TextureHandle textures)
+        public static unsafe void DeleteTexture(in TextureHandle texture)
         {
             int n = 1;
-            fixed(TextureHandle* textures_handle = &textures)
+            fixed(TextureHandle* textures_handle = &texture)
             {
                 DeleteTextures(n, textures_handle);
             }
@@ -320,9 +320,9 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <inheritdoc cref="GenBuffers"/>
         public static unsafe BufferHandle GenBuffer()
         {
-            BufferHandle buffers;
+            BufferHandle buffer;
             int n = 1;
-            Unsafe.SkipInit(out buffers);
+            Unsafe.SkipInit(out buffer);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -331,15 +331,15 @@ namespace OpenTK.Graphics.OpenGLES3
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            BufferHandle* buffers_handle = (BufferHandle*)Unsafe.AsPointer(ref buffers);
+            BufferHandle* buffers_handle = (BufferHandle*)Unsafe.AsPointer(ref buffer);
             GenBuffers(n, buffers_handle);
-            return buffers;
+            return buffer;
         }
         /// <inheritdoc cref="GenBuffers"/>
-        public static unsafe void GenBuffer(out BufferHandle buffers)
+        public static unsafe void GenBuffer(out BufferHandle buffer)
         {
             int n = 1;
-            Unsafe.SkipInit(out buffers);
+            Unsafe.SkipInit(out buffer);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -348,7 +348,7 @@ namespace OpenTK.Graphics.OpenGLES3
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            BufferHandle* buffers_handle = (BufferHandle*)Unsafe.AsPointer(ref buffers);
+            BufferHandle* buffers_handle = (BufferHandle*)Unsafe.AsPointer(ref buffer);
             GenBuffers(n, buffers_handle);
         }
         /// <inheritdoc cref="GenBuffers"/>
@@ -380,9 +380,9 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <inheritdoc cref="GenFramebuffers"/>
         public static unsafe FramebufferHandle GenFramebuffer()
         {
-            FramebufferHandle framebuffers;
+            FramebufferHandle framebuffer;
             int n = 1;
-            Unsafe.SkipInit(out framebuffers);
+            Unsafe.SkipInit(out framebuffer);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -391,15 +391,15 @@ namespace OpenTK.Graphics.OpenGLES3
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            FramebufferHandle* framebuffers_handle = (FramebufferHandle*)Unsafe.AsPointer(ref framebuffers);
+            FramebufferHandle* framebuffers_handle = (FramebufferHandle*)Unsafe.AsPointer(ref framebuffer);
             GenFramebuffers(n, framebuffers_handle);
-            return framebuffers;
+            return framebuffer;
         }
         /// <inheritdoc cref="GenFramebuffers"/>
-        public static unsafe void GenFramebuffer(out FramebufferHandle framebuffers)
+        public static unsafe void GenFramebuffer(out FramebufferHandle framebuffer)
         {
             int n = 1;
-            Unsafe.SkipInit(out framebuffers);
+            Unsafe.SkipInit(out framebuffer);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -408,7 +408,7 @@ namespace OpenTK.Graphics.OpenGLES3
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            FramebufferHandle* framebuffers_handle = (FramebufferHandle*)Unsafe.AsPointer(ref framebuffers);
+            FramebufferHandle* framebuffers_handle = (FramebufferHandle*)Unsafe.AsPointer(ref framebuffer);
             GenFramebuffers(n, framebuffers_handle);
         }
         /// <inheritdoc cref="GenFramebuffers"/>
@@ -440,9 +440,9 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <inheritdoc cref="GenRenderbuffers"/>
         public static unsafe RenderbufferHandle GenRenderbuffer()
         {
-            RenderbufferHandle renderbuffers;
+            RenderbufferHandle renderbuffer;
             int n = 1;
-            Unsafe.SkipInit(out renderbuffers);
+            Unsafe.SkipInit(out renderbuffer);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -451,15 +451,15 @@ namespace OpenTK.Graphics.OpenGLES3
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            RenderbufferHandle* renderbuffers_handle = (RenderbufferHandle*)Unsafe.AsPointer(ref renderbuffers);
+            RenderbufferHandle* renderbuffers_handle = (RenderbufferHandle*)Unsafe.AsPointer(ref renderbuffer);
             GenRenderbuffers(n, renderbuffers_handle);
-            return renderbuffers;
+            return renderbuffer;
         }
         /// <inheritdoc cref="GenRenderbuffers"/>
-        public static unsafe void GenRenderbuffer(out RenderbufferHandle renderbuffers)
+        public static unsafe void GenRenderbuffer(out RenderbufferHandle renderbuffer)
         {
             int n = 1;
-            Unsafe.SkipInit(out renderbuffers);
+            Unsafe.SkipInit(out renderbuffer);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -468,7 +468,7 @@ namespace OpenTK.Graphics.OpenGLES3
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            RenderbufferHandle* renderbuffers_handle = (RenderbufferHandle*)Unsafe.AsPointer(ref renderbuffers);
+            RenderbufferHandle* renderbuffers_handle = (RenderbufferHandle*)Unsafe.AsPointer(ref renderbuffer);
             GenRenderbuffers(n, renderbuffers_handle);
         }
         /// <inheritdoc cref="GenRenderbuffers"/>
@@ -500,9 +500,9 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <inheritdoc cref="GenTextures"/>
         public static unsafe TextureHandle GenTexture()
         {
-            TextureHandle textures;
+            TextureHandle texture;
             int n = 1;
-            Unsafe.SkipInit(out textures);
+            Unsafe.SkipInit(out texture);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -511,15 +511,15 @@ namespace OpenTK.Graphics.OpenGLES3
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            TextureHandle* textures_handle = (TextureHandle*)Unsafe.AsPointer(ref textures);
+            TextureHandle* textures_handle = (TextureHandle*)Unsafe.AsPointer(ref texture);
             GenTextures(n, textures_handle);
-            return textures;
+            return texture;
         }
         /// <inheritdoc cref="GenTextures"/>
-        public static unsafe void GenTexture(out TextureHandle textures)
+        public static unsafe void GenTexture(out TextureHandle texture)
         {
             int n = 1;
-            Unsafe.SkipInit(out textures);
+            Unsafe.SkipInit(out texture);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -528,7 +528,7 @@ namespace OpenTK.Graphics.OpenGLES3
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            TextureHandle* textures_handle = (TextureHandle*)Unsafe.AsPointer(ref textures);
+            TextureHandle* textures_handle = (TextureHandle*)Unsafe.AsPointer(ref texture);
             GenTextures(n, textures_handle);
         }
         /// <inheritdoc cref="GenTextures"/>
@@ -2212,11 +2212,11 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GenQueries"/>
-        public static unsafe QueryHandle GenQuerie()
+        public static unsafe QueryHandle GenQuery()
         {
-            QueryHandle ids;
+            QueryHandle id;
             int n = 1;
-            Unsafe.SkipInit(out ids);
+            Unsafe.SkipInit(out id);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -2225,15 +2225,15 @@ namespace OpenTK.Graphics.OpenGLES3
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            QueryHandle* ids_handle = (QueryHandle*)Unsafe.AsPointer(ref ids);
+            QueryHandle* ids_handle = (QueryHandle*)Unsafe.AsPointer(ref id);
             GenQueries(n, ids_handle);
-            return ids;
+            return id;
         }
         /// <inheritdoc cref="GenQueries"/>
-        public static unsafe void GenQuerie(out QueryHandle ids)
+        public static unsafe void GenQuery(out QueryHandle id)
         {
             int n = 1;
-            Unsafe.SkipInit(out ids);
+            Unsafe.SkipInit(out id);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -2242,7 +2242,7 @@ namespace OpenTK.Graphics.OpenGLES3
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            QueryHandle* ids_handle = (QueryHandle*)Unsafe.AsPointer(ref ids);
+            QueryHandle* ids_handle = (QueryHandle*)Unsafe.AsPointer(ref id);
             GenQueries(n, ids_handle);
         }
         /// <inheritdoc cref="GenQueries"/>
@@ -2272,10 +2272,10 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="DeleteQueries"/>
-        public static unsafe void DeleteQuerie(in QueryHandle ids)
+        public static unsafe void DeleteQuery(in QueryHandle id)
         {
             int n = 1;
-            fixed(QueryHandle* ids_handle = &ids)
+            fixed(QueryHandle* ids_handle = &id)
             {
                 DeleteQueries(n, ids_handle);
             }
@@ -2572,10 +2572,10 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="DeleteVertexArrays"/>
-        public static unsafe void DeleteVertexArray(in VertexArrayHandle arrays)
+        public static unsafe void DeleteVertexArray(in VertexArrayHandle array)
         {
             int n = 1;
-            fixed(VertexArrayHandle* arrays_handle = &arrays)
+            fixed(VertexArrayHandle* arrays_handle = &array)
             {
                 DeleteVertexArrays(n, arrays_handle);
             }
@@ -2609,9 +2609,9 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <inheritdoc cref="GenVertexArrays"/>
         public static unsafe VertexArrayHandle GenVertexArray()
         {
-            VertexArrayHandle arrays;
+            VertexArrayHandle array;
             int n = 1;
-            Unsafe.SkipInit(out arrays);
+            Unsafe.SkipInit(out array);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -2620,15 +2620,15 @@ namespace OpenTK.Graphics.OpenGLES3
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            VertexArrayHandle* arrays_handle = (VertexArrayHandle*)Unsafe.AsPointer(ref arrays);
+            VertexArrayHandle* arrays_handle = (VertexArrayHandle*)Unsafe.AsPointer(ref array);
             GenVertexArrays(n, arrays_handle);
-            return arrays;
+            return array;
         }
         /// <inheritdoc cref="GenVertexArrays"/>
-        public static unsafe void GenVertexArray(out VertexArrayHandle arrays)
+        public static unsafe void GenVertexArray(out VertexArrayHandle array)
         {
             int n = 1;
-            Unsafe.SkipInit(out arrays);
+            Unsafe.SkipInit(out array);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -2637,7 +2637,7 @@ namespace OpenTK.Graphics.OpenGLES3
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            VertexArrayHandle* arrays_handle = (VertexArrayHandle*)Unsafe.AsPointer(ref arrays);
+            VertexArrayHandle* arrays_handle = (VertexArrayHandle*)Unsafe.AsPointer(ref array);
             GenVertexArrays(n, arrays_handle);
         }
         /// <inheritdoc cref="GenVertexArrays"/>
@@ -3391,9 +3391,9 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <inheritdoc cref="GenSamplers"/>
         public static unsafe SamplerHandle GenSampler()
         {
-            SamplerHandle samplers;
+            SamplerHandle sampler;
             int count = 1;
-            Unsafe.SkipInit(out samplers);
+            Unsafe.SkipInit(out sampler);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -3402,15 +3402,15 @@ namespace OpenTK.Graphics.OpenGLES3
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            SamplerHandle* samplers_handle = (SamplerHandle*)Unsafe.AsPointer(ref samplers);
+            SamplerHandle* samplers_handle = (SamplerHandle*)Unsafe.AsPointer(ref sampler);
             GenSamplers(count, samplers_handle);
-            return samplers;
+            return sampler;
         }
         /// <inheritdoc cref="GenSamplers"/>
-        public static unsafe void GenSampler(out SamplerHandle samplers)
+        public static unsafe void GenSampler(out SamplerHandle sampler)
         {
             int count = 1;
-            Unsafe.SkipInit(out samplers);
+            Unsafe.SkipInit(out sampler);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -3419,7 +3419,7 @@ namespace OpenTK.Graphics.OpenGLES3
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            SamplerHandle* samplers_handle = (SamplerHandle*)Unsafe.AsPointer(ref samplers);
+            SamplerHandle* samplers_handle = (SamplerHandle*)Unsafe.AsPointer(ref sampler);
             GenSamplers(count, samplers_handle);
         }
         /// <inheritdoc cref="GenSamplers"/>
@@ -3449,10 +3449,10 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="DeleteSamplers"/>
-        public static unsafe void DeleteSampler(in SamplerHandle samplers)
+        public static unsafe void DeleteSampler(in SamplerHandle sampler)
         {
             int count = 1;
-            fixed(SamplerHandle* samplers_handle = &samplers)
+            fixed(SamplerHandle* samplers_handle = &sampler)
             {
                 DeleteSamplers(count, samplers_handle);
             }
@@ -3580,10 +3580,10 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="DeleteTransformFeedbacks"/>
-        public static unsafe void DeleteTransformFeedback(in TransformFeedbackHandle ids)
+        public static unsafe void DeleteTransformFeedback(in TransformFeedbackHandle id)
         {
             int n = 1;
-            fixed(TransformFeedbackHandle* ids_handle = &ids)
+            fixed(TransformFeedbackHandle* ids_handle = &id)
             {
                 DeleteTransformFeedbacks(n, ids_handle);
             }
@@ -3617,9 +3617,9 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <inheritdoc cref="GenTransformFeedbacks"/>
         public static unsafe TransformFeedbackHandle GenTransformFeedback()
         {
-            TransformFeedbackHandle ids;
+            TransformFeedbackHandle id;
             int n = 1;
-            Unsafe.SkipInit(out ids);
+            Unsafe.SkipInit(out id);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -3628,15 +3628,15 @@ namespace OpenTK.Graphics.OpenGLES3
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            TransformFeedbackHandle* ids_handle = (TransformFeedbackHandle*)Unsafe.AsPointer(ref ids);
+            TransformFeedbackHandle* ids_handle = (TransformFeedbackHandle*)Unsafe.AsPointer(ref id);
             GenTransformFeedbacks(n, ids_handle);
-            return ids;
+            return id;
         }
         /// <inheritdoc cref="GenTransformFeedbacks"/>
-        public static unsafe void GenTransformFeedback(out TransformFeedbackHandle ids)
+        public static unsafe void GenTransformFeedback(out TransformFeedbackHandle id)
         {
             int n = 1;
-            Unsafe.SkipInit(out ids);
+            Unsafe.SkipInit(out id);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -3645,7 +3645,7 @@ namespace OpenTK.Graphics.OpenGLES3
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            TransformFeedbackHandle* ids_handle = (TransformFeedbackHandle*)Unsafe.AsPointer(ref ids);
+            TransformFeedbackHandle* ids_handle = (TransformFeedbackHandle*)Unsafe.AsPointer(ref id);
             GenTransformFeedbacks(n, ids_handle);
         }
         /// <inheritdoc cref="GenTransformFeedbacks"/>
@@ -4082,10 +4082,10 @@ namespace OpenTK.Graphics.OpenGLES3
             return returnValue;
         }
         /// <inheritdoc cref="DeleteProgramPipelines"/>
-        public static unsafe void DeleteProgramPipeline(in ProgramPipelineHandle pipelines)
+        public static unsafe void DeleteProgramPipeline(in ProgramPipelineHandle pipeline)
         {
             int n = 1;
-            fixed(ProgramPipelineHandle* pipelines_handle = &pipelines)
+            fixed(ProgramPipelineHandle* pipelines_handle = &pipeline)
             {
                 DeleteProgramPipelines(n, pipelines_handle);
             }
@@ -4119,9 +4119,9 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <inheritdoc cref="GenProgramPipelines"/>
         public static unsafe ProgramPipelineHandle GenProgramPipeline()
         {
-            ProgramPipelineHandle pipelines;
+            ProgramPipelineHandle pipeline;
             int n = 1;
-            Unsafe.SkipInit(out pipelines);
+            Unsafe.SkipInit(out pipeline);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -4130,15 +4130,15 @@ namespace OpenTK.Graphics.OpenGLES3
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            ProgramPipelineHandle* pipelines_handle = (ProgramPipelineHandle*)Unsafe.AsPointer(ref pipelines);
+            ProgramPipelineHandle* pipelines_handle = (ProgramPipelineHandle*)Unsafe.AsPointer(ref pipeline);
             GenProgramPipelines(n, pipelines_handle);
-            return pipelines;
+            return pipeline;
         }
         /// <inheritdoc cref="GenProgramPipelines"/>
-        public static unsafe void GenProgramPipeline(out ProgramPipelineHandle pipelines)
+        public static unsafe void GenProgramPipeline(out ProgramPipelineHandle pipeline)
         {
             int n = 1;
-            Unsafe.SkipInit(out pipelines);
+            Unsafe.SkipInit(out pipeline);
             // FIXME: This could be a problem for the overloads that take an out parameter
             // as this parameter could *potentially* move while inside of this function
             // which would mean that the new value never gets written to the out parameter.
@@ -4147,7 +4147,7 @@ namespace OpenTK.Graphics.OpenGLES3
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            ProgramPipelineHandle* pipelines_handle = (ProgramPipelineHandle*)Unsafe.AsPointer(ref pipelines);
+            ProgramPipelineHandle* pipelines_handle = (ProgramPipelineHandle*)Unsafe.AsPointer(ref pipeline);
             GenProgramPipelines(n, pipelines_handle);
         }
         /// <inheritdoc cref="GenProgramPipelines"/>


### PR DESCRIPTION
### Purpose of this PR

Makes functions like `GenQueries` get named `GenQuery` instead of the previous `GenQuerie`.

### Testing status

The resulting code looks good, and it builds.