### PR TITLE
Changed box3i.contains to be border inclusive

### DIFF
--- a/src/OpenTK.Mathematics/Geometry/Box3i.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box3i.cs
@@ -119,9 +119,9 @@ namespace OpenTK.Mathematics
         [Pure]
         public bool Contains(Vector3i point)
         {
-            return _min.X < point.X && point.X < _max.X &&
-                   _min.Y < point.Y && point.Y < _max.Y &&
-                   _min.Z < point.Z && point.Z < _max.Z;
+            return _min.X <= point.X && point.X <= _max.X &&
+                   _min.Y <= point.Y && point.Y <= _max.Y &&
+                   _min.Z <= point.Z && point.Z <= _max.Z;
         }
 
         /// <summary>


### PR DESCRIPTION
The comment of Box3i.Contains explicitly mentions the method being border inclusive, while it actually isn't.
`/// Returns whether the box contains the specified point (borders inclusive).`

I propose to change the method to fit its description. 

This is a breaking change for other projects who might rely on the old behavior and we could also just change the comment to be correct. But I don't like this as much. It introduces a source of headache for all newcomers who assume the function to work like it does in every other math package. I stumbled over this in my project.

For example Unity's:
https://docs.unity3d.com/ScriptReference/BoundsInt.Contains.html
