### PR TITLE
Fixed issue where dpi scaling caused test to fail when running on win…

### DIFF
--- a/tests/OpenTK.Tests.Integration/GameWindowTests.fs
+++ b/tests/OpenTK.Tests.Integration/GameWindowTests.fs
@@ -45,6 +45,8 @@ module GameWindow =
     module Constructors =
         [<Fact>]
         let ``Width and Height can be set via constructor`` () =
+            // FIXME: DPI scaling will mess with the width and height values and will break this test.
+            ToolkitOptions.Default.EnableHighResolution <- false
             use gw = new OpenTK.GameWindow(200, 100)
             Assert.Equal(200, gw.Width)
             Assert.Equal(100, gw.Height)


### PR DESCRIPTION
### Purpose of this PR

Fixes a test-case failure on windows by bypassing dpi scaling.
This test can be properly fixed when #1324 is merged.

### Testing status

This is tested by running the tests on windows.