### PR TITLE
[5.0] Properly bind functions using GLboolean

### DIFF
--- a/src/Generator/Process/OutputData.cs
+++ b/src/Generator/Process/OutputData.cs
@@ -111,7 +111,7 @@ namespace Generator.Writing
     {
         public override string ToCSString()
         {
-            return "byte";
+            return "bool";
         }
     }
 

--- a/src/OpenTK.Graphics/OpenGL/Compatibility/GL.Native.cs
+++ b/src/OpenTK.Graphics/OpenGL/Compatibility/GL.Native.cs
@@ -266,30 +266,30 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             _StencilMask_fnptr(mask);
         }
         
-        private static delegate* unmanaged<byte, byte, byte, byte, void> _ColorMask_fnptr = &ColorMask_Lazy;
+        private static delegate* unmanaged<bool, bool, bool, bool, void> _ColorMask_fnptr = &ColorMask_Lazy;
         /// <summary> <b>[requires: v1.0]</b> Enable and disable writing of frame buffer color components. </summary>
         /// <param name="red"> Specify whether red, green, blue, and alpha are to be written into the frame buffer. The initial values are all GL_TRUE, indicating that the color components are written. </param>
         /// <param name="green"> Specify whether red, green, blue, and alpha are to be written into the frame buffer. The initial values are all GL_TRUE, indicating that the color components are written. </param>
         /// <param name="blue"> Specify whether red, green, blue, and alpha are to be written into the frame buffer. The initial values are all GL_TRUE, indicating that the color components are written. </param>
         /// <param name="alpha"> Specify whether red, green, blue, and alpha are to be written into the frame buffer. The initial values are all GL_TRUE, indicating that the color components are written. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glColorMask.xhtml" /></remarks>
-        public static void ColorMask(byte red, byte green, byte blue, byte alpha) => _ColorMask_fnptr(red, green, blue, alpha);
+        public static void ColorMask(bool red, bool green, bool blue, bool alpha) => _ColorMask_fnptr(red, green, blue, alpha);
         [UnmanagedCallersOnly]
-        private static void ColorMask_Lazy(byte red, byte green, byte blue, byte alpha)
+        private static void ColorMask_Lazy(bool red, bool green, bool blue, bool alpha)
         {
-            _ColorMask_fnptr = (delegate* unmanaged<byte, byte, byte, byte, void>)GLLoader.BindingsContext.GetProcAddress("glColorMask");
+            _ColorMask_fnptr = (delegate* unmanaged<bool, bool, bool, bool, void>)GLLoader.BindingsContext.GetProcAddress("glColorMask");
             _ColorMask_fnptr(red, green, blue, alpha);
         }
         
-        private static delegate* unmanaged<byte, void> _DepthMask_fnptr = &DepthMask_Lazy;
+        private static delegate* unmanaged<bool, void> _DepthMask_fnptr = &DepthMask_Lazy;
         /// <summary> <b>[requires: v1.0]</b> Enable or disable writing into the depth buffer. </summary>
         /// <param name="flag"> Specifies whether the depth buffer is enabled for writing. If flag is GL_FALSE, depth buffer writing is disabled. Otherwise, it is enabled. Initially, depth buffer writing is enabled. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDepthMask.xhtml" /></remarks>
-        public static void DepthMask(byte flag) => _DepthMask_fnptr(flag);
+        public static void DepthMask(bool flag) => _DepthMask_fnptr(flag);
         [UnmanagedCallersOnly]
-        private static void DepthMask_Lazy(byte flag)
+        private static void DepthMask_Lazy(bool flag)
         {
-            _DepthMask_fnptr = (delegate* unmanaged<byte, void>)GLLoader.BindingsContext.GetProcAddress("glDepthMask");
+            _DepthMask_fnptr = (delegate* unmanaged<bool, void>)GLLoader.BindingsContext.GetProcAddress("glDepthMask");
             _DepthMask_fnptr(flag);
         }
         
@@ -460,16 +460,16 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             _ReadPixels_fnptr(x, y, width, height, format, type, pixels);
         }
         
-        private static delegate* unmanaged<GetPName, byte*, void> _GetBooleanv_fnptr = &GetBooleanv_Lazy;
+        private static delegate* unmanaged<GetPName, bool*, void> _GetBooleanv_fnptr = &GetBooleanv_Lazy;
         /// <summary> <b>[requires: v1.0]</b> Return the value or values of a selected parameter. </summary>
         /// <param name="pname"> Specifies the parameter value to be returned for non-indexed versions of glGet. The symbolic constants in the list below are accepted. </param>
         /// <param name="data"> Returns the value or values of the specified parameter. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGet.xhtml" /></remarks>
-        public static void GetBooleanv(GetPName pname, byte* data) => _GetBooleanv_fnptr(pname, data);
+        public static void GetBooleanv(GetPName pname, bool* data) => _GetBooleanv_fnptr(pname, data);
         [UnmanagedCallersOnly]
-        private static void GetBooleanv_Lazy(GetPName pname, byte* data)
+        private static void GetBooleanv_Lazy(GetPName pname, bool* data)
         {
-            _GetBooleanv_fnptr = (delegate* unmanaged<GetPName, byte*, void>)GLLoader.BindingsContext.GetProcAddress("glGetBooleanv");
+            _GetBooleanv_fnptr = (delegate* unmanaged<GetPName, bool*, void>)GLLoader.BindingsContext.GetProcAddress("glGetBooleanv");
             _GetBooleanv_fnptr(pname, data);
         }
         
@@ -609,15 +609,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             _GetTexLevelParameteriv_fnptr(target, level, pname, parameters);
         }
         
-        private static delegate* unmanaged<EnableCap, byte> _IsEnabled_fnptr = &IsEnabled_Lazy;
+        private static delegate* unmanaged<EnableCap, bool> _IsEnabled_fnptr = &IsEnabled_Lazy;
         /// <summary> <b>[requires: v1.0]</b> Test whether a capability is enabled. </summary>
         /// <param name="cap"> Specifies a symbolic constant indicating a GL capability. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsEnabled.xhtml" /></remarks>
-        public static byte IsEnabled(EnableCap cap) => _IsEnabled_fnptr(cap);
+        public static bool IsEnabled(EnableCap cap) => _IsEnabled_fnptr(cap);
         [UnmanagedCallersOnly]
-        private static byte IsEnabled_Lazy(EnableCap cap)
+        private static bool IsEnabled_Lazy(EnableCap cap)
         {
-            _IsEnabled_fnptr = (delegate* unmanaged<EnableCap, byte>)GLLoader.BindingsContext.GetProcAddress("glIsEnabled");
+            _IsEnabled_fnptr = (delegate* unmanaged<EnableCap, bool>)GLLoader.BindingsContext.GetProcAddress("glIsEnabled");
             return _IsEnabled_fnptr(cap);
         }
         
@@ -1140,24 +1140,24 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             _Color4usv_fnptr(v);
         }
         
-        private static delegate* unmanaged<byte, void> _EdgeFlag_fnptr = &EdgeFlag_Lazy;
+        private static delegate* unmanaged<bool, void> _EdgeFlag_fnptr = &EdgeFlag_Lazy;
         /// <summary> <b>[requires: v1.0]</b> Flag edges as either boundary or nonboundary. </summary>
         /// <param name="flag"> Specifies the current edge flag value, either GL_TRUE or GL_FALSE. The initial value is GL_TRUE. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/glEdgeFlag.xml" /></remarks>
-        public static void EdgeFlag(byte flag) => _EdgeFlag_fnptr(flag);
+        public static void EdgeFlag(bool flag) => _EdgeFlag_fnptr(flag);
         [UnmanagedCallersOnly]
-        private static void EdgeFlag_Lazy(byte flag)
+        private static void EdgeFlag_Lazy(bool flag)
         {
-            _EdgeFlag_fnptr = (delegate* unmanaged<byte, void>)GLLoader.BindingsContext.GetProcAddress("glEdgeFlag");
+            _EdgeFlag_fnptr = (delegate* unmanaged<bool, void>)GLLoader.BindingsContext.GetProcAddress("glEdgeFlag");
             _EdgeFlag_fnptr(flag);
         }
         
-        private static delegate* unmanaged<byte*, void> _EdgeFlagv_fnptr = &EdgeFlagv_Lazy;
-        public static void EdgeFlagv(byte* flag) => _EdgeFlagv_fnptr(flag);
+        private static delegate* unmanaged<bool*, void> _EdgeFlagv_fnptr = &EdgeFlagv_Lazy;
+        public static void EdgeFlagv(bool* flag) => _EdgeFlagv_fnptr(flag);
         [UnmanagedCallersOnly]
-        private static void EdgeFlagv_Lazy(byte* flag)
+        private static void EdgeFlagv_Lazy(bool* flag)
         {
-            _EdgeFlagv_fnptr = (delegate* unmanaged<byte*, void>)GLLoader.BindingsContext.GetProcAddress("glEdgeFlagv");
+            _EdgeFlagv_fnptr = (delegate* unmanaged<bool*, void>)GLLoader.BindingsContext.GetProcAddress("glEdgeFlagv");
             _EdgeFlagv_fnptr(flag);
         }
         
@@ -3533,15 +3533,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             _GetTexGeniv_fnptr(coord, pname, parameters);
         }
         
-        private static delegate* unmanaged<DisplayListHandle, byte> _IsList_fnptr = &IsList_Lazy;
+        private static delegate* unmanaged<DisplayListHandle, bool> _IsList_fnptr = &IsList_Lazy;
         /// <summary> <b>[requires: v1.0]</b> Determine if a name corresponds to a display list. </summary>
         /// <param name="list"> Specifies a potential display list name. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/glIsList.xml" /></remarks>
-        public static byte IsList(DisplayListHandle list) => _IsList_fnptr(list);
+        public static bool IsList(DisplayListHandle list) => _IsList_fnptr(list);
         [UnmanagedCallersOnly]
-        private static byte IsList_Lazy(DisplayListHandle list)
+        private static bool IsList_Lazy(DisplayListHandle list)
         {
-            _IsList_fnptr = (delegate* unmanaged<DisplayListHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsList");
+            _IsList_fnptr = (delegate* unmanaged<DisplayListHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsList");
             return _IsList_fnptr(list);
         }
         
@@ -3961,15 +3961,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             _GenTextures_fnptr(n, textures);
         }
         
-        private static delegate* unmanaged<TextureHandle, byte> _IsTexture_fnptr = &IsTexture_Lazy;
+        private static delegate* unmanaged<TextureHandle, bool> _IsTexture_fnptr = &IsTexture_Lazy;
         /// <summary> <b>[requires: v1.1]</b> Determine if a name corresponds to a texture. </summary>
         /// <param name="texture"> Specifies a value that may be the name of a texture. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsTexture.xhtml" /></remarks>
-        public static byte IsTexture(TextureHandle texture) => _IsTexture_fnptr(texture);
+        public static bool IsTexture(TextureHandle texture) => _IsTexture_fnptr(texture);
         [UnmanagedCallersOnly]
-        private static byte IsTexture_Lazy(TextureHandle texture)
+        private static bool IsTexture_Lazy(TextureHandle texture)
         {
-            _IsTexture_fnptr = (delegate* unmanaged<TextureHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsTexture");
+            _IsTexture_fnptr = (delegate* unmanaged<TextureHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsTexture");
             return _IsTexture_fnptr(texture);
         }
         
@@ -4106,17 +4106,17 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             _VertexPointer_fnptr(size, type, stride, pointer);
         }
         
-        private static delegate* unmanaged<int, TextureHandle*, byte*, byte> _AreTexturesResident_fnptr = &AreTexturesResident_Lazy;
+        private static delegate* unmanaged<int, TextureHandle*, bool*, bool> _AreTexturesResident_fnptr = &AreTexturesResident_Lazy;
         /// <summary> <b>[requires: v1.1]</b> Determine if textures are loaded in texture memory. </summary>
         /// <param name="n"> Specifies the number of textures to be queried. </param>
         /// <param name="textures"> Specifies an array containing the names of the textures to be queried. </param>
         /// <param name="residences"> Specifies an array in which the texture residence status is returned. The residence status of a texture named by an element of textures is returned in the corresponding element of residences. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/glAreTexturesResident.xml" /></remarks>
-        public static byte AreTexturesResident(int n, TextureHandle* textures, byte* residences) => _AreTexturesResident_fnptr(n, textures, residences);
+        public static bool AreTexturesResident(int n, TextureHandle* textures, bool* residences) => _AreTexturesResident_fnptr(n, textures, residences);
         [UnmanagedCallersOnly]
-        private static byte AreTexturesResident_Lazy(int n, TextureHandle* textures, byte* residences)
+        private static bool AreTexturesResident_Lazy(int n, TextureHandle* textures, bool* residences)
         {
-            _AreTexturesResident_fnptr = (delegate* unmanaged<int, TextureHandle*, byte*, byte>)GLLoader.BindingsContext.GetProcAddress("glAreTexturesResident");
+            _AreTexturesResident_fnptr = (delegate* unmanaged<int, TextureHandle*, bool*, bool>)GLLoader.BindingsContext.GetProcAddress("glAreTexturesResident");
             return _AreTexturesResident_fnptr(n, textures, residences);
         }
         
@@ -4268,16 +4268,16 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             _ActiveTexture_fnptr(texture);
         }
         
-        private static delegate* unmanaged<float, byte, void> _SampleCoverage_fnptr = &SampleCoverage_Lazy;
+        private static delegate* unmanaged<float, bool, void> _SampleCoverage_fnptr = &SampleCoverage_Lazy;
         /// <summary> <b>[requires: v1.3]</b> Specify multisample coverage parameters. </summary>
         /// <param name="value"> Specify a single floating-point sample coverage value. The value is clamped to the range 0 1 . The initial value is 1.0. </param>
         /// <param name="invert"> Specify a single boolean value representing if the coverage masks should be inverted. GL_TRUE and GL_FALSE are accepted. The initial value is GL_FALSE. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glSampleCoverage.xhtml" /></remarks>
-        public static void SampleCoverage(float value, byte invert) => _SampleCoverage_fnptr(value, invert);
+        public static void SampleCoverage(float value, bool invert) => _SampleCoverage_fnptr(value, invert);
         [UnmanagedCallersOnly]
-        private static void SampleCoverage_Lazy(float value, byte invert)
+        private static void SampleCoverage_Lazy(float value, bool invert)
         {
-            _SampleCoverage_fnptr = (delegate* unmanaged<float, byte, void>)GLLoader.BindingsContext.GetProcAddress("glSampleCoverage");
+            _SampleCoverage_fnptr = (delegate* unmanaged<float, bool, void>)GLLoader.BindingsContext.GetProcAddress("glSampleCoverage");
             _SampleCoverage_fnptr(value, invert);
         }
         
@@ -5434,15 +5434,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             _DeleteQueries_fnptr(n, ids);
         }
         
-        private static delegate* unmanaged<QueryHandle, byte> _IsQuery_fnptr = &IsQuery_Lazy;
+        private static delegate* unmanaged<QueryHandle, bool> _IsQuery_fnptr = &IsQuery_Lazy;
         /// <summary> <b>[requires: v1.5]</b> Determine if a name corresponds to a query object. </summary>
         /// <param name="id"> Specifies a value that may be the name of a query object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsQuery.xhtml" /></remarks>
-        public static byte IsQuery(QueryHandle id) => _IsQuery_fnptr(id);
+        public static bool IsQuery(QueryHandle id) => _IsQuery_fnptr(id);
         [UnmanagedCallersOnly]
-        private static byte IsQuery_Lazy(QueryHandle id)
+        private static bool IsQuery_Lazy(QueryHandle id)
         {
-            _IsQuery_fnptr = (delegate* unmanaged<QueryHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsQuery");
+            _IsQuery_fnptr = (delegate* unmanaged<QueryHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsQuery");
             return _IsQuery_fnptr(id);
         }
         
@@ -5552,15 +5552,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             _GenBuffers_fnptr(n, buffers);
         }
         
-        private static delegate* unmanaged<BufferHandle, byte> _IsBuffer_fnptr = &IsBuffer_Lazy;
+        private static delegate* unmanaged<BufferHandle, bool> _IsBuffer_fnptr = &IsBuffer_Lazy;
         /// <summary> <b>[requires: v1.5]</b> Determine if a name corresponds to a buffer object. </summary>
         /// <param name="buffer"> Specifies a value that may be the name of a buffer object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsBuffer.xhtml" /></remarks>
-        public static byte IsBuffer(BufferHandle buffer) => _IsBuffer_fnptr(buffer);
+        public static bool IsBuffer(BufferHandle buffer) => _IsBuffer_fnptr(buffer);
         [UnmanagedCallersOnly]
-        private static byte IsBuffer_Lazy(BufferHandle buffer)
+        private static bool IsBuffer_Lazy(BufferHandle buffer)
         {
-            _IsBuffer_fnptr = (delegate* unmanaged<BufferHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsBuffer");
+            _IsBuffer_fnptr = (delegate* unmanaged<BufferHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsBuffer");
             return _IsBuffer_fnptr(buffer);
         }
         
@@ -5622,15 +5622,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             return _MapBuffer_fnptr(target, access);
         }
         
-        private static delegate* unmanaged<BufferTargetARB, byte> _UnmapBuffer_fnptr = &UnmapBuffer_Lazy;
+        private static delegate* unmanaged<BufferTargetARB, bool> _UnmapBuffer_fnptr = &UnmapBuffer_Lazy;
         /// <summary> <b>[requires: v1.5]</b> Release the mapping of a buffer object's data store into the client's address space. </summary>
         /// <param name="target"> Specifies the target to which the buffer object is bound for glUnmapBuffer, which must be one of the buffer binding targets in the following table: </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glUnmapBuffer.xhtml" /></remarks>
-        public static byte UnmapBuffer(BufferTargetARB target) => _UnmapBuffer_fnptr(target);
+        public static bool UnmapBuffer(BufferTargetARB target) => _UnmapBuffer_fnptr(target);
         [UnmanagedCallersOnly]
-        private static byte UnmapBuffer_Lazy(BufferTargetARB target)
+        private static bool UnmapBuffer_Lazy(BufferTargetARB target)
         {
-            _UnmapBuffer_fnptr = (delegate* unmanaged<BufferTargetARB, byte>)GLLoader.BindingsContext.GetProcAddress("glUnmapBuffer");
+            _UnmapBuffer_fnptr = (delegate* unmanaged<BufferTargetARB, bool>)GLLoader.BindingsContext.GetProcAddress("glUnmapBuffer");
             return _UnmapBuffer_fnptr(target);
         }
         
@@ -6088,27 +6088,27 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             _GetVertexAttribPointerv_fnptr(index, pname, pointer);
         }
         
-        private static delegate* unmanaged<ProgramHandle, byte> _IsProgram_fnptr = &IsProgram_Lazy;
+        private static delegate* unmanaged<ProgramHandle, bool> _IsProgram_fnptr = &IsProgram_Lazy;
         /// <summary> <b>[requires: v2.0]</b> Determines if a name corresponds to a program object. </summary>
         /// <param name="program">Specifies a potential program object.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsProgram.xhtml" /></remarks>
-        public static byte IsProgram(ProgramHandle program) => _IsProgram_fnptr(program);
+        public static bool IsProgram(ProgramHandle program) => _IsProgram_fnptr(program);
         [UnmanagedCallersOnly]
-        private static byte IsProgram_Lazy(ProgramHandle program)
+        private static bool IsProgram_Lazy(ProgramHandle program)
         {
-            _IsProgram_fnptr = (delegate* unmanaged<ProgramHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsProgram");
+            _IsProgram_fnptr = (delegate* unmanaged<ProgramHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsProgram");
             return _IsProgram_fnptr(program);
         }
         
-        private static delegate* unmanaged<ShaderHandle, byte> _IsShader_fnptr = &IsShader_Lazy;
+        private static delegate* unmanaged<ShaderHandle, bool> _IsShader_fnptr = &IsShader_Lazy;
         /// <summary> <b>[requires: v2.0]</b> Determines if a name corresponds to a shader object. </summary>
         /// <param name="shader">Specifies a potential shader object.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsShader.xhtml" /></remarks>
-        public static byte IsShader(ShaderHandle shader) => _IsShader_fnptr(shader);
+        public static bool IsShader(ShaderHandle shader) => _IsShader_fnptr(shader);
         [UnmanagedCallersOnly]
-        private static byte IsShader_Lazy(ShaderHandle shader)
+        private static bool IsShader_Lazy(ShaderHandle shader)
         {
-            _IsShader_fnptr = (delegate* unmanaged<ShaderHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsShader");
+            _IsShader_fnptr = (delegate* unmanaged<ShaderHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsShader");
             return _IsShader_fnptr(shader);
         }
         
@@ -6379,48 +6379,48 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             _Uniform4iv_fnptr(location, count, value);
         }
         
-        private static delegate* unmanaged<int, int, byte, float*, void> _UniformMatrix2fv_fnptr = &UniformMatrix2fv_Lazy;
+        private static delegate* unmanaged<int, int, bool, float*, void> _UniformMatrix2fv_fnptr = &UniformMatrix2fv_Lazy;
         /// <summary> <b>[requires: v2.0]</b> Specify the value of a uniform variable for the current program object. </summary>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
         /// <param name="count"> For the vector (glUniform*v) commands, specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glUniform.xhtml" /></remarks>
-        public static void UniformMatrix2fv(int location, int count, byte transpose, float* value) => _UniformMatrix2fv_fnptr(location, count, transpose, value);
+        public static void UniformMatrix2fv(int location, int count, bool transpose, float* value) => _UniformMatrix2fv_fnptr(location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void UniformMatrix2fv_Lazy(int location, int count, byte transpose, float* value)
+        private static void UniformMatrix2fv_Lazy(int location, int count, bool transpose, float* value)
         {
-            _UniformMatrix2fv_fnptr = (delegate* unmanaged<int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix2fv");
+            _UniformMatrix2fv_fnptr = (delegate* unmanaged<int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix2fv");
             _UniformMatrix2fv_fnptr(location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<int, int, byte, float*, void> _UniformMatrix3fv_fnptr = &UniformMatrix3fv_Lazy;
+        private static delegate* unmanaged<int, int, bool, float*, void> _UniformMatrix3fv_fnptr = &UniformMatrix3fv_Lazy;
         /// <summary> <b>[requires: v2.0]</b> Specify the value of a uniform variable for the current program object. </summary>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
         /// <param name="count"> For the vector (glUniform*v) commands, specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glUniform.xhtml" /></remarks>
-        public static void UniformMatrix3fv(int location, int count, byte transpose, float* value) => _UniformMatrix3fv_fnptr(location, count, transpose, value);
+        public static void UniformMatrix3fv(int location, int count, bool transpose, float* value) => _UniformMatrix3fv_fnptr(location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void UniformMatrix3fv_Lazy(int location, int count, byte transpose, float* value)
+        private static void UniformMatrix3fv_Lazy(int location, int count, bool transpose, float* value)
         {
-            _UniformMatrix3fv_fnptr = (delegate* unmanaged<int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix3fv");
+            _UniformMatrix3fv_fnptr = (delegate* unmanaged<int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix3fv");
             _UniformMatrix3fv_fnptr(location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<int, int, byte, float*, void> _UniformMatrix4fv_fnptr = &UniformMatrix4fv_Lazy;
+        private static delegate* unmanaged<int, int, bool, float*, void> _UniformMatrix4fv_fnptr = &UniformMatrix4fv_Lazy;
         /// <summary> <b>[requires: v2.0]</b> Specify the value of a uniform variable for the current program object. </summary>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
         /// <param name="count"> For the vector (glUniform*v) commands, specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glUniform.xhtml" /></remarks>
-        public static void UniformMatrix4fv(int location, int count, byte transpose, float* value) => _UniformMatrix4fv_fnptr(location, count, transpose, value);
+        public static void UniformMatrix4fv(int location, int count, bool transpose, float* value) => _UniformMatrix4fv_fnptr(location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void UniformMatrix4fv_Lazy(int location, int count, byte transpose, float* value)
+        private static void UniformMatrix4fv_Lazy(int location, int count, bool transpose, float* value)
         {
-            _UniformMatrix4fv_fnptr = (delegate* unmanaged<int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix4fv");
+            _UniformMatrix4fv_fnptr = (delegate* unmanaged<int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix4fv");
             _UniformMatrix4fv_fnptr(location, count, transpose, value);
         }
         
@@ -6925,7 +6925,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             _VertexAttrib4usv_fnptr(index, v);
         }
         
-        private static delegate* unmanaged<uint, int, VertexAttribPointerType, byte, int, void*, void> _VertexAttribPointer_fnptr = &VertexAttribPointer_Lazy;
+        private static delegate* unmanaged<uint, int, VertexAttribPointerType, bool, int, void*, void> _VertexAttribPointer_fnptr = &VertexAttribPointer_Lazy;
         /// <summary> <b>[requires: v2.0]</b> Define an array of generic vertex attribute data. </summary>
         /// <param name="index">Specifies the index of the generic vertex attribute to be modified.</param>
         /// <param name="size">Specifies the number of components per generic vertex attribute. Must be 1, 2, 3, 4. Additionally, the symbolic constant GL_BGRA is accepted by glVertexAttribPointer. The initial value is 4.</param>
@@ -6934,105 +6934,105 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="stride">Specifies the byte offset between consecutive generic vertex attributes. If stride is 0, the generic vertex attributes are understood to be tightly packed in the array. The initial value is 0.</param>
         /// <param name="pointer">Specifies a offset of the first component of the first generic vertex attribute in the array in the data store of the buffer currently bound to the GL_ARRAY_BUFFER target. The initial value is 0.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glVertexAttribPointer.xhtml" /></remarks>
-        public static void VertexAttribPointer(uint index, int size, VertexAttribPointerType type, byte normalized, int stride, void* pointer) => _VertexAttribPointer_fnptr(index, size, type, normalized, stride, pointer);
+        public static void VertexAttribPointer(uint index, int size, VertexAttribPointerType type, bool normalized, int stride, void* pointer) => _VertexAttribPointer_fnptr(index, size, type, normalized, stride, pointer);
         [UnmanagedCallersOnly]
-        private static void VertexAttribPointer_Lazy(uint index, int size, VertexAttribPointerType type, byte normalized, int stride, void* pointer)
+        private static void VertexAttribPointer_Lazy(uint index, int size, VertexAttribPointerType type, bool normalized, int stride, void* pointer)
         {
-            _VertexAttribPointer_fnptr = (delegate* unmanaged<uint, int, VertexAttribPointerType, byte, int, void*, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribPointer");
+            _VertexAttribPointer_fnptr = (delegate* unmanaged<uint, int, VertexAttribPointerType, bool, int, void*, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribPointer");
             _VertexAttribPointer_fnptr(index, size, type, normalized, stride, pointer);
         }
         
-        private static delegate* unmanaged<int, int, byte, float*, void> _UniformMatrix2x3fv_fnptr = &UniformMatrix2x3fv_Lazy;
+        private static delegate* unmanaged<int, int, bool, float*, void> _UniformMatrix2x3fv_fnptr = &UniformMatrix2x3fv_Lazy;
         /// <summary> <b>[requires: v2.1]</b> Specify the value of a uniform variable for the current program object. </summary>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
         /// <param name="count"> For the vector (glUniform*v) commands, specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glUniform.xhtml" /></remarks>
-        public static void UniformMatrix2x3fv(int location, int count, byte transpose, float* value) => _UniformMatrix2x3fv_fnptr(location, count, transpose, value);
+        public static void UniformMatrix2x3fv(int location, int count, bool transpose, float* value) => _UniformMatrix2x3fv_fnptr(location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void UniformMatrix2x3fv_Lazy(int location, int count, byte transpose, float* value)
+        private static void UniformMatrix2x3fv_Lazy(int location, int count, bool transpose, float* value)
         {
-            _UniformMatrix2x3fv_fnptr = (delegate* unmanaged<int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix2x3fv");
+            _UniformMatrix2x3fv_fnptr = (delegate* unmanaged<int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix2x3fv");
             _UniformMatrix2x3fv_fnptr(location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<int, int, byte, float*, void> _UniformMatrix3x2fv_fnptr = &UniformMatrix3x2fv_Lazy;
+        private static delegate* unmanaged<int, int, bool, float*, void> _UniformMatrix3x2fv_fnptr = &UniformMatrix3x2fv_Lazy;
         /// <summary> <b>[requires: v2.1]</b> Specify the value of a uniform variable for the current program object. </summary>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
         /// <param name="count"> For the vector (glUniform*v) commands, specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glUniform.xhtml" /></remarks>
-        public static void UniformMatrix3x2fv(int location, int count, byte transpose, float* value) => _UniformMatrix3x2fv_fnptr(location, count, transpose, value);
+        public static void UniformMatrix3x2fv(int location, int count, bool transpose, float* value) => _UniformMatrix3x2fv_fnptr(location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void UniformMatrix3x2fv_Lazy(int location, int count, byte transpose, float* value)
+        private static void UniformMatrix3x2fv_Lazy(int location, int count, bool transpose, float* value)
         {
-            _UniformMatrix3x2fv_fnptr = (delegate* unmanaged<int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix3x2fv");
+            _UniformMatrix3x2fv_fnptr = (delegate* unmanaged<int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix3x2fv");
             _UniformMatrix3x2fv_fnptr(location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<int, int, byte, float*, void> _UniformMatrix2x4fv_fnptr = &UniformMatrix2x4fv_Lazy;
+        private static delegate* unmanaged<int, int, bool, float*, void> _UniformMatrix2x4fv_fnptr = &UniformMatrix2x4fv_Lazy;
         /// <summary> <b>[requires: v2.1]</b> Specify the value of a uniform variable for the current program object. </summary>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
         /// <param name="count"> For the vector (glUniform*v) commands, specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glUniform.xhtml" /></remarks>
-        public static void UniformMatrix2x4fv(int location, int count, byte transpose, float* value) => _UniformMatrix2x4fv_fnptr(location, count, transpose, value);
+        public static void UniformMatrix2x4fv(int location, int count, bool transpose, float* value) => _UniformMatrix2x4fv_fnptr(location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void UniformMatrix2x4fv_Lazy(int location, int count, byte transpose, float* value)
+        private static void UniformMatrix2x4fv_Lazy(int location, int count, bool transpose, float* value)
         {
-            _UniformMatrix2x4fv_fnptr = (delegate* unmanaged<int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix2x4fv");
+            _UniformMatrix2x4fv_fnptr = (delegate* unmanaged<int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix2x4fv");
             _UniformMatrix2x4fv_fnptr(location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<int, int, byte, float*, void> _UniformMatrix4x2fv_fnptr = &UniformMatrix4x2fv_Lazy;
+        private static delegate* unmanaged<int, int, bool, float*, void> _UniformMatrix4x2fv_fnptr = &UniformMatrix4x2fv_Lazy;
         /// <summary> <b>[requires: v2.1]</b> Specify the value of a uniform variable for the current program object. </summary>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
         /// <param name="count"> For the vector (glUniform*v) commands, specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glUniform.xhtml" /></remarks>
-        public static void UniformMatrix4x2fv(int location, int count, byte transpose, float* value) => _UniformMatrix4x2fv_fnptr(location, count, transpose, value);
+        public static void UniformMatrix4x2fv(int location, int count, bool transpose, float* value) => _UniformMatrix4x2fv_fnptr(location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void UniformMatrix4x2fv_Lazy(int location, int count, byte transpose, float* value)
+        private static void UniformMatrix4x2fv_Lazy(int location, int count, bool transpose, float* value)
         {
-            _UniformMatrix4x2fv_fnptr = (delegate* unmanaged<int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix4x2fv");
+            _UniformMatrix4x2fv_fnptr = (delegate* unmanaged<int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix4x2fv");
             _UniformMatrix4x2fv_fnptr(location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<int, int, byte, float*, void> _UniformMatrix3x4fv_fnptr = &UniformMatrix3x4fv_Lazy;
+        private static delegate* unmanaged<int, int, bool, float*, void> _UniformMatrix3x4fv_fnptr = &UniformMatrix3x4fv_Lazy;
         /// <summary> <b>[requires: v2.1]</b> Specify the value of a uniform variable for the current program object. </summary>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
         /// <param name="count"> For the vector (glUniform*v) commands, specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glUniform.xhtml" /></remarks>
-        public static void UniformMatrix3x4fv(int location, int count, byte transpose, float* value) => _UniformMatrix3x4fv_fnptr(location, count, transpose, value);
+        public static void UniformMatrix3x4fv(int location, int count, bool transpose, float* value) => _UniformMatrix3x4fv_fnptr(location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void UniformMatrix3x4fv_Lazy(int location, int count, byte transpose, float* value)
+        private static void UniformMatrix3x4fv_Lazy(int location, int count, bool transpose, float* value)
         {
-            _UniformMatrix3x4fv_fnptr = (delegate* unmanaged<int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix3x4fv");
+            _UniformMatrix3x4fv_fnptr = (delegate* unmanaged<int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix3x4fv");
             _UniformMatrix3x4fv_fnptr(location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<int, int, byte, float*, void> _UniformMatrix4x3fv_fnptr = &UniformMatrix4x3fv_Lazy;
+        private static delegate* unmanaged<int, int, bool, float*, void> _UniformMatrix4x3fv_fnptr = &UniformMatrix4x3fv_Lazy;
         /// <summary> <b>[requires: v2.1]</b> Specify the value of a uniform variable for the current program object. </summary>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
         /// <param name="count"> For the vector (glUniform*v) commands, specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glUniform.xhtml" /></remarks>
-        public static void UniformMatrix4x3fv(int location, int count, byte transpose, float* value) => _UniformMatrix4x3fv_fnptr(location, count, transpose, value);
+        public static void UniformMatrix4x3fv(int location, int count, bool transpose, float* value) => _UniformMatrix4x3fv_fnptr(location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void UniformMatrix4x3fv_Lazy(int location, int count, byte transpose, float* value)
+        private static void UniformMatrix4x3fv_Lazy(int location, int count, bool transpose, float* value)
         {
-            _UniformMatrix4x3fv_fnptr = (delegate* unmanaged<int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix4x3fv");
+            _UniformMatrix4x3fv_fnptr = (delegate* unmanaged<int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix4x3fv");
             _UniformMatrix4x3fv_fnptr(location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<uint, byte, byte, byte, byte, void> _ColorMaski_fnptr = &ColorMaski_Lazy;
+        private static delegate* unmanaged<uint, bool, bool, bool, bool, void> _ColorMaski_fnptr = &ColorMaski_Lazy;
         /// <summary> <b>[requires: v3.0]</b> Enable and disable writing of frame buffer color components. </summary>
         /// <param name="buf"> For glColorMaski, specifies the index of the draw buffer whose color mask to set. </param>
         /// <param name="red"> Specify whether red, green, blue, and alpha are to be written into the frame buffer. The initial values are all GL_TRUE, indicating that the color components are written. </param>
@@ -7040,25 +7040,25 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="blue"> Specify whether red, green, blue, and alpha are to be written into the frame buffer. The initial values are all GL_TRUE, indicating that the color components are written. </param>
         /// <param name="alpha"> Specify whether red, green, blue, and alpha are to be written into the frame buffer. The initial values are all GL_TRUE, indicating that the color components are written. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glColorMask.xhtml" /></remarks>
-        public static void ColorMaski(uint index, byte r, byte g, byte b, byte a) => _ColorMaski_fnptr(index, r, g, b, a);
+        public static void ColorMaski(uint index, bool r, bool g, bool b, bool a) => _ColorMaski_fnptr(index, r, g, b, a);
         [UnmanagedCallersOnly]
-        private static void ColorMaski_Lazy(uint index, byte r, byte g, byte b, byte a)
+        private static void ColorMaski_Lazy(uint index, bool r, bool g, bool b, bool a)
         {
-            _ColorMaski_fnptr = (delegate* unmanaged<uint, byte, byte, byte, byte, void>)GLLoader.BindingsContext.GetProcAddress("glColorMaski");
+            _ColorMaski_fnptr = (delegate* unmanaged<uint, bool, bool, bool, bool, void>)GLLoader.BindingsContext.GetProcAddress("glColorMaski");
             _ColorMaski_fnptr(index, r, g, b, a);
         }
         
-        private static delegate* unmanaged<BufferTargetARB, uint, byte*, void> _GetBooleani_v_fnptr = &GetBooleani_v_Lazy;
+        private static delegate* unmanaged<BufferTargetARB, uint, bool*, void> _GetBooleani_v_fnptr = &GetBooleani_v_Lazy;
         /// <summary> <b>[requires: v3.0]</b> Return the value or values of a selected parameter. </summary>
         /// <param name="target"> Specifies the parameter value to be returned for indexed versions of glGet. The symbolic constants in the list below are accepted. </param>
         /// <param name="index"> Specifies the index of the particular element being queried. </param>
         /// <param name="data"> Returns the value or values of the specified parameter. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGet.xhtml" /></remarks>
-        public static void GetBooleani_v(BufferTargetARB target, uint index, byte* data) => _GetBooleani_v_fnptr(target, index, data);
+        public static void GetBooleani_v(BufferTargetARB target, uint index, bool* data) => _GetBooleani_v_fnptr(target, index, data);
         [UnmanagedCallersOnly]
-        private static void GetBooleani_v_Lazy(BufferTargetARB target, uint index, byte* data)
+        private static void GetBooleani_v_Lazy(BufferTargetARB target, uint index, bool* data)
         {
-            _GetBooleani_v_fnptr = (delegate* unmanaged<BufferTargetARB, uint, byte*, void>)GLLoader.BindingsContext.GetProcAddress("glGetBooleani_v");
+            _GetBooleani_v_fnptr = (delegate* unmanaged<BufferTargetARB, uint, bool*, void>)GLLoader.BindingsContext.GetProcAddress("glGetBooleani_v");
             _GetBooleani_v_fnptr(target, index, data);
         }
         
@@ -7102,16 +7102,16 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             _Disablei_fnptr(target, index);
         }
         
-        private static delegate* unmanaged<EnableCap, uint, byte> _IsEnabledi_fnptr = &IsEnabledi_Lazy;
+        private static delegate* unmanaged<EnableCap, uint, bool> _IsEnabledi_fnptr = &IsEnabledi_Lazy;
         /// <summary> <b>[requires: v3.0]</b> Test whether a capability is enabled. </summary>
         /// <param name="cap"> Specifies a symbolic constant indicating a GL capability. </param>
         /// <param name="index"> Specifies the index of the capability. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsEnabled.xhtml" /></remarks>
-        public static byte IsEnabledi(EnableCap target, uint index) => _IsEnabledi_fnptr(target, index);
+        public static bool IsEnabledi(EnableCap target, uint index) => _IsEnabledi_fnptr(target, index);
         [UnmanagedCallersOnly]
-        private static byte IsEnabledi_Lazy(EnableCap target, uint index)
+        private static bool IsEnabledi_Lazy(EnableCap target, uint index)
         {
-            _IsEnabledi_fnptr = (delegate* unmanaged<EnableCap, uint, byte>)GLLoader.BindingsContext.GetProcAddress("glIsEnabledi");
+            _IsEnabledi_fnptr = (delegate* unmanaged<EnableCap, uint, bool>)GLLoader.BindingsContext.GetProcAddress("glIsEnabledi");
             return _IsEnabledi_fnptr(target, index);
         }
         
@@ -7835,15 +7835,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             return _GetStringi__fnptr(name, index);
         }
         
-        private static delegate* unmanaged<RenderbufferHandle, byte> _IsRenderbuffer_fnptr = &IsRenderbuffer_Lazy;
+        private static delegate* unmanaged<RenderbufferHandle, bool> _IsRenderbuffer_fnptr = &IsRenderbuffer_Lazy;
         /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Determine if a name corresponds to a renderbuffer object. </summary>
         /// <param name="renderbuffer"> Specifies a value that may be the name of a renderbuffer object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsRenderbuffer.xhtml" /></remarks>
-        public static byte IsRenderbuffer(RenderbufferHandle renderbuffer) => _IsRenderbuffer_fnptr(renderbuffer);
+        public static bool IsRenderbuffer(RenderbufferHandle renderbuffer) => _IsRenderbuffer_fnptr(renderbuffer);
         [UnmanagedCallersOnly]
-        private static byte IsRenderbuffer_Lazy(RenderbufferHandle renderbuffer)
+        private static bool IsRenderbuffer_Lazy(RenderbufferHandle renderbuffer)
         {
-            _IsRenderbuffer_fnptr = (delegate* unmanaged<RenderbufferHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsRenderbuffer");
+            _IsRenderbuffer_fnptr = (delegate* unmanaged<RenderbufferHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsRenderbuffer");
             return _IsRenderbuffer_fnptr(renderbuffer);
         }
         
@@ -7915,15 +7915,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             _GetRenderbufferParameteriv_fnptr(target, pname, parameters);
         }
         
-        private static delegate* unmanaged<FramebufferHandle, byte> _IsFramebuffer_fnptr = &IsFramebuffer_Lazy;
+        private static delegate* unmanaged<FramebufferHandle, bool> _IsFramebuffer_fnptr = &IsFramebuffer_Lazy;
         /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Determine if a name corresponds to a framebuffer object. </summary>
         /// <param name="framebuffer"> Specifies a value that may be the name of a framebuffer object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsFramebuffer.xhtml" /></remarks>
-        public static byte IsFramebuffer(FramebufferHandle framebuffer) => _IsFramebuffer_fnptr(framebuffer);
+        public static bool IsFramebuffer(FramebufferHandle framebuffer) => _IsFramebuffer_fnptr(framebuffer);
         [UnmanagedCallersOnly]
-        private static byte IsFramebuffer_Lazy(FramebufferHandle framebuffer)
+        private static bool IsFramebuffer_Lazy(FramebufferHandle framebuffer)
         {
-            _IsFramebuffer_fnptr = (delegate* unmanaged<FramebufferHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsFramebuffer");
+            _IsFramebuffer_fnptr = (delegate* unmanaged<FramebufferHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsFramebuffer");
             return _IsFramebuffer_fnptr(framebuffer);
         }
         
@@ -8189,15 +8189,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             _GenVertexArrays_fnptr(n, arrays);
         }
         
-        private static delegate* unmanaged<VertexArrayHandle, byte> _IsVertexArray_fnptr = &IsVertexArray_Lazy;
+        private static delegate* unmanaged<VertexArrayHandle, bool> _IsVertexArray_fnptr = &IsVertexArray_Lazy;
         /// <summary> <b>[requires: v3.0 | GL_ARB_vertex_array_object]</b> Determine if a name corresponds to a vertex array object. </summary>
         /// <param name="array"> Specifies a value that may be the name of a vertex array object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsVertexArray.xhtml" /></remarks>
-        public static byte IsVertexArray(VertexArrayHandle array) => _IsVertexArray_fnptr(array);
+        public static bool IsVertexArray(VertexArrayHandle array) => _IsVertexArray_fnptr(array);
         [UnmanagedCallersOnly]
-        private static byte IsVertexArray_Lazy(VertexArrayHandle array)
+        private static bool IsVertexArray_Lazy(VertexArrayHandle array)
         {
-            _IsVertexArray_fnptr = (delegate* unmanaged<VertexArrayHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsVertexArray");
+            _IsVertexArray_fnptr = (delegate* unmanaged<VertexArrayHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsVertexArray");
             return _IsVertexArray_fnptr(array);
         }
         
@@ -8472,15 +8472,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             return _FenceSync_fnptr(condition, flags);
         }
         
-        private static delegate* unmanaged<GLSync, byte> _IsSync_fnptr = &IsSync_Lazy;
+        private static delegate* unmanaged<GLSync, bool> _IsSync_fnptr = &IsSync_Lazy;
         /// <summary> <b>[requires: v3.2 | GL_ARB_sync]</b> Determine if a name corresponds to a sync object. </summary>
         /// <param name="sync"> Specifies a value that may be the name of a sync object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsSync.xhtml" /></remarks>
-        public static byte IsSync(GLSync sync) => _IsSync_fnptr(sync);
+        public static bool IsSync(GLSync sync) => _IsSync_fnptr(sync);
         [UnmanagedCallersOnly]
-        private static byte IsSync_Lazy(GLSync sync)
+        private static bool IsSync_Lazy(GLSync sync)
         {
-            _IsSync_fnptr = (delegate* unmanaged<GLSync, byte>)GLLoader.BindingsContext.GetProcAddress("glIsSync");
+            _IsSync_fnptr = (delegate* unmanaged<GLSync, bool>)GLLoader.BindingsContext.GetProcAddress("glIsSync");
             return _IsSync_fnptr(sync);
         }
         
@@ -8596,7 +8596,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             _FramebufferTexture_fnptr(target, attachment, texture, level);
         }
         
-        private static delegate* unmanaged<TextureTarget, int, InternalFormat, int, int, byte, void> _TexImage2DMultisample_fnptr = &TexImage2DMultisample_Lazy;
+        private static delegate* unmanaged<TextureTarget, int, InternalFormat, int, int, bool, void> _TexImage2DMultisample_fnptr = &TexImage2DMultisample_Lazy;
         /// <summary> <b>[requires: v3.2 | GL_ARB_texture_multisample]</b> Establish the data storage, format, dimensions, and number of samples of a multisample texture's image. </summary>
         /// <param name="target"> Specifies the target of the operation. target must be GL_TEXTURE_2D_MULTISAMPLE or GL_PROXY_TEXTURE_2D_MULTISAMPLE. </param>
         /// <param name="samples"> The number of samples in the multisample texture's image. </param>
@@ -8605,15 +8605,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="height"> The height of the multisample texture's image, in texels. </param>
         /// <param name="fixedsamplelocations"> Specifies whether the image will use identical sample locations and the same number of samples for all texels in the image, and the sample locations will not depend on the internal format or size of the image. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexImage2DMultisample.xhtml" /></remarks>
-        public static void TexImage2DMultisample(TextureTarget target, int samples, InternalFormat internalformat, int width, int height, byte fixedsamplelocations) => _TexImage2DMultisample_fnptr(target, samples, internalformat, width, height, fixedsamplelocations);
+        public static void TexImage2DMultisample(TextureTarget target, int samples, InternalFormat internalformat, int width, int height, bool fixedsamplelocations) => _TexImage2DMultisample_fnptr(target, samples, internalformat, width, height, fixedsamplelocations);
         [UnmanagedCallersOnly]
-        private static void TexImage2DMultisample_Lazy(TextureTarget target, int samples, InternalFormat internalformat, int width, int height, byte fixedsamplelocations)
+        private static void TexImage2DMultisample_Lazy(TextureTarget target, int samples, InternalFormat internalformat, int width, int height, bool fixedsamplelocations)
         {
-            _TexImage2DMultisample_fnptr = (delegate* unmanaged<TextureTarget, int, InternalFormat, int, int, byte, void>)GLLoader.BindingsContext.GetProcAddress("glTexImage2DMultisample");
+            _TexImage2DMultisample_fnptr = (delegate* unmanaged<TextureTarget, int, InternalFormat, int, int, bool, void>)GLLoader.BindingsContext.GetProcAddress("glTexImage2DMultisample");
             _TexImage2DMultisample_fnptr(target, samples, internalformat, width, height, fixedsamplelocations);
         }
         
-        private static delegate* unmanaged<TextureTarget, int, InternalFormat, int, int, int, byte, void> _TexImage3DMultisample_fnptr = &TexImage3DMultisample_Lazy;
+        private static delegate* unmanaged<TextureTarget, int, InternalFormat, int, int, int, bool, void> _TexImage3DMultisample_fnptr = &TexImage3DMultisample_Lazy;
         /// <summary> <b>[requires: v3.2 | GL_ARB_texture_multisample]</b> Establish the data storage, format, dimensions, and number of samples of a multisample texture's image. </summary>
         /// <param name="target"> Specifies the target of the operation. target must be GL_TEXTURE_2D_MULTISAMPLE_ARRAY or GL_PROXY_TEXTURE_2D_MULTISAMPLE_ARRAY. </param>
         /// <param name="samples"> The number of samples in the multisample texture's image. </param>
@@ -8623,11 +8623,11 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="depth">!!missing documentation!!</param>
         /// <param name="fixedsamplelocations"> Specifies whether the image will use identical sample locations and the same number of samples for all texels in the image, and the sample locations will not depend on the internal format or size of the image. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexImage3DMultisample.xhtml" /></remarks>
-        public static void TexImage3DMultisample(TextureTarget target, int samples, InternalFormat internalformat, int width, int height, int depth, byte fixedsamplelocations) => _TexImage3DMultisample_fnptr(target, samples, internalformat, width, height, depth, fixedsamplelocations);
+        public static void TexImage3DMultisample(TextureTarget target, int samples, InternalFormat internalformat, int width, int height, int depth, bool fixedsamplelocations) => _TexImage3DMultisample_fnptr(target, samples, internalformat, width, height, depth, fixedsamplelocations);
         [UnmanagedCallersOnly]
-        private static void TexImage3DMultisample_Lazy(TextureTarget target, int samples, InternalFormat internalformat, int width, int height, int depth, byte fixedsamplelocations)
+        private static void TexImage3DMultisample_Lazy(TextureTarget target, int samples, InternalFormat internalformat, int width, int height, int depth, bool fixedsamplelocations)
         {
-            _TexImage3DMultisample_fnptr = (delegate* unmanaged<TextureTarget, int, InternalFormat, int, int, int, byte, void>)GLLoader.BindingsContext.GetProcAddress("glTexImage3DMultisample");
+            _TexImage3DMultisample_fnptr = (delegate* unmanaged<TextureTarget, int, InternalFormat, int, int, int, bool, void>)GLLoader.BindingsContext.GetProcAddress("glTexImage3DMultisample");
             _TexImage3DMultisample_fnptr(target, samples, internalformat, width, height, depth, fixedsamplelocations);
         }
         
@@ -8712,15 +8712,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             _DeleteSamplers_fnptr(count, samplers);
         }
         
-        private static delegate* unmanaged<SamplerHandle, byte> _IsSampler_fnptr = &IsSampler_Lazy;
+        private static delegate* unmanaged<SamplerHandle, bool> _IsSampler_fnptr = &IsSampler_Lazy;
         /// <summary> <b>[requires: v3.3 | GL_ARB_sampler_objects]</b> Determine if a name corresponds to a sampler object. </summary>
         /// <param name="id"> Specifies a value that may be the name of a sampler object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsSampler.xhtml" /></remarks>
-        public static byte IsSampler(SamplerHandle sampler) => _IsSampler_fnptr(sampler);
+        public static bool IsSampler(SamplerHandle sampler) => _IsSampler_fnptr(sampler);
         [UnmanagedCallersOnly]
-        private static byte IsSampler_Lazy(SamplerHandle sampler)
+        private static bool IsSampler_Lazy(SamplerHandle sampler)
         {
-            _IsSampler_fnptr = (delegate* unmanaged<SamplerHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsSampler");
+            _IsSampler_fnptr = (delegate* unmanaged<SamplerHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsSampler");
             return _IsSampler_fnptr(sampler);
         }
         
@@ -8931,107 +8931,107 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             _VertexAttribDivisor_fnptr(index, divisor);
         }
         
-        private static delegate* unmanaged<uint, VertexAttribPointerType, byte, uint, void> _VertexAttribP1ui_fnptr = &VertexAttribP1ui_Lazy;
+        private static delegate* unmanaged<uint, VertexAttribPointerType, bool, uint, void> _VertexAttribP1ui_fnptr = &VertexAttribP1ui_Lazy;
         /// <summary> <b>[requires: v3.3 | GL_ARB_vertex_type_2_10_10_10_rev]</b> Specifies the value of a generic vertex attribute. </summary>
         /// <param name="index">Specifies the index of the generic vertex attribute to be modified.</param>
         /// <param name="type"> For the packed commands (glVertexAttribP*), specified the type of packing used on the data. This parameter must be GL_INT_2_10_10_10_REV or GL_UNSIGNED_INT_2_10_10_10_REV, to specify signed or unsigned data, respectively, or GL_UNSIGNED_INT_10F_11F_11F_REV to specify floating point data. </param>
         /// <param name="normalized"> For the packed commands, if GL_TRUE, then the values are to be converted to floating point values by normalizing. Otherwise, they are converted directly to floating-point values. If type indicates a floating-pont format, then normalized value must be GL_FALSE. </param>
         /// <param name="value"> For the packed commands, specifies the new packed value to be used for the specified vertex attribute. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glVertexAttrib.xhtml" /></remarks>
-        public static void VertexAttribP1ui(uint index, VertexAttribPointerType type, byte normalized, uint value) => _VertexAttribP1ui_fnptr(index, type, normalized, value);
+        public static void VertexAttribP1ui(uint index, VertexAttribPointerType type, bool normalized, uint value) => _VertexAttribP1ui_fnptr(index, type, normalized, value);
         [UnmanagedCallersOnly]
-        private static void VertexAttribP1ui_Lazy(uint index, VertexAttribPointerType type, byte normalized, uint value)
+        private static void VertexAttribP1ui_Lazy(uint index, VertexAttribPointerType type, bool normalized, uint value)
         {
-            _VertexAttribP1ui_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, byte, uint, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP1ui");
+            _VertexAttribP1ui_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, bool, uint, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP1ui");
             _VertexAttribP1ui_fnptr(index, type, normalized, value);
         }
         
-        private static delegate* unmanaged<uint, VertexAttribPointerType, byte, uint*, void> _VertexAttribP1uiv_fnptr = &VertexAttribP1uiv_Lazy;
+        private static delegate* unmanaged<uint, VertexAttribPointerType, bool, uint*, void> _VertexAttribP1uiv_fnptr = &VertexAttribP1uiv_Lazy;
         /// <summary> <b>[requires: v3.3 | GL_ARB_vertex_type_2_10_10_10_rev]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void VertexAttribP1uiv(uint index, VertexAttribPointerType type, byte normalized, uint* value) => _VertexAttribP1uiv_fnptr(index, type, normalized, value);
+        public static void VertexAttribP1uiv(uint index, VertexAttribPointerType type, bool normalized, uint* value) => _VertexAttribP1uiv_fnptr(index, type, normalized, value);
         [UnmanagedCallersOnly]
-        private static void VertexAttribP1uiv_Lazy(uint index, VertexAttribPointerType type, byte normalized, uint* value)
+        private static void VertexAttribP1uiv_Lazy(uint index, VertexAttribPointerType type, bool normalized, uint* value)
         {
-            _VertexAttribP1uiv_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, byte, uint*, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP1uiv");
+            _VertexAttribP1uiv_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, bool, uint*, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP1uiv");
             _VertexAttribP1uiv_fnptr(index, type, normalized, value);
         }
         
-        private static delegate* unmanaged<uint, VertexAttribPointerType, byte, uint, void> _VertexAttribP2ui_fnptr = &VertexAttribP2ui_Lazy;
+        private static delegate* unmanaged<uint, VertexAttribPointerType, bool, uint, void> _VertexAttribP2ui_fnptr = &VertexAttribP2ui_Lazy;
         /// <summary> <b>[requires: v3.3 | GL_ARB_vertex_type_2_10_10_10_rev]</b> Specifies the value of a generic vertex attribute. </summary>
         /// <param name="index">Specifies the index of the generic vertex attribute to be modified.</param>
         /// <param name="type"> For the packed commands (glVertexAttribP*), specified the type of packing used on the data. This parameter must be GL_INT_2_10_10_10_REV or GL_UNSIGNED_INT_2_10_10_10_REV, to specify signed or unsigned data, respectively, or GL_UNSIGNED_INT_10F_11F_11F_REV to specify floating point data. </param>
         /// <param name="normalized"> For the packed commands, if GL_TRUE, then the values are to be converted to floating point values by normalizing. Otherwise, they are converted directly to floating-point values. If type indicates a floating-pont format, then normalized value must be GL_FALSE. </param>
         /// <param name="value"> For the packed commands, specifies the new packed value to be used for the specified vertex attribute. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glVertexAttrib.xhtml" /></remarks>
-        public static void VertexAttribP2ui(uint index, VertexAttribPointerType type, byte normalized, uint value) => _VertexAttribP2ui_fnptr(index, type, normalized, value);
+        public static void VertexAttribP2ui(uint index, VertexAttribPointerType type, bool normalized, uint value) => _VertexAttribP2ui_fnptr(index, type, normalized, value);
         [UnmanagedCallersOnly]
-        private static void VertexAttribP2ui_Lazy(uint index, VertexAttribPointerType type, byte normalized, uint value)
+        private static void VertexAttribP2ui_Lazy(uint index, VertexAttribPointerType type, bool normalized, uint value)
         {
-            _VertexAttribP2ui_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, byte, uint, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP2ui");
+            _VertexAttribP2ui_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, bool, uint, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP2ui");
             _VertexAttribP2ui_fnptr(index, type, normalized, value);
         }
         
-        private static delegate* unmanaged<uint, VertexAttribPointerType, byte, uint*, void> _VertexAttribP2uiv_fnptr = &VertexAttribP2uiv_Lazy;
+        private static delegate* unmanaged<uint, VertexAttribPointerType, bool, uint*, void> _VertexAttribP2uiv_fnptr = &VertexAttribP2uiv_Lazy;
         /// <summary> <b>[requires: v3.3 | GL_ARB_vertex_type_2_10_10_10_rev]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void VertexAttribP2uiv(uint index, VertexAttribPointerType type, byte normalized, uint* value) => _VertexAttribP2uiv_fnptr(index, type, normalized, value);
+        public static void VertexAttribP2uiv(uint index, VertexAttribPointerType type, bool normalized, uint* value) => _VertexAttribP2uiv_fnptr(index, type, normalized, value);
         [UnmanagedCallersOnly]
-        private static void VertexAttribP2uiv_Lazy(uint index, VertexAttribPointerType type, byte normalized, uint* value)
+        private static void VertexAttribP2uiv_Lazy(uint index, VertexAttribPointerType type, bool normalized, uint* value)
         {
-            _VertexAttribP2uiv_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, byte, uint*, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP2uiv");
+            _VertexAttribP2uiv_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, bool, uint*, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP2uiv");
             _VertexAttribP2uiv_fnptr(index, type, normalized, value);
         }
         
-        private static delegate* unmanaged<uint, VertexAttribPointerType, byte, uint, void> _VertexAttribP3ui_fnptr = &VertexAttribP3ui_Lazy;
+        private static delegate* unmanaged<uint, VertexAttribPointerType, bool, uint, void> _VertexAttribP3ui_fnptr = &VertexAttribP3ui_Lazy;
         /// <summary> <b>[requires: v3.3 | GL_ARB_vertex_type_2_10_10_10_rev]</b> Specifies the value of a generic vertex attribute. </summary>
         /// <param name="index">Specifies the index of the generic vertex attribute to be modified.</param>
         /// <param name="type"> For the packed commands (glVertexAttribP*), specified the type of packing used on the data. This parameter must be GL_INT_2_10_10_10_REV or GL_UNSIGNED_INT_2_10_10_10_REV, to specify signed or unsigned data, respectively, or GL_UNSIGNED_INT_10F_11F_11F_REV to specify floating point data. </param>
         /// <param name="normalized"> For the packed commands, if GL_TRUE, then the values are to be converted to floating point values by normalizing. Otherwise, they are converted directly to floating-point values. If type indicates a floating-pont format, then normalized value must be GL_FALSE. </param>
         /// <param name="value"> For the packed commands, specifies the new packed value to be used for the specified vertex attribute. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glVertexAttrib.xhtml" /></remarks>
-        public static void VertexAttribP3ui(uint index, VertexAttribPointerType type, byte normalized, uint value) => _VertexAttribP3ui_fnptr(index, type, normalized, value);
+        public static void VertexAttribP3ui(uint index, VertexAttribPointerType type, bool normalized, uint value) => _VertexAttribP3ui_fnptr(index, type, normalized, value);
         [UnmanagedCallersOnly]
-        private static void VertexAttribP3ui_Lazy(uint index, VertexAttribPointerType type, byte normalized, uint value)
+        private static void VertexAttribP3ui_Lazy(uint index, VertexAttribPointerType type, bool normalized, uint value)
         {
-            _VertexAttribP3ui_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, byte, uint, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP3ui");
+            _VertexAttribP3ui_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, bool, uint, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP3ui");
             _VertexAttribP3ui_fnptr(index, type, normalized, value);
         }
         
-        private static delegate* unmanaged<uint, VertexAttribPointerType, byte, uint*, void> _VertexAttribP3uiv_fnptr = &VertexAttribP3uiv_Lazy;
+        private static delegate* unmanaged<uint, VertexAttribPointerType, bool, uint*, void> _VertexAttribP3uiv_fnptr = &VertexAttribP3uiv_Lazy;
         /// <summary> <b>[requires: v3.3 | GL_ARB_vertex_type_2_10_10_10_rev]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void VertexAttribP3uiv(uint index, VertexAttribPointerType type, byte normalized, uint* value) => _VertexAttribP3uiv_fnptr(index, type, normalized, value);
+        public static void VertexAttribP3uiv(uint index, VertexAttribPointerType type, bool normalized, uint* value) => _VertexAttribP3uiv_fnptr(index, type, normalized, value);
         [UnmanagedCallersOnly]
-        private static void VertexAttribP3uiv_Lazy(uint index, VertexAttribPointerType type, byte normalized, uint* value)
+        private static void VertexAttribP3uiv_Lazy(uint index, VertexAttribPointerType type, bool normalized, uint* value)
         {
-            _VertexAttribP3uiv_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, byte, uint*, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP3uiv");
+            _VertexAttribP3uiv_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, bool, uint*, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP3uiv");
             _VertexAttribP3uiv_fnptr(index, type, normalized, value);
         }
         
-        private static delegate* unmanaged<uint, VertexAttribPointerType, byte, uint, void> _VertexAttribP4ui_fnptr = &VertexAttribP4ui_Lazy;
+        private static delegate* unmanaged<uint, VertexAttribPointerType, bool, uint, void> _VertexAttribP4ui_fnptr = &VertexAttribP4ui_Lazy;
         /// <summary> <b>[requires: v3.3 | GL_ARB_vertex_type_2_10_10_10_rev]</b> Specifies the value of a generic vertex attribute. </summary>
         /// <param name="index">Specifies the index of the generic vertex attribute to be modified.</param>
         /// <param name="type"> For the packed commands (glVertexAttribP*), specified the type of packing used on the data. This parameter must be GL_INT_2_10_10_10_REV or GL_UNSIGNED_INT_2_10_10_10_REV, to specify signed or unsigned data, respectively, or GL_UNSIGNED_INT_10F_11F_11F_REV to specify floating point data. </param>
         /// <param name="normalized"> For the packed commands, if GL_TRUE, then the values are to be converted to floating point values by normalizing. Otherwise, they are converted directly to floating-point values. If type indicates a floating-pont format, then normalized value must be GL_FALSE. </param>
         /// <param name="value"> For the packed commands, specifies the new packed value to be used for the specified vertex attribute. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glVertexAttrib.xhtml" /></remarks>
-        public static void VertexAttribP4ui(uint index, VertexAttribPointerType type, byte normalized, uint value) => _VertexAttribP4ui_fnptr(index, type, normalized, value);
+        public static void VertexAttribP4ui(uint index, VertexAttribPointerType type, bool normalized, uint value) => _VertexAttribP4ui_fnptr(index, type, normalized, value);
         [UnmanagedCallersOnly]
-        private static void VertexAttribP4ui_Lazy(uint index, VertexAttribPointerType type, byte normalized, uint value)
+        private static void VertexAttribP4ui_Lazy(uint index, VertexAttribPointerType type, bool normalized, uint value)
         {
-            _VertexAttribP4ui_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, byte, uint, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP4ui");
+            _VertexAttribP4ui_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, bool, uint, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP4ui");
             _VertexAttribP4ui_fnptr(index, type, normalized, value);
         }
         
-        private static delegate* unmanaged<uint, VertexAttribPointerType, byte, uint*, void> _VertexAttribP4uiv_fnptr = &VertexAttribP4uiv_Lazy;
+        private static delegate* unmanaged<uint, VertexAttribPointerType, bool, uint*, void> _VertexAttribP4uiv_fnptr = &VertexAttribP4uiv_Lazy;
         /// <summary> <b>[requires: v3.3 | GL_ARB_vertex_type_2_10_10_10_rev]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void VertexAttribP4uiv(uint index, VertexAttribPointerType type, byte normalized, uint* value) => _VertexAttribP4uiv_fnptr(index, type, normalized, value);
+        public static void VertexAttribP4uiv(uint index, VertexAttribPointerType type, bool normalized, uint* value) => _VertexAttribP4uiv_fnptr(index, type, normalized, value);
         [UnmanagedCallersOnly]
-        private static void VertexAttribP4uiv_Lazy(uint index, VertexAttribPointerType type, byte normalized, uint* value)
+        private static void VertexAttribP4uiv_Lazy(uint index, VertexAttribPointerType type, bool normalized, uint* value)
         {
-            _VertexAttribP4uiv_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, byte, uint*, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP4uiv");
+            _VertexAttribP4uiv_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, bool, uint*, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP4uiv");
             _VertexAttribP4uiv_fnptr(index, type, normalized, value);
         }
         
@@ -9549,102 +9549,102 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             _Uniform4dv_fnptr(location, count, value);
         }
         
-        private static delegate* unmanaged<int, int, byte, double*, void> _UniformMatrix2dv_fnptr = &UniformMatrix2dv_Lazy;
+        private static delegate* unmanaged<int, int, bool, double*, void> _UniformMatrix2dv_fnptr = &UniformMatrix2dv_Lazy;
         /// <summary> <b>[requires: v4.0 | GL_ARB_gpu_shader_fp64]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void UniformMatrix2dv(int location, int count, byte transpose, double* value) => _UniformMatrix2dv_fnptr(location, count, transpose, value);
+        public static void UniformMatrix2dv(int location, int count, bool transpose, double* value) => _UniformMatrix2dv_fnptr(location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void UniformMatrix2dv_Lazy(int location, int count, byte transpose, double* value)
+        private static void UniformMatrix2dv_Lazy(int location, int count, bool transpose, double* value)
         {
-            _UniformMatrix2dv_fnptr = (delegate* unmanaged<int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix2dv");
+            _UniformMatrix2dv_fnptr = (delegate* unmanaged<int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix2dv");
             _UniformMatrix2dv_fnptr(location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<int, int, byte, double*, void> _UniformMatrix3dv_fnptr = &UniformMatrix3dv_Lazy;
+        private static delegate* unmanaged<int, int, bool, double*, void> _UniformMatrix3dv_fnptr = &UniformMatrix3dv_Lazy;
         /// <summary> <b>[requires: v4.0 | GL_ARB_gpu_shader_fp64]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void UniformMatrix3dv(int location, int count, byte transpose, double* value) => _UniformMatrix3dv_fnptr(location, count, transpose, value);
+        public static void UniformMatrix3dv(int location, int count, bool transpose, double* value) => _UniformMatrix3dv_fnptr(location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void UniformMatrix3dv_Lazy(int location, int count, byte transpose, double* value)
+        private static void UniformMatrix3dv_Lazy(int location, int count, bool transpose, double* value)
         {
-            _UniformMatrix3dv_fnptr = (delegate* unmanaged<int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix3dv");
+            _UniformMatrix3dv_fnptr = (delegate* unmanaged<int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix3dv");
             _UniformMatrix3dv_fnptr(location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<int, int, byte, double*, void> _UniformMatrix4dv_fnptr = &UniformMatrix4dv_Lazy;
+        private static delegate* unmanaged<int, int, bool, double*, void> _UniformMatrix4dv_fnptr = &UniformMatrix4dv_Lazy;
         /// <summary> <b>[requires: v4.0 | GL_ARB_gpu_shader_fp64]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void UniformMatrix4dv(int location, int count, byte transpose, double* value) => _UniformMatrix4dv_fnptr(location, count, transpose, value);
+        public static void UniformMatrix4dv(int location, int count, bool transpose, double* value) => _UniformMatrix4dv_fnptr(location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void UniformMatrix4dv_Lazy(int location, int count, byte transpose, double* value)
+        private static void UniformMatrix4dv_Lazy(int location, int count, bool transpose, double* value)
         {
-            _UniformMatrix4dv_fnptr = (delegate* unmanaged<int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix4dv");
+            _UniformMatrix4dv_fnptr = (delegate* unmanaged<int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix4dv");
             _UniformMatrix4dv_fnptr(location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<int, int, byte, double*, void> _UniformMatrix2x3dv_fnptr = &UniformMatrix2x3dv_Lazy;
+        private static delegate* unmanaged<int, int, bool, double*, void> _UniformMatrix2x3dv_fnptr = &UniformMatrix2x3dv_Lazy;
         /// <summary> <b>[requires: v4.0 | GL_ARB_gpu_shader_fp64]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void UniformMatrix2x3dv(int location, int count, byte transpose, double* value) => _UniformMatrix2x3dv_fnptr(location, count, transpose, value);
+        public static void UniformMatrix2x3dv(int location, int count, bool transpose, double* value) => _UniformMatrix2x3dv_fnptr(location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void UniformMatrix2x3dv_Lazy(int location, int count, byte transpose, double* value)
+        private static void UniformMatrix2x3dv_Lazy(int location, int count, bool transpose, double* value)
         {
-            _UniformMatrix2x3dv_fnptr = (delegate* unmanaged<int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix2x3dv");
+            _UniformMatrix2x3dv_fnptr = (delegate* unmanaged<int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix2x3dv");
             _UniformMatrix2x3dv_fnptr(location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<int, int, byte, double*, void> _UniformMatrix2x4dv_fnptr = &UniformMatrix2x4dv_Lazy;
+        private static delegate* unmanaged<int, int, bool, double*, void> _UniformMatrix2x4dv_fnptr = &UniformMatrix2x4dv_Lazy;
         /// <summary> <b>[requires: v4.0 | GL_ARB_gpu_shader_fp64]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void UniformMatrix2x4dv(int location, int count, byte transpose, double* value) => _UniformMatrix2x4dv_fnptr(location, count, transpose, value);
+        public static void UniformMatrix2x4dv(int location, int count, bool transpose, double* value) => _UniformMatrix2x4dv_fnptr(location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void UniformMatrix2x4dv_Lazy(int location, int count, byte transpose, double* value)
+        private static void UniformMatrix2x4dv_Lazy(int location, int count, bool transpose, double* value)
         {
-            _UniformMatrix2x4dv_fnptr = (delegate* unmanaged<int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix2x4dv");
+            _UniformMatrix2x4dv_fnptr = (delegate* unmanaged<int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix2x4dv");
             _UniformMatrix2x4dv_fnptr(location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<int, int, byte, double*, void> _UniformMatrix3x2dv_fnptr = &UniformMatrix3x2dv_Lazy;
+        private static delegate* unmanaged<int, int, bool, double*, void> _UniformMatrix3x2dv_fnptr = &UniformMatrix3x2dv_Lazy;
         /// <summary> <b>[requires: v4.0 | GL_ARB_gpu_shader_fp64]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void UniformMatrix3x2dv(int location, int count, byte transpose, double* value) => _UniformMatrix3x2dv_fnptr(location, count, transpose, value);
+        public static void UniformMatrix3x2dv(int location, int count, bool transpose, double* value) => _UniformMatrix3x2dv_fnptr(location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void UniformMatrix3x2dv_Lazy(int location, int count, byte transpose, double* value)
+        private static void UniformMatrix3x2dv_Lazy(int location, int count, bool transpose, double* value)
         {
-            _UniformMatrix3x2dv_fnptr = (delegate* unmanaged<int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix3x2dv");
+            _UniformMatrix3x2dv_fnptr = (delegate* unmanaged<int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix3x2dv");
             _UniformMatrix3x2dv_fnptr(location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<int, int, byte, double*, void> _UniformMatrix3x4dv_fnptr = &UniformMatrix3x4dv_Lazy;
+        private static delegate* unmanaged<int, int, bool, double*, void> _UniformMatrix3x4dv_fnptr = &UniformMatrix3x4dv_Lazy;
         /// <summary> <b>[requires: v4.0 | GL_ARB_gpu_shader_fp64]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void UniformMatrix3x4dv(int location, int count, byte transpose, double* value) => _UniformMatrix3x4dv_fnptr(location, count, transpose, value);
+        public static void UniformMatrix3x4dv(int location, int count, bool transpose, double* value) => _UniformMatrix3x4dv_fnptr(location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void UniformMatrix3x4dv_Lazy(int location, int count, byte transpose, double* value)
+        private static void UniformMatrix3x4dv_Lazy(int location, int count, bool transpose, double* value)
         {
-            _UniformMatrix3x4dv_fnptr = (delegate* unmanaged<int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix3x4dv");
+            _UniformMatrix3x4dv_fnptr = (delegate* unmanaged<int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix3x4dv");
             _UniformMatrix3x4dv_fnptr(location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<int, int, byte, double*, void> _UniformMatrix4x2dv_fnptr = &UniformMatrix4x2dv_Lazy;
+        private static delegate* unmanaged<int, int, bool, double*, void> _UniformMatrix4x2dv_fnptr = &UniformMatrix4x2dv_Lazy;
         /// <summary> <b>[requires: v4.0 | GL_ARB_gpu_shader_fp64]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void UniformMatrix4x2dv(int location, int count, byte transpose, double* value) => _UniformMatrix4x2dv_fnptr(location, count, transpose, value);
+        public static void UniformMatrix4x2dv(int location, int count, bool transpose, double* value) => _UniformMatrix4x2dv_fnptr(location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void UniformMatrix4x2dv_Lazy(int location, int count, byte transpose, double* value)
+        private static void UniformMatrix4x2dv_Lazy(int location, int count, bool transpose, double* value)
         {
-            _UniformMatrix4x2dv_fnptr = (delegate* unmanaged<int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix4x2dv");
+            _UniformMatrix4x2dv_fnptr = (delegate* unmanaged<int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix4x2dv");
             _UniformMatrix4x2dv_fnptr(location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<int, int, byte, double*, void> _UniformMatrix4x3dv_fnptr = &UniformMatrix4x3dv_Lazy;
+        private static delegate* unmanaged<int, int, bool, double*, void> _UniformMatrix4x3dv_fnptr = &UniformMatrix4x3dv_Lazy;
         /// <summary> <b>[requires: v4.0 | GL_ARB_gpu_shader_fp64]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void UniformMatrix4x3dv(int location, int count, byte transpose, double* value) => _UniformMatrix4x3dv_fnptr(location, count, transpose, value);
+        public static void UniformMatrix4x3dv(int location, int count, bool transpose, double* value) => _UniformMatrix4x3dv_fnptr(location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void UniformMatrix4x3dv_Lazy(int location, int count, byte transpose, double* value)
+        private static void UniformMatrix4x3dv_Lazy(int location, int count, bool transpose, double* value)
         {
-            _UniformMatrix4x3dv_fnptr = (delegate* unmanaged<int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix4x3dv");
+            _UniformMatrix4x3dv_fnptr = (delegate* unmanaged<int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix4x3dv");
             _UniformMatrix4x3dv_fnptr(location, count, transpose, value);
         }
         
@@ -9848,15 +9848,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             _GenTransformFeedbacks_fnptr(n, ids);
         }
         
-        private static delegate* unmanaged<TransformFeedbackHandle, byte> _IsTransformFeedback_fnptr = &IsTransformFeedback_Lazy;
+        private static delegate* unmanaged<TransformFeedbackHandle, bool> _IsTransformFeedback_fnptr = &IsTransformFeedback_Lazy;
         /// <summary> <b>[requires: v4.0 | GL_ARB_transform_feedback2]</b> Determine if a name corresponds to a transform feedback object. </summary>
         /// <param name="id"> Specifies a value that may be the name of a transform feedback object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsTransformFeedback.xhtml" /></remarks>
-        public static byte IsTransformFeedback(TransformFeedbackHandle id) => _IsTransformFeedback_fnptr(id);
+        public static bool IsTransformFeedback(TransformFeedbackHandle id) => _IsTransformFeedback_fnptr(id);
         [UnmanagedCallersOnly]
-        private static byte IsTransformFeedback_Lazy(TransformFeedbackHandle id)
+        private static bool IsTransformFeedback_Lazy(TransformFeedbackHandle id)
         {
-            _IsTransformFeedback_fnptr = (delegate* unmanaged<TransformFeedbackHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsTransformFeedback");
+            _IsTransformFeedback_fnptr = (delegate* unmanaged<TransformFeedbackHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsTransformFeedback");
             return _IsTransformFeedback_fnptr(id);
         }
         
@@ -10142,15 +10142,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             _GenProgramPipelines_fnptr(n, pipelines);
         }
         
-        private static delegate* unmanaged<ProgramPipelineHandle, byte> _IsProgramPipeline_fnptr = &IsProgramPipeline_Lazy;
+        private static delegate* unmanaged<ProgramPipelineHandle, bool> _IsProgramPipeline_fnptr = &IsProgramPipeline_Lazy;
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Determine if a name corresponds to a program pipeline object. </summary>
         /// <param name="pipeline"> Specifies a value that may be the name of a program pipeline object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsProgramPipeline.xhtml" /></remarks>
-        public static byte IsProgramPipeline(ProgramPipelineHandle pipeline) => _IsProgramPipeline_fnptr(pipeline);
+        public static bool IsProgramPipeline(ProgramPipelineHandle pipeline) => _IsProgramPipeline_fnptr(pipeline);
         [UnmanagedCallersOnly]
-        private static byte IsProgramPipeline_Lazy(ProgramPipelineHandle pipeline)
+        private static bool IsProgramPipeline_Lazy(ProgramPipelineHandle pipeline)
         {
-            _IsProgramPipeline_fnptr = (delegate* unmanaged<ProgramPipelineHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsProgramPipeline");
+            _IsProgramPipeline_fnptr = (delegate* unmanaged<ProgramPipelineHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsProgramPipeline");
             return _IsProgramPipeline_fnptr(pipeline);
         }
         
@@ -10622,7 +10622,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             _ProgramUniform4uiv_fnptr(program, location, count, value);
         }
         
-        private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix2fv_fnptr = &ProgramUniformMatrix2fv_Lazy;
+        private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix2fv_fnptr = &ProgramUniformMatrix2fv_Lazy;
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
@@ -10630,15 +10630,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniformMatrix2fv(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix2fv_fnptr(program, location, count, transpose, value);
+        public static void ProgramUniformMatrix2fv(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix2fv_fnptr(program, location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void ProgramUniformMatrix2fv_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+        private static void ProgramUniformMatrix2fv_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
         {
-            _ProgramUniformMatrix2fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2fv");
+            _ProgramUniformMatrix2fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2fv");
             _ProgramUniformMatrix2fv_fnptr(program, location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix3fv_fnptr = &ProgramUniformMatrix3fv_Lazy;
+        private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix3fv_fnptr = &ProgramUniformMatrix3fv_Lazy;
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
@@ -10646,15 +10646,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniformMatrix3fv(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix3fv_fnptr(program, location, count, transpose, value);
+        public static void ProgramUniformMatrix3fv(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix3fv_fnptr(program, location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void ProgramUniformMatrix3fv_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+        private static void ProgramUniformMatrix3fv_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
         {
-            _ProgramUniformMatrix3fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3fv");
+            _ProgramUniformMatrix3fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3fv");
             _ProgramUniformMatrix3fv_fnptr(program, location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix4fv_fnptr = &ProgramUniformMatrix4fv_Lazy;
+        private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix4fv_fnptr = &ProgramUniformMatrix4fv_Lazy;
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
@@ -10662,48 +10662,48 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniformMatrix4fv(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix4fv_fnptr(program, location, count, transpose, value);
+        public static void ProgramUniformMatrix4fv(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix4fv_fnptr(program, location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void ProgramUniformMatrix4fv_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+        private static void ProgramUniformMatrix4fv_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
         {
-            _ProgramUniformMatrix4fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4fv");
+            _ProgramUniformMatrix4fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4fv");
             _ProgramUniformMatrix4fv_fnptr(program, location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<ProgramHandle, int, int, byte, double*, void> _ProgramUniformMatrix2dv_fnptr = &ProgramUniformMatrix2dv_Lazy;
+        private static delegate* unmanaged<ProgramHandle, int, int, bool, double*, void> _ProgramUniformMatrix2dv_fnptr = &ProgramUniformMatrix2dv_Lazy;
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void ProgramUniformMatrix2dv(ProgramHandle program, int location, int count, byte transpose, double* value) => _ProgramUniformMatrix2dv_fnptr(program, location, count, transpose, value);
+        public static void ProgramUniformMatrix2dv(ProgramHandle program, int location, int count, bool transpose, double* value) => _ProgramUniformMatrix2dv_fnptr(program, location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void ProgramUniformMatrix2dv_Lazy(ProgramHandle program, int location, int count, byte transpose, double* value)
+        private static void ProgramUniformMatrix2dv_Lazy(ProgramHandle program, int location, int count, bool transpose, double* value)
         {
-            _ProgramUniformMatrix2dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2dv");
+            _ProgramUniformMatrix2dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2dv");
             _ProgramUniformMatrix2dv_fnptr(program, location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<ProgramHandle, int, int, byte, double*, void> _ProgramUniformMatrix3dv_fnptr = &ProgramUniformMatrix3dv_Lazy;
+        private static delegate* unmanaged<ProgramHandle, int, int, bool, double*, void> _ProgramUniformMatrix3dv_fnptr = &ProgramUniformMatrix3dv_Lazy;
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void ProgramUniformMatrix3dv(ProgramHandle program, int location, int count, byte transpose, double* value) => _ProgramUniformMatrix3dv_fnptr(program, location, count, transpose, value);
+        public static void ProgramUniformMatrix3dv(ProgramHandle program, int location, int count, bool transpose, double* value) => _ProgramUniformMatrix3dv_fnptr(program, location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void ProgramUniformMatrix3dv_Lazy(ProgramHandle program, int location, int count, byte transpose, double* value)
+        private static void ProgramUniformMatrix3dv_Lazy(ProgramHandle program, int location, int count, bool transpose, double* value)
         {
-            _ProgramUniformMatrix3dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3dv");
+            _ProgramUniformMatrix3dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3dv");
             _ProgramUniformMatrix3dv_fnptr(program, location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<ProgramHandle, int, int, byte, double*, void> _ProgramUniformMatrix4dv_fnptr = &ProgramUniformMatrix4dv_Lazy;
+        private static delegate* unmanaged<ProgramHandle, int, int, bool, double*, void> _ProgramUniformMatrix4dv_fnptr = &ProgramUniformMatrix4dv_Lazy;
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void ProgramUniformMatrix4dv(ProgramHandle program, int location, int count, byte transpose, double* value) => _ProgramUniformMatrix4dv_fnptr(program, location, count, transpose, value);
+        public static void ProgramUniformMatrix4dv(ProgramHandle program, int location, int count, bool transpose, double* value) => _ProgramUniformMatrix4dv_fnptr(program, location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void ProgramUniformMatrix4dv_Lazy(ProgramHandle program, int location, int count, byte transpose, double* value)
+        private static void ProgramUniformMatrix4dv_Lazy(ProgramHandle program, int location, int count, bool transpose, double* value)
         {
-            _ProgramUniformMatrix4dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4dv");
+            _ProgramUniformMatrix4dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4dv");
             _ProgramUniformMatrix4dv_fnptr(program, location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix2x3fv_fnptr = &ProgramUniformMatrix2x3fv_Lazy;
+        private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix2x3fv_fnptr = &ProgramUniformMatrix2x3fv_Lazy;
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
@@ -10711,15 +10711,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniformMatrix2x3fv(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix2x3fv_fnptr(program, location, count, transpose, value);
+        public static void ProgramUniformMatrix2x3fv(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix2x3fv_fnptr(program, location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void ProgramUniformMatrix2x3fv_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+        private static void ProgramUniformMatrix2x3fv_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
         {
-            _ProgramUniformMatrix2x3fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2x3fv");
+            _ProgramUniformMatrix2x3fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2x3fv");
             _ProgramUniformMatrix2x3fv_fnptr(program, location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix3x2fv_fnptr = &ProgramUniformMatrix3x2fv_Lazy;
+        private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix3x2fv_fnptr = &ProgramUniformMatrix3x2fv_Lazy;
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
@@ -10727,15 +10727,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniformMatrix3x2fv(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix3x2fv_fnptr(program, location, count, transpose, value);
+        public static void ProgramUniformMatrix3x2fv(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix3x2fv_fnptr(program, location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void ProgramUniformMatrix3x2fv_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+        private static void ProgramUniformMatrix3x2fv_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
         {
-            _ProgramUniformMatrix3x2fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3x2fv");
+            _ProgramUniformMatrix3x2fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3x2fv");
             _ProgramUniformMatrix3x2fv_fnptr(program, location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix2x4fv_fnptr = &ProgramUniformMatrix2x4fv_Lazy;
+        private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix2x4fv_fnptr = &ProgramUniformMatrix2x4fv_Lazy;
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
@@ -10743,15 +10743,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniformMatrix2x4fv(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix2x4fv_fnptr(program, location, count, transpose, value);
+        public static void ProgramUniformMatrix2x4fv(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix2x4fv_fnptr(program, location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void ProgramUniformMatrix2x4fv_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+        private static void ProgramUniformMatrix2x4fv_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
         {
-            _ProgramUniformMatrix2x4fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2x4fv");
+            _ProgramUniformMatrix2x4fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2x4fv");
             _ProgramUniformMatrix2x4fv_fnptr(program, location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix4x2fv_fnptr = &ProgramUniformMatrix4x2fv_Lazy;
+        private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix4x2fv_fnptr = &ProgramUniformMatrix4x2fv_Lazy;
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
@@ -10759,15 +10759,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniformMatrix4x2fv(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix4x2fv_fnptr(program, location, count, transpose, value);
+        public static void ProgramUniformMatrix4x2fv(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix4x2fv_fnptr(program, location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void ProgramUniformMatrix4x2fv_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+        private static void ProgramUniformMatrix4x2fv_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
         {
-            _ProgramUniformMatrix4x2fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4x2fv");
+            _ProgramUniformMatrix4x2fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4x2fv");
             _ProgramUniformMatrix4x2fv_fnptr(program, location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix3x4fv_fnptr = &ProgramUniformMatrix3x4fv_Lazy;
+        private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix3x4fv_fnptr = &ProgramUniformMatrix3x4fv_Lazy;
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
@@ -10775,15 +10775,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniformMatrix3x4fv(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix3x4fv_fnptr(program, location, count, transpose, value);
+        public static void ProgramUniformMatrix3x4fv(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix3x4fv_fnptr(program, location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void ProgramUniformMatrix3x4fv_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+        private static void ProgramUniformMatrix3x4fv_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
         {
-            _ProgramUniformMatrix3x4fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3x4fv");
+            _ProgramUniformMatrix3x4fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3x4fv");
             _ProgramUniformMatrix3x4fv_fnptr(program, location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix4x3fv_fnptr = &ProgramUniformMatrix4x3fv_Lazy;
+        private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix4x3fv_fnptr = &ProgramUniformMatrix4x3fv_Lazy;
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
@@ -10791,77 +10791,77 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniformMatrix4x3fv(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix4x3fv_fnptr(program, location, count, transpose, value);
+        public static void ProgramUniformMatrix4x3fv(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix4x3fv_fnptr(program, location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void ProgramUniformMatrix4x3fv_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+        private static void ProgramUniformMatrix4x3fv_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
         {
-            _ProgramUniformMatrix4x3fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4x3fv");
+            _ProgramUniformMatrix4x3fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4x3fv");
             _ProgramUniformMatrix4x3fv_fnptr(program, location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<ProgramHandle, int, int, byte, double*, void> _ProgramUniformMatrix2x3dv_fnptr = &ProgramUniformMatrix2x3dv_Lazy;
+        private static delegate* unmanaged<ProgramHandle, int, int, bool, double*, void> _ProgramUniformMatrix2x3dv_fnptr = &ProgramUniformMatrix2x3dv_Lazy;
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void ProgramUniformMatrix2x3dv(ProgramHandle program, int location, int count, byte transpose, double* value) => _ProgramUniformMatrix2x3dv_fnptr(program, location, count, transpose, value);
+        public static void ProgramUniformMatrix2x3dv(ProgramHandle program, int location, int count, bool transpose, double* value) => _ProgramUniformMatrix2x3dv_fnptr(program, location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void ProgramUniformMatrix2x3dv_Lazy(ProgramHandle program, int location, int count, byte transpose, double* value)
+        private static void ProgramUniformMatrix2x3dv_Lazy(ProgramHandle program, int location, int count, bool transpose, double* value)
         {
-            _ProgramUniformMatrix2x3dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2x3dv");
+            _ProgramUniformMatrix2x3dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2x3dv");
             _ProgramUniformMatrix2x3dv_fnptr(program, location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<ProgramHandle, int, int, byte, double*, void> _ProgramUniformMatrix3x2dv_fnptr = &ProgramUniformMatrix3x2dv_Lazy;
+        private static delegate* unmanaged<ProgramHandle, int, int, bool, double*, void> _ProgramUniformMatrix3x2dv_fnptr = &ProgramUniformMatrix3x2dv_Lazy;
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void ProgramUniformMatrix3x2dv(ProgramHandle program, int location, int count, byte transpose, double* value) => _ProgramUniformMatrix3x2dv_fnptr(program, location, count, transpose, value);
+        public static void ProgramUniformMatrix3x2dv(ProgramHandle program, int location, int count, bool transpose, double* value) => _ProgramUniformMatrix3x2dv_fnptr(program, location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void ProgramUniformMatrix3x2dv_Lazy(ProgramHandle program, int location, int count, byte transpose, double* value)
+        private static void ProgramUniformMatrix3x2dv_Lazy(ProgramHandle program, int location, int count, bool transpose, double* value)
         {
-            _ProgramUniformMatrix3x2dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3x2dv");
+            _ProgramUniformMatrix3x2dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3x2dv");
             _ProgramUniformMatrix3x2dv_fnptr(program, location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<ProgramHandle, int, int, byte, double*, void> _ProgramUniformMatrix2x4dv_fnptr = &ProgramUniformMatrix2x4dv_Lazy;
+        private static delegate* unmanaged<ProgramHandle, int, int, bool, double*, void> _ProgramUniformMatrix2x4dv_fnptr = &ProgramUniformMatrix2x4dv_Lazy;
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void ProgramUniformMatrix2x4dv(ProgramHandle program, int location, int count, byte transpose, double* value) => _ProgramUniformMatrix2x4dv_fnptr(program, location, count, transpose, value);
+        public static void ProgramUniformMatrix2x4dv(ProgramHandle program, int location, int count, bool transpose, double* value) => _ProgramUniformMatrix2x4dv_fnptr(program, location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void ProgramUniformMatrix2x4dv_Lazy(ProgramHandle program, int location, int count, byte transpose, double* value)
+        private static void ProgramUniformMatrix2x4dv_Lazy(ProgramHandle program, int location, int count, bool transpose, double* value)
         {
-            _ProgramUniformMatrix2x4dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2x4dv");
+            _ProgramUniformMatrix2x4dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2x4dv");
             _ProgramUniformMatrix2x4dv_fnptr(program, location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<ProgramHandle, int, int, byte, double*, void> _ProgramUniformMatrix4x2dv_fnptr = &ProgramUniformMatrix4x2dv_Lazy;
+        private static delegate* unmanaged<ProgramHandle, int, int, bool, double*, void> _ProgramUniformMatrix4x2dv_fnptr = &ProgramUniformMatrix4x2dv_Lazy;
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void ProgramUniformMatrix4x2dv(ProgramHandle program, int location, int count, byte transpose, double* value) => _ProgramUniformMatrix4x2dv_fnptr(program, location, count, transpose, value);
+        public static void ProgramUniformMatrix4x2dv(ProgramHandle program, int location, int count, bool transpose, double* value) => _ProgramUniformMatrix4x2dv_fnptr(program, location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void ProgramUniformMatrix4x2dv_Lazy(ProgramHandle program, int location, int count, byte transpose, double* value)
+        private static void ProgramUniformMatrix4x2dv_Lazy(ProgramHandle program, int location, int count, bool transpose, double* value)
         {
-            _ProgramUniformMatrix4x2dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4x2dv");
+            _ProgramUniformMatrix4x2dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4x2dv");
             _ProgramUniformMatrix4x2dv_fnptr(program, location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<ProgramHandle, int, int, byte, double*, void> _ProgramUniformMatrix3x4dv_fnptr = &ProgramUniformMatrix3x4dv_Lazy;
+        private static delegate* unmanaged<ProgramHandle, int, int, bool, double*, void> _ProgramUniformMatrix3x4dv_fnptr = &ProgramUniformMatrix3x4dv_Lazy;
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void ProgramUniformMatrix3x4dv(ProgramHandle program, int location, int count, byte transpose, double* value) => _ProgramUniformMatrix3x4dv_fnptr(program, location, count, transpose, value);
+        public static void ProgramUniformMatrix3x4dv(ProgramHandle program, int location, int count, bool transpose, double* value) => _ProgramUniformMatrix3x4dv_fnptr(program, location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void ProgramUniformMatrix3x4dv_Lazy(ProgramHandle program, int location, int count, byte transpose, double* value)
+        private static void ProgramUniformMatrix3x4dv_Lazy(ProgramHandle program, int location, int count, bool transpose, double* value)
         {
-            _ProgramUniformMatrix3x4dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3x4dv");
+            _ProgramUniformMatrix3x4dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3x4dv");
             _ProgramUniformMatrix3x4dv_fnptr(program, location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<ProgramHandle, int, int, byte, double*, void> _ProgramUniformMatrix4x3dv_fnptr = &ProgramUniformMatrix4x3dv_Lazy;
+        private static delegate* unmanaged<ProgramHandle, int, int, bool, double*, void> _ProgramUniformMatrix4x3dv_fnptr = &ProgramUniformMatrix4x3dv_Lazy;
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void ProgramUniformMatrix4x3dv(ProgramHandle program, int location, int count, byte transpose, double* value) => _ProgramUniformMatrix4x3dv_fnptr(program, location, count, transpose, value);
+        public static void ProgramUniformMatrix4x3dv(ProgramHandle program, int location, int count, bool transpose, double* value) => _ProgramUniformMatrix4x3dv_fnptr(program, location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void ProgramUniformMatrix4x3dv_Lazy(ProgramHandle program, int location, int count, byte transpose, double* value)
+        private static void ProgramUniformMatrix4x3dv_Lazy(ProgramHandle program, int location, int count, bool transpose, double* value)
         {
-            _ProgramUniformMatrix4x3dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4x3dv");
+            _ProgramUniformMatrix4x3dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4x3dv");
             _ProgramUniformMatrix4x3dv_fnptr(program, location, count, transpose, value);
         }
         
@@ -11256,7 +11256,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             _GetActiveAtomicCounterBufferiv_fnptr(program, bufferIndex, pname, parameters);
         }
         
-        private static delegate* unmanaged<uint, TextureHandle, int, byte, int, BufferAccessARB, InternalFormat, void> _BindImageTexture_fnptr = &BindImageTexture_Lazy;
+        private static delegate* unmanaged<uint, TextureHandle, int, bool, int, BufferAccessARB, InternalFormat, void> _BindImageTexture_fnptr = &BindImageTexture_Lazy;
         /// <summary> <b>[requires: v4.2 | GL_ARB_shader_image_load_store]</b> Bind a level of a texture to an image unit. </summary>
         /// <param name="unit"> Specifies the index of the image unit to which to bind the texture </param>
         /// <param name="texture"> Specifies the name of the texture to bind to the image unit. </param>
@@ -11266,11 +11266,11 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="access"> Specifies a token indicating the type of access that will be performed on the image. </param>
         /// <param name="format"> Specifies the format that the elements of the image will be treated as for the purposes of formatted stores. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindImageTexture.xhtml" /></remarks>
-        public static void BindImageTexture(uint unit, TextureHandle texture, int level, byte layered, int layer, BufferAccessARB access, InternalFormat format) => _BindImageTexture_fnptr(unit, texture, level, layered, layer, access, format);
+        public static void BindImageTexture(uint unit, TextureHandle texture, int level, bool layered, int layer, BufferAccessARB access, InternalFormat format) => _BindImageTexture_fnptr(unit, texture, level, layered, layer, access, format);
         [UnmanagedCallersOnly]
-        private static void BindImageTexture_Lazy(uint unit, TextureHandle texture, int level, byte layered, int layer, BufferAccessARB access, InternalFormat format)
+        private static void BindImageTexture_Lazy(uint unit, TextureHandle texture, int level, bool layered, int layer, BufferAccessARB access, InternalFormat format)
         {
-            _BindImageTexture_fnptr = (delegate* unmanaged<uint, TextureHandle, int, byte, int, BufferAccessARB, InternalFormat, void>)GLLoader.BindingsContext.GetProcAddress("glBindImageTexture");
+            _BindImageTexture_fnptr = (delegate* unmanaged<uint, TextureHandle, int, bool, int, BufferAccessARB, InternalFormat, void>)GLLoader.BindingsContext.GetProcAddress("glBindImageTexture");
             _BindImageTexture_fnptr(unit, texture, level, layered, layer, access, format);
         }
         
@@ -11737,7 +11737,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             _TexBufferRange_fnptr(target, internalformat, buffer, offset, size);
         }
         
-        private static delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, byte, void> _TexStorage2DMultisample_fnptr = &TexStorage2DMultisample_Lazy;
+        private static delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, bool, void> _TexStorage2DMultisample_fnptr = &TexStorage2DMultisample_Lazy;
         /// <summary> <b>[requires: v4.3 | GL_ARB_texture_storage_multisample]</b> Specify storage for a two-dimensional multisample texture. </summary>
         /// <param name="target"> Specifies the target to which the texture object is bound for glTexStorage2DMultisample. Must be one of GL_TEXTURE_2D_MULTISAMPLE or GL_PROXY_TEXTURE_2D_MULTISAMPLE. </param>
         /// <param name="samples"> Specify the number of samples in the texture. </param>
@@ -11746,15 +11746,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="height"> Specifies the height of the texture, in texels. </param>
         /// <param name="fixedsamplelocations"> Specifies whether the image will use identical sample locations and the same number of samples for all texels in the image, and the sample locations will not depend on the internal format or size of the image. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexStorage2DMultisample.xhtml" /></remarks>
-        public static void TexStorage2DMultisample(TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, byte fixedsamplelocations) => _TexStorage2DMultisample_fnptr(target, samples, internalformat, width, height, fixedsamplelocations);
+        public static void TexStorage2DMultisample(TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, bool fixedsamplelocations) => _TexStorage2DMultisample_fnptr(target, samples, internalformat, width, height, fixedsamplelocations);
         [UnmanagedCallersOnly]
-        private static void TexStorage2DMultisample_Lazy(TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, byte fixedsamplelocations)
+        private static void TexStorage2DMultisample_Lazy(TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, bool fixedsamplelocations)
         {
-            _TexStorage2DMultisample_fnptr = (delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, byte, void>)GLLoader.BindingsContext.GetProcAddress("glTexStorage2DMultisample");
+            _TexStorage2DMultisample_fnptr = (delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, bool, void>)GLLoader.BindingsContext.GetProcAddress("glTexStorage2DMultisample");
             _TexStorage2DMultisample_fnptr(target, samples, internalformat, width, height, fixedsamplelocations);
         }
         
-        private static delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, int, byte, void> _TexStorage3DMultisample_fnptr = &TexStorage3DMultisample_Lazy;
+        private static delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, int, bool, void> _TexStorage3DMultisample_fnptr = &TexStorage3DMultisample_Lazy;
         /// <summary> <b>[requires: v4.3 | GL_ARB_texture_storage_multisample]</b> Specify storage for a two-dimensional multisample array texture. </summary>
         /// <param name="target"> Specifies the target to which the texture object is bound for glTexStorage3DMultisample. Must be one of GL_TEXTURE_2D_MULTISAMPLE_ARRAY or GL_PROXY_TEXTURE_2D_MULTISAMPLE_ARRAY. </param>
         /// <param name="samples"> Specify the number of samples in the texture. </param>
@@ -11764,11 +11764,11 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="depth"> Specifies the depth of the texture, in layers. </param>
         /// <param name="fixedsamplelocations"> Specifies whether the image will use identical sample locations and the same number of samples for all texels in the image, and the sample locations will not depend on the internal format or size of the image. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexStorage3DMultisample.xhtml" /></remarks>
-        public static void TexStorage3DMultisample(TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, int depth, byte fixedsamplelocations) => _TexStorage3DMultisample_fnptr(target, samples, internalformat, width, height, depth, fixedsamplelocations);
+        public static void TexStorage3DMultisample(TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, int depth, bool fixedsamplelocations) => _TexStorage3DMultisample_fnptr(target, samples, internalformat, width, height, depth, fixedsamplelocations);
         [UnmanagedCallersOnly]
-        private static void TexStorage3DMultisample_Lazy(TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, int depth, byte fixedsamplelocations)
+        private static void TexStorage3DMultisample_Lazy(TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, int depth, bool fixedsamplelocations)
         {
-            _TexStorage3DMultisample_fnptr = (delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, int, byte, void>)GLLoader.BindingsContext.GetProcAddress("glTexStorage3DMultisample");
+            _TexStorage3DMultisample_fnptr = (delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, int, bool, void>)GLLoader.BindingsContext.GetProcAddress("glTexStorage3DMultisample");
             _TexStorage3DMultisample_fnptr(target, samples, internalformat, width, height, depth, fixedsamplelocations);
         }
         
@@ -11806,7 +11806,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             _BindVertexBuffer_fnptr(bindingindex, buffer, offset, stride);
         }
         
-        private static delegate* unmanaged<uint, int, VertexAttribType, byte, uint, void> _VertexAttribFormat_fnptr = &VertexAttribFormat_Lazy;
+        private static delegate* unmanaged<uint, int, VertexAttribType, bool, uint, void> _VertexAttribFormat_fnptr = &VertexAttribFormat_Lazy;
         /// <summary> <b>[requires: v4.3 | GL_ARB_vertex_attrib_binding]</b> Specify the organization of vertex arrays. </summary>
         /// <param name="attribindex">The generic vertex attribute array being described.</param>
         /// <param name="size">The number of values per vertex that are stored in the array.</param>
@@ -11814,11 +11814,11 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="normalized"> Specifies whether fixed-point data values should be normalized (GL_TRUE) or converted directly as fixed-point values (GL_FALSE) when they are accessed. This parameter is ignored if type is GL_FIXED. </param>
         /// <param name="relativeoffset">The distance between elements within the buffer.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glVertexAttribFormat.xhtml" /></remarks>
-        public static void VertexAttribFormat(uint attribindex, int size, VertexAttribType type, byte normalized, uint relativeoffset) => _VertexAttribFormat_fnptr(attribindex, size, type, normalized, relativeoffset);
+        public static void VertexAttribFormat(uint attribindex, int size, VertexAttribType type, bool normalized, uint relativeoffset) => _VertexAttribFormat_fnptr(attribindex, size, type, normalized, relativeoffset);
         [UnmanagedCallersOnly]
-        private static void VertexAttribFormat_Lazy(uint attribindex, int size, VertexAttribType type, byte normalized, uint relativeoffset)
+        private static void VertexAttribFormat_Lazy(uint attribindex, int size, VertexAttribType type, bool normalized, uint relativeoffset)
         {
-            _VertexAttribFormat_fnptr = (delegate* unmanaged<uint, int, VertexAttribType, byte, uint, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribFormat");
+            _VertexAttribFormat_fnptr = (delegate* unmanaged<uint, int, VertexAttribType, bool, uint, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribFormat");
             _VertexAttribFormat_fnptr(attribindex, size, type, normalized, relativeoffset);
         }
         
@@ -11878,7 +11878,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             _VertexBindingDivisor_fnptr(bindingindex, divisor);
         }
         
-        private static delegate* unmanaged<DebugSource, DebugType, DebugSeverity, int, uint*, byte, void> _DebugMessageControl_fnptr = &DebugMessageControl_Lazy;
+        private static delegate* unmanaged<DebugSource, DebugType, DebugSeverity, int, uint*, bool, void> _DebugMessageControl_fnptr = &DebugMessageControl_Lazy;
         /// <summary> <b>[requires: v4.3 | GL_KHR_debug]</b> Control the reporting of debug messages in a debug context. </summary>
         /// <param name="source"> The source of debug messages to enable or disable. </param>
         /// <param name="type"> The type of debug messages to enable or disable. </param>
@@ -11887,11 +11887,11 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="ids"> The address of an array of unsigned integers contianing the ids of the messages to enable or disable. </param>
         /// <param name="enabled"> A Boolean flag determining whether the selected messages should be enabled or disabled. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDebugMessageControl.xhtml" /></remarks>
-        public static void DebugMessageControl(DebugSource source, DebugType type, DebugSeverity severity, int count, uint* ids, byte enabled) => _DebugMessageControl_fnptr(source, type, severity, count, ids, enabled);
+        public static void DebugMessageControl(DebugSource source, DebugType type, DebugSeverity severity, int count, uint* ids, bool enabled) => _DebugMessageControl_fnptr(source, type, severity, count, ids, enabled);
         [UnmanagedCallersOnly]
-        private static void DebugMessageControl_Lazy(DebugSource source, DebugType type, DebugSeverity severity, int count, uint* ids, byte enabled)
+        private static void DebugMessageControl_Lazy(DebugSource source, DebugType type, DebugSeverity severity, int count, uint* ids, bool enabled)
         {
-            _DebugMessageControl_fnptr = (delegate* unmanaged<DebugSource, DebugType, DebugSeverity, int, uint*, byte, void>)GLLoader.BindingsContext.GetProcAddress("glDebugMessageControl");
+            _DebugMessageControl_fnptr = (delegate* unmanaged<DebugSource, DebugType, DebugSeverity, int, uint*, bool, void>)GLLoader.BindingsContext.GetProcAddress("glDebugMessageControl");
             _DebugMessageControl_fnptr(source, type, severity, count, ids, enabled);
         }
         
@@ -12409,15 +12409,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             return _MapNamedBufferRange_fnptr(buffer, offset, length, access);
         }
         
-        private static delegate* unmanaged<BufferHandle, byte> _UnmapNamedBuffer_fnptr = &UnmapNamedBuffer_Lazy;
+        private static delegate* unmanaged<BufferHandle, bool> _UnmapNamedBuffer_fnptr = &UnmapNamedBuffer_Lazy;
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Release the mapping of a buffer object's data store into the client's address space. </summary>
         /// <param name="buffer"> Specifies the name of the buffer object for glUnmapNamedBuffer. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glUnmapBuffer.xhtml" /></remarks>
-        public static byte UnmapNamedBuffer(BufferHandle buffer) => _UnmapNamedBuffer_fnptr(buffer);
+        public static bool UnmapNamedBuffer(BufferHandle buffer) => _UnmapNamedBuffer_fnptr(buffer);
         [UnmanagedCallersOnly]
-        private static byte UnmapNamedBuffer_Lazy(BufferHandle buffer)
+        private static bool UnmapNamedBuffer_Lazy(BufferHandle buffer)
         {
-            _UnmapNamedBuffer_fnptr = (delegate* unmanaged<BufferHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glUnmapNamedBuffer");
+            _UnmapNamedBuffer_fnptr = (delegate* unmanaged<BufferHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glUnmapNamedBuffer");
             return _UnmapNamedBuffer_fnptr(buffer);
         }
         
@@ -12913,7 +12913,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             _TextureStorage3D_fnptr(texture, levels, internalformat, width, height, depth);
         }
         
-        private static delegate* unmanaged<TextureHandle, int, SizedInternalFormat, int, int, byte, void> _TextureStorage2DMultisample_fnptr = &TextureStorage2DMultisample_Lazy;
+        private static delegate* unmanaged<TextureHandle, int, SizedInternalFormat, int, int, bool, void> _TextureStorage2DMultisample_fnptr = &TextureStorage2DMultisample_Lazy;
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specify storage for a two-dimensional multisample texture. </summary>
         /// <param name="texture"> Specifies the texture object name for glTextureStorage2DMultisample. The effective target of texture must be one of the valid non-proxy target values above. </param>
         /// <param name="samples"> Specify the number of samples in the texture. </param>
@@ -12922,15 +12922,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="height"> Specifies the height of the texture, in texels. </param>
         /// <param name="fixedsamplelocations"> Specifies whether the image will use identical sample locations and the same number of samples for all texels in the image, and the sample locations will not depend on the internal format or size of the image. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexStorage2DMultisample.xhtml" /></remarks>
-        public static void TextureStorage2DMultisample(TextureHandle texture, int samples, SizedInternalFormat internalformat, int width, int height, byte fixedsamplelocations) => _TextureStorage2DMultisample_fnptr(texture, samples, internalformat, width, height, fixedsamplelocations);
+        public static void TextureStorage2DMultisample(TextureHandle texture, int samples, SizedInternalFormat internalformat, int width, int height, bool fixedsamplelocations) => _TextureStorage2DMultisample_fnptr(texture, samples, internalformat, width, height, fixedsamplelocations);
         [UnmanagedCallersOnly]
-        private static void TextureStorage2DMultisample_Lazy(TextureHandle texture, int samples, SizedInternalFormat internalformat, int width, int height, byte fixedsamplelocations)
+        private static void TextureStorage2DMultisample_Lazy(TextureHandle texture, int samples, SizedInternalFormat internalformat, int width, int height, bool fixedsamplelocations)
         {
-            _TextureStorage2DMultisample_fnptr = (delegate* unmanaged<TextureHandle, int, SizedInternalFormat, int, int, byte, void>)GLLoader.BindingsContext.GetProcAddress("glTextureStorage2DMultisample");
+            _TextureStorage2DMultisample_fnptr = (delegate* unmanaged<TextureHandle, int, SizedInternalFormat, int, int, bool, void>)GLLoader.BindingsContext.GetProcAddress("glTextureStorage2DMultisample");
             _TextureStorage2DMultisample_fnptr(texture, samples, internalformat, width, height, fixedsamplelocations);
         }
         
-        private static delegate* unmanaged<TextureHandle, int, SizedInternalFormat, int, int, int, byte, void> _TextureStorage3DMultisample_fnptr = &TextureStorage3DMultisample_Lazy;
+        private static delegate* unmanaged<TextureHandle, int, SizedInternalFormat, int, int, int, bool, void> _TextureStorage3DMultisample_fnptr = &TextureStorage3DMultisample_Lazy;
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specify storage for a two-dimensional multisample array texture. </summary>
         /// <param name="texture"> Specifies the texture object name for glTextureStorage3DMultisample. The effective target of texture must be one of the valid non-proxy target values above. </param>
         /// <param name="samples"> Specify the number of samples in the texture. </param>
@@ -12940,11 +12940,11 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="depth"> Specifies the depth of the texture, in layers. </param>
         /// <param name="fixedsamplelocations"> Specifies whether the image will use identical sample locations and the same number of samples for all texels in the image, and the sample locations will not depend on the internal format or size of the image. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexStorage3DMultisample.xhtml" /></remarks>
-        public static void TextureStorage3DMultisample(TextureHandle texture, int samples, SizedInternalFormat internalformat, int width, int height, int depth, byte fixedsamplelocations) => _TextureStorage3DMultisample_fnptr(texture, samples, internalformat, width, height, depth, fixedsamplelocations);
+        public static void TextureStorage3DMultisample(TextureHandle texture, int samples, SizedInternalFormat internalformat, int width, int height, int depth, bool fixedsamplelocations) => _TextureStorage3DMultisample_fnptr(texture, samples, internalformat, width, height, depth, fixedsamplelocations);
         [UnmanagedCallersOnly]
-        private static void TextureStorage3DMultisample_Lazy(TextureHandle texture, int samples, SizedInternalFormat internalformat, int width, int height, int depth, byte fixedsamplelocations)
+        private static void TextureStorage3DMultisample_Lazy(TextureHandle texture, int samples, SizedInternalFormat internalformat, int width, int height, int depth, bool fixedsamplelocations)
         {
-            _TextureStorage3DMultisample_fnptr = (delegate* unmanaged<TextureHandle, int, SizedInternalFormat, int, int, int, byte, void>)GLLoader.BindingsContext.GetProcAddress("glTextureStorage3DMultisample");
+            _TextureStorage3DMultisample_fnptr = (delegate* unmanaged<TextureHandle, int, SizedInternalFormat, int, int, int, bool, void>)GLLoader.BindingsContext.GetProcAddress("glTextureStorage3DMultisample");
             _TextureStorage3DMultisample_fnptr(texture, samples, internalformat, width, height, depth, fixedsamplelocations);
         }
         
@@ -13450,7 +13450,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             _VertexArrayAttribBinding_fnptr(vaobj, attribindex, bindingindex);
         }
         
-        private static delegate* unmanaged<VertexArrayHandle, uint, int, VertexAttribType, byte, uint, void> _VertexArrayAttribFormat_fnptr = &VertexArrayAttribFormat_Lazy;
+        private static delegate* unmanaged<VertexArrayHandle, uint, int, VertexAttribType, bool, uint, void> _VertexArrayAttribFormat_fnptr = &VertexArrayAttribFormat_Lazy;
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specify the organization of vertex arrays. </summary>
         /// <param name="vaobj">Specifies the name of the vertex array object for glVertexArrayAttrib{I, L}Format functions.</param>
         /// <param name="attribindex">The generic vertex attribute array being described.</param>
@@ -13459,11 +13459,11 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="normalized"> Specifies whether fixed-point data values should be normalized (GL_TRUE) or converted directly as fixed-point values (GL_FALSE) when they are accessed. This parameter is ignored if type is GL_FIXED. </param>
         /// <param name="relativeoffset">The distance between elements within the buffer.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glVertexAttribFormat.xhtml" /></remarks>
-        public static void VertexArrayAttribFormat(VertexArrayHandle vaobj, uint attribindex, int size, VertexAttribType type, byte normalized, uint relativeoffset) => _VertexArrayAttribFormat_fnptr(vaobj, attribindex, size, type, normalized, relativeoffset);
+        public static void VertexArrayAttribFormat(VertexArrayHandle vaobj, uint attribindex, int size, VertexAttribType type, bool normalized, uint relativeoffset) => _VertexArrayAttribFormat_fnptr(vaobj, attribindex, size, type, normalized, relativeoffset);
         [UnmanagedCallersOnly]
-        private static void VertexArrayAttribFormat_Lazy(VertexArrayHandle vaobj, uint attribindex, int size, VertexAttribType type, byte normalized, uint relativeoffset)
+        private static void VertexArrayAttribFormat_Lazy(VertexArrayHandle vaobj, uint attribindex, int size, VertexAttribType type, bool normalized, uint relativeoffset)
         {
-            _VertexArrayAttribFormat_fnptr = (delegate* unmanaged<VertexArrayHandle, uint, int, VertexAttribType, byte, uint, void>)GLLoader.BindingsContext.GetProcAddress("glVertexArrayAttribFormat");
+            _VertexArrayAttribFormat_fnptr = (delegate* unmanaged<VertexArrayHandle, uint, int, VertexAttribType, bool, uint, void>)GLLoader.BindingsContext.GetProcAddress("glVertexArrayAttribFormat");
             _VertexArrayAttribFormat_fnptr(vaobj, attribindex, size, type, normalized, relativeoffset);
         }
         
@@ -13925,21 +13925,21 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             _GetnSeparableFilter_fnptr(target, format, type, rowBufSize, row, columnBufSize, column, span);
         }
         
-        private static delegate* unmanaged<HistogramTarget, byte, PixelFormat, PixelType, int, void*, void> _GetnHistogram_fnptr = &GetnHistogram_Lazy;
-        public static void GetnHistogram(HistogramTarget target, byte reset, PixelFormat format, PixelType type, int bufSize, void* values) => _GetnHistogram_fnptr(target, reset, format, type, bufSize, values);
+        private static delegate* unmanaged<HistogramTarget, bool, PixelFormat, PixelType, int, void*, void> _GetnHistogram_fnptr = &GetnHistogram_Lazy;
+        public static void GetnHistogram(HistogramTarget target, bool reset, PixelFormat format, PixelType type, int bufSize, void* values) => _GetnHistogram_fnptr(target, reset, format, type, bufSize, values);
         [UnmanagedCallersOnly]
-        private static void GetnHistogram_Lazy(HistogramTarget target, byte reset, PixelFormat format, PixelType type, int bufSize, void* values)
+        private static void GetnHistogram_Lazy(HistogramTarget target, bool reset, PixelFormat format, PixelType type, int bufSize, void* values)
         {
-            _GetnHistogram_fnptr = (delegate* unmanaged<HistogramTarget, byte, PixelFormat, PixelType, int, void*, void>)GLLoader.BindingsContext.GetProcAddress("glGetnHistogram");
+            _GetnHistogram_fnptr = (delegate* unmanaged<HistogramTarget, bool, PixelFormat, PixelType, int, void*, void>)GLLoader.BindingsContext.GetProcAddress("glGetnHistogram");
             _GetnHistogram_fnptr(target, reset, format, type, bufSize, values);
         }
         
-        private static delegate* unmanaged<MinmaxTarget, byte, PixelFormat, PixelType, int, void*, void> _GetnMinmax_fnptr = &GetnMinmax_Lazy;
-        public static void GetnMinmax(MinmaxTarget target, byte reset, PixelFormat format, PixelType type, int bufSize, void* values) => _GetnMinmax_fnptr(target, reset, format, type, bufSize, values);
+        private static delegate* unmanaged<MinmaxTarget, bool, PixelFormat, PixelType, int, void*, void> _GetnMinmax_fnptr = &GetnMinmax_Lazy;
+        public static void GetnMinmax(MinmaxTarget target, bool reset, PixelFormat format, PixelType type, int bufSize, void* values) => _GetnMinmax_fnptr(target, reset, format, type, bufSize, values);
         [UnmanagedCallersOnly]
-        private static void GetnMinmax_Lazy(MinmaxTarget target, byte reset, PixelFormat format, PixelType type, int bufSize, void* values)
+        private static void GetnMinmax_Lazy(MinmaxTarget target, bool reset, PixelFormat format, PixelType type, int bufSize, void* values)
         {
-            _GetnMinmax_fnptr = (delegate* unmanaged<MinmaxTarget, byte, PixelFormat, PixelType, int, void*, void>)GLLoader.BindingsContext.GetProcAddress("glGetnMinmax");
+            _GetnMinmax_fnptr = (delegate* unmanaged<MinmaxTarget, bool, PixelFormat, PixelType, int, void*, void>)GLLoader.BindingsContext.GetProcAddress("glGetnMinmax");
             _GetnMinmax_fnptr(target, reset, format, type, bufSize, values);
         }
         
@@ -14008,14 +14008,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         }
         public static unsafe partial class AMD
         {
-            private static delegate* unmanaged<All, DebugSeverity, int, uint*, byte, void> _DebugMessageEnableAMD_fnptr = &DebugMessageEnableAMD_Lazy;
+            private static delegate* unmanaged<All, DebugSeverity, int, uint*, bool, void> _DebugMessageEnableAMD_fnptr = &DebugMessageEnableAMD_Lazy;
             /// <summary> <b>[requires: GL_AMD_debug_output]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void DebugMessageEnableAMD(All category, DebugSeverity severity, int count, uint* ids, byte enabled) => _DebugMessageEnableAMD_fnptr(category, severity, count, ids, enabled);
+            public static void DebugMessageEnableAMD(All category, DebugSeverity severity, int count, uint* ids, bool enabled) => _DebugMessageEnableAMD_fnptr(category, severity, count, ids, enabled);
             [UnmanagedCallersOnly]
-            private static void DebugMessageEnableAMD_Lazy(All category, DebugSeverity severity, int count, uint* ids, byte enabled)
+            private static void DebugMessageEnableAMD_Lazy(All category, DebugSeverity severity, int count, uint* ids, bool enabled)
             {
-                _DebugMessageEnableAMD_fnptr = (delegate* unmanaged<All, DebugSeverity, int, uint*, byte, void>)GLLoader.BindingsContext.GetProcAddress("glDebugMessageEnableAMD");
+                _DebugMessageEnableAMD_fnptr = (delegate* unmanaged<All, DebugSeverity, int, uint*, bool, void>)GLLoader.BindingsContext.GetProcAddress("glDebugMessageEnableAMD");
                 _DebugMessageEnableAMD_fnptr(category, severity, count, ids, enabled);
             }
             
@@ -14591,14 +14591,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _DeleteNamesAMD_fnptr(identifier, num, names);
             }
             
-            private static delegate* unmanaged<All, uint, byte> _IsNameAMD_fnptr = &IsNameAMD_Lazy;
+            private static delegate* unmanaged<All, uint, bool> _IsNameAMD_fnptr = &IsNameAMD_Lazy;
             /// <summary> <b>[requires: GL_AMD_name_gen_delete]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsNameAMD(All identifier, uint name) => _IsNameAMD_fnptr(identifier, name);
+            public static bool IsNameAMD(All identifier, uint name) => _IsNameAMD_fnptr(identifier, name);
             [UnmanagedCallersOnly]
-            private static byte IsNameAMD_Lazy(All identifier, uint name)
+            private static bool IsNameAMD_Lazy(All identifier, uint name)
             {
-                _IsNameAMD_fnptr = (delegate* unmanaged<All, uint, byte>)GLLoader.BindingsContext.GetProcAddress("glIsNameAMD");
+                _IsNameAMD_fnptr = (delegate* unmanaged<All, uint, bool>)GLLoader.BindingsContext.GetProcAddress("glIsNameAMD");
                 return _IsNameAMD_fnptr(identifier, name);
             }
             
@@ -14690,14 +14690,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _DeletePerfMonitorsAMD_fnptr(n, monitors);
             }
             
-            private static delegate* unmanaged<uint, byte, uint, int, uint*, void> _SelectPerfMonitorCountersAMD_fnptr = &SelectPerfMonitorCountersAMD_Lazy;
+            private static delegate* unmanaged<uint, bool, uint, int, uint*, void> _SelectPerfMonitorCountersAMD_fnptr = &SelectPerfMonitorCountersAMD_Lazy;
             /// <summary> <b>[requires: GL_AMD_performance_monitor]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void SelectPerfMonitorCountersAMD(uint monitor, byte enable, uint group, int numCounters, uint* counterList) => _SelectPerfMonitorCountersAMD_fnptr(monitor, enable, group, numCounters, counterList);
+            public static void SelectPerfMonitorCountersAMD(uint monitor, bool enable, uint group, int numCounters, uint* counterList) => _SelectPerfMonitorCountersAMD_fnptr(monitor, enable, group, numCounters, counterList);
             [UnmanagedCallersOnly]
-            private static void SelectPerfMonitorCountersAMD_Lazy(uint monitor, byte enable, uint group, int numCounters, uint* counterList)
+            private static void SelectPerfMonitorCountersAMD_Lazy(uint monitor, bool enable, uint group, int numCounters, uint* counterList)
             {
-                _SelectPerfMonitorCountersAMD_fnptr = (delegate* unmanaged<uint, byte, uint, int, uint*, void>)GLLoader.BindingsContext.GetProcAddress("glSelectPerfMonitorCountersAMD");
+                _SelectPerfMonitorCountersAMD_fnptr = (delegate* unmanaged<uint, bool, uint, int, uint*, void>)GLLoader.BindingsContext.GetProcAddress("glSelectPerfMonitorCountersAMD");
                 _SelectPerfMonitorCountersAMD_fnptr(monitor, enable, group, numCounters, counterList);
             }
             
@@ -14891,25 +14891,25 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _SetFenceAPPLE_fnptr(fence);
             }
             
-            private static delegate* unmanaged<uint, byte> _IsFenceAPPLE_fnptr = &IsFenceAPPLE_Lazy;
+            private static delegate* unmanaged<uint, bool> _IsFenceAPPLE_fnptr = &IsFenceAPPLE_Lazy;
             /// <summary> <b>[requires: GL_APPLE_fence]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsFenceAPPLE(uint fence) => _IsFenceAPPLE_fnptr(fence);
+            public static bool IsFenceAPPLE(uint fence) => _IsFenceAPPLE_fnptr(fence);
             [UnmanagedCallersOnly]
-            private static byte IsFenceAPPLE_Lazy(uint fence)
+            private static bool IsFenceAPPLE_Lazy(uint fence)
             {
-                _IsFenceAPPLE_fnptr = (delegate* unmanaged<uint, byte>)GLLoader.BindingsContext.GetProcAddress("glIsFenceAPPLE");
+                _IsFenceAPPLE_fnptr = (delegate* unmanaged<uint, bool>)GLLoader.BindingsContext.GetProcAddress("glIsFenceAPPLE");
                 return _IsFenceAPPLE_fnptr(fence);
             }
             
-            private static delegate* unmanaged<uint, byte> _TestFenceAPPLE_fnptr = &TestFenceAPPLE_Lazy;
+            private static delegate* unmanaged<uint, bool> _TestFenceAPPLE_fnptr = &TestFenceAPPLE_Lazy;
             /// <summary> <b>[requires: GL_APPLE_fence]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte TestFenceAPPLE(uint fence) => _TestFenceAPPLE_fnptr(fence);
+            public static bool TestFenceAPPLE(uint fence) => _TestFenceAPPLE_fnptr(fence);
             [UnmanagedCallersOnly]
-            private static byte TestFenceAPPLE_Lazy(uint fence)
+            private static bool TestFenceAPPLE_Lazy(uint fence)
             {
-                _TestFenceAPPLE_fnptr = (delegate* unmanaged<uint, byte>)GLLoader.BindingsContext.GetProcAddress("glTestFenceAPPLE");
+                _TestFenceAPPLE_fnptr = (delegate* unmanaged<uint, bool>)GLLoader.BindingsContext.GetProcAddress("glTestFenceAPPLE");
                 return _TestFenceAPPLE_fnptr(fence);
             }
             
@@ -14924,14 +14924,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _FinishFenceAPPLE_fnptr(fence);
             }
             
-            private static delegate* unmanaged<ObjectTypeAPPLE, uint, byte> _TestObjectAPPLE_fnptr = &TestObjectAPPLE_Lazy;
+            private static delegate* unmanaged<ObjectTypeAPPLE, uint, bool> _TestObjectAPPLE_fnptr = &TestObjectAPPLE_Lazy;
             /// <summary> <b>[requires: GL_APPLE_fence]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte TestObjectAPPLE(ObjectTypeAPPLE obj, uint name) => _TestObjectAPPLE_fnptr(obj, name);
+            public static bool TestObjectAPPLE(ObjectTypeAPPLE obj, uint name) => _TestObjectAPPLE_fnptr(obj, name);
             [UnmanagedCallersOnly]
-            private static byte TestObjectAPPLE_Lazy(ObjectTypeAPPLE obj, uint name)
+            private static bool TestObjectAPPLE_Lazy(ObjectTypeAPPLE obj, uint name)
             {
-                _TestObjectAPPLE_fnptr = (delegate* unmanaged<ObjectTypeAPPLE, uint, byte>)GLLoader.BindingsContext.GetProcAddress("glTestObjectAPPLE");
+                _TestObjectAPPLE_fnptr = (delegate* unmanaged<ObjectTypeAPPLE, uint, bool>)GLLoader.BindingsContext.GetProcAddress("glTestObjectAPPLE");
                 return _TestObjectAPPLE_fnptr(obj, name);
             }
             
@@ -15056,14 +15056,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _GenVertexArraysAPPLE_fnptr(n, arrays);
             }
             
-            private static delegate* unmanaged<VertexArrayHandle, byte> _IsVertexArrayAPPLE_fnptr = &IsVertexArrayAPPLE_Lazy;
+            private static delegate* unmanaged<VertexArrayHandle, bool> _IsVertexArrayAPPLE_fnptr = &IsVertexArrayAPPLE_Lazy;
             /// <summary> <b>[requires: GL_APPLE_vertex_array_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsVertexArrayAPPLE(VertexArrayHandle array) => _IsVertexArrayAPPLE_fnptr(array);
+            public static bool IsVertexArrayAPPLE(VertexArrayHandle array) => _IsVertexArrayAPPLE_fnptr(array);
             [UnmanagedCallersOnly]
-            private static byte IsVertexArrayAPPLE_Lazy(VertexArrayHandle array)
+            private static bool IsVertexArrayAPPLE_Lazy(VertexArrayHandle array)
             {
-                _IsVertexArrayAPPLE_fnptr = (delegate* unmanaged<VertexArrayHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsVertexArrayAPPLE");
+                _IsVertexArrayAPPLE_fnptr = (delegate* unmanaged<VertexArrayHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsVertexArrayAPPLE");
                 return _IsVertexArrayAPPLE_fnptr(array);
             }
             
@@ -15122,14 +15122,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _DisableVertexAttribAPPLE_fnptr(index, pname);
             }
             
-            private static delegate* unmanaged<uint, All, byte> _IsVertexAttribEnabledAPPLE_fnptr = &IsVertexAttribEnabledAPPLE_Lazy;
+            private static delegate* unmanaged<uint, All, bool> _IsVertexAttribEnabledAPPLE_fnptr = &IsVertexAttribEnabledAPPLE_Lazy;
             /// <summary> <b>[requires: GL_APPLE_vertex_program_evaluators]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsVertexAttribEnabledAPPLE(uint index, All pname) => _IsVertexAttribEnabledAPPLE_fnptr(index, pname);
+            public static bool IsVertexAttribEnabledAPPLE(uint index, All pname) => _IsVertexAttribEnabledAPPLE_fnptr(index, pname);
             [UnmanagedCallersOnly]
-            private static byte IsVertexAttribEnabledAPPLE_Lazy(uint index, All pname)
+            private static bool IsVertexAttribEnabledAPPLE_Lazy(uint index, All pname)
             {
-                _IsVertexAttribEnabledAPPLE_fnptr = (delegate* unmanaged<uint, All, byte>)GLLoader.BindingsContext.GetProcAddress("glIsVertexAttribEnabledAPPLE");
+                _IsVertexAttribEnabledAPPLE_fnptr = (delegate* unmanaged<uint, All, bool>)GLLoader.BindingsContext.GetProcAddress("glIsVertexAttribEnabledAPPLE");
                 return _IsVertexAttribEnabledAPPLE_fnptr(index, pname);
             }
             
@@ -15365,14 +15365,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _MakeTextureHandleNonResidentARB_fnptr(handle);
             }
             
-            private static delegate* unmanaged<TextureHandle, int, byte, int, PixelFormat, ulong> _GetImageHandleARB_fnptr = &GetImageHandleARB_Lazy;
+            private static delegate* unmanaged<TextureHandle, int, bool, int, PixelFormat, ulong> _GetImageHandleARB_fnptr = &GetImageHandleARB_Lazy;
             /// <summary> <b>[requires: GL_ARB_bindless_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static ulong GetImageHandleARB(TextureHandle texture, int level, byte layered, int layer, PixelFormat format) => _GetImageHandleARB_fnptr(texture, level, layered, layer, format);
+            public static ulong GetImageHandleARB(TextureHandle texture, int level, bool layered, int layer, PixelFormat format) => _GetImageHandleARB_fnptr(texture, level, layered, layer, format);
             [UnmanagedCallersOnly]
-            private static ulong GetImageHandleARB_Lazy(TextureHandle texture, int level, byte layered, int layer, PixelFormat format)
+            private static ulong GetImageHandleARB_Lazy(TextureHandle texture, int level, bool layered, int layer, PixelFormat format)
             {
-                _GetImageHandleARB_fnptr = (delegate* unmanaged<TextureHandle, int, byte, int, PixelFormat, ulong>)GLLoader.BindingsContext.GetProcAddress("glGetImageHandleARB");
+                _GetImageHandleARB_fnptr = (delegate* unmanaged<TextureHandle, int, bool, int, PixelFormat, ulong>)GLLoader.BindingsContext.GetProcAddress("glGetImageHandleARB");
                 return _GetImageHandleARB_fnptr(texture, level, layered, layer, format);
             }
             
@@ -15442,25 +15442,25 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _ProgramUniformHandleui64vARB_fnptr(program, location, count, values);
             }
             
-            private static delegate* unmanaged<ulong, byte> _IsTextureHandleResidentARB_fnptr = &IsTextureHandleResidentARB_Lazy;
+            private static delegate* unmanaged<ulong, bool> _IsTextureHandleResidentARB_fnptr = &IsTextureHandleResidentARB_Lazy;
             /// <summary> <b>[requires: GL_ARB_bindless_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsTextureHandleResidentARB(ulong handle) => _IsTextureHandleResidentARB_fnptr(handle);
+            public static bool IsTextureHandleResidentARB(ulong handle) => _IsTextureHandleResidentARB_fnptr(handle);
             [UnmanagedCallersOnly]
-            private static byte IsTextureHandleResidentARB_Lazy(ulong handle)
+            private static bool IsTextureHandleResidentARB_Lazy(ulong handle)
             {
-                _IsTextureHandleResidentARB_fnptr = (delegate* unmanaged<ulong, byte>)GLLoader.BindingsContext.GetProcAddress("glIsTextureHandleResidentARB");
+                _IsTextureHandleResidentARB_fnptr = (delegate* unmanaged<ulong, bool>)GLLoader.BindingsContext.GetProcAddress("glIsTextureHandleResidentARB");
                 return _IsTextureHandleResidentARB_fnptr(handle);
             }
             
-            private static delegate* unmanaged<ulong, byte> _IsImageHandleResidentARB_fnptr = &IsImageHandleResidentARB_Lazy;
+            private static delegate* unmanaged<ulong, bool> _IsImageHandleResidentARB_fnptr = &IsImageHandleResidentARB_Lazy;
             /// <summary> <b>[requires: GL_ARB_bindless_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsImageHandleResidentARB(ulong handle) => _IsImageHandleResidentARB_fnptr(handle);
+            public static bool IsImageHandleResidentARB(ulong handle) => _IsImageHandleResidentARB_fnptr(handle);
             [UnmanagedCallersOnly]
-            private static byte IsImageHandleResidentARB_Lazy(ulong handle)
+            private static bool IsImageHandleResidentARB_Lazy(ulong handle)
             {
-                _IsImageHandleResidentARB_fnptr = (delegate* unmanaged<ulong, byte>)GLLoader.BindingsContext.GetProcAddress("glIsImageHandleResidentARB");
+                _IsImageHandleResidentARB_fnptr = (delegate* unmanaged<ulong, bool>)GLLoader.BindingsContext.GetProcAddress("glIsImageHandleResidentARB");
                 return _IsImageHandleResidentARB_fnptr(handle);
             }
             
@@ -15726,14 +15726,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _CopyImageSubData_fnptr(srcName, srcTarget, srcLevel, srcX, srcY, srcZ, dstName, dstTarget, dstLevel, dstX, dstY, dstZ, srcWidth, srcHeight, srcDepth);
             }
             
-            private static delegate* unmanaged<DebugSource, DebugType, DebugSeverity, int, uint*, byte, void> _DebugMessageControlARB_fnptr = &DebugMessageControlARB_Lazy;
+            private static delegate* unmanaged<DebugSource, DebugType, DebugSeverity, int, uint*, bool, void> _DebugMessageControlARB_fnptr = &DebugMessageControlARB_Lazy;
             /// <summary> <b>[requires: GL_ARB_debug_output]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void DebugMessageControlARB(DebugSource source, DebugType type, DebugSeverity severity, int count, uint* ids, byte enabled) => _DebugMessageControlARB_fnptr(source, type, severity, count, ids, enabled);
+            public static void DebugMessageControlARB(DebugSource source, DebugType type, DebugSeverity severity, int count, uint* ids, bool enabled) => _DebugMessageControlARB_fnptr(source, type, severity, count, ids, enabled);
             [UnmanagedCallersOnly]
-            private static void DebugMessageControlARB_Lazy(DebugSource source, DebugType type, DebugSeverity severity, int count, uint* ids, byte enabled)
+            private static void DebugMessageControlARB_Lazy(DebugSource source, DebugType type, DebugSeverity severity, int count, uint* ids, bool enabled)
             {
-                _DebugMessageControlARB_fnptr = (delegate* unmanaged<DebugSource, DebugType, DebugSeverity, int, uint*, byte, void>)GLLoader.BindingsContext.GetProcAddress("glDebugMessageControlARB");
+                _DebugMessageControlARB_fnptr = (delegate* unmanaged<DebugSource, DebugType, DebugSeverity, int, uint*, bool, void>)GLLoader.BindingsContext.GetProcAddress("glDebugMessageControlARB");
                 _DebugMessageControlARB_fnptr(source, type, severity, count, ids, enabled);
             }
             
@@ -15993,15 +15993,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return _MapNamedBufferRange_fnptr(buffer, offset, length, access);
             }
             
-            private static delegate* unmanaged<BufferHandle, byte> _UnmapNamedBuffer_fnptr = &UnmapNamedBuffer_Lazy;
+            private static delegate* unmanaged<BufferHandle, bool> _UnmapNamedBuffer_fnptr = &UnmapNamedBuffer_Lazy;
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Release the mapping of a buffer object's data store into the client's address space. </summary>
             /// <param name="buffer"> Specifies the name of the buffer object for glUnmapNamedBuffer. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glUnmapBuffer.xhtml" /></remarks>
-            public static byte UnmapNamedBuffer(BufferHandle buffer) => _UnmapNamedBuffer_fnptr(buffer);
+            public static bool UnmapNamedBuffer(BufferHandle buffer) => _UnmapNamedBuffer_fnptr(buffer);
             [UnmanagedCallersOnly]
-            private static byte UnmapNamedBuffer_Lazy(BufferHandle buffer)
+            private static bool UnmapNamedBuffer_Lazy(BufferHandle buffer)
             {
-                _UnmapNamedBuffer_fnptr = (delegate* unmanaged<BufferHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glUnmapNamedBuffer");
+                _UnmapNamedBuffer_fnptr = (delegate* unmanaged<BufferHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glUnmapNamedBuffer");
                 return _UnmapNamedBuffer_fnptr(buffer);
             }
             
@@ -16497,7 +16497,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _TextureStorage3D_fnptr(texture, levels, internalformat, width, height, depth);
             }
             
-            private static delegate* unmanaged<TextureHandle, int, SizedInternalFormat, int, int, byte, void> _TextureStorage2DMultisample_fnptr = &TextureStorage2DMultisample_Lazy;
+            private static delegate* unmanaged<TextureHandle, int, SizedInternalFormat, int, int, bool, void> _TextureStorage2DMultisample_fnptr = &TextureStorage2DMultisample_Lazy;
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specify storage for a two-dimensional multisample texture. </summary>
             /// <param name="texture"> Specifies the texture object name for glTextureStorage2DMultisample. The effective target of texture must be one of the valid non-proxy target values above. </param>
             /// <param name="samples"> Specify the number of samples in the texture. </param>
@@ -16506,15 +16506,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="height"> Specifies the height of the texture, in texels. </param>
             /// <param name="fixedsamplelocations"> Specifies whether the image will use identical sample locations and the same number of samples for all texels in the image, and the sample locations will not depend on the internal format or size of the image. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexStorage2DMultisample.xhtml" /></remarks>
-            public static void TextureStorage2DMultisample(TextureHandle texture, int samples, SizedInternalFormat internalformat, int width, int height, byte fixedsamplelocations) => _TextureStorage2DMultisample_fnptr(texture, samples, internalformat, width, height, fixedsamplelocations);
+            public static void TextureStorage2DMultisample(TextureHandle texture, int samples, SizedInternalFormat internalformat, int width, int height, bool fixedsamplelocations) => _TextureStorage2DMultisample_fnptr(texture, samples, internalformat, width, height, fixedsamplelocations);
             [UnmanagedCallersOnly]
-            private static void TextureStorage2DMultisample_Lazy(TextureHandle texture, int samples, SizedInternalFormat internalformat, int width, int height, byte fixedsamplelocations)
+            private static void TextureStorage2DMultisample_Lazy(TextureHandle texture, int samples, SizedInternalFormat internalformat, int width, int height, bool fixedsamplelocations)
             {
-                _TextureStorage2DMultisample_fnptr = (delegate* unmanaged<TextureHandle, int, SizedInternalFormat, int, int, byte, void>)GLLoader.BindingsContext.GetProcAddress("glTextureStorage2DMultisample");
+                _TextureStorage2DMultisample_fnptr = (delegate* unmanaged<TextureHandle, int, SizedInternalFormat, int, int, bool, void>)GLLoader.BindingsContext.GetProcAddress("glTextureStorage2DMultisample");
                 _TextureStorage2DMultisample_fnptr(texture, samples, internalformat, width, height, fixedsamplelocations);
             }
             
-            private static delegate* unmanaged<TextureHandle, int, SizedInternalFormat, int, int, int, byte, void> _TextureStorage3DMultisample_fnptr = &TextureStorage3DMultisample_Lazy;
+            private static delegate* unmanaged<TextureHandle, int, SizedInternalFormat, int, int, int, bool, void> _TextureStorage3DMultisample_fnptr = &TextureStorage3DMultisample_Lazy;
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specify storage for a two-dimensional multisample array texture. </summary>
             /// <param name="texture"> Specifies the texture object name for glTextureStorage3DMultisample. The effective target of texture must be one of the valid non-proxy target values above. </param>
             /// <param name="samples"> Specify the number of samples in the texture. </param>
@@ -16524,11 +16524,11 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="depth"> Specifies the depth of the texture, in layers. </param>
             /// <param name="fixedsamplelocations"> Specifies whether the image will use identical sample locations and the same number of samples for all texels in the image, and the sample locations will not depend on the internal format or size of the image. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexStorage3DMultisample.xhtml" /></remarks>
-            public static void TextureStorage3DMultisample(TextureHandle texture, int samples, SizedInternalFormat internalformat, int width, int height, int depth, byte fixedsamplelocations) => _TextureStorage3DMultisample_fnptr(texture, samples, internalformat, width, height, depth, fixedsamplelocations);
+            public static void TextureStorage3DMultisample(TextureHandle texture, int samples, SizedInternalFormat internalformat, int width, int height, int depth, bool fixedsamplelocations) => _TextureStorage3DMultisample_fnptr(texture, samples, internalformat, width, height, depth, fixedsamplelocations);
             [UnmanagedCallersOnly]
-            private static void TextureStorage3DMultisample_Lazy(TextureHandle texture, int samples, SizedInternalFormat internalformat, int width, int height, int depth, byte fixedsamplelocations)
+            private static void TextureStorage3DMultisample_Lazy(TextureHandle texture, int samples, SizedInternalFormat internalformat, int width, int height, int depth, bool fixedsamplelocations)
             {
-                _TextureStorage3DMultisample_fnptr = (delegate* unmanaged<TextureHandle, int, SizedInternalFormat, int, int, int, byte, void>)GLLoader.BindingsContext.GetProcAddress("glTextureStorage3DMultisample");
+                _TextureStorage3DMultisample_fnptr = (delegate* unmanaged<TextureHandle, int, SizedInternalFormat, int, int, int, bool, void>)GLLoader.BindingsContext.GetProcAddress("glTextureStorage3DMultisample");
                 _TextureStorage3DMultisample_fnptr(texture, samples, internalformat, width, height, depth, fixedsamplelocations);
             }
             
@@ -17034,7 +17034,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _VertexArrayAttribBinding_fnptr(vaobj, attribindex, bindingindex);
             }
             
-            private static delegate* unmanaged<VertexArrayHandle, uint, int, VertexAttribType, byte, uint, void> _VertexArrayAttribFormat_fnptr = &VertexArrayAttribFormat_Lazy;
+            private static delegate* unmanaged<VertexArrayHandle, uint, int, VertexAttribType, bool, uint, void> _VertexArrayAttribFormat_fnptr = &VertexArrayAttribFormat_Lazy;
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specify the organization of vertex arrays. </summary>
             /// <param name="vaobj">Specifies the name of the vertex array object for glVertexArrayAttrib{I, L}Format functions.</param>
             /// <param name="attribindex">The generic vertex attribute array being described.</param>
@@ -17043,11 +17043,11 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="normalized"> Specifies whether fixed-point data values should be normalized (GL_TRUE) or converted directly as fixed-point values (GL_FALSE) when they are accessed. This parameter is ignored if type is GL_FIXED. </param>
             /// <param name="relativeoffset">The distance between elements within the buffer.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glVertexAttribFormat.xhtml" /></remarks>
-            public static void VertexArrayAttribFormat(VertexArrayHandle vaobj, uint attribindex, int size, VertexAttribType type, byte normalized, uint relativeoffset) => _VertexArrayAttribFormat_fnptr(vaobj, attribindex, size, type, normalized, relativeoffset);
+            public static void VertexArrayAttribFormat(VertexArrayHandle vaobj, uint attribindex, int size, VertexAttribType type, bool normalized, uint relativeoffset) => _VertexArrayAttribFormat_fnptr(vaobj, attribindex, size, type, normalized, relativeoffset);
             [UnmanagedCallersOnly]
-            private static void VertexArrayAttribFormat_Lazy(VertexArrayHandle vaobj, uint attribindex, int size, VertexAttribType type, byte normalized, uint relativeoffset)
+            private static void VertexArrayAttribFormat_Lazy(VertexArrayHandle vaobj, uint attribindex, int size, VertexAttribType type, bool normalized, uint relativeoffset)
             {
-                _VertexArrayAttribFormat_fnptr = (delegate* unmanaged<VertexArrayHandle, uint, int, VertexAttribType, byte, uint, void>)GLLoader.BindingsContext.GetProcAddress("glVertexArrayAttribFormat");
+                _VertexArrayAttribFormat_fnptr = (delegate* unmanaged<VertexArrayHandle, uint, int, VertexAttribType, bool, uint, void>)GLLoader.BindingsContext.GetProcAddress("glVertexArrayAttribFormat");
                 _VertexArrayAttribFormat_fnptr(vaobj, attribindex, size, type, normalized, relativeoffset);
             }
             
@@ -17611,14 +17611,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _GetProgramStringARB_fnptr(target, pname, str);
             }
             
-            private static delegate* unmanaged<ProgramHandle, byte> _IsProgramARB_fnptr = &IsProgramARB_Lazy;
+            private static delegate* unmanaged<ProgramHandle, bool> _IsProgramARB_fnptr = &IsProgramARB_Lazy;
             /// <summary> <b>[requires: GL_ARB_fragment_program | GL_ARB_vertex_program]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsProgramARB(ProgramHandle program) => _IsProgramARB_fnptr(program);
+            public static bool IsProgramARB(ProgramHandle program) => _IsProgramARB_fnptr(program);
             [UnmanagedCallersOnly]
-            private static byte IsProgramARB_Lazy(ProgramHandle program)
+            private static bool IsProgramARB_Lazy(ProgramHandle program)
             {
-                _IsProgramARB_fnptr = (delegate* unmanaged<ProgramHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsProgramARB");
+                _IsProgramARB_fnptr = (delegate* unmanaged<ProgramHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsProgramARB");
                 return _IsProgramARB_fnptr(program);
             }
             
@@ -17650,15 +17650,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _GetFramebufferParameteriv_fnptr(target, pname, parameters);
             }
             
-            private static delegate* unmanaged<RenderbufferHandle, byte> _IsRenderbuffer_fnptr = &IsRenderbuffer_Lazy;
+            private static delegate* unmanaged<RenderbufferHandle, bool> _IsRenderbuffer_fnptr = &IsRenderbuffer_Lazy;
             /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Determine if a name corresponds to a renderbuffer object. </summary>
             /// <param name="renderbuffer"> Specifies a value that may be the name of a renderbuffer object. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsRenderbuffer.xhtml" /></remarks>
-            public static byte IsRenderbuffer(RenderbufferHandle renderbuffer) => _IsRenderbuffer_fnptr(renderbuffer);
+            public static bool IsRenderbuffer(RenderbufferHandle renderbuffer) => _IsRenderbuffer_fnptr(renderbuffer);
             [UnmanagedCallersOnly]
-            private static byte IsRenderbuffer_Lazy(RenderbufferHandle renderbuffer)
+            private static bool IsRenderbuffer_Lazy(RenderbufferHandle renderbuffer)
             {
-                _IsRenderbuffer_fnptr = (delegate* unmanaged<RenderbufferHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsRenderbuffer");
+                _IsRenderbuffer_fnptr = (delegate* unmanaged<RenderbufferHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsRenderbuffer");
                 return _IsRenderbuffer_fnptr(renderbuffer);
             }
             
@@ -17730,15 +17730,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _GetRenderbufferParameteriv_fnptr(target, pname, parameters);
             }
             
-            private static delegate* unmanaged<FramebufferHandle, byte> _IsFramebuffer_fnptr = &IsFramebuffer_Lazy;
+            private static delegate* unmanaged<FramebufferHandle, bool> _IsFramebuffer_fnptr = &IsFramebuffer_Lazy;
             /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Determine if a name corresponds to a framebuffer object. </summary>
             /// <param name="framebuffer"> Specifies a value that may be the name of a framebuffer object. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsFramebuffer.xhtml" /></remarks>
-            public static byte IsFramebuffer(FramebufferHandle framebuffer) => _IsFramebuffer_fnptr(framebuffer);
+            public static bool IsFramebuffer(FramebufferHandle framebuffer) => _IsFramebuffer_fnptr(framebuffer);
             [UnmanagedCallersOnly]
-            private static byte IsFramebuffer_Lazy(FramebufferHandle framebuffer)
+            private static bool IsFramebuffer_Lazy(FramebufferHandle framebuffer)
             {
-                _IsFramebuffer_fnptr = (delegate* unmanaged<FramebufferHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsFramebuffer");
+                _IsFramebuffer_fnptr = (delegate* unmanaged<FramebufferHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsFramebuffer");
                 return _IsFramebuffer_fnptr(framebuffer);
             }
             
@@ -18169,102 +18169,102 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _Uniform4dv_fnptr(location, count, value);
             }
             
-            private static delegate* unmanaged<int, int, byte, double*, void> _UniformMatrix2dv_fnptr = &UniformMatrix2dv_Lazy;
+            private static delegate* unmanaged<int, int, bool, double*, void> _UniformMatrix2dv_fnptr = &UniformMatrix2dv_Lazy;
             /// <summary> <b>[requires: v4.0 | GL_ARB_gpu_shader_fp64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void UniformMatrix2dv(int location, int count, byte transpose, double* value) => _UniformMatrix2dv_fnptr(location, count, transpose, value);
+            public static void UniformMatrix2dv(int location, int count, bool transpose, double* value) => _UniformMatrix2dv_fnptr(location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void UniformMatrix2dv_Lazy(int location, int count, byte transpose, double* value)
+            private static void UniformMatrix2dv_Lazy(int location, int count, bool transpose, double* value)
             {
-                _UniformMatrix2dv_fnptr = (delegate* unmanaged<int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix2dv");
+                _UniformMatrix2dv_fnptr = (delegate* unmanaged<int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix2dv");
                 _UniformMatrix2dv_fnptr(location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<int, int, byte, double*, void> _UniformMatrix3dv_fnptr = &UniformMatrix3dv_Lazy;
+            private static delegate* unmanaged<int, int, bool, double*, void> _UniformMatrix3dv_fnptr = &UniformMatrix3dv_Lazy;
             /// <summary> <b>[requires: v4.0 | GL_ARB_gpu_shader_fp64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void UniformMatrix3dv(int location, int count, byte transpose, double* value) => _UniformMatrix3dv_fnptr(location, count, transpose, value);
+            public static void UniformMatrix3dv(int location, int count, bool transpose, double* value) => _UniformMatrix3dv_fnptr(location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void UniformMatrix3dv_Lazy(int location, int count, byte transpose, double* value)
+            private static void UniformMatrix3dv_Lazy(int location, int count, bool transpose, double* value)
             {
-                _UniformMatrix3dv_fnptr = (delegate* unmanaged<int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix3dv");
+                _UniformMatrix3dv_fnptr = (delegate* unmanaged<int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix3dv");
                 _UniformMatrix3dv_fnptr(location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<int, int, byte, double*, void> _UniformMatrix4dv_fnptr = &UniformMatrix4dv_Lazy;
+            private static delegate* unmanaged<int, int, bool, double*, void> _UniformMatrix4dv_fnptr = &UniformMatrix4dv_Lazy;
             /// <summary> <b>[requires: v4.0 | GL_ARB_gpu_shader_fp64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void UniformMatrix4dv(int location, int count, byte transpose, double* value) => _UniformMatrix4dv_fnptr(location, count, transpose, value);
+            public static void UniformMatrix4dv(int location, int count, bool transpose, double* value) => _UniformMatrix4dv_fnptr(location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void UniformMatrix4dv_Lazy(int location, int count, byte transpose, double* value)
+            private static void UniformMatrix4dv_Lazy(int location, int count, bool transpose, double* value)
             {
-                _UniformMatrix4dv_fnptr = (delegate* unmanaged<int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix4dv");
+                _UniformMatrix4dv_fnptr = (delegate* unmanaged<int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix4dv");
                 _UniformMatrix4dv_fnptr(location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<int, int, byte, double*, void> _UniformMatrix2x3dv_fnptr = &UniformMatrix2x3dv_Lazy;
+            private static delegate* unmanaged<int, int, bool, double*, void> _UniformMatrix2x3dv_fnptr = &UniformMatrix2x3dv_Lazy;
             /// <summary> <b>[requires: v4.0 | GL_ARB_gpu_shader_fp64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void UniformMatrix2x3dv(int location, int count, byte transpose, double* value) => _UniformMatrix2x3dv_fnptr(location, count, transpose, value);
+            public static void UniformMatrix2x3dv(int location, int count, bool transpose, double* value) => _UniformMatrix2x3dv_fnptr(location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void UniformMatrix2x3dv_Lazy(int location, int count, byte transpose, double* value)
+            private static void UniformMatrix2x3dv_Lazy(int location, int count, bool transpose, double* value)
             {
-                _UniformMatrix2x3dv_fnptr = (delegate* unmanaged<int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix2x3dv");
+                _UniformMatrix2x3dv_fnptr = (delegate* unmanaged<int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix2x3dv");
                 _UniformMatrix2x3dv_fnptr(location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<int, int, byte, double*, void> _UniformMatrix2x4dv_fnptr = &UniformMatrix2x4dv_Lazy;
+            private static delegate* unmanaged<int, int, bool, double*, void> _UniformMatrix2x4dv_fnptr = &UniformMatrix2x4dv_Lazy;
             /// <summary> <b>[requires: v4.0 | GL_ARB_gpu_shader_fp64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void UniformMatrix2x4dv(int location, int count, byte transpose, double* value) => _UniformMatrix2x4dv_fnptr(location, count, transpose, value);
+            public static void UniformMatrix2x4dv(int location, int count, bool transpose, double* value) => _UniformMatrix2x4dv_fnptr(location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void UniformMatrix2x4dv_Lazy(int location, int count, byte transpose, double* value)
+            private static void UniformMatrix2x4dv_Lazy(int location, int count, bool transpose, double* value)
             {
-                _UniformMatrix2x4dv_fnptr = (delegate* unmanaged<int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix2x4dv");
+                _UniformMatrix2x4dv_fnptr = (delegate* unmanaged<int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix2x4dv");
                 _UniformMatrix2x4dv_fnptr(location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<int, int, byte, double*, void> _UniformMatrix3x2dv_fnptr = &UniformMatrix3x2dv_Lazy;
+            private static delegate* unmanaged<int, int, bool, double*, void> _UniformMatrix3x2dv_fnptr = &UniformMatrix3x2dv_Lazy;
             /// <summary> <b>[requires: v4.0 | GL_ARB_gpu_shader_fp64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void UniformMatrix3x2dv(int location, int count, byte transpose, double* value) => _UniformMatrix3x2dv_fnptr(location, count, transpose, value);
+            public static void UniformMatrix3x2dv(int location, int count, bool transpose, double* value) => _UniformMatrix3x2dv_fnptr(location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void UniformMatrix3x2dv_Lazy(int location, int count, byte transpose, double* value)
+            private static void UniformMatrix3x2dv_Lazy(int location, int count, bool transpose, double* value)
             {
-                _UniformMatrix3x2dv_fnptr = (delegate* unmanaged<int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix3x2dv");
+                _UniformMatrix3x2dv_fnptr = (delegate* unmanaged<int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix3x2dv");
                 _UniformMatrix3x2dv_fnptr(location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<int, int, byte, double*, void> _UniformMatrix3x4dv_fnptr = &UniformMatrix3x4dv_Lazy;
+            private static delegate* unmanaged<int, int, bool, double*, void> _UniformMatrix3x4dv_fnptr = &UniformMatrix3x4dv_Lazy;
             /// <summary> <b>[requires: v4.0 | GL_ARB_gpu_shader_fp64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void UniformMatrix3x4dv(int location, int count, byte transpose, double* value) => _UniformMatrix3x4dv_fnptr(location, count, transpose, value);
+            public static void UniformMatrix3x4dv(int location, int count, bool transpose, double* value) => _UniformMatrix3x4dv_fnptr(location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void UniformMatrix3x4dv_Lazy(int location, int count, byte transpose, double* value)
+            private static void UniformMatrix3x4dv_Lazy(int location, int count, bool transpose, double* value)
             {
-                _UniformMatrix3x4dv_fnptr = (delegate* unmanaged<int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix3x4dv");
+                _UniformMatrix3x4dv_fnptr = (delegate* unmanaged<int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix3x4dv");
                 _UniformMatrix3x4dv_fnptr(location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<int, int, byte, double*, void> _UniformMatrix4x2dv_fnptr = &UniformMatrix4x2dv_Lazy;
+            private static delegate* unmanaged<int, int, bool, double*, void> _UniformMatrix4x2dv_fnptr = &UniformMatrix4x2dv_Lazy;
             /// <summary> <b>[requires: v4.0 | GL_ARB_gpu_shader_fp64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void UniformMatrix4x2dv(int location, int count, byte transpose, double* value) => _UniformMatrix4x2dv_fnptr(location, count, transpose, value);
+            public static void UniformMatrix4x2dv(int location, int count, bool transpose, double* value) => _UniformMatrix4x2dv_fnptr(location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void UniformMatrix4x2dv_Lazy(int location, int count, byte transpose, double* value)
+            private static void UniformMatrix4x2dv_Lazy(int location, int count, bool transpose, double* value)
             {
-                _UniformMatrix4x2dv_fnptr = (delegate* unmanaged<int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix4x2dv");
+                _UniformMatrix4x2dv_fnptr = (delegate* unmanaged<int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix4x2dv");
                 _UniformMatrix4x2dv_fnptr(location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<int, int, byte, double*, void> _UniformMatrix4x3dv_fnptr = &UniformMatrix4x3dv_Lazy;
+            private static delegate* unmanaged<int, int, bool, double*, void> _UniformMatrix4x3dv_fnptr = &UniformMatrix4x3dv_Lazy;
             /// <summary> <b>[requires: v4.0 | GL_ARB_gpu_shader_fp64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void UniformMatrix4x3dv(int location, int count, byte transpose, double* value) => _UniformMatrix4x3dv_fnptr(location, count, transpose, value);
+            public static void UniformMatrix4x3dv(int location, int count, bool transpose, double* value) => _UniformMatrix4x3dv_fnptr(location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void UniformMatrix4x3dv_Lazy(int location, int count, byte transpose, double* value)
+            private static void UniformMatrix4x3dv_Lazy(int location, int count, bool transpose, double* value)
             {
-                _UniformMatrix4x3dv_fnptr = (delegate* unmanaged<int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix4x3dv");
+                _UniformMatrix4x3dv_fnptr = (delegate* unmanaged<int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix4x3dv");
                 _UniformMatrix4x3dv_fnptr(location, count, transpose, value);
             }
             
@@ -19039,7 +19039,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _SeparableFilter2D_fnptr(target, internalformat, width, height, format, type, row, column);
             }
             
-            private static delegate* unmanaged<HistogramTargetEXT, byte, PixelFormat, PixelType, void*, void> _GetHistogram_fnptr = &GetHistogram_Lazy;
+            private static delegate* unmanaged<HistogramTargetEXT, bool, PixelFormat, PixelType, void*, void> _GetHistogram_fnptr = &GetHistogram_Lazy;
             /// <summary> <b>[requires: GL_ARB_imaging]</b> Get histogram table. </summary>
             /// <param name="target"> Must be GL_HISTOGRAM. </param>
             /// <param name="reset"> If GL_TRUE, each component counter that is actually returned is reset to zero. (Other counters are unaffected.) If GL_FALSE, none of the counters in the histogram table is modified. </param>
@@ -19047,11 +19047,11 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="type"> The type of values to be returned in values. Symbolic constants GL_UNSIGNED_BYTE, GL_BYTE, GL_BITMAP, GL_UNSIGNED_SHORT, GL_SHORT, GL_UNSIGNED_INT, GL_INT, GL_FLOAT, GL_UNSIGNED_BYTE_3_3_2, GL_UNSIGNED_BYTE_2_3_3_REV, GL_UNSIGNED_SHORT_5_6_5, GL_UNSIGNED_SHORT_5_6_5_REV, GL_UNSIGNED_SHORT_4_4_4_4, GL_UNSIGNED_SHORT_4_4_4_4_REV, GL_UNSIGNED_SHORT_5_5_5_1, GL_UNSIGNED_SHORT_1_5_5_5_REV, GL_UNSIGNED_INT_8_8_8_8, GL_UNSIGNED_INT_8_8_8_8_REV, GL_UNSIGNED_INT_10_10_10_2, and GL_UNSIGNED_INT_2_10_10_10_REV are accepted. </param>
             /// <param name="values"> A pointer to storage for the returned histogram table. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/glGetHistogram.xml" /></remarks>
-            public static void GetHistogram(HistogramTargetEXT target, byte reset, PixelFormat format, PixelType type, void* values) => _GetHistogram_fnptr(target, reset, format, type, values);
+            public static void GetHistogram(HistogramTargetEXT target, bool reset, PixelFormat format, PixelType type, void* values) => _GetHistogram_fnptr(target, reset, format, type, values);
             [UnmanagedCallersOnly]
-            private static void GetHistogram_Lazy(HistogramTargetEXT target, byte reset, PixelFormat format, PixelType type, void* values)
+            private static void GetHistogram_Lazy(HistogramTargetEXT target, bool reset, PixelFormat format, PixelType type, void* values)
             {
-                _GetHistogram_fnptr = (delegate* unmanaged<HistogramTargetEXT, byte, PixelFormat, PixelType, void*, void>)GLLoader.BindingsContext.GetProcAddress("glGetHistogram");
+                _GetHistogram_fnptr = (delegate* unmanaged<HistogramTargetEXT, bool, PixelFormat, PixelType, void*, void>)GLLoader.BindingsContext.GetProcAddress("glGetHistogram");
                 _GetHistogram_fnptr(target, reset, format, type, values);
             }
             
@@ -19083,7 +19083,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _GetHistogramParameteriv_fnptr(target, pname, parameters);
             }
             
-            private static delegate* unmanaged<MinmaxTargetEXT, byte, PixelFormat, PixelType, void*, void> _GetMinmax_fnptr = &GetMinmax_Lazy;
+            private static delegate* unmanaged<MinmaxTargetEXT, bool, PixelFormat, PixelType, void*, void> _GetMinmax_fnptr = &GetMinmax_Lazy;
             /// <summary> <b>[requires: GL_ARB_imaging]</b> Get minimum and maximum pixel values. </summary>
             /// <param name="target"> Must be GL_MINMAX. </param>
             /// <param name="reset"> If GL_TRUE, all entries in the minmax table that are actually returned are reset to their initial values. (Other entries are unaltered.) If GL_FALSE, the minmax table is unaltered. </param>
@@ -19091,11 +19091,11 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="types"> The type of the data to be returned in values. Symbolic constants GL_UNSIGNED_BYTE, GL_BYTE, GL_BITMAP, GL_UNSIGNED_SHORT, GL_SHORT, GL_UNSIGNED_INT, GL_INT, GL_FLOAT, GL_UNSIGNED_BYTE_3_3_2, GL_UNSIGNED_BYTE_2_3_3_REV, GL_UNSIGNED_SHORT_5_6_5, GL_UNSIGNED_SHORT_5_6_5_REV, GL_UNSIGNED_SHORT_4_4_4_4, GL_UNSIGNED_SHORT_4_4_4_4_REV, GL_UNSIGNED_SHORT_5_5_5_1, GL_UNSIGNED_SHORT_1_5_5_5_REV, GL_UNSIGNED_INT_8_8_8_8, GL_UNSIGNED_INT_8_8_8_8_REV, GL_UNSIGNED_INT_10_10_10_2, and GL_UNSIGNED_INT_2_10_10_10_REV are accepted. </param>
             /// <param name="values"> A pointer to storage for the returned values. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/glGetMinmax.xml" /></remarks>
-            public static void GetMinmax(MinmaxTargetEXT target, byte reset, PixelFormat format, PixelType type, void* values) => _GetMinmax_fnptr(target, reset, format, type, values);
+            public static void GetMinmax(MinmaxTargetEXT target, bool reset, PixelFormat format, PixelType type, void* values) => _GetMinmax_fnptr(target, reset, format, type, values);
             [UnmanagedCallersOnly]
-            private static void GetMinmax_Lazy(MinmaxTargetEXT target, byte reset, PixelFormat format, PixelType type, void* values)
+            private static void GetMinmax_Lazy(MinmaxTargetEXT target, bool reset, PixelFormat format, PixelType type, void* values)
             {
-                _GetMinmax_fnptr = (delegate* unmanaged<MinmaxTargetEXT, byte, PixelFormat, PixelType, void*, void>)GLLoader.BindingsContext.GetProcAddress("glGetMinmax");
+                _GetMinmax_fnptr = (delegate* unmanaged<MinmaxTargetEXT, bool, PixelFormat, PixelType, void*, void>)GLLoader.BindingsContext.GetProcAddress("glGetMinmax");
                 _GetMinmax_fnptr(target, reset, format, type, values);
             }
             
@@ -19127,32 +19127,32 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _GetMinmaxParameteriv_fnptr(target, pname, parameters);
             }
             
-            private static delegate* unmanaged<HistogramTargetEXT, int, InternalFormat, byte, void> _Histogram_fnptr = &Histogram_Lazy;
+            private static delegate* unmanaged<HistogramTargetEXT, int, InternalFormat, bool, void> _Histogram_fnptr = &Histogram_Lazy;
             /// <summary> <b>[requires: GL_ARB_imaging]</b> Define histogram table. </summary>
             /// <param name="target"> The histogram whose parameters are to be set. Must be one of GL_HISTOGRAM or GL_PROXY_HISTOGRAM. </param>
             /// <param name="width"> The number of entries in the histogram table. Must be a power of 2. </param>
             /// <param name="internalformat"> The format of entries in the histogram table. Must be one of GL_ALPHA, GL_ALPHA4, GL_ALPHA8, GL_ALPHA12, GL_ALPHA16, GL_LUMINANCE, GL_LUMINANCE4, GL_LUMINANCE8, GL_LUMINANCE12, GL_LUMINANCE16, GL_LUMINANCE_ALPHA, GL_LUMINANCE4_ALPHA4, GL_LUMINANCE6_ALPHA2, GL_LUMINANCE8_ALPHA8, GL_LUMINANCE12_ALPHA4, GL_LUMINANCE12_ALPHA12, GL_LUMINANCE16_ALPHA16, GL_R3_G3_B2, GL_RGB, GL_RGB4, GL_RGB5, GL_RGB8, GL_RGB10, GL_RGB12, GL_RGB16, GL_RGBA, GL_RGBA2, GL_RGBA4, GL_RGB5_A1, GL_RGBA8, GL_RGB10_A2, GL_RGBA12, or GL_RGBA16. </param>
             /// <param name="sink"> If GL_TRUE, pixels will be consumed by the histogramming process and no drawing or texture loading will take place. If GL_FALSE, pixels will proceed to the minmax process after histogramming. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/glHistogram.xml" /></remarks>
-            public static void Histogram(HistogramTargetEXT target, int width, InternalFormat internalformat, byte sink) => _Histogram_fnptr(target, width, internalformat, sink);
+            public static void Histogram(HistogramTargetEXT target, int width, InternalFormat internalformat, bool sink) => _Histogram_fnptr(target, width, internalformat, sink);
             [UnmanagedCallersOnly]
-            private static void Histogram_Lazy(HistogramTargetEXT target, int width, InternalFormat internalformat, byte sink)
+            private static void Histogram_Lazy(HistogramTargetEXT target, int width, InternalFormat internalformat, bool sink)
             {
-                _Histogram_fnptr = (delegate* unmanaged<HistogramTargetEXT, int, InternalFormat, byte, void>)GLLoader.BindingsContext.GetProcAddress("glHistogram");
+                _Histogram_fnptr = (delegate* unmanaged<HistogramTargetEXT, int, InternalFormat, bool, void>)GLLoader.BindingsContext.GetProcAddress("glHistogram");
                 _Histogram_fnptr(target, width, internalformat, sink);
             }
             
-            private static delegate* unmanaged<MinmaxTargetEXT, InternalFormat, byte, void> _Minmax_fnptr = &Minmax_Lazy;
+            private static delegate* unmanaged<MinmaxTargetEXT, InternalFormat, bool, void> _Minmax_fnptr = &Minmax_Lazy;
             /// <summary> <b>[requires: GL_ARB_imaging]</b> Define minmax table. </summary>
             /// <param name="target"> The minmax table whose parameters are to be set. Must be GL_MINMAX. </param>
             /// <param name="internalformat"> The format of entries in the minmax table. Must be one of GL_ALPHA, GL_ALPHA4, GL_ALPHA8, GL_ALPHA12, GL_ALPHA16, GL_LUMINANCE, GL_LUMINANCE4, GL_LUMINANCE8, GL_LUMINANCE12, GL_LUMINANCE16, GL_LUMINANCE_ALPHA, GL_LUMINANCE4_ALPHA4, GL_LUMINANCE6_ALPHA2, GL_LUMINANCE8_ALPHA8, GL_LUMINANCE12_ALPHA4, GL_LUMINANCE12_ALPHA12, GL_LUMINANCE16_ALPHA16, GL_R3_G3_B2, GL_RGB, GL_RGB4, GL_RGB5, GL_RGB8, GL_RGB10, GL_RGB12, GL_RGB16, GL_RGBA, GL_RGBA2, GL_RGBA4, GL_RGB5_A1, GL_RGBA8, GL_RGB10_A2, GL_RGBA12, or GL_RGBA16. </param>
             /// <param name="sink"> If GL_TRUE, pixels will be consumed by the minmax process and no drawing or texture loading will take place. If GL_FALSE, pixels will proceed to the final conversion process after minmax. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/glMinmax.xml" /></remarks>
-            public static void Minmax(MinmaxTargetEXT target, InternalFormat internalformat, byte sink) => _Minmax_fnptr(target, internalformat, sink);
+            public static void Minmax(MinmaxTargetEXT target, InternalFormat internalformat, bool sink) => _Minmax_fnptr(target, internalformat, sink);
             [UnmanagedCallersOnly]
-            private static void Minmax_Lazy(MinmaxTargetEXT target, InternalFormat internalformat, byte sink)
+            private static void Minmax_Lazy(MinmaxTargetEXT target, InternalFormat internalformat, bool sink)
             {
-                _Minmax_fnptr = (delegate* unmanaged<MinmaxTargetEXT, InternalFormat, byte, void>)GLLoader.BindingsContext.GetProcAddress("glMinmax");
+                _Minmax_fnptr = (delegate* unmanaged<MinmaxTargetEXT, InternalFormat, bool, void>)GLLoader.BindingsContext.GetProcAddress("glMinmax");
                 _Minmax_fnptr(target, internalformat, sink);
             }
             
@@ -19540,14 +19540,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _MultiDrawElementsIndirect_fnptr(mode, type, indirect, drawcount, stride);
             }
             
-            private static delegate* unmanaged<float, byte, void> _SampleCoverageARB_fnptr = &SampleCoverageARB_Lazy;
+            private static delegate* unmanaged<float, bool, void> _SampleCoverageARB_fnptr = &SampleCoverageARB_Lazy;
             /// <summary> <b>[requires: GL_ARB_multisample]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void SampleCoverageARB(float value, byte invert) => _SampleCoverageARB_fnptr(value, invert);
+            public static void SampleCoverageARB(float value, bool invert) => _SampleCoverageARB_fnptr(value, invert);
             [UnmanagedCallersOnly]
-            private static void SampleCoverageARB_Lazy(float value, byte invert)
+            private static void SampleCoverageARB_Lazy(float value, bool invert)
             {
-                _SampleCoverageARB_fnptr = (delegate* unmanaged<float, byte, void>)GLLoader.BindingsContext.GetProcAddress("glSampleCoverageARB");
+                _SampleCoverageARB_fnptr = (delegate* unmanaged<float, bool, void>)GLLoader.BindingsContext.GetProcAddress("glSampleCoverageARB");
                 _SampleCoverageARB_fnptr(value, invert);
             }
             
@@ -19947,14 +19947,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _DeleteQueriesARB_fnptr(n, ids);
             }
             
-            private static delegate* unmanaged<QueryHandle, byte> _IsQueryARB_fnptr = &IsQueryARB_Lazy;
+            private static delegate* unmanaged<QueryHandle, bool> _IsQueryARB_fnptr = &IsQueryARB_Lazy;
             /// <summary> <b>[requires: GL_ARB_occlusion_query]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsQueryARB(QueryHandle id) => _IsQueryARB_fnptr(id);
+            public static bool IsQueryARB(QueryHandle id) => _IsQueryARB_fnptr(id);
             [UnmanagedCallersOnly]
-            private static byte IsQueryARB_Lazy(QueryHandle id)
+            private static bool IsQueryARB_Lazy(QueryHandle id)
             {
-                _IsQueryARB_fnptr = (delegate* unmanaged<QueryHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsQueryARB");
+                _IsQueryARB_fnptr = (delegate* unmanaged<QueryHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsQueryARB");
                 return _IsQueryARB_fnptr(id);
             }
             
@@ -20360,25 +20360,25 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _GetnSeparableFilterARB_fnptr(target, format, type, rowBufSize, row, columnBufSize, column, span);
             }
             
-            private static delegate* unmanaged<HistogramTargetEXT, byte, PixelFormat, PixelType, int, void*, void> _GetnHistogramARB_fnptr = &GetnHistogramARB_Lazy;
+            private static delegate* unmanaged<HistogramTargetEXT, bool, PixelFormat, PixelType, int, void*, void> _GetnHistogramARB_fnptr = &GetnHistogramARB_Lazy;
             /// <summary> <b>[requires: GL_ARB_robustness]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetnHistogramARB(HistogramTargetEXT target, byte reset, PixelFormat format, PixelType type, int bufSize, void* values) => _GetnHistogramARB_fnptr(target, reset, format, type, bufSize, values);
+            public static void GetnHistogramARB(HistogramTargetEXT target, bool reset, PixelFormat format, PixelType type, int bufSize, void* values) => _GetnHistogramARB_fnptr(target, reset, format, type, bufSize, values);
             [UnmanagedCallersOnly]
-            private static void GetnHistogramARB_Lazy(HistogramTargetEXT target, byte reset, PixelFormat format, PixelType type, int bufSize, void* values)
+            private static void GetnHistogramARB_Lazy(HistogramTargetEXT target, bool reset, PixelFormat format, PixelType type, int bufSize, void* values)
             {
-                _GetnHistogramARB_fnptr = (delegate* unmanaged<HistogramTargetEXT, byte, PixelFormat, PixelType, int, void*, void>)GLLoader.BindingsContext.GetProcAddress("glGetnHistogramARB");
+                _GetnHistogramARB_fnptr = (delegate* unmanaged<HistogramTargetEXT, bool, PixelFormat, PixelType, int, void*, void>)GLLoader.BindingsContext.GetProcAddress("glGetnHistogramARB");
                 _GetnHistogramARB_fnptr(target, reset, format, type, bufSize, values);
             }
             
-            private static delegate* unmanaged<MinmaxTargetEXT, byte, PixelFormat, PixelType, int, void*, void> _GetnMinmaxARB_fnptr = &GetnMinmaxARB_Lazy;
+            private static delegate* unmanaged<MinmaxTargetEXT, bool, PixelFormat, PixelType, int, void*, void> _GetnMinmaxARB_fnptr = &GetnMinmaxARB_Lazy;
             /// <summary> <b>[requires: GL_ARB_robustness]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetnMinmaxARB(MinmaxTargetEXT target, byte reset, PixelFormat format, PixelType type, int bufSize, void* values) => _GetnMinmaxARB_fnptr(target, reset, format, type, bufSize, values);
+            public static void GetnMinmaxARB(MinmaxTargetEXT target, bool reset, PixelFormat format, PixelType type, int bufSize, void* values) => _GetnMinmaxARB_fnptr(target, reset, format, type, bufSize, values);
             [UnmanagedCallersOnly]
-            private static void GetnMinmaxARB_Lazy(MinmaxTargetEXT target, byte reset, PixelFormat format, PixelType type, int bufSize, void* values)
+            private static void GetnMinmaxARB_Lazy(MinmaxTargetEXT target, bool reset, PixelFormat format, PixelType type, int bufSize, void* values)
             {
-                _GetnMinmaxARB_fnptr = (delegate* unmanaged<MinmaxTargetEXT, byte, PixelFormat, PixelType, int, void*, void>)GLLoader.BindingsContext.GetProcAddress("glGetnMinmaxARB");
+                _GetnMinmaxARB_fnptr = (delegate* unmanaged<MinmaxTargetEXT, bool, PixelFormat, PixelType, int, void*, void>)GLLoader.BindingsContext.GetProcAddress("glGetnMinmaxARB");
                 _GetnMinmaxARB_fnptr(target, reset, format, type, bufSize, values);
             }
             
@@ -20452,15 +20452,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _DeleteSamplers_fnptr(count, samplers);
             }
             
-            private static delegate* unmanaged<SamplerHandle, byte> _IsSampler_fnptr = &IsSampler_Lazy;
+            private static delegate* unmanaged<SamplerHandle, bool> _IsSampler_fnptr = &IsSampler_Lazy;
             /// <summary> <b>[requires: v3.3 | GL_ARB_sampler_objects]</b> Determine if a name corresponds to a sampler object. </summary>
             /// <param name="id"> Specifies a value that may be the name of a sampler object. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsSampler.xhtml" /></remarks>
-            public static byte IsSampler(SamplerHandle sampler) => _IsSampler_fnptr(sampler);
+            public static bool IsSampler(SamplerHandle sampler) => _IsSampler_fnptr(sampler);
             [UnmanagedCallersOnly]
-            private static byte IsSampler_Lazy(SamplerHandle sampler)
+            private static bool IsSampler_Lazy(SamplerHandle sampler)
             {
-                _IsSampler_fnptr = (delegate* unmanaged<SamplerHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsSampler");
+                _IsSampler_fnptr = (delegate* unmanaged<SamplerHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsSampler");
                 return _IsSampler_fnptr(sampler);
             }
             
@@ -20696,15 +20696,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _GenProgramPipelines_fnptr(n, pipelines);
             }
             
-            private static delegate* unmanaged<ProgramPipelineHandle, byte> _IsProgramPipeline_fnptr = &IsProgramPipeline_Lazy;
+            private static delegate* unmanaged<ProgramPipelineHandle, bool> _IsProgramPipeline_fnptr = &IsProgramPipeline_Lazy;
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Determine if a name corresponds to a program pipeline object. </summary>
             /// <param name="pipeline"> Specifies a value that may be the name of a program pipeline object. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsProgramPipeline.xhtml" /></remarks>
-            public static byte IsProgramPipeline(ProgramPipelineHandle pipeline) => _IsProgramPipeline_fnptr(pipeline);
+            public static bool IsProgramPipeline(ProgramPipelineHandle pipeline) => _IsProgramPipeline_fnptr(pipeline);
             [UnmanagedCallersOnly]
-            private static byte IsProgramPipeline_Lazy(ProgramPipelineHandle pipeline)
+            private static bool IsProgramPipeline_Lazy(ProgramPipelineHandle pipeline)
             {
-                _IsProgramPipeline_fnptr = (delegate* unmanaged<ProgramPipelineHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsProgramPipeline");
+                _IsProgramPipeline_fnptr = (delegate* unmanaged<ProgramPipelineHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsProgramPipeline");
                 return _IsProgramPipeline_fnptr(pipeline);
             }
             
@@ -21176,7 +21176,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _ProgramUniform4uiv_fnptr(program, location, count, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix2fv_fnptr = &ProgramUniformMatrix2fv_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix2fv_fnptr = &ProgramUniformMatrix2fv_Lazy;
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
             /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
@@ -21184,15 +21184,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
             /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniformMatrix2fv(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix2fv_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix2fv(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix2fv_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix2fv_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+            private static void ProgramUniformMatrix2fv_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
             {
-                _ProgramUniformMatrix2fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2fv");
+                _ProgramUniformMatrix2fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2fv");
                 _ProgramUniformMatrix2fv_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix3fv_fnptr = &ProgramUniformMatrix3fv_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix3fv_fnptr = &ProgramUniformMatrix3fv_Lazy;
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
             /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
@@ -21200,15 +21200,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
             /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniformMatrix3fv(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix3fv_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix3fv(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix3fv_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix3fv_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+            private static void ProgramUniformMatrix3fv_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
             {
-                _ProgramUniformMatrix3fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3fv");
+                _ProgramUniformMatrix3fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3fv");
                 _ProgramUniformMatrix3fv_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix4fv_fnptr = &ProgramUniformMatrix4fv_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix4fv_fnptr = &ProgramUniformMatrix4fv_Lazy;
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
             /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
@@ -21216,48 +21216,48 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
             /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniformMatrix4fv(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix4fv_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix4fv(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix4fv_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix4fv_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+            private static void ProgramUniformMatrix4fv_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
             {
-                _ProgramUniformMatrix4fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4fv");
+                _ProgramUniformMatrix4fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4fv");
                 _ProgramUniformMatrix4fv_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, double*, void> _ProgramUniformMatrix2dv_fnptr = &ProgramUniformMatrix2dv_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, double*, void> _ProgramUniformMatrix2dv_fnptr = &ProgramUniformMatrix2dv_Lazy;
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix2dv(ProgramHandle program, int location, int count, byte transpose, double* value) => _ProgramUniformMatrix2dv_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix2dv(ProgramHandle program, int location, int count, bool transpose, double* value) => _ProgramUniformMatrix2dv_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix2dv_Lazy(ProgramHandle program, int location, int count, byte transpose, double* value)
+            private static void ProgramUniformMatrix2dv_Lazy(ProgramHandle program, int location, int count, bool transpose, double* value)
             {
-                _ProgramUniformMatrix2dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2dv");
+                _ProgramUniformMatrix2dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2dv");
                 _ProgramUniformMatrix2dv_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, double*, void> _ProgramUniformMatrix3dv_fnptr = &ProgramUniformMatrix3dv_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, double*, void> _ProgramUniformMatrix3dv_fnptr = &ProgramUniformMatrix3dv_Lazy;
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix3dv(ProgramHandle program, int location, int count, byte transpose, double* value) => _ProgramUniformMatrix3dv_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix3dv(ProgramHandle program, int location, int count, bool transpose, double* value) => _ProgramUniformMatrix3dv_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix3dv_Lazy(ProgramHandle program, int location, int count, byte transpose, double* value)
+            private static void ProgramUniformMatrix3dv_Lazy(ProgramHandle program, int location, int count, bool transpose, double* value)
             {
-                _ProgramUniformMatrix3dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3dv");
+                _ProgramUniformMatrix3dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3dv");
                 _ProgramUniformMatrix3dv_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, double*, void> _ProgramUniformMatrix4dv_fnptr = &ProgramUniformMatrix4dv_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, double*, void> _ProgramUniformMatrix4dv_fnptr = &ProgramUniformMatrix4dv_Lazy;
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix4dv(ProgramHandle program, int location, int count, byte transpose, double* value) => _ProgramUniformMatrix4dv_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix4dv(ProgramHandle program, int location, int count, bool transpose, double* value) => _ProgramUniformMatrix4dv_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix4dv_Lazy(ProgramHandle program, int location, int count, byte transpose, double* value)
+            private static void ProgramUniformMatrix4dv_Lazy(ProgramHandle program, int location, int count, bool transpose, double* value)
             {
-                _ProgramUniformMatrix4dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4dv");
+                _ProgramUniformMatrix4dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4dv");
                 _ProgramUniformMatrix4dv_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix2x3fv_fnptr = &ProgramUniformMatrix2x3fv_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix2x3fv_fnptr = &ProgramUniformMatrix2x3fv_Lazy;
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
             /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
@@ -21265,15 +21265,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
             /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniformMatrix2x3fv(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix2x3fv_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix2x3fv(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix2x3fv_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix2x3fv_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+            private static void ProgramUniformMatrix2x3fv_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
             {
-                _ProgramUniformMatrix2x3fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2x3fv");
+                _ProgramUniformMatrix2x3fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2x3fv");
                 _ProgramUniformMatrix2x3fv_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix3x2fv_fnptr = &ProgramUniformMatrix3x2fv_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix3x2fv_fnptr = &ProgramUniformMatrix3x2fv_Lazy;
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
             /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
@@ -21281,15 +21281,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
             /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniformMatrix3x2fv(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix3x2fv_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix3x2fv(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix3x2fv_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix3x2fv_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+            private static void ProgramUniformMatrix3x2fv_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
             {
-                _ProgramUniformMatrix3x2fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3x2fv");
+                _ProgramUniformMatrix3x2fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3x2fv");
                 _ProgramUniformMatrix3x2fv_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix2x4fv_fnptr = &ProgramUniformMatrix2x4fv_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix2x4fv_fnptr = &ProgramUniformMatrix2x4fv_Lazy;
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
             /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
@@ -21297,15 +21297,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
             /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniformMatrix2x4fv(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix2x4fv_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix2x4fv(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix2x4fv_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix2x4fv_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+            private static void ProgramUniformMatrix2x4fv_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
             {
-                _ProgramUniformMatrix2x4fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2x4fv");
+                _ProgramUniformMatrix2x4fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2x4fv");
                 _ProgramUniformMatrix2x4fv_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix4x2fv_fnptr = &ProgramUniformMatrix4x2fv_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix4x2fv_fnptr = &ProgramUniformMatrix4x2fv_Lazy;
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
             /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
@@ -21313,15 +21313,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
             /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniformMatrix4x2fv(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix4x2fv_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix4x2fv(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix4x2fv_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix4x2fv_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+            private static void ProgramUniformMatrix4x2fv_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
             {
-                _ProgramUniformMatrix4x2fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4x2fv");
+                _ProgramUniformMatrix4x2fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4x2fv");
                 _ProgramUniformMatrix4x2fv_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix3x4fv_fnptr = &ProgramUniformMatrix3x4fv_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix3x4fv_fnptr = &ProgramUniformMatrix3x4fv_Lazy;
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
             /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
@@ -21329,15 +21329,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
             /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniformMatrix3x4fv(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix3x4fv_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix3x4fv(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix3x4fv_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix3x4fv_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+            private static void ProgramUniformMatrix3x4fv_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
             {
-                _ProgramUniformMatrix3x4fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3x4fv");
+                _ProgramUniformMatrix3x4fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3x4fv");
                 _ProgramUniformMatrix3x4fv_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix4x3fv_fnptr = &ProgramUniformMatrix4x3fv_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix4x3fv_fnptr = &ProgramUniformMatrix4x3fv_Lazy;
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
             /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
@@ -21345,77 +21345,77 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
             /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniformMatrix4x3fv(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix4x3fv_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix4x3fv(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix4x3fv_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix4x3fv_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+            private static void ProgramUniformMatrix4x3fv_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
             {
-                _ProgramUniformMatrix4x3fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4x3fv");
+                _ProgramUniformMatrix4x3fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4x3fv");
                 _ProgramUniformMatrix4x3fv_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, double*, void> _ProgramUniformMatrix2x3dv_fnptr = &ProgramUniformMatrix2x3dv_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, double*, void> _ProgramUniformMatrix2x3dv_fnptr = &ProgramUniformMatrix2x3dv_Lazy;
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix2x3dv(ProgramHandle program, int location, int count, byte transpose, double* value) => _ProgramUniformMatrix2x3dv_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix2x3dv(ProgramHandle program, int location, int count, bool transpose, double* value) => _ProgramUniformMatrix2x3dv_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix2x3dv_Lazy(ProgramHandle program, int location, int count, byte transpose, double* value)
+            private static void ProgramUniformMatrix2x3dv_Lazy(ProgramHandle program, int location, int count, bool transpose, double* value)
             {
-                _ProgramUniformMatrix2x3dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2x3dv");
+                _ProgramUniformMatrix2x3dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2x3dv");
                 _ProgramUniformMatrix2x3dv_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, double*, void> _ProgramUniformMatrix3x2dv_fnptr = &ProgramUniformMatrix3x2dv_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, double*, void> _ProgramUniformMatrix3x2dv_fnptr = &ProgramUniformMatrix3x2dv_Lazy;
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix3x2dv(ProgramHandle program, int location, int count, byte transpose, double* value) => _ProgramUniformMatrix3x2dv_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix3x2dv(ProgramHandle program, int location, int count, bool transpose, double* value) => _ProgramUniformMatrix3x2dv_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix3x2dv_Lazy(ProgramHandle program, int location, int count, byte transpose, double* value)
+            private static void ProgramUniformMatrix3x2dv_Lazy(ProgramHandle program, int location, int count, bool transpose, double* value)
             {
-                _ProgramUniformMatrix3x2dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3x2dv");
+                _ProgramUniformMatrix3x2dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3x2dv");
                 _ProgramUniformMatrix3x2dv_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, double*, void> _ProgramUniformMatrix2x4dv_fnptr = &ProgramUniformMatrix2x4dv_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, double*, void> _ProgramUniformMatrix2x4dv_fnptr = &ProgramUniformMatrix2x4dv_Lazy;
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix2x4dv(ProgramHandle program, int location, int count, byte transpose, double* value) => _ProgramUniformMatrix2x4dv_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix2x4dv(ProgramHandle program, int location, int count, bool transpose, double* value) => _ProgramUniformMatrix2x4dv_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix2x4dv_Lazy(ProgramHandle program, int location, int count, byte transpose, double* value)
+            private static void ProgramUniformMatrix2x4dv_Lazy(ProgramHandle program, int location, int count, bool transpose, double* value)
             {
-                _ProgramUniformMatrix2x4dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2x4dv");
+                _ProgramUniformMatrix2x4dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2x4dv");
                 _ProgramUniformMatrix2x4dv_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, double*, void> _ProgramUniformMatrix4x2dv_fnptr = &ProgramUniformMatrix4x2dv_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, double*, void> _ProgramUniformMatrix4x2dv_fnptr = &ProgramUniformMatrix4x2dv_Lazy;
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix4x2dv(ProgramHandle program, int location, int count, byte transpose, double* value) => _ProgramUniformMatrix4x2dv_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix4x2dv(ProgramHandle program, int location, int count, bool transpose, double* value) => _ProgramUniformMatrix4x2dv_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix4x2dv_Lazy(ProgramHandle program, int location, int count, byte transpose, double* value)
+            private static void ProgramUniformMatrix4x2dv_Lazy(ProgramHandle program, int location, int count, bool transpose, double* value)
             {
-                _ProgramUniformMatrix4x2dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4x2dv");
+                _ProgramUniformMatrix4x2dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4x2dv");
                 _ProgramUniformMatrix4x2dv_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, double*, void> _ProgramUniformMatrix3x4dv_fnptr = &ProgramUniformMatrix3x4dv_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, double*, void> _ProgramUniformMatrix3x4dv_fnptr = &ProgramUniformMatrix3x4dv_Lazy;
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix3x4dv(ProgramHandle program, int location, int count, byte transpose, double* value) => _ProgramUniformMatrix3x4dv_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix3x4dv(ProgramHandle program, int location, int count, bool transpose, double* value) => _ProgramUniformMatrix3x4dv_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix3x4dv_Lazy(ProgramHandle program, int location, int count, byte transpose, double* value)
+            private static void ProgramUniformMatrix3x4dv_Lazy(ProgramHandle program, int location, int count, bool transpose, double* value)
             {
-                _ProgramUniformMatrix3x4dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3x4dv");
+                _ProgramUniformMatrix3x4dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3x4dv");
                 _ProgramUniformMatrix3x4dv_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, double*, void> _ProgramUniformMatrix4x3dv_fnptr = &ProgramUniformMatrix4x3dv_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, double*, void> _ProgramUniformMatrix4x3dv_fnptr = &ProgramUniformMatrix4x3dv_Lazy;
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix4x3dv(ProgramHandle program, int location, int count, byte transpose, double* value) => _ProgramUniformMatrix4x3dv_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix4x3dv(ProgramHandle program, int location, int count, bool transpose, double* value) => _ProgramUniformMatrix4x3dv_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix4x3dv_Lazy(ProgramHandle program, int location, int count, byte transpose, double* value)
+            private static void ProgramUniformMatrix4x3dv_Lazy(ProgramHandle program, int location, int count, bool transpose, double* value)
             {
-                _ProgramUniformMatrix4x3dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4x3dv");
+                _ProgramUniformMatrix4x3dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4x3dv");
                 _ProgramUniformMatrix4x3dv_fnptr(program, location, count, transpose, value);
             }
             
@@ -21461,7 +21461,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _GetActiveAtomicCounterBufferiv_fnptr(program, bufferIndex, pname, parameters);
             }
             
-            private static delegate* unmanaged<uint, TextureHandle, int, byte, int, BufferAccessARB, InternalFormat, void> _BindImageTexture_fnptr = &BindImageTexture_Lazy;
+            private static delegate* unmanaged<uint, TextureHandle, int, bool, int, BufferAccessARB, InternalFormat, void> _BindImageTexture_fnptr = &BindImageTexture_Lazy;
             /// <summary> <b>[requires: v4.2 | GL_ARB_shader_image_load_store]</b> Bind a level of a texture to an image unit. </summary>
             /// <param name="unit"> Specifies the index of the image unit to which to bind the texture </param>
             /// <param name="texture"> Specifies the name of the texture to bind to the image unit. </param>
@@ -21471,11 +21471,11 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="access"> Specifies a token indicating the type of access that will be performed on the image. </param>
             /// <param name="format"> Specifies the format that the elements of the image will be treated as for the purposes of formatted stores. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindImageTexture.xhtml" /></remarks>
-            public static void BindImageTexture(uint unit, TextureHandle texture, int level, byte layered, int layer, BufferAccessARB access, InternalFormat format) => _BindImageTexture_fnptr(unit, texture, level, layered, layer, access, format);
+            public static void BindImageTexture(uint unit, TextureHandle texture, int level, bool layered, int layer, BufferAccessARB access, InternalFormat format) => _BindImageTexture_fnptr(unit, texture, level, layered, layer, access, format);
             [UnmanagedCallersOnly]
-            private static void BindImageTexture_Lazy(uint unit, TextureHandle texture, int level, byte layered, int layer, BufferAccessARB access, InternalFormat format)
+            private static void BindImageTexture_Lazy(uint unit, TextureHandle texture, int level, bool layered, int layer, BufferAccessARB access, InternalFormat format)
             {
-                _BindImageTexture_fnptr = (delegate* unmanaged<uint, TextureHandle, int, byte, int, BufferAccessARB, InternalFormat, void>)GLLoader.BindingsContext.GetProcAddress("glBindImageTexture");
+                _BindImageTexture_fnptr = (delegate* unmanaged<uint, TextureHandle, int, bool, int, BufferAccessARB, InternalFormat, void>)GLLoader.BindingsContext.GetProcAddress("glBindImageTexture");
                 _BindImageTexture_fnptr(unit, texture, level, layered, layer, access, format);
             }
             
@@ -21788,36 +21788,36 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _Uniform4ivARB_fnptr(location, count, value);
             }
             
-            private static delegate* unmanaged<int, int, byte, float*, void> _UniformMatrix2fvARB_fnptr = &UniformMatrix2fvARB_Lazy;
+            private static delegate* unmanaged<int, int, bool, float*, void> _UniformMatrix2fvARB_fnptr = &UniformMatrix2fvARB_Lazy;
             /// <summary> <b>[requires: GL_ARB_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void UniformMatrix2fvARB(int location, int count, byte transpose, float* value) => _UniformMatrix2fvARB_fnptr(location, count, transpose, value);
+            public static void UniformMatrix2fvARB(int location, int count, bool transpose, float* value) => _UniformMatrix2fvARB_fnptr(location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void UniformMatrix2fvARB_Lazy(int location, int count, byte transpose, float* value)
+            private static void UniformMatrix2fvARB_Lazy(int location, int count, bool transpose, float* value)
             {
-                _UniformMatrix2fvARB_fnptr = (delegate* unmanaged<int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix2fvARB");
+                _UniformMatrix2fvARB_fnptr = (delegate* unmanaged<int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix2fvARB");
                 _UniformMatrix2fvARB_fnptr(location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<int, int, byte, float*, void> _UniformMatrix3fvARB_fnptr = &UniformMatrix3fvARB_Lazy;
+            private static delegate* unmanaged<int, int, bool, float*, void> _UniformMatrix3fvARB_fnptr = &UniformMatrix3fvARB_Lazy;
             /// <summary> <b>[requires: GL_ARB_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void UniformMatrix3fvARB(int location, int count, byte transpose, float* value) => _UniformMatrix3fvARB_fnptr(location, count, transpose, value);
+            public static void UniformMatrix3fvARB(int location, int count, bool transpose, float* value) => _UniformMatrix3fvARB_fnptr(location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void UniformMatrix3fvARB_Lazy(int location, int count, byte transpose, float* value)
+            private static void UniformMatrix3fvARB_Lazy(int location, int count, bool transpose, float* value)
             {
-                _UniformMatrix3fvARB_fnptr = (delegate* unmanaged<int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix3fvARB");
+                _UniformMatrix3fvARB_fnptr = (delegate* unmanaged<int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix3fvARB");
                 _UniformMatrix3fvARB_fnptr(location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<int, int, byte, float*, void> _UniformMatrix4fvARB_fnptr = &UniformMatrix4fvARB_Lazy;
+            private static delegate* unmanaged<int, int, bool, float*, void> _UniformMatrix4fvARB_fnptr = &UniformMatrix4fvARB_Lazy;
             /// <summary> <b>[requires: GL_ARB_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void UniformMatrix4fvARB(int location, int count, byte transpose, float* value) => _UniformMatrix4fvARB_fnptr(location, count, transpose, value);
+            public static void UniformMatrix4fvARB(int location, int count, bool transpose, float* value) => _UniformMatrix4fvARB_fnptr(location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void UniformMatrix4fvARB_Lazy(int location, int count, byte transpose, float* value)
+            private static void UniformMatrix4fvARB_Lazy(int location, int count, bool transpose, float* value)
             {
-                _UniformMatrix4fvARB_fnptr = (delegate* unmanaged<int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix4fvARB");
+                _UniformMatrix4fvARB_fnptr = (delegate* unmanaged<int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix4fvARB");
                 _UniformMatrix4fvARB_fnptr(location, count, transpose, value);
             }
             
@@ -22088,14 +22088,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _CompileShaderIncludeARB_fnptr(shader, count, path, length);
             }
             
-            private static delegate* unmanaged<int, byte*, byte> _IsNamedStringARB_fnptr = &IsNamedStringARB_Lazy;
+            private static delegate* unmanaged<int, byte*, bool> _IsNamedStringARB_fnptr = &IsNamedStringARB_Lazy;
             /// <summary> <b>[requires: GL_ARB_shading_language_include]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsNamedStringARB(int namelen, byte* name) => _IsNamedStringARB_fnptr(namelen, name);
+            public static bool IsNamedStringARB(int namelen, byte* name) => _IsNamedStringARB_fnptr(namelen, name);
             [UnmanagedCallersOnly]
-            private static byte IsNamedStringARB_Lazy(int namelen, byte* name)
+            private static bool IsNamedStringARB_Lazy(int namelen, byte* name)
             {
-                _IsNamedStringARB_fnptr = (delegate* unmanaged<int, byte*, byte>)GLLoader.BindingsContext.GetProcAddress("glIsNamedStringARB");
+                _IsNamedStringARB_fnptr = (delegate* unmanaged<int, byte*, bool>)GLLoader.BindingsContext.GetProcAddress("glIsNamedStringARB");
                 return _IsNamedStringARB_fnptr(namelen, name);
             }
             
@@ -22121,47 +22121,47 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _GetNamedStringivARB_fnptr(namelen, name, pname, parameters);
             }
             
-            private static delegate* unmanaged<All, IntPtr, nint, byte, void> _BufferPageCommitmentARB_fnptr = &BufferPageCommitmentARB_Lazy;
+            private static delegate* unmanaged<All, IntPtr, nint, bool, void> _BufferPageCommitmentARB_fnptr = &BufferPageCommitmentARB_Lazy;
             /// <summary> <b>[requires: GL_ARB_sparse_buffer]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void BufferPageCommitmentARB(All target, IntPtr offset, nint size, byte commit) => _BufferPageCommitmentARB_fnptr(target, offset, size, commit);
+            public static void BufferPageCommitmentARB(All target, IntPtr offset, nint size, bool commit) => _BufferPageCommitmentARB_fnptr(target, offset, size, commit);
             [UnmanagedCallersOnly]
-            private static void BufferPageCommitmentARB_Lazy(All target, IntPtr offset, nint size, byte commit)
+            private static void BufferPageCommitmentARB_Lazy(All target, IntPtr offset, nint size, bool commit)
             {
-                _BufferPageCommitmentARB_fnptr = (delegate* unmanaged<All, IntPtr, nint, byte, void>)GLLoader.BindingsContext.GetProcAddress("glBufferPageCommitmentARB");
+                _BufferPageCommitmentARB_fnptr = (delegate* unmanaged<All, IntPtr, nint, bool, void>)GLLoader.BindingsContext.GetProcAddress("glBufferPageCommitmentARB");
                 _BufferPageCommitmentARB_fnptr(target, offset, size, commit);
             }
             
-            private static delegate* unmanaged<BufferHandle, IntPtr, nint, byte, void> _NamedBufferPageCommitmentEXT_fnptr = &NamedBufferPageCommitmentEXT_Lazy;
+            private static delegate* unmanaged<BufferHandle, IntPtr, nint, bool, void> _NamedBufferPageCommitmentEXT_fnptr = &NamedBufferPageCommitmentEXT_Lazy;
             /// <summary> <b>[requires: GL_ARB_sparse_buffer]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedBufferPageCommitmentEXT(BufferHandle buffer, IntPtr offset, nint size, byte commit) => _NamedBufferPageCommitmentEXT_fnptr(buffer, offset, size, commit);
+            public static void NamedBufferPageCommitmentEXT(BufferHandle buffer, IntPtr offset, nint size, bool commit) => _NamedBufferPageCommitmentEXT_fnptr(buffer, offset, size, commit);
             [UnmanagedCallersOnly]
-            private static void NamedBufferPageCommitmentEXT_Lazy(BufferHandle buffer, IntPtr offset, nint size, byte commit)
+            private static void NamedBufferPageCommitmentEXT_Lazy(BufferHandle buffer, IntPtr offset, nint size, bool commit)
             {
-                _NamedBufferPageCommitmentEXT_fnptr = (delegate* unmanaged<BufferHandle, IntPtr, nint, byte, void>)GLLoader.BindingsContext.GetProcAddress("glNamedBufferPageCommitmentEXT");
+                _NamedBufferPageCommitmentEXT_fnptr = (delegate* unmanaged<BufferHandle, IntPtr, nint, bool, void>)GLLoader.BindingsContext.GetProcAddress("glNamedBufferPageCommitmentEXT");
                 _NamedBufferPageCommitmentEXT_fnptr(buffer, offset, size, commit);
             }
             
-            private static delegate* unmanaged<BufferHandle, IntPtr, nint, byte, void> _NamedBufferPageCommitmentARB_fnptr = &NamedBufferPageCommitmentARB_Lazy;
+            private static delegate* unmanaged<BufferHandle, IntPtr, nint, bool, void> _NamedBufferPageCommitmentARB_fnptr = &NamedBufferPageCommitmentARB_Lazy;
             /// <summary> <b>[requires: GL_ARB_sparse_buffer]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedBufferPageCommitmentARB(BufferHandle buffer, IntPtr offset, nint size, byte commit) => _NamedBufferPageCommitmentARB_fnptr(buffer, offset, size, commit);
+            public static void NamedBufferPageCommitmentARB(BufferHandle buffer, IntPtr offset, nint size, bool commit) => _NamedBufferPageCommitmentARB_fnptr(buffer, offset, size, commit);
             [UnmanagedCallersOnly]
-            private static void NamedBufferPageCommitmentARB_Lazy(BufferHandle buffer, IntPtr offset, nint size, byte commit)
+            private static void NamedBufferPageCommitmentARB_Lazy(BufferHandle buffer, IntPtr offset, nint size, bool commit)
             {
-                _NamedBufferPageCommitmentARB_fnptr = (delegate* unmanaged<BufferHandle, IntPtr, nint, byte, void>)GLLoader.BindingsContext.GetProcAddress("glNamedBufferPageCommitmentARB");
+                _NamedBufferPageCommitmentARB_fnptr = (delegate* unmanaged<BufferHandle, IntPtr, nint, bool, void>)GLLoader.BindingsContext.GetProcAddress("glNamedBufferPageCommitmentARB");
                 _NamedBufferPageCommitmentARB_fnptr(buffer, offset, size, commit);
             }
             
-            private static delegate* unmanaged<All, int, int, int, int, int, int, int, byte, void> _TexPageCommitmentARB_fnptr = &TexPageCommitmentARB_Lazy;
+            private static delegate* unmanaged<All, int, int, int, int, int, int, int, bool, void> _TexPageCommitmentARB_fnptr = &TexPageCommitmentARB_Lazy;
             /// <summary> <b>[requires: GL_ARB_sparse_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TexPageCommitmentARB(All target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, byte commit) => _TexPageCommitmentARB_fnptr(target, level, xoffset, yoffset, zoffset, width, height, depth, commit);
+            public static void TexPageCommitmentARB(All target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, bool commit) => _TexPageCommitmentARB_fnptr(target, level, xoffset, yoffset, zoffset, width, height, depth, commit);
             [UnmanagedCallersOnly]
-            private static void TexPageCommitmentARB_Lazy(All target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, byte commit)
+            private static void TexPageCommitmentARB_Lazy(All target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, bool commit)
             {
-                _TexPageCommitmentARB_fnptr = (delegate* unmanaged<All, int, int, int, int, int, int, int, byte, void>)GLLoader.BindingsContext.GetProcAddress("glTexPageCommitmentARB");
+                _TexPageCommitmentARB_fnptr = (delegate* unmanaged<All, int, int, int, int, int, int, int, bool, void>)GLLoader.BindingsContext.GetProcAddress("glTexPageCommitmentARB");
                 _TexPageCommitmentARB_fnptr(target, level, xoffset, yoffset, zoffset, width, height, depth, commit);
             }
             
@@ -22178,15 +22178,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return _FenceSync_fnptr(condition, flags);
             }
             
-            private static delegate* unmanaged<GLSync, byte> _IsSync_fnptr = &IsSync_Lazy;
+            private static delegate* unmanaged<GLSync, bool> _IsSync_fnptr = &IsSync_Lazy;
             /// <summary> <b>[requires: v3.2 | GL_ARB_sync]</b> Determine if a name corresponds to a sync object. </summary>
             /// <param name="sync"> Specifies a value that may be the name of a sync object. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsSync.xhtml" /></remarks>
-            public static byte IsSync(GLSync sync) => _IsSync_fnptr(sync);
+            public static bool IsSync(GLSync sync) => _IsSync_fnptr(sync);
             [UnmanagedCallersOnly]
-            private static byte IsSync_Lazy(GLSync sync)
+            private static bool IsSync_Lazy(GLSync sync)
             {
-                _IsSync_fnptr = (delegate* unmanaged<GLSync, byte>)GLLoader.BindingsContext.GetProcAddress("glIsSync");
+                _IsSync_fnptr = (delegate* unmanaged<GLSync, bool>)GLLoader.BindingsContext.GetProcAddress("glIsSync");
                 return _IsSync_fnptr(sync);
             }
             
@@ -22400,7 +22400,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _GetCompressedTexImageARB_fnptr(target, level, img);
             }
             
-            private static delegate* unmanaged<TextureTarget, int, InternalFormat, int, int, byte, void> _TexImage2DMultisample_fnptr = &TexImage2DMultisample_Lazy;
+            private static delegate* unmanaged<TextureTarget, int, InternalFormat, int, int, bool, void> _TexImage2DMultisample_fnptr = &TexImage2DMultisample_Lazy;
             /// <summary> <b>[requires: v3.2 | GL_ARB_texture_multisample]</b> Establish the data storage, format, dimensions, and number of samples of a multisample texture's image. </summary>
             /// <param name="target"> Specifies the target of the operation. target must be GL_TEXTURE_2D_MULTISAMPLE or GL_PROXY_TEXTURE_2D_MULTISAMPLE. </param>
             /// <param name="samples"> The number of samples in the multisample texture's image. </param>
@@ -22409,15 +22409,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="height"> The height of the multisample texture's image, in texels. </param>
             /// <param name="fixedsamplelocations"> Specifies whether the image will use identical sample locations and the same number of samples for all texels in the image, and the sample locations will not depend on the internal format or size of the image. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexImage2DMultisample.xhtml" /></remarks>
-            public static void TexImage2DMultisample(TextureTarget target, int samples, InternalFormat internalformat, int width, int height, byte fixedsamplelocations) => _TexImage2DMultisample_fnptr(target, samples, internalformat, width, height, fixedsamplelocations);
+            public static void TexImage2DMultisample(TextureTarget target, int samples, InternalFormat internalformat, int width, int height, bool fixedsamplelocations) => _TexImage2DMultisample_fnptr(target, samples, internalformat, width, height, fixedsamplelocations);
             [UnmanagedCallersOnly]
-            private static void TexImage2DMultisample_Lazy(TextureTarget target, int samples, InternalFormat internalformat, int width, int height, byte fixedsamplelocations)
+            private static void TexImage2DMultisample_Lazy(TextureTarget target, int samples, InternalFormat internalformat, int width, int height, bool fixedsamplelocations)
             {
-                _TexImage2DMultisample_fnptr = (delegate* unmanaged<TextureTarget, int, InternalFormat, int, int, byte, void>)GLLoader.BindingsContext.GetProcAddress("glTexImage2DMultisample");
+                _TexImage2DMultisample_fnptr = (delegate* unmanaged<TextureTarget, int, InternalFormat, int, int, bool, void>)GLLoader.BindingsContext.GetProcAddress("glTexImage2DMultisample");
                 _TexImage2DMultisample_fnptr(target, samples, internalformat, width, height, fixedsamplelocations);
             }
             
-            private static delegate* unmanaged<TextureTarget, int, InternalFormat, int, int, int, byte, void> _TexImage3DMultisample_fnptr = &TexImage3DMultisample_Lazy;
+            private static delegate* unmanaged<TextureTarget, int, InternalFormat, int, int, int, bool, void> _TexImage3DMultisample_fnptr = &TexImage3DMultisample_Lazy;
             /// <summary> <b>[requires: v3.2 | GL_ARB_texture_multisample]</b> Establish the data storage, format, dimensions, and number of samples of a multisample texture's image. </summary>
             /// <param name="target"> Specifies the target of the operation. target must be GL_TEXTURE_2D_MULTISAMPLE_ARRAY or GL_PROXY_TEXTURE_2D_MULTISAMPLE_ARRAY. </param>
             /// <param name="samples"> The number of samples in the multisample texture's image. </param>
@@ -22427,11 +22427,11 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="depth">!!missing documentation!!</param>
             /// <param name="fixedsamplelocations"> Specifies whether the image will use identical sample locations and the same number of samples for all texels in the image, and the sample locations will not depend on the internal format or size of the image. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexImage3DMultisample.xhtml" /></remarks>
-            public static void TexImage3DMultisample(TextureTarget target, int samples, InternalFormat internalformat, int width, int height, int depth, byte fixedsamplelocations) => _TexImage3DMultisample_fnptr(target, samples, internalformat, width, height, depth, fixedsamplelocations);
+            public static void TexImage3DMultisample(TextureTarget target, int samples, InternalFormat internalformat, int width, int height, int depth, bool fixedsamplelocations) => _TexImage3DMultisample_fnptr(target, samples, internalformat, width, height, depth, fixedsamplelocations);
             [UnmanagedCallersOnly]
-            private static void TexImage3DMultisample_Lazy(TextureTarget target, int samples, InternalFormat internalformat, int width, int height, int depth, byte fixedsamplelocations)
+            private static void TexImage3DMultisample_Lazy(TextureTarget target, int samples, InternalFormat internalformat, int width, int height, int depth, bool fixedsamplelocations)
             {
-                _TexImage3DMultisample_fnptr = (delegate* unmanaged<TextureTarget, int, InternalFormat, int, int, int, byte, void>)GLLoader.BindingsContext.GetProcAddress("glTexImage3DMultisample");
+                _TexImage3DMultisample_fnptr = (delegate* unmanaged<TextureTarget, int, InternalFormat, int, int, int, bool, void>)GLLoader.BindingsContext.GetProcAddress("glTexImage3DMultisample");
                 _TexImage3DMultisample_fnptr(target, samples, internalformat, width, height, depth, fixedsamplelocations);
             }
             
@@ -22510,7 +22510,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _TexStorage3D_fnptr(target, levels, internalformat, width, height, depth);
             }
             
-            private static delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, byte, void> _TexStorage2DMultisample_fnptr = &TexStorage2DMultisample_Lazy;
+            private static delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, bool, void> _TexStorage2DMultisample_fnptr = &TexStorage2DMultisample_Lazy;
             /// <summary> <b>[requires: v4.3 | GL_ARB_texture_storage_multisample]</b> Specify storage for a two-dimensional multisample texture. </summary>
             /// <param name="target"> Specifies the target to which the texture object is bound for glTexStorage2DMultisample. Must be one of GL_TEXTURE_2D_MULTISAMPLE or GL_PROXY_TEXTURE_2D_MULTISAMPLE. </param>
             /// <param name="samples"> Specify the number of samples in the texture. </param>
@@ -22519,15 +22519,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="height"> Specifies the height of the texture, in texels. </param>
             /// <param name="fixedsamplelocations"> Specifies whether the image will use identical sample locations and the same number of samples for all texels in the image, and the sample locations will not depend on the internal format or size of the image. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexStorage2DMultisample.xhtml" /></remarks>
-            public static void TexStorage2DMultisample(TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, byte fixedsamplelocations) => _TexStorage2DMultisample_fnptr(target, samples, internalformat, width, height, fixedsamplelocations);
+            public static void TexStorage2DMultisample(TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, bool fixedsamplelocations) => _TexStorage2DMultisample_fnptr(target, samples, internalformat, width, height, fixedsamplelocations);
             [UnmanagedCallersOnly]
-            private static void TexStorage2DMultisample_Lazy(TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, byte fixedsamplelocations)
+            private static void TexStorage2DMultisample_Lazy(TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, bool fixedsamplelocations)
             {
-                _TexStorage2DMultisample_fnptr = (delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, byte, void>)GLLoader.BindingsContext.GetProcAddress("glTexStorage2DMultisample");
+                _TexStorage2DMultisample_fnptr = (delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, bool, void>)GLLoader.BindingsContext.GetProcAddress("glTexStorage2DMultisample");
                 _TexStorage2DMultisample_fnptr(target, samples, internalformat, width, height, fixedsamplelocations);
             }
             
-            private static delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, int, byte, void> _TexStorage3DMultisample_fnptr = &TexStorage3DMultisample_Lazy;
+            private static delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, int, bool, void> _TexStorage3DMultisample_fnptr = &TexStorage3DMultisample_Lazy;
             /// <summary> <b>[requires: v4.3 | GL_ARB_texture_storage_multisample]</b> Specify storage for a two-dimensional multisample array texture. </summary>
             /// <param name="target"> Specifies the target to which the texture object is bound for glTexStorage3DMultisample. Must be one of GL_TEXTURE_2D_MULTISAMPLE_ARRAY or GL_PROXY_TEXTURE_2D_MULTISAMPLE_ARRAY. </param>
             /// <param name="samples"> Specify the number of samples in the texture. </param>
@@ -22537,11 +22537,11 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="depth"> Specifies the depth of the texture, in layers. </param>
             /// <param name="fixedsamplelocations"> Specifies whether the image will use identical sample locations and the same number of samples for all texels in the image, and the sample locations will not depend on the internal format or size of the image. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexStorage3DMultisample.xhtml" /></remarks>
-            public static void TexStorage3DMultisample(TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, int depth, byte fixedsamplelocations) => _TexStorage3DMultisample_fnptr(target, samples, internalformat, width, height, depth, fixedsamplelocations);
+            public static void TexStorage3DMultisample(TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, int depth, bool fixedsamplelocations) => _TexStorage3DMultisample_fnptr(target, samples, internalformat, width, height, depth, fixedsamplelocations);
             [UnmanagedCallersOnly]
-            private static void TexStorage3DMultisample_Lazy(TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, int depth, byte fixedsamplelocations)
+            private static void TexStorage3DMultisample_Lazy(TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, int depth, bool fixedsamplelocations)
             {
-                _TexStorage3DMultisample_fnptr = (delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, int, byte, void>)GLLoader.BindingsContext.GetProcAddress("glTexStorage3DMultisample");
+                _TexStorage3DMultisample_fnptr = (delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, int, bool, void>)GLLoader.BindingsContext.GetProcAddress("glTexStorage3DMultisample");
                 _TexStorage3DMultisample_fnptr(target, samples, internalformat, width, height, depth, fixedsamplelocations);
             }
             
@@ -22644,15 +22644,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _GenTransformFeedbacks_fnptr(n, ids);
             }
             
-            private static delegate* unmanaged<TransformFeedbackHandle, byte> _IsTransformFeedback_fnptr = &IsTransformFeedback_Lazy;
+            private static delegate* unmanaged<TransformFeedbackHandle, bool> _IsTransformFeedback_fnptr = &IsTransformFeedback_Lazy;
             /// <summary> <b>[requires: v4.0 | GL_ARB_transform_feedback2]</b> Determine if a name corresponds to a transform feedback object. </summary>
             /// <param name="id"> Specifies a value that may be the name of a transform feedback object. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsTransformFeedback.xhtml" /></remarks>
-            public static byte IsTransformFeedback(TransformFeedbackHandle id) => _IsTransformFeedback_fnptr(id);
+            public static bool IsTransformFeedback(TransformFeedbackHandle id) => _IsTransformFeedback_fnptr(id);
             [UnmanagedCallersOnly]
-            private static byte IsTransformFeedback_Lazy(TransformFeedbackHandle id)
+            private static bool IsTransformFeedback_Lazy(TransformFeedbackHandle id)
             {
-                _IsTransformFeedback_fnptr = (delegate* unmanaged<TransformFeedbackHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsTransformFeedback");
+                _IsTransformFeedback_fnptr = (delegate* unmanaged<TransformFeedbackHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsTransformFeedback");
                 return _IsTransformFeedback_fnptr(id);
             }
             
@@ -23007,15 +23007,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _GenVertexArrays_fnptr(n, arrays);
             }
             
-            private static delegate* unmanaged<VertexArrayHandle, byte> _IsVertexArray_fnptr = &IsVertexArray_Lazy;
+            private static delegate* unmanaged<VertexArrayHandle, bool> _IsVertexArray_fnptr = &IsVertexArray_Lazy;
             /// <summary> <b>[requires: v3.0 | GL_ARB_vertex_array_object]</b> Determine if a name corresponds to a vertex array object. </summary>
             /// <param name="array"> Specifies a value that may be the name of a vertex array object. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsVertexArray.xhtml" /></remarks>
-            public static byte IsVertexArray(VertexArrayHandle array) => _IsVertexArray_fnptr(array);
+            public static bool IsVertexArray(VertexArrayHandle array) => _IsVertexArray_fnptr(array);
             [UnmanagedCallersOnly]
-            private static byte IsVertexArray_Lazy(VertexArrayHandle array)
+            private static bool IsVertexArray_Lazy(VertexArrayHandle array)
             {
-                _IsVertexArray_fnptr = (delegate* unmanaged<VertexArrayHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsVertexArray");
+                _IsVertexArray_fnptr = (delegate* unmanaged<VertexArrayHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsVertexArray");
                 return _IsVertexArray_fnptr(array);
             }
             
@@ -23174,7 +23174,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _BindVertexBuffer_fnptr(bindingindex, buffer, offset, stride);
             }
             
-            private static delegate* unmanaged<uint, int, VertexAttribType, byte, uint, void> _VertexAttribFormat_fnptr = &VertexAttribFormat_Lazy;
+            private static delegate* unmanaged<uint, int, VertexAttribType, bool, uint, void> _VertexAttribFormat_fnptr = &VertexAttribFormat_Lazy;
             /// <summary> <b>[requires: v4.3 | GL_ARB_vertex_attrib_binding]</b> Specify the organization of vertex arrays. </summary>
             /// <param name="attribindex">The generic vertex attribute array being described.</param>
             /// <param name="size">The number of values per vertex that are stored in the array.</param>
@@ -23182,11 +23182,11 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="normalized"> Specifies whether fixed-point data values should be normalized (GL_TRUE) or converted directly as fixed-point values (GL_FALSE) when they are accessed. This parameter is ignored if type is GL_FIXED. </param>
             /// <param name="relativeoffset">The distance between elements within the buffer.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glVertexAttribFormat.xhtml" /></remarks>
-            public static void VertexAttribFormat(uint attribindex, int size, VertexAttribType type, byte normalized, uint relativeoffset) => _VertexAttribFormat_fnptr(attribindex, size, type, normalized, relativeoffset);
+            public static void VertexAttribFormat(uint attribindex, int size, VertexAttribType type, bool normalized, uint relativeoffset) => _VertexAttribFormat_fnptr(attribindex, size, type, normalized, relativeoffset);
             [UnmanagedCallersOnly]
-            private static void VertexAttribFormat_Lazy(uint attribindex, int size, VertexAttribType type, byte normalized, uint relativeoffset)
+            private static void VertexAttribFormat_Lazy(uint attribindex, int size, VertexAttribType type, bool normalized, uint relativeoffset)
             {
-                _VertexAttribFormat_fnptr = (delegate* unmanaged<uint, int, VertexAttribType, byte, uint, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribFormat");
+                _VertexAttribFormat_fnptr = (delegate* unmanaged<uint, int, VertexAttribType, bool, uint, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribFormat");
                 _VertexAttribFormat_fnptr(attribindex, size, type, normalized, relativeoffset);
             }
             
@@ -23389,14 +23389,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _GenBuffersARB_fnptr(n, buffers);
             }
             
-            private static delegate* unmanaged<BufferHandle, byte> _IsBufferARB_fnptr = &IsBufferARB_Lazy;
+            private static delegate* unmanaged<BufferHandle, bool> _IsBufferARB_fnptr = &IsBufferARB_Lazy;
             /// <summary> <b>[requires: GL_ARB_vertex_buffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsBufferARB(BufferHandle buffer) => _IsBufferARB_fnptr(buffer);
+            public static bool IsBufferARB(BufferHandle buffer) => _IsBufferARB_fnptr(buffer);
             [UnmanagedCallersOnly]
-            private static byte IsBufferARB_Lazy(BufferHandle buffer)
+            private static bool IsBufferARB_Lazy(BufferHandle buffer)
             {
-                _IsBufferARB_fnptr = (delegate* unmanaged<BufferHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsBufferARB");
+                _IsBufferARB_fnptr = (delegate* unmanaged<BufferHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsBufferARB");
                 return _IsBufferARB_fnptr(buffer);
             }
             
@@ -23444,14 +23444,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return _MapBufferARB_fnptr(target, access);
             }
             
-            private static delegate* unmanaged<BufferTargetARB, byte> _UnmapBufferARB_fnptr = &UnmapBufferARB_Lazy;
+            private static delegate* unmanaged<BufferTargetARB, bool> _UnmapBufferARB_fnptr = &UnmapBufferARB_Lazy;
             /// <summary> <b>[requires: GL_ARB_vertex_buffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte UnmapBufferARB(BufferTargetARB target) => _UnmapBufferARB_fnptr(target);
+            public static bool UnmapBufferARB(BufferTargetARB target) => _UnmapBufferARB_fnptr(target);
             [UnmanagedCallersOnly]
-            private static byte UnmapBufferARB_Lazy(BufferTargetARB target)
+            private static bool UnmapBufferARB_Lazy(BufferTargetARB target)
             {
-                _UnmapBufferARB_fnptr = (delegate* unmanaged<BufferTargetARB, byte>)GLLoader.BindingsContext.GetProcAddress("glUnmapBufferARB");
+                _UnmapBufferARB_fnptr = (delegate* unmanaged<BufferTargetARB, bool>)GLLoader.BindingsContext.GetProcAddress("glUnmapBufferARB");
                 return _UnmapBufferARB_fnptr(target);
             }
             
@@ -23873,14 +23873,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _VertexAttrib4usvARB_fnptr(index, v);
             }
             
-            private static delegate* unmanaged<uint, int, VertexAttribPointerType, byte, int, void*, void> _VertexAttribPointerARB_fnptr = &VertexAttribPointerARB_Lazy;
+            private static delegate* unmanaged<uint, int, VertexAttribPointerType, bool, int, void*, void> _VertexAttribPointerARB_fnptr = &VertexAttribPointerARB_Lazy;
             /// <summary> <b>[requires: GL_ARB_vertex_program | GL_ARB_vertex_shader]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void VertexAttribPointerARB(uint index, int size, VertexAttribPointerType type, byte normalized, int stride, void* pointer) => _VertexAttribPointerARB_fnptr(index, size, type, normalized, stride, pointer);
+            public static void VertexAttribPointerARB(uint index, int size, VertexAttribPointerType type, bool normalized, int stride, void* pointer) => _VertexAttribPointerARB_fnptr(index, size, type, normalized, stride, pointer);
             [UnmanagedCallersOnly]
-            private static void VertexAttribPointerARB_Lazy(uint index, int size, VertexAttribPointerType type, byte normalized, int stride, void* pointer)
+            private static void VertexAttribPointerARB_Lazy(uint index, int size, VertexAttribPointerType type, bool normalized, int stride, void* pointer)
             {
-                _VertexAttribPointerARB_fnptr = (delegate* unmanaged<uint, int, VertexAttribPointerType, byte, int, void*, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribPointerARB");
+                _VertexAttribPointerARB_fnptr = (delegate* unmanaged<uint, int, VertexAttribPointerType, bool, int, void*, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribPointerARB");
                 _VertexAttribPointerARB_fnptr(index, size, type, normalized, stride, pointer);
             }
             
@@ -23983,107 +23983,107 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return _GetAttribLocationARB_fnptr(programObj, name);
             }
             
-            private static delegate* unmanaged<uint, VertexAttribPointerType, byte, uint, void> _VertexAttribP1ui_fnptr = &VertexAttribP1ui_Lazy;
+            private static delegate* unmanaged<uint, VertexAttribPointerType, bool, uint, void> _VertexAttribP1ui_fnptr = &VertexAttribP1ui_Lazy;
             /// <summary> <b>[requires: v3.3 | GL_ARB_vertex_type_2_10_10_10_rev]</b> Specifies the value of a generic vertex attribute. </summary>
             /// <param name="index">Specifies the index of the generic vertex attribute to be modified.</param>
             /// <param name="type"> For the packed commands (glVertexAttribP*), specified the type of packing used on the data. This parameter must be GL_INT_2_10_10_10_REV or GL_UNSIGNED_INT_2_10_10_10_REV, to specify signed or unsigned data, respectively, or GL_UNSIGNED_INT_10F_11F_11F_REV to specify floating point data. </param>
             /// <param name="normalized"> For the packed commands, if GL_TRUE, then the values are to be converted to floating point values by normalizing. Otherwise, they are converted directly to floating-point values. If type indicates a floating-pont format, then normalized value must be GL_FALSE. </param>
             /// <param name="value"> For the packed commands, specifies the new packed value to be used for the specified vertex attribute. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glVertexAttrib.xhtml" /></remarks>
-            public static void VertexAttribP1ui(uint index, VertexAttribPointerType type, byte normalized, uint value) => _VertexAttribP1ui_fnptr(index, type, normalized, value);
+            public static void VertexAttribP1ui(uint index, VertexAttribPointerType type, bool normalized, uint value) => _VertexAttribP1ui_fnptr(index, type, normalized, value);
             [UnmanagedCallersOnly]
-            private static void VertexAttribP1ui_Lazy(uint index, VertexAttribPointerType type, byte normalized, uint value)
+            private static void VertexAttribP1ui_Lazy(uint index, VertexAttribPointerType type, bool normalized, uint value)
             {
-                _VertexAttribP1ui_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, byte, uint, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP1ui");
+                _VertexAttribP1ui_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, bool, uint, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP1ui");
                 _VertexAttribP1ui_fnptr(index, type, normalized, value);
             }
             
-            private static delegate* unmanaged<uint, VertexAttribPointerType, byte, uint*, void> _VertexAttribP1uiv_fnptr = &VertexAttribP1uiv_Lazy;
+            private static delegate* unmanaged<uint, VertexAttribPointerType, bool, uint*, void> _VertexAttribP1uiv_fnptr = &VertexAttribP1uiv_Lazy;
             /// <summary> <b>[requires: v3.3 | GL_ARB_vertex_type_2_10_10_10_rev]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void VertexAttribP1uiv(uint index, VertexAttribPointerType type, byte normalized, uint* value) => _VertexAttribP1uiv_fnptr(index, type, normalized, value);
+            public static void VertexAttribP1uiv(uint index, VertexAttribPointerType type, bool normalized, uint* value) => _VertexAttribP1uiv_fnptr(index, type, normalized, value);
             [UnmanagedCallersOnly]
-            private static void VertexAttribP1uiv_Lazy(uint index, VertexAttribPointerType type, byte normalized, uint* value)
+            private static void VertexAttribP1uiv_Lazy(uint index, VertexAttribPointerType type, bool normalized, uint* value)
             {
-                _VertexAttribP1uiv_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, byte, uint*, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP1uiv");
+                _VertexAttribP1uiv_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, bool, uint*, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP1uiv");
                 _VertexAttribP1uiv_fnptr(index, type, normalized, value);
             }
             
-            private static delegate* unmanaged<uint, VertexAttribPointerType, byte, uint, void> _VertexAttribP2ui_fnptr = &VertexAttribP2ui_Lazy;
+            private static delegate* unmanaged<uint, VertexAttribPointerType, bool, uint, void> _VertexAttribP2ui_fnptr = &VertexAttribP2ui_Lazy;
             /// <summary> <b>[requires: v3.3 | GL_ARB_vertex_type_2_10_10_10_rev]</b> Specifies the value of a generic vertex attribute. </summary>
             /// <param name="index">Specifies the index of the generic vertex attribute to be modified.</param>
             /// <param name="type"> For the packed commands (glVertexAttribP*), specified the type of packing used on the data. This parameter must be GL_INT_2_10_10_10_REV or GL_UNSIGNED_INT_2_10_10_10_REV, to specify signed or unsigned data, respectively, or GL_UNSIGNED_INT_10F_11F_11F_REV to specify floating point data. </param>
             /// <param name="normalized"> For the packed commands, if GL_TRUE, then the values are to be converted to floating point values by normalizing. Otherwise, they are converted directly to floating-point values. If type indicates a floating-pont format, then normalized value must be GL_FALSE. </param>
             /// <param name="value"> For the packed commands, specifies the new packed value to be used for the specified vertex attribute. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glVertexAttrib.xhtml" /></remarks>
-            public static void VertexAttribP2ui(uint index, VertexAttribPointerType type, byte normalized, uint value) => _VertexAttribP2ui_fnptr(index, type, normalized, value);
+            public static void VertexAttribP2ui(uint index, VertexAttribPointerType type, bool normalized, uint value) => _VertexAttribP2ui_fnptr(index, type, normalized, value);
             [UnmanagedCallersOnly]
-            private static void VertexAttribP2ui_Lazy(uint index, VertexAttribPointerType type, byte normalized, uint value)
+            private static void VertexAttribP2ui_Lazy(uint index, VertexAttribPointerType type, bool normalized, uint value)
             {
-                _VertexAttribP2ui_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, byte, uint, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP2ui");
+                _VertexAttribP2ui_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, bool, uint, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP2ui");
                 _VertexAttribP2ui_fnptr(index, type, normalized, value);
             }
             
-            private static delegate* unmanaged<uint, VertexAttribPointerType, byte, uint*, void> _VertexAttribP2uiv_fnptr = &VertexAttribP2uiv_Lazy;
+            private static delegate* unmanaged<uint, VertexAttribPointerType, bool, uint*, void> _VertexAttribP2uiv_fnptr = &VertexAttribP2uiv_Lazy;
             /// <summary> <b>[requires: v3.3 | GL_ARB_vertex_type_2_10_10_10_rev]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void VertexAttribP2uiv(uint index, VertexAttribPointerType type, byte normalized, uint* value) => _VertexAttribP2uiv_fnptr(index, type, normalized, value);
+            public static void VertexAttribP2uiv(uint index, VertexAttribPointerType type, bool normalized, uint* value) => _VertexAttribP2uiv_fnptr(index, type, normalized, value);
             [UnmanagedCallersOnly]
-            private static void VertexAttribP2uiv_Lazy(uint index, VertexAttribPointerType type, byte normalized, uint* value)
+            private static void VertexAttribP2uiv_Lazy(uint index, VertexAttribPointerType type, bool normalized, uint* value)
             {
-                _VertexAttribP2uiv_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, byte, uint*, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP2uiv");
+                _VertexAttribP2uiv_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, bool, uint*, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP2uiv");
                 _VertexAttribP2uiv_fnptr(index, type, normalized, value);
             }
             
-            private static delegate* unmanaged<uint, VertexAttribPointerType, byte, uint, void> _VertexAttribP3ui_fnptr = &VertexAttribP3ui_Lazy;
+            private static delegate* unmanaged<uint, VertexAttribPointerType, bool, uint, void> _VertexAttribP3ui_fnptr = &VertexAttribP3ui_Lazy;
             /// <summary> <b>[requires: v3.3 | GL_ARB_vertex_type_2_10_10_10_rev]</b> Specifies the value of a generic vertex attribute. </summary>
             /// <param name="index">Specifies the index of the generic vertex attribute to be modified.</param>
             /// <param name="type"> For the packed commands (glVertexAttribP*), specified the type of packing used on the data. This parameter must be GL_INT_2_10_10_10_REV or GL_UNSIGNED_INT_2_10_10_10_REV, to specify signed or unsigned data, respectively, or GL_UNSIGNED_INT_10F_11F_11F_REV to specify floating point data. </param>
             /// <param name="normalized"> For the packed commands, if GL_TRUE, then the values are to be converted to floating point values by normalizing. Otherwise, they are converted directly to floating-point values. If type indicates a floating-pont format, then normalized value must be GL_FALSE. </param>
             /// <param name="value"> For the packed commands, specifies the new packed value to be used for the specified vertex attribute. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glVertexAttrib.xhtml" /></remarks>
-            public static void VertexAttribP3ui(uint index, VertexAttribPointerType type, byte normalized, uint value) => _VertexAttribP3ui_fnptr(index, type, normalized, value);
+            public static void VertexAttribP3ui(uint index, VertexAttribPointerType type, bool normalized, uint value) => _VertexAttribP3ui_fnptr(index, type, normalized, value);
             [UnmanagedCallersOnly]
-            private static void VertexAttribP3ui_Lazy(uint index, VertexAttribPointerType type, byte normalized, uint value)
+            private static void VertexAttribP3ui_Lazy(uint index, VertexAttribPointerType type, bool normalized, uint value)
             {
-                _VertexAttribP3ui_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, byte, uint, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP3ui");
+                _VertexAttribP3ui_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, bool, uint, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP3ui");
                 _VertexAttribP3ui_fnptr(index, type, normalized, value);
             }
             
-            private static delegate* unmanaged<uint, VertexAttribPointerType, byte, uint*, void> _VertexAttribP3uiv_fnptr = &VertexAttribP3uiv_Lazy;
+            private static delegate* unmanaged<uint, VertexAttribPointerType, bool, uint*, void> _VertexAttribP3uiv_fnptr = &VertexAttribP3uiv_Lazy;
             /// <summary> <b>[requires: v3.3 | GL_ARB_vertex_type_2_10_10_10_rev]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void VertexAttribP3uiv(uint index, VertexAttribPointerType type, byte normalized, uint* value) => _VertexAttribP3uiv_fnptr(index, type, normalized, value);
+            public static void VertexAttribP3uiv(uint index, VertexAttribPointerType type, bool normalized, uint* value) => _VertexAttribP3uiv_fnptr(index, type, normalized, value);
             [UnmanagedCallersOnly]
-            private static void VertexAttribP3uiv_Lazy(uint index, VertexAttribPointerType type, byte normalized, uint* value)
+            private static void VertexAttribP3uiv_Lazy(uint index, VertexAttribPointerType type, bool normalized, uint* value)
             {
-                _VertexAttribP3uiv_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, byte, uint*, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP3uiv");
+                _VertexAttribP3uiv_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, bool, uint*, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP3uiv");
                 _VertexAttribP3uiv_fnptr(index, type, normalized, value);
             }
             
-            private static delegate* unmanaged<uint, VertexAttribPointerType, byte, uint, void> _VertexAttribP4ui_fnptr = &VertexAttribP4ui_Lazy;
+            private static delegate* unmanaged<uint, VertexAttribPointerType, bool, uint, void> _VertexAttribP4ui_fnptr = &VertexAttribP4ui_Lazy;
             /// <summary> <b>[requires: v3.3 | GL_ARB_vertex_type_2_10_10_10_rev]</b> Specifies the value of a generic vertex attribute. </summary>
             /// <param name="index">Specifies the index of the generic vertex attribute to be modified.</param>
             /// <param name="type"> For the packed commands (glVertexAttribP*), specified the type of packing used on the data. This parameter must be GL_INT_2_10_10_10_REV or GL_UNSIGNED_INT_2_10_10_10_REV, to specify signed or unsigned data, respectively, or GL_UNSIGNED_INT_10F_11F_11F_REV to specify floating point data. </param>
             /// <param name="normalized"> For the packed commands, if GL_TRUE, then the values are to be converted to floating point values by normalizing. Otherwise, they are converted directly to floating-point values. If type indicates a floating-pont format, then normalized value must be GL_FALSE. </param>
             /// <param name="value"> For the packed commands, specifies the new packed value to be used for the specified vertex attribute. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glVertexAttrib.xhtml" /></remarks>
-            public static void VertexAttribP4ui(uint index, VertexAttribPointerType type, byte normalized, uint value) => _VertexAttribP4ui_fnptr(index, type, normalized, value);
+            public static void VertexAttribP4ui(uint index, VertexAttribPointerType type, bool normalized, uint value) => _VertexAttribP4ui_fnptr(index, type, normalized, value);
             [UnmanagedCallersOnly]
-            private static void VertexAttribP4ui_Lazy(uint index, VertexAttribPointerType type, byte normalized, uint value)
+            private static void VertexAttribP4ui_Lazy(uint index, VertexAttribPointerType type, bool normalized, uint value)
             {
-                _VertexAttribP4ui_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, byte, uint, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP4ui");
+                _VertexAttribP4ui_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, bool, uint, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP4ui");
                 _VertexAttribP4ui_fnptr(index, type, normalized, value);
             }
             
-            private static delegate* unmanaged<uint, VertexAttribPointerType, byte, uint*, void> _VertexAttribP4uiv_fnptr = &VertexAttribP4uiv_Lazy;
+            private static delegate* unmanaged<uint, VertexAttribPointerType, bool, uint*, void> _VertexAttribP4uiv_fnptr = &VertexAttribP4uiv_Lazy;
             /// <summary> <b>[requires: v3.3 | GL_ARB_vertex_type_2_10_10_10_rev]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void VertexAttribP4uiv(uint index, VertexAttribPointerType type, byte normalized, uint* value) => _VertexAttribP4uiv_fnptr(index, type, normalized, value);
+            public static void VertexAttribP4uiv(uint index, VertexAttribPointerType type, bool normalized, uint* value) => _VertexAttribP4uiv_fnptr(index, type, normalized, value);
             [UnmanagedCallersOnly]
-            private static void VertexAttribP4uiv_Lazy(uint index, VertexAttribPointerType type, byte normalized, uint* value)
+            private static void VertexAttribP4uiv_Lazy(uint index, VertexAttribPointerType type, bool normalized, uint* value)
             {
-                _VertexAttribP4uiv_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, byte, uint*, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP4uiv");
+                _VertexAttribP4uiv_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, bool, uint*, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP4uiv");
                 _VertexAttribP4uiv_fnptr(index, type, normalized, value);
             }
             
@@ -25079,14 +25079,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return _NewObjectBufferATI_fnptr(size, pointer, usage);
             }
             
-            private static delegate* unmanaged<BufferHandle, byte> _IsObjectBufferATI_fnptr = &IsObjectBufferATI_Lazy;
+            private static delegate* unmanaged<BufferHandle, bool> _IsObjectBufferATI_fnptr = &IsObjectBufferATI_Lazy;
             /// <summary> <b>[requires: GL_ATI_vertex_array_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsObjectBufferATI(BufferHandle buffer) => _IsObjectBufferATI_fnptr(buffer);
+            public static bool IsObjectBufferATI(BufferHandle buffer) => _IsObjectBufferATI_fnptr(buffer);
             [UnmanagedCallersOnly]
-            private static byte IsObjectBufferATI_Lazy(BufferHandle buffer)
+            private static bool IsObjectBufferATI_Lazy(BufferHandle buffer)
             {
-                _IsObjectBufferATI_fnptr = (delegate* unmanaged<BufferHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsObjectBufferATI");
+                _IsObjectBufferATI_fnptr = (delegate* unmanaged<BufferHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsObjectBufferATI");
                 return _IsObjectBufferATI_fnptr(buffer);
             }
             
@@ -25200,14 +25200,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _GetVariantArrayObjectivATI_fnptr(id, pname, parameters);
             }
             
-            private static delegate* unmanaged<uint, int, VertexAttribPointerType, byte, int, BufferHandle, uint, void> _VertexAttribArrayObjectATI_fnptr = &VertexAttribArrayObjectATI_Lazy;
+            private static delegate* unmanaged<uint, int, VertexAttribPointerType, bool, int, BufferHandle, uint, void> _VertexAttribArrayObjectATI_fnptr = &VertexAttribArrayObjectATI_Lazy;
             /// <summary> <b>[requires: GL_ATI_vertex_attrib_array_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void VertexAttribArrayObjectATI(uint index, int size, VertexAttribPointerType type, byte normalized, int stride, BufferHandle buffer, uint offset) => _VertexAttribArrayObjectATI_fnptr(index, size, type, normalized, stride, buffer, offset);
+            public static void VertexAttribArrayObjectATI(uint index, int size, VertexAttribPointerType type, bool normalized, int stride, BufferHandle buffer, uint offset) => _VertexAttribArrayObjectATI_fnptr(index, size, type, normalized, stride, buffer, offset);
             [UnmanagedCallersOnly]
-            private static void VertexAttribArrayObjectATI_Lazy(uint index, int size, VertexAttribPointerType type, byte normalized, int stride, BufferHandle buffer, uint offset)
+            private static void VertexAttribArrayObjectATI_Lazy(uint index, int size, VertexAttribPointerType type, bool normalized, int stride, BufferHandle buffer, uint offset)
             {
-                _VertexAttribArrayObjectATI_fnptr = (delegate* unmanaged<uint, int, VertexAttribPointerType, byte, int, BufferHandle, uint, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribArrayObjectATI");
+                _VertexAttribArrayObjectATI_fnptr = (delegate* unmanaged<uint, int, VertexAttribPointerType, bool, int, BufferHandle, uint, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribArrayObjectATI");
                 _VertexAttribArrayObjectATI_fnptr(index, size, type, normalized, stride, buffer, offset);
             }
             
@@ -27293,14 +27293,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _DisableIndexedEXT_fnptr(target, index);
             }
             
-            private static delegate* unmanaged<EnableCap, uint, byte> _IsEnabledIndexedEXT_fnptr = &IsEnabledIndexedEXT_Lazy;
+            private static delegate* unmanaged<EnableCap, uint, bool> _IsEnabledIndexedEXT_fnptr = &IsEnabledIndexedEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_draw_buffers2]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsEnabledIndexedEXT(EnableCap target, uint index) => _IsEnabledIndexedEXT_fnptr(target, index);
+            public static bool IsEnabledIndexedEXT(EnableCap target, uint index) => _IsEnabledIndexedEXT_fnptr(target, index);
             [UnmanagedCallersOnly]
-            private static byte IsEnabledIndexedEXT_Lazy(EnableCap target, uint index)
+            private static bool IsEnabledIndexedEXT_Lazy(EnableCap target, uint index)
             {
-                _IsEnabledIndexedEXT_fnptr = (delegate* unmanaged<EnableCap, uint, byte>)GLLoader.BindingsContext.GetProcAddress("glIsEnabledIndexedEXT");
+                _IsEnabledIndexedEXT_fnptr = (delegate* unmanaged<EnableCap, uint, bool>)GLLoader.BindingsContext.GetProcAddress("glIsEnabledIndexedEXT");
                 return _IsEnabledIndexedEXT_fnptr(target, index);
             }
             
@@ -27315,14 +27315,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _GetIntegerIndexedvEXT_fnptr(target, index, data);
             }
             
-            private static delegate* unmanaged<BufferTargetARB, uint, byte*, void> _GetBooleanIndexedvEXT_fnptr = &GetBooleanIndexedvEXT_Lazy;
+            private static delegate* unmanaged<BufferTargetARB, uint, bool*, void> _GetBooleanIndexedvEXT_fnptr = &GetBooleanIndexedvEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_draw_buffers2]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetBooleanIndexedvEXT(BufferTargetARB target, uint index, byte* data) => _GetBooleanIndexedvEXT_fnptr(target, index, data);
+            public static void GetBooleanIndexedvEXT(BufferTargetARB target, uint index, bool* data) => _GetBooleanIndexedvEXT_fnptr(target, index, data);
             [UnmanagedCallersOnly]
-            private static void GetBooleanIndexedvEXT_Lazy(BufferTargetARB target, uint index, byte* data)
+            private static void GetBooleanIndexedvEXT_Lazy(BufferTargetARB target, uint index, bool* data)
             {
-                _GetBooleanIndexedvEXT_fnptr = (delegate* unmanaged<BufferTargetARB, uint, byte*, void>)GLLoader.BindingsContext.GetProcAddress("glGetBooleanIndexedvEXT");
+                _GetBooleanIndexedvEXT_fnptr = (delegate* unmanaged<BufferTargetARB, uint, bool*, void>)GLLoader.BindingsContext.GetProcAddress("glGetBooleanIndexedvEXT");
                 _GetBooleanIndexedvEXT_fnptr(target, index, data);
             }
             
@@ -27557,14 +27557,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return _MapNamedBufferEXT_fnptr(buffer, access);
             }
             
-            private static delegate* unmanaged<BufferHandle, byte> _UnmapNamedBufferEXT_fnptr = &UnmapNamedBufferEXT_Lazy;
+            private static delegate* unmanaged<BufferHandle, bool> _UnmapNamedBufferEXT_fnptr = &UnmapNamedBufferEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte UnmapNamedBufferEXT(BufferHandle buffer) => _UnmapNamedBufferEXT_fnptr(buffer);
+            public static bool UnmapNamedBufferEXT(BufferHandle buffer) => _UnmapNamedBufferEXT_fnptr(buffer);
             [UnmanagedCallersOnly]
-            private static byte UnmapNamedBufferEXT_Lazy(BufferHandle buffer)
+            private static bool UnmapNamedBufferEXT_Lazy(BufferHandle buffer)
             {
-                _UnmapNamedBufferEXT_fnptr = (delegate* unmanaged<BufferHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glUnmapNamedBufferEXT");
+                _UnmapNamedBufferEXT_fnptr = (delegate* unmanaged<BufferHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glUnmapNamedBufferEXT");
                 return _UnmapNamedBufferEXT_fnptr(buffer);
             }
             
@@ -27777,102 +27777,102 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _ProgramUniform4ivEXT_fnptr(program, location, count, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix2fvEXT_fnptr = &ProgramUniformMatrix2fvEXT_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix2fvEXT_fnptr = &ProgramUniformMatrix2fvEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix2fvEXT(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix2fvEXT_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix2fvEXT(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix2fvEXT_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix2fvEXT_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+            private static void ProgramUniformMatrix2fvEXT_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
             {
-                _ProgramUniformMatrix2fvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2fvEXT");
+                _ProgramUniformMatrix2fvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2fvEXT");
                 _ProgramUniformMatrix2fvEXT_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix3fvEXT_fnptr = &ProgramUniformMatrix3fvEXT_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix3fvEXT_fnptr = &ProgramUniformMatrix3fvEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix3fvEXT(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix3fvEXT_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix3fvEXT(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix3fvEXT_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix3fvEXT_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+            private static void ProgramUniformMatrix3fvEXT_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
             {
-                _ProgramUniformMatrix3fvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3fvEXT");
+                _ProgramUniformMatrix3fvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3fvEXT");
                 _ProgramUniformMatrix3fvEXT_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix4fvEXT_fnptr = &ProgramUniformMatrix4fvEXT_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix4fvEXT_fnptr = &ProgramUniformMatrix4fvEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix4fvEXT(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix4fvEXT_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix4fvEXT(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix4fvEXT_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix4fvEXT_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+            private static void ProgramUniformMatrix4fvEXT_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
             {
-                _ProgramUniformMatrix4fvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4fvEXT");
+                _ProgramUniformMatrix4fvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4fvEXT");
                 _ProgramUniformMatrix4fvEXT_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix2x3fvEXT_fnptr = &ProgramUniformMatrix2x3fvEXT_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix2x3fvEXT_fnptr = &ProgramUniformMatrix2x3fvEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix2x3fvEXT(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix2x3fvEXT_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix2x3fvEXT(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix2x3fvEXT_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix2x3fvEXT_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+            private static void ProgramUniformMatrix2x3fvEXT_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
             {
-                _ProgramUniformMatrix2x3fvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2x3fvEXT");
+                _ProgramUniformMatrix2x3fvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2x3fvEXT");
                 _ProgramUniformMatrix2x3fvEXT_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix3x2fvEXT_fnptr = &ProgramUniformMatrix3x2fvEXT_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix3x2fvEXT_fnptr = &ProgramUniformMatrix3x2fvEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix3x2fvEXT(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix3x2fvEXT_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix3x2fvEXT(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix3x2fvEXT_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix3x2fvEXT_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+            private static void ProgramUniformMatrix3x2fvEXT_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
             {
-                _ProgramUniformMatrix3x2fvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3x2fvEXT");
+                _ProgramUniformMatrix3x2fvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3x2fvEXT");
                 _ProgramUniformMatrix3x2fvEXT_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix2x4fvEXT_fnptr = &ProgramUniformMatrix2x4fvEXT_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix2x4fvEXT_fnptr = &ProgramUniformMatrix2x4fvEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix2x4fvEXT(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix2x4fvEXT_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix2x4fvEXT(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix2x4fvEXT_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix2x4fvEXT_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+            private static void ProgramUniformMatrix2x4fvEXT_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
             {
-                _ProgramUniformMatrix2x4fvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2x4fvEXT");
+                _ProgramUniformMatrix2x4fvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2x4fvEXT");
                 _ProgramUniformMatrix2x4fvEXT_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix4x2fvEXT_fnptr = &ProgramUniformMatrix4x2fvEXT_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix4x2fvEXT_fnptr = &ProgramUniformMatrix4x2fvEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix4x2fvEXT(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix4x2fvEXT_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix4x2fvEXT(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix4x2fvEXT_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix4x2fvEXT_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+            private static void ProgramUniformMatrix4x2fvEXT_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
             {
-                _ProgramUniformMatrix4x2fvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4x2fvEXT");
+                _ProgramUniformMatrix4x2fvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4x2fvEXT");
                 _ProgramUniformMatrix4x2fvEXT_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix3x4fvEXT_fnptr = &ProgramUniformMatrix3x4fvEXT_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix3x4fvEXT_fnptr = &ProgramUniformMatrix3x4fvEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix3x4fvEXT(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix3x4fvEXT_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix3x4fvEXT(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix3x4fvEXT_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix3x4fvEXT_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+            private static void ProgramUniformMatrix3x4fvEXT_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
             {
-                _ProgramUniformMatrix3x4fvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3x4fvEXT");
+                _ProgramUniformMatrix3x4fvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3x4fvEXT");
                 _ProgramUniformMatrix3x4fvEXT_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix4x3fvEXT_fnptr = &ProgramUniformMatrix4x3fvEXT_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix4x3fvEXT_fnptr = &ProgramUniformMatrix4x3fvEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix4x3fvEXT(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix4x3fvEXT_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix4x3fvEXT(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix4x3fvEXT_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix4x3fvEXT_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+            private static void ProgramUniformMatrix4x3fvEXT_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
             {
-                _ProgramUniformMatrix4x3fvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4x3fvEXT");
+                _ProgramUniformMatrix4x3fvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4x3fvEXT");
                 _ProgramUniformMatrix4x3fvEXT_fnptr(program, location, count, transpose, value);
             }
             
@@ -28668,14 +28668,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _VertexArraySecondaryColorOffsetEXT_fnptr(vaobj, buffer, size, type, stride, offset);
             }
             
-            private static delegate* unmanaged<VertexArrayHandle, BufferHandle, uint, int, VertexAttribPointerType, byte, int, IntPtr, void> _VertexArrayVertexAttribOffsetEXT_fnptr = &VertexArrayVertexAttribOffsetEXT_Lazy;
+            private static delegate* unmanaged<VertexArrayHandle, BufferHandle, uint, int, VertexAttribPointerType, bool, int, IntPtr, void> _VertexArrayVertexAttribOffsetEXT_fnptr = &VertexArrayVertexAttribOffsetEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void VertexArrayVertexAttribOffsetEXT(VertexArrayHandle vaobj, BufferHandle buffer, uint index, int size, VertexAttribPointerType type, byte normalized, int stride, IntPtr offset) => _VertexArrayVertexAttribOffsetEXT_fnptr(vaobj, buffer, index, size, type, normalized, stride, offset);
+            public static void VertexArrayVertexAttribOffsetEXT(VertexArrayHandle vaobj, BufferHandle buffer, uint index, int size, VertexAttribPointerType type, bool normalized, int stride, IntPtr offset) => _VertexArrayVertexAttribOffsetEXT_fnptr(vaobj, buffer, index, size, type, normalized, stride, offset);
             [UnmanagedCallersOnly]
-            private static void VertexArrayVertexAttribOffsetEXT_Lazy(VertexArrayHandle vaobj, BufferHandle buffer, uint index, int size, VertexAttribPointerType type, byte normalized, int stride, IntPtr offset)
+            private static void VertexArrayVertexAttribOffsetEXT_Lazy(VertexArrayHandle vaobj, BufferHandle buffer, uint index, int size, VertexAttribPointerType type, bool normalized, int stride, IntPtr offset)
             {
-                _VertexArrayVertexAttribOffsetEXT_fnptr = (delegate* unmanaged<VertexArrayHandle, BufferHandle, uint, int, VertexAttribPointerType, byte, int, IntPtr, void>)GLLoader.BindingsContext.GetProcAddress("glVertexArrayVertexAttribOffsetEXT");
+                _VertexArrayVertexAttribOffsetEXT_fnptr = (delegate* unmanaged<VertexArrayHandle, BufferHandle, uint, int, VertexAttribPointerType, bool, int, IntPtr, void>)GLLoader.BindingsContext.GetProcAddress("glVertexArrayVertexAttribOffsetEXT");
                 _VertexArrayVertexAttribOffsetEXT_fnptr(vaobj, buffer, index, size, type, normalized, stride, offset);
             }
             
@@ -28943,102 +28943,102 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _ProgramUniform4dvEXT_fnptr(program, location, count, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, double*, void> _ProgramUniformMatrix2dvEXT_fnptr = &ProgramUniformMatrix2dvEXT_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, double*, void> _ProgramUniformMatrix2dvEXT_fnptr = &ProgramUniformMatrix2dvEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix2dvEXT(ProgramHandle program, int location, int count, byte transpose, double* value) => _ProgramUniformMatrix2dvEXT_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix2dvEXT(ProgramHandle program, int location, int count, bool transpose, double* value) => _ProgramUniformMatrix2dvEXT_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix2dvEXT_Lazy(ProgramHandle program, int location, int count, byte transpose, double* value)
+            private static void ProgramUniformMatrix2dvEXT_Lazy(ProgramHandle program, int location, int count, bool transpose, double* value)
             {
-                _ProgramUniformMatrix2dvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2dvEXT");
+                _ProgramUniformMatrix2dvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2dvEXT");
                 _ProgramUniformMatrix2dvEXT_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, double*, void> _ProgramUniformMatrix3dvEXT_fnptr = &ProgramUniformMatrix3dvEXT_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, double*, void> _ProgramUniformMatrix3dvEXT_fnptr = &ProgramUniformMatrix3dvEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix3dvEXT(ProgramHandle program, int location, int count, byte transpose, double* value) => _ProgramUniformMatrix3dvEXT_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix3dvEXT(ProgramHandle program, int location, int count, bool transpose, double* value) => _ProgramUniformMatrix3dvEXT_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix3dvEXT_Lazy(ProgramHandle program, int location, int count, byte transpose, double* value)
+            private static void ProgramUniformMatrix3dvEXT_Lazy(ProgramHandle program, int location, int count, bool transpose, double* value)
             {
-                _ProgramUniformMatrix3dvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3dvEXT");
+                _ProgramUniformMatrix3dvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3dvEXT");
                 _ProgramUniformMatrix3dvEXT_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, double*, void> _ProgramUniformMatrix4dvEXT_fnptr = &ProgramUniformMatrix4dvEXT_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, double*, void> _ProgramUniformMatrix4dvEXT_fnptr = &ProgramUniformMatrix4dvEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix4dvEXT(ProgramHandle program, int location, int count, byte transpose, double* value) => _ProgramUniformMatrix4dvEXT_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix4dvEXT(ProgramHandle program, int location, int count, bool transpose, double* value) => _ProgramUniformMatrix4dvEXT_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix4dvEXT_Lazy(ProgramHandle program, int location, int count, byte transpose, double* value)
+            private static void ProgramUniformMatrix4dvEXT_Lazy(ProgramHandle program, int location, int count, bool transpose, double* value)
             {
-                _ProgramUniformMatrix4dvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4dvEXT");
+                _ProgramUniformMatrix4dvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4dvEXT");
                 _ProgramUniformMatrix4dvEXT_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, double*, void> _ProgramUniformMatrix2x3dvEXT_fnptr = &ProgramUniformMatrix2x3dvEXT_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, double*, void> _ProgramUniformMatrix2x3dvEXT_fnptr = &ProgramUniformMatrix2x3dvEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix2x3dvEXT(ProgramHandle program, int location, int count, byte transpose, double* value) => _ProgramUniformMatrix2x3dvEXT_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix2x3dvEXT(ProgramHandle program, int location, int count, bool transpose, double* value) => _ProgramUniformMatrix2x3dvEXT_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix2x3dvEXT_Lazy(ProgramHandle program, int location, int count, byte transpose, double* value)
+            private static void ProgramUniformMatrix2x3dvEXT_Lazy(ProgramHandle program, int location, int count, bool transpose, double* value)
             {
-                _ProgramUniformMatrix2x3dvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2x3dvEXT");
+                _ProgramUniformMatrix2x3dvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2x3dvEXT");
                 _ProgramUniformMatrix2x3dvEXT_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, double*, void> _ProgramUniformMatrix2x4dvEXT_fnptr = &ProgramUniformMatrix2x4dvEXT_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, double*, void> _ProgramUniformMatrix2x4dvEXT_fnptr = &ProgramUniformMatrix2x4dvEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix2x4dvEXT(ProgramHandle program, int location, int count, byte transpose, double* value) => _ProgramUniformMatrix2x4dvEXT_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix2x4dvEXT(ProgramHandle program, int location, int count, bool transpose, double* value) => _ProgramUniformMatrix2x4dvEXT_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix2x4dvEXT_Lazy(ProgramHandle program, int location, int count, byte transpose, double* value)
+            private static void ProgramUniformMatrix2x4dvEXT_Lazy(ProgramHandle program, int location, int count, bool transpose, double* value)
             {
-                _ProgramUniformMatrix2x4dvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2x4dvEXT");
+                _ProgramUniformMatrix2x4dvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2x4dvEXT");
                 _ProgramUniformMatrix2x4dvEXT_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, double*, void> _ProgramUniformMatrix3x2dvEXT_fnptr = &ProgramUniformMatrix3x2dvEXT_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, double*, void> _ProgramUniformMatrix3x2dvEXT_fnptr = &ProgramUniformMatrix3x2dvEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix3x2dvEXT(ProgramHandle program, int location, int count, byte transpose, double* value) => _ProgramUniformMatrix3x2dvEXT_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix3x2dvEXT(ProgramHandle program, int location, int count, bool transpose, double* value) => _ProgramUniformMatrix3x2dvEXT_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix3x2dvEXT_Lazy(ProgramHandle program, int location, int count, byte transpose, double* value)
+            private static void ProgramUniformMatrix3x2dvEXT_Lazy(ProgramHandle program, int location, int count, bool transpose, double* value)
             {
-                _ProgramUniformMatrix3x2dvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3x2dvEXT");
+                _ProgramUniformMatrix3x2dvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3x2dvEXT");
                 _ProgramUniformMatrix3x2dvEXT_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, double*, void> _ProgramUniformMatrix3x4dvEXT_fnptr = &ProgramUniformMatrix3x4dvEXT_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, double*, void> _ProgramUniformMatrix3x4dvEXT_fnptr = &ProgramUniformMatrix3x4dvEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix3x4dvEXT(ProgramHandle program, int location, int count, byte transpose, double* value) => _ProgramUniformMatrix3x4dvEXT_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix3x4dvEXT(ProgramHandle program, int location, int count, bool transpose, double* value) => _ProgramUniformMatrix3x4dvEXT_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix3x4dvEXT_Lazy(ProgramHandle program, int location, int count, byte transpose, double* value)
+            private static void ProgramUniformMatrix3x4dvEXT_Lazy(ProgramHandle program, int location, int count, bool transpose, double* value)
             {
-                _ProgramUniformMatrix3x4dvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3x4dvEXT");
+                _ProgramUniformMatrix3x4dvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3x4dvEXT");
                 _ProgramUniformMatrix3x4dvEXT_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, double*, void> _ProgramUniformMatrix4x2dvEXT_fnptr = &ProgramUniformMatrix4x2dvEXT_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, double*, void> _ProgramUniformMatrix4x2dvEXT_fnptr = &ProgramUniformMatrix4x2dvEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix4x2dvEXT(ProgramHandle program, int location, int count, byte transpose, double* value) => _ProgramUniformMatrix4x2dvEXT_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix4x2dvEXT(ProgramHandle program, int location, int count, bool transpose, double* value) => _ProgramUniformMatrix4x2dvEXT_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix4x2dvEXT_Lazy(ProgramHandle program, int location, int count, byte transpose, double* value)
+            private static void ProgramUniformMatrix4x2dvEXT_Lazy(ProgramHandle program, int location, int count, bool transpose, double* value)
             {
-                _ProgramUniformMatrix4x2dvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4x2dvEXT");
+                _ProgramUniformMatrix4x2dvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4x2dvEXT");
                 _ProgramUniformMatrix4x2dvEXT_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, double*, void> _ProgramUniformMatrix4x3dvEXT_fnptr = &ProgramUniformMatrix4x3dvEXT_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, double*, void> _ProgramUniformMatrix4x3dvEXT_fnptr = &ProgramUniformMatrix4x3dvEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix4x3dvEXT(ProgramHandle program, int location, int count, byte transpose, double* value) => _ProgramUniformMatrix4x3dvEXT_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix4x3dvEXT(ProgramHandle program, int location, int count, bool transpose, double* value) => _ProgramUniformMatrix4x3dvEXT_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix4x3dvEXT_Lazy(ProgramHandle program, int location, int count, byte transpose, double* value)
+            private static void ProgramUniformMatrix4x3dvEXT_Lazy(ProgramHandle program, int location, int count, bool transpose, double* value)
             {
-                _ProgramUniformMatrix4x3dvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4x3dvEXT");
+                _ProgramUniformMatrix4x3dvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4x3dvEXT");
                 _ProgramUniformMatrix4x3dvEXT_fnptr(program, location, count, transpose, value);
             }
             
@@ -29086,25 +29086,25 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _TextureStorage3DEXT_fnptr(texture, target, levels, internalformat, width, height, depth);
             }
             
-            private static delegate* unmanaged<TextureHandle, TextureTarget, int, SizedInternalFormat, int, int, byte, void> _TextureStorage2DMultisampleEXT_fnptr = &TextureStorage2DMultisampleEXT_Lazy;
+            private static delegate* unmanaged<TextureHandle, TextureTarget, int, SizedInternalFormat, int, int, bool, void> _TextureStorage2DMultisampleEXT_fnptr = &TextureStorage2DMultisampleEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureStorage2DMultisampleEXT(TextureHandle texture, TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, byte fixedsamplelocations) => _TextureStorage2DMultisampleEXT_fnptr(texture, target, samples, internalformat, width, height, fixedsamplelocations);
+            public static void TextureStorage2DMultisampleEXT(TextureHandle texture, TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, bool fixedsamplelocations) => _TextureStorage2DMultisampleEXT_fnptr(texture, target, samples, internalformat, width, height, fixedsamplelocations);
             [UnmanagedCallersOnly]
-            private static void TextureStorage2DMultisampleEXT_Lazy(TextureHandle texture, TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, byte fixedsamplelocations)
+            private static void TextureStorage2DMultisampleEXT_Lazy(TextureHandle texture, TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, bool fixedsamplelocations)
             {
-                _TextureStorage2DMultisampleEXT_fnptr = (delegate* unmanaged<TextureHandle, TextureTarget, int, SizedInternalFormat, int, int, byte, void>)GLLoader.BindingsContext.GetProcAddress("glTextureStorage2DMultisampleEXT");
+                _TextureStorage2DMultisampleEXT_fnptr = (delegate* unmanaged<TextureHandle, TextureTarget, int, SizedInternalFormat, int, int, bool, void>)GLLoader.BindingsContext.GetProcAddress("glTextureStorage2DMultisampleEXT");
                 _TextureStorage2DMultisampleEXT_fnptr(texture, target, samples, internalformat, width, height, fixedsamplelocations);
             }
             
-            private static delegate* unmanaged<TextureHandle, All, int, SizedInternalFormat, int, int, int, byte, void> _TextureStorage3DMultisampleEXT_fnptr = &TextureStorage3DMultisampleEXT_Lazy;
+            private static delegate* unmanaged<TextureHandle, All, int, SizedInternalFormat, int, int, int, bool, void> _TextureStorage3DMultisampleEXT_fnptr = &TextureStorage3DMultisampleEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureStorage3DMultisampleEXT(TextureHandle texture, All target, int samples, SizedInternalFormat internalformat, int width, int height, int depth, byte fixedsamplelocations) => _TextureStorage3DMultisampleEXT_fnptr(texture, target, samples, internalformat, width, height, depth, fixedsamplelocations);
+            public static void TextureStorage3DMultisampleEXT(TextureHandle texture, All target, int samples, SizedInternalFormat internalformat, int width, int height, int depth, bool fixedsamplelocations) => _TextureStorage3DMultisampleEXT_fnptr(texture, target, samples, internalformat, width, height, depth, fixedsamplelocations);
             [UnmanagedCallersOnly]
-            private static void TextureStorage3DMultisampleEXT_Lazy(TextureHandle texture, All target, int samples, SizedInternalFormat internalformat, int width, int height, int depth, byte fixedsamplelocations)
+            private static void TextureStorage3DMultisampleEXT_Lazy(TextureHandle texture, All target, int samples, SizedInternalFormat internalformat, int width, int height, int depth, bool fixedsamplelocations)
             {
-                _TextureStorage3DMultisampleEXT_fnptr = (delegate* unmanaged<TextureHandle, All, int, SizedInternalFormat, int, int, int, byte, void>)GLLoader.BindingsContext.GetProcAddress("glTextureStorage3DMultisampleEXT");
+                _TextureStorage3DMultisampleEXT_fnptr = (delegate* unmanaged<TextureHandle, All, int, SizedInternalFormat, int, int, int, bool, void>)GLLoader.BindingsContext.GetProcAddress("glTextureStorage3DMultisampleEXT");
                 _TextureStorage3DMultisampleEXT_fnptr(texture, target, samples, internalformat, width, height, depth, fixedsamplelocations);
             }
             
@@ -29119,14 +29119,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _VertexArrayBindVertexBufferEXT_fnptr(vaobj, bindingindex, buffer, offset, stride);
             }
             
-            private static delegate* unmanaged<VertexArrayHandle, uint, int, VertexAttribType, byte, uint, void> _VertexArrayVertexAttribFormatEXT_fnptr = &VertexArrayVertexAttribFormatEXT_Lazy;
+            private static delegate* unmanaged<VertexArrayHandle, uint, int, VertexAttribType, bool, uint, void> _VertexArrayVertexAttribFormatEXT_fnptr = &VertexArrayVertexAttribFormatEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void VertexArrayVertexAttribFormatEXT(VertexArrayHandle vaobj, uint attribindex, int size, VertexAttribType type, byte normalized, uint relativeoffset) => _VertexArrayVertexAttribFormatEXT_fnptr(vaobj, attribindex, size, type, normalized, relativeoffset);
+            public static void VertexArrayVertexAttribFormatEXT(VertexArrayHandle vaobj, uint attribindex, int size, VertexAttribType type, bool normalized, uint relativeoffset) => _VertexArrayVertexAttribFormatEXT_fnptr(vaobj, attribindex, size, type, normalized, relativeoffset);
             [UnmanagedCallersOnly]
-            private static void VertexArrayVertexAttribFormatEXT_Lazy(VertexArrayHandle vaobj, uint attribindex, int size, VertexAttribType type, byte normalized, uint relativeoffset)
+            private static void VertexArrayVertexAttribFormatEXT_Lazy(VertexArrayHandle vaobj, uint attribindex, int size, VertexAttribType type, bool normalized, uint relativeoffset)
             {
-                _VertexArrayVertexAttribFormatEXT_fnptr = (delegate* unmanaged<VertexArrayHandle, uint, int, VertexAttribType, byte, uint, void>)GLLoader.BindingsContext.GetProcAddress("glVertexArrayVertexAttribFormatEXT");
+                _VertexArrayVertexAttribFormatEXT_fnptr = (delegate* unmanaged<VertexArrayHandle, uint, int, VertexAttribType, bool, uint, void>)GLLoader.BindingsContext.GetProcAddress("glVertexArrayVertexAttribFormatEXT");
                 _VertexArrayVertexAttribFormatEXT_fnptr(vaobj, attribindex, size, type, normalized, relativeoffset);
             }
             
@@ -29185,14 +29185,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _VertexArrayVertexAttribLOffsetEXT_fnptr(vaobj, buffer, index, size, type, stride, offset);
             }
             
-            private static delegate* unmanaged<TextureHandle, int, int, int, int, int, int, int, byte, void> _TexturePageCommitmentEXT_fnptr = &TexturePageCommitmentEXT_Lazy;
+            private static delegate* unmanaged<TextureHandle, int, int, int, int, int, int, int, bool, void> _TexturePageCommitmentEXT_fnptr = &TexturePageCommitmentEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TexturePageCommitmentEXT(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, byte commit) => _TexturePageCommitmentEXT_fnptr(texture, level, xoffset, yoffset, zoffset, width, height, depth, commit);
+            public static void TexturePageCommitmentEXT(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, bool commit) => _TexturePageCommitmentEXT_fnptr(texture, level, xoffset, yoffset, zoffset, width, height, depth, commit);
             [UnmanagedCallersOnly]
-            private static void TexturePageCommitmentEXT_Lazy(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, byte commit)
+            private static void TexturePageCommitmentEXT_Lazy(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, bool commit)
             {
-                _TexturePageCommitmentEXT_fnptr = (delegate* unmanaged<TextureHandle, int, int, int, int, int, int, int, byte, void>)GLLoader.BindingsContext.GetProcAddress("glTexturePageCommitmentEXT");
+                _TexturePageCommitmentEXT_fnptr = (delegate* unmanaged<TextureHandle, int, int, int, int, int, int, int, bool, void>)GLLoader.BindingsContext.GetProcAddress("glTexturePageCommitmentEXT");
                 _TexturePageCommitmentEXT_fnptr(texture, level, xoffset, yoffset, zoffset, width, height, depth, commit);
             }
             
@@ -29207,14 +29207,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _VertexArrayVertexAttribDivisorEXT_fnptr(vaobj, index, divisor);
             }
             
-            private static delegate* unmanaged<uint, byte, byte, byte, byte, void> _ColorMaskIndexedEXT_fnptr = &ColorMaskIndexedEXT_Lazy;
+            private static delegate* unmanaged<uint, bool, bool, bool, bool, void> _ColorMaskIndexedEXT_fnptr = &ColorMaskIndexedEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_draw_buffers2]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ColorMaskIndexedEXT(uint index, byte r, byte g, byte b, byte a) => _ColorMaskIndexedEXT_fnptr(index, r, g, b, a);
+            public static void ColorMaskIndexedEXT(uint index, bool r, bool g, bool b, bool a) => _ColorMaskIndexedEXT_fnptr(index, r, g, b, a);
             [UnmanagedCallersOnly]
-            private static void ColorMaskIndexedEXT_Lazy(uint index, byte r, byte g, byte b, byte a)
+            private static void ColorMaskIndexedEXT_Lazy(uint index, bool r, bool g, bool b, bool a)
             {
-                _ColorMaskIndexedEXT_fnptr = (delegate* unmanaged<uint, byte, byte, byte, byte, void>)GLLoader.BindingsContext.GetProcAddress("glColorMaskIndexedEXT");
+                _ColorMaskIndexedEXT_fnptr = (delegate* unmanaged<uint, bool, bool, bool, bool, void>)GLLoader.BindingsContext.GetProcAddress("glColorMaskIndexedEXT");
                 _ColorMaskIndexedEXT_fnptr(index, r, g, b, a);
             }
             
@@ -29350,14 +29350,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _RenderbufferStorageMultisampleEXT_fnptr(target, samples, internalformat, width, height);
             }
             
-            private static delegate* unmanaged<RenderbufferHandle, byte> _IsRenderbufferEXT_fnptr = &IsRenderbufferEXT_Lazy;
+            private static delegate* unmanaged<RenderbufferHandle, bool> _IsRenderbufferEXT_fnptr = &IsRenderbufferEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_framebuffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsRenderbufferEXT(RenderbufferHandle renderbuffer) => _IsRenderbufferEXT_fnptr(renderbuffer);
+            public static bool IsRenderbufferEXT(RenderbufferHandle renderbuffer) => _IsRenderbufferEXT_fnptr(renderbuffer);
             [UnmanagedCallersOnly]
-            private static byte IsRenderbufferEXT_Lazy(RenderbufferHandle renderbuffer)
+            private static bool IsRenderbufferEXT_Lazy(RenderbufferHandle renderbuffer)
             {
-                _IsRenderbufferEXT_fnptr = (delegate* unmanaged<RenderbufferHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsRenderbufferEXT");
+                _IsRenderbufferEXT_fnptr = (delegate* unmanaged<RenderbufferHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsRenderbufferEXT");
                 return _IsRenderbufferEXT_fnptr(renderbuffer);
             }
             
@@ -29416,14 +29416,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _GetRenderbufferParameterivEXT_fnptr(target, pname, parameters);
             }
             
-            private static delegate* unmanaged<FramebufferHandle, byte> _IsFramebufferEXT_fnptr = &IsFramebufferEXT_Lazy;
+            private static delegate* unmanaged<FramebufferHandle, bool> _IsFramebufferEXT_fnptr = &IsFramebufferEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_framebuffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsFramebufferEXT(FramebufferHandle framebuffer) => _IsFramebufferEXT_fnptr(framebuffer);
+            public static bool IsFramebufferEXT(FramebufferHandle framebuffer) => _IsFramebufferEXT_fnptr(framebuffer);
             [UnmanagedCallersOnly]
-            private static byte IsFramebufferEXT_Lazy(FramebufferHandle framebuffer)
+            private static bool IsFramebufferEXT_Lazy(FramebufferHandle framebuffer)
             {
-                _IsFramebufferEXT_fnptr = (delegate* unmanaged<FramebufferHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsFramebufferEXT");
+                _IsFramebufferEXT_fnptr = (delegate* unmanaged<FramebufferHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsFramebufferEXT");
                 return _IsFramebufferEXT_fnptr(framebuffer);
             }
             
@@ -29944,14 +29944,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _GetVertexAttribIuivEXT_fnptr(index, pname, parameters);
             }
             
-            private static delegate* unmanaged<HistogramTargetEXT, byte, PixelFormat, PixelType, void*, void> _GetHistogramEXT_fnptr = &GetHistogramEXT_Lazy;
+            private static delegate* unmanaged<HistogramTargetEXT, bool, PixelFormat, PixelType, void*, void> _GetHistogramEXT_fnptr = &GetHistogramEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_histogram]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetHistogramEXT(HistogramTargetEXT target, byte reset, PixelFormat format, PixelType type, void* values) => _GetHistogramEXT_fnptr(target, reset, format, type, values);
+            public static void GetHistogramEXT(HistogramTargetEXT target, bool reset, PixelFormat format, PixelType type, void* values) => _GetHistogramEXT_fnptr(target, reset, format, type, values);
             [UnmanagedCallersOnly]
-            private static void GetHistogramEXT_Lazy(HistogramTargetEXT target, byte reset, PixelFormat format, PixelType type, void* values)
+            private static void GetHistogramEXT_Lazy(HistogramTargetEXT target, bool reset, PixelFormat format, PixelType type, void* values)
             {
-                _GetHistogramEXT_fnptr = (delegate* unmanaged<HistogramTargetEXT, byte, PixelFormat, PixelType, void*, void>)GLLoader.BindingsContext.GetProcAddress("glGetHistogramEXT");
+                _GetHistogramEXT_fnptr = (delegate* unmanaged<HistogramTargetEXT, bool, PixelFormat, PixelType, void*, void>)GLLoader.BindingsContext.GetProcAddress("glGetHistogramEXT");
                 _GetHistogramEXT_fnptr(target, reset, format, type, values);
             }
             
@@ -29977,14 +29977,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _GetHistogramParameterivEXT_fnptr(target, pname, parameters);
             }
             
-            private static delegate* unmanaged<MinmaxTargetEXT, byte, PixelFormat, PixelType, void*, void> _GetMinmaxEXT_fnptr = &GetMinmaxEXT_Lazy;
+            private static delegate* unmanaged<MinmaxTargetEXT, bool, PixelFormat, PixelType, void*, void> _GetMinmaxEXT_fnptr = &GetMinmaxEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_histogram]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetMinmaxEXT(MinmaxTargetEXT target, byte reset, PixelFormat format, PixelType type, void* values) => _GetMinmaxEXT_fnptr(target, reset, format, type, values);
+            public static void GetMinmaxEXT(MinmaxTargetEXT target, bool reset, PixelFormat format, PixelType type, void* values) => _GetMinmaxEXT_fnptr(target, reset, format, type, values);
             [UnmanagedCallersOnly]
-            private static void GetMinmaxEXT_Lazy(MinmaxTargetEXT target, byte reset, PixelFormat format, PixelType type, void* values)
+            private static void GetMinmaxEXT_Lazy(MinmaxTargetEXT target, bool reset, PixelFormat format, PixelType type, void* values)
             {
-                _GetMinmaxEXT_fnptr = (delegate* unmanaged<MinmaxTargetEXT, byte, PixelFormat, PixelType, void*, void>)GLLoader.BindingsContext.GetProcAddress("glGetMinmaxEXT");
+                _GetMinmaxEXT_fnptr = (delegate* unmanaged<MinmaxTargetEXT, bool, PixelFormat, PixelType, void*, void>)GLLoader.BindingsContext.GetProcAddress("glGetMinmaxEXT");
                 _GetMinmaxEXT_fnptr(target, reset, format, type, values);
             }
             
@@ -30010,25 +30010,25 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _GetMinmaxParameterivEXT_fnptr(target, pname, parameters);
             }
             
-            private static delegate* unmanaged<HistogramTargetEXT, int, InternalFormat, byte, void> _HistogramEXT_fnptr = &HistogramEXT_Lazy;
+            private static delegate* unmanaged<HistogramTargetEXT, int, InternalFormat, bool, void> _HistogramEXT_fnptr = &HistogramEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_histogram]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void HistogramEXT(HistogramTargetEXT target, int width, InternalFormat internalformat, byte sink) => _HistogramEXT_fnptr(target, width, internalformat, sink);
+            public static void HistogramEXT(HistogramTargetEXT target, int width, InternalFormat internalformat, bool sink) => _HistogramEXT_fnptr(target, width, internalformat, sink);
             [UnmanagedCallersOnly]
-            private static void HistogramEXT_Lazy(HistogramTargetEXT target, int width, InternalFormat internalformat, byte sink)
+            private static void HistogramEXT_Lazy(HistogramTargetEXT target, int width, InternalFormat internalformat, bool sink)
             {
-                _HistogramEXT_fnptr = (delegate* unmanaged<HistogramTargetEXT, int, InternalFormat, byte, void>)GLLoader.BindingsContext.GetProcAddress("glHistogramEXT");
+                _HistogramEXT_fnptr = (delegate* unmanaged<HistogramTargetEXT, int, InternalFormat, bool, void>)GLLoader.BindingsContext.GetProcAddress("glHistogramEXT");
                 _HistogramEXT_fnptr(target, width, internalformat, sink);
             }
             
-            private static delegate* unmanaged<MinmaxTargetEXT, InternalFormat, byte, void> _MinmaxEXT_fnptr = &MinmaxEXT_Lazy;
+            private static delegate* unmanaged<MinmaxTargetEXT, InternalFormat, bool, void> _MinmaxEXT_fnptr = &MinmaxEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_histogram]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void MinmaxEXT(MinmaxTargetEXT target, InternalFormat internalformat, byte sink) => _MinmaxEXT_fnptr(target, internalformat, sink);
+            public static void MinmaxEXT(MinmaxTargetEXT target, InternalFormat internalformat, bool sink) => _MinmaxEXT_fnptr(target, internalformat, sink);
             [UnmanagedCallersOnly]
-            private static void MinmaxEXT_Lazy(MinmaxTargetEXT target, InternalFormat internalformat, byte sink)
+            private static void MinmaxEXT_Lazy(MinmaxTargetEXT target, InternalFormat internalformat, bool sink)
             {
-                _MinmaxEXT_fnptr = (delegate* unmanaged<MinmaxTargetEXT, InternalFormat, byte, void>)GLLoader.BindingsContext.GetProcAddress("glMinmaxEXT");
+                _MinmaxEXT_fnptr = (delegate* unmanaged<MinmaxTargetEXT, InternalFormat, bool, void>)GLLoader.BindingsContext.GetProcAddress("glMinmaxEXT");
                 _MinmaxEXT_fnptr(target, internalformat, sink);
             }
             
@@ -30142,14 +30142,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _DeleteMemoryObjectsEXT_fnptr(n, memoryObjects);
             }
             
-            private static delegate* unmanaged<uint, byte> _IsMemoryObjectEXT_fnptr = &IsMemoryObjectEXT_Lazy;
+            private static delegate* unmanaged<uint, bool> _IsMemoryObjectEXT_fnptr = &IsMemoryObjectEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_memory_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsMemoryObjectEXT(uint memoryObject) => _IsMemoryObjectEXT_fnptr(memoryObject);
+            public static bool IsMemoryObjectEXT(uint memoryObject) => _IsMemoryObjectEXT_fnptr(memoryObject);
             [UnmanagedCallersOnly]
-            private static byte IsMemoryObjectEXT_Lazy(uint memoryObject)
+            private static bool IsMemoryObjectEXT_Lazy(uint memoryObject)
             {
-                _IsMemoryObjectEXT_fnptr = (delegate* unmanaged<uint, byte>)GLLoader.BindingsContext.GetProcAddress("glIsMemoryObjectEXT");
+                _IsMemoryObjectEXT_fnptr = (delegate* unmanaged<uint, bool>)GLLoader.BindingsContext.GetProcAddress("glIsMemoryObjectEXT");
                 return _IsMemoryObjectEXT_fnptr(memoryObject);
             }
             
@@ -30197,14 +30197,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _TexStorageMem2DEXT_fnptr(target, levels, internalFormat, width, height, memory, offset);
             }
             
-            private static delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, byte, uint, ulong, void> _TexStorageMem2DMultisampleEXT_fnptr = &TexStorageMem2DMultisampleEXT_Lazy;
+            private static delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, bool, uint, ulong, void> _TexStorageMem2DMultisampleEXT_fnptr = &TexStorageMem2DMultisampleEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_memory_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TexStorageMem2DMultisampleEXT(TextureTarget target, int samples, SizedInternalFormat internalFormat, int width, int height, byte fixedSampleLocations, uint memory, ulong offset) => _TexStorageMem2DMultisampleEXT_fnptr(target, samples, internalFormat, width, height, fixedSampleLocations, memory, offset);
+            public static void TexStorageMem2DMultisampleEXT(TextureTarget target, int samples, SizedInternalFormat internalFormat, int width, int height, bool fixedSampleLocations, uint memory, ulong offset) => _TexStorageMem2DMultisampleEXT_fnptr(target, samples, internalFormat, width, height, fixedSampleLocations, memory, offset);
             [UnmanagedCallersOnly]
-            private static void TexStorageMem2DMultisampleEXT_Lazy(TextureTarget target, int samples, SizedInternalFormat internalFormat, int width, int height, byte fixedSampleLocations, uint memory, ulong offset)
+            private static void TexStorageMem2DMultisampleEXT_Lazy(TextureTarget target, int samples, SizedInternalFormat internalFormat, int width, int height, bool fixedSampleLocations, uint memory, ulong offset)
             {
-                _TexStorageMem2DMultisampleEXT_fnptr = (delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, byte, uint, ulong, void>)GLLoader.BindingsContext.GetProcAddress("glTexStorageMem2DMultisampleEXT");
+                _TexStorageMem2DMultisampleEXT_fnptr = (delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, bool, uint, ulong, void>)GLLoader.BindingsContext.GetProcAddress("glTexStorageMem2DMultisampleEXT");
                 _TexStorageMem2DMultisampleEXT_fnptr(target, samples, internalFormat, width, height, fixedSampleLocations, memory, offset);
             }
             
@@ -30219,14 +30219,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _TexStorageMem3DEXT_fnptr(target, levels, internalFormat, width, height, depth, memory, offset);
             }
             
-            private static delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, int, byte, uint, ulong, void> _TexStorageMem3DMultisampleEXT_fnptr = &TexStorageMem3DMultisampleEXT_Lazy;
+            private static delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, int, bool, uint, ulong, void> _TexStorageMem3DMultisampleEXT_fnptr = &TexStorageMem3DMultisampleEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_memory_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TexStorageMem3DMultisampleEXT(TextureTarget target, int samples, SizedInternalFormat internalFormat, int width, int height, int depth, byte fixedSampleLocations, uint memory, ulong offset) => _TexStorageMem3DMultisampleEXT_fnptr(target, samples, internalFormat, width, height, depth, fixedSampleLocations, memory, offset);
+            public static void TexStorageMem3DMultisampleEXT(TextureTarget target, int samples, SizedInternalFormat internalFormat, int width, int height, int depth, bool fixedSampleLocations, uint memory, ulong offset) => _TexStorageMem3DMultisampleEXT_fnptr(target, samples, internalFormat, width, height, depth, fixedSampleLocations, memory, offset);
             [UnmanagedCallersOnly]
-            private static void TexStorageMem3DMultisampleEXT_Lazy(TextureTarget target, int samples, SizedInternalFormat internalFormat, int width, int height, int depth, byte fixedSampleLocations, uint memory, ulong offset)
+            private static void TexStorageMem3DMultisampleEXT_Lazy(TextureTarget target, int samples, SizedInternalFormat internalFormat, int width, int height, int depth, bool fixedSampleLocations, uint memory, ulong offset)
             {
-                _TexStorageMem3DMultisampleEXT_fnptr = (delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, int, byte, uint, ulong, void>)GLLoader.BindingsContext.GetProcAddress("glTexStorageMem3DMultisampleEXT");
+                _TexStorageMem3DMultisampleEXT_fnptr = (delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, int, bool, uint, ulong, void>)GLLoader.BindingsContext.GetProcAddress("glTexStorageMem3DMultisampleEXT");
                 _TexStorageMem3DMultisampleEXT_fnptr(target, samples, internalFormat, width, height, depth, fixedSampleLocations, memory, offset);
             }
             
@@ -30252,14 +30252,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _TextureStorageMem2DEXT_fnptr(texture, levels, internalFormat, width, height, memory, offset);
             }
             
-            private static delegate* unmanaged<TextureHandle, int, SizedInternalFormat, int, int, byte, uint, ulong, void> _TextureStorageMem2DMultisampleEXT_fnptr = &TextureStorageMem2DMultisampleEXT_Lazy;
+            private static delegate* unmanaged<TextureHandle, int, SizedInternalFormat, int, int, bool, uint, ulong, void> _TextureStorageMem2DMultisampleEXT_fnptr = &TextureStorageMem2DMultisampleEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_memory_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureStorageMem2DMultisampleEXT(TextureHandle texture, int samples, SizedInternalFormat internalFormat, int width, int height, byte fixedSampleLocations, uint memory, ulong offset) => _TextureStorageMem2DMultisampleEXT_fnptr(texture, samples, internalFormat, width, height, fixedSampleLocations, memory, offset);
+            public static void TextureStorageMem2DMultisampleEXT(TextureHandle texture, int samples, SizedInternalFormat internalFormat, int width, int height, bool fixedSampleLocations, uint memory, ulong offset) => _TextureStorageMem2DMultisampleEXT_fnptr(texture, samples, internalFormat, width, height, fixedSampleLocations, memory, offset);
             [UnmanagedCallersOnly]
-            private static void TextureStorageMem2DMultisampleEXT_Lazy(TextureHandle texture, int samples, SizedInternalFormat internalFormat, int width, int height, byte fixedSampleLocations, uint memory, ulong offset)
+            private static void TextureStorageMem2DMultisampleEXT_Lazy(TextureHandle texture, int samples, SizedInternalFormat internalFormat, int width, int height, bool fixedSampleLocations, uint memory, ulong offset)
             {
-                _TextureStorageMem2DMultisampleEXT_fnptr = (delegate* unmanaged<TextureHandle, int, SizedInternalFormat, int, int, byte, uint, ulong, void>)GLLoader.BindingsContext.GetProcAddress("glTextureStorageMem2DMultisampleEXT");
+                _TextureStorageMem2DMultisampleEXT_fnptr = (delegate* unmanaged<TextureHandle, int, SizedInternalFormat, int, int, bool, uint, ulong, void>)GLLoader.BindingsContext.GetProcAddress("glTextureStorageMem2DMultisampleEXT");
                 _TextureStorageMem2DMultisampleEXT_fnptr(texture, samples, internalFormat, width, height, fixedSampleLocations, memory, offset);
             }
             
@@ -30274,14 +30274,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _TextureStorageMem3DEXT_fnptr(texture, levels, internalFormat, width, height, depth, memory, offset);
             }
             
-            private static delegate* unmanaged<TextureHandle, int, SizedInternalFormat, int, int, int, byte, uint, ulong, void> _TextureStorageMem3DMultisampleEXT_fnptr = &TextureStorageMem3DMultisampleEXT_Lazy;
+            private static delegate* unmanaged<TextureHandle, int, SizedInternalFormat, int, int, int, bool, uint, ulong, void> _TextureStorageMem3DMultisampleEXT_fnptr = &TextureStorageMem3DMultisampleEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_memory_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureStorageMem3DMultisampleEXT(TextureHandle texture, int samples, SizedInternalFormat internalFormat, int width, int height, int depth, byte fixedSampleLocations, uint memory, ulong offset) => _TextureStorageMem3DMultisampleEXT_fnptr(texture, samples, internalFormat, width, height, depth, fixedSampleLocations, memory, offset);
+            public static void TextureStorageMem3DMultisampleEXT(TextureHandle texture, int samples, SizedInternalFormat internalFormat, int width, int height, int depth, bool fixedSampleLocations, uint memory, ulong offset) => _TextureStorageMem3DMultisampleEXT_fnptr(texture, samples, internalFormat, width, height, depth, fixedSampleLocations, memory, offset);
             [UnmanagedCallersOnly]
-            private static void TextureStorageMem3DMultisampleEXT_Lazy(TextureHandle texture, int samples, SizedInternalFormat internalFormat, int width, int height, int depth, byte fixedSampleLocations, uint memory, ulong offset)
+            private static void TextureStorageMem3DMultisampleEXT_Lazy(TextureHandle texture, int samples, SizedInternalFormat internalFormat, int width, int height, int depth, bool fixedSampleLocations, uint memory, ulong offset)
             {
-                _TextureStorageMem3DMultisampleEXT_fnptr = (delegate* unmanaged<TextureHandle, int, SizedInternalFormat, int, int, int, byte, uint, ulong, void>)GLLoader.BindingsContext.GetProcAddress("glTextureStorageMem3DMultisampleEXT");
+                _TextureStorageMem3DMultisampleEXT_fnptr = (delegate* unmanaged<TextureHandle, int, SizedInternalFormat, int, int, int, bool, uint, ulong, void>)GLLoader.BindingsContext.GetProcAddress("glTextureStorageMem3DMultisampleEXT");
                 _TextureStorageMem3DMultisampleEXT_fnptr(texture, samples, internalFormat, width, height, depth, fixedSampleLocations, memory, offset);
             }
             
@@ -30373,14 +30373,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _MultiDrawElementsEXT_fnptr(mode, count, type, indices, primcount);
             }
             
-            private static delegate* unmanaged<float, byte, void> _SampleMaskEXT_fnptr = &SampleMaskEXT_Lazy;
+            private static delegate* unmanaged<float, bool, void> _SampleMaskEXT_fnptr = &SampleMaskEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_multisample]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void SampleMaskEXT(float value, byte invert) => _SampleMaskEXT_fnptr(value, invert);
+            public static void SampleMaskEXT(float value, bool invert) => _SampleMaskEXT_fnptr(value, invert);
             [UnmanagedCallersOnly]
-            private static void SampleMaskEXT_Lazy(float value, byte invert)
+            private static void SampleMaskEXT_Lazy(float value, bool invert)
             {
-                _SampleMaskEXT_fnptr = (delegate* unmanaged<float, byte, void>)GLLoader.BindingsContext.GetProcAddress("glSampleMaskEXT");
+                _SampleMaskEXT_fnptr = (delegate* unmanaged<float, bool, void>)GLLoader.BindingsContext.GetProcAddress("glSampleMaskEXT");
                 _SampleMaskEXT_fnptr(value, invert);
             }
             
@@ -30560,14 +30560,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _ProvokingVertexEXT_fnptr(mode);
             }
             
-            private static delegate* unmanaged<uint, byte, void> _RasterSamplesEXT_fnptr = &RasterSamplesEXT_Lazy;
+            private static delegate* unmanaged<uint, bool, void> _RasterSamplesEXT_fnptr = &RasterSamplesEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_raster_multisample | GL_NV_framebuffer_mixed_samples]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void RasterSamplesEXT(uint samples, byte fixedsamplelocations) => _RasterSamplesEXT_fnptr(samples, fixedsamplelocations);
+            public static void RasterSamplesEXT(uint samples, bool fixedsamplelocations) => _RasterSamplesEXT_fnptr(samples, fixedsamplelocations);
             [UnmanagedCallersOnly]
-            private static void RasterSamplesEXT_Lazy(uint samples, byte fixedsamplelocations)
+            private static void RasterSamplesEXT_Lazy(uint samples, bool fixedsamplelocations)
             {
-                _RasterSamplesEXT_fnptr = (delegate* unmanaged<uint, byte, void>)GLLoader.BindingsContext.GetProcAddress("glRasterSamplesEXT");
+                _RasterSamplesEXT_fnptr = (delegate* unmanaged<uint, bool, void>)GLLoader.BindingsContext.GetProcAddress("glRasterSamplesEXT");
                 _RasterSamplesEXT_fnptr(samples, fixedsamplelocations);
             }
             
@@ -30593,14 +30593,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _DeleteSemaphoresEXT_fnptr(n, semaphores);
             }
             
-            private static delegate* unmanaged<uint, byte> _IsSemaphoreEXT_fnptr = &IsSemaphoreEXT_Lazy;
+            private static delegate* unmanaged<uint, bool> _IsSemaphoreEXT_fnptr = &IsSemaphoreEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_semaphore]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsSemaphoreEXT(uint semaphore) => _IsSemaphoreEXT_fnptr(semaphore);
+            public static bool IsSemaphoreEXT(uint semaphore) => _IsSemaphoreEXT_fnptr(semaphore);
             [UnmanagedCallersOnly]
-            private static byte IsSemaphoreEXT_Lazy(uint semaphore)
+            private static bool IsSemaphoreEXT_Lazy(uint semaphore)
             {
-                _IsSemaphoreEXT_fnptr = (delegate* unmanaged<uint, byte>)GLLoader.BindingsContext.GetProcAddress("glIsSemaphoreEXT");
+                _IsSemaphoreEXT_fnptr = (delegate* unmanaged<uint, bool>)GLLoader.BindingsContext.GetProcAddress("glIsSemaphoreEXT");
                 return _IsSemaphoreEXT_fnptr(semaphore);
             }
             
@@ -30978,14 +30978,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _GetProgramPipelineivEXT_fnptr(pipeline, pname, parameters);
             }
             
-            private static delegate* unmanaged<ProgramPipelineHandle, byte> _IsProgramPipelineEXT_fnptr = &IsProgramPipelineEXT_Lazy;
+            private static delegate* unmanaged<ProgramPipelineHandle, bool> _IsProgramPipelineEXT_fnptr = &IsProgramPipelineEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsProgramPipelineEXT(ProgramPipelineHandle pipeline) => _IsProgramPipelineEXT_fnptr(pipeline);
+            public static bool IsProgramPipelineEXT(ProgramPipelineHandle pipeline) => _IsProgramPipelineEXT_fnptr(pipeline);
             [UnmanagedCallersOnly]
-            private static byte IsProgramPipelineEXT_Lazy(ProgramPipelineHandle pipeline)
+            private static bool IsProgramPipelineEXT_Lazy(ProgramPipelineHandle pipeline)
             {
-                _IsProgramPipelineEXT_fnptr = (delegate* unmanaged<ProgramPipelineHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsProgramPipelineEXT");
+                _IsProgramPipelineEXT_fnptr = (delegate* unmanaged<ProgramPipelineHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsProgramPipelineEXT");
                 return _IsProgramPipelineEXT_fnptr(pipeline);
             }
             
@@ -31022,14 +31022,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _FramebufferFetchBarrierEXT_fnptr();
             }
             
-            private static delegate* unmanaged<uint, TextureHandle, int, byte, int, BufferAccessARB, int, void> _BindImageTextureEXT_fnptr = &BindImageTextureEXT_Lazy;
+            private static delegate* unmanaged<uint, TextureHandle, int, bool, int, BufferAccessARB, int, void> _BindImageTextureEXT_fnptr = &BindImageTextureEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_shader_image_load_store]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void BindImageTextureEXT(uint index, TextureHandle texture, int level, byte layered, int layer, BufferAccessARB access, int format) => _BindImageTextureEXT_fnptr(index, texture, level, layered, layer, access, format);
+            public static void BindImageTextureEXT(uint index, TextureHandle texture, int level, bool layered, int layer, BufferAccessARB access, int format) => _BindImageTextureEXT_fnptr(index, texture, level, layered, layer, access, format);
             [UnmanagedCallersOnly]
-            private static void BindImageTextureEXT_Lazy(uint index, TextureHandle texture, int level, byte layered, int layer, BufferAccessARB access, int format)
+            private static void BindImageTextureEXT_Lazy(uint index, TextureHandle texture, int level, bool layered, int layer, BufferAccessARB access, int format)
             {
-                _BindImageTextureEXT_fnptr = (delegate* unmanaged<uint, TextureHandle, int, byte, int, BufferAccessARB, int, void>)GLLoader.BindingsContext.GetProcAddress("glBindImageTextureEXT");
+                _BindImageTextureEXT_fnptr = (delegate* unmanaged<uint, TextureHandle, int, bool, int, BufferAccessARB, int, void>)GLLoader.BindingsContext.GetProcAddress("glBindImageTextureEXT");
                 _BindImageTextureEXT_fnptr(index, texture, level, layered, layer, access, format);
             }
             
@@ -31198,14 +31198,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _ClearColorIuiEXT_fnptr(red, green, blue, alpha);
             }
             
-            private static delegate* unmanaged<int, TextureHandle*, byte*, byte> _AreTexturesResidentEXT_fnptr = &AreTexturesResidentEXT_Lazy;
+            private static delegate* unmanaged<int, TextureHandle*, bool*, bool> _AreTexturesResidentEXT_fnptr = &AreTexturesResidentEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_texture_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte AreTexturesResidentEXT(int n, TextureHandle* textures, byte* residences) => _AreTexturesResidentEXT_fnptr(n, textures, residences);
+            public static bool AreTexturesResidentEXT(int n, TextureHandle* textures, bool* residences) => _AreTexturesResidentEXT_fnptr(n, textures, residences);
             [UnmanagedCallersOnly]
-            private static byte AreTexturesResidentEXT_Lazy(int n, TextureHandle* textures, byte* residences)
+            private static bool AreTexturesResidentEXT_Lazy(int n, TextureHandle* textures, bool* residences)
             {
-                _AreTexturesResidentEXT_fnptr = (delegate* unmanaged<int, TextureHandle*, byte*, byte>)GLLoader.BindingsContext.GetProcAddress("glAreTexturesResidentEXT");
+                _AreTexturesResidentEXT_fnptr = (delegate* unmanaged<int, TextureHandle*, bool*, bool>)GLLoader.BindingsContext.GetProcAddress("glAreTexturesResidentEXT");
                 return _AreTexturesResidentEXT_fnptr(n, textures, residences);
             }
             
@@ -31242,14 +31242,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _GenTexturesEXT_fnptr(n, textures);
             }
             
-            private static delegate* unmanaged<TextureHandle, byte> _IsTextureEXT_fnptr = &IsTextureEXT_Lazy;
+            private static delegate* unmanaged<TextureHandle, bool> _IsTextureEXT_fnptr = &IsTextureEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_texture_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsTextureEXT(TextureHandle texture) => _IsTextureEXT_fnptr(texture);
+            public static bool IsTextureEXT(TextureHandle texture) => _IsTextureEXT_fnptr(texture);
             [UnmanagedCallersOnly]
-            private static byte IsTextureEXT_Lazy(TextureHandle texture)
+            private static bool IsTextureEXT_Lazy(TextureHandle texture)
             {
-                _IsTextureEXT_fnptr = (delegate* unmanaged<TextureHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsTextureEXT");
+                _IsTextureEXT_fnptr = (delegate* unmanaged<TextureHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsTextureEXT");
                 return _IsTextureEXT_fnptr(texture);
             }
             
@@ -31440,14 +31440,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _DrawArraysEXT_fnptr(mode, first, count);
             }
             
-            private static delegate* unmanaged<int, int, byte*, void> _EdgeFlagPointerEXT_fnptr = &EdgeFlagPointerEXT_Lazy;
+            private static delegate* unmanaged<int, int, bool*, void> _EdgeFlagPointerEXT_fnptr = &EdgeFlagPointerEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_vertex_array]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void EdgeFlagPointerEXT(int stride, int count, byte* pointer) => _EdgeFlagPointerEXT_fnptr(stride, count, pointer);
+            public static void EdgeFlagPointerEXT(int stride, int count, bool* pointer) => _EdgeFlagPointerEXT_fnptr(stride, count, pointer);
             [UnmanagedCallersOnly]
-            private static void EdgeFlagPointerEXT_Lazy(int stride, int count, byte* pointer)
+            private static void EdgeFlagPointerEXT_Lazy(int stride, int count, bool* pointer)
             {
-                _EdgeFlagPointerEXT_fnptr = (delegate* unmanaged<int, int, byte*, void>)GLLoader.BindingsContext.GetProcAddress("glEdgeFlagPointerEXT");
+                _EdgeFlagPointerEXT_fnptr = (delegate* unmanaged<int, int, bool*, void>)GLLoader.BindingsContext.GetProcAddress("glEdgeFlagPointerEXT");
                 _EdgeFlagPointerEXT_fnptr(stride, count, pointer);
             }
             
@@ -31957,25 +31957,25 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return _BindParameterEXT_fnptr(value);
             }
             
-            private static delegate* unmanaged<uint, VariantCapEXT, byte> _IsVariantEnabledEXT_fnptr = &IsVariantEnabledEXT_Lazy;
+            private static delegate* unmanaged<uint, VariantCapEXT, bool> _IsVariantEnabledEXT_fnptr = &IsVariantEnabledEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_vertex_shader]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsVariantEnabledEXT(uint id, VariantCapEXT cap) => _IsVariantEnabledEXT_fnptr(id, cap);
+            public static bool IsVariantEnabledEXT(uint id, VariantCapEXT cap) => _IsVariantEnabledEXT_fnptr(id, cap);
             [UnmanagedCallersOnly]
-            private static byte IsVariantEnabledEXT_Lazy(uint id, VariantCapEXT cap)
+            private static bool IsVariantEnabledEXT_Lazy(uint id, VariantCapEXT cap)
             {
-                _IsVariantEnabledEXT_fnptr = (delegate* unmanaged<uint, VariantCapEXT, byte>)GLLoader.BindingsContext.GetProcAddress("glIsVariantEnabledEXT");
+                _IsVariantEnabledEXT_fnptr = (delegate* unmanaged<uint, VariantCapEXT, bool>)GLLoader.BindingsContext.GetProcAddress("glIsVariantEnabledEXT");
                 return _IsVariantEnabledEXT_fnptr(id, cap);
             }
             
-            private static delegate* unmanaged<uint, GetVariantValueEXT, byte*, void> _GetVariantBooleanvEXT_fnptr = &GetVariantBooleanvEXT_Lazy;
+            private static delegate* unmanaged<uint, GetVariantValueEXT, bool*, void> _GetVariantBooleanvEXT_fnptr = &GetVariantBooleanvEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_vertex_shader]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetVariantBooleanvEXT(uint id, GetVariantValueEXT value, byte* data) => _GetVariantBooleanvEXT_fnptr(id, value, data);
+            public static void GetVariantBooleanvEXT(uint id, GetVariantValueEXT value, bool* data) => _GetVariantBooleanvEXT_fnptr(id, value, data);
             [UnmanagedCallersOnly]
-            private static void GetVariantBooleanvEXT_Lazy(uint id, GetVariantValueEXT value, byte* data)
+            private static void GetVariantBooleanvEXT_Lazy(uint id, GetVariantValueEXT value, bool* data)
             {
-                _GetVariantBooleanvEXT_fnptr = (delegate* unmanaged<uint, GetVariantValueEXT, byte*, void>)GLLoader.BindingsContext.GetProcAddress("glGetVariantBooleanvEXT");
+                _GetVariantBooleanvEXT_fnptr = (delegate* unmanaged<uint, GetVariantValueEXT, bool*, void>)GLLoader.BindingsContext.GetProcAddress("glGetVariantBooleanvEXT");
                 _GetVariantBooleanvEXT_fnptr(id, value, data);
             }
             
@@ -32012,14 +32012,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _GetVariantPointervEXT_fnptr(id, value, data);
             }
             
-            private static delegate* unmanaged<uint, GetVariantValueEXT, byte*, void> _GetInvariantBooleanvEXT_fnptr = &GetInvariantBooleanvEXT_Lazy;
+            private static delegate* unmanaged<uint, GetVariantValueEXT, bool*, void> _GetInvariantBooleanvEXT_fnptr = &GetInvariantBooleanvEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_vertex_shader]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetInvariantBooleanvEXT(uint id, GetVariantValueEXT value, byte* data) => _GetInvariantBooleanvEXT_fnptr(id, value, data);
+            public static void GetInvariantBooleanvEXT(uint id, GetVariantValueEXT value, bool* data) => _GetInvariantBooleanvEXT_fnptr(id, value, data);
             [UnmanagedCallersOnly]
-            private static void GetInvariantBooleanvEXT_Lazy(uint id, GetVariantValueEXT value, byte* data)
+            private static void GetInvariantBooleanvEXT_Lazy(uint id, GetVariantValueEXT value, bool* data)
             {
-                _GetInvariantBooleanvEXT_fnptr = (delegate* unmanaged<uint, GetVariantValueEXT, byte*, void>)GLLoader.BindingsContext.GetProcAddress("glGetInvariantBooleanvEXT");
+                _GetInvariantBooleanvEXT_fnptr = (delegate* unmanaged<uint, GetVariantValueEXT, bool*, void>)GLLoader.BindingsContext.GetProcAddress("glGetInvariantBooleanvEXT");
                 _GetInvariantBooleanvEXT_fnptr(id, value, data);
             }
             
@@ -32045,14 +32045,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _GetInvariantFloatvEXT_fnptr(id, value, data);
             }
             
-            private static delegate* unmanaged<uint, GetVariantValueEXT, byte*, void> _GetLocalConstantBooleanvEXT_fnptr = &GetLocalConstantBooleanvEXT_Lazy;
+            private static delegate* unmanaged<uint, GetVariantValueEXT, bool*, void> _GetLocalConstantBooleanvEXT_fnptr = &GetLocalConstantBooleanvEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_vertex_shader]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetLocalConstantBooleanvEXT(uint id, GetVariantValueEXT value, byte* data) => _GetLocalConstantBooleanvEXT_fnptr(id, value, data);
+            public static void GetLocalConstantBooleanvEXT(uint id, GetVariantValueEXT value, bool* data) => _GetLocalConstantBooleanvEXT_fnptr(id, value, data);
             [UnmanagedCallersOnly]
-            private static void GetLocalConstantBooleanvEXT_Lazy(uint id, GetVariantValueEXT value, byte* data)
+            private static void GetLocalConstantBooleanvEXT_Lazy(uint id, GetVariantValueEXT value, bool* data)
             {
-                _GetLocalConstantBooleanvEXT_fnptr = (delegate* unmanaged<uint, GetVariantValueEXT, byte*, void>)GLLoader.BindingsContext.GetProcAddress("glGetLocalConstantBooleanvEXT");
+                _GetLocalConstantBooleanvEXT_fnptr = (delegate* unmanaged<uint, GetVariantValueEXT, bool*, void>)GLLoader.BindingsContext.GetProcAddress("glGetLocalConstantBooleanvEXT");
                 _GetLocalConstantBooleanvEXT_fnptr(id, value, data);
             }
             
@@ -32111,25 +32111,25 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _VertexWeightPointerEXT_fnptr(size, type, stride, pointer);
             }
             
-            private static delegate* unmanaged<uint, ulong, uint, byte> _AcquireKeyedMutexWin32EXT_fnptr = &AcquireKeyedMutexWin32EXT_Lazy;
+            private static delegate* unmanaged<uint, ulong, uint, bool> _AcquireKeyedMutexWin32EXT_fnptr = &AcquireKeyedMutexWin32EXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_win32_keyed_mutex]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte AcquireKeyedMutexWin32EXT(uint memory, ulong key, uint timeout) => _AcquireKeyedMutexWin32EXT_fnptr(memory, key, timeout);
+            public static bool AcquireKeyedMutexWin32EXT(uint memory, ulong key, uint timeout) => _AcquireKeyedMutexWin32EXT_fnptr(memory, key, timeout);
             [UnmanagedCallersOnly]
-            private static byte AcquireKeyedMutexWin32EXT_Lazy(uint memory, ulong key, uint timeout)
+            private static bool AcquireKeyedMutexWin32EXT_Lazy(uint memory, ulong key, uint timeout)
             {
-                _AcquireKeyedMutexWin32EXT_fnptr = (delegate* unmanaged<uint, ulong, uint, byte>)GLLoader.BindingsContext.GetProcAddress("glAcquireKeyedMutexWin32EXT");
+                _AcquireKeyedMutexWin32EXT_fnptr = (delegate* unmanaged<uint, ulong, uint, bool>)GLLoader.BindingsContext.GetProcAddress("glAcquireKeyedMutexWin32EXT");
                 return _AcquireKeyedMutexWin32EXT_fnptr(memory, key, timeout);
             }
             
-            private static delegate* unmanaged<uint, ulong, byte> _ReleaseKeyedMutexWin32EXT_fnptr = &ReleaseKeyedMutexWin32EXT_Lazy;
+            private static delegate* unmanaged<uint, ulong, bool> _ReleaseKeyedMutexWin32EXT_fnptr = &ReleaseKeyedMutexWin32EXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_win32_keyed_mutex]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte ReleaseKeyedMutexWin32EXT(uint memory, ulong key) => _ReleaseKeyedMutexWin32EXT_fnptr(memory, key);
+            public static bool ReleaseKeyedMutexWin32EXT(uint memory, ulong key) => _ReleaseKeyedMutexWin32EXT_fnptr(memory, key);
             [UnmanagedCallersOnly]
-            private static byte ReleaseKeyedMutexWin32EXT_Lazy(uint memory, ulong key)
+            private static bool ReleaseKeyedMutexWin32EXT_Lazy(uint memory, ulong key)
             {
-                _ReleaseKeyedMutexWin32EXT_fnptr = (delegate* unmanaged<uint, ulong, byte>)GLLoader.BindingsContext.GetProcAddress("glReleaseKeyedMutexWin32EXT");
+                _ReleaseKeyedMutexWin32EXT_fnptr = (delegate* unmanaged<uint, ulong, bool>)GLLoader.BindingsContext.GetProcAddress("glReleaseKeyedMutexWin32EXT");
                 return _ReleaseKeyedMutexWin32EXT_fnptr(memory, key);
             }
             
@@ -32290,14 +32290,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _MakeTextureHandleNonResidentNV_fnptr(handle);
             }
             
-            private static delegate* unmanaged<TextureHandle, int, byte, int, PixelFormat, ulong> _GetImageHandleNV_fnptr = &GetImageHandleNV_Lazy;
+            private static delegate* unmanaged<TextureHandle, int, bool, int, PixelFormat, ulong> _GetImageHandleNV_fnptr = &GetImageHandleNV_Lazy;
             /// <summary> <b>[requires: GL_NV_bindless_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static ulong GetImageHandleNV(TextureHandle texture, int level, byte layered, int layer, PixelFormat format) => _GetImageHandleNV_fnptr(texture, level, layered, layer, format);
+            public static ulong GetImageHandleNV(TextureHandle texture, int level, bool layered, int layer, PixelFormat format) => _GetImageHandleNV_fnptr(texture, level, layered, layer, format);
             [UnmanagedCallersOnly]
-            private static ulong GetImageHandleNV_Lazy(TextureHandle texture, int level, byte layered, int layer, PixelFormat format)
+            private static ulong GetImageHandleNV_Lazy(TextureHandle texture, int level, bool layered, int layer, PixelFormat format)
             {
-                _GetImageHandleNV_fnptr = (delegate* unmanaged<TextureHandle, int, byte, int, PixelFormat, ulong>)GLLoader.BindingsContext.GetProcAddress("glGetImageHandleNV");
+                _GetImageHandleNV_fnptr = (delegate* unmanaged<TextureHandle, int, bool, int, PixelFormat, ulong>)GLLoader.BindingsContext.GetProcAddress("glGetImageHandleNV");
                 return _GetImageHandleNV_fnptr(texture, level, layered, layer, format);
             }
             
@@ -32367,25 +32367,25 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _ProgramUniformHandleui64vNV_fnptr(program, location, count, values);
             }
             
-            private static delegate* unmanaged<ulong, byte> _IsTextureHandleResidentNV_fnptr = &IsTextureHandleResidentNV_Lazy;
+            private static delegate* unmanaged<ulong, bool> _IsTextureHandleResidentNV_fnptr = &IsTextureHandleResidentNV_Lazy;
             /// <summary> <b>[requires: GL_NV_bindless_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsTextureHandleResidentNV(ulong handle) => _IsTextureHandleResidentNV_fnptr(handle);
+            public static bool IsTextureHandleResidentNV(ulong handle) => _IsTextureHandleResidentNV_fnptr(handle);
             [UnmanagedCallersOnly]
-            private static byte IsTextureHandleResidentNV_Lazy(ulong handle)
+            private static bool IsTextureHandleResidentNV_Lazy(ulong handle)
             {
-                _IsTextureHandleResidentNV_fnptr = (delegate* unmanaged<ulong, byte>)GLLoader.BindingsContext.GetProcAddress("glIsTextureHandleResidentNV");
+                _IsTextureHandleResidentNV_fnptr = (delegate* unmanaged<ulong, bool>)GLLoader.BindingsContext.GetProcAddress("glIsTextureHandleResidentNV");
                 return _IsTextureHandleResidentNV_fnptr(handle);
             }
             
-            private static delegate* unmanaged<ulong, byte> _IsImageHandleResidentNV_fnptr = &IsImageHandleResidentNV_Lazy;
+            private static delegate* unmanaged<ulong, bool> _IsImageHandleResidentNV_fnptr = &IsImageHandleResidentNV_Lazy;
             /// <summary> <b>[requires: GL_NV_bindless_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsImageHandleResidentNV(ulong handle) => _IsImageHandleResidentNV_fnptr(handle);
+            public static bool IsImageHandleResidentNV(ulong handle) => _IsImageHandleResidentNV_fnptr(handle);
             [UnmanagedCallersOnly]
-            private static byte IsImageHandleResidentNV_Lazy(ulong handle)
+            private static bool IsImageHandleResidentNV_Lazy(ulong handle)
             {
-                _IsImageHandleResidentNV_fnptr = (delegate* unmanaged<ulong, byte>)GLLoader.BindingsContext.GetProcAddress("glIsImageHandleResidentNV");
+                _IsImageHandleResidentNV_fnptr = (delegate* unmanaged<ulong, bool>)GLLoader.BindingsContext.GetProcAddress("glIsImageHandleResidentNV");
                 return _IsImageHandleResidentNV_fnptr(handle);
             }
             
@@ -32444,14 +32444,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _DeleteStatesNV_fnptr(n, states);
             }
             
-            private static delegate* unmanaged<uint, byte> _IsStateNV_fnptr = &IsStateNV_Lazy;
+            private static delegate* unmanaged<uint, bool> _IsStateNV_fnptr = &IsStateNV_Lazy;
             /// <summary> <b>[requires: GL_NV_command_list]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsStateNV(uint state) => _IsStateNV_fnptr(state);
+            public static bool IsStateNV(uint state) => _IsStateNV_fnptr(state);
             [UnmanagedCallersOnly]
-            private static byte IsStateNV_Lazy(uint state)
+            private static bool IsStateNV_Lazy(uint state)
             {
-                _IsStateNV_fnptr = (delegate* unmanaged<uint, byte>)GLLoader.BindingsContext.GetProcAddress("glIsStateNV");
+                _IsStateNV_fnptr = (delegate* unmanaged<uint, bool>)GLLoader.BindingsContext.GetProcAddress("glIsStateNV");
                 return _IsStateNV_fnptr(state);
             }
             
@@ -32554,14 +32554,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _DeleteCommandListsNV_fnptr(n, lists);
             }
             
-            private static delegate* unmanaged<uint, byte> _IsCommandListNV_fnptr = &IsCommandListNV_Lazy;
+            private static delegate* unmanaged<uint, bool> _IsCommandListNV_fnptr = &IsCommandListNV_Lazy;
             /// <summary> <b>[requires: GL_NV_command_list]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsCommandListNV(uint list) => _IsCommandListNV_fnptr(list);
+            public static bool IsCommandListNV(uint list) => _IsCommandListNV_fnptr(list);
             [UnmanagedCallersOnly]
-            private static byte IsCommandListNV_Lazy(uint list)
+            private static bool IsCommandListNV_Lazy(uint list)
             {
-                _IsCommandListNV_fnptr = (delegate* unmanaged<uint, byte>)GLLoader.BindingsContext.GetProcAddress("glIsCommandListNV");
+                _IsCommandListNV_fnptr = (delegate* unmanaged<uint, bool>)GLLoader.BindingsContext.GetProcAddress("glIsCommandListNV");
                 return _IsCommandListNV_fnptr(list);
             }
             
@@ -32774,14 +32774,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _SignalVkFenceNV_fnptr(vkFence);
             }
             
-            private static delegate* unmanaged<EvalTargetNV, uint, MapTypeNV, int, int, int, int, byte, void*, void> _MapControlPointsNV_fnptr = &MapControlPointsNV_Lazy;
+            private static delegate* unmanaged<EvalTargetNV, uint, MapTypeNV, int, int, int, int, bool, void*, void> _MapControlPointsNV_fnptr = &MapControlPointsNV_Lazy;
             /// <summary> <b>[requires: GL_NV_evaluators]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void MapControlPointsNV(EvalTargetNV target, uint index, MapTypeNV type, int ustride, int vstride, int uorder, int vorder, byte packed, void* points) => _MapControlPointsNV_fnptr(target, index, type, ustride, vstride, uorder, vorder, packed, points);
+            public static void MapControlPointsNV(EvalTargetNV target, uint index, MapTypeNV type, int ustride, int vstride, int uorder, int vorder, bool packed, void* points) => _MapControlPointsNV_fnptr(target, index, type, ustride, vstride, uorder, vorder, packed, points);
             [UnmanagedCallersOnly]
-            private static void MapControlPointsNV_Lazy(EvalTargetNV target, uint index, MapTypeNV type, int ustride, int vstride, int uorder, int vorder, byte packed, void* points)
+            private static void MapControlPointsNV_Lazy(EvalTargetNV target, uint index, MapTypeNV type, int ustride, int vstride, int uorder, int vorder, bool packed, void* points)
             {
-                _MapControlPointsNV_fnptr = (delegate* unmanaged<EvalTargetNV, uint, MapTypeNV, int, int, int, int, byte, void*, void>)GLLoader.BindingsContext.GetProcAddress("glMapControlPointsNV");
+                _MapControlPointsNV_fnptr = (delegate* unmanaged<EvalTargetNV, uint, MapTypeNV, int, int, int, int, bool, void*, void>)GLLoader.BindingsContext.GetProcAddress("glMapControlPointsNV");
                 _MapControlPointsNV_fnptr(target, index, type, ustride, vstride, uorder, vorder, packed, points);
             }
             
@@ -32807,14 +32807,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _MapParameterfvNV_fnptr(target, pname, parameters);
             }
             
-            private static delegate* unmanaged<EvalTargetNV, uint, MapTypeNV, int, int, byte, void*, void> _GetMapControlPointsNV_fnptr = &GetMapControlPointsNV_Lazy;
+            private static delegate* unmanaged<EvalTargetNV, uint, MapTypeNV, int, int, bool, void*, void> _GetMapControlPointsNV_fnptr = &GetMapControlPointsNV_Lazy;
             /// <summary> <b>[requires: GL_NV_evaluators]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetMapControlPointsNV(EvalTargetNV target, uint index, MapTypeNV type, int ustride, int vstride, byte packed, void* points) => _GetMapControlPointsNV_fnptr(target, index, type, ustride, vstride, packed, points);
+            public static void GetMapControlPointsNV(EvalTargetNV target, uint index, MapTypeNV type, int ustride, int vstride, bool packed, void* points) => _GetMapControlPointsNV_fnptr(target, index, type, ustride, vstride, packed, points);
             [UnmanagedCallersOnly]
-            private static void GetMapControlPointsNV_Lazy(EvalTargetNV target, uint index, MapTypeNV type, int ustride, int vstride, byte packed, void* points)
+            private static void GetMapControlPointsNV_Lazy(EvalTargetNV target, uint index, MapTypeNV type, int ustride, int vstride, bool packed, void* points)
             {
-                _GetMapControlPointsNV_fnptr = (delegate* unmanaged<EvalTargetNV, uint, MapTypeNV, int, int, byte, void*, void>)GLLoader.BindingsContext.GetProcAddress("glGetMapControlPointsNV");
+                _GetMapControlPointsNV_fnptr = (delegate* unmanaged<EvalTargetNV, uint, MapTypeNV, int, int, bool, void*, void>)GLLoader.BindingsContext.GetProcAddress("glGetMapControlPointsNV");
                 _GetMapControlPointsNV_fnptr(target, index, type, ustride, vstride, packed, points);
             }
             
@@ -32928,25 +32928,25 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _GenFencesNV_fnptr(n, fences);
             }
             
-            private static delegate* unmanaged<uint, byte> _IsFenceNV_fnptr = &IsFenceNV_Lazy;
+            private static delegate* unmanaged<uint, bool> _IsFenceNV_fnptr = &IsFenceNV_Lazy;
             /// <summary> <b>[requires: GL_NV_fence]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsFenceNV(uint fence) => _IsFenceNV_fnptr(fence);
+            public static bool IsFenceNV(uint fence) => _IsFenceNV_fnptr(fence);
             [UnmanagedCallersOnly]
-            private static byte IsFenceNV_Lazy(uint fence)
+            private static bool IsFenceNV_Lazy(uint fence)
             {
-                _IsFenceNV_fnptr = (delegate* unmanaged<uint, byte>)GLLoader.BindingsContext.GetProcAddress("glIsFenceNV");
+                _IsFenceNV_fnptr = (delegate* unmanaged<uint, bool>)GLLoader.BindingsContext.GetProcAddress("glIsFenceNV");
                 return _IsFenceNV_fnptr(fence);
             }
             
-            private static delegate* unmanaged<uint, byte> _TestFenceNV_fnptr = &TestFenceNV_Lazy;
+            private static delegate* unmanaged<uint, bool> _TestFenceNV_fnptr = &TestFenceNV_Lazy;
             /// <summary> <b>[requires: GL_NV_fence]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte TestFenceNV(uint fence) => _TestFenceNV_fnptr(fence);
+            public static bool TestFenceNV(uint fence) => _TestFenceNV_fnptr(fence);
             [UnmanagedCallersOnly]
-            private static byte TestFenceNV_Lazy(uint fence)
+            private static bool TestFenceNV_Lazy(uint fence)
             {
-                _TestFenceNV_fnptr = (delegate* unmanaged<uint, byte>)GLLoader.BindingsContext.GetProcAddress("glTestFenceNV");
+                _TestFenceNV_fnptr = (delegate* unmanaged<uint, bool>)GLLoader.BindingsContext.GetProcAddress("glTestFenceNV");
                 return _TestFenceNV_fnptr(fence);
             }
             
@@ -33060,14 +33060,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _GetProgramNamedParameterdvNV_fnptr(id, len, name, parameters);
             }
             
-            private static delegate* unmanaged<uint, byte, void> _RasterSamplesEXT_fnptr = &RasterSamplesEXT_Lazy;
+            private static delegate* unmanaged<uint, bool, void> _RasterSamplesEXT_fnptr = &RasterSamplesEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_raster_multisample | GL_NV_framebuffer_mixed_samples]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void RasterSamplesEXT(uint samples, byte fixedsamplelocations) => _RasterSamplesEXT_fnptr(samples, fixedsamplelocations);
+            public static void RasterSamplesEXT(uint samples, bool fixedsamplelocations) => _RasterSamplesEXT_fnptr(samples, fixedsamplelocations);
             [UnmanagedCallersOnly]
-            private static void RasterSamplesEXT_Lazy(uint samples, byte fixedsamplelocations)
+            private static void RasterSamplesEXT_Lazy(uint samples, bool fixedsamplelocations)
             {
-                _RasterSamplesEXT_fnptr = (delegate* unmanaged<uint, byte, void>)GLLoader.BindingsContext.GetProcAddress("glRasterSamplesEXT");
+                _RasterSamplesEXT_fnptr = (delegate* unmanaged<uint, bool, void>)GLLoader.BindingsContext.GetProcAddress("glRasterSamplesEXT");
                 _RasterSamplesEXT_fnptr(samples, fixedsamplelocations);
             }
             
@@ -34435,47 +34435,47 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _NamedBufferAttachMemoryNV_fnptr(buffer, memory, offset);
             }
             
-            private static delegate* unmanaged<BufferStorageTarget, IntPtr, nint, uint, ulong, byte, void> _BufferPageCommitmentMemNV_fnptr = &BufferPageCommitmentMemNV_Lazy;
+            private static delegate* unmanaged<BufferStorageTarget, IntPtr, nint, uint, ulong, bool, void> _BufferPageCommitmentMemNV_fnptr = &BufferPageCommitmentMemNV_Lazy;
             /// <summary> <b>[requires: GL_NV_memory_object_sparse]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void BufferPageCommitmentMemNV(BufferStorageTarget target, IntPtr offset, nint size, uint memory, ulong memOffset, byte commit) => _BufferPageCommitmentMemNV_fnptr(target, offset, size, memory, memOffset, commit);
+            public static void BufferPageCommitmentMemNV(BufferStorageTarget target, IntPtr offset, nint size, uint memory, ulong memOffset, bool commit) => _BufferPageCommitmentMemNV_fnptr(target, offset, size, memory, memOffset, commit);
             [UnmanagedCallersOnly]
-            private static void BufferPageCommitmentMemNV_Lazy(BufferStorageTarget target, IntPtr offset, nint size, uint memory, ulong memOffset, byte commit)
+            private static void BufferPageCommitmentMemNV_Lazy(BufferStorageTarget target, IntPtr offset, nint size, uint memory, ulong memOffset, bool commit)
             {
-                _BufferPageCommitmentMemNV_fnptr = (delegate* unmanaged<BufferStorageTarget, IntPtr, nint, uint, ulong, byte, void>)GLLoader.BindingsContext.GetProcAddress("glBufferPageCommitmentMemNV");
+                _BufferPageCommitmentMemNV_fnptr = (delegate* unmanaged<BufferStorageTarget, IntPtr, nint, uint, ulong, bool, void>)GLLoader.BindingsContext.GetProcAddress("glBufferPageCommitmentMemNV");
                 _BufferPageCommitmentMemNV_fnptr(target, offset, size, memory, memOffset, commit);
             }
             
-            private static delegate* unmanaged<TextureTarget, int, int, int, int, int, int, int, int, uint, ulong, byte, void> _TexPageCommitmentMemNV_fnptr = &TexPageCommitmentMemNV_Lazy;
+            private static delegate* unmanaged<TextureTarget, int, int, int, int, int, int, int, int, uint, ulong, bool, void> _TexPageCommitmentMemNV_fnptr = &TexPageCommitmentMemNV_Lazy;
             /// <summary> <b>[requires: GL_NV_memory_object_sparse]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TexPageCommitmentMemNV(TextureTarget target, int layer, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, uint memory, ulong offset, byte commit) => _TexPageCommitmentMemNV_fnptr(target, layer, level, xoffset, yoffset, zoffset, width, height, depth, memory, offset, commit);
+            public static void TexPageCommitmentMemNV(TextureTarget target, int layer, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, uint memory, ulong offset, bool commit) => _TexPageCommitmentMemNV_fnptr(target, layer, level, xoffset, yoffset, zoffset, width, height, depth, memory, offset, commit);
             [UnmanagedCallersOnly]
-            private static void TexPageCommitmentMemNV_Lazy(TextureTarget target, int layer, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, uint memory, ulong offset, byte commit)
+            private static void TexPageCommitmentMemNV_Lazy(TextureTarget target, int layer, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, uint memory, ulong offset, bool commit)
             {
-                _TexPageCommitmentMemNV_fnptr = (delegate* unmanaged<TextureTarget, int, int, int, int, int, int, int, int, uint, ulong, byte, void>)GLLoader.BindingsContext.GetProcAddress("glTexPageCommitmentMemNV");
+                _TexPageCommitmentMemNV_fnptr = (delegate* unmanaged<TextureTarget, int, int, int, int, int, int, int, int, uint, ulong, bool, void>)GLLoader.BindingsContext.GetProcAddress("glTexPageCommitmentMemNV");
                 _TexPageCommitmentMemNV_fnptr(target, layer, level, xoffset, yoffset, zoffset, width, height, depth, memory, offset, commit);
             }
             
-            private static delegate* unmanaged<BufferHandle, IntPtr, nint, uint, ulong, byte, void> _NamedBufferPageCommitmentMemNV_fnptr = &NamedBufferPageCommitmentMemNV_Lazy;
+            private static delegate* unmanaged<BufferHandle, IntPtr, nint, uint, ulong, bool, void> _NamedBufferPageCommitmentMemNV_fnptr = &NamedBufferPageCommitmentMemNV_Lazy;
             /// <summary> <b>[requires: GL_NV_memory_object_sparse]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedBufferPageCommitmentMemNV(BufferHandle buffer, IntPtr offset, nint size, uint memory, ulong memOffset, byte commit) => _NamedBufferPageCommitmentMemNV_fnptr(buffer, offset, size, memory, memOffset, commit);
+            public static void NamedBufferPageCommitmentMemNV(BufferHandle buffer, IntPtr offset, nint size, uint memory, ulong memOffset, bool commit) => _NamedBufferPageCommitmentMemNV_fnptr(buffer, offset, size, memory, memOffset, commit);
             [UnmanagedCallersOnly]
-            private static void NamedBufferPageCommitmentMemNV_Lazy(BufferHandle buffer, IntPtr offset, nint size, uint memory, ulong memOffset, byte commit)
+            private static void NamedBufferPageCommitmentMemNV_Lazy(BufferHandle buffer, IntPtr offset, nint size, uint memory, ulong memOffset, bool commit)
             {
-                _NamedBufferPageCommitmentMemNV_fnptr = (delegate* unmanaged<BufferHandle, IntPtr, nint, uint, ulong, byte, void>)GLLoader.BindingsContext.GetProcAddress("glNamedBufferPageCommitmentMemNV");
+                _NamedBufferPageCommitmentMemNV_fnptr = (delegate* unmanaged<BufferHandle, IntPtr, nint, uint, ulong, bool, void>)GLLoader.BindingsContext.GetProcAddress("glNamedBufferPageCommitmentMemNV");
                 _NamedBufferPageCommitmentMemNV_fnptr(buffer, offset, size, memory, memOffset, commit);
             }
             
-            private static delegate* unmanaged<TextureHandle, int, int, int, int, int, int, int, int, uint, ulong, byte, void> _TexturePageCommitmentMemNV_fnptr = &TexturePageCommitmentMemNV_Lazy;
+            private static delegate* unmanaged<TextureHandle, int, int, int, int, int, int, int, int, uint, ulong, bool, void> _TexturePageCommitmentMemNV_fnptr = &TexturePageCommitmentMemNV_Lazy;
             /// <summary> <b>[requires: GL_NV_memory_object_sparse]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TexturePageCommitmentMemNV(TextureHandle texture, int layer, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, uint memory, ulong offset, byte commit) => _TexturePageCommitmentMemNV_fnptr(texture, layer, level, xoffset, yoffset, zoffset, width, height, depth, memory, offset, commit);
+            public static void TexturePageCommitmentMemNV(TextureHandle texture, int layer, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, uint memory, ulong offset, bool commit) => _TexturePageCommitmentMemNV_fnptr(texture, layer, level, xoffset, yoffset, zoffset, width, height, depth, memory, offset, commit);
             [UnmanagedCallersOnly]
-            private static void TexturePageCommitmentMemNV_Lazy(TextureHandle texture, int layer, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, uint memory, ulong offset, byte commit)
+            private static void TexturePageCommitmentMemNV_Lazy(TextureHandle texture, int layer, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, uint memory, ulong offset, bool commit)
             {
-                _TexturePageCommitmentMemNV_fnptr = (delegate* unmanaged<TextureHandle, int, int, int, int, int, int, int, int, uint, ulong, byte, void>)GLLoader.BindingsContext.GetProcAddress("glTexturePageCommitmentMemNV");
+                _TexturePageCommitmentMemNV_fnptr = (delegate* unmanaged<TextureHandle, int, int, int, int, int, int, int, int, uint, ulong, bool, void>)GLLoader.BindingsContext.GetProcAddress("glTexturePageCommitmentMemNV");
                 _TexturePageCommitmentMemNV_fnptr(texture, layer, level, xoffset, yoffset, zoffset, width, height, depth, memory, offset, commit);
             }
             
@@ -34545,14 +34545,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _DeleteOcclusionQueriesNV_fnptr(n, ids);
             }
             
-            private static delegate* unmanaged<uint, byte> _IsOcclusionQueryNV_fnptr = &IsOcclusionQueryNV_Lazy;
+            private static delegate* unmanaged<uint, bool> _IsOcclusionQueryNV_fnptr = &IsOcclusionQueryNV_Lazy;
             /// <summary> <b>[requires: GL_NV_occlusion_query]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsOcclusionQueryNV(uint id) => _IsOcclusionQueryNV_fnptr(id);
+            public static bool IsOcclusionQueryNV(uint id) => _IsOcclusionQueryNV_fnptr(id);
             [UnmanagedCallersOnly]
-            private static byte IsOcclusionQueryNV_Lazy(uint id)
+            private static bool IsOcclusionQueryNV_Lazy(uint id)
             {
-                _IsOcclusionQueryNV_fnptr = (delegate* unmanaged<uint, byte>)GLLoader.BindingsContext.GetProcAddress("glIsOcclusionQueryNV");
+                _IsOcclusionQueryNV_fnptr = (delegate* unmanaged<uint, bool>)GLLoader.BindingsContext.GetProcAddress("glIsOcclusionQueryNV");
                 return _IsOcclusionQueryNV_fnptr(id);
             }
             
@@ -34655,14 +34655,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _DeletePathsNV_fnptr(path, range);
             }
             
-            private static delegate* unmanaged<uint, byte> _IsPathNV_fnptr = &IsPathNV_Lazy;
+            private static delegate* unmanaged<uint, bool> _IsPathNV_fnptr = &IsPathNV_Lazy;
             /// <summary> <b>[requires: GL_NV_path_rendering]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsPathNV(uint path) => _IsPathNV_fnptr(path);
+            public static bool IsPathNV(uint path) => _IsPathNV_fnptr(path);
             [UnmanagedCallersOnly]
-            private static byte IsPathNV_Lazy(uint path)
+            private static bool IsPathNV_Lazy(uint path)
             {
-                _IsPathNV_fnptr = (delegate* unmanaged<uint, byte>)GLLoader.BindingsContext.GetProcAddress("glIsPathNV");
+                _IsPathNV_fnptr = (delegate* unmanaged<uint, bool>)GLLoader.BindingsContext.GetProcAddress("glIsPathNV");
                 return _IsPathNV_fnptr(path);
             }
             
@@ -35051,25 +35051,25 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _GetPathSpacingNV_fnptr(pathListMode, numPaths, pathNameType, paths, pathBase, advanceScale, kerningScale, transformType, returnedSpacing);
             }
             
-            private static delegate* unmanaged<uint, uint, float, float, byte> _IsPointInFillPathNV_fnptr = &IsPointInFillPathNV_Lazy;
+            private static delegate* unmanaged<uint, uint, float, float, bool> _IsPointInFillPathNV_fnptr = &IsPointInFillPathNV_Lazy;
             /// <summary> <b>[requires: GL_NV_path_rendering]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsPointInFillPathNV(uint path, uint mask, float x, float y) => _IsPointInFillPathNV_fnptr(path, mask, x, y);
+            public static bool IsPointInFillPathNV(uint path, uint mask, float x, float y) => _IsPointInFillPathNV_fnptr(path, mask, x, y);
             [UnmanagedCallersOnly]
-            private static byte IsPointInFillPathNV_Lazy(uint path, uint mask, float x, float y)
+            private static bool IsPointInFillPathNV_Lazy(uint path, uint mask, float x, float y)
             {
-                _IsPointInFillPathNV_fnptr = (delegate* unmanaged<uint, uint, float, float, byte>)GLLoader.BindingsContext.GetProcAddress("glIsPointInFillPathNV");
+                _IsPointInFillPathNV_fnptr = (delegate* unmanaged<uint, uint, float, float, bool>)GLLoader.BindingsContext.GetProcAddress("glIsPointInFillPathNV");
                 return _IsPointInFillPathNV_fnptr(path, mask, x, y);
             }
             
-            private static delegate* unmanaged<uint, float, float, byte> _IsPointInStrokePathNV_fnptr = &IsPointInStrokePathNV_Lazy;
+            private static delegate* unmanaged<uint, float, float, bool> _IsPointInStrokePathNV_fnptr = &IsPointInStrokePathNV_Lazy;
             /// <summary> <b>[requires: GL_NV_path_rendering]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsPointInStrokePathNV(uint path, float x, float y) => _IsPointInStrokePathNV_fnptr(path, x, y);
+            public static bool IsPointInStrokePathNV(uint path, float x, float y) => _IsPointInStrokePathNV_fnptr(path, x, y);
             [UnmanagedCallersOnly]
-            private static byte IsPointInStrokePathNV_Lazy(uint path, float x, float y)
+            private static bool IsPointInStrokePathNV_Lazy(uint path, float x, float y)
             {
-                _IsPointInStrokePathNV_fnptr = (delegate* unmanaged<uint, float, float, byte>)GLLoader.BindingsContext.GetProcAddress("glIsPointInStrokePathNV");
+                _IsPointInStrokePathNV_fnptr = (delegate* unmanaged<uint, float, float, bool>)GLLoader.BindingsContext.GetProcAddress("glIsPointInStrokePathNV");
                 return _IsPointInStrokePathNV_fnptr(path, x, y);
             }
             
@@ -35084,14 +35084,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return _GetPathLengthNV_fnptr(path, startSegment, numSegments);
             }
             
-            private static delegate* unmanaged<uint, int, int, float, float*, float*, float*, float*, byte> _PointAlongPathNV_fnptr = &PointAlongPathNV_Lazy;
+            private static delegate* unmanaged<uint, int, int, float, float*, float*, float*, float*, bool> _PointAlongPathNV_fnptr = &PointAlongPathNV_Lazy;
             /// <summary> <b>[requires: GL_NV_path_rendering]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte PointAlongPathNV(uint path, int startSegment, int numSegments, float distance, float* x, float* y, float* tangentX, float* tangentY) => _PointAlongPathNV_fnptr(path, startSegment, numSegments, distance, x, y, tangentX, tangentY);
+            public static bool PointAlongPathNV(uint path, int startSegment, int numSegments, float distance, float* x, float* y, float* tangentX, float* tangentY) => _PointAlongPathNV_fnptr(path, startSegment, numSegments, distance, x, y, tangentX, tangentY);
             [UnmanagedCallersOnly]
-            private static byte PointAlongPathNV_Lazy(uint path, int startSegment, int numSegments, float distance, float* x, float* y, float* tangentX, float* tangentY)
+            private static bool PointAlongPathNV_Lazy(uint path, int startSegment, int numSegments, float distance, float* x, float* y, float* tangentX, float* tangentY)
             {
-                _PointAlongPathNV_fnptr = (delegate* unmanaged<uint, int, int, float, float*, float*, float*, float*, byte>)GLLoader.BindingsContext.GetProcAddress("glPointAlongPathNV");
+                _PointAlongPathNV_fnptr = (delegate* unmanaged<uint, int, int, float, float*, float*, float*, float*, bool>)GLLoader.BindingsContext.GetProcAddress("glPointAlongPathNV");
                 return _PointAlongPathNV_fnptr(path, startSegment, numSegments, distance, x, y, tangentX, tangentY);
             }
             
@@ -35777,14 +35777,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _CombinerInputNV_fnptr(stage, portion, variable, input, mapping, componentUsage);
             }
             
-            private static delegate* unmanaged<CombinerStageNV, CombinerPortionNV, CombinerRegisterNV, CombinerRegisterNV, CombinerRegisterNV, CombinerScaleNV, CombinerBiasNV, byte, byte, byte, void> _CombinerOutputNV_fnptr = &CombinerOutputNV_Lazy;
+            private static delegate* unmanaged<CombinerStageNV, CombinerPortionNV, CombinerRegisterNV, CombinerRegisterNV, CombinerRegisterNV, CombinerScaleNV, CombinerBiasNV, bool, bool, bool, void> _CombinerOutputNV_fnptr = &CombinerOutputNV_Lazy;
             /// <summary> <b>[requires: GL_NV_register_combiners]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void CombinerOutputNV(CombinerStageNV stage, CombinerPortionNV portion, CombinerRegisterNV abOutput, CombinerRegisterNV cdOutput, CombinerRegisterNV sumOutput, CombinerScaleNV scale, CombinerBiasNV bias, byte abDotProduct, byte cdDotProduct, byte muxSum) => _CombinerOutputNV_fnptr(stage, portion, abOutput, cdOutput, sumOutput, scale, bias, abDotProduct, cdDotProduct, muxSum);
+            public static void CombinerOutputNV(CombinerStageNV stage, CombinerPortionNV portion, CombinerRegisterNV abOutput, CombinerRegisterNV cdOutput, CombinerRegisterNV sumOutput, CombinerScaleNV scale, CombinerBiasNV bias, bool abDotProduct, bool cdDotProduct, bool muxSum) => _CombinerOutputNV_fnptr(stage, portion, abOutput, cdOutput, sumOutput, scale, bias, abDotProduct, cdDotProduct, muxSum);
             [UnmanagedCallersOnly]
-            private static void CombinerOutputNV_Lazy(CombinerStageNV stage, CombinerPortionNV portion, CombinerRegisterNV abOutput, CombinerRegisterNV cdOutput, CombinerRegisterNV sumOutput, CombinerScaleNV scale, CombinerBiasNV bias, byte abDotProduct, byte cdDotProduct, byte muxSum)
+            private static void CombinerOutputNV_Lazy(CombinerStageNV stage, CombinerPortionNV portion, CombinerRegisterNV abOutput, CombinerRegisterNV cdOutput, CombinerRegisterNV sumOutput, CombinerScaleNV scale, CombinerBiasNV bias, bool abDotProduct, bool cdDotProduct, bool muxSum)
             {
-                _CombinerOutputNV_fnptr = (delegate* unmanaged<CombinerStageNV, CombinerPortionNV, CombinerRegisterNV, CombinerRegisterNV, CombinerRegisterNV, CombinerScaleNV, CombinerBiasNV, byte, byte, byte, void>)GLLoader.BindingsContext.GetProcAddress("glCombinerOutputNV");
+                _CombinerOutputNV_fnptr = (delegate* unmanaged<CombinerStageNV, CombinerPortionNV, CombinerRegisterNV, CombinerRegisterNV, CombinerRegisterNV, CombinerScaleNV, CombinerBiasNV, bool, bool, bool, void>)GLLoader.BindingsContext.GetProcAddress("glCombinerOutputNV");
                 _CombinerOutputNV_fnptr(stage, portion, abOutput, cdOutput, sumOutput, scale, bias, abDotProduct, cdDotProduct, muxSum);
             }
             
@@ -35964,14 +35964,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _MakeBufferNonResidentNV_fnptr(target);
             }
             
-            private static delegate* unmanaged<All, byte> _IsBufferResidentNV_fnptr = &IsBufferResidentNV_Lazy;
+            private static delegate* unmanaged<All, bool> _IsBufferResidentNV_fnptr = &IsBufferResidentNV_Lazy;
             /// <summary> <b>[requires: GL_NV_shader_buffer_load]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsBufferResidentNV(All target) => _IsBufferResidentNV_fnptr(target);
+            public static bool IsBufferResidentNV(All target) => _IsBufferResidentNV_fnptr(target);
             [UnmanagedCallersOnly]
-            private static byte IsBufferResidentNV_Lazy(All target)
+            private static bool IsBufferResidentNV_Lazy(All target)
             {
-                _IsBufferResidentNV_fnptr = (delegate* unmanaged<All, byte>)GLLoader.BindingsContext.GetProcAddress("glIsBufferResidentNV");
+                _IsBufferResidentNV_fnptr = (delegate* unmanaged<All, bool>)GLLoader.BindingsContext.GetProcAddress("glIsBufferResidentNV");
                 return _IsBufferResidentNV_fnptr(target);
             }
             
@@ -35997,14 +35997,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _MakeNamedBufferNonResidentNV_fnptr(buffer);
             }
             
-            private static delegate* unmanaged<BufferHandle, byte> _IsNamedBufferResidentNV_fnptr = &IsNamedBufferResidentNV_Lazy;
+            private static delegate* unmanaged<BufferHandle, bool> _IsNamedBufferResidentNV_fnptr = &IsNamedBufferResidentNV_Lazy;
             /// <summary> <b>[requires: GL_NV_shader_buffer_load]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsNamedBufferResidentNV(BufferHandle buffer) => _IsNamedBufferResidentNV_fnptr(buffer);
+            public static bool IsNamedBufferResidentNV(BufferHandle buffer) => _IsNamedBufferResidentNV_fnptr(buffer);
             [UnmanagedCallersOnly]
-            private static byte IsNamedBufferResidentNV_Lazy(BufferHandle buffer)
+            private static bool IsNamedBufferResidentNV_Lazy(BufferHandle buffer)
             {
-                _IsNamedBufferResidentNV_fnptr = (delegate* unmanaged<BufferHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsNamedBufferResidentNV");
+                _IsNamedBufferResidentNV_fnptr = (delegate* unmanaged<BufferHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsNamedBufferResidentNV");
                 return _IsNamedBufferResidentNV_fnptr(buffer);
             }
             
@@ -36129,14 +36129,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _GetShadingRateSampleLocationivNV_fnptr(rate, samples, index, location);
             }
             
-            private static delegate* unmanaged<byte, void> _ShadingRateImageBarrierNV_fnptr = &ShadingRateImageBarrierNV_Lazy;
+            private static delegate* unmanaged<bool, void> _ShadingRateImageBarrierNV_fnptr = &ShadingRateImageBarrierNV_Lazy;
             /// <summary> <b>[requires: GL_NV_shading_rate_image]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ShadingRateImageBarrierNV(byte synchronize) => _ShadingRateImageBarrierNV_fnptr(synchronize);
+            public static void ShadingRateImageBarrierNV(bool synchronize) => _ShadingRateImageBarrierNV_fnptr(synchronize);
             [UnmanagedCallersOnly]
-            private static void ShadingRateImageBarrierNV_Lazy(byte synchronize)
+            private static void ShadingRateImageBarrierNV_Lazy(bool synchronize)
             {
-                _ShadingRateImageBarrierNV_fnptr = (delegate* unmanaged<byte, void>)GLLoader.BindingsContext.GetProcAddress("glShadingRateImageBarrierNV");
+                _ShadingRateImageBarrierNV_fnptr = (delegate* unmanaged<bool, void>)GLLoader.BindingsContext.GetProcAddress("glShadingRateImageBarrierNV");
                 _ShadingRateImageBarrierNV_fnptr(synchronize);
             }
             
@@ -36184,69 +36184,69 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _TextureBarrierNV_fnptr();
             }
             
-            private static delegate* unmanaged<TextureTarget, int, int, int, int, int, byte, void> _TexImage2DMultisampleCoverageNV_fnptr = &TexImage2DMultisampleCoverageNV_Lazy;
+            private static delegate* unmanaged<TextureTarget, int, int, int, int, int, bool, void> _TexImage2DMultisampleCoverageNV_fnptr = &TexImage2DMultisampleCoverageNV_Lazy;
             /// <summary> <b>[requires: GL_NV_texture_multisample]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TexImage2DMultisampleCoverageNV(TextureTarget target, int coverageSamples, int colorSamples, int internalFormat, int width, int height, byte fixedSampleLocations) => _TexImage2DMultisampleCoverageNV_fnptr(target, coverageSamples, colorSamples, internalFormat, width, height, fixedSampleLocations);
+            public static void TexImage2DMultisampleCoverageNV(TextureTarget target, int coverageSamples, int colorSamples, int internalFormat, int width, int height, bool fixedSampleLocations) => _TexImage2DMultisampleCoverageNV_fnptr(target, coverageSamples, colorSamples, internalFormat, width, height, fixedSampleLocations);
             [UnmanagedCallersOnly]
-            private static void TexImage2DMultisampleCoverageNV_Lazy(TextureTarget target, int coverageSamples, int colorSamples, int internalFormat, int width, int height, byte fixedSampleLocations)
+            private static void TexImage2DMultisampleCoverageNV_Lazy(TextureTarget target, int coverageSamples, int colorSamples, int internalFormat, int width, int height, bool fixedSampleLocations)
             {
-                _TexImage2DMultisampleCoverageNV_fnptr = (delegate* unmanaged<TextureTarget, int, int, int, int, int, byte, void>)GLLoader.BindingsContext.GetProcAddress("glTexImage2DMultisampleCoverageNV");
+                _TexImage2DMultisampleCoverageNV_fnptr = (delegate* unmanaged<TextureTarget, int, int, int, int, int, bool, void>)GLLoader.BindingsContext.GetProcAddress("glTexImage2DMultisampleCoverageNV");
                 _TexImage2DMultisampleCoverageNV_fnptr(target, coverageSamples, colorSamples, internalFormat, width, height, fixedSampleLocations);
             }
             
-            private static delegate* unmanaged<TextureTarget, int, int, int, int, int, int, byte, void> _TexImage3DMultisampleCoverageNV_fnptr = &TexImage3DMultisampleCoverageNV_Lazy;
+            private static delegate* unmanaged<TextureTarget, int, int, int, int, int, int, bool, void> _TexImage3DMultisampleCoverageNV_fnptr = &TexImage3DMultisampleCoverageNV_Lazy;
             /// <summary> <b>[requires: GL_NV_texture_multisample]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TexImage3DMultisampleCoverageNV(TextureTarget target, int coverageSamples, int colorSamples, int internalFormat, int width, int height, int depth, byte fixedSampleLocations) => _TexImage3DMultisampleCoverageNV_fnptr(target, coverageSamples, colorSamples, internalFormat, width, height, depth, fixedSampleLocations);
+            public static void TexImage3DMultisampleCoverageNV(TextureTarget target, int coverageSamples, int colorSamples, int internalFormat, int width, int height, int depth, bool fixedSampleLocations) => _TexImage3DMultisampleCoverageNV_fnptr(target, coverageSamples, colorSamples, internalFormat, width, height, depth, fixedSampleLocations);
             [UnmanagedCallersOnly]
-            private static void TexImage3DMultisampleCoverageNV_Lazy(TextureTarget target, int coverageSamples, int colorSamples, int internalFormat, int width, int height, int depth, byte fixedSampleLocations)
+            private static void TexImage3DMultisampleCoverageNV_Lazy(TextureTarget target, int coverageSamples, int colorSamples, int internalFormat, int width, int height, int depth, bool fixedSampleLocations)
             {
-                _TexImage3DMultisampleCoverageNV_fnptr = (delegate* unmanaged<TextureTarget, int, int, int, int, int, int, byte, void>)GLLoader.BindingsContext.GetProcAddress("glTexImage3DMultisampleCoverageNV");
+                _TexImage3DMultisampleCoverageNV_fnptr = (delegate* unmanaged<TextureTarget, int, int, int, int, int, int, bool, void>)GLLoader.BindingsContext.GetProcAddress("glTexImage3DMultisampleCoverageNV");
                 _TexImage3DMultisampleCoverageNV_fnptr(target, coverageSamples, colorSamples, internalFormat, width, height, depth, fixedSampleLocations);
             }
             
-            private static delegate* unmanaged<TextureHandle, TextureTarget, int, int, int, int, byte, void> _TextureImage2DMultisampleNV_fnptr = &TextureImage2DMultisampleNV_Lazy;
+            private static delegate* unmanaged<TextureHandle, TextureTarget, int, int, int, int, bool, void> _TextureImage2DMultisampleNV_fnptr = &TextureImage2DMultisampleNV_Lazy;
             /// <summary> <b>[requires: GL_NV_texture_multisample]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureImage2DMultisampleNV(TextureHandle texture, TextureTarget target, int samples, int internalFormat, int width, int height, byte fixedSampleLocations) => _TextureImage2DMultisampleNV_fnptr(texture, target, samples, internalFormat, width, height, fixedSampleLocations);
+            public static void TextureImage2DMultisampleNV(TextureHandle texture, TextureTarget target, int samples, int internalFormat, int width, int height, bool fixedSampleLocations) => _TextureImage2DMultisampleNV_fnptr(texture, target, samples, internalFormat, width, height, fixedSampleLocations);
             [UnmanagedCallersOnly]
-            private static void TextureImage2DMultisampleNV_Lazy(TextureHandle texture, TextureTarget target, int samples, int internalFormat, int width, int height, byte fixedSampleLocations)
+            private static void TextureImage2DMultisampleNV_Lazy(TextureHandle texture, TextureTarget target, int samples, int internalFormat, int width, int height, bool fixedSampleLocations)
             {
-                _TextureImage2DMultisampleNV_fnptr = (delegate* unmanaged<TextureHandle, TextureTarget, int, int, int, int, byte, void>)GLLoader.BindingsContext.GetProcAddress("glTextureImage2DMultisampleNV");
+                _TextureImage2DMultisampleNV_fnptr = (delegate* unmanaged<TextureHandle, TextureTarget, int, int, int, int, bool, void>)GLLoader.BindingsContext.GetProcAddress("glTextureImage2DMultisampleNV");
                 _TextureImage2DMultisampleNV_fnptr(texture, target, samples, internalFormat, width, height, fixedSampleLocations);
             }
             
-            private static delegate* unmanaged<TextureHandle, TextureTarget, int, int, int, int, int, byte, void> _TextureImage3DMultisampleNV_fnptr = &TextureImage3DMultisampleNV_Lazy;
+            private static delegate* unmanaged<TextureHandle, TextureTarget, int, int, int, int, int, bool, void> _TextureImage3DMultisampleNV_fnptr = &TextureImage3DMultisampleNV_Lazy;
             /// <summary> <b>[requires: GL_NV_texture_multisample]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureImage3DMultisampleNV(TextureHandle texture, TextureTarget target, int samples, int internalFormat, int width, int height, int depth, byte fixedSampleLocations) => _TextureImage3DMultisampleNV_fnptr(texture, target, samples, internalFormat, width, height, depth, fixedSampleLocations);
+            public static void TextureImage3DMultisampleNV(TextureHandle texture, TextureTarget target, int samples, int internalFormat, int width, int height, int depth, bool fixedSampleLocations) => _TextureImage3DMultisampleNV_fnptr(texture, target, samples, internalFormat, width, height, depth, fixedSampleLocations);
             [UnmanagedCallersOnly]
-            private static void TextureImage3DMultisampleNV_Lazy(TextureHandle texture, TextureTarget target, int samples, int internalFormat, int width, int height, int depth, byte fixedSampleLocations)
+            private static void TextureImage3DMultisampleNV_Lazy(TextureHandle texture, TextureTarget target, int samples, int internalFormat, int width, int height, int depth, bool fixedSampleLocations)
             {
-                _TextureImage3DMultisampleNV_fnptr = (delegate* unmanaged<TextureHandle, TextureTarget, int, int, int, int, int, byte, void>)GLLoader.BindingsContext.GetProcAddress("glTextureImage3DMultisampleNV");
+                _TextureImage3DMultisampleNV_fnptr = (delegate* unmanaged<TextureHandle, TextureTarget, int, int, int, int, int, bool, void>)GLLoader.BindingsContext.GetProcAddress("glTextureImage3DMultisampleNV");
                 _TextureImage3DMultisampleNV_fnptr(texture, target, samples, internalFormat, width, height, depth, fixedSampleLocations);
             }
             
-            private static delegate* unmanaged<TextureHandle, TextureTarget, int, int, int, int, int, byte, void> _TextureImage2DMultisampleCoverageNV_fnptr = &TextureImage2DMultisampleCoverageNV_Lazy;
+            private static delegate* unmanaged<TextureHandle, TextureTarget, int, int, int, int, int, bool, void> _TextureImage2DMultisampleCoverageNV_fnptr = &TextureImage2DMultisampleCoverageNV_Lazy;
             /// <summary> <b>[requires: GL_NV_texture_multisample]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureImage2DMultisampleCoverageNV(TextureHandle texture, TextureTarget target, int coverageSamples, int colorSamples, int internalFormat, int width, int height, byte fixedSampleLocations) => _TextureImage2DMultisampleCoverageNV_fnptr(texture, target, coverageSamples, colorSamples, internalFormat, width, height, fixedSampleLocations);
+            public static void TextureImage2DMultisampleCoverageNV(TextureHandle texture, TextureTarget target, int coverageSamples, int colorSamples, int internalFormat, int width, int height, bool fixedSampleLocations) => _TextureImage2DMultisampleCoverageNV_fnptr(texture, target, coverageSamples, colorSamples, internalFormat, width, height, fixedSampleLocations);
             [UnmanagedCallersOnly]
-            private static void TextureImage2DMultisampleCoverageNV_Lazy(TextureHandle texture, TextureTarget target, int coverageSamples, int colorSamples, int internalFormat, int width, int height, byte fixedSampleLocations)
+            private static void TextureImage2DMultisampleCoverageNV_Lazy(TextureHandle texture, TextureTarget target, int coverageSamples, int colorSamples, int internalFormat, int width, int height, bool fixedSampleLocations)
             {
-                _TextureImage2DMultisampleCoverageNV_fnptr = (delegate* unmanaged<TextureHandle, TextureTarget, int, int, int, int, int, byte, void>)GLLoader.BindingsContext.GetProcAddress("glTextureImage2DMultisampleCoverageNV");
+                _TextureImage2DMultisampleCoverageNV_fnptr = (delegate* unmanaged<TextureHandle, TextureTarget, int, int, int, int, int, bool, void>)GLLoader.BindingsContext.GetProcAddress("glTextureImage2DMultisampleCoverageNV");
                 _TextureImage2DMultisampleCoverageNV_fnptr(texture, target, coverageSamples, colorSamples, internalFormat, width, height, fixedSampleLocations);
             }
             
-            private static delegate* unmanaged<TextureHandle, TextureTarget, int, int, int, int, int, int, byte, void> _TextureImage3DMultisampleCoverageNV_fnptr = &TextureImage3DMultisampleCoverageNV_Lazy;
+            private static delegate* unmanaged<TextureHandle, TextureTarget, int, int, int, int, int, int, bool, void> _TextureImage3DMultisampleCoverageNV_fnptr = &TextureImage3DMultisampleCoverageNV_Lazy;
             /// <summary> <b>[requires: GL_NV_texture_multisample]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureImage3DMultisampleCoverageNV(TextureHandle texture, TextureTarget target, int coverageSamples, int colorSamples, int internalFormat, int width, int height, int depth, byte fixedSampleLocations) => _TextureImage3DMultisampleCoverageNV_fnptr(texture, target, coverageSamples, colorSamples, internalFormat, width, height, depth, fixedSampleLocations);
+            public static void TextureImage3DMultisampleCoverageNV(TextureHandle texture, TextureTarget target, int coverageSamples, int colorSamples, int internalFormat, int width, int height, int depth, bool fixedSampleLocations) => _TextureImage3DMultisampleCoverageNV_fnptr(texture, target, coverageSamples, colorSamples, internalFormat, width, height, depth, fixedSampleLocations);
             [UnmanagedCallersOnly]
-            private static void TextureImage3DMultisampleCoverageNV_Lazy(TextureHandle texture, TextureTarget target, int coverageSamples, int colorSamples, int internalFormat, int width, int height, int depth, byte fixedSampleLocations)
+            private static void TextureImage3DMultisampleCoverageNV_Lazy(TextureHandle texture, TextureTarget target, int coverageSamples, int colorSamples, int internalFormat, int width, int height, int depth, bool fixedSampleLocations)
             {
-                _TextureImage3DMultisampleCoverageNV_fnptr = (delegate* unmanaged<TextureHandle, TextureTarget, int, int, int, int, int, int, byte, void>)GLLoader.BindingsContext.GetProcAddress("glTextureImage3DMultisampleCoverageNV");
+                _TextureImage3DMultisampleCoverageNV_fnptr = (delegate* unmanaged<TextureHandle, TextureTarget, int, int, int, int, int, int, bool, void>)GLLoader.BindingsContext.GetProcAddress("glTextureImage3DMultisampleCoverageNV");
                 _TextureImage3DMultisampleCoverageNV_fnptr(texture, target, coverageSamples, colorSamples, internalFormat, width, height, depth, fixedSampleLocations);
             }
             
@@ -36415,14 +36415,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _GenTransformFeedbacksNV_fnptr(n, ids);
             }
             
-            private static delegate* unmanaged<TransformFeedbackHandle, byte> _IsTransformFeedbackNV_fnptr = &IsTransformFeedbackNV_Lazy;
+            private static delegate* unmanaged<TransformFeedbackHandle, bool> _IsTransformFeedbackNV_fnptr = &IsTransformFeedbackNV_Lazy;
             /// <summary> <b>[requires: GL_NV_transform_feedback2]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsTransformFeedbackNV(TransformFeedbackHandle id) => _IsTransformFeedbackNV_fnptr(id);
+            public static bool IsTransformFeedbackNV(TransformFeedbackHandle id) => _IsTransformFeedbackNV_fnptr(id);
             [UnmanagedCallersOnly]
-            private static byte IsTransformFeedbackNV_Lazy(TransformFeedbackHandle id)
+            private static bool IsTransformFeedbackNV_Lazy(TransformFeedbackHandle id)
             {
-                _IsTransformFeedbackNV_fnptr = (delegate* unmanaged<TransformFeedbackHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsTransformFeedbackNV");
+                _IsTransformFeedbackNV_fnptr = (delegate* unmanaged<TransformFeedbackHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsTransformFeedbackNV");
                 return _IsTransformFeedbackNV_fnptr(id);
             }
             
@@ -36503,14 +36503,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return _VDPAURegisterOutputSurfaceNV_fnptr(vdpSurface, target, numTextureNames, textureNames);
             }
             
-            private static delegate* unmanaged<IntPtr, byte> _VDPAUIsSurfaceNV_fnptr = &VDPAUIsSurfaceNV_Lazy;
+            private static delegate* unmanaged<IntPtr, bool> _VDPAUIsSurfaceNV_fnptr = &VDPAUIsSurfaceNV_Lazy;
             /// <summary> <b>[requires: GL_NV_vdpau_interop]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte VDPAUIsSurfaceNV(IntPtr surface) => _VDPAUIsSurfaceNV_fnptr(surface);
+            public static bool VDPAUIsSurfaceNV(IntPtr surface) => _VDPAUIsSurfaceNV_fnptr(surface);
             [UnmanagedCallersOnly]
-            private static byte VDPAUIsSurfaceNV_Lazy(IntPtr surface)
+            private static bool VDPAUIsSurfaceNV_Lazy(IntPtr surface)
             {
-                _VDPAUIsSurfaceNV_fnptr = (delegate* unmanaged<IntPtr, byte>)GLLoader.BindingsContext.GetProcAddress("glVDPAUIsSurfaceNV");
+                _VDPAUIsSurfaceNV_fnptr = (delegate* unmanaged<IntPtr, bool>)GLLoader.BindingsContext.GetProcAddress("glVDPAUIsSurfaceNV");
                 return _VDPAUIsSurfaceNV_fnptr(surface);
             }
             
@@ -36569,14 +36569,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _VDPAUUnmapSurfacesNV_fnptr(numSurface, surfaces);
             }
             
-            private static delegate* unmanaged<void*, All, int, uint*, byte, IntPtr> _VDPAURegisterVideoSurfaceWithPictureStructureNV_fnptr = &VDPAURegisterVideoSurfaceWithPictureStructureNV_Lazy;
+            private static delegate* unmanaged<void*, All, int, uint*, bool, IntPtr> _VDPAURegisterVideoSurfaceWithPictureStructureNV_fnptr = &VDPAURegisterVideoSurfaceWithPictureStructureNV_Lazy;
             /// <summary> <b>[requires: GL_NV_vdpau_interop2]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static IntPtr VDPAURegisterVideoSurfaceWithPictureStructureNV(void* vdpSurface, All target, int numTextureNames, uint* textureNames, byte isFrameStructure) => _VDPAURegisterVideoSurfaceWithPictureStructureNV_fnptr(vdpSurface, target, numTextureNames, textureNames, isFrameStructure);
+            public static IntPtr VDPAURegisterVideoSurfaceWithPictureStructureNV(void* vdpSurface, All target, int numTextureNames, uint* textureNames, bool isFrameStructure) => _VDPAURegisterVideoSurfaceWithPictureStructureNV_fnptr(vdpSurface, target, numTextureNames, textureNames, isFrameStructure);
             [UnmanagedCallersOnly]
-            private static IntPtr VDPAURegisterVideoSurfaceWithPictureStructureNV_Lazy(void* vdpSurface, All target, int numTextureNames, uint* textureNames, byte isFrameStructure)
+            private static IntPtr VDPAURegisterVideoSurfaceWithPictureStructureNV_Lazy(void* vdpSurface, All target, int numTextureNames, uint* textureNames, bool isFrameStructure)
             {
-                _VDPAURegisterVideoSurfaceWithPictureStructureNV_fnptr = (delegate* unmanaged<void*, All, int, uint*, byte, IntPtr>)GLLoader.BindingsContext.GetProcAddress("glVDPAURegisterVideoSurfaceWithPictureStructureNV");
+                _VDPAURegisterVideoSurfaceWithPictureStructureNV_fnptr = (delegate* unmanaged<void*, All, int, uint*, bool, IntPtr>)GLLoader.BindingsContext.GetProcAddress("glVDPAURegisterVideoSurfaceWithPictureStructureNV");
                 return _VDPAURegisterVideoSurfaceWithPictureStructureNV_fnptr(vdpSurface, target, numTextureNames, textureNames, isFrameStructure);
             }
             
@@ -36910,14 +36910,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _FogCoordFormatNV_fnptr(type, stride);
             }
             
-            private static delegate* unmanaged<uint, int, VertexAttribType, byte, int, void> _VertexAttribFormatNV_fnptr = &VertexAttribFormatNV_Lazy;
+            private static delegate* unmanaged<uint, int, VertexAttribType, bool, int, void> _VertexAttribFormatNV_fnptr = &VertexAttribFormatNV_Lazy;
             /// <summary> <b>[requires: GL_NV_vertex_buffer_unified_memory]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void VertexAttribFormatNV(uint index, int size, VertexAttribType type, byte normalized, int stride) => _VertexAttribFormatNV_fnptr(index, size, type, normalized, stride);
+            public static void VertexAttribFormatNV(uint index, int size, VertexAttribType type, bool normalized, int stride) => _VertexAttribFormatNV_fnptr(index, size, type, normalized, stride);
             [UnmanagedCallersOnly]
-            private static void VertexAttribFormatNV_Lazy(uint index, int size, VertexAttribType type, byte normalized, int stride)
+            private static void VertexAttribFormatNV_Lazy(uint index, int size, VertexAttribType type, bool normalized, int stride)
             {
-                _VertexAttribFormatNV_fnptr = (delegate* unmanaged<uint, int, VertexAttribType, byte, int, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribFormatNV");
+                _VertexAttribFormatNV_fnptr = (delegate* unmanaged<uint, int, VertexAttribType, bool, int, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribFormatNV");
                 _VertexAttribFormatNV_fnptr(index, size, type, normalized, stride);
             }
             
@@ -36943,14 +36943,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _GetIntegerui64i_vNV_fnptr(value, index, result);
             }
             
-            private static delegate* unmanaged<int, ProgramHandle*, byte*, byte> _AreProgramsResidentNV_fnptr = &AreProgramsResidentNV_Lazy;
+            private static delegate* unmanaged<int, ProgramHandle*, bool*, bool> _AreProgramsResidentNV_fnptr = &AreProgramsResidentNV_Lazy;
             /// <summary> <b>[requires: GL_NV_vertex_program]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte AreProgramsResidentNV(int n, ProgramHandle* programs, byte* residences) => _AreProgramsResidentNV_fnptr(n, programs, residences);
+            public static bool AreProgramsResidentNV(int n, ProgramHandle* programs, bool* residences) => _AreProgramsResidentNV_fnptr(n, programs, residences);
             [UnmanagedCallersOnly]
-            private static byte AreProgramsResidentNV_Lazy(int n, ProgramHandle* programs, byte* residences)
+            private static bool AreProgramsResidentNV_Lazy(int n, ProgramHandle* programs, bool* residences)
             {
-                _AreProgramsResidentNV_fnptr = (delegate* unmanaged<int, ProgramHandle*, byte*, byte>)GLLoader.BindingsContext.GetProcAddress("glAreProgramsResidentNV");
+                _AreProgramsResidentNV_fnptr = (delegate* unmanaged<int, ProgramHandle*, bool*, bool>)GLLoader.BindingsContext.GetProcAddress("glAreProgramsResidentNV");
                 return _AreProgramsResidentNV_fnptr(n, programs, residences);
             }
             
@@ -37097,14 +37097,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _GetVertexAttribPointervNV_fnptr(index, pname, pointer);
             }
             
-            private static delegate* unmanaged<ProgramHandle, byte> _IsProgramNV_fnptr = &IsProgramNV_Lazy;
+            private static delegate* unmanaged<ProgramHandle, bool> _IsProgramNV_fnptr = &IsProgramNV_Lazy;
             /// <summary> <b>[requires: GL_NV_vertex_program]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsProgramNV(ProgramHandle id) => _IsProgramNV_fnptr(id);
+            public static bool IsProgramNV(ProgramHandle id) => _IsProgramNV_fnptr(id);
             [UnmanagedCallersOnly]
-            private static byte IsProgramNV_Lazy(ProgramHandle id)
+            private static bool IsProgramNV_Lazy(ProgramHandle id)
             {
-                _IsProgramNV_fnptr = (delegate* unmanaged<ProgramHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsProgramNV");
+                _IsProgramNV_fnptr = (delegate* unmanaged<ProgramHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsProgramNV");
                 return _IsProgramNV_fnptr(id);
             }
             
@@ -38195,14 +38195,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _SecondaryColorPointerListIBM_fnptr(size, type, stride, pointer, ptrstride);
             }
             
-            private static delegate* unmanaged<int, byte**, int, void> _EdgeFlagPointerListIBM_fnptr = &EdgeFlagPointerListIBM_Lazy;
+            private static delegate* unmanaged<int, bool**, int, void> _EdgeFlagPointerListIBM_fnptr = &EdgeFlagPointerListIBM_Lazy;
             /// <summary> <b>[requires: GL_IBM_vertex_array_lists]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void EdgeFlagPointerListIBM(int stride, byte** pointer, int ptrstride) => _EdgeFlagPointerListIBM_fnptr(stride, pointer, ptrstride);
+            public static void EdgeFlagPointerListIBM(int stride, bool** pointer, int ptrstride) => _EdgeFlagPointerListIBM_fnptr(stride, pointer, ptrstride);
             [UnmanagedCallersOnly]
-            private static void EdgeFlagPointerListIBM_Lazy(int stride, byte** pointer, int ptrstride)
+            private static void EdgeFlagPointerListIBM_Lazy(int stride, bool** pointer, int ptrstride)
             {
-                _EdgeFlagPointerListIBM_fnptr = (delegate* unmanaged<int, byte**, int, void>)GLLoader.BindingsContext.GetProcAddress("glEdgeFlagPointerListIBM");
+                _EdgeFlagPointerListIBM_fnptr = (delegate* unmanaged<int, bool**, int, void>)GLLoader.BindingsContext.GetProcAddress("glEdgeFlagPointerListIBM");
                 _EdgeFlagPointerListIBM_fnptr(stride, pointer, ptrstride);
             }
             
@@ -38490,7 +38490,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _BlendBarrierKHR_fnptr();
             }
             
-            private static delegate* unmanaged<DebugSource, DebugType, DebugSeverity, int, uint*, byte, void> _DebugMessageControl_fnptr = &DebugMessageControl_Lazy;
+            private static delegate* unmanaged<DebugSource, DebugType, DebugSeverity, int, uint*, bool, void> _DebugMessageControl_fnptr = &DebugMessageControl_Lazy;
             /// <summary> <b>[requires: v4.3 | GL_KHR_debug]</b> Control the reporting of debug messages in a debug context. </summary>
             /// <param name="source"> The source of debug messages to enable or disable. </param>
             /// <param name="type"> The type of debug messages to enable or disable. </param>
@@ -38499,11 +38499,11 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="ids"> The address of an array of unsigned integers contianing the ids of the messages to enable or disable. </param>
             /// <param name="enabled"> A Boolean flag determining whether the selected messages should be enabled or disabled. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDebugMessageControl.xhtml" /></remarks>
-            public static void DebugMessageControl(DebugSource source, DebugType type, DebugSeverity severity, int count, uint* ids, byte enabled) => _DebugMessageControl_fnptr(source, type, severity, count, ids, enabled);
+            public static void DebugMessageControl(DebugSource source, DebugType type, DebugSeverity severity, int count, uint* ids, bool enabled) => _DebugMessageControl_fnptr(source, type, severity, count, ids, enabled);
             [UnmanagedCallersOnly]
-            private static void DebugMessageControl_Lazy(DebugSource source, DebugType type, DebugSeverity severity, int count, uint* ids, byte enabled)
+            private static void DebugMessageControl_Lazy(DebugSource source, DebugType type, DebugSeverity severity, int count, uint* ids, bool enabled)
             {
-                _DebugMessageControl_fnptr = (delegate* unmanaged<DebugSource, DebugType, DebugSeverity, int, uint*, byte, void>)GLLoader.BindingsContext.GetProcAddress("glDebugMessageControl");
+                _DebugMessageControl_fnptr = (delegate* unmanaged<DebugSource, DebugType, DebugSeverity, int, uint*, bool, void>)GLLoader.BindingsContext.GetProcAddress("glDebugMessageControl");
                 _DebugMessageControl_fnptr(source, type, severity, count, ids, enabled);
             }
             
@@ -38655,14 +38655,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _GetPointerv_fnptr(pname, parameters);
             }
             
-            private static delegate* unmanaged<DebugSource, DebugType, DebugSeverity, int, uint*, byte, void> _DebugMessageControlKHR_fnptr = &DebugMessageControlKHR_Lazy;
+            private static delegate* unmanaged<DebugSource, DebugType, DebugSeverity, int, uint*, bool, void> _DebugMessageControlKHR_fnptr = &DebugMessageControlKHR_Lazy;
             /// <summary> <b>[requires: GL_KHR_debug]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void DebugMessageControlKHR(DebugSource source, DebugType type, DebugSeverity severity, int count, uint* ids, byte enabled) => _DebugMessageControlKHR_fnptr(source, type, severity, count, ids, enabled);
+            public static void DebugMessageControlKHR(DebugSource source, DebugType type, DebugSeverity severity, int count, uint* ids, bool enabled) => _DebugMessageControlKHR_fnptr(source, type, severity, count, ids, enabled);
             [UnmanagedCallersOnly]
-            private static void DebugMessageControlKHR_Lazy(DebugSource source, DebugType type, DebugSeverity severity, int count, uint* ids, byte enabled)
+            private static void DebugMessageControlKHR_Lazy(DebugSource source, DebugType type, DebugSeverity severity, int count, uint* ids, bool enabled)
             {
-                _DebugMessageControlKHR_fnptr = (delegate* unmanaged<DebugSource, DebugType, DebugSeverity, int, uint*, byte, void>)GLLoader.BindingsContext.GetProcAddress("glDebugMessageControlKHR");
+                _DebugMessageControlKHR_fnptr = (delegate* unmanaged<DebugSource, DebugType, DebugSeverity, int, uint*, bool, void>)GLLoader.BindingsContext.GetProcAddress("glDebugMessageControlKHR");
                 _DebugMessageControlKHR_fnptr(source, type, severity, count, ids, enabled);
             }
             
@@ -40048,14 +40048,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _PointParameterxOES_fnptr(pname, param);
             }
             
-            private static delegate* unmanaged<int, byte, void> _SampleCoveragexOES_fnptr = &SampleCoveragexOES_Lazy;
+            private static delegate* unmanaged<int, bool, void> _SampleCoveragexOES_fnptr = &SampleCoveragexOES_Lazy;
             /// <summary> <b>[requires: GL_OES_fixed_point]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void SampleCoveragexOES(int value, byte invert) => _SampleCoveragexOES_fnptr(value, invert);
+            public static void SampleCoveragexOES(int value, bool invert) => _SampleCoveragexOES_fnptr(value, invert);
             [UnmanagedCallersOnly]
-            private static void SampleCoveragexOES_Lazy(int value, byte invert)
+            private static void SampleCoveragexOES_Lazy(int value, bool invert)
             {
-                _SampleCoveragexOES_fnptr = (delegate* unmanaged<int, byte, void>)GLLoader.BindingsContext.GetProcAddress("glSampleCoveragexOES");
+                _SampleCoveragexOES_fnptr = (delegate* unmanaged<int, bool, void>)GLLoader.BindingsContext.GetProcAddress("glSampleCoveragexOES");
                 _SampleCoveragexOES_fnptr(value, invert);
             }
             
@@ -40959,14 +40959,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _GetFogFuncSGIS_fnptr(points);
             }
             
-            private static delegate* unmanaged<float, byte, void> _SampleMaskSGIS_fnptr = &SampleMaskSGIS_Lazy;
+            private static delegate* unmanaged<float, bool, void> _SampleMaskSGIS_fnptr = &SampleMaskSGIS_Lazy;
             /// <summary> <b>[requires: GL_SGIS_multisample]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void SampleMaskSGIS(float value, byte invert) => _SampleMaskSGIS_fnptr(value, invert);
+            public static void SampleMaskSGIS(float value, bool invert) => _SampleMaskSGIS_fnptr(value, invert);
             [UnmanagedCallersOnly]
-            private static void SampleMaskSGIS_Lazy(float value, byte invert)
+            private static void SampleMaskSGIS_Lazy(float value, bool invert)
             {
-                _SampleMaskSGIS_fnptr = (delegate* unmanaged<float, byte, void>)GLLoader.BindingsContext.GetProcAddress("glSampleMaskSGIS");
+                _SampleMaskSGIS_fnptr = (delegate* unmanaged<float, bool, void>)GLLoader.BindingsContext.GetProcAddress("glSampleMaskSGIS");
                 _SampleMaskSGIS_fnptr(value, invert);
             }
             
@@ -41113,14 +41113,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _TexSubImage4DSGIS_fnptr(target, level, xoffset, yoffset, zoffset, woffset, width, height, depth, size4d, format, type, pixels);
             }
             
-            private static delegate* unmanaged<byte, byte, byte, byte, void> _TextureColorMaskSGIS_fnptr = &TextureColorMaskSGIS_Lazy;
+            private static delegate* unmanaged<bool, bool, bool, bool, void> _TextureColorMaskSGIS_fnptr = &TextureColorMaskSGIS_Lazy;
             /// <summary> <b>[requires: GL_SGIS_texture_color_mask]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureColorMaskSGIS(byte red, byte green, byte blue, byte alpha) => _TextureColorMaskSGIS_fnptr(red, green, blue, alpha);
+            public static void TextureColorMaskSGIS(bool red, bool green, bool blue, bool alpha) => _TextureColorMaskSGIS_fnptr(red, green, blue, alpha);
             [UnmanagedCallersOnly]
-            private static void TextureColorMaskSGIS_Lazy(byte red, byte green, byte blue, byte alpha)
+            private static void TextureColorMaskSGIS_Lazy(bool red, bool green, bool blue, bool alpha)
             {
-                _TextureColorMaskSGIS_fnptr = (delegate* unmanaged<byte, byte, byte, byte, void>)GLLoader.BindingsContext.GetProcAddress("glTextureColorMaskSGIS");
+                _TextureColorMaskSGIS_fnptr = (delegate* unmanaged<bool, bool, bool, bool, void>)GLLoader.BindingsContext.GetProcAddress("glTextureColorMaskSGIS");
                 _TextureColorMaskSGIS_fnptr(red, green, blue, alpha);
             }
             
@@ -41204,14 +41204,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 _DeleteAsyncMarkersSGIX_fnptr(marker, range);
             }
             
-            private static delegate* unmanaged<uint, byte> _IsAsyncMarkerSGIX_fnptr = &IsAsyncMarkerSGIX_Lazy;
+            private static delegate* unmanaged<uint, bool> _IsAsyncMarkerSGIX_fnptr = &IsAsyncMarkerSGIX_Lazy;
             /// <summary> <b>[requires: GL_SGIX_async]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsAsyncMarkerSGIX(uint marker) => _IsAsyncMarkerSGIX_fnptr(marker);
+            public static bool IsAsyncMarkerSGIX(uint marker) => _IsAsyncMarkerSGIX_fnptr(marker);
             [UnmanagedCallersOnly]
-            private static byte IsAsyncMarkerSGIX_Lazy(uint marker)
+            private static bool IsAsyncMarkerSGIX_Lazy(uint marker)
             {
-                _IsAsyncMarkerSGIX_fnptr = (delegate* unmanaged<uint, byte>)GLLoader.BindingsContext.GetProcAddress("glIsAsyncMarkerSGIX");
+                _IsAsyncMarkerSGIX_fnptr = (delegate* unmanaged<uint, bool>)GLLoader.BindingsContext.GetProcAddress("glIsAsyncMarkerSGIX");
                 return _IsAsyncMarkerSGIX_fnptr(marker);
             }
             

--- a/src/OpenTK.Graphics/OpenGL/Compatibility/GL.Overloads.cs
+++ b/src/OpenTK.Graphics/OpenGL/Compatibility/GL.Overloads.cs
@@ -172,25 +172,25 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetBooleanv"/>
-        public static unsafe void GetBoolean(GetPName pname, Span<byte> data)
+        public static unsafe void GetBoolean(GetPName pname, Span<bool> data)
         {
-            fixed (byte* data_ptr = data)
+            fixed (bool* data_ptr = data)
             {
                 GetBooleanv(pname, data_ptr);
             }
         }
         /// <inheritdoc cref="GetBooleanv"/>
-        public static unsafe void GetBoolean(GetPName pname, byte[] data)
+        public static unsafe void GetBoolean(GetPName pname, bool[] data)
         {
-            fixed (byte* data_ptr = data)
+            fixed (bool* data_ptr = data)
             {
                 GetBooleanv(pname, data_ptr);
             }
         }
         /// <inheritdoc cref="GetBooleanv"/>
-        public static unsafe void GetBoolean(GetPName pname, ref byte data)
+        public static unsafe void GetBoolean(GetPName pname, ref bool data)
         {
-            fixed (byte* data_ptr = &data)
+            fixed (bool* data_ptr = &data)
             {
                 GetBooleanv(pname, data_ptr);
             }
@@ -893,25 +893,25 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             EdgeFlag(flag_byte);
         }
         /// <inheritdoc cref="EdgeFlagv"/>
-        public static unsafe void EdgeFlag(ReadOnlySpan<byte> flag)
+        public static unsafe void EdgeFlag(ReadOnlySpan<bool> flag)
         {
-            fixed (byte* flag_ptr = flag)
+            fixed (bool* flag_ptr = flag)
             {
                 EdgeFlagv(flag_ptr);
             }
         }
         /// <inheritdoc cref="EdgeFlagv"/>
-        public static unsafe void EdgeFlag(byte[] flag)
+        public static unsafe void EdgeFlag(bool[] flag)
         {
-            fixed (byte* flag_ptr = flag)
+            fixed (bool* flag_ptr = flag)
             {
                 EdgeFlagv(flag_ptr);
             }
         }
         /// <inheritdoc cref="EdgeFlagv"/>
-        public static unsafe void EdgeFlag(in byte flag)
+        public static unsafe void EdgeFlag(in bool flag)
         {
-            fixed (byte* flag_ptr = &flag)
+            fixed (bool* flag_ptr = &flag)
             {
                 EdgeFlagv(flag_ptr);
             }
@@ -3904,12 +3904,12 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="AreTexturesResident"/>
-        public static unsafe byte AreTexturesResident(int n, ReadOnlySpan<TextureHandle> textures, Span<byte> residences)
+        public static unsafe bool AreTexturesResident(int n, ReadOnlySpan<TextureHandle> textures, Span<bool> residences)
         {
-            byte returnValue;
+            bool returnValue;
             fixed (TextureHandle* textures_ptr = textures)
             {
-                fixed (byte* residences_ptr = residences)
+                fixed (bool* residences_ptr = residences)
                 {
                     returnValue = AreTexturesResident(n, textures_ptr, residences_ptr);
                 }
@@ -3917,12 +3917,12 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             return returnValue;
         }
         /// <inheritdoc cref="AreTexturesResident"/>
-        public static unsafe byte AreTexturesResident(int n, TextureHandle[] textures, byte[] residences)
+        public static unsafe bool AreTexturesResident(int n, TextureHandle[] textures, bool[] residences)
         {
-            byte returnValue;
+            bool returnValue;
             fixed (TextureHandle* textures_ptr = textures)
             {
-                fixed (byte* residences_ptr = residences)
+                fixed (bool* residences_ptr = residences)
                 {
                     returnValue = AreTexturesResident(n, textures_ptr, residences_ptr);
                 }
@@ -3930,11 +3930,11 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             return returnValue;
         }
         /// <inheritdoc cref="AreTexturesResident"/>
-        public static unsafe byte AreTexturesResident(int n, in TextureHandle textures, ref byte residences)
+        public static unsafe bool AreTexturesResident(int n, in TextureHandle textures, ref bool residences)
         {
-            byte returnValue;
+            bool returnValue;
             fixed (TextureHandle* textures_ptr = &textures)
-            fixed (byte* residences_ptr = &residences)
+            fixed (bool* residences_ptr = &residences)
             {
                 returnValue = AreTexturesResident(n, textures_ptr, residences_ptr);
             }
@@ -7642,25 +7642,25 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             ColorMaski(index, r_byte, g_byte, b_byte, a_byte);
         }
         /// <inheritdoc cref="GetBooleani_v"/>
-        public static unsafe void GetBoolean(BufferTargetARB target, uint index, Span<byte> data)
+        public static unsafe void GetBoolean(BufferTargetARB target, uint index, Span<bool> data)
         {
-            fixed (byte* data_ptr = data)
+            fixed (bool* data_ptr = data)
             {
                 GetBooleani_v(target, index, data_ptr);
             }
         }
         /// <inheritdoc cref="GetBooleani_v"/>
-        public static unsafe void GetBoolean(BufferTargetARB target, uint index, byte[] data)
+        public static unsafe void GetBoolean(BufferTargetARB target, uint index, bool[] data)
         {
-            fixed (byte* data_ptr = data)
+            fixed (bool* data_ptr = data)
             {
                 GetBooleani_v(target, index, data_ptr);
             }
         }
         /// <inheritdoc cref="GetBooleani_v"/>
-        public static unsafe void GetBoolean(BufferTargetARB target, uint index, ref byte data)
+        public static unsafe void GetBoolean(BufferTargetARB target, uint index, ref bool data)
         {
-            fixed (byte* data_ptr = &data)
+            fixed (bool* data_ptr = &data)
             {
                 GetBooleani_v(target, index, data_ptr);
             }
@@ -25334,9 +25334,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="IsNamedStringARB"/>
-            public static unsafe byte IsNamedStringARB(int namelen, string name)
+            public static unsafe bool IsNamedStringARB(int namelen, string name)
             {
-                byte returnValue;
+                bool returnValue;
                 byte* name_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(name);
                 returnValue = IsNamedStringARB(namelen, name_ptr);
                 Marshal.FreeCoTaskMem((IntPtr)name_ptr);
@@ -31628,25 +31628,25 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetBooleanIndexedvEXT"/>
-            public static unsafe void GetBooleanIndexedvEXT(BufferTargetARB target, uint index, Span<byte> data)
+            public static unsafe void GetBooleanIndexedvEXT(BufferTargetARB target, uint index, Span<bool> data)
             {
-                fixed (byte* data_ptr = data)
+                fixed (bool* data_ptr = data)
                 {
                     GetBooleanIndexedvEXT(target, index, data_ptr);
                 }
             }
             /// <inheritdoc cref="GetBooleanIndexedvEXT"/>
-            public static unsafe void GetBooleanIndexedvEXT(BufferTargetARB target, uint index, byte[] data)
+            public static unsafe void GetBooleanIndexedvEXT(BufferTargetARB target, uint index, bool[] data)
             {
-                fixed (byte* data_ptr = data)
+                fixed (bool* data_ptr = data)
                 {
                     GetBooleanIndexedvEXT(target, index, data_ptr);
                 }
             }
             /// <inheritdoc cref="GetBooleanIndexedvEXT"/>
-            public static unsafe void GetBooleanIndexedvEXT(BufferTargetARB target, uint index, ref byte data)
+            public static unsafe void GetBooleanIndexedvEXT(BufferTargetARB target, uint index, ref bool data)
             {
-                fixed (byte* data_ptr = &data)
+                fixed (bool* data_ptr = &data)
                 {
                     GetBooleanIndexedvEXT(target, index, data_ptr);
                 }
@@ -36424,12 +36424,12 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="AreTexturesResidentEXT"/>
-            public static unsafe byte AreTexturesResidentEXT(int n, ReadOnlySpan<TextureHandle> textures, Span<byte> residences)
+            public static unsafe bool AreTexturesResidentEXT(int n, ReadOnlySpan<TextureHandle> textures, Span<bool> residences)
             {
-                byte returnValue;
+                bool returnValue;
                 fixed (TextureHandle* textures_ptr = textures)
                 {
-                    fixed (byte* residences_ptr = residences)
+                    fixed (bool* residences_ptr = residences)
                     {
                         returnValue = AreTexturesResidentEXT(n, textures_ptr, residences_ptr);
                     }
@@ -36437,12 +36437,12 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return returnValue;
             }
             /// <inheritdoc cref="AreTexturesResidentEXT"/>
-            public static unsafe byte AreTexturesResidentEXT(int n, TextureHandle[] textures, byte[] residences)
+            public static unsafe bool AreTexturesResidentEXT(int n, TextureHandle[] textures, bool[] residences)
             {
-                byte returnValue;
+                bool returnValue;
                 fixed (TextureHandle* textures_ptr = textures)
                 {
-                    fixed (byte* residences_ptr = residences)
+                    fixed (bool* residences_ptr = residences)
                     {
                         returnValue = AreTexturesResidentEXT(n, textures_ptr, residences_ptr);
                     }
@@ -36450,11 +36450,11 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return returnValue;
             }
             /// <inheritdoc cref="AreTexturesResidentEXT"/>
-            public static unsafe byte AreTexturesResidentEXT(int n, in TextureHandle textures, ref byte residences)
+            public static unsafe bool AreTexturesResidentEXT(int n, in TextureHandle textures, ref bool residences)
             {
-                byte returnValue;
+                bool returnValue;
                 fixed (TextureHandle* textures_ptr = &textures)
-                fixed (byte* residences_ptr = &residences)
+                fixed (bool* residences_ptr = &residences)
                 {
                     returnValue = AreTexturesResidentEXT(n, textures_ptr, residences_ptr);
                 }
@@ -36725,25 +36725,25 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="EdgeFlagPointerEXT"/>
-            public static unsafe void EdgeFlagPointerEXT(int stride, int count, ReadOnlySpan<byte> pointer)
+            public static unsafe void EdgeFlagPointerEXT(int stride, int count, ReadOnlySpan<bool> pointer)
             {
-                fixed (byte* pointer_ptr = pointer)
+                fixed (bool* pointer_ptr = pointer)
                 {
                     EdgeFlagPointerEXT(stride, count, pointer_ptr);
                 }
             }
             /// <inheritdoc cref="EdgeFlagPointerEXT"/>
-            public static unsafe void EdgeFlagPointerEXT(int stride, int count, byte[] pointer)
+            public static unsafe void EdgeFlagPointerEXT(int stride, int count, bool[] pointer)
             {
-                fixed (byte* pointer_ptr = pointer)
+                fixed (bool* pointer_ptr = pointer)
                 {
                     EdgeFlagPointerEXT(stride, count, pointer_ptr);
                 }
             }
             /// <inheritdoc cref="EdgeFlagPointerEXT"/>
-            public static unsafe void EdgeFlagPointerEXT(int stride, int count, in byte pointer)
+            public static unsafe void EdgeFlagPointerEXT(int stride, int count, in bool pointer)
             {
-                fixed (byte* pointer_ptr = &pointer)
+                fixed (bool* pointer_ptr = &pointer)
                 {
                     EdgeFlagPointerEXT(stride, count, pointer_ptr);
                 }
@@ -37327,25 +37327,25 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetVariantBooleanvEXT"/>
-            public static unsafe void GetVariantBooleanvEXT(uint id, GetVariantValueEXT value, Span<byte> data)
+            public static unsafe void GetVariantBooleanvEXT(uint id, GetVariantValueEXT value, Span<bool> data)
             {
-                fixed (byte* data_ptr = data)
+                fixed (bool* data_ptr = data)
                 {
                     GetVariantBooleanvEXT(id, value, data_ptr);
                 }
             }
             /// <inheritdoc cref="GetVariantBooleanvEXT"/>
-            public static unsafe void GetVariantBooleanvEXT(uint id, GetVariantValueEXT value, byte[] data)
+            public static unsafe void GetVariantBooleanvEXT(uint id, GetVariantValueEXT value, bool[] data)
             {
-                fixed (byte* data_ptr = data)
+                fixed (bool* data_ptr = data)
                 {
                     GetVariantBooleanvEXT(id, value, data_ptr);
                 }
             }
             /// <inheritdoc cref="GetVariantBooleanvEXT"/>
-            public static unsafe void GetVariantBooleanvEXT(uint id, GetVariantValueEXT value, ref byte data)
+            public static unsafe void GetVariantBooleanvEXT(uint id, GetVariantValueEXT value, ref bool data)
             {
-                fixed (byte* data_ptr = &data)
+                fixed (bool* data_ptr = &data)
                 {
                     GetVariantBooleanvEXT(id, value, data_ptr);
                 }
@@ -37399,25 +37399,25 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetInvariantBooleanvEXT"/>
-            public static unsafe void GetInvariantBooleanvEXT(uint id, GetVariantValueEXT value, Span<byte> data)
+            public static unsafe void GetInvariantBooleanvEXT(uint id, GetVariantValueEXT value, Span<bool> data)
             {
-                fixed (byte* data_ptr = data)
+                fixed (bool* data_ptr = data)
                 {
                     GetInvariantBooleanvEXT(id, value, data_ptr);
                 }
             }
             /// <inheritdoc cref="GetInvariantBooleanvEXT"/>
-            public static unsafe void GetInvariantBooleanvEXT(uint id, GetVariantValueEXT value, byte[] data)
+            public static unsafe void GetInvariantBooleanvEXT(uint id, GetVariantValueEXT value, bool[] data)
             {
-                fixed (byte* data_ptr = data)
+                fixed (bool* data_ptr = data)
                 {
                     GetInvariantBooleanvEXT(id, value, data_ptr);
                 }
             }
             /// <inheritdoc cref="GetInvariantBooleanvEXT"/>
-            public static unsafe void GetInvariantBooleanvEXT(uint id, GetVariantValueEXT value, ref byte data)
+            public static unsafe void GetInvariantBooleanvEXT(uint id, GetVariantValueEXT value, ref bool data)
             {
-                fixed (byte* data_ptr = &data)
+                fixed (bool* data_ptr = &data)
                 {
                     GetInvariantBooleanvEXT(id, value, data_ptr);
                 }
@@ -37471,25 +37471,25 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetLocalConstantBooleanvEXT"/>
-            public static unsafe void GetLocalConstantBooleanvEXT(uint id, GetVariantValueEXT value, Span<byte> data)
+            public static unsafe void GetLocalConstantBooleanvEXT(uint id, GetVariantValueEXT value, Span<bool> data)
             {
-                fixed (byte* data_ptr = data)
+                fixed (bool* data_ptr = data)
                 {
                     GetLocalConstantBooleanvEXT(id, value, data_ptr);
                 }
             }
             /// <inheritdoc cref="GetLocalConstantBooleanvEXT"/>
-            public static unsafe void GetLocalConstantBooleanvEXT(uint id, GetVariantValueEXT value, byte[] data)
+            public static unsafe void GetLocalConstantBooleanvEXT(uint id, GetVariantValueEXT value, bool[] data)
             {
-                fixed (byte* data_ptr = data)
+                fixed (bool* data_ptr = data)
                 {
                     GetLocalConstantBooleanvEXT(id, value, data_ptr);
                 }
             }
             /// <inheritdoc cref="GetLocalConstantBooleanvEXT"/>
-            public static unsafe void GetLocalConstantBooleanvEXT(uint id, GetVariantValueEXT value, ref byte data)
+            public static unsafe void GetLocalConstantBooleanvEXT(uint id, GetVariantValueEXT value, ref bool data)
             {
-                fixed (byte* data_ptr = &data)
+                fixed (bool* data_ptr = &data)
                 {
                     GetLocalConstantBooleanvEXT(id, value, data_ptr);
                 }
@@ -41142,9 +41142,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="PointAlongPathNV"/>
-            public static unsafe byte PointAlongPathNV(uint path, int startSegment, int numSegments, float distance, Span<float> x, Span<float> y, Span<float> tangentX, Span<float> tangentY)
+            public static unsafe bool PointAlongPathNV(uint path, int startSegment, int numSegments, float distance, Span<float> x, Span<float> y, Span<float> tangentX, Span<float> tangentY)
             {
-                byte returnValue;
+                bool returnValue;
                 fixed (float* x_ptr = x)
                 {
                     fixed (float* y_ptr = y)
@@ -41161,9 +41161,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return returnValue;
             }
             /// <inheritdoc cref="PointAlongPathNV"/>
-            public static unsafe byte PointAlongPathNV(uint path, int startSegment, int numSegments, float distance, float[] x, float[] y, float[] tangentX, float[] tangentY)
+            public static unsafe bool PointAlongPathNV(uint path, int startSegment, int numSegments, float distance, float[] x, float[] y, float[] tangentX, float[] tangentY)
             {
-                byte returnValue;
+                bool returnValue;
                 fixed (float* x_ptr = x)
                 {
                     fixed (float* y_ptr = y)
@@ -41180,9 +41180,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return returnValue;
             }
             /// <inheritdoc cref="PointAlongPathNV"/>
-            public static unsafe byte PointAlongPathNV(uint path, int startSegment, int numSegments, float distance, ref float x, ref float y, ref float tangentX, ref float tangentY)
+            public static unsafe bool PointAlongPathNV(uint path, int startSegment, int numSegments, float distance, ref float x, ref float y, ref float tangentX, ref float tangentY)
             {
-                byte returnValue;
+                bool returnValue;
                 fixed (float* x_ptr = &x)
                 fixed (float* y_ptr = &y)
                 fixed (float* tangentX_ptr = &tangentX)
@@ -43516,12 +43516,12 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="AreProgramsResidentNV"/>
-            public static unsafe byte AreProgramsResidentNV(int n, ReadOnlySpan<ProgramHandle> programs, Span<byte> residences)
+            public static unsafe bool AreProgramsResidentNV(int n, ReadOnlySpan<ProgramHandle> programs, Span<bool> residences)
             {
-                byte returnValue;
+                bool returnValue;
                 fixed (ProgramHandle* programs_ptr = programs)
                 {
-                    fixed (byte* residences_ptr = residences)
+                    fixed (bool* residences_ptr = residences)
                     {
                         returnValue = AreProgramsResidentNV(n, programs_ptr, residences_ptr);
                     }
@@ -43529,12 +43529,12 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return returnValue;
             }
             /// <inheritdoc cref="AreProgramsResidentNV"/>
-            public static unsafe byte AreProgramsResidentNV(int n, ProgramHandle[] programs, byte[] residences)
+            public static unsafe bool AreProgramsResidentNV(int n, ProgramHandle[] programs, bool[] residences)
             {
-                byte returnValue;
+                bool returnValue;
                 fixed (ProgramHandle* programs_ptr = programs)
                 {
-                    fixed (byte* residences_ptr = residences)
+                    fixed (bool* residences_ptr = residences)
                     {
                         returnValue = AreProgramsResidentNV(n, programs_ptr, residences_ptr);
                     }
@@ -43542,11 +43542,11 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return returnValue;
             }
             /// <inheritdoc cref="AreProgramsResidentNV"/>
-            public static unsafe byte AreProgramsResidentNV(int n, in ProgramHandle programs, ref byte residences)
+            public static unsafe bool AreProgramsResidentNV(int n, in ProgramHandle programs, ref bool residences)
             {
-                byte returnValue;
+                bool returnValue;
                 fixed (ProgramHandle* programs_ptr = &programs)
-                fixed (byte* residences_ptr = &residences)
+                fixed (bool* residences_ptr = &residences)
                 {
                     returnValue = AreProgramsResidentNV(n, programs_ptr, residences_ptr);
                 }

--- a/src/OpenTK.Graphics/OpenGL/Compatibility/GL.Overloads.cs
+++ b/src/OpenTK.Graphics/OpenGL/Compatibility/GL.Overloads.cs
@@ -123,21 +123,6 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 TexImage2D(target, level, internalformat, width, height, border, format, type, pixels_ptr);
             }
         }
-        /// <inheritdoc cref="ColorMask"/>
-        public static unsafe void ColorMask(bool red, bool green, bool blue, bool alpha)
-        {
-            byte red_byte = (byte)(red ? 1 : 0);
-            byte green_byte = (byte)(green ? 1 : 0);
-            byte blue_byte = (byte)(blue ? 1 : 0);
-            byte alpha_byte = (byte)(alpha ? 1 : 0);
-            ColorMask(red_byte, green_byte, blue_byte, alpha_byte);
-        }
-        /// <inheritdoc cref="DepthMask"/>
-        public static unsafe void DepthMask(bool flag)
-        {
-            byte flag_byte = (byte)(flag ? 1 : 0);
-            DepthMask(flag_byte);
-        }
         /// <inheritdoc cref="ReadPixels"/>
         public static unsafe void ReadPixels(int x, int y, int width, int height, PixelFormat format, PixelType type, IntPtr pixels)
         {
@@ -885,12 +870,6 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             {
                 Color4usv(v_ptr);
             }
-        }
-        /// <inheritdoc cref="EdgeFlag"/>
-        public static unsafe void EdgeFlag(bool flag)
-        {
-            byte flag_byte = (byte)(flag ? 1 : 0);
-            EdgeFlag(flag_byte);
         }
         /// <inheritdoc cref="EdgeFlagv"/>
         public static unsafe void EdgeFlag(ReadOnlySpan<bool> flag)
@@ -4072,12 +4051,6 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 TexSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, pixels_ptr);
             }
         }
-        /// <inheritdoc cref="SampleCoverage"/>
-        public static unsafe void SampleCoverage(float value, bool invert)
-        {
-            byte invert_byte = (byte)(invert ? 1 : 0);
-            SampleCoverage(value, invert_byte);
-        }
         /// <inheritdoc cref="CompressedTexImage3D"/>
         public static unsafe void CompressedTexImage3D(TextureTarget target, int level, InternalFormat internalformat, int width, int height, int depth, int border, int imageSize, IntPtr data)
         {
@@ -6776,8 +6749,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix2* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix2fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix2fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix2fv"/>
@@ -6786,8 +6758,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix2* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix2fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix2fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix2fv"/>
@@ -6796,8 +6767,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix2* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix2fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix2fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix3fv"/>
@@ -6807,8 +6777,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix3* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix3fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix3fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix3fv"/>
@@ -6817,8 +6786,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix3* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix3fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix3fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix3fv"/>
@@ -6827,8 +6795,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix3* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix3fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix3fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix4fv"/>
@@ -6838,8 +6805,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix4* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix4fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix4fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix4fv"/>
@@ -6848,8 +6814,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix4* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix4fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix4fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix4fv"/>
@@ -6858,8 +6823,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix4* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix4fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix4fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="VertexAttrib1dv"/>
@@ -7443,8 +7407,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         public static unsafe void VertexAttribPointer(uint index, int size, VertexAttribPointerType type, bool normalized, int stride, nint offset)
         {
             void* pointer = (void*)offset;
-            byte normalized_byte = (byte)(normalized ? 1 : 0);
-            VertexAttribPointer(index, size, type, normalized_byte, stride, pointer);
+            VertexAttribPointer(index, size, type, normalized, stride, pointer);
         }
         /// <inheritdoc cref="UniformMatrix2x3fv"/>
         public static unsafe void UniformMatrix2x3f(int location, bool transpose, in Matrix2x3 value)
@@ -7453,8 +7416,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix2x3* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix2x3fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix2x3fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix2x3fv"/>
@@ -7463,8 +7425,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix2x3* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix2x3fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix2x3fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix2x3fv"/>
@@ -7473,8 +7434,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix2x3* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix2x3fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix2x3fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix3x2fv"/>
@@ -7484,8 +7444,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix3x2* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix3x2fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix3x2fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix3x2fv"/>
@@ -7494,8 +7453,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix3x2* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix3x2fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix3x2fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix3x2fv"/>
@@ -7504,8 +7462,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix3x2* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix3x2fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix3x2fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix2x4fv"/>
@@ -7515,8 +7472,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix2x4* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix2x4fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix2x4fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix2x4fv"/>
@@ -7525,8 +7481,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix2x4* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix2x4fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix2x4fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix2x4fv"/>
@@ -7535,8 +7490,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix2x4* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix2x4fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix2x4fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix4x2fv"/>
@@ -7546,8 +7500,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix4x2* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix4x2fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix4x2fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix4x2fv"/>
@@ -7556,8 +7509,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix4x2* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix4x2fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix4x2fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix4x2fv"/>
@@ -7566,8 +7518,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix4x2* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix4x2fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix4x2fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix3x4fv"/>
@@ -7577,8 +7528,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix3x4* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix3x4fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix3x4fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix3x4fv"/>
@@ -7587,8 +7537,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix3x4* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix3x4fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix3x4fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix3x4fv"/>
@@ -7597,8 +7546,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix3x4* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix3x4fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix3x4fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix4x3fv"/>
@@ -7608,8 +7556,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix4x3* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix4x3fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix4x3fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix4x3fv"/>
@@ -7618,8 +7565,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix4x3* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix4x3fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix4x3fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix4x3fv"/>
@@ -7628,18 +7574,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix4x3* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix4x3fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix4x3fv(location, count, transpose, value_ptr);
             }
-        }
-        /// <inheritdoc cref="ColorMaski"/>
-        public static unsafe void ColorMaski(uint index, bool r, bool g, bool b, bool a)
-        {
-            byte r_byte = (byte)(r ? 1 : 0);
-            byte g_byte = (byte)(g ? 1 : 0);
-            byte b_byte = (byte)(b ? 1 : 0);
-            byte a_byte = (byte)(a ? 1 : 0);
-            ColorMaski(index, r_byte, g_byte, b_byte, a_byte);
         }
         /// <inheritdoc cref="GetBooleani_v"/>
         public static unsafe void GetBoolean(BufferTargetARB target, uint index, Span<bool> data)
@@ -9184,18 +9120,6 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 GetBufferParameteri64v(target, pname, parameters_ptr);
             }
         }
-        /// <inheritdoc cref="TexImage2DMultisample"/>
-        public static unsafe void TexImage2DMultisample(TextureTarget target, int samples, InternalFormat internalformat, int width, int height, bool fixedsamplelocations)
-        {
-            byte fixedsamplelocations_byte = (byte)(fixedsamplelocations ? 1 : 0);
-            TexImage2DMultisample(target, samples, internalformat, width, height, fixedsamplelocations_byte);
-        }
-        /// <inheritdoc cref="TexImage3DMultisample"/>
-        public static unsafe void TexImage3DMultisample(TextureTarget target, int samples, InternalFormat internalformat, int width, int height, int depth, bool fixedsamplelocations)
-        {
-            byte fixedsamplelocations_byte = (byte)(fixedsamplelocations ? 1 : 0);
-            TexImage3DMultisample(target, samples, internalformat, width, height, depth, fixedsamplelocations_byte);
-        }
         /// <inheritdoc cref="GetMultisamplefv"/>
         public static unsafe void GetMultisamplef(GetMultisamplePNameNV pname, uint index, Span<float> val)
         {
@@ -9571,19 +9495,12 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 GetQueryObjectui64v(id, pname, parameters_ptr);
             }
         }
-        /// <inheritdoc cref="VertexAttribP1ui"/>
-        public static unsafe void VertexAttribP1ui(uint index, VertexAttribPointerType type, bool normalized, uint value)
-        {
-            byte normalized_byte = (byte)(normalized ? 1 : 0);
-            VertexAttribP1ui(index, type, normalized_byte, value);
-        }
         /// <inheritdoc cref="VertexAttribP1uiv"/>
         public static unsafe void VertexAttribP1ui(uint index, VertexAttribPointerType type, bool normalized, ReadOnlySpan<uint> value)
         {
             fixed (uint* value_ptr = value)
             {
-                byte normalized_byte = (byte)(normalized ? 1 : 0);
-                VertexAttribP1uiv(index, type, normalized_byte, value_ptr);
+                VertexAttribP1uiv(index, type, normalized, value_ptr);
             }
         }
         /// <inheritdoc cref="VertexAttribP1uiv"/>
@@ -9591,8 +9508,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         {
             fixed (uint* value_ptr = value)
             {
-                byte normalized_byte = (byte)(normalized ? 1 : 0);
-                VertexAttribP1uiv(index, type, normalized_byte, value_ptr);
+                VertexAttribP1uiv(index, type, normalized, value_ptr);
             }
         }
         /// <inheritdoc cref="VertexAttribP1uiv"/>
@@ -9600,23 +9516,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         {
             fixed (uint* value_ptr = &value)
             {
-                byte normalized_byte = (byte)(normalized ? 1 : 0);
-                VertexAttribP1uiv(index, type, normalized_byte, value_ptr);
+                VertexAttribP1uiv(index, type, normalized, value_ptr);
             }
-        }
-        /// <inheritdoc cref="VertexAttribP2ui"/>
-        public static unsafe void VertexAttribP2ui(uint index, VertexAttribPointerType type, bool normalized, uint value)
-        {
-            byte normalized_byte = (byte)(normalized ? 1 : 0);
-            VertexAttribP2ui(index, type, normalized_byte, value);
         }
         /// <inheritdoc cref="VertexAttribP2uiv"/>
         public static unsafe void VertexAttribP2ui(uint index, VertexAttribPointerType type, bool normalized, ReadOnlySpan<uint> value)
         {
             fixed (uint* value_ptr = value)
             {
-                byte normalized_byte = (byte)(normalized ? 1 : 0);
-                VertexAttribP2uiv(index, type, normalized_byte, value_ptr);
+                VertexAttribP2uiv(index, type, normalized, value_ptr);
             }
         }
         /// <inheritdoc cref="VertexAttribP2uiv"/>
@@ -9624,8 +9532,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         {
             fixed (uint* value_ptr = value)
             {
-                byte normalized_byte = (byte)(normalized ? 1 : 0);
-                VertexAttribP2uiv(index, type, normalized_byte, value_ptr);
+                VertexAttribP2uiv(index, type, normalized, value_ptr);
             }
         }
         /// <inheritdoc cref="VertexAttribP2uiv"/>
@@ -9633,23 +9540,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         {
             fixed (uint* value_ptr = &value)
             {
-                byte normalized_byte = (byte)(normalized ? 1 : 0);
-                VertexAttribP2uiv(index, type, normalized_byte, value_ptr);
+                VertexAttribP2uiv(index, type, normalized, value_ptr);
             }
-        }
-        /// <inheritdoc cref="VertexAttribP3ui"/>
-        public static unsafe void VertexAttribP3ui(uint index, VertexAttribPointerType type, bool normalized, uint value)
-        {
-            byte normalized_byte = (byte)(normalized ? 1 : 0);
-            VertexAttribP3ui(index, type, normalized_byte, value);
         }
         /// <inheritdoc cref="VertexAttribP3uiv"/>
         public static unsafe void VertexAttribP3ui(uint index, VertexAttribPointerType type, bool normalized, ReadOnlySpan<uint> value)
         {
             fixed (uint* value_ptr = value)
             {
-                byte normalized_byte = (byte)(normalized ? 1 : 0);
-                VertexAttribP3uiv(index, type, normalized_byte, value_ptr);
+                VertexAttribP3uiv(index, type, normalized, value_ptr);
             }
         }
         /// <inheritdoc cref="VertexAttribP3uiv"/>
@@ -9657,8 +9556,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         {
             fixed (uint* value_ptr = value)
             {
-                byte normalized_byte = (byte)(normalized ? 1 : 0);
-                VertexAttribP3uiv(index, type, normalized_byte, value_ptr);
+                VertexAttribP3uiv(index, type, normalized, value_ptr);
             }
         }
         /// <inheritdoc cref="VertexAttribP3uiv"/>
@@ -9666,23 +9564,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         {
             fixed (uint* value_ptr = &value)
             {
-                byte normalized_byte = (byte)(normalized ? 1 : 0);
-                VertexAttribP3uiv(index, type, normalized_byte, value_ptr);
+                VertexAttribP3uiv(index, type, normalized, value_ptr);
             }
-        }
-        /// <inheritdoc cref="VertexAttribP4ui"/>
-        public static unsafe void VertexAttribP4ui(uint index, VertexAttribPointerType type, bool normalized, uint value)
-        {
-            byte normalized_byte = (byte)(normalized ? 1 : 0);
-            VertexAttribP4ui(index, type, normalized_byte, value);
         }
         /// <inheritdoc cref="VertexAttribP4uiv"/>
         public static unsafe void VertexAttribP4ui(uint index, VertexAttribPointerType type, bool normalized, ReadOnlySpan<uint> value)
         {
             fixed (uint* value_ptr = value)
             {
-                byte normalized_byte = (byte)(normalized ? 1 : 0);
-                VertexAttribP4uiv(index, type, normalized_byte, value_ptr);
+                VertexAttribP4uiv(index, type, normalized, value_ptr);
             }
         }
         /// <inheritdoc cref="VertexAttribP4uiv"/>
@@ -9690,8 +9580,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         {
             fixed (uint* value_ptr = value)
             {
-                byte normalized_byte = (byte)(normalized ? 1 : 0);
-                VertexAttribP4uiv(index, type, normalized_byte, value_ptr);
+                VertexAttribP4uiv(index, type, normalized, value_ptr);
             }
         }
         /// <inheritdoc cref="VertexAttribP4uiv"/>
@@ -9699,8 +9588,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         {
             fixed (uint* value_ptr = &value)
             {
-                byte normalized_byte = (byte)(normalized ? 1 : 0);
-                VertexAttribP4uiv(index, type, normalized_byte, value_ptr);
+                VertexAttribP4uiv(index, type, normalized, value_ptr);
             }
         }
         /// <inheritdoc cref="VertexP2uiv"/>
@@ -10212,8 +10100,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix2d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix2dv(location, count, transpose_byte, value_ptr);
+                UniformMatrix2dv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix2dv"/>
@@ -10222,8 +10109,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix2d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix2dv(location, count, transpose_byte, value_ptr);
+                UniformMatrix2dv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix2dv"/>
@@ -10232,8 +10118,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix2d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix2dv(location, count, transpose_byte, value_ptr);
+                UniformMatrix2dv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix3dv"/>
@@ -10243,8 +10128,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix3d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix3dv(location, count, transpose_byte, value_ptr);
+                UniformMatrix3dv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix3dv"/>
@@ -10253,8 +10137,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix3d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix3dv(location, count, transpose_byte, value_ptr);
+                UniformMatrix3dv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix3dv"/>
@@ -10263,8 +10146,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix3d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix3dv(location, count, transpose_byte, value_ptr);
+                UniformMatrix3dv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix4dv"/>
@@ -10274,8 +10156,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix4d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix4dv(location, count, transpose_byte, value_ptr);
+                UniformMatrix4dv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix4dv"/>
@@ -10284,8 +10165,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix4d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix4dv(location, count, transpose_byte, value_ptr);
+                UniformMatrix4dv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix4dv"/>
@@ -10294,8 +10174,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix4d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix4dv(location, count, transpose_byte, value_ptr);
+                UniformMatrix4dv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix2x3dv"/>
@@ -10305,8 +10184,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix2x3d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix2x3dv(location, count, transpose_byte, value_ptr);
+                UniformMatrix2x3dv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix2x3dv"/>
@@ -10315,8 +10193,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix2x3d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix2x3dv(location, count, transpose_byte, value_ptr);
+                UniformMatrix2x3dv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix2x3dv"/>
@@ -10325,8 +10202,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix2x3d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix2x3dv(location, count, transpose_byte, value_ptr);
+                UniformMatrix2x3dv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix2x4dv"/>
@@ -10336,8 +10212,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix2x4d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix2x4dv(location, count, transpose_byte, value_ptr);
+                UniformMatrix2x4dv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix2x4dv"/>
@@ -10346,8 +10221,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix2x4d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix2x4dv(location, count, transpose_byte, value_ptr);
+                UniformMatrix2x4dv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix2x4dv"/>
@@ -10356,8 +10230,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix2x4d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix2x4dv(location, count, transpose_byte, value_ptr);
+                UniformMatrix2x4dv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix3x2dv"/>
@@ -10367,8 +10240,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix3x2d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix3x2dv(location, count, transpose_byte, value_ptr);
+                UniformMatrix3x2dv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix3x2dv"/>
@@ -10377,8 +10249,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix3x2d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix3x2dv(location, count, transpose_byte, value_ptr);
+                UniformMatrix3x2dv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix3x2dv"/>
@@ -10387,8 +10258,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix3x2d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix3x2dv(location, count, transpose_byte, value_ptr);
+                UniformMatrix3x2dv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix3x4dv"/>
@@ -10398,8 +10268,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix3x4d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix3x4dv(location, count, transpose_byte, value_ptr);
+                UniformMatrix3x4dv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix3x4dv"/>
@@ -10408,8 +10277,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix3x4d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix3x4dv(location, count, transpose_byte, value_ptr);
+                UniformMatrix3x4dv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix3x4dv"/>
@@ -10418,8 +10286,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix3x4d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix3x4dv(location, count, transpose_byte, value_ptr);
+                UniformMatrix3x4dv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix4x2dv"/>
@@ -10429,8 +10296,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix4x2d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix4x2dv(location, count, transpose_byte, value_ptr);
+                UniformMatrix4x2dv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix4x2dv"/>
@@ -10439,8 +10305,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix4x2d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix4x2dv(location, count, transpose_byte, value_ptr);
+                UniformMatrix4x2dv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix4x2dv"/>
@@ -10449,8 +10314,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix4x2d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix4x2dv(location, count, transpose_byte, value_ptr);
+                UniformMatrix4x2dv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix4x3dv"/>
@@ -10460,8 +10324,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix4x3d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix4x3dv(location, count, transpose_byte, value_ptr);
+                UniformMatrix4x3dv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix4x3dv"/>
@@ -10470,8 +10333,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix4x3d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix4x3dv(location, count, transpose_byte, value_ptr);
+                UniformMatrix4x3dv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix4x3dv"/>
@@ -10480,8 +10342,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix4x3d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix4x3dv(location, count, transpose_byte, value_ptr);
+                UniformMatrix4x3dv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="GetUniformdv"/>
@@ -11688,8 +11549,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix2* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix2fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix2fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2fv"/>
@@ -11698,8 +11558,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix2* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix2fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix2fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2fv"/>
@@ -11708,8 +11567,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix2* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix2fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix2fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3fv"/>
@@ -11719,8 +11577,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix3* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix3fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix3fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3fv"/>
@@ -11729,8 +11586,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix3* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix3fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix3fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3fv"/>
@@ -11739,8 +11595,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix3* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix3fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix3fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
@@ -11750,8 +11605,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix4* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix4fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix4fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
@@ -11760,8 +11614,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix4* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix4fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix4fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
@@ -11770,8 +11623,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix4* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix4fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix4fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2dv"/>
@@ -11781,8 +11633,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix2d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix2dv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix2dv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2dv"/>
@@ -11791,8 +11642,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix2d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix2dv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix2dv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2dv"/>
@@ -11801,8 +11651,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix2d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix2dv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix2dv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3dv"/>
@@ -11812,8 +11661,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix3d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix3dv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix3dv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3dv"/>
@@ -11822,8 +11670,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix3d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix3dv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix3dv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3dv"/>
@@ -11832,8 +11679,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix3d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix3dv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix3dv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4dv"/>
@@ -11843,8 +11689,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix4d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix4dv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix4dv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4dv"/>
@@ -11853,8 +11698,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix4d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix4dv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix4dv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4dv"/>
@@ -11863,8 +11707,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix4d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix4dv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix4dv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x3fv"/>
@@ -11874,8 +11717,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix2x3* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix2x3fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix2x3fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x3fv"/>
@@ -11884,8 +11726,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix2x3* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix2x3fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix2x3fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x3fv"/>
@@ -11894,8 +11735,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix2x3* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix2x3fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix2x3fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
@@ -11905,8 +11745,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix3x2* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix3x2fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix3x2fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
@@ -11915,8 +11754,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix3x2* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix3x2fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix3x2fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
@@ -11925,8 +11763,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix3x2* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix3x2fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix3x2fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x4fv"/>
@@ -11936,8 +11773,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix2x4* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix2x4fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix2x4fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x4fv"/>
@@ -11946,8 +11782,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix2x4* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix2x4fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix2x4fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x4fv"/>
@@ -11956,8 +11791,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix2x4* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix2x4fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix2x4fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x2fv"/>
@@ -11967,8 +11801,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix4x2* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix4x2fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix4x2fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x2fv"/>
@@ -11977,8 +11810,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix4x2* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix4x2fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix4x2fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x2fv"/>
@@ -11987,8 +11819,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix4x2* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix4x2fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix4x2fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x4fv"/>
@@ -11998,8 +11829,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix3x4* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix3x4fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix3x4fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x4fv"/>
@@ -12008,8 +11838,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix3x4* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix3x4fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix3x4fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x4fv"/>
@@ -12018,8 +11847,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix3x4* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix3x4fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix3x4fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x3fv"/>
@@ -12029,8 +11857,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix4x3* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix4x3fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix4x3fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x3fv"/>
@@ -12039,8 +11866,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix4x3* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix4x3fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix4x3fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x3fv"/>
@@ -12049,8 +11875,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix4x3* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix4x3fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix4x3fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x3dv"/>
@@ -12060,8 +11885,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix2x3d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix2x3dv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix2x3dv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x3dv"/>
@@ -12070,8 +11894,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix2x3d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix2x3dv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix2x3dv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x3dv"/>
@@ -12080,8 +11903,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix2x3d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix2x3dv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix2x3dv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x2dv"/>
@@ -12091,8 +11913,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix3x2d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix3x2dv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix3x2dv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x2dv"/>
@@ -12101,8 +11922,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix3x2d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix3x2dv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix3x2dv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x2dv"/>
@@ -12111,8 +11931,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix3x2d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix3x2dv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix3x2dv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x4dv"/>
@@ -12122,8 +11941,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix2x4d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix2x4dv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix2x4dv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x4dv"/>
@@ -12132,8 +11950,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix2x4d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix2x4dv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix2x4dv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x4dv"/>
@@ -12142,8 +11959,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix2x4d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix2x4dv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix2x4dv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x2dv"/>
@@ -12153,8 +11969,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix4x2d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix4x2dv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix4x2dv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x2dv"/>
@@ -12163,8 +11978,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix4x2d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix4x2dv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix4x2dv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x2dv"/>
@@ -12173,8 +11987,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix4x2d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix4x2dv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix4x2dv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x4dv"/>
@@ -12184,8 +11997,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix3x4d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix3x4dv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix3x4dv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x4dv"/>
@@ -12194,8 +12006,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix3x4d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix3x4dv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix3x4dv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x4dv"/>
@@ -12204,8 +12015,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix3x4d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix3x4dv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix3x4dv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x3dv"/>
@@ -12215,8 +12025,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix4x3d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix4x3dv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix4x3dv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x3dv"/>
@@ -12225,8 +12034,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix4x3d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix4x3dv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix4x3dv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x3dv"/>
@@ -12235,8 +12043,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             fixed (Matrix4x3d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix4x3dv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix4x3dv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="GetProgramPipelineInfoLog"/>
@@ -12667,12 +12474,6 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 GetActiveAtomicCounterBufferiv(program, bufferIndex, pname, parameters_ptr);
             }
         }
-        /// <inheritdoc cref="BindImageTexture"/>
-        public static unsafe void BindImageTexture(uint unit, TextureHandle texture, int level, bool layered, int layer, BufferAccessARB access, InternalFormat format)
-        {
-            byte layered_byte = (byte)(layered ? 1 : 0);
-            BindImageTexture(unit, texture, level, layered_byte, layer, access, format);
-        }
         /// <inheritdoc cref="ClearBufferData"/>
         public static unsafe void ClearBufferData(BufferStorageTarget target, SizedInternalFormat internalformat, PixelFormat format, PixelType type, IntPtr data)
         {
@@ -13072,32 +12873,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             Marshal.FreeCoTaskMem((IntPtr)name_ptr);
             return returnValue;
         }
-        /// <inheritdoc cref="TexStorage2DMultisample"/>
-        public static unsafe void TexStorage2DMultisample(TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, bool fixedsamplelocations)
-        {
-            byte fixedsamplelocations_byte = (byte)(fixedsamplelocations ? 1 : 0);
-            TexStorage2DMultisample(target, samples, internalformat, width, height, fixedsamplelocations_byte);
-        }
-        /// <inheritdoc cref="TexStorage3DMultisample"/>
-        public static unsafe void TexStorage3DMultisample(TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, int depth, bool fixedsamplelocations)
-        {
-            byte fixedsamplelocations_byte = (byte)(fixedsamplelocations ? 1 : 0);
-            TexStorage3DMultisample(target, samples, internalformat, width, height, depth, fixedsamplelocations_byte);
-        }
-        /// <inheritdoc cref="VertexAttribFormat"/>
-        public static unsafe void VertexAttribFormat(uint attribindex, int size, VertexAttribType type, bool normalized, uint relativeoffset)
-        {
-            byte normalized_byte = (byte)(normalized ? 1 : 0);
-            VertexAttribFormat(attribindex, size, type, normalized_byte, relativeoffset);
-        }
         /// <inheritdoc cref="DebugMessageControl"/>
         public static unsafe void DebugMessageControl(DebugSource source, DebugType type, DebugSeverity severity, ReadOnlySpan<uint> ids, bool enabled)
         {
             int count = (int)(ids.Length);
             fixed (uint* ids_ptr = ids)
             {
-                byte enabled_byte = (byte)(enabled ? 1 : 0);
-                DebugMessageControl(source, type, severity, count, ids_ptr, enabled_byte);
+                DebugMessageControl(source, type, severity, count, ids_ptr, enabled);
             }
         }
         /// <inheritdoc cref="DebugMessageControl"/>
@@ -13106,8 +12888,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             int count = (int)(ids.Length);
             fixed (uint* ids_ptr = ids)
             {
-                byte enabled_byte = (byte)(enabled ? 1 : 0);
-                DebugMessageControl(source, type, severity, count, ids_ptr, enabled_byte);
+                DebugMessageControl(source, type, severity, count, ids_ptr, enabled);
             }
         }
         /// <inheritdoc cref="DebugMessageControl"/>
@@ -13115,8 +12896,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         {
             fixed (uint* ids_ptr = &ids)
             {
-                byte enabled_byte = (byte)(enabled ? 1 : 0);
-                DebugMessageControl(source, type, severity, count, ids_ptr, enabled_byte);
+                DebugMessageControl(source, type, severity, count, ids_ptr, enabled);
             }
         }
         /// <inheritdoc cref="DebugMessageInsert"/>
@@ -14316,18 +14096,6 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 CreateTextures(target, n, textures_ptr);
             }
         }
-        /// <inheritdoc cref="TextureStorage2DMultisample"/>
-        public static unsafe void TextureStorage2DMultisample(TextureHandle texture, int samples, SizedInternalFormat internalformat, int width, int height, bool fixedsamplelocations)
-        {
-            byte fixedsamplelocations_byte = (byte)(fixedsamplelocations ? 1 : 0);
-            TextureStorage2DMultisample(texture, samples, internalformat, width, height, fixedsamplelocations_byte);
-        }
-        /// <inheritdoc cref="TextureStorage3DMultisample"/>
-        public static unsafe void TextureStorage3DMultisample(TextureHandle texture, int samples, SizedInternalFormat internalformat, int width, int height, int depth, bool fixedsamplelocations)
-        {
-            byte fixedsamplelocations_byte = (byte)(fixedsamplelocations ? 1 : 0);
-            TextureStorage3DMultisample(texture, samples, internalformat, width, height, depth, fixedsamplelocations_byte);
-        }
         /// <inheritdoc cref="TextureSubImage1D"/>
         public static unsafe void TextureSubImage1D(TextureHandle texture, int level, int xoffset, int width, PixelFormat format, PixelType type, IntPtr pixels)
         {
@@ -14597,12 +14365,6 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             {
                 VertexArrayVertexBuffers(vaobj, first, count, buffers_ptr, offsets_ptr, strides_ptr);
             }
-        }
-        /// <inheritdoc cref="VertexArrayAttribFormat"/>
-        public static unsafe void VertexArrayAttribFormat(VertexArrayHandle vaobj, uint attribindex, int size, VertexAttribType type, bool normalized, uint relativeoffset)
-        {
-            byte normalized_byte = (byte)(normalized ? 1 : 0);
-            VertexArrayAttribFormat(vaobj, attribindex, size, type, normalized_byte, relativeoffset);
         }
         /// <inheritdoc cref="GetVertexArrayiv"/>
         public static unsafe void GetVertexArrayi(VertexArrayHandle vaobj, VertexArrayPName pname, ref int param)
@@ -15306,8 +15068,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         public static unsafe void GetnHistogram(HistogramTarget target, bool reset, PixelFormat format, PixelType type, int bufSize, IntPtr values)
         {
             void* values_vptr = (void*)values;
-            byte reset_byte = (byte)(reset ? 1 : 0);
-            GetnHistogram(target, reset_byte, format, type, bufSize, values_vptr);
+            GetnHistogram(target, reset, format, type, bufSize, values_vptr);
         }
         /// <inheritdoc cref="GetnHistogram"/>
         public static unsafe void GetnHistogram<T1>(HistogramTarget target, bool reset, PixelFormat format, PixelType type, Span<T1> values)
@@ -15316,8 +15077,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             int bufSize = (int)(values.Length * sizeof(T1));
             fixed (void* values_ptr = values)
             {
-                byte reset_byte = (byte)(reset ? 1 : 0);
-                GetnHistogram(target, reset_byte, format, type, bufSize, values_ptr);
+                GetnHistogram(target, reset, format, type, bufSize, values_ptr);
             }
         }
         /// <inheritdoc cref="GetnHistogram"/>
@@ -15327,8 +15087,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             int bufSize = (int)(values.Length * sizeof(T1));
             fixed (void* values_ptr = values)
             {
-                byte reset_byte = (byte)(reset ? 1 : 0);
-                GetnHistogram(target, reset_byte, format, type, bufSize, values_ptr);
+                GetnHistogram(target, reset, format, type, bufSize, values_ptr);
             }
         }
         /// <inheritdoc cref="GetnHistogram"/>
@@ -15337,16 +15096,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         {
             fixed (void* values_ptr = &values)
             {
-                byte reset_byte = (byte)(reset ? 1 : 0);
-                GetnHistogram(target, reset_byte, format, type, bufSize, values_ptr);
+                GetnHistogram(target, reset, format, type, bufSize, values_ptr);
             }
         }
         /// <inheritdoc cref="GetnMinmax"/>
         public static unsafe void GetnMinmax(MinmaxTarget target, bool reset, PixelFormat format, PixelType type, int bufSize, IntPtr values)
         {
             void* values_vptr = (void*)values;
-            byte reset_byte = (byte)(reset ? 1 : 0);
-            GetnMinmax(target, reset_byte, format, type, bufSize, values_vptr);
+            GetnMinmax(target, reset, format, type, bufSize, values_vptr);
         }
         /// <inheritdoc cref="GetnMinmax"/>
         public static unsafe void GetnMinmax<T1>(MinmaxTarget target, bool reset, PixelFormat format, PixelType type, Span<T1> values)
@@ -15355,8 +15112,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             int bufSize = (int)(values.Length * sizeof(T1));
             fixed (void* values_ptr = values)
             {
-                byte reset_byte = (byte)(reset ? 1 : 0);
-                GetnMinmax(target, reset_byte, format, type, bufSize, values_ptr);
+                GetnMinmax(target, reset, format, type, bufSize, values_ptr);
             }
         }
         /// <inheritdoc cref="GetnMinmax"/>
@@ -15366,8 +15122,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             int bufSize = (int)(values.Length * sizeof(T1));
             fixed (void* values_ptr = values)
             {
-                byte reset_byte = (byte)(reset ? 1 : 0);
-                GetnMinmax(target, reset_byte, format, type, bufSize, values_ptr);
+                GetnMinmax(target, reset, format, type, bufSize, values_ptr);
             }
         }
         /// <inheritdoc cref="GetnMinmax"/>
@@ -15376,8 +15131,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         {
             fixed (void* values_ptr = &values)
             {
-                byte reset_byte = (byte)(reset ? 1 : 0);
-                GetnMinmax(target, reset_byte, format, type, bufSize, values_ptr);
+                GetnMinmax(target, reset, format, type, bufSize, values_ptr);
             }
         }
         /// <inheritdoc cref="SpecializeShader"/>
@@ -15432,8 +15186,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 int count = (int)(ids.Length);
                 fixed (uint* ids_ptr = ids)
                 {
-                    byte enabled_byte = (byte)(enabled ? 1 : 0);
-                    DebugMessageEnableAMD(category, severity, count, ids_ptr, enabled_byte);
+                    DebugMessageEnableAMD(category, severity, count, ids_ptr, enabled);
                 }
             }
             /// <inheritdoc cref="DebugMessageEnableAMD"/>
@@ -15442,8 +15195,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 int count = (int)(ids.Length);
                 fixed (uint* ids_ptr = ids)
                 {
-                    byte enabled_byte = (byte)(enabled ? 1 : 0);
-                    DebugMessageEnableAMD(category, severity, count, ids_ptr, enabled_byte);
+                    DebugMessageEnableAMD(category, severity, count, ids_ptr, enabled);
                 }
             }
             /// <inheritdoc cref="DebugMessageEnableAMD"/>
@@ -15451,8 +15203,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             {
                 fixed (uint* ids_ptr = &ids)
                 {
-                    byte enabled_byte = (byte)(enabled ? 1 : 0);
-                    DebugMessageEnableAMD(category, severity, count, ids_ptr, enabled_byte);
+                    DebugMessageEnableAMD(category, severity, count, ids_ptr, enabled);
                 }
             }
             /// <inheritdoc cref="DebugMessageInsertAMD"/>
@@ -16461,8 +16212,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 int numCounters = (int)(counterList.Length);
                 fixed (uint* counterList_ptr = counterList)
                 {
-                    byte enable_byte = (byte)(enable ? 1 : 0);
-                    SelectPerfMonitorCountersAMD(monitor, enable_byte, group, numCounters, counterList_ptr);
+                    SelectPerfMonitorCountersAMD(monitor, enable, group, numCounters, counterList_ptr);
                 }
             }
             /// <inheritdoc cref="SelectPerfMonitorCountersAMD"/>
@@ -16471,8 +16221,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 int numCounters = (int)(counterList.Length);
                 fixed (uint* counterList_ptr = counterList)
                 {
-                    byte enable_byte = (byte)(enable ? 1 : 0);
-                    SelectPerfMonitorCountersAMD(monitor, enable_byte, group, numCounters, counterList_ptr);
+                    SelectPerfMonitorCountersAMD(monitor, enable, group, numCounters, counterList_ptr);
                 }
             }
             /// <inheritdoc cref="SelectPerfMonitorCountersAMD"/>
@@ -16480,8 +16229,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             {
                 fixed (uint* counterList_ptr = &counterList)
                 {
-                    byte enable_byte = (byte)(enable ? 1 : 0);
-                    SelectPerfMonitorCountersAMD(monitor, enable_byte, group, numCounters, counterList_ptr);
+                    SelectPerfMonitorCountersAMD(monitor, enable, group, numCounters, counterList_ptr);
                 }
             }
             /// <inheritdoc cref="GetPerfMonitorCounterDataAMD"/>
@@ -17081,14 +16829,6 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 void* indices = (void*)offset;
                 DrawElementsInstancedBaseVertexBaseInstance(mode, count, type, indices, instancecount, basevertex, baseinstance);
             }
-            /// <inheritdoc cref="GetImageHandleARB"/>
-            public static unsafe ulong GetImageHandleARB(TextureHandle texture, int level, bool layered, int layer, PixelFormat format)
-            {
-                ulong returnValue;
-                byte layered_byte = (byte)(layered ? 1 : 0);
-                returnValue = GetImageHandleARB(texture, level, layered_byte, layer, format);
-                return returnValue;
-            }
             /// <inheritdoc cref="UniformHandleui64vARB"/>
             public static unsafe void UniformHandleui64vARB(int location, ReadOnlySpan<ulong> value)
             {
@@ -17357,8 +17097,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 int count = (int)(ids.Length);
                 fixed (uint* ids_ptr = ids)
                 {
-                    byte enabled_byte = (byte)(enabled ? 1 : 0);
-                    DebugMessageControlARB(source, type, severity, count, ids_ptr, enabled_byte);
+                    DebugMessageControlARB(source, type, severity, count, ids_ptr, enabled);
                 }
             }
             /// <inheritdoc cref="DebugMessageControlARB"/>
@@ -17367,8 +17106,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 int count = (int)(ids.Length);
                 fixed (uint* ids_ptr = ids)
                 {
-                    byte enabled_byte = (byte)(enabled ? 1 : 0);
-                    DebugMessageControlARB(source, type, severity, count, ids_ptr, enabled_byte);
+                    DebugMessageControlARB(source, type, severity, count, ids_ptr, enabled);
                 }
             }
             /// <inheritdoc cref="DebugMessageControlARB"/>
@@ -17376,8 +17114,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             {
                 fixed (uint* ids_ptr = &ids)
                 {
-                    byte enabled_byte = (byte)(enabled ? 1 : 0);
-                    DebugMessageControlARB(source, type, severity, count, ids_ptr, enabled_byte);
+                    DebugMessageControlARB(source, type, severity, count, ids_ptr, enabled);
                 }
             }
             /// <inheritdoc cref="DebugMessageInsertARB"/>
@@ -18041,18 +17778,6 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                     CreateTextures(target, n, textures_ptr);
                 }
             }
-            /// <inheritdoc cref="TextureStorage2DMultisample"/>
-            public static unsafe void TextureStorage2DMultisample(TextureHandle texture, int samples, SizedInternalFormat internalformat, int width, int height, bool fixedsamplelocations)
-            {
-                byte fixedsamplelocations_byte = (byte)(fixedsamplelocations ? 1 : 0);
-                TextureStorage2DMultisample(texture, samples, internalformat, width, height, fixedsamplelocations_byte);
-            }
-            /// <inheritdoc cref="TextureStorage3DMultisample"/>
-            public static unsafe void TextureStorage3DMultisample(TextureHandle texture, int samples, SizedInternalFormat internalformat, int width, int height, int depth, bool fixedsamplelocations)
-            {
-                byte fixedsamplelocations_byte = (byte)(fixedsamplelocations ? 1 : 0);
-                TextureStorage3DMultisample(texture, samples, internalformat, width, height, depth, fixedsamplelocations_byte);
-            }
             /// <inheritdoc cref="TextureSubImage1D"/>
             public static unsafe void TextureSubImage1D(TextureHandle texture, int level, int xoffset, int width, PixelFormat format, PixelType type, IntPtr pixels)
             {
@@ -18322,12 +18047,6 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 {
                     VertexArrayVertexBuffers(vaobj, first, count, buffers_ptr, offsets_ptr, strides_ptr);
                 }
-            }
-            /// <inheritdoc cref="VertexArrayAttribFormat"/>
-            public static unsafe void VertexArrayAttribFormat(VertexArrayHandle vaobj, uint attribindex, int size, VertexAttribType type, bool normalized, uint relativeoffset)
-            {
-                byte normalized_byte = (byte)(normalized ? 1 : 0);
-                VertexArrayAttribFormat(vaobj, attribindex, size, type, normalized_byte, relativeoffset);
             }
             /// <inheritdoc cref="GetVertexArrayiv"/>
             public static unsafe void GetVertexArrayi(VertexArrayHandle vaobj, VertexArrayPName pname, ref int param)
@@ -19534,8 +19253,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix2d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix2dv(location, count, transpose_byte, value_ptr);
+                    UniformMatrix2dv(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix2dv"/>
@@ -19544,8 +19262,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix2d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix2dv(location, count, transpose_byte, value_ptr);
+                    UniformMatrix2dv(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix2dv"/>
@@ -19554,8 +19271,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix2d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix2dv(location, count, transpose_byte, value_ptr);
+                    UniformMatrix2dv(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix3dv"/>
@@ -19565,8 +19281,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix3d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix3dv(location, count, transpose_byte, value_ptr);
+                    UniformMatrix3dv(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix3dv"/>
@@ -19575,8 +19290,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix3d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix3dv(location, count, transpose_byte, value_ptr);
+                    UniformMatrix3dv(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix3dv"/>
@@ -19585,8 +19299,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix3d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix3dv(location, count, transpose_byte, value_ptr);
+                    UniformMatrix3dv(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix4dv"/>
@@ -19596,8 +19309,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix4d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix4dv(location, count, transpose_byte, value_ptr);
+                    UniformMatrix4dv(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix4dv"/>
@@ -19606,8 +19318,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix4d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix4dv(location, count, transpose_byte, value_ptr);
+                    UniformMatrix4dv(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix4dv"/>
@@ -19616,8 +19327,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix4d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix4dv(location, count, transpose_byte, value_ptr);
+                    UniformMatrix4dv(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix2x3dv"/>
@@ -19627,8 +19337,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix2x3d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix2x3dv(location, count, transpose_byte, value_ptr);
+                    UniformMatrix2x3dv(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix2x3dv"/>
@@ -19637,8 +19346,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix2x3d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix2x3dv(location, count, transpose_byte, value_ptr);
+                    UniformMatrix2x3dv(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix2x3dv"/>
@@ -19647,8 +19355,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix2x3d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix2x3dv(location, count, transpose_byte, value_ptr);
+                    UniformMatrix2x3dv(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix2x4dv"/>
@@ -19658,8 +19365,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix2x4d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix2x4dv(location, count, transpose_byte, value_ptr);
+                    UniformMatrix2x4dv(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix2x4dv"/>
@@ -19668,8 +19374,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix2x4d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix2x4dv(location, count, transpose_byte, value_ptr);
+                    UniformMatrix2x4dv(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix2x4dv"/>
@@ -19678,8 +19383,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix2x4d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix2x4dv(location, count, transpose_byte, value_ptr);
+                    UniformMatrix2x4dv(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix3x2dv"/>
@@ -19689,8 +19393,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix3x2d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix3x2dv(location, count, transpose_byte, value_ptr);
+                    UniformMatrix3x2dv(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix3x2dv"/>
@@ -19699,8 +19402,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix3x2d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix3x2dv(location, count, transpose_byte, value_ptr);
+                    UniformMatrix3x2dv(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix3x2dv"/>
@@ -19709,8 +19411,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix3x2d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix3x2dv(location, count, transpose_byte, value_ptr);
+                    UniformMatrix3x2dv(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix3x4dv"/>
@@ -19720,8 +19421,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix3x4d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix3x4dv(location, count, transpose_byte, value_ptr);
+                    UniformMatrix3x4dv(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix3x4dv"/>
@@ -19730,8 +19430,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix3x4d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix3x4dv(location, count, transpose_byte, value_ptr);
+                    UniformMatrix3x4dv(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix3x4dv"/>
@@ -19740,8 +19439,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix3x4d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix3x4dv(location, count, transpose_byte, value_ptr);
+                    UniformMatrix3x4dv(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix4x2dv"/>
@@ -19751,8 +19449,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix4x2d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix4x2dv(location, count, transpose_byte, value_ptr);
+                    UniformMatrix4x2dv(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix4x2dv"/>
@@ -19761,8 +19458,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix4x2d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix4x2dv(location, count, transpose_byte, value_ptr);
+                    UniformMatrix4x2dv(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix4x2dv"/>
@@ -19771,8 +19467,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix4x2d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix4x2dv(location, count, transpose_byte, value_ptr);
+                    UniformMatrix4x2dv(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix4x3dv"/>
@@ -19782,8 +19477,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix4x3d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix4x3dv(location, count, transpose_byte, value_ptr);
+                    UniformMatrix4x3dv(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix4x3dv"/>
@@ -19792,8 +19486,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix4x3d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix4x3dv(location, count, transpose_byte, value_ptr);
+                    UniformMatrix4x3dv(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix4x3dv"/>
@@ -19802,8 +19495,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix4x3d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix4x3dv(location, count, transpose_byte, value_ptr);
+                    UniformMatrix4x3dv(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="GetUniformdv"/>
@@ -20839,8 +20531,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             public static unsafe void GetHistogram(HistogramTargetEXT target, bool reset, PixelFormat format, PixelType type, IntPtr values)
             {
                 void* values_vptr = (void*)values;
-                byte reset_byte = (byte)(reset ? 1 : 0);
-                GetHistogram(target, reset_byte, format, type, values_vptr);
+                GetHistogram(target, reset, format, type, values_vptr);
             }
             /// <inheritdoc cref="GetHistogram"/>
             public static unsafe void GetHistogram<T1>(HistogramTargetEXT target, bool reset, PixelFormat format, PixelType type, Span<T1> values)
@@ -20848,8 +20539,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             {
                 fixed (void* values_ptr = values)
                 {
-                    byte reset_byte = (byte)(reset ? 1 : 0);
-                    GetHistogram(target, reset_byte, format, type, values_ptr);
+                    GetHistogram(target, reset, format, type, values_ptr);
                 }
             }
             /// <inheritdoc cref="GetHistogram"/>
@@ -20858,8 +20548,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             {
                 fixed (void* values_ptr = values)
                 {
-                    byte reset_byte = (byte)(reset ? 1 : 0);
-                    GetHistogram(target, reset_byte, format, type, values_ptr);
+                    GetHistogram(target, reset, format, type, values_ptr);
                 }
             }
             /// <inheritdoc cref="GetHistogram"/>
@@ -20868,8 +20557,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             {
                 fixed (void* values_ptr = &values)
                 {
-                    byte reset_byte = (byte)(reset ? 1 : 0);
-                    GetHistogram(target, reset_byte, format, type, values_ptr);
+                    GetHistogram(target, reset, format, type, values_ptr);
                 }
             }
             /// <inheritdoc cref="GetHistogramParameterfv"/>
@@ -20924,8 +20612,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             public static unsafe void GetMinmax(MinmaxTargetEXT target, bool reset, PixelFormat format, PixelType type, IntPtr values)
             {
                 void* values_vptr = (void*)values;
-                byte reset_byte = (byte)(reset ? 1 : 0);
-                GetMinmax(target, reset_byte, format, type, values_vptr);
+                GetMinmax(target, reset, format, type, values_vptr);
             }
             /// <inheritdoc cref="GetMinmax"/>
             public static unsafe void GetMinmax<T1>(MinmaxTargetEXT target, bool reset, PixelFormat format, PixelType type, Span<T1> values)
@@ -20933,8 +20620,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             {
                 fixed (void* values_ptr = values)
                 {
-                    byte reset_byte = (byte)(reset ? 1 : 0);
-                    GetMinmax(target, reset_byte, format, type, values_ptr);
+                    GetMinmax(target, reset, format, type, values_ptr);
                 }
             }
             /// <inheritdoc cref="GetMinmax"/>
@@ -20943,8 +20629,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             {
                 fixed (void* values_ptr = values)
                 {
-                    byte reset_byte = (byte)(reset ? 1 : 0);
-                    GetMinmax(target, reset_byte, format, type, values_ptr);
+                    GetMinmax(target, reset, format, type, values_ptr);
                 }
             }
             /// <inheritdoc cref="GetMinmax"/>
@@ -20953,8 +20638,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             {
                 fixed (void* values_ptr = &values)
                 {
-                    byte reset_byte = (byte)(reset ? 1 : 0);
-                    GetMinmax(target, reset_byte, format, type, values_ptr);
+                    GetMinmax(target, reset, format, type, values_ptr);
                 }
             }
             /// <inheritdoc cref="GetMinmaxParameterfv"/>
@@ -21004,18 +20688,6 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 {
                     GetMinmaxParameteriv(target, pname, parameters_ptr);
                 }
-            }
-            /// <inheritdoc cref="Histogram"/>
-            public static unsafe void Histogram(HistogramTargetEXT target, int width, InternalFormat internalformat, bool sink)
-            {
-                byte sink_byte = (byte)(sink ? 1 : 0);
-                Histogram(target, width, internalformat, sink_byte);
-            }
-            /// <inheritdoc cref="Minmax"/>
-            public static unsafe void Minmax(MinmaxTargetEXT target, InternalFormat internalformat, bool sink)
-            {
-                byte sink_byte = (byte)(sink ? 1 : 0);
-                Minmax(target, internalformat, sink_byte);
             }
             /// <inheritdoc cref="MultiDrawArraysIndirectCountARB"/>
             public static unsafe void MultiDrawArraysIndirectCountARB(PrimitiveType mode, IntPtr indirect, IntPtr drawcount, int maxdrawcount, int stride)
@@ -21507,12 +21179,6 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 {
                     MultiDrawElementsIndirect(mode, type, indirect_ptr, drawcount, stride);
                 }
-            }
-            /// <inheritdoc cref="SampleCoverageARB"/>
-            public static unsafe void SampleCoverageARB(float value, bool invert)
-            {
-                byte invert_byte = (byte)(invert ? 1 : 0);
-                SampleCoverageARB(value, invert_byte);
             }
             /// <inheritdoc cref="MultiTexCoord1dvARB"/>
             public static unsafe void MultiTexCoord1dvARB(TextureUnit target, ReadOnlySpan<double> v)
@@ -22735,8 +22401,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             public static unsafe void GetnHistogramARB(HistogramTargetEXT target, bool reset, PixelFormat format, PixelType type, int bufSize, IntPtr values)
             {
                 void* values_vptr = (void*)values;
-                byte reset_byte = (byte)(reset ? 1 : 0);
-                GetnHistogramARB(target, reset_byte, format, type, bufSize, values_vptr);
+                GetnHistogramARB(target, reset, format, type, bufSize, values_vptr);
             }
             /// <inheritdoc cref="GetnHistogramARB"/>
             public static unsafe void GetnHistogramARB<T1>(HistogramTargetEXT target, bool reset, PixelFormat format, PixelType type, Span<T1> values)
@@ -22745,8 +22410,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 int bufSize = (int)(values.Length * sizeof(T1));
                 fixed (void* values_ptr = values)
                 {
-                    byte reset_byte = (byte)(reset ? 1 : 0);
-                    GetnHistogramARB(target, reset_byte, format, type, bufSize, values_ptr);
+                    GetnHistogramARB(target, reset, format, type, bufSize, values_ptr);
                 }
             }
             /// <inheritdoc cref="GetnHistogramARB"/>
@@ -22756,8 +22420,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 int bufSize = (int)(values.Length * sizeof(T1));
                 fixed (void* values_ptr = values)
                 {
-                    byte reset_byte = (byte)(reset ? 1 : 0);
-                    GetnHistogramARB(target, reset_byte, format, type, bufSize, values_ptr);
+                    GetnHistogramARB(target, reset, format, type, bufSize, values_ptr);
                 }
             }
             /// <inheritdoc cref="GetnHistogramARB"/>
@@ -22766,16 +22429,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             {
                 fixed (void* values_ptr = &values)
                 {
-                    byte reset_byte = (byte)(reset ? 1 : 0);
-                    GetnHistogramARB(target, reset_byte, format, type, bufSize, values_ptr);
+                    GetnHistogramARB(target, reset, format, type, bufSize, values_ptr);
                 }
             }
             /// <inheritdoc cref="GetnMinmaxARB"/>
             public static unsafe void GetnMinmaxARB(MinmaxTargetEXT target, bool reset, PixelFormat format, PixelType type, int bufSize, IntPtr values)
             {
                 void* values_vptr = (void*)values;
-                byte reset_byte = (byte)(reset ? 1 : 0);
-                GetnMinmaxARB(target, reset_byte, format, type, bufSize, values_vptr);
+                GetnMinmaxARB(target, reset, format, type, bufSize, values_vptr);
             }
             /// <inheritdoc cref="GetnMinmaxARB"/>
             public static unsafe void GetnMinmaxARB<T1>(MinmaxTargetEXT target, bool reset, PixelFormat format, PixelType type, Span<T1> values)
@@ -22784,8 +22445,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 int bufSize = (int)(values.Length * sizeof(T1));
                 fixed (void* values_ptr = values)
                 {
-                    byte reset_byte = (byte)(reset ? 1 : 0);
-                    GetnMinmaxARB(target, reset_byte, format, type, bufSize, values_ptr);
+                    GetnMinmaxARB(target, reset, format, type, bufSize, values_ptr);
                 }
             }
             /// <inheritdoc cref="GetnMinmaxARB"/>
@@ -22795,8 +22455,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 int bufSize = (int)(values.Length * sizeof(T1));
                 fixed (void* values_ptr = values)
                 {
-                    byte reset_byte = (byte)(reset ? 1 : 0);
-                    GetnMinmaxARB(target, reset_byte, format, type, bufSize, values_ptr);
+                    GetnMinmaxARB(target, reset, format, type, bufSize, values_ptr);
                 }
             }
             /// <inheritdoc cref="GetnMinmaxARB"/>
@@ -22805,8 +22464,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             {
                 fixed (void* values_ptr = &values)
                 {
-                    byte reset_byte = (byte)(reset ? 1 : 0);
-                    GetnMinmaxARB(target, reset_byte, format, type, bufSize, values_ptr);
+                    GetnMinmaxARB(target, reset, format, type, bufSize, values_ptr);
                 }
             }
             /// <inheritdoc cref="FramebufferSampleLocationsfvARB"/>
@@ -23679,8 +23337,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix2* tmp_vecPtr = &value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2fv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2fv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2fv"/>
@@ -23689,8 +23346,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix2* tmp_vecPtr = value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2fv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2fv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2fv"/>
@@ -23699,8 +23355,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix2* tmp_vecPtr = value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2fv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2fv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3fv"/>
@@ -23710,8 +23365,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix3* tmp_vecPtr = &value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3fv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3fv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3fv"/>
@@ -23720,8 +23374,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix3* tmp_vecPtr = value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3fv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3fv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3fv"/>
@@ -23730,8 +23383,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix3* tmp_vecPtr = value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3fv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3fv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
@@ -23741,8 +23393,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix4* tmp_vecPtr = &value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4fv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4fv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
@@ -23751,8 +23402,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix4* tmp_vecPtr = value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4fv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4fv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
@@ -23761,8 +23411,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix4* tmp_vecPtr = value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4fv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4fv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2dv"/>
@@ -23772,8 +23421,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix2d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2dv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2dv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2dv"/>
@@ -23782,8 +23430,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix2d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2dv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2dv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2dv"/>
@@ -23792,8 +23439,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix2d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2dv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2dv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3dv"/>
@@ -23803,8 +23449,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix3d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3dv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3dv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3dv"/>
@@ -23813,8 +23458,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix3d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3dv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3dv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3dv"/>
@@ -23823,8 +23467,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix3d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3dv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3dv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4dv"/>
@@ -23834,8 +23477,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix4d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4dv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4dv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4dv"/>
@@ -23844,8 +23486,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix4d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4dv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4dv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4dv"/>
@@ -23854,8 +23495,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix4d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4dv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4dv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x3fv"/>
@@ -23865,8 +23505,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix2x3* tmp_vecPtr = &value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2x3fv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2x3fv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x3fv"/>
@@ -23875,8 +23514,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix2x3* tmp_vecPtr = value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2x3fv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2x3fv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x3fv"/>
@@ -23885,8 +23523,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix2x3* tmp_vecPtr = value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2x3fv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2x3fv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
@@ -23896,8 +23533,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix3x2* tmp_vecPtr = &value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3x2fv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3x2fv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
@@ -23906,8 +23542,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix3x2* tmp_vecPtr = value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3x2fv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3x2fv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
@@ -23916,8 +23551,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix3x2* tmp_vecPtr = value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3x2fv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3x2fv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x4fv"/>
@@ -23927,8 +23561,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix2x4* tmp_vecPtr = &value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2x4fv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2x4fv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x4fv"/>
@@ -23937,8 +23570,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix2x4* tmp_vecPtr = value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2x4fv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2x4fv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x4fv"/>
@@ -23947,8 +23579,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix2x4* tmp_vecPtr = value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2x4fv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2x4fv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x2fv"/>
@@ -23958,8 +23589,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix4x2* tmp_vecPtr = &value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4x2fv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4x2fv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x2fv"/>
@@ -23968,8 +23598,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix4x2* tmp_vecPtr = value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4x2fv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4x2fv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x2fv"/>
@@ -23978,8 +23607,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix4x2* tmp_vecPtr = value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4x2fv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4x2fv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x4fv"/>
@@ -23989,8 +23617,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix3x4* tmp_vecPtr = &value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3x4fv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3x4fv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x4fv"/>
@@ -23999,8 +23626,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix3x4* tmp_vecPtr = value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3x4fv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3x4fv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x4fv"/>
@@ -24009,8 +23635,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix3x4* tmp_vecPtr = value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3x4fv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3x4fv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x3fv"/>
@@ -24020,8 +23645,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix4x3* tmp_vecPtr = &value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4x3fv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4x3fv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x3fv"/>
@@ -24030,8 +23654,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix4x3* tmp_vecPtr = value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4x3fv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4x3fv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x3fv"/>
@@ -24040,8 +23663,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix4x3* tmp_vecPtr = value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4x3fv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4x3fv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x3dv"/>
@@ -24051,8 +23673,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix2x3d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2x3dv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2x3dv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x3dv"/>
@@ -24061,8 +23682,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix2x3d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2x3dv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2x3dv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x3dv"/>
@@ -24071,8 +23691,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix2x3d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2x3dv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2x3dv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2dv"/>
@@ -24082,8 +23701,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix3x2d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3x2dv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3x2dv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2dv"/>
@@ -24092,8 +23710,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix3x2d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3x2dv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3x2dv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2dv"/>
@@ -24102,8 +23719,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix3x2d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3x2dv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3x2dv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x4dv"/>
@@ -24113,8 +23729,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix2x4d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2x4dv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2x4dv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x4dv"/>
@@ -24123,8 +23738,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix2x4d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2x4dv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2x4dv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x4dv"/>
@@ -24133,8 +23747,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix2x4d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2x4dv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2x4dv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x2dv"/>
@@ -24144,8 +23757,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix4x2d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4x2dv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4x2dv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x2dv"/>
@@ -24154,8 +23766,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix4x2d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4x2dv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4x2dv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x2dv"/>
@@ -24164,8 +23775,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix4x2d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4x2dv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4x2dv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x4dv"/>
@@ -24175,8 +23785,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix3x4d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3x4dv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3x4dv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x4dv"/>
@@ -24185,8 +23794,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix3x4d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3x4dv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3x4dv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x4dv"/>
@@ -24195,8 +23803,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix3x4d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3x4dv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3x4dv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x3dv"/>
@@ -24206,8 +23813,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix4x3d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4x3dv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4x3dv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x3dv"/>
@@ -24216,8 +23822,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix4x3d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4x3dv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4x3dv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x3dv"/>
@@ -24226,8 +23831,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (Matrix4x3d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4x3dv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4x3dv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="GetProgramPipelineInfoLog"/>
@@ -24325,12 +23929,6 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 {
                     GetActiveAtomicCounterBufferiv(program, bufferIndex, pname, parameters_ptr);
                 }
-            }
-            /// <inheritdoc cref="BindImageTexture"/>
-            public static unsafe void BindImageTexture(uint unit, TextureHandle texture, int level, bool layered, int layer, BufferAccessARB access, InternalFormat format)
-            {
-                byte layered_byte = (byte)(layered ? 1 : 0);
-                BindImageTexture(unit, texture, level, layered_byte, layer, access, format);
             }
             /// <inheritdoc cref="ShaderSourceARB"/>
             public static unsafe void ShaderSourceARB(GLHandleARB shaderObj, int count, byte** str, ReadOnlySpan<int> length)
@@ -24570,8 +24168,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 int count = (int)(value.Length / 4);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix2fvARB(location, count, transpose_byte, value_ptr);
+                    UniformMatrix2fvARB(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix2fvARB"/>
@@ -24580,8 +24177,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 int count = (int)(value.Length / 4);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix2fvARB(location, count, transpose_byte, value_ptr);
+                    UniformMatrix2fvARB(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix2fvARB"/>
@@ -24589,8 +24185,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             {
                 fixed (float* value_ptr = &value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix2fvARB(location, count, transpose_byte, value_ptr);
+                    UniformMatrix2fvARB(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix3fvARB"/>
@@ -24599,8 +24194,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 int count = (int)(value.Length / 9);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix3fvARB(location, count, transpose_byte, value_ptr);
+                    UniformMatrix3fvARB(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix3fvARB"/>
@@ -24609,8 +24203,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 int count = (int)(value.Length / 9);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix3fvARB(location, count, transpose_byte, value_ptr);
+                    UniformMatrix3fvARB(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix3fvARB"/>
@@ -24618,8 +24211,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             {
                 fixed (float* value_ptr = &value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix3fvARB(location, count, transpose_byte, value_ptr);
+                    UniformMatrix3fvARB(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix4fvARB"/>
@@ -24628,8 +24220,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 int count = (int)(value.Length / 16);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix4fvARB(location, count, transpose_byte, value_ptr);
+                    UniformMatrix4fvARB(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix4fvARB"/>
@@ -24638,8 +24229,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 int count = (int)(value.Length / 16);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix4fvARB(location, count, transpose_byte, value_ptr);
+                    UniformMatrix4fvARB(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix4fvARB"/>
@@ -24647,8 +24237,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             {
                 fixed (float* value_ptr = &value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix4fvARB(location, count, transpose_byte, value_ptr);
+                    UniformMatrix4fvARB(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="GetObjectParameterfvARB"/>
@@ -25456,30 +25045,6 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                     Marshal.FreeCoTaskMem((IntPtr)name_ptr);
                 }
             }
-            /// <inheritdoc cref="BufferPageCommitmentARB"/>
-            public static unsafe void BufferPageCommitmentARB(All target, IntPtr offset, nint size, bool commit)
-            {
-                byte commit_byte = (byte)(commit ? 1 : 0);
-                BufferPageCommitmentARB(target, offset, size, commit_byte);
-            }
-            /// <inheritdoc cref="NamedBufferPageCommitmentEXT"/>
-            public static unsafe void NamedBufferPageCommitmentEXT(BufferHandle buffer, IntPtr offset, nint size, bool commit)
-            {
-                byte commit_byte = (byte)(commit ? 1 : 0);
-                NamedBufferPageCommitmentEXT(buffer, offset, size, commit_byte);
-            }
-            /// <inheritdoc cref="NamedBufferPageCommitmentARB"/>
-            public static unsafe void NamedBufferPageCommitmentARB(BufferHandle buffer, IntPtr offset, nint size, bool commit)
-            {
-                byte commit_byte = (byte)(commit ? 1 : 0);
-                NamedBufferPageCommitmentARB(buffer, offset, size, commit_byte);
-            }
-            /// <inheritdoc cref="TexPageCommitmentARB"/>
-            public static unsafe void TexPageCommitmentARB(All target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, bool commit)
-            {
-                byte commit_byte = (byte)(commit ? 1 : 0);
-                TexPageCommitmentARB(target, level, xoffset, yoffset, zoffset, width, height, depth, commit_byte);
-            }
             /// <inheritdoc cref="GetInteger64v"/>
             public static unsafe void GetInteger64(GetPName pname, Span<long> data)
             {
@@ -25804,18 +25369,6 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                     GetCompressedTexImageARB(target, level, img_ptr);
                 }
             }
-            /// <inheritdoc cref="TexImage2DMultisample"/>
-            public static unsafe void TexImage2DMultisample(TextureTarget target, int samples, InternalFormat internalformat, int width, int height, bool fixedsamplelocations)
-            {
-                byte fixedsamplelocations_byte = (byte)(fixedsamplelocations ? 1 : 0);
-                TexImage2DMultisample(target, samples, internalformat, width, height, fixedsamplelocations_byte);
-            }
-            /// <inheritdoc cref="TexImage3DMultisample"/>
-            public static unsafe void TexImage3DMultisample(TextureTarget target, int samples, InternalFormat internalformat, int width, int height, int depth, bool fixedsamplelocations)
-            {
-                byte fixedsamplelocations_byte = (byte)(fixedsamplelocations ? 1 : 0);
-                TexImage3DMultisample(target, samples, internalformat, width, height, depth, fixedsamplelocations_byte);
-            }
             /// <inheritdoc cref="GetMultisamplefv"/>
             public static unsafe void GetMultisamplef(GetMultisamplePNameNV pname, uint index, Span<float> val)
             {
@@ -25839,18 +25392,6 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 {
                     GetMultisamplefv(pname, index, val_ptr);
                 }
-            }
-            /// <inheritdoc cref="TexStorage2DMultisample"/>
-            public static unsafe void TexStorage2DMultisample(TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, bool fixedsamplelocations)
-            {
-                byte fixedsamplelocations_byte = (byte)(fixedsamplelocations ? 1 : 0);
-                TexStorage2DMultisample(target, samples, internalformat, width, height, fixedsamplelocations_byte);
-            }
-            /// <inheritdoc cref="TexStorage3DMultisample"/>
-            public static unsafe void TexStorage3DMultisample(TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, int depth, bool fixedsamplelocations)
-            {
-                byte fixedsamplelocations_byte = (byte)(fixedsamplelocations ? 1 : 0);
-                TexStorage3DMultisample(target, samples, internalformat, width, height, depth, fixedsamplelocations_byte);
             }
             /// <inheritdoc cref="GetQueryObjecti64v"/>
             public static unsafe void GetQueryObjecti64(QueryHandle id, QueryObjectParameterName pname, Span<long> parameters)
@@ -26593,12 +26134,6 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 {
                     GetVertexAttribLdv(index, pname, parameters_ptr);
                 }
-            }
-            /// <inheritdoc cref="VertexAttribFormat"/>
-            public static unsafe void VertexAttribFormat(uint attribindex, int size, VertexAttribType type, bool normalized, uint relativeoffset)
-            {
-                byte normalized_byte = (byte)(normalized ? 1 : 0);
-                VertexAttribFormat(attribindex, size, type, normalized_byte, relativeoffset);
             }
             /// <inheritdoc cref="WeightbvARB"/>
             public static unsafe void WeightbvARB(ReadOnlySpan<sbyte> weights)
@@ -27578,8 +27113,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             public static unsafe void VertexAttribPointerARB(uint index, int size, VertexAttribPointerType type, bool normalized, int stride, IntPtr pointer)
             {
                 void* pointer_vptr = (void*)pointer;
-                byte normalized_byte = (byte)(normalized ? 1 : 0);
-                VertexAttribPointerARB(index, size, type, normalized_byte, stride, pointer_vptr);
+                VertexAttribPointerARB(index, size, type, normalized, stride, pointer_vptr);
             }
             /// <inheritdoc cref="VertexAttribPointerARB"/>
             public static unsafe void VertexAttribPointerARB<T1>(uint index, int size, VertexAttribPointerType type, bool normalized, int stride, ReadOnlySpan<T1> pointer)
@@ -27587,8 +27121,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             {
                 fixed (void* pointer_ptr = pointer)
                 {
-                    byte normalized_byte = (byte)(normalized ? 1 : 0);
-                    VertexAttribPointerARB(index, size, type, normalized_byte, stride, pointer_ptr);
+                    VertexAttribPointerARB(index, size, type, normalized, stride, pointer_ptr);
                 }
             }
             /// <inheritdoc cref="VertexAttribPointerARB"/>
@@ -27597,8 +27130,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             {
                 fixed (void* pointer_ptr = pointer)
                 {
-                    byte normalized_byte = (byte)(normalized ? 1 : 0);
-                    VertexAttribPointerARB(index, size, type, normalized_byte, stride, pointer_ptr);
+                    VertexAttribPointerARB(index, size, type, normalized, stride, pointer_ptr);
                 }
             }
             /// <inheritdoc cref="VertexAttribPointerARB"/>
@@ -27607,8 +27139,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             {
                 fixed (void* pointer_ptr = &pointer)
                 {
-                    byte normalized_byte = (byte)(normalized ? 1 : 0);
-                    VertexAttribPointerARB(index, size, type, normalized_byte, stride, pointer_ptr);
+                    VertexAttribPointerARB(index, size, type, normalized, stride, pointer_ptr);
                 }
             }
             /// <inheritdoc cref="GetVertexAttribdvARB"/>
@@ -27799,19 +27330,12 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 Marshal.FreeCoTaskMem((IntPtr)name_ptr);
                 return returnValue;
             }
-            /// <inheritdoc cref="VertexAttribP1ui"/>
-            public static unsafe void VertexAttribP1ui(uint index, VertexAttribPointerType type, bool normalized, uint value)
-            {
-                byte normalized_byte = (byte)(normalized ? 1 : 0);
-                VertexAttribP1ui(index, type, normalized_byte, value);
-            }
             /// <inheritdoc cref="VertexAttribP1uiv"/>
             public static unsafe void VertexAttribP1ui(uint index, VertexAttribPointerType type, bool normalized, ReadOnlySpan<uint> value)
             {
                 fixed (uint* value_ptr = value)
                 {
-                    byte normalized_byte = (byte)(normalized ? 1 : 0);
-                    VertexAttribP1uiv(index, type, normalized_byte, value_ptr);
+                    VertexAttribP1uiv(index, type, normalized, value_ptr);
                 }
             }
             /// <inheritdoc cref="VertexAttribP1uiv"/>
@@ -27819,8 +27343,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             {
                 fixed (uint* value_ptr = value)
                 {
-                    byte normalized_byte = (byte)(normalized ? 1 : 0);
-                    VertexAttribP1uiv(index, type, normalized_byte, value_ptr);
+                    VertexAttribP1uiv(index, type, normalized, value_ptr);
                 }
             }
             /// <inheritdoc cref="VertexAttribP1uiv"/>
@@ -27828,23 +27351,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             {
                 fixed (uint* value_ptr = &value)
                 {
-                    byte normalized_byte = (byte)(normalized ? 1 : 0);
-                    VertexAttribP1uiv(index, type, normalized_byte, value_ptr);
+                    VertexAttribP1uiv(index, type, normalized, value_ptr);
                 }
-            }
-            /// <inheritdoc cref="VertexAttribP2ui"/>
-            public static unsafe void VertexAttribP2ui(uint index, VertexAttribPointerType type, bool normalized, uint value)
-            {
-                byte normalized_byte = (byte)(normalized ? 1 : 0);
-                VertexAttribP2ui(index, type, normalized_byte, value);
             }
             /// <inheritdoc cref="VertexAttribP2uiv"/>
             public static unsafe void VertexAttribP2ui(uint index, VertexAttribPointerType type, bool normalized, ReadOnlySpan<uint> value)
             {
                 fixed (uint* value_ptr = value)
                 {
-                    byte normalized_byte = (byte)(normalized ? 1 : 0);
-                    VertexAttribP2uiv(index, type, normalized_byte, value_ptr);
+                    VertexAttribP2uiv(index, type, normalized, value_ptr);
                 }
             }
             /// <inheritdoc cref="VertexAttribP2uiv"/>
@@ -27852,8 +27367,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             {
                 fixed (uint* value_ptr = value)
                 {
-                    byte normalized_byte = (byte)(normalized ? 1 : 0);
-                    VertexAttribP2uiv(index, type, normalized_byte, value_ptr);
+                    VertexAttribP2uiv(index, type, normalized, value_ptr);
                 }
             }
             /// <inheritdoc cref="VertexAttribP2uiv"/>
@@ -27861,23 +27375,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             {
                 fixed (uint* value_ptr = &value)
                 {
-                    byte normalized_byte = (byte)(normalized ? 1 : 0);
-                    VertexAttribP2uiv(index, type, normalized_byte, value_ptr);
+                    VertexAttribP2uiv(index, type, normalized, value_ptr);
                 }
-            }
-            /// <inheritdoc cref="VertexAttribP3ui"/>
-            public static unsafe void VertexAttribP3ui(uint index, VertexAttribPointerType type, bool normalized, uint value)
-            {
-                byte normalized_byte = (byte)(normalized ? 1 : 0);
-                VertexAttribP3ui(index, type, normalized_byte, value);
             }
             /// <inheritdoc cref="VertexAttribP3uiv"/>
             public static unsafe void VertexAttribP3ui(uint index, VertexAttribPointerType type, bool normalized, ReadOnlySpan<uint> value)
             {
                 fixed (uint* value_ptr = value)
                 {
-                    byte normalized_byte = (byte)(normalized ? 1 : 0);
-                    VertexAttribP3uiv(index, type, normalized_byte, value_ptr);
+                    VertexAttribP3uiv(index, type, normalized, value_ptr);
                 }
             }
             /// <inheritdoc cref="VertexAttribP3uiv"/>
@@ -27885,8 +27391,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             {
                 fixed (uint* value_ptr = value)
                 {
-                    byte normalized_byte = (byte)(normalized ? 1 : 0);
-                    VertexAttribP3uiv(index, type, normalized_byte, value_ptr);
+                    VertexAttribP3uiv(index, type, normalized, value_ptr);
                 }
             }
             /// <inheritdoc cref="VertexAttribP3uiv"/>
@@ -27894,23 +27399,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             {
                 fixed (uint* value_ptr = &value)
                 {
-                    byte normalized_byte = (byte)(normalized ? 1 : 0);
-                    VertexAttribP3uiv(index, type, normalized_byte, value_ptr);
+                    VertexAttribP3uiv(index, type, normalized, value_ptr);
                 }
-            }
-            /// <inheritdoc cref="VertexAttribP4ui"/>
-            public static unsafe void VertexAttribP4ui(uint index, VertexAttribPointerType type, bool normalized, uint value)
-            {
-                byte normalized_byte = (byte)(normalized ? 1 : 0);
-                VertexAttribP4ui(index, type, normalized_byte, value);
             }
             /// <inheritdoc cref="VertexAttribP4uiv"/>
             public static unsafe void VertexAttribP4ui(uint index, VertexAttribPointerType type, bool normalized, ReadOnlySpan<uint> value)
             {
                 fixed (uint* value_ptr = value)
                 {
-                    byte normalized_byte = (byte)(normalized ? 1 : 0);
-                    VertexAttribP4uiv(index, type, normalized_byte, value_ptr);
+                    VertexAttribP4uiv(index, type, normalized, value_ptr);
                 }
             }
             /// <inheritdoc cref="VertexAttribP4uiv"/>
@@ -27918,8 +27415,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             {
                 fixed (uint* value_ptr = value)
                 {
-                    byte normalized_byte = (byte)(normalized ? 1 : 0);
-                    VertexAttribP4uiv(index, type, normalized_byte, value_ptr);
+                    VertexAttribP4uiv(index, type, normalized, value_ptr);
                 }
             }
             /// <inheritdoc cref="VertexAttribP4uiv"/>
@@ -27927,8 +27423,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             {
                 fixed (uint* value_ptr = &value)
                 {
-                    byte normalized_byte = (byte)(normalized ? 1 : 0);
-                    VertexAttribP4uiv(index, type, normalized_byte, value_ptr);
+                    VertexAttribP4uiv(index, type, normalized, value_ptr);
                 }
             }
             /// <inheritdoc cref="VertexP2uiv"/>
@@ -29062,12 +28557,6 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 {
                     GetVariantArrayObjectivATI(id, pname, parameters_ptr);
                 }
-            }
-            /// <inheritdoc cref="VertexAttribArrayObjectATI"/>
-            public static unsafe void VertexAttribArrayObjectATI(uint index, int size, VertexAttribPointerType type, bool normalized, int stride, BufferHandle buffer, uint offset)
-            {
-                byte normalized_byte = (byte)(normalized ? 1 : 0);
-                VertexAttribArrayObjectATI(index, size, type, normalized_byte, stride, buffer, offset);
             }
             /// <inheritdoc cref="GetVertexAttribArrayObjectfvATI"/>
             public static unsafe void GetVertexAttribArrayObjectfvATI(uint index, ArrayObjectPNameATI pname, Span<float> parameters)
@@ -32570,8 +32059,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 int count = (int)(value.Length / 4);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2fvEXT"/>
@@ -32580,8 +32068,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 int count = (int)(value.Length / 4);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2fvEXT"/>
@@ -32589,8 +32076,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             {
                 fixed (float* value_ptr = &value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3fvEXT"/>
@@ -32599,8 +32085,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 int count = (int)(value.Length / 9);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3fvEXT"/>
@@ -32609,8 +32094,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 int count = (int)(value.Length / 9);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3fvEXT"/>
@@ -32618,8 +32102,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             {
                 fixed (float* value_ptr = &value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4fvEXT"/>
@@ -32628,8 +32111,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 int count = (int)(value.Length / 16);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4fvEXT"/>
@@ -32638,8 +32120,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 int count = (int)(value.Length / 16);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4fvEXT"/>
@@ -32647,8 +32128,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             {
                 fixed (float* value_ptr = &value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x3fvEXT"/>
@@ -32657,8 +32137,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 int count = (int)(value.Length / 6);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2x3fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2x3fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x3fvEXT"/>
@@ -32667,8 +32146,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 int count = (int)(value.Length / 6);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2x3fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2x3fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x3fvEXT"/>
@@ -32676,8 +32154,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             {
                 fixed (float* value_ptr = &value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2x3fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2x3fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2fvEXT"/>
@@ -32686,8 +32163,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 int count = (int)(value.Length / 6);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3x2fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3x2fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2fvEXT"/>
@@ -32696,8 +32172,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 int count = (int)(value.Length / 6);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3x2fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3x2fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2fvEXT"/>
@@ -32705,8 +32180,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             {
                 fixed (float* value_ptr = &value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3x2fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3x2fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x4fvEXT"/>
@@ -32715,8 +32189,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 int count = (int)(value.Length / 8);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2x4fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2x4fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x4fvEXT"/>
@@ -32725,8 +32198,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 int count = (int)(value.Length / 8);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2x4fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2x4fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x4fvEXT"/>
@@ -32734,8 +32206,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             {
                 fixed (float* value_ptr = &value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2x4fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2x4fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x2fvEXT"/>
@@ -32744,8 +32215,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 int count = (int)(value.Length / 8);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4x2fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4x2fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x2fvEXT"/>
@@ -32754,8 +32224,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 int count = (int)(value.Length / 8);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4x2fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4x2fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x2fvEXT"/>
@@ -32763,8 +32232,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             {
                 fixed (float* value_ptr = &value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4x2fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4x2fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x4fvEXT"/>
@@ -32773,8 +32241,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 int count = (int)(value.Length / 12);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3x4fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3x4fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x4fvEXT"/>
@@ -32783,8 +32250,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 int count = (int)(value.Length / 12);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3x4fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3x4fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x4fvEXT"/>
@@ -32792,8 +32258,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             {
                 fixed (float* value_ptr = &value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3x4fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3x4fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x3fvEXT"/>
@@ -32802,8 +32267,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 int count = (int)(value.Length / 12);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4x3fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4x3fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x3fvEXT"/>
@@ -32812,8 +32276,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 int count = (int)(value.Length / 12);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4x3fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4x3fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x3fvEXT"/>
@@ -32821,8 +32284,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             {
                 fixed (float* value_ptr = &value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4x3fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4x3fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="TextureParameterIivEXT"/>
@@ -33629,12 +33091,6 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                     GetFramebufferParameterivEXT(framebuffer, pname, parameters_ptr);
                 }
             }
-            /// <inheritdoc cref="VertexArrayVertexAttribOffsetEXT"/>
-            public static unsafe void VertexArrayVertexAttribOffsetEXT(VertexArrayHandle vaobj, BufferHandle buffer, uint index, int size, VertexAttribPointerType type, bool normalized, int stride, IntPtr offset)
-            {
-                byte normalized_byte = (byte)(normalized ? 1 : 0);
-                VertexArrayVertexAttribOffsetEXT(vaobj, buffer, index, size, type, normalized_byte, stride, offset);
-            }
             /// <inheritdoc cref="GetVertexArrayIntegervEXT"/>
             public static unsafe void GetVertexArrayIntegervEXT(VertexArrayHandle vaobj, VertexArrayPName pname, ref int param)
             {
@@ -33886,8 +33342,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 int count = (int)(value.Length / 4);
                 fixed (double* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2dvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2dvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2dvEXT"/>
@@ -33896,8 +33351,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 int count = (int)(value.Length / 4);
                 fixed (double* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2dvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2dvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2dvEXT"/>
@@ -33905,8 +33359,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             {
                 fixed (double* value_ptr = &value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2dvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2dvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3dvEXT"/>
@@ -33915,8 +33368,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 int count = (int)(value.Length / 9);
                 fixed (double* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3dvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3dvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3dvEXT"/>
@@ -33925,8 +33377,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 int count = (int)(value.Length / 9);
                 fixed (double* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3dvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3dvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3dvEXT"/>
@@ -33934,8 +33385,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             {
                 fixed (double* value_ptr = &value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3dvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3dvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4dvEXT"/>
@@ -33944,8 +33394,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 int count = (int)(value.Length / 16);
                 fixed (double* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4dvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4dvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4dvEXT"/>
@@ -33954,8 +33403,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 int count = (int)(value.Length / 16);
                 fixed (double* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4dvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4dvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4dvEXT"/>
@@ -33963,8 +33411,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             {
                 fixed (double* value_ptr = &value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4dvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4dvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x3dvEXT"/>
@@ -33973,8 +33420,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 int count = (int)(value.Length / 6);
                 fixed (double* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2x3dvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2x3dvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x3dvEXT"/>
@@ -33983,8 +33429,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 int count = (int)(value.Length / 6);
                 fixed (double* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2x3dvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2x3dvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x3dvEXT"/>
@@ -33992,8 +33437,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             {
                 fixed (double* value_ptr = &value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2x3dvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2x3dvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x4dvEXT"/>
@@ -34002,8 +33446,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 int count = (int)(value.Length / 8);
                 fixed (double* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2x4dvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2x4dvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x4dvEXT"/>
@@ -34012,8 +33455,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 int count = (int)(value.Length / 8);
                 fixed (double* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2x4dvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2x4dvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x4dvEXT"/>
@@ -34021,8 +33463,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             {
                 fixed (double* value_ptr = &value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2x4dvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2x4dvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2dvEXT"/>
@@ -34031,8 +33472,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 int count = (int)(value.Length / 6);
                 fixed (double* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3x2dvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3x2dvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2dvEXT"/>
@@ -34041,8 +33481,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 int count = (int)(value.Length / 6);
                 fixed (double* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3x2dvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3x2dvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2dvEXT"/>
@@ -34050,8 +33489,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             {
                 fixed (double* value_ptr = &value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3x2dvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3x2dvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x4dvEXT"/>
@@ -34060,8 +33498,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 int count = (int)(value.Length / 12);
                 fixed (double* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3x4dvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3x4dvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x4dvEXT"/>
@@ -34070,8 +33507,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 int count = (int)(value.Length / 12);
                 fixed (double* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3x4dvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3x4dvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x4dvEXT"/>
@@ -34079,8 +33515,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             {
                 fixed (double* value_ptr = &value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3x4dvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3x4dvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x2dvEXT"/>
@@ -34089,8 +33524,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 int count = (int)(value.Length / 8);
                 fixed (double* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4x2dvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4x2dvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x2dvEXT"/>
@@ -34099,8 +33533,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 int count = (int)(value.Length / 8);
                 fixed (double* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4x2dvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4x2dvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x2dvEXT"/>
@@ -34108,8 +33541,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             {
                 fixed (double* value_ptr = &value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4x2dvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4x2dvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x3dvEXT"/>
@@ -34118,8 +33550,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 int count = (int)(value.Length / 12);
                 fixed (double* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4x3dvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4x3dvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x3dvEXT"/>
@@ -34128,8 +33559,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 int count = (int)(value.Length / 12);
                 fixed (double* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4x3dvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4x3dvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x3dvEXT"/>
@@ -34137,42 +33567,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             {
                 fixed (double* value_ptr = &value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4x3dvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4x3dvEXT(program, location, count, transpose, value_ptr);
                 }
-            }
-            /// <inheritdoc cref="TextureStorage2DMultisampleEXT"/>
-            public static unsafe void TextureStorage2DMultisampleEXT(TextureHandle texture, TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, bool fixedsamplelocations)
-            {
-                byte fixedsamplelocations_byte = (byte)(fixedsamplelocations ? 1 : 0);
-                TextureStorage2DMultisampleEXT(texture, target, samples, internalformat, width, height, fixedsamplelocations_byte);
-            }
-            /// <inheritdoc cref="TextureStorage3DMultisampleEXT"/>
-            public static unsafe void TextureStorage3DMultisampleEXT(TextureHandle texture, All target, int samples, SizedInternalFormat internalformat, int width, int height, int depth, bool fixedsamplelocations)
-            {
-                byte fixedsamplelocations_byte = (byte)(fixedsamplelocations ? 1 : 0);
-                TextureStorage3DMultisampleEXT(texture, target, samples, internalformat, width, height, depth, fixedsamplelocations_byte);
-            }
-            /// <inheritdoc cref="VertexArrayVertexAttribFormatEXT"/>
-            public static unsafe void VertexArrayVertexAttribFormatEXT(VertexArrayHandle vaobj, uint attribindex, int size, VertexAttribType type, bool normalized, uint relativeoffset)
-            {
-                byte normalized_byte = (byte)(normalized ? 1 : 0);
-                VertexArrayVertexAttribFormatEXT(vaobj, attribindex, size, type, normalized_byte, relativeoffset);
-            }
-            /// <inheritdoc cref="TexturePageCommitmentEXT"/>
-            public static unsafe void TexturePageCommitmentEXT(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, bool commit)
-            {
-                byte commit_byte = (byte)(commit ? 1 : 0);
-                TexturePageCommitmentEXT(texture, level, xoffset, yoffset, zoffset, width, height, depth, commit_byte);
-            }
-            /// <inheritdoc cref="ColorMaskIndexedEXT"/>
-            public static unsafe void ColorMaskIndexedEXT(uint index, bool r, bool g, bool b, bool a)
-            {
-                byte r_byte = (byte)(r ? 1 : 0);
-                byte g_byte = (byte)(g ? 1 : 0);
-                byte b_byte = (byte)(b ? 1 : 0);
-                byte a_byte = (byte)(a ? 1 : 0);
-                ColorMaskIndexedEXT(index, r_byte, g_byte, b_byte, a_byte);
             }
             /// <inheritdoc cref="DrawElementsInstancedEXT"/>
             public static unsafe void DrawElementsInstancedEXT(PrimitiveType mode, int count, DrawElementsType type, nint offset, int primcount)
@@ -35018,8 +34414,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             public static unsafe void GetHistogramEXT(HistogramTargetEXT target, bool reset, PixelFormat format, PixelType type, IntPtr values)
             {
                 void* values_vptr = (void*)values;
-                byte reset_byte = (byte)(reset ? 1 : 0);
-                GetHistogramEXT(target, reset_byte, format, type, values_vptr);
+                GetHistogramEXT(target, reset, format, type, values_vptr);
             }
             /// <inheritdoc cref="GetHistogramEXT"/>
             public static unsafe void GetHistogramEXT<T1>(HistogramTargetEXT target, bool reset, PixelFormat format, PixelType type, Span<T1> values)
@@ -35027,8 +34422,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             {
                 fixed (void* values_ptr = values)
                 {
-                    byte reset_byte = (byte)(reset ? 1 : 0);
-                    GetHistogramEXT(target, reset_byte, format, type, values_ptr);
+                    GetHistogramEXT(target, reset, format, type, values_ptr);
                 }
             }
             /// <inheritdoc cref="GetHistogramEXT"/>
@@ -35037,8 +34431,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             {
                 fixed (void* values_ptr = values)
                 {
-                    byte reset_byte = (byte)(reset ? 1 : 0);
-                    GetHistogramEXT(target, reset_byte, format, type, values_ptr);
+                    GetHistogramEXT(target, reset, format, type, values_ptr);
                 }
             }
             /// <inheritdoc cref="GetHistogramEXT"/>
@@ -35047,8 +34440,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             {
                 fixed (void* values_ptr = &values)
                 {
-                    byte reset_byte = (byte)(reset ? 1 : 0);
-                    GetHistogramEXT(target, reset_byte, format, type, values_ptr);
+                    GetHistogramEXT(target, reset, format, type, values_ptr);
                 }
             }
             /// <inheritdoc cref="GetHistogramParameterfvEXT"/>
@@ -35103,8 +34495,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             public static unsafe void GetMinmaxEXT(MinmaxTargetEXT target, bool reset, PixelFormat format, PixelType type, IntPtr values)
             {
                 void* values_vptr = (void*)values;
-                byte reset_byte = (byte)(reset ? 1 : 0);
-                GetMinmaxEXT(target, reset_byte, format, type, values_vptr);
+                GetMinmaxEXT(target, reset, format, type, values_vptr);
             }
             /// <inheritdoc cref="GetMinmaxEXT"/>
             public static unsafe void GetMinmaxEXT<T1>(MinmaxTargetEXT target, bool reset, PixelFormat format, PixelType type, Span<T1> values)
@@ -35112,8 +34503,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             {
                 fixed (void* values_ptr = values)
                 {
-                    byte reset_byte = (byte)(reset ? 1 : 0);
-                    GetMinmaxEXT(target, reset_byte, format, type, values_ptr);
+                    GetMinmaxEXT(target, reset, format, type, values_ptr);
                 }
             }
             /// <inheritdoc cref="GetMinmaxEXT"/>
@@ -35122,8 +34512,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             {
                 fixed (void* values_ptr = values)
                 {
-                    byte reset_byte = (byte)(reset ? 1 : 0);
-                    GetMinmaxEXT(target, reset_byte, format, type, values_ptr);
+                    GetMinmaxEXT(target, reset, format, type, values_ptr);
                 }
             }
             /// <inheritdoc cref="GetMinmaxEXT"/>
@@ -35132,8 +34521,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             {
                 fixed (void* values_ptr = &values)
                 {
-                    byte reset_byte = (byte)(reset ? 1 : 0);
-                    GetMinmaxEXT(target, reset_byte, format, type, values_ptr);
+                    GetMinmaxEXT(target, reset, format, type, values_ptr);
                 }
             }
             /// <inheritdoc cref="GetMinmaxParameterfvEXT"/>
@@ -35183,18 +34571,6 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 {
                     GetMinmaxParameterivEXT(target, pname, parameters_ptr);
                 }
-            }
-            /// <inheritdoc cref="HistogramEXT"/>
-            public static unsafe void HistogramEXT(HistogramTargetEXT target, int width, InternalFormat internalformat, bool sink)
-            {
-                byte sink_byte = (byte)(sink ? 1 : 0);
-                HistogramEXT(target, width, internalformat, sink_byte);
-            }
-            /// <inheritdoc cref="MinmaxEXT"/>
-            public static unsafe void MinmaxEXT(MinmaxTargetEXT target, InternalFormat internalformat, bool sink)
-            {
-                byte sink_byte = (byte)(sink ? 1 : 0);
-                MinmaxEXT(target, internalformat, sink_byte);
             }
             /// <inheritdoc cref="GetUnsignedBytevEXT"/>
             public static unsafe void GetUnsignedBytevEXT(GetPName pname, Span<byte> data)
@@ -35294,30 +34670,6 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                     GetMemoryObjectParameterivEXT(memoryObject, pname, parameters_ptr);
                 }
             }
-            /// <inheritdoc cref="TexStorageMem2DMultisampleEXT"/>
-            public static unsafe void TexStorageMem2DMultisampleEXT(TextureTarget target, int samples, SizedInternalFormat internalFormat, int width, int height, bool fixedSampleLocations, uint memory, ulong offset)
-            {
-                byte fixedSampleLocations_byte = (byte)(fixedSampleLocations ? 1 : 0);
-                TexStorageMem2DMultisampleEXT(target, samples, internalFormat, width, height, fixedSampleLocations_byte, memory, offset);
-            }
-            /// <inheritdoc cref="TexStorageMem3DMultisampleEXT"/>
-            public static unsafe void TexStorageMem3DMultisampleEXT(TextureTarget target, int samples, SizedInternalFormat internalFormat, int width, int height, int depth, bool fixedSampleLocations, uint memory, ulong offset)
-            {
-                byte fixedSampleLocations_byte = (byte)(fixedSampleLocations ? 1 : 0);
-                TexStorageMem3DMultisampleEXT(target, samples, internalFormat, width, height, depth, fixedSampleLocations_byte, memory, offset);
-            }
-            /// <inheritdoc cref="TextureStorageMem2DMultisampleEXT"/>
-            public static unsafe void TextureStorageMem2DMultisampleEXT(TextureHandle texture, int samples, SizedInternalFormat internalFormat, int width, int height, bool fixedSampleLocations, uint memory, ulong offset)
-            {
-                byte fixedSampleLocations_byte = (byte)(fixedSampleLocations ? 1 : 0);
-                TextureStorageMem2DMultisampleEXT(texture, samples, internalFormat, width, height, fixedSampleLocations_byte, memory, offset);
-            }
-            /// <inheritdoc cref="TextureStorageMem3DMultisampleEXT"/>
-            public static unsafe void TextureStorageMem3DMultisampleEXT(TextureHandle texture, int samples, SizedInternalFormat internalFormat, int width, int height, int depth, bool fixedSampleLocations, uint memory, ulong offset)
-            {
-                byte fixedSampleLocations_byte = (byte)(fixedSampleLocations ? 1 : 0);
-                TextureStorageMem3DMultisampleEXT(texture, samples, internalFormat, width, height, depth, fixedSampleLocations_byte, memory, offset);
-            }
             /// <inheritdoc cref="ImportMemoryWin32HandleEXT"/>
             public static unsafe void ImportMemoryWin32HandleEXT(uint memory, ulong size, ExternalHandleType handleType, IntPtr handle)
             {
@@ -35402,12 +34754,6 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 {
                     MultiDrawElementsEXT(mode, count_ptr, type, indices, primcount);
                 }
-            }
-            /// <inheritdoc cref="SampleMaskEXT"/>
-            public static unsafe void SampleMaskEXT(float value, bool invert)
-            {
-                byte invert_byte = (byte)(invert ? 1 : 0);
-                SampleMaskEXT(value, invert_byte);
             }
             /// <inheritdoc cref="ColorTableEXT"/>
             public static unsafe void ColorTableEXT(ColorTableTarget target, InternalFormat internalFormat, int width, PixelFormat format, PixelType type, IntPtr table)
@@ -35642,12 +34988,6 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 {
                     PointParameterfvEXT(pname, parameters_ptr);
                 }
-            }
-            /// <inheritdoc cref="RasterSamplesEXT"/>
-            public static unsafe void RasterSamplesEXT(uint samples, bool fixedsamplelocations)
-            {
-                byte fixedsamplelocations_byte = (byte)(fixedsamplelocations ? 1 : 0);
-                RasterSamplesEXT(samples, fixedsamplelocations_byte);
             }
             /// <inheritdoc cref="GenSemaphoresEXT"/>
             public static unsafe void GenSemaphoresEXT(Span<uint> semaphores)
@@ -36188,12 +35528,6 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 {
                     GetProgramPipelineivEXT(pipeline, pname, parameters_ptr);
                 }
-            }
-            /// <inheritdoc cref="BindImageTextureEXT"/>
-            public static unsafe void BindImageTextureEXT(uint index, TextureHandle texture, int level, bool layered, int layer, BufferAccessARB access, int format)
-            {
-                byte layered_byte = (byte)(layered ? 1 : 0);
-                BindImageTextureEXT(index, texture, level, layered_byte, layer, access, format);
             }
             /// <inheritdoc cref="TexSubImage1DEXT"/>
             public static unsafe void TexSubImage1DEXT(TextureTarget target, int level, int xoffset, int width, PixelFormat format, PixelType type, IntPtr pixels)
@@ -37728,14 +37062,6 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                     MultiDrawElementsIndirectBindlessCountNV(mode, type, indirect_ptr, drawCount, maxDrawCount, stride, vertexBufferCount);
                 }
             }
-            /// <inheritdoc cref="GetImageHandleNV"/>
-            public static unsafe ulong GetImageHandleNV(TextureHandle texture, int level, bool layered, int layer, PixelFormat format)
-            {
-                ulong returnValue;
-                byte layered_byte = (byte)(layered ? 1 : 0);
-                returnValue = GetImageHandleNV(texture, level, layered_byte, layer, format);
-                return returnValue;
-            }
             /// <inheritdoc cref="UniformHandleui64vNV"/>
             public static unsafe void UniformHandleui64vNV(int location, ReadOnlySpan<ulong> value)
             {
@@ -37983,8 +37309,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             public static unsafe void MapControlPointsNV(EvalTargetNV target, uint index, MapTypeNV type, int ustride, int vstride, int uorder, int vorder, bool packed, IntPtr points)
             {
                 void* points_vptr = (void*)points;
-                byte packed_byte = (byte)(packed ? 1 : 0);
-                MapControlPointsNV(target, index, type, ustride, vstride, uorder, vorder, packed_byte, points_vptr);
+                MapControlPointsNV(target, index, type, ustride, vstride, uorder, vorder, packed, points_vptr);
             }
             /// <inheritdoc cref="MapControlPointsNV"/>
             public static unsafe void MapControlPointsNV<T1>(EvalTargetNV target, uint index, MapTypeNV type, int ustride, int vstride, int uorder, int vorder, bool packed, ReadOnlySpan<T1> points)
@@ -37992,8 +37317,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             {
                 fixed (void* points_ptr = points)
                 {
-                    byte packed_byte = (byte)(packed ? 1 : 0);
-                    MapControlPointsNV(target, index, type, ustride, vstride, uorder, vorder, packed_byte, points_ptr);
+                    MapControlPointsNV(target, index, type, ustride, vstride, uorder, vorder, packed, points_ptr);
                 }
             }
             /// <inheritdoc cref="MapControlPointsNV"/>
@@ -38002,8 +37326,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             {
                 fixed (void* points_ptr = points)
                 {
-                    byte packed_byte = (byte)(packed ? 1 : 0);
-                    MapControlPointsNV(target, index, type, ustride, vstride, uorder, vorder, packed_byte, points_ptr);
+                    MapControlPointsNV(target, index, type, ustride, vstride, uorder, vorder, packed, points_ptr);
                 }
             }
             /// <inheritdoc cref="MapControlPointsNV"/>
@@ -38012,8 +37335,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             {
                 fixed (void* points_ptr = &points)
                 {
-                    byte packed_byte = (byte)(packed ? 1 : 0);
-                    MapControlPointsNV(target, index, type, ustride, vstride, uorder, vorder, packed_byte, points_ptr);
+                    MapControlPointsNV(target, index, type, ustride, vstride, uorder, vorder, packed, points_ptr);
                 }
             }
             /// <inheritdoc cref="MapParameterivNV"/>
@@ -38068,8 +37390,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             public static unsafe void GetMapControlPointsNV(EvalTargetNV target, uint index, MapTypeNV type, int ustride, int vstride, bool packed, IntPtr points)
             {
                 void* points_vptr = (void*)points;
-                byte packed_byte = (byte)(packed ? 1 : 0);
-                GetMapControlPointsNV(target, index, type, ustride, vstride, packed_byte, points_vptr);
+                GetMapControlPointsNV(target, index, type, ustride, vstride, packed, points_vptr);
             }
             /// <inheritdoc cref="GetMapControlPointsNV"/>
             public static unsafe void GetMapControlPointsNV<T1>(EvalTargetNV target, uint index, MapTypeNV type, int ustride, int vstride, bool packed, Span<T1> points)
@@ -38077,8 +37398,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             {
                 fixed (void* points_ptr = points)
                 {
-                    byte packed_byte = (byte)(packed ? 1 : 0);
-                    GetMapControlPointsNV(target, index, type, ustride, vstride, packed_byte, points_ptr);
+                    GetMapControlPointsNV(target, index, type, ustride, vstride, packed, points_ptr);
                 }
             }
             /// <inheritdoc cref="GetMapControlPointsNV"/>
@@ -38087,8 +37407,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             {
                 fixed (void* points_ptr = points)
                 {
-                    byte packed_byte = (byte)(packed ? 1 : 0);
-                    GetMapControlPointsNV(target, index, type, ustride, vstride, packed_byte, points_ptr);
+                    GetMapControlPointsNV(target, index, type, ustride, vstride, packed, points_ptr);
                 }
             }
             /// <inheritdoc cref="GetMapControlPointsNV"/>
@@ -38097,8 +37416,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             {
                 fixed (void* points_ptr = &points)
                 {
-                    byte packed_byte = (byte)(packed ? 1 : 0);
-                    GetMapControlPointsNV(target, index, type, ustride, vstride, packed_byte, points_ptr);
+                    GetMapControlPointsNV(target, index, type, ustride, vstride, packed, points_ptr);
                 }
             }
             /// <inheritdoc cref="GetMapParameterivNV"/>
@@ -38468,12 +37786,6 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 {
                     GetProgramNamedParameterdvNV(id, len, name_ptr, parameters_ptr);
                 }
-            }
-            /// <inheritdoc cref="RasterSamplesEXT"/>
-            public static unsafe void RasterSamplesEXT(uint samples, bool fixedsamplelocations)
-            {
-                byte fixedsamplelocations_byte = (byte)(fixedsamplelocations ? 1 : 0);
-                RasterSamplesEXT(samples, fixedsamplelocations_byte);
             }
             /// <inheritdoc cref="CoverageModulationTableNV"/>
             public static unsafe void CoverageModulationTableNV(ReadOnlySpan<float> v)
@@ -39991,30 +39303,6 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 {
                     GetMemoryObjectDetachedResourcesuivNV(memory, pname, first, count, parameters_ptr);
                 }
-            }
-            /// <inheritdoc cref="BufferPageCommitmentMemNV"/>
-            public static unsafe void BufferPageCommitmentMemNV(BufferStorageTarget target, IntPtr offset, nint size, uint memory, ulong memOffset, bool commit)
-            {
-                byte commit_byte = (byte)(commit ? 1 : 0);
-                BufferPageCommitmentMemNV(target, offset, size, memory, memOffset, commit_byte);
-            }
-            /// <inheritdoc cref="TexPageCommitmentMemNV"/>
-            public static unsafe void TexPageCommitmentMemNV(TextureTarget target, int layer, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, uint memory, ulong offset, bool commit)
-            {
-                byte commit_byte = (byte)(commit ? 1 : 0);
-                TexPageCommitmentMemNV(target, layer, level, xoffset, yoffset, zoffset, width, height, depth, memory, offset, commit_byte);
-            }
-            /// <inheritdoc cref="NamedBufferPageCommitmentMemNV"/>
-            public static unsafe void NamedBufferPageCommitmentMemNV(BufferHandle buffer, IntPtr offset, nint size, uint memory, ulong memOffset, bool commit)
-            {
-                byte commit_byte = (byte)(commit ? 1 : 0);
-                NamedBufferPageCommitmentMemNV(buffer, offset, size, memory, memOffset, commit_byte);
-            }
-            /// <inheritdoc cref="TexturePageCommitmentMemNV"/>
-            public static unsafe void TexturePageCommitmentMemNV(TextureHandle texture, int layer, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, uint memory, ulong offset, bool commit)
-            {
-                byte commit_byte = (byte)(commit ? 1 : 0);
-                TexturePageCommitmentMemNV(texture, layer, level, xoffset, yoffset, zoffset, width, height, depth, memory, offset, commit_byte);
             }
             /// <inheritdoc cref="GenOcclusionQueriesNV"/>
             public static unsafe void GenOcclusionQueriesNV(Span<uint> ids)
@@ -42067,14 +41355,6 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                     CombinerParameterivNV(pname, parameters_ptr);
                 }
             }
-            /// <inheritdoc cref="CombinerOutputNV"/>
-            public static unsafe void CombinerOutputNV(CombinerStageNV stage, CombinerPortionNV portion, CombinerRegisterNV abOutput, CombinerRegisterNV cdOutput, CombinerRegisterNV sumOutput, CombinerScaleNV scale, CombinerBiasNV bias, bool abDotProduct, bool cdDotProduct, bool muxSum)
-            {
-                byte abDotProduct_byte = (byte)(abDotProduct ? 1 : 0);
-                byte cdDotProduct_byte = (byte)(cdDotProduct ? 1 : 0);
-                byte muxSum_byte = (byte)(muxSum ? 1 : 0);
-                CombinerOutputNV(stage, portion, abOutput, cdOutput, sumOutput, scale, bias, abDotProduct_byte, cdDotProduct_byte, muxSum_byte);
-            }
             /// <inheritdoc cref="GetCombinerInputParameterfvNV"/>
             public static unsafe void GetCombinerInputParameterfvNV(CombinerStageNV stage, CombinerPortionNV portion, CombinerVariableNV variable, CombinerParameterNV pname, Span<float> parameters)
             {
@@ -42503,12 +41783,6 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                     GetShadingRateSampleLocationivNV(rate, samples, index, location_ptr);
                 }
             }
-            /// <inheritdoc cref="ShadingRateImageBarrierNV"/>
-            public static unsafe void ShadingRateImageBarrierNV(bool synchronize)
-            {
-                byte synchronize_byte = (byte)(synchronize ? 1 : 0);
-                ShadingRateImageBarrierNV(synchronize_byte);
-            }
             /// <inheritdoc cref="ShadingRateImagePaletteNV"/>
             public static unsafe void ShadingRateImagePaletteNV(uint viewport, uint first, ReadOnlySpan<All> rates)
             {
@@ -42558,42 +41832,6 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 {
                     ShadingRateSampleOrderCustomNV(rate, samples, locations_ptr);
                 }
-            }
-            /// <inheritdoc cref="TexImage2DMultisampleCoverageNV"/>
-            public static unsafe void TexImage2DMultisampleCoverageNV(TextureTarget target, int coverageSamples, int colorSamples, int internalFormat, int width, int height, bool fixedSampleLocations)
-            {
-                byte fixedSampleLocations_byte = (byte)(fixedSampleLocations ? 1 : 0);
-                TexImage2DMultisampleCoverageNV(target, coverageSamples, colorSamples, internalFormat, width, height, fixedSampleLocations_byte);
-            }
-            /// <inheritdoc cref="TexImage3DMultisampleCoverageNV"/>
-            public static unsafe void TexImage3DMultisampleCoverageNV(TextureTarget target, int coverageSamples, int colorSamples, int internalFormat, int width, int height, int depth, bool fixedSampleLocations)
-            {
-                byte fixedSampleLocations_byte = (byte)(fixedSampleLocations ? 1 : 0);
-                TexImage3DMultisampleCoverageNV(target, coverageSamples, colorSamples, internalFormat, width, height, depth, fixedSampleLocations_byte);
-            }
-            /// <inheritdoc cref="TextureImage2DMultisampleNV"/>
-            public static unsafe void TextureImage2DMultisampleNV(TextureHandle texture, TextureTarget target, int samples, int internalFormat, int width, int height, bool fixedSampleLocations)
-            {
-                byte fixedSampleLocations_byte = (byte)(fixedSampleLocations ? 1 : 0);
-                TextureImage2DMultisampleNV(texture, target, samples, internalFormat, width, height, fixedSampleLocations_byte);
-            }
-            /// <inheritdoc cref="TextureImage3DMultisampleNV"/>
-            public static unsafe void TextureImage3DMultisampleNV(TextureHandle texture, TextureTarget target, int samples, int internalFormat, int width, int height, int depth, bool fixedSampleLocations)
-            {
-                byte fixedSampleLocations_byte = (byte)(fixedSampleLocations ? 1 : 0);
-                TextureImage3DMultisampleNV(texture, target, samples, internalFormat, width, height, depth, fixedSampleLocations_byte);
-            }
-            /// <inheritdoc cref="TextureImage2DMultisampleCoverageNV"/>
-            public static unsafe void TextureImage2DMultisampleCoverageNV(TextureHandle texture, TextureTarget target, int coverageSamples, int colorSamples, int internalFormat, int width, int height, bool fixedSampleLocations)
-            {
-                byte fixedSampleLocations_byte = (byte)(fixedSampleLocations ? 1 : 0);
-                TextureImage2DMultisampleCoverageNV(texture, target, coverageSamples, colorSamples, internalFormat, width, height, fixedSampleLocations_byte);
-            }
-            /// <inheritdoc cref="TextureImage3DMultisampleCoverageNV"/>
-            public static unsafe void TextureImage3DMultisampleCoverageNV(TextureHandle texture, TextureTarget target, int coverageSamples, int colorSamples, int internalFormat, int width, int height, int depth, bool fixedSampleLocations)
-            {
-                byte fixedSampleLocations_byte = (byte)(fixedSampleLocations ? 1 : 0);
-                TextureImage3DMultisampleCoverageNV(texture, target, coverageSamples, colorSamples, internalFormat, width, height, depth, fixedSampleLocations_byte);
             }
             /// <inheritdoc cref="TransformFeedbackAttribsNV"/>
             public static unsafe void TransformFeedbackAttribsNV(int count, ReadOnlySpan<int> attribs, All bufferMode)
@@ -43137,8 +42375,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (uint* textureNames_ptr = textureNames)
                 {
                     void* vdpSurface_vptr = (void*)vdpSurface;
-                    byte isFrameStructure_byte = (byte)(isFrameStructure ? 1 : 0);
-                    returnValue = VDPAURegisterVideoSurfaceWithPictureStructureNV(vdpSurface_vptr, target, numTextureNames, textureNames_ptr, isFrameStructure_byte);
+                    returnValue = VDPAURegisterVideoSurfaceWithPictureStructureNV(vdpSurface_vptr, target, numTextureNames, textureNames_ptr, isFrameStructure);
                 }
                 return returnValue;
             }
@@ -43150,8 +42387,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (uint* textureNames_ptr = textureNames)
                 {
                     void* vdpSurface_vptr = (void*)vdpSurface;
-                    byte isFrameStructure_byte = (byte)(isFrameStructure ? 1 : 0);
-                    returnValue = VDPAURegisterVideoSurfaceWithPictureStructureNV(vdpSurface_vptr, target, numTextureNames, textureNames_ptr, isFrameStructure_byte);
+                    returnValue = VDPAURegisterVideoSurfaceWithPictureStructureNV(vdpSurface_vptr, target, numTextureNames, textureNames_ptr, isFrameStructure);
                 }
                 return returnValue;
             }
@@ -43162,8 +42398,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (uint* textureNames_ptr = &textureNames)
                 {
                     void* vdpSurface_vptr = (void*)vdpSurface;
-                    byte isFrameStructure_byte = (byte)(isFrameStructure ? 1 : 0);
-                    returnValue = VDPAURegisterVideoSurfaceWithPictureStructureNV(vdpSurface_vptr, target, numTextureNames, textureNames_ptr, isFrameStructure_byte);
+                    returnValue = VDPAURegisterVideoSurfaceWithPictureStructureNV(vdpSurface_vptr, target, numTextureNames, textureNames_ptr, isFrameStructure);
                 }
                 return returnValue;
             }
@@ -43177,8 +42412,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                     int numTextureNames = (int)(textureNames.Length);
                     fixed (uint* textureNames_ptr = textureNames)
                     {
-                        byte isFrameStructure_byte = (byte)(isFrameStructure ? 1 : 0);
-                        returnValue = VDPAURegisterVideoSurfaceWithPictureStructureNV(vdpSurface_ptr, target, numTextureNames, textureNames_ptr, isFrameStructure_byte);
+                        returnValue = VDPAURegisterVideoSurfaceWithPictureStructureNV(vdpSurface_ptr, target, numTextureNames, textureNames_ptr, isFrameStructure);
                     }
                 }
                 return returnValue;
@@ -43193,8 +42427,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                     int numTextureNames = (int)(textureNames.Length);
                     fixed (uint* textureNames_ptr = textureNames)
                     {
-                        byte isFrameStructure_byte = (byte)(isFrameStructure ? 1 : 0);
-                        returnValue = VDPAURegisterVideoSurfaceWithPictureStructureNV(vdpSurface_ptr, target, numTextureNames, textureNames_ptr, isFrameStructure_byte);
+                        returnValue = VDPAURegisterVideoSurfaceWithPictureStructureNV(vdpSurface_ptr, target, numTextureNames, textureNames_ptr, isFrameStructure);
                     }
                 }
                 return returnValue;
@@ -43207,8 +42440,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 fixed (void* vdpSurface_ptr = &vdpSurface)
                 fixed (uint* textureNames_ptr = &textureNames)
                 {
-                    byte isFrameStructure_byte = (byte)(isFrameStructure ? 1 : 0);
-                    returnValue = VDPAURegisterVideoSurfaceWithPictureStructureNV(vdpSurface_ptr, target, numTextureNames, textureNames_ptr, isFrameStructure_byte);
+                    returnValue = VDPAURegisterVideoSurfaceWithPictureStructureNV(vdpSurface_ptr, target, numTextureNames, textureNames_ptr, isFrameStructure);
                 }
                 return returnValue;
             }
@@ -43484,12 +42716,6 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 {
                     GetVertexAttribLui64vNV(index, pname, parameters_ptr);
                 }
-            }
-            /// <inheritdoc cref="VertexAttribFormatNV"/>
-            public static unsafe void VertexAttribFormatNV(uint index, int size, VertexAttribType type, bool normalized, int stride)
-            {
-                byte normalized_byte = (byte)(normalized ? 1 : 0);
-                VertexAttribFormatNV(index, size, type, normalized_byte, stride);
             }
             /// <inheritdoc cref="GetIntegerui64i_vNV"/>
             public static unsafe void GetIntegerui64i_vNV(All value, uint index, Span<ulong> result)
@@ -45563,8 +44789,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 int count = (int)(ids.Length);
                 fixed (uint* ids_ptr = ids)
                 {
-                    byte enabled_byte = (byte)(enabled ? 1 : 0);
-                    DebugMessageControl(source, type, severity, count, ids_ptr, enabled_byte);
+                    DebugMessageControl(source, type, severity, count, ids_ptr, enabled);
                 }
             }
             /// <inheritdoc cref="DebugMessageControl"/>
@@ -45573,8 +44798,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 int count = (int)(ids.Length);
                 fixed (uint* ids_ptr = ids)
                 {
-                    byte enabled_byte = (byte)(enabled ? 1 : 0);
-                    DebugMessageControl(source, type, severity, count, ids_ptr, enabled_byte);
+                    DebugMessageControl(source, type, severity, count, ids_ptr, enabled);
                 }
             }
             /// <inheritdoc cref="DebugMessageControl"/>
@@ -45582,8 +44806,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             {
                 fixed (uint* ids_ptr = &ids)
                 {
-                    byte enabled_byte = (byte)(enabled ? 1 : 0);
-                    DebugMessageControl(source, type, severity, count, ids_ptr, enabled_byte);
+                    DebugMessageControl(source, type, severity, count, ids_ptr, enabled);
                 }
             }
             /// <inheritdoc cref="DebugMessageInsert"/>
@@ -45962,8 +45185,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             {
                 fixed (uint* ids_ptr = &ids)
                 {
-                    byte enabled_byte = (byte)(enabled ? 1 : 0);
-                    DebugMessageControlKHR(source, type, severity, count, ids_ptr, enabled_byte);
+                    DebugMessageControlKHR(source, type, severity, count, ids_ptr, enabled);
                 }
             }
             /// <inheritdoc cref="DebugMessageInsertKHR"/>
@@ -47737,12 +46959,6 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                     GetMaterialxvOES(face, pname, parameters_ptr);
                 }
             }
-            /// <inheritdoc cref="SampleCoveragexOES"/>
-            public static unsafe void SampleCoveragexOES(int value, bool invert)
-            {
-                byte invert_byte = (byte)(invert ? 1 : 0);
-                SampleCoveragexOES(value, invert_byte);
-            }
             /// <inheritdoc cref="BitmapxOES"/>
             public static unsafe void BitmapxOES(int width, int height, int xorig, int yorig, int xmove, int ymove, ReadOnlySpan<byte> bitmap)
             {
@@ -48821,12 +48037,6 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                     GetFogFuncSGIS(points_ptr);
                 }
             }
-            /// <inheritdoc cref="SampleMaskSGIS"/>
-            public static unsafe void SampleMaskSGIS(float value, bool invert)
-            {
-                byte invert_byte = (byte)(invert ? 1 : 0);
-                SampleMaskSGIS(value, invert_byte);
-            }
             /// <inheritdoc cref="PixelTexGenParameterivSGIS"/>
             public static unsafe void PixelTexGenParameterivSGIS(PixelTexGenParameterNameSGIS pname, ReadOnlySpan<int> parameters)
             {
@@ -49062,15 +48272,6 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 {
                     TexSubImage4DSGIS(target, level, xoffset, yoffset, zoffset, woffset, width, height, depth, size4d, format, type, pixels_ptr);
                 }
-            }
-            /// <inheritdoc cref="TextureColorMaskSGIS"/>
-            public static unsafe void TextureColorMaskSGIS(bool red, bool green, bool blue, bool alpha)
-            {
-                byte red_byte = (byte)(red ? 1 : 0);
-                byte green_byte = (byte)(green ? 1 : 0);
-                byte blue_byte = (byte)(blue ? 1 : 0);
-                byte alpha_byte = (byte)(alpha ? 1 : 0);
-                TextureColorMaskSGIS(red_byte, green_byte, blue_byte, alpha_byte);
             }
             /// <inheritdoc cref="GetTexFilterFuncSGIS"/>
             public static unsafe void GetTexFilterFuncSGIS(TextureTarget target, TextureFilterSGIS filter, Span<float> weights)

--- a/src/OpenTK.Graphics/OpenGL/GL.Native.cs
+++ b/src/OpenTK.Graphics/OpenGL/GL.Native.cs
@@ -266,30 +266,30 @@ namespace OpenTK.Graphics.OpenGL
             _StencilMask_fnptr(mask);
         }
         
-        private static delegate* unmanaged<byte, byte, byte, byte, void> _ColorMask_fnptr = &ColorMask_Lazy;
+        private static delegate* unmanaged<bool, bool, bool, bool, void> _ColorMask_fnptr = &ColorMask_Lazy;
         /// <summary> <b>[requires: v1.0]</b> Enable and disable writing of frame buffer color components. </summary>
         /// <param name="red"> Specify whether red, green, blue, and alpha are to be written into the frame buffer. The initial values are all GL_TRUE, indicating that the color components are written. </param>
         /// <param name="green"> Specify whether red, green, blue, and alpha are to be written into the frame buffer. The initial values are all GL_TRUE, indicating that the color components are written. </param>
         /// <param name="blue"> Specify whether red, green, blue, and alpha are to be written into the frame buffer. The initial values are all GL_TRUE, indicating that the color components are written. </param>
         /// <param name="alpha"> Specify whether red, green, blue, and alpha are to be written into the frame buffer. The initial values are all GL_TRUE, indicating that the color components are written. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glColorMask.xhtml" /></remarks>
-        public static void ColorMask(byte red, byte green, byte blue, byte alpha) => _ColorMask_fnptr(red, green, blue, alpha);
+        public static void ColorMask(bool red, bool green, bool blue, bool alpha) => _ColorMask_fnptr(red, green, blue, alpha);
         [UnmanagedCallersOnly]
-        private static void ColorMask_Lazy(byte red, byte green, byte blue, byte alpha)
+        private static void ColorMask_Lazy(bool red, bool green, bool blue, bool alpha)
         {
-            _ColorMask_fnptr = (delegate* unmanaged<byte, byte, byte, byte, void>)GLLoader.BindingsContext.GetProcAddress("glColorMask");
+            _ColorMask_fnptr = (delegate* unmanaged<bool, bool, bool, bool, void>)GLLoader.BindingsContext.GetProcAddress("glColorMask");
             _ColorMask_fnptr(red, green, blue, alpha);
         }
         
-        private static delegate* unmanaged<byte, void> _DepthMask_fnptr = &DepthMask_Lazy;
+        private static delegate* unmanaged<bool, void> _DepthMask_fnptr = &DepthMask_Lazy;
         /// <summary> <b>[requires: v1.0]</b> Enable or disable writing into the depth buffer. </summary>
         /// <param name="flag"> Specifies whether the depth buffer is enabled for writing. If flag is GL_FALSE, depth buffer writing is disabled. Otherwise, it is enabled. Initially, depth buffer writing is enabled. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDepthMask.xhtml" /></remarks>
-        public static void DepthMask(byte flag) => _DepthMask_fnptr(flag);
+        public static void DepthMask(bool flag) => _DepthMask_fnptr(flag);
         [UnmanagedCallersOnly]
-        private static void DepthMask_Lazy(byte flag)
+        private static void DepthMask_Lazy(bool flag)
         {
-            _DepthMask_fnptr = (delegate* unmanaged<byte, void>)GLLoader.BindingsContext.GetProcAddress("glDepthMask");
+            _DepthMask_fnptr = (delegate* unmanaged<bool, void>)GLLoader.BindingsContext.GetProcAddress("glDepthMask");
             _DepthMask_fnptr(flag);
         }
         
@@ -460,16 +460,16 @@ namespace OpenTK.Graphics.OpenGL
             _ReadPixels_fnptr(x, y, width, height, format, type, pixels);
         }
         
-        private static delegate* unmanaged<GetPName, byte*, void> _GetBooleanv_fnptr = &GetBooleanv_Lazy;
+        private static delegate* unmanaged<GetPName, bool*, void> _GetBooleanv_fnptr = &GetBooleanv_Lazy;
         /// <summary> <b>[requires: v1.0]</b> Return the value or values of a selected parameter. </summary>
         /// <param name="pname"> Specifies the parameter value to be returned for non-indexed versions of glGet. The symbolic constants in the list below are accepted. </param>
         /// <param name="data"> Returns the value or values of the specified parameter. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGet.xhtml" /></remarks>
-        public static void GetBooleanv(GetPName pname, byte* data) => _GetBooleanv_fnptr(pname, data);
+        public static void GetBooleanv(GetPName pname, bool* data) => _GetBooleanv_fnptr(pname, data);
         [UnmanagedCallersOnly]
-        private static void GetBooleanv_Lazy(GetPName pname, byte* data)
+        private static void GetBooleanv_Lazy(GetPName pname, bool* data)
         {
-            _GetBooleanv_fnptr = (delegate* unmanaged<GetPName, byte*, void>)GLLoader.BindingsContext.GetProcAddress("glGetBooleanv");
+            _GetBooleanv_fnptr = (delegate* unmanaged<GetPName, bool*, void>)GLLoader.BindingsContext.GetProcAddress("glGetBooleanv");
             _GetBooleanv_fnptr(pname, data);
         }
         
@@ -609,15 +609,15 @@ namespace OpenTK.Graphics.OpenGL
             _GetTexLevelParameteriv_fnptr(target, level, pname, parameters);
         }
         
-        private static delegate* unmanaged<EnableCap, byte> _IsEnabled_fnptr = &IsEnabled_Lazy;
+        private static delegate* unmanaged<EnableCap, bool> _IsEnabled_fnptr = &IsEnabled_Lazy;
         /// <summary> <b>[requires: v1.0]</b> Test whether a capability is enabled. </summary>
         /// <param name="cap"> Specifies a symbolic constant indicating a GL capability. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsEnabled.xhtml" /></remarks>
-        public static byte IsEnabled(EnableCap cap) => _IsEnabled_fnptr(cap);
+        public static bool IsEnabled(EnableCap cap) => _IsEnabled_fnptr(cap);
         [UnmanagedCallersOnly]
-        private static byte IsEnabled_Lazy(EnableCap cap)
+        private static bool IsEnabled_Lazy(EnableCap cap)
         {
-            _IsEnabled_fnptr = (delegate* unmanaged<EnableCap, byte>)GLLoader.BindingsContext.GetProcAddress("glIsEnabled");
+            _IsEnabled_fnptr = (delegate* unmanaged<EnableCap, bool>)GLLoader.BindingsContext.GetProcAddress("glIsEnabled");
             return _IsEnabled_fnptr(cap);
         }
         
@@ -841,15 +841,15 @@ namespace OpenTK.Graphics.OpenGL
             _GenTextures_fnptr(n, textures);
         }
         
-        private static delegate* unmanaged<TextureHandle, byte> _IsTexture_fnptr = &IsTexture_Lazy;
+        private static delegate* unmanaged<TextureHandle, bool> _IsTexture_fnptr = &IsTexture_Lazy;
         /// <summary> <b>[requires: v1.1]</b> Determine if a name corresponds to a texture. </summary>
         /// <param name="texture"> Specifies a value that may be the name of a texture. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsTexture.xhtml" /></remarks>
-        public static byte IsTexture(TextureHandle texture) => _IsTexture_fnptr(texture);
+        public static bool IsTexture(TextureHandle texture) => _IsTexture_fnptr(texture);
         [UnmanagedCallersOnly]
-        private static byte IsTexture_Lazy(TextureHandle texture)
+        private static bool IsTexture_Lazy(TextureHandle texture)
         {
-            _IsTexture_fnptr = (delegate* unmanaged<TextureHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsTexture");
+            _IsTexture_fnptr = (delegate* unmanaged<TextureHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsTexture");
             return _IsTexture_fnptr(texture);
         }
         
@@ -945,16 +945,16 @@ namespace OpenTK.Graphics.OpenGL
             _ActiveTexture_fnptr(texture);
         }
         
-        private static delegate* unmanaged<float, byte, void> _SampleCoverage_fnptr = &SampleCoverage_Lazy;
+        private static delegate* unmanaged<float, bool, void> _SampleCoverage_fnptr = &SampleCoverage_Lazy;
         /// <summary> <b>[requires: v1.3]</b> Specify multisample coverage parameters. </summary>
         /// <param name="value"> Specify a single floating-point sample coverage value. The value is clamped to the range 0 1 . The initial value is 1.0. </param>
         /// <param name="invert"> Specify a single boolean value representing if the coverage masks should be inverted. GL_TRUE and GL_FALSE are accepted. The initial value is GL_FALSE. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glSampleCoverage.xhtml" /></remarks>
-        public static void SampleCoverage(float value, byte invert) => _SampleCoverage_fnptr(value, invert);
+        public static void SampleCoverage(float value, bool invert) => _SampleCoverage_fnptr(value, invert);
         [UnmanagedCallersOnly]
-        private static void SampleCoverage_Lazy(float value, byte invert)
+        private static void SampleCoverage_Lazy(float value, bool invert)
         {
-            _SampleCoverage_fnptr = (delegate* unmanaged<float, byte, void>)GLLoader.BindingsContext.GetProcAddress("glSampleCoverage");
+            _SampleCoverage_fnptr = (delegate* unmanaged<float, bool, void>)GLLoader.BindingsContext.GetProcAddress("glSampleCoverage");
             _SampleCoverage_fnptr(value, invert);
         }
         
@@ -1240,15 +1240,15 @@ namespace OpenTK.Graphics.OpenGL
             _DeleteQueries_fnptr(n, ids);
         }
         
-        private static delegate* unmanaged<QueryHandle, byte> _IsQuery_fnptr = &IsQuery_Lazy;
+        private static delegate* unmanaged<QueryHandle, bool> _IsQuery_fnptr = &IsQuery_Lazy;
         /// <summary> <b>[requires: v1.5]</b> Determine if a name corresponds to a query object. </summary>
         /// <param name="id"> Specifies a value that may be the name of a query object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsQuery.xhtml" /></remarks>
-        public static byte IsQuery(QueryHandle id) => _IsQuery_fnptr(id);
+        public static bool IsQuery(QueryHandle id) => _IsQuery_fnptr(id);
         [UnmanagedCallersOnly]
-        private static byte IsQuery_Lazy(QueryHandle id)
+        private static bool IsQuery_Lazy(QueryHandle id)
         {
-            _IsQuery_fnptr = (delegate* unmanaged<QueryHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsQuery");
+            _IsQuery_fnptr = (delegate* unmanaged<QueryHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsQuery");
             return _IsQuery_fnptr(id);
         }
         
@@ -1358,15 +1358,15 @@ namespace OpenTK.Graphics.OpenGL
             _GenBuffers_fnptr(n, buffers);
         }
         
-        private static delegate* unmanaged<BufferHandle, byte> _IsBuffer_fnptr = &IsBuffer_Lazy;
+        private static delegate* unmanaged<BufferHandle, bool> _IsBuffer_fnptr = &IsBuffer_Lazy;
         /// <summary> <b>[requires: v1.5]</b> Determine if a name corresponds to a buffer object. </summary>
         /// <param name="buffer"> Specifies a value that may be the name of a buffer object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsBuffer.xhtml" /></remarks>
-        public static byte IsBuffer(BufferHandle buffer) => _IsBuffer_fnptr(buffer);
+        public static bool IsBuffer(BufferHandle buffer) => _IsBuffer_fnptr(buffer);
         [UnmanagedCallersOnly]
-        private static byte IsBuffer_Lazy(BufferHandle buffer)
+        private static bool IsBuffer_Lazy(BufferHandle buffer)
         {
-            _IsBuffer_fnptr = (delegate* unmanaged<BufferHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsBuffer");
+            _IsBuffer_fnptr = (delegate* unmanaged<BufferHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsBuffer");
             return _IsBuffer_fnptr(buffer);
         }
         
@@ -1428,15 +1428,15 @@ namespace OpenTK.Graphics.OpenGL
             return _MapBuffer_fnptr(target, access);
         }
         
-        private static delegate* unmanaged<BufferTargetARB, byte> _UnmapBuffer_fnptr = &UnmapBuffer_Lazy;
+        private static delegate* unmanaged<BufferTargetARB, bool> _UnmapBuffer_fnptr = &UnmapBuffer_Lazy;
         /// <summary> <b>[requires: v1.5]</b> Release the mapping of a buffer object's data store into the client's address space. </summary>
         /// <param name="target"> Specifies the target to which the buffer object is bound for glUnmapBuffer, which must be one of the buffer binding targets in the following table: </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glUnmapBuffer.xhtml" /></remarks>
-        public static byte UnmapBuffer(BufferTargetARB target) => _UnmapBuffer_fnptr(target);
+        public static bool UnmapBuffer(BufferTargetARB target) => _UnmapBuffer_fnptr(target);
         [UnmanagedCallersOnly]
-        private static byte UnmapBuffer_Lazy(BufferTargetARB target)
+        private static bool UnmapBuffer_Lazy(BufferTargetARB target)
         {
-            _UnmapBuffer_fnptr = (delegate* unmanaged<BufferTargetARB, byte>)GLLoader.BindingsContext.GetProcAddress("glUnmapBuffer");
+            _UnmapBuffer_fnptr = (delegate* unmanaged<BufferTargetARB, bool>)GLLoader.BindingsContext.GetProcAddress("glUnmapBuffer");
             return _UnmapBuffer_fnptr(target);
         }
         
@@ -1894,27 +1894,27 @@ namespace OpenTK.Graphics.OpenGL
             _GetVertexAttribPointerv_fnptr(index, pname, pointer);
         }
         
-        private static delegate* unmanaged<ProgramHandle, byte> _IsProgram_fnptr = &IsProgram_Lazy;
+        private static delegate* unmanaged<ProgramHandle, bool> _IsProgram_fnptr = &IsProgram_Lazy;
         /// <summary> <b>[requires: v2.0]</b> Determines if a name corresponds to a program object. </summary>
         /// <param name="program">Specifies a potential program object.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsProgram.xhtml" /></remarks>
-        public static byte IsProgram(ProgramHandle program) => _IsProgram_fnptr(program);
+        public static bool IsProgram(ProgramHandle program) => _IsProgram_fnptr(program);
         [UnmanagedCallersOnly]
-        private static byte IsProgram_Lazy(ProgramHandle program)
+        private static bool IsProgram_Lazy(ProgramHandle program)
         {
-            _IsProgram_fnptr = (delegate* unmanaged<ProgramHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsProgram");
+            _IsProgram_fnptr = (delegate* unmanaged<ProgramHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsProgram");
             return _IsProgram_fnptr(program);
         }
         
-        private static delegate* unmanaged<ShaderHandle, byte> _IsShader_fnptr = &IsShader_Lazy;
+        private static delegate* unmanaged<ShaderHandle, bool> _IsShader_fnptr = &IsShader_Lazy;
         /// <summary> <b>[requires: v2.0]</b> Determines if a name corresponds to a shader object. </summary>
         /// <param name="shader">Specifies a potential shader object.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsShader.xhtml" /></remarks>
-        public static byte IsShader(ShaderHandle shader) => _IsShader_fnptr(shader);
+        public static bool IsShader(ShaderHandle shader) => _IsShader_fnptr(shader);
         [UnmanagedCallersOnly]
-        private static byte IsShader_Lazy(ShaderHandle shader)
+        private static bool IsShader_Lazy(ShaderHandle shader)
         {
-            _IsShader_fnptr = (delegate* unmanaged<ShaderHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsShader");
+            _IsShader_fnptr = (delegate* unmanaged<ShaderHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsShader");
             return _IsShader_fnptr(shader);
         }
         
@@ -2185,48 +2185,48 @@ namespace OpenTK.Graphics.OpenGL
             _Uniform4iv_fnptr(location, count, value);
         }
         
-        private static delegate* unmanaged<int, int, byte, float*, void> _UniformMatrix2fv_fnptr = &UniformMatrix2fv_Lazy;
+        private static delegate* unmanaged<int, int, bool, float*, void> _UniformMatrix2fv_fnptr = &UniformMatrix2fv_Lazy;
         /// <summary> <b>[requires: v2.0]</b> Specify the value of a uniform variable for the current program object. </summary>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
         /// <param name="count"> For the vector (glUniform*v) commands, specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glUniform.xhtml" /></remarks>
-        public static void UniformMatrix2fv(int location, int count, byte transpose, float* value) => _UniformMatrix2fv_fnptr(location, count, transpose, value);
+        public static void UniformMatrix2fv(int location, int count, bool transpose, float* value) => _UniformMatrix2fv_fnptr(location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void UniformMatrix2fv_Lazy(int location, int count, byte transpose, float* value)
+        private static void UniformMatrix2fv_Lazy(int location, int count, bool transpose, float* value)
         {
-            _UniformMatrix2fv_fnptr = (delegate* unmanaged<int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix2fv");
+            _UniformMatrix2fv_fnptr = (delegate* unmanaged<int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix2fv");
             _UniformMatrix2fv_fnptr(location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<int, int, byte, float*, void> _UniformMatrix3fv_fnptr = &UniformMatrix3fv_Lazy;
+        private static delegate* unmanaged<int, int, bool, float*, void> _UniformMatrix3fv_fnptr = &UniformMatrix3fv_Lazy;
         /// <summary> <b>[requires: v2.0]</b> Specify the value of a uniform variable for the current program object. </summary>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
         /// <param name="count"> For the vector (glUniform*v) commands, specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glUniform.xhtml" /></remarks>
-        public static void UniformMatrix3fv(int location, int count, byte transpose, float* value) => _UniformMatrix3fv_fnptr(location, count, transpose, value);
+        public static void UniformMatrix3fv(int location, int count, bool transpose, float* value) => _UniformMatrix3fv_fnptr(location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void UniformMatrix3fv_Lazy(int location, int count, byte transpose, float* value)
+        private static void UniformMatrix3fv_Lazy(int location, int count, bool transpose, float* value)
         {
-            _UniformMatrix3fv_fnptr = (delegate* unmanaged<int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix3fv");
+            _UniformMatrix3fv_fnptr = (delegate* unmanaged<int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix3fv");
             _UniformMatrix3fv_fnptr(location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<int, int, byte, float*, void> _UniformMatrix4fv_fnptr = &UniformMatrix4fv_Lazy;
+        private static delegate* unmanaged<int, int, bool, float*, void> _UniformMatrix4fv_fnptr = &UniformMatrix4fv_Lazy;
         /// <summary> <b>[requires: v2.0]</b> Specify the value of a uniform variable for the current program object. </summary>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
         /// <param name="count"> For the vector (glUniform*v) commands, specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glUniform.xhtml" /></remarks>
-        public static void UniformMatrix4fv(int location, int count, byte transpose, float* value) => _UniformMatrix4fv_fnptr(location, count, transpose, value);
+        public static void UniformMatrix4fv(int location, int count, bool transpose, float* value) => _UniformMatrix4fv_fnptr(location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void UniformMatrix4fv_Lazy(int location, int count, byte transpose, float* value)
+        private static void UniformMatrix4fv_Lazy(int location, int count, bool transpose, float* value)
         {
-            _UniformMatrix4fv_fnptr = (delegate* unmanaged<int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix4fv");
+            _UniformMatrix4fv_fnptr = (delegate* unmanaged<int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix4fv");
             _UniformMatrix4fv_fnptr(location, count, transpose, value);
         }
         
@@ -2731,7 +2731,7 @@ namespace OpenTK.Graphics.OpenGL
             _VertexAttrib4usv_fnptr(index, v);
         }
         
-        private static delegate* unmanaged<uint, int, VertexAttribPointerType, byte, int, void*, void> _VertexAttribPointer_fnptr = &VertexAttribPointer_Lazy;
+        private static delegate* unmanaged<uint, int, VertexAttribPointerType, bool, int, void*, void> _VertexAttribPointer_fnptr = &VertexAttribPointer_Lazy;
         /// <summary> <b>[requires: v2.0]</b> Define an array of generic vertex attribute data. </summary>
         /// <param name="index">Specifies the index of the generic vertex attribute to be modified.</param>
         /// <param name="size">Specifies the number of components per generic vertex attribute. Must be 1, 2, 3, 4. Additionally, the symbolic constant GL_BGRA is accepted by glVertexAttribPointer. The initial value is 4.</param>
@@ -2740,105 +2740,105 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="stride">Specifies the byte offset between consecutive generic vertex attributes. If stride is 0, the generic vertex attributes are understood to be tightly packed in the array. The initial value is 0.</param>
         /// <param name="pointer">Specifies a offset of the first component of the first generic vertex attribute in the array in the data store of the buffer currently bound to the GL_ARRAY_BUFFER target. The initial value is 0.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glVertexAttribPointer.xhtml" /></remarks>
-        public static void VertexAttribPointer(uint index, int size, VertexAttribPointerType type, byte normalized, int stride, void* pointer) => _VertexAttribPointer_fnptr(index, size, type, normalized, stride, pointer);
+        public static void VertexAttribPointer(uint index, int size, VertexAttribPointerType type, bool normalized, int stride, void* pointer) => _VertexAttribPointer_fnptr(index, size, type, normalized, stride, pointer);
         [UnmanagedCallersOnly]
-        private static void VertexAttribPointer_Lazy(uint index, int size, VertexAttribPointerType type, byte normalized, int stride, void* pointer)
+        private static void VertexAttribPointer_Lazy(uint index, int size, VertexAttribPointerType type, bool normalized, int stride, void* pointer)
         {
-            _VertexAttribPointer_fnptr = (delegate* unmanaged<uint, int, VertexAttribPointerType, byte, int, void*, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribPointer");
+            _VertexAttribPointer_fnptr = (delegate* unmanaged<uint, int, VertexAttribPointerType, bool, int, void*, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribPointer");
             _VertexAttribPointer_fnptr(index, size, type, normalized, stride, pointer);
         }
         
-        private static delegate* unmanaged<int, int, byte, float*, void> _UniformMatrix2x3fv_fnptr = &UniformMatrix2x3fv_Lazy;
+        private static delegate* unmanaged<int, int, bool, float*, void> _UniformMatrix2x3fv_fnptr = &UniformMatrix2x3fv_Lazy;
         /// <summary> <b>[requires: v2.1]</b> Specify the value of a uniform variable for the current program object. </summary>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
         /// <param name="count"> For the vector (glUniform*v) commands, specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glUniform.xhtml" /></remarks>
-        public static void UniformMatrix2x3fv(int location, int count, byte transpose, float* value) => _UniformMatrix2x3fv_fnptr(location, count, transpose, value);
+        public static void UniformMatrix2x3fv(int location, int count, bool transpose, float* value) => _UniformMatrix2x3fv_fnptr(location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void UniformMatrix2x3fv_Lazy(int location, int count, byte transpose, float* value)
+        private static void UniformMatrix2x3fv_Lazy(int location, int count, bool transpose, float* value)
         {
-            _UniformMatrix2x3fv_fnptr = (delegate* unmanaged<int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix2x3fv");
+            _UniformMatrix2x3fv_fnptr = (delegate* unmanaged<int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix2x3fv");
             _UniformMatrix2x3fv_fnptr(location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<int, int, byte, float*, void> _UniformMatrix3x2fv_fnptr = &UniformMatrix3x2fv_Lazy;
+        private static delegate* unmanaged<int, int, bool, float*, void> _UniformMatrix3x2fv_fnptr = &UniformMatrix3x2fv_Lazy;
         /// <summary> <b>[requires: v2.1]</b> Specify the value of a uniform variable for the current program object. </summary>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
         /// <param name="count"> For the vector (glUniform*v) commands, specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glUniform.xhtml" /></remarks>
-        public static void UniformMatrix3x2fv(int location, int count, byte transpose, float* value) => _UniformMatrix3x2fv_fnptr(location, count, transpose, value);
+        public static void UniformMatrix3x2fv(int location, int count, bool transpose, float* value) => _UniformMatrix3x2fv_fnptr(location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void UniformMatrix3x2fv_Lazy(int location, int count, byte transpose, float* value)
+        private static void UniformMatrix3x2fv_Lazy(int location, int count, bool transpose, float* value)
         {
-            _UniformMatrix3x2fv_fnptr = (delegate* unmanaged<int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix3x2fv");
+            _UniformMatrix3x2fv_fnptr = (delegate* unmanaged<int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix3x2fv");
             _UniformMatrix3x2fv_fnptr(location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<int, int, byte, float*, void> _UniformMatrix2x4fv_fnptr = &UniformMatrix2x4fv_Lazy;
+        private static delegate* unmanaged<int, int, bool, float*, void> _UniformMatrix2x4fv_fnptr = &UniformMatrix2x4fv_Lazy;
         /// <summary> <b>[requires: v2.1]</b> Specify the value of a uniform variable for the current program object. </summary>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
         /// <param name="count"> For the vector (glUniform*v) commands, specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glUniform.xhtml" /></remarks>
-        public static void UniformMatrix2x4fv(int location, int count, byte transpose, float* value) => _UniformMatrix2x4fv_fnptr(location, count, transpose, value);
+        public static void UniformMatrix2x4fv(int location, int count, bool transpose, float* value) => _UniformMatrix2x4fv_fnptr(location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void UniformMatrix2x4fv_Lazy(int location, int count, byte transpose, float* value)
+        private static void UniformMatrix2x4fv_Lazy(int location, int count, bool transpose, float* value)
         {
-            _UniformMatrix2x4fv_fnptr = (delegate* unmanaged<int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix2x4fv");
+            _UniformMatrix2x4fv_fnptr = (delegate* unmanaged<int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix2x4fv");
             _UniformMatrix2x4fv_fnptr(location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<int, int, byte, float*, void> _UniformMatrix4x2fv_fnptr = &UniformMatrix4x2fv_Lazy;
+        private static delegate* unmanaged<int, int, bool, float*, void> _UniformMatrix4x2fv_fnptr = &UniformMatrix4x2fv_Lazy;
         /// <summary> <b>[requires: v2.1]</b> Specify the value of a uniform variable for the current program object. </summary>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
         /// <param name="count"> For the vector (glUniform*v) commands, specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glUniform.xhtml" /></remarks>
-        public static void UniformMatrix4x2fv(int location, int count, byte transpose, float* value) => _UniformMatrix4x2fv_fnptr(location, count, transpose, value);
+        public static void UniformMatrix4x2fv(int location, int count, bool transpose, float* value) => _UniformMatrix4x2fv_fnptr(location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void UniformMatrix4x2fv_Lazy(int location, int count, byte transpose, float* value)
+        private static void UniformMatrix4x2fv_Lazy(int location, int count, bool transpose, float* value)
         {
-            _UniformMatrix4x2fv_fnptr = (delegate* unmanaged<int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix4x2fv");
+            _UniformMatrix4x2fv_fnptr = (delegate* unmanaged<int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix4x2fv");
             _UniformMatrix4x2fv_fnptr(location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<int, int, byte, float*, void> _UniformMatrix3x4fv_fnptr = &UniformMatrix3x4fv_Lazy;
+        private static delegate* unmanaged<int, int, bool, float*, void> _UniformMatrix3x4fv_fnptr = &UniformMatrix3x4fv_Lazy;
         /// <summary> <b>[requires: v2.1]</b> Specify the value of a uniform variable for the current program object. </summary>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
         /// <param name="count"> For the vector (glUniform*v) commands, specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glUniform.xhtml" /></remarks>
-        public static void UniformMatrix3x4fv(int location, int count, byte transpose, float* value) => _UniformMatrix3x4fv_fnptr(location, count, transpose, value);
+        public static void UniformMatrix3x4fv(int location, int count, bool transpose, float* value) => _UniformMatrix3x4fv_fnptr(location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void UniformMatrix3x4fv_Lazy(int location, int count, byte transpose, float* value)
+        private static void UniformMatrix3x4fv_Lazy(int location, int count, bool transpose, float* value)
         {
-            _UniformMatrix3x4fv_fnptr = (delegate* unmanaged<int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix3x4fv");
+            _UniformMatrix3x4fv_fnptr = (delegate* unmanaged<int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix3x4fv");
             _UniformMatrix3x4fv_fnptr(location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<int, int, byte, float*, void> _UniformMatrix4x3fv_fnptr = &UniformMatrix4x3fv_Lazy;
+        private static delegate* unmanaged<int, int, bool, float*, void> _UniformMatrix4x3fv_fnptr = &UniformMatrix4x3fv_Lazy;
         /// <summary> <b>[requires: v2.1]</b> Specify the value of a uniform variable for the current program object. </summary>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
         /// <param name="count"> For the vector (glUniform*v) commands, specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glUniform.xhtml" /></remarks>
-        public static void UniformMatrix4x3fv(int location, int count, byte transpose, float* value) => _UniformMatrix4x3fv_fnptr(location, count, transpose, value);
+        public static void UniformMatrix4x3fv(int location, int count, bool transpose, float* value) => _UniformMatrix4x3fv_fnptr(location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void UniformMatrix4x3fv_Lazy(int location, int count, byte transpose, float* value)
+        private static void UniformMatrix4x3fv_Lazy(int location, int count, bool transpose, float* value)
         {
-            _UniformMatrix4x3fv_fnptr = (delegate* unmanaged<int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix4x3fv");
+            _UniformMatrix4x3fv_fnptr = (delegate* unmanaged<int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix4x3fv");
             _UniformMatrix4x3fv_fnptr(location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<uint, byte, byte, byte, byte, void> _ColorMaski_fnptr = &ColorMaski_Lazy;
+        private static delegate* unmanaged<uint, bool, bool, bool, bool, void> _ColorMaski_fnptr = &ColorMaski_Lazy;
         /// <summary> <b>[requires: v3.0]</b> Enable and disable writing of frame buffer color components. </summary>
         /// <param name="buf"> For glColorMaski, specifies the index of the draw buffer whose color mask to set. </param>
         /// <param name="red"> Specify whether red, green, blue, and alpha are to be written into the frame buffer. The initial values are all GL_TRUE, indicating that the color components are written. </param>
@@ -2846,25 +2846,25 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="blue"> Specify whether red, green, blue, and alpha are to be written into the frame buffer. The initial values are all GL_TRUE, indicating that the color components are written. </param>
         /// <param name="alpha"> Specify whether red, green, blue, and alpha are to be written into the frame buffer. The initial values are all GL_TRUE, indicating that the color components are written. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glColorMask.xhtml" /></remarks>
-        public static void ColorMaski(uint index, byte r, byte g, byte b, byte a) => _ColorMaski_fnptr(index, r, g, b, a);
+        public static void ColorMaski(uint index, bool r, bool g, bool b, bool a) => _ColorMaski_fnptr(index, r, g, b, a);
         [UnmanagedCallersOnly]
-        private static void ColorMaski_Lazy(uint index, byte r, byte g, byte b, byte a)
+        private static void ColorMaski_Lazy(uint index, bool r, bool g, bool b, bool a)
         {
-            _ColorMaski_fnptr = (delegate* unmanaged<uint, byte, byte, byte, byte, void>)GLLoader.BindingsContext.GetProcAddress("glColorMaski");
+            _ColorMaski_fnptr = (delegate* unmanaged<uint, bool, bool, bool, bool, void>)GLLoader.BindingsContext.GetProcAddress("glColorMaski");
             _ColorMaski_fnptr(index, r, g, b, a);
         }
         
-        private static delegate* unmanaged<BufferTargetARB, uint, byte*, void> _GetBooleani_v_fnptr = &GetBooleani_v_Lazy;
+        private static delegate* unmanaged<BufferTargetARB, uint, bool*, void> _GetBooleani_v_fnptr = &GetBooleani_v_Lazy;
         /// <summary> <b>[requires: v3.0]</b> Return the value or values of a selected parameter. </summary>
         /// <param name="target"> Specifies the parameter value to be returned for indexed versions of glGet. The symbolic constants in the list below are accepted. </param>
         /// <param name="index"> Specifies the index of the particular element being queried. </param>
         /// <param name="data"> Returns the value or values of the specified parameter. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGet.xhtml" /></remarks>
-        public static void GetBooleani_v(BufferTargetARB target, uint index, byte* data) => _GetBooleani_v_fnptr(target, index, data);
+        public static void GetBooleani_v(BufferTargetARB target, uint index, bool* data) => _GetBooleani_v_fnptr(target, index, data);
         [UnmanagedCallersOnly]
-        private static void GetBooleani_v_Lazy(BufferTargetARB target, uint index, byte* data)
+        private static void GetBooleani_v_Lazy(BufferTargetARB target, uint index, bool* data)
         {
-            _GetBooleani_v_fnptr = (delegate* unmanaged<BufferTargetARB, uint, byte*, void>)GLLoader.BindingsContext.GetProcAddress("glGetBooleani_v");
+            _GetBooleani_v_fnptr = (delegate* unmanaged<BufferTargetARB, uint, bool*, void>)GLLoader.BindingsContext.GetProcAddress("glGetBooleani_v");
             _GetBooleani_v_fnptr(target, index, data);
         }
         
@@ -2908,16 +2908,16 @@ namespace OpenTK.Graphics.OpenGL
             _Disablei_fnptr(target, index);
         }
         
-        private static delegate* unmanaged<EnableCap, uint, byte> _IsEnabledi_fnptr = &IsEnabledi_Lazy;
+        private static delegate* unmanaged<EnableCap, uint, bool> _IsEnabledi_fnptr = &IsEnabledi_Lazy;
         /// <summary> <b>[requires: v3.0]</b> Test whether a capability is enabled. </summary>
         /// <param name="cap"> Specifies a symbolic constant indicating a GL capability. </param>
         /// <param name="index"> Specifies the index of the capability. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsEnabled.xhtml" /></remarks>
-        public static byte IsEnabledi(EnableCap target, uint index) => _IsEnabledi_fnptr(target, index);
+        public static bool IsEnabledi(EnableCap target, uint index) => _IsEnabledi_fnptr(target, index);
         [UnmanagedCallersOnly]
-        private static byte IsEnabledi_Lazy(EnableCap target, uint index)
+        private static bool IsEnabledi_Lazy(EnableCap target, uint index)
         {
-            _IsEnabledi_fnptr = (delegate* unmanaged<EnableCap, uint, byte>)GLLoader.BindingsContext.GetProcAddress("glIsEnabledi");
+            _IsEnabledi_fnptr = (delegate* unmanaged<EnableCap, uint, bool>)GLLoader.BindingsContext.GetProcAddress("glIsEnabledi");
             return _IsEnabledi_fnptr(target, index);
         }
         
@@ -3641,15 +3641,15 @@ namespace OpenTK.Graphics.OpenGL
             return _GetStringi__fnptr(name, index);
         }
         
-        private static delegate* unmanaged<RenderbufferHandle, byte> _IsRenderbuffer_fnptr = &IsRenderbuffer_Lazy;
+        private static delegate* unmanaged<RenderbufferHandle, bool> _IsRenderbuffer_fnptr = &IsRenderbuffer_Lazy;
         /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Determine if a name corresponds to a renderbuffer object. </summary>
         /// <param name="renderbuffer"> Specifies a value that may be the name of a renderbuffer object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsRenderbuffer.xhtml" /></remarks>
-        public static byte IsRenderbuffer(RenderbufferHandle renderbuffer) => _IsRenderbuffer_fnptr(renderbuffer);
+        public static bool IsRenderbuffer(RenderbufferHandle renderbuffer) => _IsRenderbuffer_fnptr(renderbuffer);
         [UnmanagedCallersOnly]
-        private static byte IsRenderbuffer_Lazy(RenderbufferHandle renderbuffer)
+        private static bool IsRenderbuffer_Lazy(RenderbufferHandle renderbuffer)
         {
-            _IsRenderbuffer_fnptr = (delegate* unmanaged<RenderbufferHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsRenderbuffer");
+            _IsRenderbuffer_fnptr = (delegate* unmanaged<RenderbufferHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsRenderbuffer");
             return _IsRenderbuffer_fnptr(renderbuffer);
         }
         
@@ -3721,15 +3721,15 @@ namespace OpenTK.Graphics.OpenGL
             _GetRenderbufferParameteriv_fnptr(target, pname, parameters);
         }
         
-        private static delegate* unmanaged<FramebufferHandle, byte> _IsFramebuffer_fnptr = &IsFramebuffer_Lazy;
+        private static delegate* unmanaged<FramebufferHandle, bool> _IsFramebuffer_fnptr = &IsFramebuffer_Lazy;
         /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Determine if a name corresponds to a framebuffer object. </summary>
         /// <param name="framebuffer"> Specifies a value that may be the name of a framebuffer object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsFramebuffer.xhtml" /></remarks>
-        public static byte IsFramebuffer(FramebufferHandle framebuffer) => _IsFramebuffer_fnptr(framebuffer);
+        public static bool IsFramebuffer(FramebufferHandle framebuffer) => _IsFramebuffer_fnptr(framebuffer);
         [UnmanagedCallersOnly]
-        private static byte IsFramebuffer_Lazy(FramebufferHandle framebuffer)
+        private static bool IsFramebuffer_Lazy(FramebufferHandle framebuffer)
         {
-            _IsFramebuffer_fnptr = (delegate* unmanaged<FramebufferHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsFramebuffer");
+            _IsFramebuffer_fnptr = (delegate* unmanaged<FramebufferHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsFramebuffer");
             return _IsFramebuffer_fnptr(framebuffer);
         }
         
@@ -3995,15 +3995,15 @@ namespace OpenTK.Graphics.OpenGL
             _GenVertexArrays_fnptr(n, arrays);
         }
         
-        private static delegate* unmanaged<VertexArrayHandle, byte> _IsVertexArray_fnptr = &IsVertexArray_Lazy;
+        private static delegate* unmanaged<VertexArrayHandle, bool> _IsVertexArray_fnptr = &IsVertexArray_Lazy;
         /// <summary> <b>[requires: v3.0 | GL_ARB_vertex_array_object]</b> Determine if a name corresponds to a vertex array object. </summary>
         /// <param name="array"> Specifies a value that may be the name of a vertex array object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsVertexArray.xhtml" /></remarks>
-        public static byte IsVertexArray(VertexArrayHandle array) => _IsVertexArray_fnptr(array);
+        public static bool IsVertexArray(VertexArrayHandle array) => _IsVertexArray_fnptr(array);
         [UnmanagedCallersOnly]
-        private static byte IsVertexArray_Lazy(VertexArrayHandle array)
+        private static bool IsVertexArray_Lazy(VertexArrayHandle array)
         {
-            _IsVertexArray_fnptr = (delegate* unmanaged<VertexArrayHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsVertexArray");
+            _IsVertexArray_fnptr = (delegate* unmanaged<VertexArrayHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsVertexArray");
             return _IsVertexArray_fnptr(array);
         }
         
@@ -4278,15 +4278,15 @@ namespace OpenTK.Graphics.OpenGL
             return _FenceSync_fnptr(condition, flags);
         }
         
-        private static delegate* unmanaged<GLSync, byte> _IsSync_fnptr = &IsSync_Lazy;
+        private static delegate* unmanaged<GLSync, bool> _IsSync_fnptr = &IsSync_Lazy;
         /// <summary> <b>[requires: v3.2 | GL_ARB_sync]</b> Determine if a name corresponds to a sync object. </summary>
         /// <param name="sync"> Specifies a value that may be the name of a sync object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsSync.xhtml" /></remarks>
-        public static byte IsSync(GLSync sync) => _IsSync_fnptr(sync);
+        public static bool IsSync(GLSync sync) => _IsSync_fnptr(sync);
         [UnmanagedCallersOnly]
-        private static byte IsSync_Lazy(GLSync sync)
+        private static bool IsSync_Lazy(GLSync sync)
         {
-            _IsSync_fnptr = (delegate* unmanaged<GLSync, byte>)GLLoader.BindingsContext.GetProcAddress("glIsSync");
+            _IsSync_fnptr = (delegate* unmanaged<GLSync, bool>)GLLoader.BindingsContext.GetProcAddress("glIsSync");
             return _IsSync_fnptr(sync);
         }
         
@@ -4402,7 +4402,7 @@ namespace OpenTK.Graphics.OpenGL
             _FramebufferTexture_fnptr(target, attachment, texture, level);
         }
         
-        private static delegate* unmanaged<TextureTarget, int, InternalFormat, int, int, byte, void> _TexImage2DMultisample_fnptr = &TexImage2DMultisample_Lazy;
+        private static delegate* unmanaged<TextureTarget, int, InternalFormat, int, int, bool, void> _TexImage2DMultisample_fnptr = &TexImage2DMultisample_Lazy;
         /// <summary> <b>[requires: v3.2 | GL_ARB_texture_multisample]</b> Establish the data storage, format, dimensions, and number of samples of a multisample texture's image. </summary>
         /// <param name="target"> Specifies the target of the operation. target must be GL_TEXTURE_2D_MULTISAMPLE or GL_PROXY_TEXTURE_2D_MULTISAMPLE. </param>
         /// <param name="samples"> The number of samples in the multisample texture's image. </param>
@@ -4411,15 +4411,15 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="height"> The height of the multisample texture's image, in texels. </param>
         /// <param name="fixedsamplelocations"> Specifies whether the image will use identical sample locations and the same number of samples for all texels in the image, and the sample locations will not depend on the internal format or size of the image. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexImage2DMultisample.xhtml" /></remarks>
-        public static void TexImage2DMultisample(TextureTarget target, int samples, InternalFormat internalformat, int width, int height, byte fixedsamplelocations) => _TexImage2DMultisample_fnptr(target, samples, internalformat, width, height, fixedsamplelocations);
+        public static void TexImage2DMultisample(TextureTarget target, int samples, InternalFormat internalformat, int width, int height, bool fixedsamplelocations) => _TexImage2DMultisample_fnptr(target, samples, internalformat, width, height, fixedsamplelocations);
         [UnmanagedCallersOnly]
-        private static void TexImage2DMultisample_Lazy(TextureTarget target, int samples, InternalFormat internalformat, int width, int height, byte fixedsamplelocations)
+        private static void TexImage2DMultisample_Lazy(TextureTarget target, int samples, InternalFormat internalformat, int width, int height, bool fixedsamplelocations)
         {
-            _TexImage2DMultisample_fnptr = (delegate* unmanaged<TextureTarget, int, InternalFormat, int, int, byte, void>)GLLoader.BindingsContext.GetProcAddress("glTexImage2DMultisample");
+            _TexImage2DMultisample_fnptr = (delegate* unmanaged<TextureTarget, int, InternalFormat, int, int, bool, void>)GLLoader.BindingsContext.GetProcAddress("glTexImage2DMultisample");
             _TexImage2DMultisample_fnptr(target, samples, internalformat, width, height, fixedsamplelocations);
         }
         
-        private static delegate* unmanaged<TextureTarget, int, InternalFormat, int, int, int, byte, void> _TexImage3DMultisample_fnptr = &TexImage3DMultisample_Lazy;
+        private static delegate* unmanaged<TextureTarget, int, InternalFormat, int, int, int, bool, void> _TexImage3DMultisample_fnptr = &TexImage3DMultisample_Lazy;
         /// <summary> <b>[requires: v3.2 | GL_ARB_texture_multisample]</b> Establish the data storage, format, dimensions, and number of samples of a multisample texture's image. </summary>
         /// <param name="target"> Specifies the target of the operation. target must be GL_TEXTURE_2D_MULTISAMPLE_ARRAY or GL_PROXY_TEXTURE_2D_MULTISAMPLE_ARRAY. </param>
         /// <param name="samples"> The number of samples in the multisample texture's image. </param>
@@ -4429,11 +4429,11 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="depth">!!missing documentation!!</param>
         /// <param name="fixedsamplelocations"> Specifies whether the image will use identical sample locations and the same number of samples for all texels in the image, and the sample locations will not depend on the internal format or size of the image. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexImage3DMultisample.xhtml" /></remarks>
-        public static void TexImage3DMultisample(TextureTarget target, int samples, InternalFormat internalformat, int width, int height, int depth, byte fixedsamplelocations) => _TexImage3DMultisample_fnptr(target, samples, internalformat, width, height, depth, fixedsamplelocations);
+        public static void TexImage3DMultisample(TextureTarget target, int samples, InternalFormat internalformat, int width, int height, int depth, bool fixedsamplelocations) => _TexImage3DMultisample_fnptr(target, samples, internalformat, width, height, depth, fixedsamplelocations);
         [UnmanagedCallersOnly]
-        private static void TexImage3DMultisample_Lazy(TextureTarget target, int samples, InternalFormat internalformat, int width, int height, int depth, byte fixedsamplelocations)
+        private static void TexImage3DMultisample_Lazy(TextureTarget target, int samples, InternalFormat internalformat, int width, int height, int depth, bool fixedsamplelocations)
         {
-            _TexImage3DMultisample_fnptr = (delegate* unmanaged<TextureTarget, int, InternalFormat, int, int, int, byte, void>)GLLoader.BindingsContext.GetProcAddress("glTexImage3DMultisample");
+            _TexImage3DMultisample_fnptr = (delegate* unmanaged<TextureTarget, int, InternalFormat, int, int, int, bool, void>)GLLoader.BindingsContext.GetProcAddress("glTexImage3DMultisample");
             _TexImage3DMultisample_fnptr(target, samples, internalformat, width, height, depth, fixedsamplelocations);
         }
         
@@ -4518,15 +4518,15 @@ namespace OpenTK.Graphics.OpenGL
             _DeleteSamplers_fnptr(count, samplers);
         }
         
-        private static delegate* unmanaged<SamplerHandle, byte> _IsSampler_fnptr = &IsSampler_Lazy;
+        private static delegate* unmanaged<SamplerHandle, bool> _IsSampler_fnptr = &IsSampler_Lazy;
         /// <summary> <b>[requires: v3.3 | GL_ARB_sampler_objects]</b> Determine if a name corresponds to a sampler object. </summary>
         /// <param name="id"> Specifies a value that may be the name of a sampler object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsSampler.xhtml" /></remarks>
-        public static byte IsSampler(SamplerHandle sampler) => _IsSampler_fnptr(sampler);
+        public static bool IsSampler(SamplerHandle sampler) => _IsSampler_fnptr(sampler);
         [UnmanagedCallersOnly]
-        private static byte IsSampler_Lazy(SamplerHandle sampler)
+        private static bool IsSampler_Lazy(SamplerHandle sampler)
         {
-            _IsSampler_fnptr = (delegate* unmanaged<SamplerHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsSampler");
+            _IsSampler_fnptr = (delegate* unmanaged<SamplerHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsSampler");
             return _IsSampler_fnptr(sampler);
         }
         
@@ -4737,107 +4737,107 @@ namespace OpenTK.Graphics.OpenGL
             _VertexAttribDivisor_fnptr(index, divisor);
         }
         
-        private static delegate* unmanaged<uint, VertexAttribPointerType, byte, uint, void> _VertexAttribP1ui_fnptr = &VertexAttribP1ui_Lazy;
+        private static delegate* unmanaged<uint, VertexAttribPointerType, bool, uint, void> _VertexAttribP1ui_fnptr = &VertexAttribP1ui_Lazy;
         /// <summary> <b>[requires: v3.3 | GL_ARB_vertex_type_2_10_10_10_rev]</b> Specifies the value of a generic vertex attribute. </summary>
         /// <param name="index">Specifies the index of the generic vertex attribute to be modified.</param>
         /// <param name="type"> For the packed commands (glVertexAttribP*), specified the type of packing used on the data. This parameter must be GL_INT_2_10_10_10_REV or GL_UNSIGNED_INT_2_10_10_10_REV, to specify signed or unsigned data, respectively, or GL_UNSIGNED_INT_10F_11F_11F_REV to specify floating point data. </param>
         /// <param name="normalized"> For the packed commands, if GL_TRUE, then the values are to be converted to floating point values by normalizing. Otherwise, they are converted directly to floating-point values. If type indicates a floating-pont format, then normalized value must be GL_FALSE. </param>
         /// <param name="value"> For the packed commands, specifies the new packed value to be used for the specified vertex attribute. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glVertexAttrib.xhtml" /></remarks>
-        public static void VertexAttribP1ui(uint index, VertexAttribPointerType type, byte normalized, uint value) => _VertexAttribP1ui_fnptr(index, type, normalized, value);
+        public static void VertexAttribP1ui(uint index, VertexAttribPointerType type, bool normalized, uint value) => _VertexAttribP1ui_fnptr(index, type, normalized, value);
         [UnmanagedCallersOnly]
-        private static void VertexAttribP1ui_Lazy(uint index, VertexAttribPointerType type, byte normalized, uint value)
+        private static void VertexAttribP1ui_Lazy(uint index, VertexAttribPointerType type, bool normalized, uint value)
         {
-            _VertexAttribP1ui_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, byte, uint, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP1ui");
+            _VertexAttribP1ui_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, bool, uint, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP1ui");
             _VertexAttribP1ui_fnptr(index, type, normalized, value);
         }
         
-        private static delegate* unmanaged<uint, VertexAttribPointerType, byte, uint*, void> _VertexAttribP1uiv_fnptr = &VertexAttribP1uiv_Lazy;
+        private static delegate* unmanaged<uint, VertexAttribPointerType, bool, uint*, void> _VertexAttribP1uiv_fnptr = &VertexAttribP1uiv_Lazy;
         /// <summary> <b>[requires: v3.3 | GL_ARB_vertex_type_2_10_10_10_rev]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void VertexAttribP1uiv(uint index, VertexAttribPointerType type, byte normalized, uint* value) => _VertexAttribP1uiv_fnptr(index, type, normalized, value);
+        public static void VertexAttribP1uiv(uint index, VertexAttribPointerType type, bool normalized, uint* value) => _VertexAttribP1uiv_fnptr(index, type, normalized, value);
         [UnmanagedCallersOnly]
-        private static void VertexAttribP1uiv_Lazy(uint index, VertexAttribPointerType type, byte normalized, uint* value)
+        private static void VertexAttribP1uiv_Lazy(uint index, VertexAttribPointerType type, bool normalized, uint* value)
         {
-            _VertexAttribP1uiv_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, byte, uint*, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP1uiv");
+            _VertexAttribP1uiv_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, bool, uint*, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP1uiv");
             _VertexAttribP1uiv_fnptr(index, type, normalized, value);
         }
         
-        private static delegate* unmanaged<uint, VertexAttribPointerType, byte, uint, void> _VertexAttribP2ui_fnptr = &VertexAttribP2ui_Lazy;
+        private static delegate* unmanaged<uint, VertexAttribPointerType, bool, uint, void> _VertexAttribP2ui_fnptr = &VertexAttribP2ui_Lazy;
         /// <summary> <b>[requires: v3.3 | GL_ARB_vertex_type_2_10_10_10_rev]</b> Specifies the value of a generic vertex attribute. </summary>
         /// <param name="index">Specifies the index of the generic vertex attribute to be modified.</param>
         /// <param name="type"> For the packed commands (glVertexAttribP*), specified the type of packing used on the data. This parameter must be GL_INT_2_10_10_10_REV or GL_UNSIGNED_INT_2_10_10_10_REV, to specify signed or unsigned data, respectively, or GL_UNSIGNED_INT_10F_11F_11F_REV to specify floating point data. </param>
         /// <param name="normalized"> For the packed commands, if GL_TRUE, then the values are to be converted to floating point values by normalizing. Otherwise, they are converted directly to floating-point values. If type indicates a floating-pont format, then normalized value must be GL_FALSE. </param>
         /// <param name="value"> For the packed commands, specifies the new packed value to be used for the specified vertex attribute. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glVertexAttrib.xhtml" /></remarks>
-        public static void VertexAttribP2ui(uint index, VertexAttribPointerType type, byte normalized, uint value) => _VertexAttribP2ui_fnptr(index, type, normalized, value);
+        public static void VertexAttribP2ui(uint index, VertexAttribPointerType type, bool normalized, uint value) => _VertexAttribP2ui_fnptr(index, type, normalized, value);
         [UnmanagedCallersOnly]
-        private static void VertexAttribP2ui_Lazy(uint index, VertexAttribPointerType type, byte normalized, uint value)
+        private static void VertexAttribP2ui_Lazy(uint index, VertexAttribPointerType type, bool normalized, uint value)
         {
-            _VertexAttribP2ui_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, byte, uint, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP2ui");
+            _VertexAttribP2ui_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, bool, uint, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP2ui");
             _VertexAttribP2ui_fnptr(index, type, normalized, value);
         }
         
-        private static delegate* unmanaged<uint, VertexAttribPointerType, byte, uint*, void> _VertexAttribP2uiv_fnptr = &VertexAttribP2uiv_Lazy;
+        private static delegate* unmanaged<uint, VertexAttribPointerType, bool, uint*, void> _VertexAttribP2uiv_fnptr = &VertexAttribP2uiv_Lazy;
         /// <summary> <b>[requires: v3.3 | GL_ARB_vertex_type_2_10_10_10_rev]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void VertexAttribP2uiv(uint index, VertexAttribPointerType type, byte normalized, uint* value) => _VertexAttribP2uiv_fnptr(index, type, normalized, value);
+        public static void VertexAttribP2uiv(uint index, VertexAttribPointerType type, bool normalized, uint* value) => _VertexAttribP2uiv_fnptr(index, type, normalized, value);
         [UnmanagedCallersOnly]
-        private static void VertexAttribP2uiv_Lazy(uint index, VertexAttribPointerType type, byte normalized, uint* value)
+        private static void VertexAttribP2uiv_Lazy(uint index, VertexAttribPointerType type, bool normalized, uint* value)
         {
-            _VertexAttribP2uiv_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, byte, uint*, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP2uiv");
+            _VertexAttribP2uiv_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, bool, uint*, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP2uiv");
             _VertexAttribP2uiv_fnptr(index, type, normalized, value);
         }
         
-        private static delegate* unmanaged<uint, VertexAttribPointerType, byte, uint, void> _VertexAttribP3ui_fnptr = &VertexAttribP3ui_Lazy;
+        private static delegate* unmanaged<uint, VertexAttribPointerType, bool, uint, void> _VertexAttribP3ui_fnptr = &VertexAttribP3ui_Lazy;
         /// <summary> <b>[requires: v3.3 | GL_ARB_vertex_type_2_10_10_10_rev]</b> Specifies the value of a generic vertex attribute. </summary>
         /// <param name="index">Specifies the index of the generic vertex attribute to be modified.</param>
         /// <param name="type"> For the packed commands (glVertexAttribP*), specified the type of packing used on the data. This parameter must be GL_INT_2_10_10_10_REV or GL_UNSIGNED_INT_2_10_10_10_REV, to specify signed or unsigned data, respectively, or GL_UNSIGNED_INT_10F_11F_11F_REV to specify floating point data. </param>
         /// <param name="normalized"> For the packed commands, if GL_TRUE, then the values are to be converted to floating point values by normalizing. Otherwise, they are converted directly to floating-point values. If type indicates a floating-pont format, then normalized value must be GL_FALSE. </param>
         /// <param name="value"> For the packed commands, specifies the new packed value to be used for the specified vertex attribute. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glVertexAttrib.xhtml" /></remarks>
-        public static void VertexAttribP3ui(uint index, VertexAttribPointerType type, byte normalized, uint value) => _VertexAttribP3ui_fnptr(index, type, normalized, value);
+        public static void VertexAttribP3ui(uint index, VertexAttribPointerType type, bool normalized, uint value) => _VertexAttribP3ui_fnptr(index, type, normalized, value);
         [UnmanagedCallersOnly]
-        private static void VertexAttribP3ui_Lazy(uint index, VertexAttribPointerType type, byte normalized, uint value)
+        private static void VertexAttribP3ui_Lazy(uint index, VertexAttribPointerType type, bool normalized, uint value)
         {
-            _VertexAttribP3ui_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, byte, uint, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP3ui");
+            _VertexAttribP3ui_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, bool, uint, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP3ui");
             _VertexAttribP3ui_fnptr(index, type, normalized, value);
         }
         
-        private static delegate* unmanaged<uint, VertexAttribPointerType, byte, uint*, void> _VertexAttribP3uiv_fnptr = &VertexAttribP3uiv_Lazy;
+        private static delegate* unmanaged<uint, VertexAttribPointerType, bool, uint*, void> _VertexAttribP3uiv_fnptr = &VertexAttribP3uiv_Lazy;
         /// <summary> <b>[requires: v3.3 | GL_ARB_vertex_type_2_10_10_10_rev]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void VertexAttribP3uiv(uint index, VertexAttribPointerType type, byte normalized, uint* value) => _VertexAttribP3uiv_fnptr(index, type, normalized, value);
+        public static void VertexAttribP3uiv(uint index, VertexAttribPointerType type, bool normalized, uint* value) => _VertexAttribP3uiv_fnptr(index, type, normalized, value);
         [UnmanagedCallersOnly]
-        private static void VertexAttribP3uiv_Lazy(uint index, VertexAttribPointerType type, byte normalized, uint* value)
+        private static void VertexAttribP3uiv_Lazy(uint index, VertexAttribPointerType type, bool normalized, uint* value)
         {
-            _VertexAttribP3uiv_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, byte, uint*, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP3uiv");
+            _VertexAttribP3uiv_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, bool, uint*, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP3uiv");
             _VertexAttribP3uiv_fnptr(index, type, normalized, value);
         }
         
-        private static delegate* unmanaged<uint, VertexAttribPointerType, byte, uint, void> _VertexAttribP4ui_fnptr = &VertexAttribP4ui_Lazy;
+        private static delegate* unmanaged<uint, VertexAttribPointerType, bool, uint, void> _VertexAttribP4ui_fnptr = &VertexAttribP4ui_Lazy;
         /// <summary> <b>[requires: v3.3 | GL_ARB_vertex_type_2_10_10_10_rev]</b> Specifies the value of a generic vertex attribute. </summary>
         /// <param name="index">Specifies the index of the generic vertex attribute to be modified.</param>
         /// <param name="type"> For the packed commands (glVertexAttribP*), specified the type of packing used on the data. This parameter must be GL_INT_2_10_10_10_REV or GL_UNSIGNED_INT_2_10_10_10_REV, to specify signed or unsigned data, respectively, or GL_UNSIGNED_INT_10F_11F_11F_REV to specify floating point data. </param>
         /// <param name="normalized"> For the packed commands, if GL_TRUE, then the values are to be converted to floating point values by normalizing. Otherwise, they are converted directly to floating-point values. If type indicates a floating-pont format, then normalized value must be GL_FALSE. </param>
         /// <param name="value"> For the packed commands, specifies the new packed value to be used for the specified vertex attribute. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glVertexAttrib.xhtml" /></remarks>
-        public static void VertexAttribP4ui(uint index, VertexAttribPointerType type, byte normalized, uint value) => _VertexAttribP4ui_fnptr(index, type, normalized, value);
+        public static void VertexAttribP4ui(uint index, VertexAttribPointerType type, bool normalized, uint value) => _VertexAttribP4ui_fnptr(index, type, normalized, value);
         [UnmanagedCallersOnly]
-        private static void VertexAttribP4ui_Lazy(uint index, VertexAttribPointerType type, byte normalized, uint value)
+        private static void VertexAttribP4ui_Lazy(uint index, VertexAttribPointerType type, bool normalized, uint value)
         {
-            _VertexAttribP4ui_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, byte, uint, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP4ui");
+            _VertexAttribP4ui_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, bool, uint, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP4ui");
             _VertexAttribP4ui_fnptr(index, type, normalized, value);
         }
         
-        private static delegate* unmanaged<uint, VertexAttribPointerType, byte, uint*, void> _VertexAttribP4uiv_fnptr = &VertexAttribP4uiv_Lazy;
+        private static delegate* unmanaged<uint, VertexAttribPointerType, bool, uint*, void> _VertexAttribP4uiv_fnptr = &VertexAttribP4uiv_Lazy;
         /// <summary> <b>[requires: v3.3 | GL_ARB_vertex_type_2_10_10_10_rev]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void VertexAttribP4uiv(uint index, VertexAttribPointerType type, byte normalized, uint* value) => _VertexAttribP4uiv_fnptr(index, type, normalized, value);
+        public static void VertexAttribP4uiv(uint index, VertexAttribPointerType type, bool normalized, uint* value) => _VertexAttribP4uiv_fnptr(index, type, normalized, value);
         [UnmanagedCallersOnly]
-        private static void VertexAttribP4uiv_Lazy(uint index, VertexAttribPointerType type, byte normalized, uint* value)
+        private static void VertexAttribP4uiv_Lazy(uint index, VertexAttribPointerType type, bool normalized, uint* value)
         {
-            _VertexAttribP4uiv_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, byte, uint*, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP4uiv");
+            _VertexAttribP4uiv_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, bool, uint*, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP4uiv");
             _VertexAttribP4uiv_fnptr(index, type, normalized, value);
         }
         
@@ -5025,102 +5025,102 @@ namespace OpenTK.Graphics.OpenGL
             _Uniform4dv_fnptr(location, count, value);
         }
         
-        private static delegate* unmanaged<int, int, byte, double*, void> _UniformMatrix2dv_fnptr = &UniformMatrix2dv_Lazy;
+        private static delegate* unmanaged<int, int, bool, double*, void> _UniformMatrix2dv_fnptr = &UniformMatrix2dv_Lazy;
         /// <summary> <b>[requires: v4.0 | GL_ARB_gpu_shader_fp64]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void UniformMatrix2dv(int location, int count, byte transpose, double* value) => _UniformMatrix2dv_fnptr(location, count, transpose, value);
+        public static void UniformMatrix2dv(int location, int count, bool transpose, double* value) => _UniformMatrix2dv_fnptr(location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void UniformMatrix2dv_Lazy(int location, int count, byte transpose, double* value)
+        private static void UniformMatrix2dv_Lazy(int location, int count, bool transpose, double* value)
         {
-            _UniformMatrix2dv_fnptr = (delegate* unmanaged<int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix2dv");
+            _UniformMatrix2dv_fnptr = (delegate* unmanaged<int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix2dv");
             _UniformMatrix2dv_fnptr(location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<int, int, byte, double*, void> _UniformMatrix3dv_fnptr = &UniformMatrix3dv_Lazy;
+        private static delegate* unmanaged<int, int, bool, double*, void> _UniformMatrix3dv_fnptr = &UniformMatrix3dv_Lazy;
         /// <summary> <b>[requires: v4.0 | GL_ARB_gpu_shader_fp64]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void UniformMatrix3dv(int location, int count, byte transpose, double* value) => _UniformMatrix3dv_fnptr(location, count, transpose, value);
+        public static void UniformMatrix3dv(int location, int count, bool transpose, double* value) => _UniformMatrix3dv_fnptr(location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void UniformMatrix3dv_Lazy(int location, int count, byte transpose, double* value)
+        private static void UniformMatrix3dv_Lazy(int location, int count, bool transpose, double* value)
         {
-            _UniformMatrix3dv_fnptr = (delegate* unmanaged<int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix3dv");
+            _UniformMatrix3dv_fnptr = (delegate* unmanaged<int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix3dv");
             _UniformMatrix3dv_fnptr(location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<int, int, byte, double*, void> _UniformMatrix4dv_fnptr = &UniformMatrix4dv_Lazy;
+        private static delegate* unmanaged<int, int, bool, double*, void> _UniformMatrix4dv_fnptr = &UniformMatrix4dv_Lazy;
         /// <summary> <b>[requires: v4.0 | GL_ARB_gpu_shader_fp64]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void UniformMatrix4dv(int location, int count, byte transpose, double* value) => _UniformMatrix4dv_fnptr(location, count, transpose, value);
+        public static void UniformMatrix4dv(int location, int count, bool transpose, double* value) => _UniformMatrix4dv_fnptr(location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void UniformMatrix4dv_Lazy(int location, int count, byte transpose, double* value)
+        private static void UniformMatrix4dv_Lazy(int location, int count, bool transpose, double* value)
         {
-            _UniformMatrix4dv_fnptr = (delegate* unmanaged<int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix4dv");
+            _UniformMatrix4dv_fnptr = (delegate* unmanaged<int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix4dv");
             _UniformMatrix4dv_fnptr(location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<int, int, byte, double*, void> _UniformMatrix2x3dv_fnptr = &UniformMatrix2x3dv_Lazy;
+        private static delegate* unmanaged<int, int, bool, double*, void> _UniformMatrix2x3dv_fnptr = &UniformMatrix2x3dv_Lazy;
         /// <summary> <b>[requires: v4.0 | GL_ARB_gpu_shader_fp64]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void UniformMatrix2x3dv(int location, int count, byte transpose, double* value) => _UniformMatrix2x3dv_fnptr(location, count, transpose, value);
+        public static void UniformMatrix2x3dv(int location, int count, bool transpose, double* value) => _UniformMatrix2x3dv_fnptr(location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void UniformMatrix2x3dv_Lazy(int location, int count, byte transpose, double* value)
+        private static void UniformMatrix2x3dv_Lazy(int location, int count, bool transpose, double* value)
         {
-            _UniformMatrix2x3dv_fnptr = (delegate* unmanaged<int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix2x3dv");
+            _UniformMatrix2x3dv_fnptr = (delegate* unmanaged<int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix2x3dv");
             _UniformMatrix2x3dv_fnptr(location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<int, int, byte, double*, void> _UniformMatrix2x4dv_fnptr = &UniformMatrix2x4dv_Lazy;
+        private static delegate* unmanaged<int, int, bool, double*, void> _UniformMatrix2x4dv_fnptr = &UniformMatrix2x4dv_Lazy;
         /// <summary> <b>[requires: v4.0 | GL_ARB_gpu_shader_fp64]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void UniformMatrix2x4dv(int location, int count, byte transpose, double* value) => _UniformMatrix2x4dv_fnptr(location, count, transpose, value);
+        public static void UniformMatrix2x4dv(int location, int count, bool transpose, double* value) => _UniformMatrix2x4dv_fnptr(location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void UniformMatrix2x4dv_Lazy(int location, int count, byte transpose, double* value)
+        private static void UniformMatrix2x4dv_Lazy(int location, int count, bool transpose, double* value)
         {
-            _UniformMatrix2x4dv_fnptr = (delegate* unmanaged<int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix2x4dv");
+            _UniformMatrix2x4dv_fnptr = (delegate* unmanaged<int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix2x4dv");
             _UniformMatrix2x4dv_fnptr(location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<int, int, byte, double*, void> _UniformMatrix3x2dv_fnptr = &UniformMatrix3x2dv_Lazy;
+        private static delegate* unmanaged<int, int, bool, double*, void> _UniformMatrix3x2dv_fnptr = &UniformMatrix3x2dv_Lazy;
         /// <summary> <b>[requires: v4.0 | GL_ARB_gpu_shader_fp64]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void UniformMatrix3x2dv(int location, int count, byte transpose, double* value) => _UniformMatrix3x2dv_fnptr(location, count, transpose, value);
+        public static void UniformMatrix3x2dv(int location, int count, bool transpose, double* value) => _UniformMatrix3x2dv_fnptr(location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void UniformMatrix3x2dv_Lazy(int location, int count, byte transpose, double* value)
+        private static void UniformMatrix3x2dv_Lazy(int location, int count, bool transpose, double* value)
         {
-            _UniformMatrix3x2dv_fnptr = (delegate* unmanaged<int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix3x2dv");
+            _UniformMatrix3x2dv_fnptr = (delegate* unmanaged<int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix3x2dv");
             _UniformMatrix3x2dv_fnptr(location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<int, int, byte, double*, void> _UniformMatrix3x4dv_fnptr = &UniformMatrix3x4dv_Lazy;
+        private static delegate* unmanaged<int, int, bool, double*, void> _UniformMatrix3x4dv_fnptr = &UniformMatrix3x4dv_Lazy;
         /// <summary> <b>[requires: v4.0 | GL_ARB_gpu_shader_fp64]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void UniformMatrix3x4dv(int location, int count, byte transpose, double* value) => _UniformMatrix3x4dv_fnptr(location, count, transpose, value);
+        public static void UniformMatrix3x4dv(int location, int count, bool transpose, double* value) => _UniformMatrix3x4dv_fnptr(location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void UniformMatrix3x4dv_Lazy(int location, int count, byte transpose, double* value)
+        private static void UniformMatrix3x4dv_Lazy(int location, int count, bool transpose, double* value)
         {
-            _UniformMatrix3x4dv_fnptr = (delegate* unmanaged<int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix3x4dv");
+            _UniformMatrix3x4dv_fnptr = (delegate* unmanaged<int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix3x4dv");
             _UniformMatrix3x4dv_fnptr(location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<int, int, byte, double*, void> _UniformMatrix4x2dv_fnptr = &UniformMatrix4x2dv_Lazy;
+        private static delegate* unmanaged<int, int, bool, double*, void> _UniformMatrix4x2dv_fnptr = &UniformMatrix4x2dv_Lazy;
         /// <summary> <b>[requires: v4.0 | GL_ARB_gpu_shader_fp64]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void UniformMatrix4x2dv(int location, int count, byte transpose, double* value) => _UniformMatrix4x2dv_fnptr(location, count, transpose, value);
+        public static void UniformMatrix4x2dv(int location, int count, bool transpose, double* value) => _UniformMatrix4x2dv_fnptr(location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void UniformMatrix4x2dv_Lazy(int location, int count, byte transpose, double* value)
+        private static void UniformMatrix4x2dv_Lazy(int location, int count, bool transpose, double* value)
         {
-            _UniformMatrix4x2dv_fnptr = (delegate* unmanaged<int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix4x2dv");
+            _UniformMatrix4x2dv_fnptr = (delegate* unmanaged<int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix4x2dv");
             _UniformMatrix4x2dv_fnptr(location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<int, int, byte, double*, void> _UniformMatrix4x3dv_fnptr = &UniformMatrix4x3dv_Lazy;
+        private static delegate* unmanaged<int, int, bool, double*, void> _UniformMatrix4x3dv_fnptr = &UniformMatrix4x3dv_Lazy;
         /// <summary> <b>[requires: v4.0 | GL_ARB_gpu_shader_fp64]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void UniformMatrix4x3dv(int location, int count, byte transpose, double* value) => _UniformMatrix4x3dv_fnptr(location, count, transpose, value);
+        public static void UniformMatrix4x3dv(int location, int count, bool transpose, double* value) => _UniformMatrix4x3dv_fnptr(location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void UniformMatrix4x3dv_Lazy(int location, int count, byte transpose, double* value)
+        private static void UniformMatrix4x3dv_Lazy(int location, int count, bool transpose, double* value)
         {
-            _UniformMatrix4x3dv_fnptr = (delegate* unmanaged<int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix4x3dv");
+            _UniformMatrix4x3dv_fnptr = (delegate* unmanaged<int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix4x3dv");
             _UniformMatrix4x3dv_fnptr(location, count, transpose, value);
         }
         
@@ -5324,15 +5324,15 @@ namespace OpenTK.Graphics.OpenGL
             _GenTransformFeedbacks_fnptr(n, ids);
         }
         
-        private static delegate* unmanaged<TransformFeedbackHandle, byte> _IsTransformFeedback_fnptr = &IsTransformFeedback_Lazy;
+        private static delegate* unmanaged<TransformFeedbackHandle, bool> _IsTransformFeedback_fnptr = &IsTransformFeedback_Lazy;
         /// <summary> <b>[requires: v4.0 | GL_ARB_transform_feedback2]</b> Determine if a name corresponds to a transform feedback object. </summary>
         /// <param name="id"> Specifies a value that may be the name of a transform feedback object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsTransformFeedback.xhtml" /></remarks>
-        public static byte IsTransformFeedback(TransformFeedbackHandle id) => _IsTransformFeedback_fnptr(id);
+        public static bool IsTransformFeedback(TransformFeedbackHandle id) => _IsTransformFeedback_fnptr(id);
         [UnmanagedCallersOnly]
-        private static byte IsTransformFeedback_Lazy(TransformFeedbackHandle id)
+        private static bool IsTransformFeedback_Lazy(TransformFeedbackHandle id)
         {
-            _IsTransformFeedback_fnptr = (delegate* unmanaged<TransformFeedbackHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsTransformFeedback");
+            _IsTransformFeedback_fnptr = (delegate* unmanaged<TransformFeedbackHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsTransformFeedback");
             return _IsTransformFeedback_fnptr(id);
         }
         
@@ -5618,15 +5618,15 @@ namespace OpenTK.Graphics.OpenGL
             _GenProgramPipelines_fnptr(n, pipelines);
         }
         
-        private static delegate* unmanaged<ProgramPipelineHandle, byte> _IsProgramPipeline_fnptr = &IsProgramPipeline_Lazy;
+        private static delegate* unmanaged<ProgramPipelineHandle, bool> _IsProgramPipeline_fnptr = &IsProgramPipeline_Lazy;
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Determine if a name corresponds to a program pipeline object. </summary>
         /// <param name="pipeline"> Specifies a value that may be the name of a program pipeline object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsProgramPipeline.xhtml" /></remarks>
-        public static byte IsProgramPipeline(ProgramPipelineHandle pipeline) => _IsProgramPipeline_fnptr(pipeline);
+        public static bool IsProgramPipeline(ProgramPipelineHandle pipeline) => _IsProgramPipeline_fnptr(pipeline);
         [UnmanagedCallersOnly]
-        private static byte IsProgramPipeline_Lazy(ProgramPipelineHandle pipeline)
+        private static bool IsProgramPipeline_Lazy(ProgramPipelineHandle pipeline)
         {
-            _IsProgramPipeline_fnptr = (delegate* unmanaged<ProgramPipelineHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsProgramPipeline");
+            _IsProgramPipeline_fnptr = (delegate* unmanaged<ProgramPipelineHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsProgramPipeline");
             return _IsProgramPipeline_fnptr(pipeline);
         }
         
@@ -6098,7 +6098,7 @@ namespace OpenTK.Graphics.OpenGL
             _ProgramUniform4uiv_fnptr(program, location, count, value);
         }
         
-        private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix2fv_fnptr = &ProgramUniformMatrix2fv_Lazy;
+        private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix2fv_fnptr = &ProgramUniformMatrix2fv_Lazy;
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
@@ -6106,15 +6106,15 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniformMatrix2fv(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix2fv_fnptr(program, location, count, transpose, value);
+        public static void ProgramUniformMatrix2fv(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix2fv_fnptr(program, location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void ProgramUniformMatrix2fv_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+        private static void ProgramUniformMatrix2fv_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
         {
-            _ProgramUniformMatrix2fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2fv");
+            _ProgramUniformMatrix2fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2fv");
             _ProgramUniformMatrix2fv_fnptr(program, location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix3fv_fnptr = &ProgramUniformMatrix3fv_Lazy;
+        private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix3fv_fnptr = &ProgramUniformMatrix3fv_Lazy;
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
@@ -6122,15 +6122,15 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniformMatrix3fv(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix3fv_fnptr(program, location, count, transpose, value);
+        public static void ProgramUniformMatrix3fv(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix3fv_fnptr(program, location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void ProgramUniformMatrix3fv_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+        private static void ProgramUniformMatrix3fv_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
         {
-            _ProgramUniformMatrix3fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3fv");
+            _ProgramUniformMatrix3fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3fv");
             _ProgramUniformMatrix3fv_fnptr(program, location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix4fv_fnptr = &ProgramUniformMatrix4fv_Lazy;
+        private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix4fv_fnptr = &ProgramUniformMatrix4fv_Lazy;
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
@@ -6138,48 +6138,48 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniformMatrix4fv(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix4fv_fnptr(program, location, count, transpose, value);
+        public static void ProgramUniformMatrix4fv(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix4fv_fnptr(program, location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void ProgramUniformMatrix4fv_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+        private static void ProgramUniformMatrix4fv_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
         {
-            _ProgramUniformMatrix4fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4fv");
+            _ProgramUniformMatrix4fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4fv");
             _ProgramUniformMatrix4fv_fnptr(program, location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<ProgramHandle, int, int, byte, double*, void> _ProgramUniformMatrix2dv_fnptr = &ProgramUniformMatrix2dv_Lazy;
+        private static delegate* unmanaged<ProgramHandle, int, int, bool, double*, void> _ProgramUniformMatrix2dv_fnptr = &ProgramUniformMatrix2dv_Lazy;
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void ProgramUniformMatrix2dv(ProgramHandle program, int location, int count, byte transpose, double* value) => _ProgramUniformMatrix2dv_fnptr(program, location, count, transpose, value);
+        public static void ProgramUniformMatrix2dv(ProgramHandle program, int location, int count, bool transpose, double* value) => _ProgramUniformMatrix2dv_fnptr(program, location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void ProgramUniformMatrix2dv_Lazy(ProgramHandle program, int location, int count, byte transpose, double* value)
+        private static void ProgramUniformMatrix2dv_Lazy(ProgramHandle program, int location, int count, bool transpose, double* value)
         {
-            _ProgramUniformMatrix2dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2dv");
+            _ProgramUniformMatrix2dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2dv");
             _ProgramUniformMatrix2dv_fnptr(program, location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<ProgramHandle, int, int, byte, double*, void> _ProgramUniformMatrix3dv_fnptr = &ProgramUniformMatrix3dv_Lazy;
+        private static delegate* unmanaged<ProgramHandle, int, int, bool, double*, void> _ProgramUniformMatrix3dv_fnptr = &ProgramUniformMatrix3dv_Lazy;
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void ProgramUniformMatrix3dv(ProgramHandle program, int location, int count, byte transpose, double* value) => _ProgramUniformMatrix3dv_fnptr(program, location, count, transpose, value);
+        public static void ProgramUniformMatrix3dv(ProgramHandle program, int location, int count, bool transpose, double* value) => _ProgramUniformMatrix3dv_fnptr(program, location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void ProgramUniformMatrix3dv_Lazy(ProgramHandle program, int location, int count, byte transpose, double* value)
+        private static void ProgramUniformMatrix3dv_Lazy(ProgramHandle program, int location, int count, bool transpose, double* value)
         {
-            _ProgramUniformMatrix3dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3dv");
+            _ProgramUniformMatrix3dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3dv");
             _ProgramUniformMatrix3dv_fnptr(program, location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<ProgramHandle, int, int, byte, double*, void> _ProgramUniformMatrix4dv_fnptr = &ProgramUniformMatrix4dv_Lazy;
+        private static delegate* unmanaged<ProgramHandle, int, int, bool, double*, void> _ProgramUniformMatrix4dv_fnptr = &ProgramUniformMatrix4dv_Lazy;
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void ProgramUniformMatrix4dv(ProgramHandle program, int location, int count, byte transpose, double* value) => _ProgramUniformMatrix4dv_fnptr(program, location, count, transpose, value);
+        public static void ProgramUniformMatrix4dv(ProgramHandle program, int location, int count, bool transpose, double* value) => _ProgramUniformMatrix4dv_fnptr(program, location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void ProgramUniformMatrix4dv_Lazy(ProgramHandle program, int location, int count, byte transpose, double* value)
+        private static void ProgramUniformMatrix4dv_Lazy(ProgramHandle program, int location, int count, bool transpose, double* value)
         {
-            _ProgramUniformMatrix4dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4dv");
+            _ProgramUniformMatrix4dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4dv");
             _ProgramUniformMatrix4dv_fnptr(program, location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix2x3fv_fnptr = &ProgramUniformMatrix2x3fv_Lazy;
+        private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix2x3fv_fnptr = &ProgramUniformMatrix2x3fv_Lazy;
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
@@ -6187,15 +6187,15 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniformMatrix2x3fv(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix2x3fv_fnptr(program, location, count, transpose, value);
+        public static void ProgramUniformMatrix2x3fv(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix2x3fv_fnptr(program, location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void ProgramUniformMatrix2x3fv_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+        private static void ProgramUniformMatrix2x3fv_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
         {
-            _ProgramUniformMatrix2x3fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2x3fv");
+            _ProgramUniformMatrix2x3fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2x3fv");
             _ProgramUniformMatrix2x3fv_fnptr(program, location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix3x2fv_fnptr = &ProgramUniformMatrix3x2fv_Lazy;
+        private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix3x2fv_fnptr = &ProgramUniformMatrix3x2fv_Lazy;
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
@@ -6203,15 +6203,15 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniformMatrix3x2fv(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix3x2fv_fnptr(program, location, count, transpose, value);
+        public static void ProgramUniformMatrix3x2fv(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix3x2fv_fnptr(program, location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void ProgramUniformMatrix3x2fv_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+        private static void ProgramUniformMatrix3x2fv_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
         {
-            _ProgramUniformMatrix3x2fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3x2fv");
+            _ProgramUniformMatrix3x2fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3x2fv");
             _ProgramUniformMatrix3x2fv_fnptr(program, location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix2x4fv_fnptr = &ProgramUniformMatrix2x4fv_Lazy;
+        private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix2x4fv_fnptr = &ProgramUniformMatrix2x4fv_Lazy;
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
@@ -6219,15 +6219,15 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniformMatrix2x4fv(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix2x4fv_fnptr(program, location, count, transpose, value);
+        public static void ProgramUniformMatrix2x4fv(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix2x4fv_fnptr(program, location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void ProgramUniformMatrix2x4fv_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+        private static void ProgramUniformMatrix2x4fv_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
         {
-            _ProgramUniformMatrix2x4fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2x4fv");
+            _ProgramUniformMatrix2x4fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2x4fv");
             _ProgramUniformMatrix2x4fv_fnptr(program, location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix4x2fv_fnptr = &ProgramUniformMatrix4x2fv_Lazy;
+        private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix4x2fv_fnptr = &ProgramUniformMatrix4x2fv_Lazy;
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
@@ -6235,15 +6235,15 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniformMatrix4x2fv(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix4x2fv_fnptr(program, location, count, transpose, value);
+        public static void ProgramUniformMatrix4x2fv(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix4x2fv_fnptr(program, location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void ProgramUniformMatrix4x2fv_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+        private static void ProgramUniformMatrix4x2fv_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
         {
-            _ProgramUniformMatrix4x2fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4x2fv");
+            _ProgramUniformMatrix4x2fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4x2fv");
             _ProgramUniformMatrix4x2fv_fnptr(program, location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix3x4fv_fnptr = &ProgramUniformMatrix3x4fv_Lazy;
+        private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix3x4fv_fnptr = &ProgramUniformMatrix3x4fv_Lazy;
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
@@ -6251,15 +6251,15 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniformMatrix3x4fv(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix3x4fv_fnptr(program, location, count, transpose, value);
+        public static void ProgramUniformMatrix3x4fv(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix3x4fv_fnptr(program, location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void ProgramUniformMatrix3x4fv_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+        private static void ProgramUniformMatrix3x4fv_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
         {
-            _ProgramUniformMatrix3x4fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3x4fv");
+            _ProgramUniformMatrix3x4fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3x4fv");
             _ProgramUniformMatrix3x4fv_fnptr(program, location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix4x3fv_fnptr = &ProgramUniformMatrix4x3fv_Lazy;
+        private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix4x3fv_fnptr = &ProgramUniformMatrix4x3fv_Lazy;
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
@@ -6267,77 +6267,77 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniformMatrix4x3fv(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix4x3fv_fnptr(program, location, count, transpose, value);
+        public static void ProgramUniformMatrix4x3fv(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix4x3fv_fnptr(program, location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void ProgramUniformMatrix4x3fv_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+        private static void ProgramUniformMatrix4x3fv_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
         {
-            _ProgramUniformMatrix4x3fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4x3fv");
+            _ProgramUniformMatrix4x3fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4x3fv");
             _ProgramUniformMatrix4x3fv_fnptr(program, location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<ProgramHandle, int, int, byte, double*, void> _ProgramUniformMatrix2x3dv_fnptr = &ProgramUniformMatrix2x3dv_Lazy;
+        private static delegate* unmanaged<ProgramHandle, int, int, bool, double*, void> _ProgramUniformMatrix2x3dv_fnptr = &ProgramUniformMatrix2x3dv_Lazy;
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void ProgramUniformMatrix2x3dv(ProgramHandle program, int location, int count, byte transpose, double* value) => _ProgramUniformMatrix2x3dv_fnptr(program, location, count, transpose, value);
+        public static void ProgramUniformMatrix2x3dv(ProgramHandle program, int location, int count, bool transpose, double* value) => _ProgramUniformMatrix2x3dv_fnptr(program, location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void ProgramUniformMatrix2x3dv_Lazy(ProgramHandle program, int location, int count, byte transpose, double* value)
+        private static void ProgramUniformMatrix2x3dv_Lazy(ProgramHandle program, int location, int count, bool transpose, double* value)
         {
-            _ProgramUniformMatrix2x3dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2x3dv");
+            _ProgramUniformMatrix2x3dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2x3dv");
             _ProgramUniformMatrix2x3dv_fnptr(program, location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<ProgramHandle, int, int, byte, double*, void> _ProgramUniformMatrix3x2dv_fnptr = &ProgramUniformMatrix3x2dv_Lazy;
+        private static delegate* unmanaged<ProgramHandle, int, int, bool, double*, void> _ProgramUniformMatrix3x2dv_fnptr = &ProgramUniformMatrix3x2dv_Lazy;
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void ProgramUniformMatrix3x2dv(ProgramHandle program, int location, int count, byte transpose, double* value) => _ProgramUniformMatrix3x2dv_fnptr(program, location, count, transpose, value);
+        public static void ProgramUniformMatrix3x2dv(ProgramHandle program, int location, int count, bool transpose, double* value) => _ProgramUniformMatrix3x2dv_fnptr(program, location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void ProgramUniformMatrix3x2dv_Lazy(ProgramHandle program, int location, int count, byte transpose, double* value)
+        private static void ProgramUniformMatrix3x2dv_Lazy(ProgramHandle program, int location, int count, bool transpose, double* value)
         {
-            _ProgramUniformMatrix3x2dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3x2dv");
+            _ProgramUniformMatrix3x2dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3x2dv");
             _ProgramUniformMatrix3x2dv_fnptr(program, location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<ProgramHandle, int, int, byte, double*, void> _ProgramUniformMatrix2x4dv_fnptr = &ProgramUniformMatrix2x4dv_Lazy;
+        private static delegate* unmanaged<ProgramHandle, int, int, bool, double*, void> _ProgramUniformMatrix2x4dv_fnptr = &ProgramUniformMatrix2x4dv_Lazy;
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void ProgramUniformMatrix2x4dv(ProgramHandle program, int location, int count, byte transpose, double* value) => _ProgramUniformMatrix2x4dv_fnptr(program, location, count, transpose, value);
+        public static void ProgramUniformMatrix2x4dv(ProgramHandle program, int location, int count, bool transpose, double* value) => _ProgramUniformMatrix2x4dv_fnptr(program, location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void ProgramUniformMatrix2x4dv_Lazy(ProgramHandle program, int location, int count, byte transpose, double* value)
+        private static void ProgramUniformMatrix2x4dv_Lazy(ProgramHandle program, int location, int count, bool transpose, double* value)
         {
-            _ProgramUniformMatrix2x4dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2x4dv");
+            _ProgramUniformMatrix2x4dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2x4dv");
             _ProgramUniformMatrix2x4dv_fnptr(program, location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<ProgramHandle, int, int, byte, double*, void> _ProgramUniformMatrix4x2dv_fnptr = &ProgramUniformMatrix4x2dv_Lazy;
+        private static delegate* unmanaged<ProgramHandle, int, int, bool, double*, void> _ProgramUniformMatrix4x2dv_fnptr = &ProgramUniformMatrix4x2dv_Lazy;
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void ProgramUniformMatrix4x2dv(ProgramHandle program, int location, int count, byte transpose, double* value) => _ProgramUniformMatrix4x2dv_fnptr(program, location, count, transpose, value);
+        public static void ProgramUniformMatrix4x2dv(ProgramHandle program, int location, int count, bool transpose, double* value) => _ProgramUniformMatrix4x2dv_fnptr(program, location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void ProgramUniformMatrix4x2dv_Lazy(ProgramHandle program, int location, int count, byte transpose, double* value)
+        private static void ProgramUniformMatrix4x2dv_Lazy(ProgramHandle program, int location, int count, bool transpose, double* value)
         {
-            _ProgramUniformMatrix4x2dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4x2dv");
+            _ProgramUniformMatrix4x2dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4x2dv");
             _ProgramUniformMatrix4x2dv_fnptr(program, location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<ProgramHandle, int, int, byte, double*, void> _ProgramUniformMatrix3x4dv_fnptr = &ProgramUniformMatrix3x4dv_Lazy;
+        private static delegate* unmanaged<ProgramHandle, int, int, bool, double*, void> _ProgramUniformMatrix3x4dv_fnptr = &ProgramUniformMatrix3x4dv_Lazy;
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void ProgramUniformMatrix3x4dv(ProgramHandle program, int location, int count, byte transpose, double* value) => _ProgramUniformMatrix3x4dv_fnptr(program, location, count, transpose, value);
+        public static void ProgramUniformMatrix3x4dv(ProgramHandle program, int location, int count, bool transpose, double* value) => _ProgramUniformMatrix3x4dv_fnptr(program, location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void ProgramUniformMatrix3x4dv_Lazy(ProgramHandle program, int location, int count, byte transpose, double* value)
+        private static void ProgramUniformMatrix3x4dv_Lazy(ProgramHandle program, int location, int count, bool transpose, double* value)
         {
-            _ProgramUniformMatrix3x4dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3x4dv");
+            _ProgramUniformMatrix3x4dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3x4dv");
             _ProgramUniformMatrix3x4dv_fnptr(program, location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<ProgramHandle, int, int, byte, double*, void> _ProgramUniformMatrix4x3dv_fnptr = &ProgramUniformMatrix4x3dv_Lazy;
+        private static delegate* unmanaged<ProgramHandle, int, int, bool, double*, void> _ProgramUniformMatrix4x3dv_fnptr = &ProgramUniformMatrix4x3dv_Lazy;
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void ProgramUniformMatrix4x3dv(ProgramHandle program, int location, int count, byte transpose, double* value) => _ProgramUniformMatrix4x3dv_fnptr(program, location, count, transpose, value);
+        public static void ProgramUniformMatrix4x3dv(ProgramHandle program, int location, int count, bool transpose, double* value) => _ProgramUniformMatrix4x3dv_fnptr(program, location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void ProgramUniformMatrix4x3dv_Lazy(ProgramHandle program, int location, int count, byte transpose, double* value)
+        private static void ProgramUniformMatrix4x3dv_Lazy(ProgramHandle program, int location, int count, bool transpose, double* value)
         {
-            _ProgramUniformMatrix4x3dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4x3dv");
+            _ProgramUniformMatrix4x3dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4x3dv");
             _ProgramUniformMatrix4x3dv_fnptr(program, location, count, transpose, value);
         }
         
@@ -6732,7 +6732,7 @@ namespace OpenTK.Graphics.OpenGL
             _GetActiveAtomicCounterBufferiv_fnptr(program, bufferIndex, pname, parameters);
         }
         
-        private static delegate* unmanaged<uint, TextureHandle, int, byte, int, BufferAccessARB, InternalFormat, void> _BindImageTexture_fnptr = &BindImageTexture_Lazy;
+        private static delegate* unmanaged<uint, TextureHandle, int, bool, int, BufferAccessARB, InternalFormat, void> _BindImageTexture_fnptr = &BindImageTexture_Lazy;
         /// <summary> <b>[requires: v4.2 | GL_ARB_shader_image_load_store]</b> Bind a level of a texture to an image unit. </summary>
         /// <param name="unit"> Specifies the index of the image unit to which to bind the texture </param>
         /// <param name="texture"> Specifies the name of the texture to bind to the image unit. </param>
@@ -6742,11 +6742,11 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="access"> Specifies a token indicating the type of access that will be performed on the image. </param>
         /// <param name="format"> Specifies the format that the elements of the image will be treated as for the purposes of formatted stores. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindImageTexture.xhtml" /></remarks>
-        public static void BindImageTexture(uint unit, TextureHandle texture, int level, byte layered, int layer, BufferAccessARB access, InternalFormat format) => _BindImageTexture_fnptr(unit, texture, level, layered, layer, access, format);
+        public static void BindImageTexture(uint unit, TextureHandle texture, int level, bool layered, int layer, BufferAccessARB access, InternalFormat format) => _BindImageTexture_fnptr(unit, texture, level, layered, layer, access, format);
         [UnmanagedCallersOnly]
-        private static void BindImageTexture_Lazy(uint unit, TextureHandle texture, int level, byte layered, int layer, BufferAccessARB access, InternalFormat format)
+        private static void BindImageTexture_Lazy(uint unit, TextureHandle texture, int level, bool layered, int layer, BufferAccessARB access, InternalFormat format)
         {
-            _BindImageTexture_fnptr = (delegate* unmanaged<uint, TextureHandle, int, byte, int, BufferAccessARB, InternalFormat, void>)GLLoader.BindingsContext.GetProcAddress("glBindImageTexture");
+            _BindImageTexture_fnptr = (delegate* unmanaged<uint, TextureHandle, int, bool, int, BufferAccessARB, InternalFormat, void>)GLLoader.BindingsContext.GetProcAddress("glBindImageTexture");
             _BindImageTexture_fnptr(unit, texture, level, layered, layer, access, format);
         }
         
@@ -7213,7 +7213,7 @@ namespace OpenTK.Graphics.OpenGL
             _TexBufferRange_fnptr(target, internalformat, buffer, offset, size);
         }
         
-        private static delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, byte, void> _TexStorage2DMultisample_fnptr = &TexStorage2DMultisample_Lazy;
+        private static delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, bool, void> _TexStorage2DMultisample_fnptr = &TexStorage2DMultisample_Lazy;
         /// <summary> <b>[requires: v4.3 | GL_ARB_texture_storage_multisample]</b> Specify storage for a two-dimensional multisample texture. </summary>
         /// <param name="target"> Specifies the target to which the texture object is bound for glTexStorage2DMultisample. Must be one of GL_TEXTURE_2D_MULTISAMPLE or GL_PROXY_TEXTURE_2D_MULTISAMPLE. </param>
         /// <param name="samples"> Specify the number of samples in the texture. </param>
@@ -7222,15 +7222,15 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="height"> Specifies the height of the texture, in texels. </param>
         /// <param name="fixedsamplelocations"> Specifies whether the image will use identical sample locations and the same number of samples for all texels in the image, and the sample locations will not depend on the internal format or size of the image. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexStorage2DMultisample.xhtml" /></remarks>
-        public static void TexStorage2DMultisample(TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, byte fixedsamplelocations) => _TexStorage2DMultisample_fnptr(target, samples, internalformat, width, height, fixedsamplelocations);
+        public static void TexStorage2DMultisample(TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, bool fixedsamplelocations) => _TexStorage2DMultisample_fnptr(target, samples, internalformat, width, height, fixedsamplelocations);
         [UnmanagedCallersOnly]
-        private static void TexStorage2DMultisample_Lazy(TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, byte fixedsamplelocations)
+        private static void TexStorage2DMultisample_Lazy(TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, bool fixedsamplelocations)
         {
-            _TexStorage2DMultisample_fnptr = (delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, byte, void>)GLLoader.BindingsContext.GetProcAddress("glTexStorage2DMultisample");
+            _TexStorage2DMultisample_fnptr = (delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, bool, void>)GLLoader.BindingsContext.GetProcAddress("glTexStorage2DMultisample");
             _TexStorage2DMultisample_fnptr(target, samples, internalformat, width, height, fixedsamplelocations);
         }
         
-        private static delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, int, byte, void> _TexStorage3DMultisample_fnptr = &TexStorage3DMultisample_Lazy;
+        private static delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, int, bool, void> _TexStorage3DMultisample_fnptr = &TexStorage3DMultisample_Lazy;
         /// <summary> <b>[requires: v4.3 | GL_ARB_texture_storage_multisample]</b> Specify storage for a two-dimensional multisample array texture. </summary>
         /// <param name="target"> Specifies the target to which the texture object is bound for glTexStorage3DMultisample. Must be one of GL_TEXTURE_2D_MULTISAMPLE_ARRAY or GL_PROXY_TEXTURE_2D_MULTISAMPLE_ARRAY. </param>
         /// <param name="samples"> Specify the number of samples in the texture. </param>
@@ -7240,11 +7240,11 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="depth"> Specifies the depth of the texture, in layers. </param>
         /// <param name="fixedsamplelocations"> Specifies whether the image will use identical sample locations and the same number of samples for all texels in the image, and the sample locations will not depend on the internal format or size of the image. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexStorage3DMultisample.xhtml" /></remarks>
-        public static void TexStorage3DMultisample(TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, int depth, byte fixedsamplelocations) => _TexStorage3DMultisample_fnptr(target, samples, internalformat, width, height, depth, fixedsamplelocations);
+        public static void TexStorage3DMultisample(TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, int depth, bool fixedsamplelocations) => _TexStorage3DMultisample_fnptr(target, samples, internalformat, width, height, depth, fixedsamplelocations);
         [UnmanagedCallersOnly]
-        private static void TexStorage3DMultisample_Lazy(TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, int depth, byte fixedsamplelocations)
+        private static void TexStorage3DMultisample_Lazy(TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, int depth, bool fixedsamplelocations)
         {
-            _TexStorage3DMultisample_fnptr = (delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, int, byte, void>)GLLoader.BindingsContext.GetProcAddress("glTexStorage3DMultisample");
+            _TexStorage3DMultisample_fnptr = (delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, int, bool, void>)GLLoader.BindingsContext.GetProcAddress("glTexStorage3DMultisample");
             _TexStorage3DMultisample_fnptr(target, samples, internalformat, width, height, depth, fixedsamplelocations);
         }
         
@@ -7282,7 +7282,7 @@ namespace OpenTK.Graphics.OpenGL
             _BindVertexBuffer_fnptr(bindingindex, buffer, offset, stride);
         }
         
-        private static delegate* unmanaged<uint, int, VertexAttribType, byte, uint, void> _VertexAttribFormat_fnptr = &VertexAttribFormat_Lazy;
+        private static delegate* unmanaged<uint, int, VertexAttribType, bool, uint, void> _VertexAttribFormat_fnptr = &VertexAttribFormat_Lazy;
         /// <summary> <b>[requires: v4.3 | GL_ARB_vertex_attrib_binding]</b> Specify the organization of vertex arrays. </summary>
         /// <param name="attribindex">The generic vertex attribute array being described.</param>
         /// <param name="size">The number of values per vertex that are stored in the array.</param>
@@ -7290,11 +7290,11 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="normalized"> Specifies whether fixed-point data values should be normalized (GL_TRUE) or converted directly as fixed-point values (GL_FALSE) when they are accessed. This parameter is ignored if type is GL_FIXED. </param>
         /// <param name="relativeoffset">The distance between elements within the buffer.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glVertexAttribFormat.xhtml" /></remarks>
-        public static void VertexAttribFormat(uint attribindex, int size, VertexAttribType type, byte normalized, uint relativeoffset) => _VertexAttribFormat_fnptr(attribindex, size, type, normalized, relativeoffset);
+        public static void VertexAttribFormat(uint attribindex, int size, VertexAttribType type, bool normalized, uint relativeoffset) => _VertexAttribFormat_fnptr(attribindex, size, type, normalized, relativeoffset);
         [UnmanagedCallersOnly]
-        private static void VertexAttribFormat_Lazy(uint attribindex, int size, VertexAttribType type, byte normalized, uint relativeoffset)
+        private static void VertexAttribFormat_Lazy(uint attribindex, int size, VertexAttribType type, bool normalized, uint relativeoffset)
         {
-            _VertexAttribFormat_fnptr = (delegate* unmanaged<uint, int, VertexAttribType, byte, uint, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribFormat");
+            _VertexAttribFormat_fnptr = (delegate* unmanaged<uint, int, VertexAttribType, bool, uint, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribFormat");
             _VertexAttribFormat_fnptr(attribindex, size, type, normalized, relativeoffset);
         }
         
@@ -7354,7 +7354,7 @@ namespace OpenTK.Graphics.OpenGL
             _VertexBindingDivisor_fnptr(bindingindex, divisor);
         }
         
-        private static delegate* unmanaged<DebugSource, DebugType, DebugSeverity, int, uint*, byte, void> _DebugMessageControl_fnptr = &DebugMessageControl_Lazy;
+        private static delegate* unmanaged<DebugSource, DebugType, DebugSeverity, int, uint*, bool, void> _DebugMessageControl_fnptr = &DebugMessageControl_Lazy;
         /// <summary> <b>[requires: v4.3 | GL_KHR_debug]</b> Control the reporting of debug messages in a debug context. </summary>
         /// <param name="source"> The source of debug messages to enable or disable. </param>
         /// <param name="type"> The type of debug messages to enable or disable. </param>
@@ -7363,11 +7363,11 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="ids"> The address of an array of unsigned integers contianing the ids of the messages to enable or disable. </param>
         /// <param name="enabled"> A Boolean flag determining whether the selected messages should be enabled or disabled. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDebugMessageControl.xhtml" /></remarks>
-        public static void DebugMessageControl(DebugSource source, DebugType type, DebugSeverity severity, int count, uint* ids, byte enabled) => _DebugMessageControl_fnptr(source, type, severity, count, ids, enabled);
+        public static void DebugMessageControl(DebugSource source, DebugType type, DebugSeverity severity, int count, uint* ids, bool enabled) => _DebugMessageControl_fnptr(source, type, severity, count, ids, enabled);
         [UnmanagedCallersOnly]
-        private static void DebugMessageControl_Lazy(DebugSource source, DebugType type, DebugSeverity severity, int count, uint* ids, byte enabled)
+        private static void DebugMessageControl_Lazy(DebugSource source, DebugType type, DebugSeverity severity, int count, uint* ids, bool enabled)
         {
-            _DebugMessageControl_fnptr = (delegate* unmanaged<DebugSource, DebugType, DebugSeverity, int, uint*, byte, void>)GLLoader.BindingsContext.GetProcAddress("glDebugMessageControl");
+            _DebugMessageControl_fnptr = (delegate* unmanaged<DebugSource, DebugType, DebugSeverity, int, uint*, bool, void>)GLLoader.BindingsContext.GetProcAddress("glDebugMessageControl");
             _DebugMessageControl_fnptr(source, type, severity, count, ids, enabled);
         }
         
@@ -7885,15 +7885,15 @@ namespace OpenTK.Graphics.OpenGL
             return _MapNamedBufferRange_fnptr(buffer, offset, length, access);
         }
         
-        private static delegate* unmanaged<BufferHandle, byte> _UnmapNamedBuffer_fnptr = &UnmapNamedBuffer_Lazy;
+        private static delegate* unmanaged<BufferHandle, bool> _UnmapNamedBuffer_fnptr = &UnmapNamedBuffer_Lazy;
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Release the mapping of a buffer object's data store into the client's address space. </summary>
         /// <param name="buffer"> Specifies the name of the buffer object for glUnmapNamedBuffer. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glUnmapBuffer.xhtml" /></remarks>
-        public static byte UnmapNamedBuffer(BufferHandle buffer) => _UnmapNamedBuffer_fnptr(buffer);
+        public static bool UnmapNamedBuffer(BufferHandle buffer) => _UnmapNamedBuffer_fnptr(buffer);
         [UnmanagedCallersOnly]
-        private static byte UnmapNamedBuffer_Lazy(BufferHandle buffer)
+        private static bool UnmapNamedBuffer_Lazy(BufferHandle buffer)
         {
-            _UnmapNamedBuffer_fnptr = (delegate* unmanaged<BufferHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glUnmapNamedBuffer");
+            _UnmapNamedBuffer_fnptr = (delegate* unmanaged<BufferHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glUnmapNamedBuffer");
             return _UnmapNamedBuffer_fnptr(buffer);
         }
         
@@ -8389,7 +8389,7 @@ namespace OpenTK.Graphics.OpenGL
             _TextureStorage3D_fnptr(texture, levels, internalformat, width, height, depth);
         }
         
-        private static delegate* unmanaged<TextureHandle, int, SizedInternalFormat, int, int, byte, void> _TextureStorage2DMultisample_fnptr = &TextureStorage2DMultisample_Lazy;
+        private static delegate* unmanaged<TextureHandle, int, SizedInternalFormat, int, int, bool, void> _TextureStorage2DMultisample_fnptr = &TextureStorage2DMultisample_Lazy;
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specify storage for a two-dimensional multisample texture. </summary>
         /// <param name="texture"> Specifies the texture object name for glTextureStorage2DMultisample. The effective target of texture must be one of the valid non-proxy target values above. </param>
         /// <param name="samples"> Specify the number of samples in the texture. </param>
@@ -8398,15 +8398,15 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="height"> Specifies the height of the texture, in texels. </param>
         /// <param name="fixedsamplelocations"> Specifies whether the image will use identical sample locations and the same number of samples for all texels in the image, and the sample locations will not depend on the internal format or size of the image. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexStorage2DMultisample.xhtml" /></remarks>
-        public static void TextureStorage2DMultisample(TextureHandle texture, int samples, SizedInternalFormat internalformat, int width, int height, byte fixedsamplelocations) => _TextureStorage2DMultisample_fnptr(texture, samples, internalformat, width, height, fixedsamplelocations);
+        public static void TextureStorage2DMultisample(TextureHandle texture, int samples, SizedInternalFormat internalformat, int width, int height, bool fixedsamplelocations) => _TextureStorage2DMultisample_fnptr(texture, samples, internalformat, width, height, fixedsamplelocations);
         [UnmanagedCallersOnly]
-        private static void TextureStorage2DMultisample_Lazy(TextureHandle texture, int samples, SizedInternalFormat internalformat, int width, int height, byte fixedsamplelocations)
+        private static void TextureStorage2DMultisample_Lazy(TextureHandle texture, int samples, SizedInternalFormat internalformat, int width, int height, bool fixedsamplelocations)
         {
-            _TextureStorage2DMultisample_fnptr = (delegate* unmanaged<TextureHandle, int, SizedInternalFormat, int, int, byte, void>)GLLoader.BindingsContext.GetProcAddress("glTextureStorage2DMultisample");
+            _TextureStorage2DMultisample_fnptr = (delegate* unmanaged<TextureHandle, int, SizedInternalFormat, int, int, bool, void>)GLLoader.BindingsContext.GetProcAddress("glTextureStorage2DMultisample");
             _TextureStorage2DMultisample_fnptr(texture, samples, internalformat, width, height, fixedsamplelocations);
         }
         
-        private static delegate* unmanaged<TextureHandle, int, SizedInternalFormat, int, int, int, byte, void> _TextureStorage3DMultisample_fnptr = &TextureStorage3DMultisample_Lazy;
+        private static delegate* unmanaged<TextureHandle, int, SizedInternalFormat, int, int, int, bool, void> _TextureStorage3DMultisample_fnptr = &TextureStorage3DMultisample_Lazy;
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specify storage for a two-dimensional multisample array texture. </summary>
         /// <param name="texture"> Specifies the texture object name for glTextureStorage3DMultisample. The effective target of texture must be one of the valid non-proxy target values above. </param>
         /// <param name="samples"> Specify the number of samples in the texture. </param>
@@ -8416,11 +8416,11 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="depth"> Specifies the depth of the texture, in layers. </param>
         /// <param name="fixedsamplelocations"> Specifies whether the image will use identical sample locations and the same number of samples for all texels in the image, and the sample locations will not depend on the internal format or size of the image. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexStorage3DMultisample.xhtml" /></remarks>
-        public static void TextureStorage3DMultisample(TextureHandle texture, int samples, SizedInternalFormat internalformat, int width, int height, int depth, byte fixedsamplelocations) => _TextureStorage3DMultisample_fnptr(texture, samples, internalformat, width, height, depth, fixedsamplelocations);
+        public static void TextureStorage3DMultisample(TextureHandle texture, int samples, SizedInternalFormat internalformat, int width, int height, int depth, bool fixedsamplelocations) => _TextureStorage3DMultisample_fnptr(texture, samples, internalformat, width, height, depth, fixedsamplelocations);
         [UnmanagedCallersOnly]
-        private static void TextureStorage3DMultisample_Lazy(TextureHandle texture, int samples, SizedInternalFormat internalformat, int width, int height, int depth, byte fixedsamplelocations)
+        private static void TextureStorage3DMultisample_Lazy(TextureHandle texture, int samples, SizedInternalFormat internalformat, int width, int height, int depth, bool fixedsamplelocations)
         {
-            _TextureStorage3DMultisample_fnptr = (delegate* unmanaged<TextureHandle, int, SizedInternalFormat, int, int, int, byte, void>)GLLoader.BindingsContext.GetProcAddress("glTextureStorage3DMultisample");
+            _TextureStorage3DMultisample_fnptr = (delegate* unmanaged<TextureHandle, int, SizedInternalFormat, int, int, int, bool, void>)GLLoader.BindingsContext.GetProcAddress("glTextureStorage3DMultisample");
             _TextureStorage3DMultisample_fnptr(texture, samples, internalformat, width, height, depth, fixedsamplelocations);
         }
         
@@ -8926,7 +8926,7 @@ namespace OpenTK.Graphics.OpenGL
             _VertexArrayAttribBinding_fnptr(vaobj, attribindex, bindingindex);
         }
         
-        private static delegate* unmanaged<VertexArrayHandle, uint, int, VertexAttribType, byte, uint, void> _VertexArrayAttribFormat_fnptr = &VertexArrayAttribFormat_Lazy;
+        private static delegate* unmanaged<VertexArrayHandle, uint, int, VertexAttribType, bool, uint, void> _VertexArrayAttribFormat_fnptr = &VertexArrayAttribFormat_Lazy;
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specify the organization of vertex arrays. </summary>
         /// <param name="vaobj">Specifies the name of the vertex array object for glVertexArrayAttrib{I, L}Format functions.</param>
         /// <param name="attribindex">The generic vertex attribute array being described.</param>
@@ -8935,11 +8935,11 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="normalized"> Specifies whether fixed-point data values should be normalized (GL_TRUE) or converted directly as fixed-point values (GL_FALSE) when they are accessed. This parameter is ignored if type is GL_FIXED. </param>
         /// <param name="relativeoffset">The distance between elements within the buffer.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glVertexAttribFormat.xhtml" /></remarks>
-        public static void VertexArrayAttribFormat(VertexArrayHandle vaobj, uint attribindex, int size, VertexAttribType type, byte normalized, uint relativeoffset) => _VertexArrayAttribFormat_fnptr(vaobj, attribindex, size, type, normalized, relativeoffset);
+        public static void VertexArrayAttribFormat(VertexArrayHandle vaobj, uint attribindex, int size, VertexAttribType type, bool normalized, uint relativeoffset) => _VertexArrayAttribFormat_fnptr(vaobj, attribindex, size, type, normalized, relativeoffset);
         [UnmanagedCallersOnly]
-        private static void VertexArrayAttribFormat_Lazy(VertexArrayHandle vaobj, uint attribindex, int size, VertexAttribType type, byte normalized, uint relativeoffset)
+        private static void VertexArrayAttribFormat_Lazy(VertexArrayHandle vaobj, uint attribindex, int size, VertexAttribType type, bool normalized, uint relativeoffset)
         {
-            _VertexArrayAttribFormat_fnptr = (delegate* unmanaged<VertexArrayHandle, uint, int, VertexAttribType, byte, uint, void>)GLLoader.BindingsContext.GetProcAddress("glVertexArrayAttribFormat");
+            _VertexArrayAttribFormat_fnptr = (delegate* unmanaged<VertexArrayHandle, uint, int, VertexAttribType, bool, uint, void>)GLLoader.BindingsContext.GetProcAddress("glVertexArrayAttribFormat");
             _VertexArrayAttribFormat_fnptr(vaobj, attribindex, size, type, normalized, relativeoffset);
         }
         
@@ -9376,14 +9376,14 @@ namespace OpenTK.Graphics.OpenGL
         }
         public static unsafe partial class AMD
         {
-            private static delegate* unmanaged<All, DebugSeverity, int, uint*, byte, void> _DebugMessageEnableAMD_fnptr = &DebugMessageEnableAMD_Lazy;
+            private static delegate* unmanaged<All, DebugSeverity, int, uint*, bool, void> _DebugMessageEnableAMD_fnptr = &DebugMessageEnableAMD_Lazy;
             /// <summary> <b>[requires: GL_AMD_debug_output]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void DebugMessageEnableAMD(All category, DebugSeverity severity, int count, uint* ids, byte enabled) => _DebugMessageEnableAMD_fnptr(category, severity, count, ids, enabled);
+            public static void DebugMessageEnableAMD(All category, DebugSeverity severity, int count, uint* ids, bool enabled) => _DebugMessageEnableAMD_fnptr(category, severity, count, ids, enabled);
             [UnmanagedCallersOnly]
-            private static void DebugMessageEnableAMD_Lazy(All category, DebugSeverity severity, int count, uint* ids, byte enabled)
+            private static void DebugMessageEnableAMD_Lazy(All category, DebugSeverity severity, int count, uint* ids, bool enabled)
             {
-                _DebugMessageEnableAMD_fnptr = (delegate* unmanaged<All, DebugSeverity, int, uint*, byte, void>)GLLoader.BindingsContext.GetProcAddress("glDebugMessageEnableAMD");
+                _DebugMessageEnableAMD_fnptr = (delegate* unmanaged<All, DebugSeverity, int, uint*, bool, void>)GLLoader.BindingsContext.GetProcAddress("glDebugMessageEnableAMD");
                 _DebugMessageEnableAMD_fnptr(category, severity, count, ids, enabled);
             }
             
@@ -9959,14 +9959,14 @@ namespace OpenTK.Graphics.OpenGL
                 _DeleteNamesAMD_fnptr(identifier, num, names);
             }
             
-            private static delegate* unmanaged<All, uint, byte> _IsNameAMD_fnptr = &IsNameAMD_Lazy;
+            private static delegate* unmanaged<All, uint, bool> _IsNameAMD_fnptr = &IsNameAMD_Lazy;
             /// <summary> <b>[requires: GL_AMD_name_gen_delete]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsNameAMD(All identifier, uint name) => _IsNameAMD_fnptr(identifier, name);
+            public static bool IsNameAMD(All identifier, uint name) => _IsNameAMD_fnptr(identifier, name);
             [UnmanagedCallersOnly]
-            private static byte IsNameAMD_Lazy(All identifier, uint name)
+            private static bool IsNameAMD_Lazy(All identifier, uint name)
             {
-                _IsNameAMD_fnptr = (delegate* unmanaged<All, uint, byte>)GLLoader.BindingsContext.GetProcAddress("glIsNameAMD");
+                _IsNameAMD_fnptr = (delegate* unmanaged<All, uint, bool>)GLLoader.BindingsContext.GetProcAddress("glIsNameAMD");
                 return _IsNameAMD_fnptr(identifier, name);
             }
             
@@ -10058,14 +10058,14 @@ namespace OpenTK.Graphics.OpenGL
                 _DeletePerfMonitorsAMD_fnptr(n, monitors);
             }
             
-            private static delegate* unmanaged<uint, byte, uint, int, uint*, void> _SelectPerfMonitorCountersAMD_fnptr = &SelectPerfMonitorCountersAMD_Lazy;
+            private static delegate* unmanaged<uint, bool, uint, int, uint*, void> _SelectPerfMonitorCountersAMD_fnptr = &SelectPerfMonitorCountersAMD_Lazy;
             /// <summary> <b>[requires: GL_AMD_performance_monitor]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void SelectPerfMonitorCountersAMD(uint monitor, byte enable, uint group, int numCounters, uint* counterList) => _SelectPerfMonitorCountersAMD_fnptr(monitor, enable, group, numCounters, counterList);
+            public static void SelectPerfMonitorCountersAMD(uint monitor, bool enable, uint group, int numCounters, uint* counterList) => _SelectPerfMonitorCountersAMD_fnptr(monitor, enable, group, numCounters, counterList);
             [UnmanagedCallersOnly]
-            private static void SelectPerfMonitorCountersAMD_Lazy(uint monitor, byte enable, uint group, int numCounters, uint* counterList)
+            private static void SelectPerfMonitorCountersAMD_Lazy(uint monitor, bool enable, uint group, int numCounters, uint* counterList)
             {
-                _SelectPerfMonitorCountersAMD_fnptr = (delegate* unmanaged<uint, byte, uint, int, uint*, void>)GLLoader.BindingsContext.GetProcAddress("glSelectPerfMonitorCountersAMD");
+                _SelectPerfMonitorCountersAMD_fnptr = (delegate* unmanaged<uint, bool, uint, int, uint*, void>)GLLoader.BindingsContext.GetProcAddress("glSelectPerfMonitorCountersAMD");
                 _SelectPerfMonitorCountersAMD_fnptr(monitor, enable, group, numCounters, counterList);
             }
             
@@ -10259,25 +10259,25 @@ namespace OpenTK.Graphics.OpenGL
                 _SetFenceAPPLE_fnptr(fence);
             }
             
-            private static delegate* unmanaged<uint, byte> _IsFenceAPPLE_fnptr = &IsFenceAPPLE_Lazy;
+            private static delegate* unmanaged<uint, bool> _IsFenceAPPLE_fnptr = &IsFenceAPPLE_Lazy;
             /// <summary> <b>[requires: GL_APPLE_fence]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsFenceAPPLE(uint fence) => _IsFenceAPPLE_fnptr(fence);
+            public static bool IsFenceAPPLE(uint fence) => _IsFenceAPPLE_fnptr(fence);
             [UnmanagedCallersOnly]
-            private static byte IsFenceAPPLE_Lazy(uint fence)
+            private static bool IsFenceAPPLE_Lazy(uint fence)
             {
-                _IsFenceAPPLE_fnptr = (delegate* unmanaged<uint, byte>)GLLoader.BindingsContext.GetProcAddress("glIsFenceAPPLE");
+                _IsFenceAPPLE_fnptr = (delegate* unmanaged<uint, bool>)GLLoader.BindingsContext.GetProcAddress("glIsFenceAPPLE");
                 return _IsFenceAPPLE_fnptr(fence);
             }
             
-            private static delegate* unmanaged<uint, byte> _TestFenceAPPLE_fnptr = &TestFenceAPPLE_Lazy;
+            private static delegate* unmanaged<uint, bool> _TestFenceAPPLE_fnptr = &TestFenceAPPLE_Lazy;
             /// <summary> <b>[requires: GL_APPLE_fence]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte TestFenceAPPLE(uint fence) => _TestFenceAPPLE_fnptr(fence);
+            public static bool TestFenceAPPLE(uint fence) => _TestFenceAPPLE_fnptr(fence);
             [UnmanagedCallersOnly]
-            private static byte TestFenceAPPLE_Lazy(uint fence)
+            private static bool TestFenceAPPLE_Lazy(uint fence)
             {
-                _TestFenceAPPLE_fnptr = (delegate* unmanaged<uint, byte>)GLLoader.BindingsContext.GetProcAddress("glTestFenceAPPLE");
+                _TestFenceAPPLE_fnptr = (delegate* unmanaged<uint, bool>)GLLoader.BindingsContext.GetProcAddress("glTestFenceAPPLE");
                 return _TestFenceAPPLE_fnptr(fence);
             }
             
@@ -10292,14 +10292,14 @@ namespace OpenTK.Graphics.OpenGL
                 _FinishFenceAPPLE_fnptr(fence);
             }
             
-            private static delegate* unmanaged<ObjectTypeAPPLE, uint, byte> _TestObjectAPPLE_fnptr = &TestObjectAPPLE_Lazy;
+            private static delegate* unmanaged<ObjectTypeAPPLE, uint, bool> _TestObjectAPPLE_fnptr = &TestObjectAPPLE_Lazy;
             /// <summary> <b>[requires: GL_APPLE_fence]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte TestObjectAPPLE(ObjectTypeAPPLE obj, uint name) => _TestObjectAPPLE_fnptr(obj, name);
+            public static bool TestObjectAPPLE(ObjectTypeAPPLE obj, uint name) => _TestObjectAPPLE_fnptr(obj, name);
             [UnmanagedCallersOnly]
-            private static byte TestObjectAPPLE_Lazy(ObjectTypeAPPLE obj, uint name)
+            private static bool TestObjectAPPLE_Lazy(ObjectTypeAPPLE obj, uint name)
             {
-                _TestObjectAPPLE_fnptr = (delegate* unmanaged<ObjectTypeAPPLE, uint, byte>)GLLoader.BindingsContext.GetProcAddress("glTestObjectAPPLE");
+                _TestObjectAPPLE_fnptr = (delegate* unmanaged<ObjectTypeAPPLE, uint, bool>)GLLoader.BindingsContext.GetProcAddress("glTestObjectAPPLE");
                 return _TestObjectAPPLE_fnptr(obj, name);
             }
             
@@ -10424,14 +10424,14 @@ namespace OpenTK.Graphics.OpenGL
                 _GenVertexArraysAPPLE_fnptr(n, arrays);
             }
             
-            private static delegate* unmanaged<VertexArrayHandle, byte> _IsVertexArrayAPPLE_fnptr = &IsVertexArrayAPPLE_Lazy;
+            private static delegate* unmanaged<VertexArrayHandle, bool> _IsVertexArrayAPPLE_fnptr = &IsVertexArrayAPPLE_Lazy;
             /// <summary> <b>[requires: GL_APPLE_vertex_array_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsVertexArrayAPPLE(VertexArrayHandle array) => _IsVertexArrayAPPLE_fnptr(array);
+            public static bool IsVertexArrayAPPLE(VertexArrayHandle array) => _IsVertexArrayAPPLE_fnptr(array);
             [UnmanagedCallersOnly]
-            private static byte IsVertexArrayAPPLE_Lazy(VertexArrayHandle array)
+            private static bool IsVertexArrayAPPLE_Lazy(VertexArrayHandle array)
             {
-                _IsVertexArrayAPPLE_fnptr = (delegate* unmanaged<VertexArrayHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsVertexArrayAPPLE");
+                _IsVertexArrayAPPLE_fnptr = (delegate* unmanaged<VertexArrayHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsVertexArrayAPPLE");
                 return _IsVertexArrayAPPLE_fnptr(array);
             }
             
@@ -10490,14 +10490,14 @@ namespace OpenTK.Graphics.OpenGL
                 _DisableVertexAttribAPPLE_fnptr(index, pname);
             }
             
-            private static delegate* unmanaged<uint, All, byte> _IsVertexAttribEnabledAPPLE_fnptr = &IsVertexAttribEnabledAPPLE_Lazy;
+            private static delegate* unmanaged<uint, All, bool> _IsVertexAttribEnabledAPPLE_fnptr = &IsVertexAttribEnabledAPPLE_Lazy;
             /// <summary> <b>[requires: GL_APPLE_vertex_program_evaluators]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsVertexAttribEnabledAPPLE(uint index, All pname) => _IsVertexAttribEnabledAPPLE_fnptr(index, pname);
+            public static bool IsVertexAttribEnabledAPPLE(uint index, All pname) => _IsVertexAttribEnabledAPPLE_fnptr(index, pname);
             [UnmanagedCallersOnly]
-            private static byte IsVertexAttribEnabledAPPLE_Lazy(uint index, All pname)
+            private static bool IsVertexAttribEnabledAPPLE_Lazy(uint index, All pname)
             {
-                _IsVertexAttribEnabledAPPLE_fnptr = (delegate* unmanaged<uint, All, byte>)GLLoader.BindingsContext.GetProcAddress("glIsVertexAttribEnabledAPPLE");
+                _IsVertexAttribEnabledAPPLE_fnptr = (delegate* unmanaged<uint, All, bool>)GLLoader.BindingsContext.GetProcAddress("glIsVertexAttribEnabledAPPLE");
                 return _IsVertexAttribEnabledAPPLE_fnptr(index, pname);
             }
             
@@ -10733,14 +10733,14 @@ namespace OpenTK.Graphics.OpenGL
                 _MakeTextureHandleNonResidentARB_fnptr(handle);
             }
             
-            private static delegate* unmanaged<TextureHandle, int, byte, int, PixelFormat, ulong> _GetImageHandleARB_fnptr = &GetImageHandleARB_Lazy;
+            private static delegate* unmanaged<TextureHandle, int, bool, int, PixelFormat, ulong> _GetImageHandleARB_fnptr = &GetImageHandleARB_Lazy;
             /// <summary> <b>[requires: GL_ARB_bindless_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static ulong GetImageHandleARB(TextureHandle texture, int level, byte layered, int layer, PixelFormat format) => _GetImageHandleARB_fnptr(texture, level, layered, layer, format);
+            public static ulong GetImageHandleARB(TextureHandle texture, int level, bool layered, int layer, PixelFormat format) => _GetImageHandleARB_fnptr(texture, level, layered, layer, format);
             [UnmanagedCallersOnly]
-            private static ulong GetImageHandleARB_Lazy(TextureHandle texture, int level, byte layered, int layer, PixelFormat format)
+            private static ulong GetImageHandleARB_Lazy(TextureHandle texture, int level, bool layered, int layer, PixelFormat format)
             {
-                _GetImageHandleARB_fnptr = (delegate* unmanaged<TextureHandle, int, byte, int, PixelFormat, ulong>)GLLoader.BindingsContext.GetProcAddress("glGetImageHandleARB");
+                _GetImageHandleARB_fnptr = (delegate* unmanaged<TextureHandle, int, bool, int, PixelFormat, ulong>)GLLoader.BindingsContext.GetProcAddress("glGetImageHandleARB");
                 return _GetImageHandleARB_fnptr(texture, level, layered, layer, format);
             }
             
@@ -10810,25 +10810,25 @@ namespace OpenTK.Graphics.OpenGL
                 _ProgramUniformHandleui64vARB_fnptr(program, location, count, values);
             }
             
-            private static delegate* unmanaged<ulong, byte> _IsTextureHandleResidentARB_fnptr = &IsTextureHandleResidentARB_Lazy;
+            private static delegate* unmanaged<ulong, bool> _IsTextureHandleResidentARB_fnptr = &IsTextureHandleResidentARB_Lazy;
             /// <summary> <b>[requires: GL_ARB_bindless_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsTextureHandleResidentARB(ulong handle) => _IsTextureHandleResidentARB_fnptr(handle);
+            public static bool IsTextureHandleResidentARB(ulong handle) => _IsTextureHandleResidentARB_fnptr(handle);
             [UnmanagedCallersOnly]
-            private static byte IsTextureHandleResidentARB_Lazy(ulong handle)
+            private static bool IsTextureHandleResidentARB_Lazy(ulong handle)
             {
-                _IsTextureHandleResidentARB_fnptr = (delegate* unmanaged<ulong, byte>)GLLoader.BindingsContext.GetProcAddress("glIsTextureHandleResidentARB");
+                _IsTextureHandleResidentARB_fnptr = (delegate* unmanaged<ulong, bool>)GLLoader.BindingsContext.GetProcAddress("glIsTextureHandleResidentARB");
                 return _IsTextureHandleResidentARB_fnptr(handle);
             }
             
-            private static delegate* unmanaged<ulong, byte> _IsImageHandleResidentARB_fnptr = &IsImageHandleResidentARB_Lazy;
+            private static delegate* unmanaged<ulong, bool> _IsImageHandleResidentARB_fnptr = &IsImageHandleResidentARB_Lazy;
             /// <summary> <b>[requires: GL_ARB_bindless_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsImageHandleResidentARB(ulong handle) => _IsImageHandleResidentARB_fnptr(handle);
+            public static bool IsImageHandleResidentARB(ulong handle) => _IsImageHandleResidentARB_fnptr(handle);
             [UnmanagedCallersOnly]
-            private static byte IsImageHandleResidentARB_Lazy(ulong handle)
+            private static bool IsImageHandleResidentARB_Lazy(ulong handle)
             {
-                _IsImageHandleResidentARB_fnptr = (delegate* unmanaged<ulong, byte>)GLLoader.BindingsContext.GetProcAddress("glIsImageHandleResidentARB");
+                _IsImageHandleResidentARB_fnptr = (delegate* unmanaged<ulong, bool>)GLLoader.BindingsContext.GetProcAddress("glIsImageHandleResidentARB");
                 return _IsImageHandleResidentARB_fnptr(handle);
             }
             
@@ -11094,14 +11094,14 @@ namespace OpenTK.Graphics.OpenGL
                 _CopyImageSubData_fnptr(srcName, srcTarget, srcLevel, srcX, srcY, srcZ, dstName, dstTarget, dstLevel, dstX, dstY, dstZ, srcWidth, srcHeight, srcDepth);
             }
             
-            private static delegate* unmanaged<DebugSource, DebugType, DebugSeverity, int, uint*, byte, void> _DebugMessageControlARB_fnptr = &DebugMessageControlARB_Lazy;
+            private static delegate* unmanaged<DebugSource, DebugType, DebugSeverity, int, uint*, bool, void> _DebugMessageControlARB_fnptr = &DebugMessageControlARB_Lazy;
             /// <summary> <b>[requires: GL_ARB_debug_output]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void DebugMessageControlARB(DebugSource source, DebugType type, DebugSeverity severity, int count, uint* ids, byte enabled) => _DebugMessageControlARB_fnptr(source, type, severity, count, ids, enabled);
+            public static void DebugMessageControlARB(DebugSource source, DebugType type, DebugSeverity severity, int count, uint* ids, bool enabled) => _DebugMessageControlARB_fnptr(source, type, severity, count, ids, enabled);
             [UnmanagedCallersOnly]
-            private static void DebugMessageControlARB_Lazy(DebugSource source, DebugType type, DebugSeverity severity, int count, uint* ids, byte enabled)
+            private static void DebugMessageControlARB_Lazy(DebugSource source, DebugType type, DebugSeverity severity, int count, uint* ids, bool enabled)
             {
-                _DebugMessageControlARB_fnptr = (delegate* unmanaged<DebugSource, DebugType, DebugSeverity, int, uint*, byte, void>)GLLoader.BindingsContext.GetProcAddress("glDebugMessageControlARB");
+                _DebugMessageControlARB_fnptr = (delegate* unmanaged<DebugSource, DebugType, DebugSeverity, int, uint*, bool, void>)GLLoader.BindingsContext.GetProcAddress("glDebugMessageControlARB");
                 _DebugMessageControlARB_fnptr(source, type, severity, count, ids, enabled);
             }
             
@@ -11361,15 +11361,15 @@ namespace OpenTK.Graphics.OpenGL
                 return _MapNamedBufferRange_fnptr(buffer, offset, length, access);
             }
             
-            private static delegate* unmanaged<BufferHandle, byte> _UnmapNamedBuffer_fnptr = &UnmapNamedBuffer_Lazy;
+            private static delegate* unmanaged<BufferHandle, bool> _UnmapNamedBuffer_fnptr = &UnmapNamedBuffer_Lazy;
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Release the mapping of a buffer object's data store into the client's address space. </summary>
             /// <param name="buffer"> Specifies the name of the buffer object for glUnmapNamedBuffer. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glUnmapBuffer.xhtml" /></remarks>
-            public static byte UnmapNamedBuffer(BufferHandle buffer) => _UnmapNamedBuffer_fnptr(buffer);
+            public static bool UnmapNamedBuffer(BufferHandle buffer) => _UnmapNamedBuffer_fnptr(buffer);
             [UnmanagedCallersOnly]
-            private static byte UnmapNamedBuffer_Lazy(BufferHandle buffer)
+            private static bool UnmapNamedBuffer_Lazy(BufferHandle buffer)
             {
-                _UnmapNamedBuffer_fnptr = (delegate* unmanaged<BufferHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glUnmapNamedBuffer");
+                _UnmapNamedBuffer_fnptr = (delegate* unmanaged<BufferHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glUnmapNamedBuffer");
                 return _UnmapNamedBuffer_fnptr(buffer);
             }
             
@@ -11865,7 +11865,7 @@ namespace OpenTK.Graphics.OpenGL
                 _TextureStorage3D_fnptr(texture, levels, internalformat, width, height, depth);
             }
             
-            private static delegate* unmanaged<TextureHandle, int, SizedInternalFormat, int, int, byte, void> _TextureStorage2DMultisample_fnptr = &TextureStorage2DMultisample_Lazy;
+            private static delegate* unmanaged<TextureHandle, int, SizedInternalFormat, int, int, bool, void> _TextureStorage2DMultisample_fnptr = &TextureStorage2DMultisample_Lazy;
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specify storage for a two-dimensional multisample texture. </summary>
             /// <param name="texture"> Specifies the texture object name for glTextureStorage2DMultisample. The effective target of texture must be one of the valid non-proxy target values above. </param>
             /// <param name="samples"> Specify the number of samples in the texture. </param>
@@ -11874,15 +11874,15 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="height"> Specifies the height of the texture, in texels. </param>
             /// <param name="fixedsamplelocations"> Specifies whether the image will use identical sample locations and the same number of samples for all texels in the image, and the sample locations will not depend on the internal format or size of the image. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexStorage2DMultisample.xhtml" /></remarks>
-            public static void TextureStorage2DMultisample(TextureHandle texture, int samples, SizedInternalFormat internalformat, int width, int height, byte fixedsamplelocations) => _TextureStorage2DMultisample_fnptr(texture, samples, internalformat, width, height, fixedsamplelocations);
+            public static void TextureStorage2DMultisample(TextureHandle texture, int samples, SizedInternalFormat internalformat, int width, int height, bool fixedsamplelocations) => _TextureStorage2DMultisample_fnptr(texture, samples, internalformat, width, height, fixedsamplelocations);
             [UnmanagedCallersOnly]
-            private static void TextureStorage2DMultisample_Lazy(TextureHandle texture, int samples, SizedInternalFormat internalformat, int width, int height, byte fixedsamplelocations)
+            private static void TextureStorage2DMultisample_Lazy(TextureHandle texture, int samples, SizedInternalFormat internalformat, int width, int height, bool fixedsamplelocations)
             {
-                _TextureStorage2DMultisample_fnptr = (delegate* unmanaged<TextureHandle, int, SizedInternalFormat, int, int, byte, void>)GLLoader.BindingsContext.GetProcAddress("glTextureStorage2DMultisample");
+                _TextureStorage2DMultisample_fnptr = (delegate* unmanaged<TextureHandle, int, SizedInternalFormat, int, int, bool, void>)GLLoader.BindingsContext.GetProcAddress("glTextureStorage2DMultisample");
                 _TextureStorage2DMultisample_fnptr(texture, samples, internalformat, width, height, fixedsamplelocations);
             }
             
-            private static delegate* unmanaged<TextureHandle, int, SizedInternalFormat, int, int, int, byte, void> _TextureStorage3DMultisample_fnptr = &TextureStorage3DMultisample_Lazy;
+            private static delegate* unmanaged<TextureHandle, int, SizedInternalFormat, int, int, int, bool, void> _TextureStorage3DMultisample_fnptr = &TextureStorage3DMultisample_Lazy;
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specify storage for a two-dimensional multisample array texture. </summary>
             /// <param name="texture"> Specifies the texture object name for glTextureStorage3DMultisample. The effective target of texture must be one of the valid non-proxy target values above. </param>
             /// <param name="samples"> Specify the number of samples in the texture. </param>
@@ -11892,11 +11892,11 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="depth"> Specifies the depth of the texture, in layers. </param>
             /// <param name="fixedsamplelocations"> Specifies whether the image will use identical sample locations and the same number of samples for all texels in the image, and the sample locations will not depend on the internal format or size of the image. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexStorage3DMultisample.xhtml" /></remarks>
-            public static void TextureStorage3DMultisample(TextureHandle texture, int samples, SizedInternalFormat internalformat, int width, int height, int depth, byte fixedsamplelocations) => _TextureStorage3DMultisample_fnptr(texture, samples, internalformat, width, height, depth, fixedsamplelocations);
+            public static void TextureStorage3DMultisample(TextureHandle texture, int samples, SizedInternalFormat internalformat, int width, int height, int depth, bool fixedsamplelocations) => _TextureStorage3DMultisample_fnptr(texture, samples, internalformat, width, height, depth, fixedsamplelocations);
             [UnmanagedCallersOnly]
-            private static void TextureStorage3DMultisample_Lazy(TextureHandle texture, int samples, SizedInternalFormat internalformat, int width, int height, int depth, byte fixedsamplelocations)
+            private static void TextureStorage3DMultisample_Lazy(TextureHandle texture, int samples, SizedInternalFormat internalformat, int width, int height, int depth, bool fixedsamplelocations)
             {
-                _TextureStorage3DMultisample_fnptr = (delegate* unmanaged<TextureHandle, int, SizedInternalFormat, int, int, int, byte, void>)GLLoader.BindingsContext.GetProcAddress("glTextureStorage3DMultisample");
+                _TextureStorage3DMultisample_fnptr = (delegate* unmanaged<TextureHandle, int, SizedInternalFormat, int, int, int, bool, void>)GLLoader.BindingsContext.GetProcAddress("glTextureStorage3DMultisample");
                 _TextureStorage3DMultisample_fnptr(texture, samples, internalformat, width, height, depth, fixedsamplelocations);
             }
             
@@ -12402,7 +12402,7 @@ namespace OpenTK.Graphics.OpenGL
                 _VertexArrayAttribBinding_fnptr(vaobj, attribindex, bindingindex);
             }
             
-            private static delegate* unmanaged<VertexArrayHandle, uint, int, VertexAttribType, byte, uint, void> _VertexArrayAttribFormat_fnptr = &VertexArrayAttribFormat_Lazy;
+            private static delegate* unmanaged<VertexArrayHandle, uint, int, VertexAttribType, bool, uint, void> _VertexArrayAttribFormat_fnptr = &VertexArrayAttribFormat_Lazy;
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specify the organization of vertex arrays. </summary>
             /// <param name="vaobj">Specifies the name of the vertex array object for glVertexArrayAttrib{I, L}Format functions.</param>
             /// <param name="attribindex">The generic vertex attribute array being described.</param>
@@ -12411,11 +12411,11 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="normalized"> Specifies whether fixed-point data values should be normalized (GL_TRUE) or converted directly as fixed-point values (GL_FALSE) when they are accessed. This parameter is ignored if type is GL_FIXED. </param>
             /// <param name="relativeoffset">The distance between elements within the buffer.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glVertexAttribFormat.xhtml" /></remarks>
-            public static void VertexArrayAttribFormat(VertexArrayHandle vaobj, uint attribindex, int size, VertexAttribType type, byte normalized, uint relativeoffset) => _VertexArrayAttribFormat_fnptr(vaobj, attribindex, size, type, normalized, relativeoffset);
+            public static void VertexArrayAttribFormat(VertexArrayHandle vaobj, uint attribindex, int size, VertexAttribType type, bool normalized, uint relativeoffset) => _VertexArrayAttribFormat_fnptr(vaobj, attribindex, size, type, normalized, relativeoffset);
             [UnmanagedCallersOnly]
-            private static void VertexArrayAttribFormat_Lazy(VertexArrayHandle vaobj, uint attribindex, int size, VertexAttribType type, byte normalized, uint relativeoffset)
+            private static void VertexArrayAttribFormat_Lazy(VertexArrayHandle vaobj, uint attribindex, int size, VertexAttribType type, bool normalized, uint relativeoffset)
             {
-                _VertexArrayAttribFormat_fnptr = (delegate* unmanaged<VertexArrayHandle, uint, int, VertexAttribType, byte, uint, void>)GLLoader.BindingsContext.GetProcAddress("glVertexArrayAttribFormat");
+                _VertexArrayAttribFormat_fnptr = (delegate* unmanaged<VertexArrayHandle, uint, int, VertexAttribType, bool, uint, void>)GLLoader.BindingsContext.GetProcAddress("glVertexArrayAttribFormat");
                 _VertexArrayAttribFormat_fnptr(vaobj, attribindex, size, type, normalized, relativeoffset);
             }
             
@@ -12979,14 +12979,14 @@ namespace OpenTK.Graphics.OpenGL
                 _GetProgramStringARB_fnptr(target, pname, str);
             }
             
-            private static delegate* unmanaged<ProgramHandle, byte> _IsProgramARB_fnptr = &IsProgramARB_Lazy;
+            private static delegate* unmanaged<ProgramHandle, bool> _IsProgramARB_fnptr = &IsProgramARB_Lazy;
             /// <summary> <b>[requires: GL_ARB_fragment_program | GL_ARB_vertex_program]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsProgramARB(ProgramHandle program) => _IsProgramARB_fnptr(program);
+            public static bool IsProgramARB(ProgramHandle program) => _IsProgramARB_fnptr(program);
             [UnmanagedCallersOnly]
-            private static byte IsProgramARB_Lazy(ProgramHandle program)
+            private static bool IsProgramARB_Lazy(ProgramHandle program)
             {
-                _IsProgramARB_fnptr = (delegate* unmanaged<ProgramHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsProgramARB");
+                _IsProgramARB_fnptr = (delegate* unmanaged<ProgramHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsProgramARB");
                 return _IsProgramARB_fnptr(program);
             }
             
@@ -13018,15 +13018,15 @@ namespace OpenTK.Graphics.OpenGL
                 _GetFramebufferParameteriv_fnptr(target, pname, parameters);
             }
             
-            private static delegate* unmanaged<RenderbufferHandle, byte> _IsRenderbuffer_fnptr = &IsRenderbuffer_Lazy;
+            private static delegate* unmanaged<RenderbufferHandle, bool> _IsRenderbuffer_fnptr = &IsRenderbuffer_Lazy;
             /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Determine if a name corresponds to a renderbuffer object. </summary>
             /// <param name="renderbuffer"> Specifies a value that may be the name of a renderbuffer object. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsRenderbuffer.xhtml" /></remarks>
-            public static byte IsRenderbuffer(RenderbufferHandle renderbuffer) => _IsRenderbuffer_fnptr(renderbuffer);
+            public static bool IsRenderbuffer(RenderbufferHandle renderbuffer) => _IsRenderbuffer_fnptr(renderbuffer);
             [UnmanagedCallersOnly]
-            private static byte IsRenderbuffer_Lazy(RenderbufferHandle renderbuffer)
+            private static bool IsRenderbuffer_Lazy(RenderbufferHandle renderbuffer)
             {
-                _IsRenderbuffer_fnptr = (delegate* unmanaged<RenderbufferHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsRenderbuffer");
+                _IsRenderbuffer_fnptr = (delegate* unmanaged<RenderbufferHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsRenderbuffer");
                 return _IsRenderbuffer_fnptr(renderbuffer);
             }
             
@@ -13098,15 +13098,15 @@ namespace OpenTK.Graphics.OpenGL
                 _GetRenderbufferParameteriv_fnptr(target, pname, parameters);
             }
             
-            private static delegate* unmanaged<FramebufferHandle, byte> _IsFramebuffer_fnptr = &IsFramebuffer_Lazy;
+            private static delegate* unmanaged<FramebufferHandle, bool> _IsFramebuffer_fnptr = &IsFramebuffer_Lazy;
             /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Determine if a name corresponds to a framebuffer object. </summary>
             /// <param name="framebuffer"> Specifies a value that may be the name of a framebuffer object. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsFramebuffer.xhtml" /></remarks>
-            public static byte IsFramebuffer(FramebufferHandle framebuffer) => _IsFramebuffer_fnptr(framebuffer);
+            public static bool IsFramebuffer(FramebufferHandle framebuffer) => _IsFramebuffer_fnptr(framebuffer);
             [UnmanagedCallersOnly]
-            private static byte IsFramebuffer_Lazy(FramebufferHandle framebuffer)
+            private static bool IsFramebuffer_Lazy(FramebufferHandle framebuffer)
             {
-                _IsFramebuffer_fnptr = (delegate* unmanaged<FramebufferHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsFramebuffer");
+                _IsFramebuffer_fnptr = (delegate* unmanaged<FramebufferHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsFramebuffer");
                 return _IsFramebuffer_fnptr(framebuffer);
             }
             
@@ -13537,102 +13537,102 @@ namespace OpenTK.Graphics.OpenGL
                 _Uniform4dv_fnptr(location, count, value);
             }
             
-            private static delegate* unmanaged<int, int, byte, double*, void> _UniformMatrix2dv_fnptr = &UniformMatrix2dv_Lazy;
+            private static delegate* unmanaged<int, int, bool, double*, void> _UniformMatrix2dv_fnptr = &UniformMatrix2dv_Lazy;
             /// <summary> <b>[requires: v4.0 | GL_ARB_gpu_shader_fp64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void UniformMatrix2dv(int location, int count, byte transpose, double* value) => _UniformMatrix2dv_fnptr(location, count, transpose, value);
+            public static void UniformMatrix2dv(int location, int count, bool transpose, double* value) => _UniformMatrix2dv_fnptr(location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void UniformMatrix2dv_Lazy(int location, int count, byte transpose, double* value)
+            private static void UniformMatrix2dv_Lazy(int location, int count, bool transpose, double* value)
             {
-                _UniformMatrix2dv_fnptr = (delegate* unmanaged<int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix2dv");
+                _UniformMatrix2dv_fnptr = (delegate* unmanaged<int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix2dv");
                 _UniformMatrix2dv_fnptr(location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<int, int, byte, double*, void> _UniformMatrix3dv_fnptr = &UniformMatrix3dv_Lazy;
+            private static delegate* unmanaged<int, int, bool, double*, void> _UniformMatrix3dv_fnptr = &UniformMatrix3dv_Lazy;
             /// <summary> <b>[requires: v4.0 | GL_ARB_gpu_shader_fp64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void UniformMatrix3dv(int location, int count, byte transpose, double* value) => _UniformMatrix3dv_fnptr(location, count, transpose, value);
+            public static void UniformMatrix3dv(int location, int count, bool transpose, double* value) => _UniformMatrix3dv_fnptr(location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void UniformMatrix3dv_Lazy(int location, int count, byte transpose, double* value)
+            private static void UniformMatrix3dv_Lazy(int location, int count, bool transpose, double* value)
             {
-                _UniformMatrix3dv_fnptr = (delegate* unmanaged<int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix3dv");
+                _UniformMatrix3dv_fnptr = (delegate* unmanaged<int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix3dv");
                 _UniformMatrix3dv_fnptr(location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<int, int, byte, double*, void> _UniformMatrix4dv_fnptr = &UniformMatrix4dv_Lazy;
+            private static delegate* unmanaged<int, int, bool, double*, void> _UniformMatrix4dv_fnptr = &UniformMatrix4dv_Lazy;
             /// <summary> <b>[requires: v4.0 | GL_ARB_gpu_shader_fp64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void UniformMatrix4dv(int location, int count, byte transpose, double* value) => _UniformMatrix4dv_fnptr(location, count, transpose, value);
+            public static void UniformMatrix4dv(int location, int count, bool transpose, double* value) => _UniformMatrix4dv_fnptr(location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void UniformMatrix4dv_Lazy(int location, int count, byte transpose, double* value)
+            private static void UniformMatrix4dv_Lazy(int location, int count, bool transpose, double* value)
             {
-                _UniformMatrix4dv_fnptr = (delegate* unmanaged<int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix4dv");
+                _UniformMatrix4dv_fnptr = (delegate* unmanaged<int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix4dv");
                 _UniformMatrix4dv_fnptr(location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<int, int, byte, double*, void> _UniformMatrix2x3dv_fnptr = &UniformMatrix2x3dv_Lazy;
+            private static delegate* unmanaged<int, int, bool, double*, void> _UniformMatrix2x3dv_fnptr = &UniformMatrix2x3dv_Lazy;
             /// <summary> <b>[requires: v4.0 | GL_ARB_gpu_shader_fp64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void UniformMatrix2x3dv(int location, int count, byte transpose, double* value) => _UniformMatrix2x3dv_fnptr(location, count, transpose, value);
+            public static void UniformMatrix2x3dv(int location, int count, bool transpose, double* value) => _UniformMatrix2x3dv_fnptr(location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void UniformMatrix2x3dv_Lazy(int location, int count, byte transpose, double* value)
+            private static void UniformMatrix2x3dv_Lazy(int location, int count, bool transpose, double* value)
             {
-                _UniformMatrix2x3dv_fnptr = (delegate* unmanaged<int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix2x3dv");
+                _UniformMatrix2x3dv_fnptr = (delegate* unmanaged<int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix2x3dv");
                 _UniformMatrix2x3dv_fnptr(location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<int, int, byte, double*, void> _UniformMatrix2x4dv_fnptr = &UniformMatrix2x4dv_Lazy;
+            private static delegate* unmanaged<int, int, bool, double*, void> _UniformMatrix2x4dv_fnptr = &UniformMatrix2x4dv_Lazy;
             /// <summary> <b>[requires: v4.0 | GL_ARB_gpu_shader_fp64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void UniformMatrix2x4dv(int location, int count, byte transpose, double* value) => _UniformMatrix2x4dv_fnptr(location, count, transpose, value);
+            public static void UniformMatrix2x4dv(int location, int count, bool transpose, double* value) => _UniformMatrix2x4dv_fnptr(location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void UniformMatrix2x4dv_Lazy(int location, int count, byte transpose, double* value)
+            private static void UniformMatrix2x4dv_Lazy(int location, int count, bool transpose, double* value)
             {
-                _UniformMatrix2x4dv_fnptr = (delegate* unmanaged<int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix2x4dv");
+                _UniformMatrix2x4dv_fnptr = (delegate* unmanaged<int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix2x4dv");
                 _UniformMatrix2x4dv_fnptr(location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<int, int, byte, double*, void> _UniformMatrix3x2dv_fnptr = &UniformMatrix3x2dv_Lazy;
+            private static delegate* unmanaged<int, int, bool, double*, void> _UniformMatrix3x2dv_fnptr = &UniformMatrix3x2dv_Lazy;
             /// <summary> <b>[requires: v4.0 | GL_ARB_gpu_shader_fp64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void UniformMatrix3x2dv(int location, int count, byte transpose, double* value) => _UniformMatrix3x2dv_fnptr(location, count, transpose, value);
+            public static void UniformMatrix3x2dv(int location, int count, bool transpose, double* value) => _UniformMatrix3x2dv_fnptr(location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void UniformMatrix3x2dv_Lazy(int location, int count, byte transpose, double* value)
+            private static void UniformMatrix3x2dv_Lazy(int location, int count, bool transpose, double* value)
             {
-                _UniformMatrix3x2dv_fnptr = (delegate* unmanaged<int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix3x2dv");
+                _UniformMatrix3x2dv_fnptr = (delegate* unmanaged<int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix3x2dv");
                 _UniformMatrix3x2dv_fnptr(location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<int, int, byte, double*, void> _UniformMatrix3x4dv_fnptr = &UniformMatrix3x4dv_Lazy;
+            private static delegate* unmanaged<int, int, bool, double*, void> _UniformMatrix3x4dv_fnptr = &UniformMatrix3x4dv_Lazy;
             /// <summary> <b>[requires: v4.0 | GL_ARB_gpu_shader_fp64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void UniformMatrix3x4dv(int location, int count, byte transpose, double* value) => _UniformMatrix3x4dv_fnptr(location, count, transpose, value);
+            public static void UniformMatrix3x4dv(int location, int count, bool transpose, double* value) => _UniformMatrix3x4dv_fnptr(location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void UniformMatrix3x4dv_Lazy(int location, int count, byte transpose, double* value)
+            private static void UniformMatrix3x4dv_Lazy(int location, int count, bool transpose, double* value)
             {
-                _UniformMatrix3x4dv_fnptr = (delegate* unmanaged<int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix3x4dv");
+                _UniformMatrix3x4dv_fnptr = (delegate* unmanaged<int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix3x4dv");
                 _UniformMatrix3x4dv_fnptr(location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<int, int, byte, double*, void> _UniformMatrix4x2dv_fnptr = &UniformMatrix4x2dv_Lazy;
+            private static delegate* unmanaged<int, int, bool, double*, void> _UniformMatrix4x2dv_fnptr = &UniformMatrix4x2dv_Lazy;
             /// <summary> <b>[requires: v4.0 | GL_ARB_gpu_shader_fp64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void UniformMatrix4x2dv(int location, int count, byte transpose, double* value) => _UniformMatrix4x2dv_fnptr(location, count, transpose, value);
+            public static void UniformMatrix4x2dv(int location, int count, bool transpose, double* value) => _UniformMatrix4x2dv_fnptr(location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void UniformMatrix4x2dv_Lazy(int location, int count, byte transpose, double* value)
+            private static void UniformMatrix4x2dv_Lazy(int location, int count, bool transpose, double* value)
             {
-                _UniformMatrix4x2dv_fnptr = (delegate* unmanaged<int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix4x2dv");
+                _UniformMatrix4x2dv_fnptr = (delegate* unmanaged<int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix4x2dv");
                 _UniformMatrix4x2dv_fnptr(location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<int, int, byte, double*, void> _UniformMatrix4x3dv_fnptr = &UniformMatrix4x3dv_Lazy;
+            private static delegate* unmanaged<int, int, bool, double*, void> _UniformMatrix4x3dv_fnptr = &UniformMatrix4x3dv_Lazy;
             /// <summary> <b>[requires: v4.0 | GL_ARB_gpu_shader_fp64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void UniformMatrix4x3dv(int location, int count, byte transpose, double* value) => _UniformMatrix4x3dv_fnptr(location, count, transpose, value);
+            public static void UniformMatrix4x3dv(int location, int count, bool transpose, double* value) => _UniformMatrix4x3dv_fnptr(location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void UniformMatrix4x3dv_Lazy(int location, int count, byte transpose, double* value)
+            private static void UniformMatrix4x3dv_Lazy(int location, int count, bool transpose, double* value)
             {
-                _UniformMatrix4x3dv_fnptr = (delegate* unmanaged<int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix4x3dv");
+                _UniformMatrix4x3dv_fnptr = (delegate* unmanaged<int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix4x3dv");
                 _UniformMatrix4x3dv_fnptr(location, count, transpose, value);
             }
             
@@ -14433,14 +14433,14 @@ namespace OpenTK.Graphics.OpenGL
                 _MultiDrawElementsIndirect_fnptr(mode, type, indirect, drawcount, stride);
             }
             
-            private static delegate* unmanaged<float, byte, void> _SampleCoverageARB_fnptr = &SampleCoverageARB_Lazy;
+            private static delegate* unmanaged<float, bool, void> _SampleCoverageARB_fnptr = &SampleCoverageARB_Lazy;
             /// <summary> <b>[requires: GL_ARB_multisample]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void SampleCoverageARB(float value, byte invert) => _SampleCoverageARB_fnptr(value, invert);
+            public static void SampleCoverageARB(float value, bool invert) => _SampleCoverageARB_fnptr(value, invert);
             [UnmanagedCallersOnly]
-            private static void SampleCoverageARB_Lazy(float value, byte invert)
+            private static void SampleCoverageARB_Lazy(float value, bool invert)
             {
-                _SampleCoverageARB_fnptr = (delegate* unmanaged<float, byte, void>)GLLoader.BindingsContext.GetProcAddress("glSampleCoverageARB");
+                _SampleCoverageARB_fnptr = (delegate* unmanaged<float, bool, void>)GLLoader.BindingsContext.GetProcAddress("glSampleCoverageARB");
                 _SampleCoverageARB_fnptr(value, invert);
             }
             
@@ -14840,14 +14840,14 @@ namespace OpenTK.Graphics.OpenGL
                 _DeleteQueriesARB_fnptr(n, ids);
             }
             
-            private static delegate* unmanaged<QueryHandle, byte> _IsQueryARB_fnptr = &IsQueryARB_Lazy;
+            private static delegate* unmanaged<QueryHandle, bool> _IsQueryARB_fnptr = &IsQueryARB_Lazy;
             /// <summary> <b>[requires: GL_ARB_occlusion_query]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsQueryARB(QueryHandle id) => _IsQueryARB_fnptr(id);
+            public static bool IsQueryARB(QueryHandle id) => _IsQueryARB_fnptr(id);
             [UnmanagedCallersOnly]
-            private static byte IsQueryARB_Lazy(QueryHandle id)
+            private static bool IsQueryARB_Lazy(QueryHandle id)
             {
-                _IsQueryARB_fnptr = (delegate* unmanaged<QueryHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsQueryARB");
+                _IsQueryARB_fnptr = (delegate* unmanaged<QueryHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsQueryARB");
                 return _IsQueryARB_fnptr(id);
             }
             
@@ -15213,15 +15213,15 @@ namespace OpenTK.Graphics.OpenGL
                 _DeleteSamplers_fnptr(count, samplers);
             }
             
-            private static delegate* unmanaged<SamplerHandle, byte> _IsSampler_fnptr = &IsSampler_Lazy;
+            private static delegate* unmanaged<SamplerHandle, bool> _IsSampler_fnptr = &IsSampler_Lazy;
             /// <summary> <b>[requires: v3.3 | GL_ARB_sampler_objects]</b> Determine if a name corresponds to a sampler object. </summary>
             /// <param name="id"> Specifies a value that may be the name of a sampler object. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsSampler.xhtml" /></remarks>
-            public static byte IsSampler(SamplerHandle sampler) => _IsSampler_fnptr(sampler);
+            public static bool IsSampler(SamplerHandle sampler) => _IsSampler_fnptr(sampler);
             [UnmanagedCallersOnly]
-            private static byte IsSampler_Lazy(SamplerHandle sampler)
+            private static bool IsSampler_Lazy(SamplerHandle sampler)
             {
-                _IsSampler_fnptr = (delegate* unmanaged<SamplerHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsSampler");
+                _IsSampler_fnptr = (delegate* unmanaged<SamplerHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsSampler");
                 return _IsSampler_fnptr(sampler);
             }
             
@@ -15457,15 +15457,15 @@ namespace OpenTK.Graphics.OpenGL
                 _GenProgramPipelines_fnptr(n, pipelines);
             }
             
-            private static delegate* unmanaged<ProgramPipelineHandle, byte> _IsProgramPipeline_fnptr = &IsProgramPipeline_Lazy;
+            private static delegate* unmanaged<ProgramPipelineHandle, bool> _IsProgramPipeline_fnptr = &IsProgramPipeline_Lazy;
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Determine if a name corresponds to a program pipeline object. </summary>
             /// <param name="pipeline"> Specifies a value that may be the name of a program pipeline object. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsProgramPipeline.xhtml" /></remarks>
-            public static byte IsProgramPipeline(ProgramPipelineHandle pipeline) => _IsProgramPipeline_fnptr(pipeline);
+            public static bool IsProgramPipeline(ProgramPipelineHandle pipeline) => _IsProgramPipeline_fnptr(pipeline);
             [UnmanagedCallersOnly]
-            private static byte IsProgramPipeline_Lazy(ProgramPipelineHandle pipeline)
+            private static bool IsProgramPipeline_Lazy(ProgramPipelineHandle pipeline)
             {
-                _IsProgramPipeline_fnptr = (delegate* unmanaged<ProgramPipelineHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsProgramPipeline");
+                _IsProgramPipeline_fnptr = (delegate* unmanaged<ProgramPipelineHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsProgramPipeline");
                 return _IsProgramPipeline_fnptr(pipeline);
             }
             
@@ -15937,7 +15937,7 @@ namespace OpenTK.Graphics.OpenGL
                 _ProgramUniform4uiv_fnptr(program, location, count, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix2fv_fnptr = &ProgramUniformMatrix2fv_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix2fv_fnptr = &ProgramUniformMatrix2fv_Lazy;
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
             /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
@@ -15945,15 +15945,15 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
             /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniformMatrix2fv(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix2fv_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix2fv(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix2fv_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix2fv_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+            private static void ProgramUniformMatrix2fv_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
             {
-                _ProgramUniformMatrix2fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2fv");
+                _ProgramUniformMatrix2fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2fv");
                 _ProgramUniformMatrix2fv_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix3fv_fnptr = &ProgramUniformMatrix3fv_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix3fv_fnptr = &ProgramUniformMatrix3fv_Lazy;
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
             /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
@@ -15961,15 +15961,15 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
             /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniformMatrix3fv(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix3fv_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix3fv(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix3fv_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix3fv_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+            private static void ProgramUniformMatrix3fv_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
             {
-                _ProgramUniformMatrix3fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3fv");
+                _ProgramUniformMatrix3fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3fv");
                 _ProgramUniformMatrix3fv_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix4fv_fnptr = &ProgramUniformMatrix4fv_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix4fv_fnptr = &ProgramUniformMatrix4fv_Lazy;
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
             /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
@@ -15977,48 +15977,48 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
             /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniformMatrix4fv(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix4fv_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix4fv(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix4fv_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix4fv_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+            private static void ProgramUniformMatrix4fv_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
             {
-                _ProgramUniformMatrix4fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4fv");
+                _ProgramUniformMatrix4fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4fv");
                 _ProgramUniformMatrix4fv_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, double*, void> _ProgramUniformMatrix2dv_fnptr = &ProgramUniformMatrix2dv_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, double*, void> _ProgramUniformMatrix2dv_fnptr = &ProgramUniformMatrix2dv_Lazy;
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix2dv(ProgramHandle program, int location, int count, byte transpose, double* value) => _ProgramUniformMatrix2dv_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix2dv(ProgramHandle program, int location, int count, bool transpose, double* value) => _ProgramUniformMatrix2dv_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix2dv_Lazy(ProgramHandle program, int location, int count, byte transpose, double* value)
+            private static void ProgramUniformMatrix2dv_Lazy(ProgramHandle program, int location, int count, bool transpose, double* value)
             {
-                _ProgramUniformMatrix2dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2dv");
+                _ProgramUniformMatrix2dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2dv");
                 _ProgramUniformMatrix2dv_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, double*, void> _ProgramUniformMatrix3dv_fnptr = &ProgramUniformMatrix3dv_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, double*, void> _ProgramUniformMatrix3dv_fnptr = &ProgramUniformMatrix3dv_Lazy;
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix3dv(ProgramHandle program, int location, int count, byte transpose, double* value) => _ProgramUniformMatrix3dv_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix3dv(ProgramHandle program, int location, int count, bool transpose, double* value) => _ProgramUniformMatrix3dv_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix3dv_Lazy(ProgramHandle program, int location, int count, byte transpose, double* value)
+            private static void ProgramUniformMatrix3dv_Lazy(ProgramHandle program, int location, int count, bool transpose, double* value)
             {
-                _ProgramUniformMatrix3dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3dv");
+                _ProgramUniformMatrix3dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3dv");
                 _ProgramUniformMatrix3dv_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, double*, void> _ProgramUniformMatrix4dv_fnptr = &ProgramUniformMatrix4dv_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, double*, void> _ProgramUniformMatrix4dv_fnptr = &ProgramUniformMatrix4dv_Lazy;
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix4dv(ProgramHandle program, int location, int count, byte transpose, double* value) => _ProgramUniformMatrix4dv_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix4dv(ProgramHandle program, int location, int count, bool transpose, double* value) => _ProgramUniformMatrix4dv_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix4dv_Lazy(ProgramHandle program, int location, int count, byte transpose, double* value)
+            private static void ProgramUniformMatrix4dv_Lazy(ProgramHandle program, int location, int count, bool transpose, double* value)
             {
-                _ProgramUniformMatrix4dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4dv");
+                _ProgramUniformMatrix4dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4dv");
                 _ProgramUniformMatrix4dv_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix2x3fv_fnptr = &ProgramUniformMatrix2x3fv_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix2x3fv_fnptr = &ProgramUniformMatrix2x3fv_Lazy;
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
             /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
@@ -16026,15 +16026,15 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
             /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniformMatrix2x3fv(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix2x3fv_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix2x3fv(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix2x3fv_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix2x3fv_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+            private static void ProgramUniformMatrix2x3fv_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
             {
-                _ProgramUniformMatrix2x3fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2x3fv");
+                _ProgramUniformMatrix2x3fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2x3fv");
                 _ProgramUniformMatrix2x3fv_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix3x2fv_fnptr = &ProgramUniformMatrix3x2fv_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix3x2fv_fnptr = &ProgramUniformMatrix3x2fv_Lazy;
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
             /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
@@ -16042,15 +16042,15 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
             /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniformMatrix3x2fv(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix3x2fv_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix3x2fv(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix3x2fv_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix3x2fv_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+            private static void ProgramUniformMatrix3x2fv_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
             {
-                _ProgramUniformMatrix3x2fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3x2fv");
+                _ProgramUniformMatrix3x2fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3x2fv");
                 _ProgramUniformMatrix3x2fv_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix2x4fv_fnptr = &ProgramUniformMatrix2x4fv_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix2x4fv_fnptr = &ProgramUniformMatrix2x4fv_Lazy;
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
             /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
@@ -16058,15 +16058,15 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
             /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniformMatrix2x4fv(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix2x4fv_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix2x4fv(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix2x4fv_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix2x4fv_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+            private static void ProgramUniformMatrix2x4fv_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
             {
-                _ProgramUniformMatrix2x4fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2x4fv");
+                _ProgramUniformMatrix2x4fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2x4fv");
                 _ProgramUniformMatrix2x4fv_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix4x2fv_fnptr = &ProgramUniformMatrix4x2fv_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix4x2fv_fnptr = &ProgramUniformMatrix4x2fv_Lazy;
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
             /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
@@ -16074,15 +16074,15 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
             /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniformMatrix4x2fv(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix4x2fv_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix4x2fv(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix4x2fv_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix4x2fv_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+            private static void ProgramUniformMatrix4x2fv_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
             {
-                _ProgramUniformMatrix4x2fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4x2fv");
+                _ProgramUniformMatrix4x2fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4x2fv");
                 _ProgramUniformMatrix4x2fv_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix3x4fv_fnptr = &ProgramUniformMatrix3x4fv_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix3x4fv_fnptr = &ProgramUniformMatrix3x4fv_Lazy;
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
             /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
@@ -16090,15 +16090,15 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
             /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniformMatrix3x4fv(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix3x4fv_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix3x4fv(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix3x4fv_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix3x4fv_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+            private static void ProgramUniformMatrix3x4fv_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
             {
-                _ProgramUniformMatrix3x4fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3x4fv");
+                _ProgramUniformMatrix3x4fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3x4fv");
                 _ProgramUniformMatrix3x4fv_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix4x3fv_fnptr = &ProgramUniformMatrix4x3fv_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix4x3fv_fnptr = &ProgramUniformMatrix4x3fv_Lazy;
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
             /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
@@ -16106,77 +16106,77 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
             /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniformMatrix4x3fv(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix4x3fv_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix4x3fv(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix4x3fv_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix4x3fv_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+            private static void ProgramUniformMatrix4x3fv_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
             {
-                _ProgramUniformMatrix4x3fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4x3fv");
+                _ProgramUniformMatrix4x3fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4x3fv");
                 _ProgramUniformMatrix4x3fv_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, double*, void> _ProgramUniformMatrix2x3dv_fnptr = &ProgramUniformMatrix2x3dv_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, double*, void> _ProgramUniformMatrix2x3dv_fnptr = &ProgramUniformMatrix2x3dv_Lazy;
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix2x3dv(ProgramHandle program, int location, int count, byte transpose, double* value) => _ProgramUniformMatrix2x3dv_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix2x3dv(ProgramHandle program, int location, int count, bool transpose, double* value) => _ProgramUniformMatrix2x3dv_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix2x3dv_Lazy(ProgramHandle program, int location, int count, byte transpose, double* value)
+            private static void ProgramUniformMatrix2x3dv_Lazy(ProgramHandle program, int location, int count, bool transpose, double* value)
             {
-                _ProgramUniformMatrix2x3dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2x3dv");
+                _ProgramUniformMatrix2x3dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2x3dv");
                 _ProgramUniformMatrix2x3dv_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, double*, void> _ProgramUniformMatrix3x2dv_fnptr = &ProgramUniformMatrix3x2dv_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, double*, void> _ProgramUniformMatrix3x2dv_fnptr = &ProgramUniformMatrix3x2dv_Lazy;
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix3x2dv(ProgramHandle program, int location, int count, byte transpose, double* value) => _ProgramUniformMatrix3x2dv_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix3x2dv(ProgramHandle program, int location, int count, bool transpose, double* value) => _ProgramUniformMatrix3x2dv_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix3x2dv_Lazy(ProgramHandle program, int location, int count, byte transpose, double* value)
+            private static void ProgramUniformMatrix3x2dv_Lazy(ProgramHandle program, int location, int count, bool transpose, double* value)
             {
-                _ProgramUniformMatrix3x2dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3x2dv");
+                _ProgramUniformMatrix3x2dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3x2dv");
                 _ProgramUniformMatrix3x2dv_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, double*, void> _ProgramUniformMatrix2x4dv_fnptr = &ProgramUniformMatrix2x4dv_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, double*, void> _ProgramUniformMatrix2x4dv_fnptr = &ProgramUniformMatrix2x4dv_Lazy;
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix2x4dv(ProgramHandle program, int location, int count, byte transpose, double* value) => _ProgramUniformMatrix2x4dv_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix2x4dv(ProgramHandle program, int location, int count, bool transpose, double* value) => _ProgramUniformMatrix2x4dv_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix2x4dv_Lazy(ProgramHandle program, int location, int count, byte transpose, double* value)
+            private static void ProgramUniformMatrix2x4dv_Lazy(ProgramHandle program, int location, int count, bool transpose, double* value)
             {
-                _ProgramUniformMatrix2x4dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2x4dv");
+                _ProgramUniformMatrix2x4dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2x4dv");
                 _ProgramUniformMatrix2x4dv_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, double*, void> _ProgramUniformMatrix4x2dv_fnptr = &ProgramUniformMatrix4x2dv_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, double*, void> _ProgramUniformMatrix4x2dv_fnptr = &ProgramUniformMatrix4x2dv_Lazy;
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix4x2dv(ProgramHandle program, int location, int count, byte transpose, double* value) => _ProgramUniformMatrix4x2dv_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix4x2dv(ProgramHandle program, int location, int count, bool transpose, double* value) => _ProgramUniformMatrix4x2dv_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix4x2dv_Lazy(ProgramHandle program, int location, int count, byte transpose, double* value)
+            private static void ProgramUniformMatrix4x2dv_Lazy(ProgramHandle program, int location, int count, bool transpose, double* value)
             {
-                _ProgramUniformMatrix4x2dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4x2dv");
+                _ProgramUniformMatrix4x2dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4x2dv");
                 _ProgramUniformMatrix4x2dv_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, double*, void> _ProgramUniformMatrix3x4dv_fnptr = &ProgramUniformMatrix3x4dv_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, double*, void> _ProgramUniformMatrix3x4dv_fnptr = &ProgramUniformMatrix3x4dv_Lazy;
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix3x4dv(ProgramHandle program, int location, int count, byte transpose, double* value) => _ProgramUniformMatrix3x4dv_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix3x4dv(ProgramHandle program, int location, int count, bool transpose, double* value) => _ProgramUniformMatrix3x4dv_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix3x4dv_Lazy(ProgramHandle program, int location, int count, byte transpose, double* value)
+            private static void ProgramUniformMatrix3x4dv_Lazy(ProgramHandle program, int location, int count, bool transpose, double* value)
             {
-                _ProgramUniformMatrix3x4dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3x4dv");
+                _ProgramUniformMatrix3x4dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3x4dv");
                 _ProgramUniformMatrix3x4dv_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, double*, void> _ProgramUniformMatrix4x3dv_fnptr = &ProgramUniformMatrix4x3dv_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, double*, void> _ProgramUniformMatrix4x3dv_fnptr = &ProgramUniformMatrix4x3dv_Lazy;
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix4x3dv(ProgramHandle program, int location, int count, byte transpose, double* value) => _ProgramUniformMatrix4x3dv_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix4x3dv(ProgramHandle program, int location, int count, bool transpose, double* value) => _ProgramUniformMatrix4x3dv_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix4x3dv_Lazy(ProgramHandle program, int location, int count, byte transpose, double* value)
+            private static void ProgramUniformMatrix4x3dv_Lazy(ProgramHandle program, int location, int count, bool transpose, double* value)
             {
-                _ProgramUniformMatrix4x3dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4x3dv");
+                _ProgramUniformMatrix4x3dv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4x3dv");
                 _ProgramUniformMatrix4x3dv_fnptr(program, location, count, transpose, value);
             }
             
@@ -16222,7 +16222,7 @@ namespace OpenTK.Graphics.OpenGL
                 _GetActiveAtomicCounterBufferiv_fnptr(program, bufferIndex, pname, parameters);
             }
             
-            private static delegate* unmanaged<uint, TextureHandle, int, byte, int, BufferAccessARB, InternalFormat, void> _BindImageTexture_fnptr = &BindImageTexture_Lazy;
+            private static delegate* unmanaged<uint, TextureHandle, int, bool, int, BufferAccessARB, InternalFormat, void> _BindImageTexture_fnptr = &BindImageTexture_Lazy;
             /// <summary> <b>[requires: v4.2 | GL_ARB_shader_image_load_store]</b> Bind a level of a texture to an image unit. </summary>
             /// <param name="unit"> Specifies the index of the image unit to which to bind the texture </param>
             /// <param name="texture"> Specifies the name of the texture to bind to the image unit. </param>
@@ -16232,11 +16232,11 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="access"> Specifies a token indicating the type of access that will be performed on the image. </param>
             /// <param name="format"> Specifies the format that the elements of the image will be treated as for the purposes of formatted stores. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindImageTexture.xhtml" /></remarks>
-            public static void BindImageTexture(uint unit, TextureHandle texture, int level, byte layered, int layer, BufferAccessARB access, InternalFormat format) => _BindImageTexture_fnptr(unit, texture, level, layered, layer, access, format);
+            public static void BindImageTexture(uint unit, TextureHandle texture, int level, bool layered, int layer, BufferAccessARB access, InternalFormat format) => _BindImageTexture_fnptr(unit, texture, level, layered, layer, access, format);
             [UnmanagedCallersOnly]
-            private static void BindImageTexture_Lazy(uint unit, TextureHandle texture, int level, byte layered, int layer, BufferAccessARB access, InternalFormat format)
+            private static void BindImageTexture_Lazy(uint unit, TextureHandle texture, int level, bool layered, int layer, BufferAccessARB access, InternalFormat format)
             {
-                _BindImageTexture_fnptr = (delegate* unmanaged<uint, TextureHandle, int, byte, int, BufferAccessARB, InternalFormat, void>)GLLoader.BindingsContext.GetProcAddress("glBindImageTexture");
+                _BindImageTexture_fnptr = (delegate* unmanaged<uint, TextureHandle, int, bool, int, BufferAccessARB, InternalFormat, void>)GLLoader.BindingsContext.GetProcAddress("glBindImageTexture");
                 _BindImageTexture_fnptr(unit, texture, level, layered, layer, access, format);
             }
             
@@ -16549,36 +16549,36 @@ namespace OpenTK.Graphics.OpenGL
                 _Uniform4ivARB_fnptr(location, count, value);
             }
             
-            private static delegate* unmanaged<int, int, byte, float*, void> _UniformMatrix2fvARB_fnptr = &UniformMatrix2fvARB_Lazy;
+            private static delegate* unmanaged<int, int, bool, float*, void> _UniformMatrix2fvARB_fnptr = &UniformMatrix2fvARB_Lazy;
             /// <summary> <b>[requires: GL_ARB_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void UniformMatrix2fvARB(int location, int count, byte transpose, float* value) => _UniformMatrix2fvARB_fnptr(location, count, transpose, value);
+            public static void UniformMatrix2fvARB(int location, int count, bool transpose, float* value) => _UniformMatrix2fvARB_fnptr(location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void UniformMatrix2fvARB_Lazy(int location, int count, byte transpose, float* value)
+            private static void UniformMatrix2fvARB_Lazy(int location, int count, bool transpose, float* value)
             {
-                _UniformMatrix2fvARB_fnptr = (delegate* unmanaged<int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix2fvARB");
+                _UniformMatrix2fvARB_fnptr = (delegate* unmanaged<int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix2fvARB");
                 _UniformMatrix2fvARB_fnptr(location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<int, int, byte, float*, void> _UniformMatrix3fvARB_fnptr = &UniformMatrix3fvARB_Lazy;
+            private static delegate* unmanaged<int, int, bool, float*, void> _UniformMatrix3fvARB_fnptr = &UniformMatrix3fvARB_Lazy;
             /// <summary> <b>[requires: GL_ARB_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void UniformMatrix3fvARB(int location, int count, byte transpose, float* value) => _UniformMatrix3fvARB_fnptr(location, count, transpose, value);
+            public static void UniformMatrix3fvARB(int location, int count, bool transpose, float* value) => _UniformMatrix3fvARB_fnptr(location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void UniformMatrix3fvARB_Lazy(int location, int count, byte transpose, float* value)
+            private static void UniformMatrix3fvARB_Lazy(int location, int count, bool transpose, float* value)
             {
-                _UniformMatrix3fvARB_fnptr = (delegate* unmanaged<int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix3fvARB");
+                _UniformMatrix3fvARB_fnptr = (delegate* unmanaged<int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix3fvARB");
                 _UniformMatrix3fvARB_fnptr(location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<int, int, byte, float*, void> _UniformMatrix4fvARB_fnptr = &UniformMatrix4fvARB_Lazy;
+            private static delegate* unmanaged<int, int, bool, float*, void> _UniformMatrix4fvARB_fnptr = &UniformMatrix4fvARB_Lazy;
             /// <summary> <b>[requires: GL_ARB_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void UniformMatrix4fvARB(int location, int count, byte transpose, float* value) => _UniformMatrix4fvARB_fnptr(location, count, transpose, value);
+            public static void UniformMatrix4fvARB(int location, int count, bool transpose, float* value) => _UniformMatrix4fvARB_fnptr(location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void UniformMatrix4fvARB_Lazy(int location, int count, byte transpose, float* value)
+            private static void UniformMatrix4fvARB_Lazy(int location, int count, bool transpose, float* value)
             {
-                _UniformMatrix4fvARB_fnptr = (delegate* unmanaged<int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix4fvARB");
+                _UniformMatrix4fvARB_fnptr = (delegate* unmanaged<int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix4fvARB");
                 _UniformMatrix4fvARB_fnptr(location, count, transpose, value);
             }
             
@@ -16849,14 +16849,14 @@ namespace OpenTK.Graphics.OpenGL
                 _CompileShaderIncludeARB_fnptr(shader, count, path, length);
             }
             
-            private static delegate* unmanaged<int, byte*, byte> _IsNamedStringARB_fnptr = &IsNamedStringARB_Lazy;
+            private static delegate* unmanaged<int, byte*, bool> _IsNamedStringARB_fnptr = &IsNamedStringARB_Lazy;
             /// <summary> <b>[requires: GL_ARB_shading_language_include]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsNamedStringARB(int namelen, byte* name) => _IsNamedStringARB_fnptr(namelen, name);
+            public static bool IsNamedStringARB(int namelen, byte* name) => _IsNamedStringARB_fnptr(namelen, name);
             [UnmanagedCallersOnly]
-            private static byte IsNamedStringARB_Lazy(int namelen, byte* name)
+            private static bool IsNamedStringARB_Lazy(int namelen, byte* name)
             {
-                _IsNamedStringARB_fnptr = (delegate* unmanaged<int, byte*, byte>)GLLoader.BindingsContext.GetProcAddress("glIsNamedStringARB");
+                _IsNamedStringARB_fnptr = (delegate* unmanaged<int, byte*, bool>)GLLoader.BindingsContext.GetProcAddress("glIsNamedStringARB");
                 return _IsNamedStringARB_fnptr(namelen, name);
             }
             
@@ -16882,47 +16882,47 @@ namespace OpenTK.Graphics.OpenGL
                 _GetNamedStringivARB_fnptr(namelen, name, pname, parameters);
             }
             
-            private static delegate* unmanaged<All, IntPtr, nint, byte, void> _BufferPageCommitmentARB_fnptr = &BufferPageCommitmentARB_Lazy;
+            private static delegate* unmanaged<All, IntPtr, nint, bool, void> _BufferPageCommitmentARB_fnptr = &BufferPageCommitmentARB_Lazy;
             /// <summary> <b>[requires: GL_ARB_sparse_buffer]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void BufferPageCommitmentARB(All target, IntPtr offset, nint size, byte commit) => _BufferPageCommitmentARB_fnptr(target, offset, size, commit);
+            public static void BufferPageCommitmentARB(All target, IntPtr offset, nint size, bool commit) => _BufferPageCommitmentARB_fnptr(target, offset, size, commit);
             [UnmanagedCallersOnly]
-            private static void BufferPageCommitmentARB_Lazy(All target, IntPtr offset, nint size, byte commit)
+            private static void BufferPageCommitmentARB_Lazy(All target, IntPtr offset, nint size, bool commit)
             {
-                _BufferPageCommitmentARB_fnptr = (delegate* unmanaged<All, IntPtr, nint, byte, void>)GLLoader.BindingsContext.GetProcAddress("glBufferPageCommitmentARB");
+                _BufferPageCommitmentARB_fnptr = (delegate* unmanaged<All, IntPtr, nint, bool, void>)GLLoader.BindingsContext.GetProcAddress("glBufferPageCommitmentARB");
                 _BufferPageCommitmentARB_fnptr(target, offset, size, commit);
             }
             
-            private static delegate* unmanaged<BufferHandle, IntPtr, nint, byte, void> _NamedBufferPageCommitmentEXT_fnptr = &NamedBufferPageCommitmentEXT_Lazy;
+            private static delegate* unmanaged<BufferHandle, IntPtr, nint, bool, void> _NamedBufferPageCommitmentEXT_fnptr = &NamedBufferPageCommitmentEXT_Lazy;
             /// <summary> <b>[requires: GL_ARB_sparse_buffer]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedBufferPageCommitmentEXT(BufferHandle buffer, IntPtr offset, nint size, byte commit) => _NamedBufferPageCommitmentEXT_fnptr(buffer, offset, size, commit);
+            public static void NamedBufferPageCommitmentEXT(BufferHandle buffer, IntPtr offset, nint size, bool commit) => _NamedBufferPageCommitmentEXT_fnptr(buffer, offset, size, commit);
             [UnmanagedCallersOnly]
-            private static void NamedBufferPageCommitmentEXT_Lazy(BufferHandle buffer, IntPtr offset, nint size, byte commit)
+            private static void NamedBufferPageCommitmentEXT_Lazy(BufferHandle buffer, IntPtr offset, nint size, bool commit)
             {
-                _NamedBufferPageCommitmentEXT_fnptr = (delegate* unmanaged<BufferHandle, IntPtr, nint, byte, void>)GLLoader.BindingsContext.GetProcAddress("glNamedBufferPageCommitmentEXT");
+                _NamedBufferPageCommitmentEXT_fnptr = (delegate* unmanaged<BufferHandle, IntPtr, nint, bool, void>)GLLoader.BindingsContext.GetProcAddress("glNamedBufferPageCommitmentEXT");
                 _NamedBufferPageCommitmentEXT_fnptr(buffer, offset, size, commit);
             }
             
-            private static delegate* unmanaged<BufferHandle, IntPtr, nint, byte, void> _NamedBufferPageCommitmentARB_fnptr = &NamedBufferPageCommitmentARB_Lazy;
+            private static delegate* unmanaged<BufferHandle, IntPtr, nint, bool, void> _NamedBufferPageCommitmentARB_fnptr = &NamedBufferPageCommitmentARB_Lazy;
             /// <summary> <b>[requires: GL_ARB_sparse_buffer]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedBufferPageCommitmentARB(BufferHandle buffer, IntPtr offset, nint size, byte commit) => _NamedBufferPageCommitmentARB_fnptr(buffer, offset, size, commit);
+            public static void NamedBufferPageCommitmentARB(BufferHandle buffer, IntPtr offset, nint size, bool commit) => _NamedBufferPageCommitmentARB_fnptr(buffer, offset, size, commit);
             [UnmanagedCallersOnly]
-            private static void NamedBufferPageCommitmentARB_Lazy(BufferHandle buffer, IntPtr offset, nint size, byte commit)
+            private static void NamedBufferPageCommitmentARB_Lazy(BufferHandle buffer, IntPtr offset, nint size, bool commit)
             {
-                _NamedBufferPageCommitmentARB_fnptr = (delegate* unmanaged<BufferHandle, IntPtr, nint, byte, void>)GLLoader.BindingsContext.GetProcAddress("glNamedBufferPageCommitmentARB");
+                _NamedBufferPageCommitmentARB_fnptr = (delegate* unmanaged<BufferHandle, IntPtr, nint, bool, void>)GLLoader.BindingsContext.GetProcAddress("glNamedBufferPageCommitmentARB");
                 _NamedBufferPageCommitmentARB_fnptr(buffer, offset, size, commit);
             }
             
-            private static delegate* unmanaged<All, int, int, int, int, int, int, int, byte, void> _TexPageCommitmentARB_fnptr = &TexPageCommitmentARB_Lazy;
+            private static delegate* unmanaged<All, int, int, int, int, int, int, int, bool, void> _TexPageCommitmentARB_fnptr = &TexPageCommitmentARB_Lazy;
             /// <summary> <b>[requires: GL_ARB_sparse_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TexPageCommitmentARB(All target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, byte commit) => _TexPageCommitmentARB_fnptr(target, level, xoffset, yoffset, zoffset, width, height, depth, commit);
+            public static void TexPageCommitmentARB(All target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, bool commit) => _TexPageCommitmentARB_fnptr(target, level, xoffset, yoffset, zoffset, width, height, depth, commit);
             [UnmanagedCallersOnly]
-            private static void TexPageCommitmentARB_Lazy(All target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, byte commit)
+            private static void TexPageCommitmentARB_Lazy(All target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, bool commit)
             {
-                _TexPageCommitmentARB_fnptr = (delegate* unmanaged<All, int, int, int, int, int, int, int, byte, void>)GLLoader.BindingsContext.GetProcAddress("glTexPageCommitmentARB");
+                _TexPageCommitmentARB_fnptr = (delegate* unmanaged<All, int, int, int, int, int, int, int, bool, void>)GLLoader.BindingsContext.GetProcAddress("glTexPageCommitmentARB");
                 _TexPageCommitmentARB_fnptr(target, level, xoffset, yoffset, zoffset, width, height, depth, commit);
             }
             
@@ -16939,15 +16939,15 @@ namespace OpenTK.Graphics.OpenGL
                 return _FenceSync_fnptr(condition, flags);
             }
             
-            private static delegate* unmanaged<GLSync, byte> _IsSync_fnptr = &IsSync_Lazy;
+            private static delegate* unmanaged<GLSync, bool> _IsSync_fnptr = &IsSync_Lazy;
             /// <summary> <b>[requires: v3.2 | GL_ARB_sync]</b> Determine if a name corresponds to a sync object. </summary>
             /// <param name="sync"> Specifies a value that may be the name of a sync object. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsSync.xhtml" /></remarks>
-            public static byte IsSync(GLSync sync) => _IsSync_fnptr(sync);
+            public static bool IsSync(GLSync sync) => _IsSync_fnptr(sync);
             [UnmanagedCallersOnly]
-            private static byte IsSync_Lazy(GLSync sync)
+            private static bool IsSync_Lazy(GLSync sync)
             {
-                _IsSync_fnptr = (delegate* unmanaged<GLSync, byte>)GLLoader.BindingsContext.GetProcAddress("glIsSync");
+                _IsSync_fnptr = (delegate* unmanaged<GLSync, bool>)GLLoader.BindingsContext.GetProcAddress("glIsSync");
                 return _IsSync_fnptr(sync);
             }
             
@@ -17161,7 +17161,7 @@ namespace OpenTK.Graphics.OpenGL
                 _GetCompressedTexImageARB_fnptr(target, level, img);
             }
             
-            private static delegate* unmanaged<TextureTarget, int, InternalFormat, int, int, byte, void> _TexImage2DMultisample_fnptr = &TexImage2DMultisample_Lazy;
+            private static delegate* unmanaged<TextureTarget, int, InternalFormat, int, int, bool, void> _TexImage2DMultisample_fnptr = &TexImage2DMultisample_Lazy;
             /// <summary> <b>[requires: v3.2 | GL_ARB_texture_multisample]</b> Establish the data storage, format, dimensions, and number of samples of a multisample texture's image. </summary>
             /// <param name="target"> Specifies the target of the operation. target must be GL_TEXTURE_2D_MULTISAMPLE or GL_PROXY_TEXTURE_2D_MULTISAMPLE. </param>
             /// <param name="samples"> The number of samples in the multisample texture's image. </param>
@@ -17170,15 +17170,15 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="height"> The height of the multisample texture's image, in texels. </param>
             /// <param name="fixedsamplelocations"> Specifies whether the image will use identical sample locations and the same number of samples for all texels in the image, and the sample locations will not depend on the internal format or size of the image. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexImage2DMultisample.xhtml" /></remarks>
-            public static void TexImage2DMultisample(TextureTarget target, int samples, InternalFormat internalformat, int width, int height, byte fixedsamplelocations) => _TexImage2DMultisample_fnptr(target, samples, internalformat, width, height, fixedsamplelocations);
+            public static void TexImage2DMultisample(TextureTarget target, int samples, InternalFormat internalformat, int width, int height, bool fixedsamplelocations) => _TexImage2DMultisample_fnptr(target, samples, internalformat, width, height, fixedsamplelocations);
             [UnmanagedCallersOnly]
-            private static void TexImage2DMultisample_Lazy(TextureTarget target, int samples, InternalFormat internalformat, int width, int height, byte fixedsamplelocations)
+            private static void TexImage2DMultisample_Lazy(TextureTarget target, int samples, InternalFormat internalformat, int width, int height, bool fixedsamplelocations)
             {
-                _TexImage2DMultisample_fnptr = (delegate* unmanaged<TextureTarget, int, InternalFormat, int, int, byte, void>)GLLoader.BindingsContext.GetProcAddress("glTexImage2DMultisample");
+                _TexImage2DMultisample_fnptr = (delegate* unmanaged<TextureTarget, int, InternalFormat, int, int, bool, void>)GLLoader.BindingsContext.GetProcAddress("glTexImage2DMultisample");
                 _TexImage2DMultisample_fnptr(target, samples, internalformat, width, height, fixedsamplelocations);
             }
             
-            private static delegate* unmanaged<TextureTarget, int, InternalFormat, int, int, int, byte, void> _TexImage3DMultisample_fnptr = &TexImage3DMultisample_Lazy;
+            private static delegate* unmanaged<TextureTarget, int, InternalFormat, int, int, int, bool, void> _TexImage3DMultisample_fnptr = &TexImage3DMultisample_Lazy;
             /// <summary> <b>[requires: v3.2 | GL_ARB_texture_multisample]</b> Establish the data storage, format, dimensions, and number of samples of a multisample texture's image. </summary>
             /// <param name="target"> Specifies the target of the operation. target must be GL_TEXTURE_2D_MULTISAMPLE_ARRAY or GL_PROXY_TEXTURE_2D_MULTISAMPLE_ARRAY. </param>
             /// <param name="samples"> The number of samples in the multisample texture's image. </param>
@@ -17188,11 +17188,11 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="depth">!!missing documentation!!</param>
             /// <param name="fixedsamplelocations"> Specifies whether the image will use identical sample locations and the same number of samples for all texels in the image, and the sample locations will not depend on the internal format or size of the image. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexImage3DMultisample.xhtml" /></remarks>
-            public static void TexImage3DMultisample(TextureTarget target, int samples, InternalFormat internalformat, int width, int height, int depth, byte fixedsamplelocations) => _TexImage3DMultisample_fnptr(target, samples, internalformat, width, height, depth, fixedsamplelocations);
+            public static void TexImage3DMultisample(TextureTarget target, int samples, InternalFormat internalformat, int width, int height, int depth, bool fixedsamplelocations) => _TexImage3DMultisample_fnptr(target, samples, internalformat, width, height, depth, fixedsamplelocations);
             [UnmanagedCallersOnly]
-            private static void TexImage3DMultisample_Lazy(TextureTarget target, int samples, InternalFormat internalformat, int width, int height, int depth, byte fixedsamplelocations)
+            private static void TexImage3DMultisample_Lazy(TextureTarget target, int samples, InternalFormat internalformat, int width, int height, int depth, bool fixedsamplelocations)
             {
-                _TexImage3DMultisample_fnptr = (delegate* unmanaged<TextureTarget, int, InternalFormat, int, int, int, byte, void>)GLLoader.BindingsContext.GetProcAddress("glTexImage3DMultisample");
+                _TexImage3DMultisample_fnptr = (delegate* unmanaged<TextureTarget, int, InternalFormat, int, int, int, bool, void>)GLLoader.BindingsContext.GetProcAddress("glTexImage3DMultisample");
                 _TexImage3DMultisample_fnptr(target, samples, internalformat, width, height, depth, fixedsamplelocations);
             }
             
@@ -17271,7 +17271,7 @@ namespace OpenTK.Graphics.OpenGL
                 _TexStorage3D_fnptr(target, levels, internalformat, width, height, depth);
             }
             
-            private static delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, byte, void> _TexStorage2DMultisample_fnptr = &TexStorage2DMultisample_Lazy;
+            private static delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, bool, void> _TexStorage2DMultisample_fnptr = &TexStorage2DMultisample_Lazy;
             /// <summary> <b>[requires: v4.3 | GL_ARB_texture_storage_multisample]</b> Specify storage for a two-dimensional multisample texture. </summary>
             /// <param name="target"> Specifies the target to which the texture object is bound for glTexStorage2DMultisample. Must be one of GL_TEXTURE_2D_MULTISAMPLE or GL_PROXY_TEXTURE_2D_MULTISAMPLE. </param>
             /// <param name="samples"> Specify the number of samples in the texture. </param>
@@ -17280,15 +17280,15 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="height"> Specifies the height of the texture, in texels. </param>
             /// <param name="fixedsamplelocations"> Specifies whether the image will use identical sample locations and the same number of samples for all texels in the image, and the sample locations will not depend on the internal format or size of the image. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexStorage2DMultisample.xhtml" /></remarks>
-            public static void TexStorage2DMultisample(TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, byte fixedsamplelocations) => _TexStorage2DMultisample_fnptr(target, samples, internalformat, width, height, fixedsamplelocations);
+            public static void TexStorage2DMultisample(TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, bool fixedsamplelocations) => _TexStorage2DMultisample_fnptr(target, samples, internalformat, width, height, fixedsamplelocations);
             [UnmanagedCallersOnly]
-            private static void TexStorage2DMultisample_Lazy(TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, byte fixedsamplelocations)
+            private static void TexStorage2DMultisample_Lazy(TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, bool fixedsamplelocations)
             {
-                _TexStorage2DMultisample_fnptr = (delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, byte, void>)GLLoader.BindingsContext.GetProcAddress("glTexStorage2DMultisample");
+                _TexStorage2DMultisample_fnptr = (delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, bool, void>)GLLoader.BindingsContext.GetProcAddress("glTexStorage2DMultisample");
                 _TexStorage2DMultisample_fnptr(target, samples, internalformat, width, height, fixedsamplelocations);
             }
             
-            private static delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, int, byte, void> _TexStorage3DMultisample_fnptr = &TexStorage3DMultisample_Lazy;
+            private static delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, int, bool, void> _TexStorage3DMultisample_fnptr = &TexStorage3DMultisample_Lazy;
             /// <summary> <b>[requires: v4.3 | GL_ARB_texture_storage_multisample]</b> Specify storage for a two-dimensional multisample array texture. </summary>
             /// <param name="target"> Specifies the target to which the texture object is bound for glTexStorage3DMultisample. Must be one of GL_TEXTURE_2D_MULTISAMPLE_ARRAY or GL_PROXY_TEXTURE_2D_MULTISAMPLE_ARRAY. </param>
             /// <param name="samples"> Specify the number of samples in the texture. </param>
@@ -17298,11 +17298,11 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="depth"> Specifies the depth of the texture, in layers. </param>
             /// <param name="fixedsamplelocations"> Specifies whether the image will use identical sample locations and the same number of samples for all texels in the image, and the sample locations will not depend on the internal format or size of the image. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexStorage3DMultisample.xhtml" /></remarks>
-            public static void TexStorage3DMultisample(TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, int depth, byte fixedsamplelocations) => _TexStorage3DMultisample_fnptr(target, samples, internalformat, width, height, depth, fixedsamplelocations);
+            public static void TexStorage3DMultisample(TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, int depth, bool fixedsamplelocations) => _TexStorage3DMultisample_fnptr(target, samples, internalformat, width, height, depth, fixedsamplelocations);
             [UnmanagedCallersOnly]
-            private static void TexStorage3DMultisample_Lazy(TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, int depth, byte fixedsamplelocations)
+            private static void TexStorage3DMultisample_Lazy(TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, int depth, bool fixedsamplelocations)
             {
-                _TexStorage3DMultisample_fnptr = (delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, int, byte, void>)GLLoader.BindingsContext.GetProcAddress("glTexStorage3DMultisample");
+                _TexStorage3DMultisample_fnptr = (delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, int, bool, void>)GLLoader.BindingsContext.GetProcAddress("glTexStorage3DMultisample");
                 _TexStorage3DMultisample_fnptr(target, samples, internalformat, width, height, depth, fixedsamplelocations);
             }
             
@@ -17405,15 +17405,15 @@ namespace OpenTK.Graphics.OpenGL
                 _GenTransformFeedbacks_fnptr(n, ids);
             }
             
-            private static delegate* unmanaged<TransformFeedbackHandle, byte> _IsTransformFeedback_fnptr = &IsTransformFeedback_Lazy;
+            private static delegate* unmanaged<TransformFeedbackHandle, bool> _IsTransformFeedback_fnptr = &IsTransformFeedback_Lazy;
             /// <summary> <b>[requires: v4.0 | GL_ARB_transform_feedback2]</b> Determine if a name corresponds to a transform feedback object. </summary>
             /// <param name="id"> Specifies a value that may be the name of a transform feedback object. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsTransformFeedback.xhtml" /></remarks>
-            public static byte IsTransformFeedback(TransformFeedbackHandle id) => _IsTransformFeedback_fnptr(id);
+            public static bool IsTransformFeedback(TransformFeedbackHandle id) => _IsTransformFeedback_fnptr(id);
             [UnmanagedCallersOnly]
-            private static byte IsTransformFeedback_Lazy(TransformFeedbackHandle id)
+            private static bool IsTransformFeedback_Lazy(TransformFeedbackHandle id)
             {
-                _IsTransformFeedback_fnptr = (delegate* unmanaged<TransformFeedbackHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsTransformFeedback");
+                _IsTransformFeedback_fnptr = (delegate* unmanaged<TransformFeedbackHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsTransformFeedback");
                 return _IsTransformFeedback_fnptr(id);
             }
             
@@ -17768,15 +17768,15 @@ namespace OpenTK.Graphics.OpenGL
                 _GenVertexArrays_fnptr(n, arrays);
             }
             
-            private static delegate* unmanaged<VertexArrayHandle, byte> _IsVertexArray_fnptr = &IsVertexArray_Lazy;
+            private static delegate* unmanaged<VertexArrayHandle, bool> _IsVertexArray_fnptr = &IsVertexArray_Lazy;
             /// <summary> <b>[requires: v3.0 | GL_ARB_vertex_array_object]</b> Determine if a name corresponds to a vertex array object. </summary>
             /// <param name="array"> Specifies a value that may be the name of a vertex array object. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsVertexArray.xhtml" /></remarks>
-            public static byte IsVertexArray(VertexArrayHandle array) => _IsVertexArray_fnptr(array);
+            public static bool IsVertexArray(VertexArrayHandle array) => _IsVertexArray_fnptr(array);
             [UnmanagedCallersOnly]
-            private static byte IsVertexArray_Lazy(VertexArrayHandle array)
+            private static bool IsVertexArray_Lazy(VertexArrayHandle array)
             {
-                _IsVertexArray_fnptr = (delegate* unmanaged<VertexArrayHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsVertexArray");
+                _IsVertexArray_fnptr = (delegate* unmanaged<VertexArrayHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsVertexArray");
                 return _IsVertexArray_fnptr(array);
             }
             
@@ -17935,7 +17935,7 @@ namespace OpenTK.Graphics.OpenGL
                 _BindVertexBuffer_fnptr(bindingindex, buffer, offset, stride);
             }
             
-            private static delegate* unmanaged<uint, int, VertexAttribType, byte, uint, void> _VertexAttribFormat_fnptr = &VertexAttribFormat_Lazy;
+            private static delegate* unmanaged<uint, int, VertexAttribType, bool, uint, void> _VertexAttribFormat_fnptr = &VertexAttribFormat_Lazy;
             /// <summary> <b>[requires: v4.3 | GL_ARB_vertex_attrib_binding]</b> Specify the organization of vertex arrays. </summary>
             /// <param name="attribindex">The generic vertex attribute array being described.</param>
             /// <param name="size">The number of values per vertex that are stored in the array.</param>
@@ -17943,11 +17943,11 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="normalized"> Specifies whether fixed-point data values should be normalized (GL_TRUE) or converted directly as fixed-point values (GL_FALSE) when they are accessed. This parameter is ignored if type is GL_FIXED. </param>
             /// <param name="relativeoffset">The distance between elements within the buffer.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glVertexAttribFormat.xhtml" /></remarks>
-            public static void VertexAttribFormat(uint attribindex, int size, VertexAttribType type, byte normalized, uint relativeoffset) => _VertexAttribFormat_fnptr(attribindex, size, type, normalized, relativeoffset);
+            public static void VertexAttribFormat(uint attribindex, int size, VertexAttribType type, bool normalized, uint relativeoffset) => _VertexAttribFormat_fnptr(attribindex, size, type, normalized, relativeoffset);
             [UnmanagedCallersOnly]
-            private static void VertexAttribFormat_Lazy(uint attribindex, int size, VertexAttribType type, byte normalized, uint relativeoffset)
+            private static void VertexAttribFormat_Lazy(uint attribindex, int size, VertexAttribType type, bool normalized, uint relativeoffset)
             {
-                _VertexAttribFormat_fnptr = (delegate* unmanaged<uint, int, VertexAttribType, byte, uint, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribFormat");
+                _VertexAttribFormat_fnptr = (delegate* unmanaged<uint, int, VertexAttribType, bool, uint, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribFormat");
                 _VertexAttribFormat_fnptr(attribindex, size, type, normalized, relativeoffset);
             }
             
@@ -18150,14 +18150,14 @@ namespace OpenTK.Graphics.OpenGL
                 _GenBuffersARB_fnptr(n, buffers);
             }
             
-            private static delegate* unmanaged<BufferHandle, byte> _IsBufferARB_fnptr = &IsBufferARB_Lazy;
+            private static delegate* unmanaged<BufferHandle, bool> _IsBufferARB_fnptr = &IsBufferARB_Lazy;
             /// <summary> <b>[requires: GL_ARB_vertex_buffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsBufferARB(BufferHandle buffer) => _IsBufferARB_fnptr(buffer);
+            public static bool IsBufferARB(BufferHandle buffer) => _IsBufferARB_fnptr(buffer);
             [UnmanagedCallersOnly]
-            private static byte IsBufferARB_Lazy(BufferHandle buffer)
+            private static bool IsBufferARB_Lazy(BufferHandle buffer)
             {
-                _IsBufferARB_fnptr = (delegate* unmanaged<BufferHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsBufferARB");
+                _IsBufferARB_fnptr = (delegate* unmanaged<BufferHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsBufferARB");
                 return _IsBufferARB_fnptr(buffer);
             }
             
@@ -18205,14 +18205,14 @@ namespace OpenTK.Graphics.OpenGL
                 return _MapBufferARB_fnptr(target, access);
             }
             
-            private static delegate* unmanaged<BufferTargetARB, byte> _UnmapBufferARB_fnptr = &UnmapBufferARB_Lazy;
+            private static delegate* unmanaged<BufferTargetARB, bool> _UnmapBufferARB_fnptr = &UnmapBufferARB_Lazy;
             /// <summary> <b>[requires: GL_ARB_vertex_buffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte UnmapBufferARB(BufferTargetARB target) => _UnmapBufferARB_fnptr(target);
+            public static bool UnmapBufferARB(BufferTargetARB target) => _UnmapBufferARB_fnptr(target);
             [UnmanagedCallersOnly]
-            private static byte UnmapBufferARB_Lazy(BufferTargetARB target)
+            private static bool UnmapBufferARB_Lazy(BufferTargetARB target)
             {
-                _UnmapBufferARB_fnptr = (delegate* unmanaged<BufferTargetARB, byte>)GLLoader.BindingsContext.GetProcAddress("glUnmapBufferARB");
+                _UnmapBufferARB_fnptr = (delegate* unmanaged<BufferTargetARB, bool>)GLLoader.BindingsContext.GetProcAddress("glUnmapBufferARB");
                 return _UnmapBufferARB_fnptr(target);
             }
             
@@ -18634,14 +18634,14 @@ namespace OpenTK.Graphics.OpenGL
                 _VertexAttrib4usvARB_fnptr(index, v);
             }
             
-            private static delegate* unmanaged<uint, int, VertexAttribPointerType, byte, int, void*, void> _VertexAttribPointerARB_fnptr = &VertexAttribPointerARB_Lazy;
+            private static delegate* unmanaged<uint, int, VertexAttribPointerType, bool, int, void*, void> _VertexAttribPointerARB_fnptr = &VertexAttribPointerARB_Lazy;
             /// <summary> <b>[requires: GL_ARB_vertex_program | GL_ARB_vertex_shader]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void VertexAttribPointerARB(uint index, int size, VertexAttribPointerType type, byte normalized, int stride, void* pointer) => _VertexAttribPointerARB_fnptr(index, size, type, normalized, stride, pointer);
+            public static void VertexAttribPointerARB(uint index, int size, VertexAttribPointerType type, bool normalized, int stride, void* pointer) => _VertexAttribPointerARB_fnptr(index, size, type, normalized, stride, pointer);
             [UnmanagedCallersOnly]
-            private static void VertexAttribPointerARB_Lazy(uint index, int size, VertexAttribPointerType type, byte normalized, int stride, void* pointer)
+            private static void VertexAttribPointerARB_Lazy(uint index, int size, VertexAttribPointerType type, bool normalized, int stride, void* pointer)
             {
-                _VertexAttribPointerARB_fnptr = (delegate* unmanaged<uint, int, VertexAttribPointerType, byte, int, void*, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribPointerARB");
+                _VertexAttribPointerARB_fnptr = (delegate* unmanaged<uint, int, VertexAttribPointerType, bool, int, void*, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribPointerARB");
                 _VertexAttribPointerARB_fnptr(index, size, type, normalized, stride, pointer);
             }
             
@@ -18744,107 +18744,107 @@ namespace OpenTK.Graphics.OpenGL
                 return _GetAttribLocationARB_fnptr(programObj, name);
             }
             
-            private static delegate* unmanaged<uint, VertexAttribPointerType, byte, uint, void> _VertexAttribP1ui_fnptr = &VertexAttribP1ui_Lazy;
+            private static delegate* unmanaged<uint, VertexAttribPointerType, bool, uint, void> _VertexAttribP1ui_fnptr = &VertexAttribP1ui_Lazy;
             /// <summary> <b>[requires: v3.3 | GL_ARB_vertex_type_2_10_10_10_rev]</b> Specifies the value of a generic vertex attribute. </summary>
             /// <param name="index">Specifies the index of the generic vertex attribute to be modified.</param>
             /// <param name="type"> For the packed commands (glVertexAttribP*), specified the type of packing used on the data. This parameter must be GL_INT_2_10_10_10_REV or GL_UNSIGNED_INT_2_10_10_10_REV, to specify signed or unsigned data, respectively, or GL_UNSIGNED_INT_10F_11F_11F_REV to specify floating point data. </param>
             /// <param name="normalized"> For the packed commands, if GL_TRUE, then the values are to be converted to floating point values by normalizing. Otherwise, they are converted directly to floating-point values. If type indicates a floating-pont format, then normalized value must be GL_FALSE. </param>
             /// <param name="value"> For the packed commands, specifies the new packed value to be used for the specified vertex attribute. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glVertexAttrib.xhtml" /></remarks>
-            public static void VertexAttribP1ui(uint index, VertexAttribPointerType type, byte normalized, uint value) => _VertexAttribP1ui_fnptr(index, type, normalized, value);
+            public static void VertexAttribP1ui(uint index, VertexAttribPointerType type, bool normalized, uint value) => _VertexAttribP1ui_fnptr(index, type, normalized, value);
             [UnmanagedCallersOnly]
-            private static void VertexAttribP1ui_Lazy(uint index, VertexAttribPointerType type, byte normalized, uint value)
+            private static void VertexAttribP1ui_Lazy(uint index, VertexAttribPointerType type, bool normalized, uint value)
             {
-                _VertexAttribP1ui_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, byte, uint, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP1ui");
+                _VertexAttribP1ui_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, bool, uint, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP1ui");
                 _VertexAttribP1ui_fnptr(index, type, normalized, value);
             }
             
-            private static delegate* unmanaged<uint, VertexAttribPointerType, byte, uint*, void> _VertexAttribP1uiv_fnptr = &VertexAttribP1uiv_Lazy;
+            private static delegate* unmanaged<uint, VertexAttribPointerType, bool, uint*, void> _VertexAttribP1uiv_fnptr = &VertexAttribP1uiv_Lazy;
             /// <summary> <b>[requires: v3.3 | GL_ARB_vertex_type_2_10_10_10_rev]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void VertexAttribP1uiv(uint index, VertexAttribPointerType type, byte normalized, uint* value) => _VertexAttribP1uiv_fnptr(index, type, normalized, value);
+            public static void VertexAttribP1uiv(uint index, VertexAttribPointerType type, bool normalized, uint* value) => _VertexAttribP1uiv_fnptr(index, type, normalized, value);
             [UnmanagedCallersOnly]
-            private static void VertexAttribP1uiv_Lazy(uint index, VertexAttribPointerType type, byte normalized, uint* value)
+            private static void VertexAttribP1uiv_Lazy(uint index, VertexAttribPointerType type, bool normalized, uint* value)
             {
-                _VertexAttribP1uiv_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, byte, uint*, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP1uiv");
+                _VertexAttribP1uiv_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, bool, uint*, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP1uiv");
                 _VertexAttribP1uiv_fnptr(index, type, normalized, value);
             }
             
-            private static delegate* unmanaged<uint, VertexAttribPointerType, byte, uint, void> _VertexAttribP2ui_fnptr = &VertexAttribP2ui_Lazy;
+            private static delegate* unmanaged<uint, VertexAttribPointerType, bool, uint, void> _VertexAttribP2ui_fnptr = &VertexAttribP2ui_Lazy;
             /// <summary> <b>[requires: v3.3 | GL_ARB_vertex_type_2_10_10_10_rev]</b> Specifies the value of a generic vertex attribute. </summary>
             /// <param name="index">Specifies the index of the generic vertex attribute to be modified.</param>
             /// <param name="type"> For the packed commands (glVertexAttribP*), specified the type of packing used on the data. This parameter must be GL_INT_2_10_10_10_REV or GL_UNSIGNED_INT_2_10_10_10_REV, to specify signed or unsigned data, respectively, or GL_UNSIGNED_INT_10F_11F_11F_REV to specify floating point data. </param>
             /// <param name="normalized"> For the packed commands, if GL_TRUE, then the values are to be converted to floating point values by normalizing. Otherwise, they are converted directly to floating-point values. If type indicates a floating-pont format, then normalized value must be GL_FALSE. </param>
             /// <param name="value"> For the packed commands, specifies the new packed value to be used for the specified vertex attribute. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glVertexAttrib.xhtml" /></remarks>
-            public static void VertexAttribP2ui(uint index, VertexAttribPointerType type, byte normalized, uint value) => _VertexAttribP2ui_fnptr(index, type, normalized, value);
+            public static void VertexAttribP2ui(uint index, VertexAttribPointerType type, bool normalized, uint value) => _VertexAttribP2ui_fnptr(index, type, normalized, value);
             [UnmanagedCallersOnly]
-            private static void VertexAttribP2ui_Lazy(uint index, VertexAttribPointerType type, byte normalized, uint value)
+            private static void VertexAttribP2ui_Lazy(uint index, VertexAttribPointerType type, bool normalized, uint value)
             {
-                _VertexAttribP2ui_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, byte, uint, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP2ui");
+                _VertexAttribP2ui_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, bool, uint, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP2ui");
                 _VertexAttribP2ui_fnptr(index, type, normalized, value);
             }
             
-            private static delegate* unmanaged<uint, VertexAttribPointerType, byte, uint*, void> _VertexAttribP2uiv_fnptr = &VertexAttribP2uiv_Lazy;
+            private static delegate* unmanaged<uint, VertexAttribPointerType, bool, uint*, void> _VertexAttribP2uiv_fnptr = &VertexAttribP2uiv_Lazy;
             /// <summary> <b>[requires: v3.3 | GL_ARB_vertex_type_2_10_10_10_rev]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void VertexAttribP2uiv(uint index, VertexAttribPointerType type, byte normalized, uint* value) => _VertexAttribP2uiv_fnptr(index, type, normalized, value);
+            public static void VertexAttribP2uiv(uint index, VertexAttribPointerType type, bool normalized, uint* value) => _VertexAttribP2uiv_fnptr(index, type, normalized, value);
             [UnmanagedCallersOnly]
-            private static void VertexAttribP2uiv_Lazy(uint index, VertexAttribPointerType type, byte normalized, uint* value)
+            private static void VertexAttribP2uiv_Lazy(uint index, VertexAttribPointerType type, bool normalized, uint* value)
             {
-                _VertexAttribP2uiv_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, byte, uint*, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP2uiv");
+                _VertexAttribP2uiv_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, bool, uint*, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP2uiv");
                 _VertexAttribP2uiv_fnptr(index, type, normalized, value);
             }
             
-            private static delegate* unmanaged<uint, VertexAttribPointerType, byte, uint, void> _VertexAttribP3ui_fnptr = &VertexAttribP3ui_Lazy;
+            private static delegate* unmanaged<uint, VertexAttribPointerType, bool, uint, void> _VertexAttribP3ui_fnptr = &VertexAttribP3ui_Lazy;
             /// <summary> <b>[requires: v3.3 | GL_ARB_vertex_type_2_10_10_10_rev]</b> Specifies the value of a generic vertex attribute. </summary>
             /// <param name="index">Specifies the index of the generic vertex attribute to be modified.</param>
             /// <param name="type"> For the packed commands (glVertexAttribP*), specified the type of packing used on the data. This parameter must be GL_INT_2_10_10_10_REV or GL_UNSIGNED_INT_2_10_10_10_REV, to specify signed or unsigned data, respectively, or GL_UNSIGNED_INT_10F_11F_11F_REV to specify floating point data. </param>
             /// <param name="normalized"> For the packed commands, if GL_TRUE, then the values are to be converted to floating point values by normalizing. Otherwise, they are converted directly to floating-point values. If type indicates a floating-pont format, then normalized value must be GL_FALSE. </param>
             /// <param name="value"> For the packed commands, specifies the new packed value to be used for the specified vertex attribute. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glVertexAttrib.xhtml" /></remarks>
-            public static void VertexAttribP3ui(uint index, VertexAttribPointerType type, byte normalized, uint value) => _VertexAttribP3ui_fnptr(index, type, normalized, value);
+            public static void VertexAttribP3ui(uint index, VertexAttribPointerType type, bool normalized, uint value) => _VertexAttribP3ui_fnptr(index, type, normalized, value);
             [UnmanagedCallersOnly]
-            private static void VertexAttribP3ui_Lazy(uint index, VertexAttribPointerType type, byte normalized, uint value)
+            private static void VertexAttribP3ui_Lazy(uint index, VertexAttribPointerType type, bool normalized, uint value)
             {
-                _VertexAttribP3ui_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, byte, uint, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP3ui");
+                _VertexAttribP3ui_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, bool, uint, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP3ui");
                 _VertexAttribP3ui_fnptr(index, type, normalized, value);
             }
             
-            private static delegate* unmanaged<uint, VertexAttribPointerType, byte, uint*, void> _VertexAttribP3uiv_fnptr = &VertexAttribP3uiv_Lazy;
+            private static delegate* unmanaged<uint, VertexAttribPointerType, bool, uint*, void> _VertexAttribP3uiv_fnptr = &VertexAttribP3uiv_Lazy;
             /// <summary> <b>[requires: v3.3 | GL_ARB_vertex_type_2_10_10_10_rev]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void VertexAttribP3uiv(uint index, VertexAttribPointerType type, byte normalized, uint* value) => _VertexAttribP3uiv_fnptr(index, type, normalized, value);
+            public static void VertexAttribP3uiv(uint index, VertexAttribPointerType type, bool normalized, uint* value) => _VertexAttribP3uiv_fnptr(index, type, normalized, value);
             [UnmanagedCallersOnly]
-            private static void VertexAttribP3uiv_Lazy(uint index, VertexAttribPointerType type, byte normalized, uint* value)
+            private static void VertexAttribP3uiv_Lazy(uint index, VertexAttribPointerType type, bool normalized, uint* value)
             {
-                _VertexAttribP3uiv_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, byte, uint*, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP3uiv");
+                _VertexAttribP3uiv_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, bool, uint*, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP3uiv");
                 _VertexAttribP3uiv_fnptr(index, type, normalized, value);
             }
             
-            private static delegate* unmanaged<uint, VertexAttribPointerType, byte, uint, void> _VertexAttribP4ui_fnptr = &VertexAttribP4ui_Lazy;
+            private static delegate* unmanaged<uint, VertexAttribPointerType, bool, uint, void> _VertexAttribP4ui_fnptr = &VertexAttribP4ui_Lazy;
             /// <summary> <b>[requires: v3.3 | GL_ARB_vertex_type_2_10_10_10_rev]</b> Specifies the value of a generic vertex attribute. </summary>
             /// <param name="index">Specifies the index of the generic vertex attribute to be modified.</param>
             /// <param name="type"> For the packed commands (glVertexAttribP*), specified the type of packing used on the data. This parameter must be GL_INT_2_10_10_10_REV or GL_UNSIGNED_INT_2_10_10_10_REV, to specify signed or unsigned data, respectively, or GL_UNSIGNED_INT_10F_11F_11F_REV to specify floating point data. </param>
             /// <param name="normalized"> For the packed commands, if GL_TRUE, then the values are to be converted to floating point values by normalizing. Otherwise, they are converted directly to floating-point values. If type indicates a floating-pont format, then normalized value must be GL_FALSE. </param>
             /// <param name="value"> For the packed commands, specifies the new packed value to be used for the specified vertex attribute. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glVertexAttrib.xhtml" /></remarks>
-            public static void VertexAttribP4ui(uint index, VertexAttribPointerType type, byte normalized, uint value) => _VertexAttribP4ui_fnptr(index, type, normalized, value);
+            public static void VertexAttribP4ui(uint index, VertexAttribPointerType type, bool normalized, uint value) => _VertexAttribP4ui_fnptr(index, type, normalized, value);
             [UnmanagedCallersOnly]
-            private static void VertexAttribP4ui_Lazy(uint index, VertexAttribPointerType type, byte normalized, uint value)
+            private static void VertexAttribP4ui_Lazy(uint index, VertexAttribPointerType type, bool normalized, uint value)
             {
-                _VertexAttribP4ui_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, byte, uint, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP4ui");
+                _VertexAttribP4ui_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, bool, uint, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP4ui");
                 _VertexAttribP4ui_fnptr(index, type, normalized, value);
             }
             
-            private static delegate* unmanaged<uint, VertexAttribPointerType, byte, uint*, void> _VertexAttribP4uiv_fnptr = &VertexAttribP4uiv_Lazy;
+            private static delegate* unmanaged<uint, VertexAttribPointerType, bool, uint*, void> _VertexAttribP4uiv_fnptr = &VertexAttribP4uiv_Lazy;
             /// <summary> <b>[requires: v3.3 | GL_ARB_vertex_type_2_10_10_10_rev]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void VertexAttribP4uiv(uint index, VertexAttribPointerType type, byte normalized, uint* value) => _VertexAttribP4uiv_fnptr(index, type, normalized, value);
+            public static void VertexAttribP4uiv(uint index, VertexAttribPointerType type, bool normalized, uint* value) => _VertexAttribP4uiv_fnptr(index, type, normalized, value);
             [UnmanagedCallersOnly]
-            private static void VertexAttribP4uiv_Lazy(uint index, VertexAttribPointerType type, byte normalized, uint* value)
+            private static void VertexAttribP4uiv_Lazy(uint index, VertexAttribPointerType type, bool normalized, uint* value)
             {
-                _VertexAttribP4uiv_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, byte, uint*, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP4uiv");
+                _VertexAttribP4uiv_fnptr = (delegate* unmanaged<uint, VertexAttribPointerType, bool, uint*, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribP4uiv");
                 _VertexAttribP4uiv_fnptr(index, type, normalized, value);
             }
             
@@ -19510,14 +19510,14 @@ namespace OpenTK.Graphics.OpenGL
                 return _NewObjectBufferATI_fnptr(size, pointer, usage);
             }
             
-            private static delegate* unmanaged<BufferHandle, byte> _IsObjectBufferATI_fnptr = &IsObjectBufferATI_Lazy;
+            private static delegate* unmanaged<BufferHandle, bool> _IsObjectBufferATI_fnptr = &IsObjectBufferATI_Lazy;
             /// <summary> <b>[requires: GL_ATI_vertex_array_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsObjectBufferATI(BufferHandle buffer) => _IsObjectBufferATI_fnptr(buffer);
+            public static bool IsObjectBufferATI(BufferHandle buffer) => _IsObjectBufferATI_fnptr(buffer);
             [UnmanagedCallersOnly]
-            private static byte IsObjectBufferATI_Lazy(BufferHandle buffer)
+            private static bool IsObjectBufferATI_Lazy(BufferHandle buffer)
             {
-                _IsObjectBufferATI_fnptr = (delegate* unmanaged<BufferHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsObjectBufferATI");
+                _IsObjectBufferATI_fnptr = (delegate* unmanaged<BufferHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsObjectBufferATI");
                 return _IsObjectBufferATI_fnptr(buffer);
             }
             
@@ -19631,14 +19631,14 @@ namespace OpenTK.Graphics.OpenGL
                 _GetVariantArrayObjectivATI_fnptr(id, pname, parameters);
             }
             
-            private static delegate* unmanaged<uint, int, VertexAttribPointerType, byte, int, BufferHandle, uint, void> _VertexAttribArrayObjectATI_fnptr = &VertexAttribArrayObjectATI_Lazy;
+            private static delegate* unmanaged<uint, int, VertexAttribPointerType, bool, int, BufferHandle, uint, void> _VertexAttribArrayObjectATI_fnptr = &VertexAttribArrayObjectATI_Lazy;
             /// <summary> <b>[requires: GL_ATI_vertex_attrib_array_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void VertexAttribArrayObjectATI(uint index, int size, VertexAttribPointerType type, byte normalized, int stride, BufferHandle buffer, uint offset) => _VertexAttribArrayObjectATI_fnptr(index, size, type, normalized, stride, buffer, offset);
+            public static void VertexAttribArrayObjectATI(uint index, int size, VertexAttribPointerType type, bool normalized, int stride, BufferHandle buffer, uint offset) => _VertexAttribArrayObjectATI_fnptr(index, size, type, normalized, stride, buffer, offset);
             [UnmanagedCallersOnly]
-            private static void VertexAttribArrayObjectATI_Lazy(uint index, int size, VertexAttribPointerType type, byte normalized, int stride, BufferHandle buffer, uint offset)
+            private static void VertexAttribArrayObjectATI_Lazy(uint index, int size, VertexAttribPointerType type, bool normalized, int stride, BufferHandle buffer, uint offset)
             {
-                _VertexAttribArrayObjectATI_fnptr = (delegate* unmanaged<uint, int, VertexAttribPointerType, byte, int, BufferHandle, uint, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribArrayObjectATI");
+                _VertexAttribArrayObjectATI_fnptr = (delegate* unmanaged<uint, int, VertexAttribPointerType, bool, int, BufferHandle, uint, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribArrayObjectATI");
                 _VertexAttribArrayObjectATI_fnptr(index, size, type, normalized, stride, buffer, offset);
             }
             
@@ -21724,14 +21724,14 @@ namespace OpenTK.Graphics.OpenGL
                 _DisableIndexedEXT_fnptr(target, index);
             }
             
-            private static delegate* unmanaged<EnableCap, uint, byte> _IsEnabledIndexedEXT_fnptr = &IsEnabledIndexedEXT_Lazy;
+            private static delegate* unmanaged<EnableCap, uint, bool> _IsEnabledIndexedEXT_fnptr = &IsEnabledIndexedEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_draw_buffers2]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsEnabledIndexedEXT(EnableCap target, uint index) => _IsEnabledIndexedEXT_fnptr(target, index);
+            public static bool IsEnabledIndexedEXT(EnableCap target, uint index) => _IsEnabledIndexedEXT_fnptr(target, index);
             [UnmanagedCallersOnly]
-            private static byte IsEnabledIndexedEXT_Lazy(EnableCap target, uint index)
+            private static bool IsEnabledIndexedEXT_Lazy(EnableCap target, uint index)
             {
-                _IsEnabledIndexedEXT_fnptr = (delegate* unmanaged<EnableCap, uint, byte>)GLLoader.BindingsContext.GetProcAddress("glIsEnabledIndexedEXT");
+                _IsEnabledIndexedEXT_fnptr = (delegate* unmanaged<EnableCap, uint, bool>)GLLoader.BindingsContext.GetProcAddress("glIsEnabledIndexedEXT");
                 return _IsEnabledIndexedEXT_fnptr(target, index);
             }
             
@@ -21746,14 +21746,14 @@ namespace OpenTK.Graphics.OpenGL
                 _GetIntegerIndexedvEXT_fnptr(target, index, data);
             }
             
-            private static delegate* unmanaged<BufferTargetARB, uint, byte*, void> _GetBooleanIndexedvEXT_fnptr = &GetBooleanIndexedvEXT_Lazy;
+            private static delegate* unmanaged<BufferTargetARB, uint, bool*, void> _GetBooleanIndexedvEXT_fnptr = &GetBooleanIndexedvEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_draw_buffers2]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetBooleanIndexedvEXT(BufferTargetARB target, uint index, byte* data) => _GetBooleanIndexedvEXT_fnptr(target, index, data);
+            public static void GetBooleanIndexedvEXT(BufferTargetARB target, uint index, bool* data) => _GetBooleanIndexedvEXT_fnptr(target, index, data);
             [UnmanagedCallersOnly]
-            private static void GetBooleanIndexedvEXT_Lazy(BufferTargetARB target, uint index, byte* data)
+            private static void GetBooleanIndexedvEXT_Lazy(BufferTargetARB target, uint index, bool* data)
             {
-                _GetBooleanIndexedvEXT_fnptr = (delegate* unmanaged<BufferTargetARB, uint, byte*, void>)GLLoader.BindingsContext.GetProcAddress("glGetBooleanIndexedvEXT");
+                _GetBooleanIndexedvEXT_fnptr = (delegate* unmanaged<BufferTargetARB, uint, bool*, void>)GLLoader.BindingsContext.GetProcAddress("glGetBooleanIndexedvEXT");
                 _GetBooleanIndexedvEXT_fnptr(target, index, data);
             }
             
@@ -21988,14 +21988,14 @@ namespace OpenTK.Graphics.OpenGL
                 return _MapNamedBufferEXT_fnptr(buffer, access);
             }
             
-            private static delegate* unmanaged<BufferHandle, byte> _UnmapNamedBufferEXT_fnptr = &UnmapNamedBufferEXT_Lazy;
+            private static delegate* unmanaged<BufferHandle, bool> _UnmapNamedBufferEXT_fnptr = &UnmapNamedBufferEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte UnmapNamedBufferEXT(BufferHandle buffer) => _UnmapNamedBufferEXT_fnptr(buffer);
+            public static bool UnmapNamedBufferEXT(BufferHandle buffer) => _UnmapNamedBufferEXT_fnptr(buffer);
             [UnmanagedCallersOnly]
-            private static byte UnmapNamedBufferEXT_Lazy(BufferHandle buffer)
+            private static bool UnmapNamedBufferEXT_Lazy(BufferHandle buffer)
             {
-                _UnmapNamedBufferEXT_fnptr = (delegate* unmanaged<BufferHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glUnmapNamedBufferEXT");
+                _UnmapNamedBufferEXT_fnptr = (delegate* unmanaged<BufferHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glUnmapNamedBufferEXT");
                 return _UnmapNamedBufferEXT_fnptr(buffer);
             }
             
@@ -22208,102 +22208,102 @@ namespace OpenTK.Graphics.OpenGL
                 _ProgramUniform4ivEXT_fnptr(program, location, count, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix2fvEXT_fnptr = &ProgramUniformMatrix2fvEXT_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix2fvEXT_fnptr = &ProgramUniformMatrix2fvEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix2fvEXT(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix2fvEXT_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix2fvEXT(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix2fvEXT_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix2fvEXT_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+            private static void ProgramUniformMatrix2fvEXT_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
             {
-                _ProgramUniformMatrix2fvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2fvEXT");
+                _ProgramUniformMatrix2fvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2fvEXT");
                 _ProgramUniformMatrix2fvEXT_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix3fvEXT_fnptr = &ProgramUniformMatrix3fvEXT_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix3fvEXT_fnptr = &ProgramUniformMatrix3fvEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix3fvEXT(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix3fvEXT_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix3fvEXT(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix3fvEXT_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix3fvEXT_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+            private static void ProgramUniformMatrix3fvEXT_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
             {
-                _ProgramUniformMatrix3fvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3fvEXT");
+                _ProgramUniformMatrix3fvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3fvEXT");
                 _ProgramUniformMatrix3fvEXT_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix4fvEXT_fnptr = &ProgramUniformMatrix4fvEXT_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix4fvEXT_fnptr = &ProgramUniformMatrix4fvEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix4fvEXT(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix4fvEXT_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix4fvEXT(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix4fvEXT_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix4fvEXT_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+            private static void ProgramUniformMatrix4fvEXT_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
             {
-                _ProgramUniformMatrix4fvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4fvEXT");
+                _ProgramUniformMatrix4fvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4fvEXT");
                 _ProgramUniformMatrix4fvEXT_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix2x3fvEXT_fnptr = &ProgramUniformMatrix2x3fvEXT_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix2x3fvEXT_fnptr = &ProgramUniformMatrix2x3fvEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix2x3fvEXT(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix2x3fvEXT_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix2x3fvEXT(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix2x3fvEXT_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix2x3fvEXT_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+            private static void ProgramUniformMatrix2x3fvEXT_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
             {
-                _ProgramUniformMatrix2x3fvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2x3fvEXT");
+                _ProgramUniformMatrix2x3fvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2x3fvEXT");
                 _ProgramUniformMatrix2x3fvEXT_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix3x2fvEXT_fnptr = &ProgramUniformMatrix3x2fvEXT_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix3x2fvEXT_fnptr = &ProgramUniformMatrix3x2fvEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix3x2fvEXT(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix3x2fvEXT_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix3x2fvEXT(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix3x2fvEXT_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix3x2fvEXT_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+            private static void ProgramUniformMatrix3x2fvEXT_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
             {
-                _ProgramUniformMatrix3x2fvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3x2fvEXT");
+                _ProgramUniformMatrix3x2fvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3x2fvEXT");
                 _ProgramUniformMatrix3x2fvEXT_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix2x4fvEXT_fnptr = &ProgramUniformMatrix2x4fvEXT_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix2x4fvEXT_fnptr = &ProgramUniformMatrix2x4fvEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix2x4fvEXT(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix2x4fvEXT_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix2x4fvEXT(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix2x4fvEXT_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix2x4fvEXT_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+            private static void ProgramUniformMatrix2x4fvEXT_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
             {
-                _ProgramUniformMatrix2x4fvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2x4fvEXT");
+                _ProgramUniformMatrix2x4fvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2x4fvEXT");
                 _ProgramUniformMatrix2x4fvEXT_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix4x2fvEXT_fnptr = &ProgramUniformMatrix4x2fvEXT_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix4x2fvEXT_fnptr = &ProgramUniformMatrix4x2fvEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix4x2fvEXT(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix4x2fvEXT_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix4x2fvEXT(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix4x2fvEXT_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix4x2fvEXT_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+            private static void ProgramUniformMatrix4x2fvEXT_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
             {
-                _ProgramUniformMatrix4x2fvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4x2fvEXT");
+                _ProgramUniformMatrix4x2fvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4x2fvEXT");
                 _ProgramUniformMatrix4x2fvEXT_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix3x4fvEXT_fnptr = &ProgramUniformMatrix3x4fvEXT_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix3x4fvEXT_fnptr = &ProgramUniformMatrix3x4fvEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix3x4fvEXT(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix3x4fvEXT_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix3x4fvEXT(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix3x4fvEXT_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix3x4fvEXT_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+            private static void ProgramUniformMatrix3x4fvEXT_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
             {
-                _ProgramUniformMatrix3x4fvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3x4fvEXT");
+                _ProgramUniformMatrix3x4fvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3x4fvEXT");
                 _ProgramUniformMatrix3x4fvEXT_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix4x3fvEXT_fnptr = &ProgramUniformMatrix4x3fvEXT_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix4x3fvEXT_fnptr = &ProgramUniformMatrix4x3fvEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix4x3fvEXT(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix4x3fvEXT_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix4x3fvEXT(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix4x3fvEXT_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix4x3fvEXT_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+            private static void ProgramUniformMatrix4x3fvEXT_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
             {
-                _ProgramUniformMatrix4x3fvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4x3fvEXT");
+                _ProgramUniformMatrix4x3fvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4x3fvEXT");
                 _ProgramUniformMatrix4x3fvEXT_fnptr(program, location, count, transpose, value);
             }
             
@@ -23099,14 +23099,14 @@ namespace OpenTK.Graphics.OpenGL
                 _VertexArraySecondaryColorOffsetEXT_fnptr(vaobj, buffer, size, type, stride, offset);
             }
             
-            private static delegate* unmanaged<VertexArrayHandle, BufferHandle, uint, int, VertexAttribPointerType, byte, int, IntPtr, void> _VertexArrayVertexAttribOffsetEXT_fnptr = &VertexArrayVertexAttribOffsetEXT_Lazy;
+            private static delegate* unmanaged<VertexArrayHandle, BufferHandle, uint, int, VertexAttribPointerType, bool, int, IntPtr, void> _VertexArrayVertexAttribOffsetEXT_fnptr = &VertexArrayVertexAttribOffsetEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void VertexArrayVertexAttribOffsetEXT(VertexArrayHandle vaobj, BufferHandle buffer, uint index, int size, VertexAttribPointerType type, byte normalized, int stride, IntPtr offset) => _VertexArrayVertexAttribOffsetEXT_fnptr(vaobj, buffer, index, size, type, normalized, stride, offset);
+            public static void VertexArrayVertexAttribOffsetEXT(VertexArrayHandle vaobj, BufferHandle buffer, uint index, int size, VertexAttribPointerType type, bool normalized, int stride, IntPtr offset) => _VertexArrayVertexAttribOffsetEXT_fnptr(vaobj, buffer, index, size, type, normalized, stride, offset);
             [UnmanagedCallersOnly]
-            private static void VertexArrayVertexAttribOffsetEXT_Lazy(VertexArrayHandle vaobj, BufferHandle buffer, uint index, int size, VertexAttribPointerType type, byte normalized, int stride, IntPtr offset)
+            private static void VertexArrayVertexAttribOffsetEXT_Lazy(VertexArrayHandle vaobj, BufferHandle buffer, uint index, int size, VertexAttribPointerType type, bool normalized, int stride, IntPtr offset)
             {
-                _VertexArrayVertexAttribOffsetEXT_fnptr = (delegate* unmanaged<VertexArrayHandle, BufferHandle, uint, int, VertexAttribPointerType, byte, int, IntPtr, void>)GLLoader.BindingsContext.GetProcAddress("glVertexArrayVertexAttribOffsetEXT");
+                _VertexArrayVertexAttribOffsetEXT_fnptr = (delegate* unmanaged<VertexArrayHandle, BufferHandle, uint, int, VertexAttribPointerType, bool, int, IntPtr, void>)GLLoader.BindingsContext.GetProcAddress("glVertexArrayVertexAttribOffsetEXT");
                 _VertexArrayVertexAttribOffsetEXT_fnptr(vaobj, buffer, index, size, type, normalized, stride, offset);
             }
             
@@ -23374,102 +23374,102 @@ namespace OpenTK.Graphics.OpenGL
                 _ProgramUniform4dvEXT_fnptr(program, location, count, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, double*, void> _ProgramUniformMatrix2dvEXT_fnptr = &ProgramUniformMatrix2dvEXT_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, double*, void> _ProgramUniformMatrix2dvEXT_fnptr = &ProgramUniformMatrix2dvEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix2dvEXT(ProgramHandle program, int location, int count, byte transpose, double* value) => _ProgramUniformMatrix2dvEXT_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix2dvEXT(ProgramHandle program, int location, int count, bool transpose, double* value) => _ProgramUniformMatrix2dvEXT_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix2dvEXT_Lazy(ProgramHandle program, int location, int count, byte transpose, double* value)
+            private static void ProgramUniformMatrix2dvEXT_Lazy(ProgramHandle program, int location, int count, bool transpose, double* value)
             {
-                _ProgramUniformMatrix2dvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2dvEXT");
+                _ProgramUniformMatrix2dvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2dvEXT");
                 _ProgramUniformMatrix2dvEXT_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, double*, void> _ProgramUniformMatrix3dvEXT_fnptr = &ProgramUniformMatrix3dvEXT_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, double*, void> _ProgramUniformMatrix3dvEXT_fnptr = &ProgramUniformMatrix3dvEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix3dvEXT(ProgramHandle program, int location, int count, byte transpose, double* value) => _ProgramUniformMatrix3dvEXT_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix3dvEXT(ProgramHandle program, int location, int count, bool transpose, double* value) => _ProgramUniformMatrix3dvEXT_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix3dvEXT_Lazy(ProgramHandle program, int location, int count, byte transpose, double* value)
+            private static void ProgramUniformMatrix3dvEXT_Lazy(ProgramHandle program, int location, int count, bool transpose, double* value)
             {
-                _ProgramUniformMatrix3dvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3dvEXT");
+                _ProgramUniformMatrix3dvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3dvEXT");
                 _ProgramUniformMatrix3dvEXT_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, double*, void> _ProgramUniformMatrix4dvEXT_fnptr = &ProgramUniformMatrix4dvEXT_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, double*, void> _ProgramUniformMatrix4dvEXT_fnptr = &ProgramUniformMatrix4dvEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix4dvEXT(ProgramHandle program, int location, int count, byte transpose, double* value) => _ProgramUniformMatrix4dvEXT_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix4dvEXT(ProgramHandle program, int location, int count, bool transpose, double* value) => _ProgramUniformMatrix4dvEXT_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix4dvEXT_Lazy(ProgramHandle program, int location, int count, byte transpose, double* value)
+            private static void ProgramUniformMatrix4dvEXT_Lazy(ProgramHandle program, int location, int count, bool transpose, double* value)
             {
-                _ProgramUniformMatrix4dvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4dvEXT");
+                _ProgramUniformMatrix4dvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4dvEXT");
                 _ProgramUniformMatrix4dvEXT_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, double*, void> _ProgramUniformMatrix2x3dvEXT_fnptr = &ProgramUniformMatrix2x3dvEXT_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, double*, void> _ProgramUniformMatrix2x3dvEXT_fnptr = &ProgramUniformMatrix2x3dvEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix2x3dvEXT(ProgramHandle program, int location, int count, byte transpose, double* value) => _ProgramUniformMatrix2x3dvEXT_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix2x3dvEXT(ProgramHandle program, int location, int count, bool transpose, double* value) => _ProgramUniformMatrix2x3dvEXT_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix2x3dvEXT_Lazy(ProgramHandle program, int location, int count, byte transpose, double* value)
+            private static void ProgramUniformMatrix2x3dvEXT_Lazy(ProgramHandle program, int location, int count, bool transpose, double* value)
             {
-                _ProgramUniformMatrix2x3dvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2x3dvEXT");
+                _ProgramUniformMatrix2x3dvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2x3dvEXT");
                 _ProgramUniformMatrix2x3dvEXT_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, double*, void> _ProgramUniformMatrix2x4dvEXT_fnptr = &ProgramUniformMatrix2x4dvEXT_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, double*, void> _ProgramUniformMatrix2x4dvEXT_fnptr = &ProgramUniformMatrix2x4dvEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix2x4dvEXT(ProgramHandle program, int location, int count, byte transpose, double* value) => _ProgramUniformMatrix2x4dvEXT_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix2x4dvEXT(ProgramHandle program, int location, int count, bool transpose, double* value) => _ProgramUniformMatrix2x4dvEXT_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix2x4dvEXT_Lazy(ProgramHandle program, int location, int count, byte transpose, double* value)
+            private static void ProgramUniformMatrix2x4dvEXT_Lazy(ProgramHandle program, int location, int count, bool transpose, double* value)
             {
-                _ProgramUniformMatrix2x4dvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2x4dvEXT");
+                _ProgramUniformMatrix2x4dvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2x4dvEXT");
                 _ProgramUniformMatrix2x4dvEXT_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, double*, void> _ProgramUniformMatrix3x2dvEXT_fnptr = &ProgramUniformMatrix3x2dvEXT_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, double*, void> _ProgramUniformMatrix3x2dvEXT_fnptr = &ProgramUniformMatrix3x2dvEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix3x2dvEXT(ProgramHandle program, int location, int count, byte transpose, double* value) => _ProgramUniformMatrix3x2dvEXT_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix3x2dvEXT(ProgramHandle program, int location, int count, bool transpose, double* value) => _ProgramUniformMatrix3x2dvEXT_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix3x2dvEXT_Lazy(ProgramHandle program, int location, int count, byte transpose, double* value)
+            private static void ProgramUniformMatrix3x2dvEXT_Lazy(ProgramHandle program, int location, int count, bool transpose, double* value)
             {
-                _ProgramUniformMatrix3x2dvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3x2dvEXT");
+                _ProgramUniformMatrix3x2dvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3x2dvEXT");
                 _ProgramUniformMatrix3x2dvEXT_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, double*, void> _ProgramUniformMatrix3x4dvEXT_fnptr = &ProgramUniformMatrix3x4dvEXT_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, double*, void> _ProgramUniformMatrix3x4dvEXT_fnptr = &ProgramUniformMatrix3x4dvEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix3x4dvEXT(ProgramHandle program, int location, int count, byte transpose, double* value) => _ProgramUniformMatrix3x4dvEXT_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix3x4dvEXT(ProgramHandle program, int location, int count, bool transpose, double* value) => _ProgramUniformMatrix3x4dvEXT_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix3x4dvEXT_Lazy(ProgramHandle program, int location, int count, byte transpose, double* value)
+            private static void ProgramUniformMatrix3x4dvEXT_Lazy(ProgramHandle program, int location, int count, bool transpose, double* value)
             {
-                _ProgramUniformMatrix3x4dvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3x4dvEXT");
+                _ProgramUniformMatrix3x4dvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3x4dvEXT");
                 _ProgramUniformMatrix3x4dvEXT_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, double*, void> _ProgramUniformMatrix4x2dvEXT_fnptr = &ProgramUniformMatrix4x2dvEXT_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, double*, void> _ProgramUniformMatrix4x2dvEXT_fnptr = &ProgramUniformMatrix4x2dvEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix4x2dvEXT(ProgramHandle program, int location, int count, byte transpose, double* value) => _ProgramUniformMatrix4x2dvEXT_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix4x2dvEXT(ProgramHandle program, int location, int count, bool transpose, double* value) => _ProgramUniformMatrix4x2dvEXT_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix4x2dvEXT_Lazy(ProgramHandle program, int location, int count, byte transpose, double* value)
+            private static void ProgramUniformMatrix4x2dvEXT_Lazy(ProgramHandle program, int location, int count, bool transpose, double* value)
             {
-                _ProgramUniformMatrix4x2dvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4x2dvEXT");
+                _ProgramUniformMatrix4x2dvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4x2dvEXT");
                 _ProgramUniformMatrix4x2dvEXT_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, double*, void> _ProgramUniformMatrix4x3dvEXT_fnptr = &ProgramUniformMatrix4x3dvEXT_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, double*, void> _ProgramUniformMatrix4x3dvEXT_fnptr = &ProgramUniformMatrix4x3dvEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix4x3dvEXT(ProgramHandle program, int location, int count, byte transpose, double* value) => _ProgramUniformMatrix4x3dvEXT_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix4x3dvEXT(ProgramHandle program, int location, int count, bool transpose, double* value) => _ProgramUniformMatrix4x3dvEXT_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix4x3dvEXT_Lazy(ProgramHandle program, int location, int count, byte transpose, double* value)
+            private static void ProgramUniformMatrix4x3dvEXT_Lazy(ProgramHandle program, int location, int count, bool transpose, double* value)
             {
-                _ProgramUniformMatrix4x3dvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4x3dvEXT");
+                _ProgramUniformMatrix4x3dvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, double*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4x3dvEXT");
                 _ProgramUniformMatrix4x3dvEXT_fnptr(program, location, count, transpose, value);
             }
             
@@ -23517,25 +23517,25 @@ namespace OpenTK.Graphics.OpenGL
                 _TextureStorage3DEXT_fnptr(texture, target, levels, internalformat, width, height, depth);
             }
             
-            private static delegate* unmanaged<TextureHandle, TextureTarget, int, SizedInternalFormat, int, int, byte, void> _TextureStorage2DMultisampleEXT_fnptr = &TextureStorage2DMultisampleEXT_Lazy;
+            private static delegate* unmanaged<TextureHandle, TextureTarget, int, SizedInternalFormat, int, int, bool, void> _TextureStorage2DMultisampleEXT_fnptr = &TextureStorage2DMultisampleEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureStorage2DMultisampleEXT(TextureHandle texture, TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, byte fixedsamplelocations) => _TextureStorage2DMultisampleEXT_fnptr(texture, target, samples, internalformat, width, height, fixedsamplelocations);
+            public static void TextureStorage2DMultisampleEXT(TextureHandle texture, TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, bool fixedsamplelocations) => _TextureStorage2DMultisampleEXT_fnptr(texture, target, samples, internalformat, width, height, fixedsamplelocations);
             [UnmanagedCallersOnly]
-            private static void TextureStorage2DMultisampleEXT_Lazy(TextureHandle texture, TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, byte fixedsamplelocations)
+            private static void TextureStorage2DMultisampleEXT_Lazy(TextureHandle texture, TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, bool fixedsamplelocations)
             {
-                _TextureStorage2DMultisampleEXT_fnptr = (delegate* unmanaged<TextureHandle, TextureTarget, int, SizedInternalFormat, int, int, byte, void>)GLLoader.BindingsContext.GetProcAddress("glTextureStorage2DMultisampleEXT");
+                _TextureStorage2DMultisampleEXT_fnptr = (delegate* unmanaged<TextureHandle, TextureTarget, int, SizedInternalFormat, int, int, bool, void>)GLLoader.BindingsContext.GetProcAddress("glTextureStorage2DMultisampleEXT");
                 _TextureStorage2DMultisampleEXT_fnptr(texture, target, samples, internalformat, width, height, fixedsamplelocations);
             }
             
-            private static delegate* unmanaged<TextureHandle, All, int, SizedInternalFormat, int, int, int, byte, void> _TextureStorage3DMultisampleEXT_fnptr = &TextureStorage3DMultisampleEXT_Lazy;
+            private static delegate* unmanaged<TextureHandle, All, int, SizedInternalFormat, int, int, int, bool, void> _TextureStorage3DMultisampleEXT_fnptr = &TextureStorage3DMultisampleEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureStorage3DMultisampleEXT(TextureHandle texture, All target, int samples, SizedInternalFormat internalformat, int width, int height, int depth, byte fixedsamplelocations) => _TextureStorage3DMultisampleEXT_fnptr(texture, target, samples, internalformat, width, height, depth, fixedsamplelocations);
+            public static void TextureStorage3DMultisampleEXT(TextureHandle texture, All target, int samples, SizedInternalFormat internalformat, int width, int height, int depth, bool fixedsamplelocations) => _TextureStorage3DMultisampleEXT_fnptr(texture, target, samples, internalformat, width, height, depth, fixedsamplelocations);
             [UnmanagedCallersOnly]
-            private static void TextureStorage3DMultisampleEXT_Lazy(TextureHandle texture, All target, int samples, SizedInternalFormat internalformat, int width, int height, int depth, byte fixedsamplelocations)
+            private static void TextureStorage3DMultisampleEXT_Lazy(TextureHandle texture, All target, int samples, SizedInternalFormat internalformat, int width, int height, int depth, bool fixedsamplelocations)
             {
-                _TextureStorage3DMultisampleEXT_fnptr = (delegate* unmanaged<TextureHandle, All, int, SizedInternalFormat, int, int, int, byte, void>)GLLoader.BindingsContext.GetProcAddress("glTextureStorage3DMultisampleEXT");
+                _TextureStorage3DMultisampleEXT_fnptr = (delegate* unmanaged<TextureHandle, All, int, SizedInternalFormat, int, int, int, bool, void>)GLLoader.BindingsContext.GetProcAddress("glTextureStorage3DMultisampleEXT");
                 _TextureStorage3DMultisampleEXT_fnptr(texture, target, samples, internalformat, width, height, depth, fixedsamplelocations);
             }
             
@@ -23550,14 +23550,14 @@ namespace OpenTK.Graphics.OpenGL
                 _VertexArrayBindVertexBufferEXT_fnptr(vaobj, bindingindex, buffer, offset, stride);
             }
             
-            private static delegate* unmanaged<VertexArrayHandle, uint, int, VertexAttribType, byte, uint, void> _VertexArrayVertexAttribFormatEXT_fnptr = &VertexArrayVertexAttribFormatEXT_Lazy;
+            private static delegate* unmanaged<VertexArrayHandle, uint, int, VertexAttribType, bool, uint, void> _VertexArrayVertexAttribFormatEXT_fnptr = &VertexArrayVertexAttribFormatEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void VertexArrayVertexAttribFormatEXT(VertexArrayHandle vaobj, uint attribindex, int size, VertexAttribType type, byte normalized, uint relativeoffset) => _VertexArrayVertexAttribFormatEXT_fnptr(vaobj, attribindex, size, type, normalized, relativeoffset);
+            public static void VertexArrayVertexAttribFormatEXT(VertexArrayHandle vaobj, uint attribindex, int size, VertexAttribType type, bool normalized, uint relativeoffset) => _VertexArrayVertexAttribFormatEXT_fnptr(vaobj, attribindex, size, type, normalized, relativeoffset);
             [UnmanagedCallersOnly]
-            private static void VertexArrayVertexAttribFormatEXT_Lazy(VertexArrayHandle vaobj, uint attribindex, int size, VertexAttribType type, byte normalized, uint relativeoffset)
+            private static void VertexArrayVertexAttribFormatEXT_Lazy(VertexArrayHandle vaobj, uint attribindex, int size, VertexAttribType type, bool normalized, uint relativeoffset)
             {
-                _VertexArrayVertexAttribFormatEXT_fnptr = (delegate* unmanaged<VertexArrayHandle, uint, int, VertexAttribType, byte, uint, void>)GLLoader.BindingsContext.GetProcAddress("glVertexArrayVertexAttribFormatEXT");
+                _VertexArrayVertexAttribFormatEXT_fnptr = (delegate* unmanaged<VertexArrayHandle, uint, int, VertexAttribType, bool, uint, void>)GLLoader.BindingsContext.GetProcAddress("glVertexArrayVertexAttribFormatEXT");
                 _VertexArrayVertexAttribFormatEXT_fnptr(vaobj, attribindex, size, type, normalized, relativeoffset);
             }
             
@@ -23616,14 +23616,14 @@ namespace OpenTK.Graphics.OpenGL
                 _VertexArrayVertexAttribLOffsetEXT_fnptr(vaobj, buffer, index, size, type, stride, offset);
             }
             
-            private static delegate* unmanaged<TextureHandle, int, int, int, int, int, int, int, byte, void> _TexturePageCommitmentEXT_fnptr = &TexturePageCommitmentEXT_Lazy;
+            private static delegate* unmanaged<TextureHandle, int, int, int, int, int, int, int, bool, void> _TexturePageCommitmentEXT_fnptr = &TexturePageCommitmentEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TexturePageCommitmentEXT(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, byte commit) => _TexturePageCommitmentEXT_fnptr(texture, level, xoffset, yoffset, zoffset, width, height, depth, commit);
+            public static void TexturePageCommitmentEXT(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, bool commit) => _TexturePageCommitmentEXT_fnptr(texture, level, xoffset, yoffset, zoffset, width, height, depth, commit);
             [UnmanagedCallersOnly]
-            private static void TexturePageCommitmentEXT_Lazy(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, byte commit)
+            private static void TexturePageCommitmentEXT_Lazy(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, bool commit)
             {
-                _TexturePageCommitmentEXT_fnptr = (delegate* unmanaged<TextureHandle, int, int, int, int, int, int, int, byte, void>)GLLoader.BindingsContext.GetProcAddress("glTexturePageCommitmentEXT");
+                _TexturePageCommitmentEXT_fnptr = (delegate* unmanaged<TextureHandle, int, int, int, int, int, int, int, bool, void>)GLLoader.BindingsContext.GetProcAddress("glTexturePageCommitmentEXT");
                 _TexturePageCommitmentEXT_fnptr(texture, level, xoffset, yoffset, zoffset, width, height, depth, commit);
             }
             
@@ -23638,14 +23638,14 @@ namespace OpenTK.Graphics.OpenGL
                 _VertexArrayVertexAttribDivisorEXT_fnptr(vaobj, index, divisor);
             }
             
-            private static delegate* unmanaged<uint, byte, byte, byte, byte, void> _ColorMaskIndexedEXT_fnptr = &ColorMaskIndexedEXT_Lazy;
+            private static delegate* unmanaged<uint, bool, bool, bool, bool, void> _ColorMaskIndexedEXT_fnptr = &ColorMaskIndexedEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_draw_buffers2]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ColorMaskIndexedEXT(uint index, byte r, byte g, byte b, byte a) => _ColorMaskIndexedEXT_fnptr(index, r, g, b, a);
+            public static void ColorMaskIndexedEXT(uint index, bool r, bool g, bool b, bool a) => _ColorMaskIndexedEXT_fnptr(index, r, g, b, a);
             [UnmanagedCallersOnly]
-            private static void ColorMaskIndexedEXT_Lazy(uint index, byte r, byte g, byte b, byte a)
+            private static void ColorMaskIndexedEXT_Lazy(uint index, bool r, bool g, bool b, bool a)
             {
-                _ColorMaskIndexedEXT_fnptr = (delegate* unmanaged<uint, byte, byte, byte, byte, void>)GLLoader.BindingsContext.GetProcAddress("glColorMaskIndexedEXT");
+                _ColorMaskIndexedEXT_fnptr = (delegate* unmanaged<uint, bool, bool, bool, bool, void>)GLLoader.BindingsContext.GetProcAddress("glColorMaskIndexedEXT");
                 _ColorMaskIndexedEXT_fnptr(index, r, g, b, a);
             }
             
@@ -23781,14 +23781,14 @@ namespace OpenTK.Graphics.OpenGL
                 _RenderbufferStorageMultisampleEXT_fnptr(target, samples, internalformat, width, height);
             }
             
-            private static delegate* unmanaged<RenderbufferHandle, byte> _IsRenderbufferEXT_fnptr = &IsRenderbufferEXT_Lazy;
+            private static delegate* unmanaged<RenderbufferHandle, bool> _IsRenderbufferEXT_fnptr = &IsRenderbufferEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_framebuffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsRenderbufferEXT(RenderbufferHandle renderbuffer) => _IsRenderbufferEXT_fnptr(renderbuffer);
+            public static bool IsRenderbufferEXT(RenderbufferHandle renderbuffer) => _IsRenderbufferEXT_fnptr(renderbuffer);
             [UnmanagedCallersOnly]
-            private static byte IsRenderbufferEXT_Lazy(RenderbufferHandle renderbuffer)
+            private static bool IsRenderbufferEXT_Lazy(RenderbufferHandle renderbuffer)
             {
-                _IsRenderbufferEXT_fnptr = (delegate* unmanaged<RenderbufferHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsRenderbufferEXT");
+                _IsRenderbufferEXT_fnptr = (delegate* unmanaged<RenderbufferHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsRenderbufferEXT");
                 return _IsRenderbufferEXT_fnptr(renderbuffer);
             }
             
@@ -23847,14 +23847,14 @@ namespace OpenTK.Graphics.OpenGL
                 _GetRenderbufferParameterivEXT_fnptr(target, pname, parameters);
             }
             
-            private static delegate* unmanaged<FramebufferHandle, byte> _IsFramebufferEXT_fnptr = &IsFramebufferEXT_Lazy;
+            private static delegate* unmanaged<FramebufferHandle, bool> _IsFramebufferEXT_fnptr = &IsFramebufferEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_framebuffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsFramebufferEXT(FramebufferHandle framebuffer) => _IsFramebufferEXT_fnptr(framebuffer);
+            public static bool IsFramebufferEXT(FramebufferHandle framebuffer) => _IsFramebufferEXT_fnptr(framebuffer);
             [UnmanagedCallersOnly]
-            private static byte IsFramebufferEXT_Lazy(FramebufferHandle framebuffer)
+            private static bool IsFramebufferEXT_Lazy(FramebufferHandle framebuffer)
             {
-                _IsFramebufferEXT_fnptr = (delegate* unmanaged<FramebufferHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsFramebufferEXT");
+                _IsFramebufferEXT_fnptr = (delegate* unmanaged<FramebufferHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsFramebufferEXT");
                 return _IsFramebufferEXT_fnptr(framebuffer);
             }
             
@@ -24375,14 +24375,14 @@ namespace OpenTK.Graphics.OpenGL
                 _GetVertexAttribIuivEXT_fnptr(index, pname, parameters);
             }
             
-            private static delegate* unmanaged<HistogramTargetEXT, byte, PixelFormat, PixelType, void*, void> _GetHistogramEXT_fnptr = &GetHistogramEXT_Lazy;
+            private static delegate* unmanaged<HistogramTargetEXT, bool, PixelFormat, PixelType, void*, void> _GetHistogramEXT_fnptr = &GetHistogramEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_histogram]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetHistogramEXT(HistogramTargetEXT target, byte reset, PixelFormat format, PixelType type, void* values) => _GetHistogramEXT_fnptr(target, reset, format, type, values);
+            public static void GetHistogramEXT(HistogramTargetEXT target, bool reset, PixelFormat format, PixelType type, void* values) => _GetHistogramEXT_fnptr(target, reset, format, type, values);
             [UnmanagedCallersOnly]
-            private static void GetHistogramEXT_Lazy(HistogramTargetEXT target, byte reset, PixelFormat format, PixelType type, void* values)
+            private static void GetHistogramEXT_Lazy(HistogramTargetEXT target, bool reset, PixelFormat format, PixelType type, void* values)
             {
-                _GetHistogramEXT_fnptr = (delegate* unmanaged<HistogramTargetEXT, byte, PixelFormat, PixelType, void*, void>)GLLoader.BindingsContext.GetProcAddress("glGetHistogramEXT");
+                _GetHistogramEXT_fnptr = (delegate* unmanaged<HistogramTargetEXT, bool, PixelFormat, PixelType, void*, void>)GLLoader.BindingsContext.GetProcAddress("glGetHistogramEXT");
                 _GetHistogramEXT_fnptr(target, reset, format, type, values);
             }
             
@@ -24408,14 +24408,14 @@ namespace OpenTK.Graphics.OpenGL
                 _GetHistogramParameterivEXT_fnptr(target, pname, parameters);
             }
             
-            private static delegate* unmanaged<MinmaxTargetEXT, byte, PixelFormat, PixelType, void*, void> _GetMinmaxEXT_fnptr = &GetMinmaxEXT_Lazy;
+            private static delegate* unmanaged<MinmaxTargetEXT, bool, PixelFormat, PixelType, void*, void> _GetMinmaxEXT_fnptr = &GetMinmaxEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_histogram]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetMinmaxEXT(MinmaxTargetEXT target, byte reset, PixelFormat format, PixelType type, void* values) => _GetMinmaxEXT_fnptr(target, reset, format, type, values);
+            public static void GetMinmaxEXT(MinmaxTargetEXT target, bool reset, PixelFormat format, PixelType type, void* values) => _GetMinmaxEXT_fnptr(target, reset, format, type, values);
             [UnmanagedCallersOnly]
-            private static void GetMinmaxEXT_Lazy(MinmaxTargetEXT target, byte reset, PixelFormat format, PixelType type, void* values)
+            private static void GetMinmaxEXT_Lazy(MinmaxTargetEXT target, bool reset, PixelFormat format, PixelType type, void* values)
             {
-                _GetMinmaxEXT_fnptr = (delegate* unmanaged<MinmaxTargetEXT, byte, PixelFormat, PixelType, void*, void>)GLLoader.BindingsContext.GetProcAddress("glGetMinmaxEXT");
+                _GetMinmaxEXT_fnptr = (delegate* unmanaged<MinmaxTargetEXT, bool, PixelFormat, PixelType, void*, void>)GLLoader.BindingsContext.GetProcAddress("glGetMinmaxEXT");
                 _GetMinmaxEXT_fnptr(target, reset, format, type, values);
             }
             
@@ -24441,25 +24441,25 @@ namespace OpenTK.Graphics.OpenGL
                 _GetMinmaxParameterivEXT_fnptr(target, pname, parameters);
             }
             
-            private static delegate* unmanaged<HistogramTargetEXT, int, InternalFormat, byte, void> _HistogramEXT_fnptr = &HistogramEXT_Lazy;
+            private static delegate* unmanaged<HistogramTargetEXT, int, InternalFormat, bool, void> _HistogramEXT_fnptr = &HistogramEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_histogram]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void HistogramEXT(HistogramTargetEXT target, int width, InternalFormat internalformat, byte sink) => _HistogramEXT_fnptr(target, width, internalformat, sink);
+            public static void HistogramEXT(HistogramTargetEXT target, int width, InternalFormat internalformat, bool sink) => _HistogramEXT_fnptr(target, width, internalformat, sink);
             [UnmanagedCallersOnly]
-            private static void HistogramEXT_Lazy(HistogramTargetEXT target, int width, InternalFormat internalformat, byte sink)
+            private static void HistogramEXT_Lazy(HistogramTargetEXT target, int width, InternalFormat internalformat, bool sink)
             {
-                _HistogramEXT_fnptr = (delegate* unmanaged<HistogramTargetEXT, int, InternalFormat, byte, void>)GLLoader.BindingsContext.GetProcAddress("glHistogramEXT");
+                _HistogramEXT_fnptr = (delegate* unmanaged<HistogramTargetEXT, int, InternalFormat, bool, void>)GLLoader.BindingsContext.GetProcAddress("glHistogramEXT");
                 _HistogramEXT_fnptr(target, width, internalformat, sink);
             }
             
-            private static delegate* unmanaged<MinmaxTargetEXT, InternalFormat, byte, void> _MinmaxEXT_fnptr = &MinmaxEXT_Lazy;
+            private static delegate* unmanaged<MinmaxTargetEXT, InternalFormat, bool, void> _MinmaxEXT_fnptr = &MinmaxEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_histogram]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void MinmaxEXT(MinmaxTargetEXT target, InternalFormat internalformat, byte sink) => _MinmaxEXT_fnptr(target, internalformat, sink);
+            public static void MinmaxEXT(MinmaxTargetEXT target, InternalFormat internalformat, bool sink) => _MinmaxEXT_fnptr(target, internalformat, sink);
             [UnmanagedCallersOnly]
-            private static void MinmaxEXT_Lazy(MinmaxTargetEXT target, InternalFormat internalformat, byte sink)
+            private static void MinmaxEXT_Lazy(MinmaxTargetEXT target, InternalFormat internalformat, bool sink)
             {
-                _MinmaxEXT_fnptr = (delegate* unmanaged<MinmaxTargetEXT, InternalFormat, byte, void>)GLLoader.BindingsContext.GetProcAddress("glMinmaxEXT");
+                _MinmaxEXT_fnptr = (delegate* unmanaged<MinmaxTargetEXT, InternalFormat, bool, void>)GLLoader.BindingsContext.GetProcAddress("glMinmaxEXT");
                 _MinmaxEXT_fnptr(target, internalformat, sink);
             }
             
@@ -24573,14 +24573,14 @@ namespace OpenTK.Graphics.OpenGL
                 _DeleteMemoryObjectsEXT_fnptr(n, memoryObjects);
             }
             
-            private static delegate* unmanaged<uint, byte> _IsMemoryObjectEXT_fnptr = &IsMemoryObjectEXT_Lazy;
+            private static delegate* unmanaged<uint, bool> _IsMemoryObjectEXT_fnptr = &IsMemoryObjectEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_memory_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsMemoryObjectEXT(uint memoryObject) => _IsMemoryObjectEXT_fnptr(memoryObject);
+            public static bool IsMemoryObjectEXT(uint memoryObject) => _IsMemoryObjectEXT_fnptr(memoryObject);
             [UnmanagedCallersOnly]
-            private static byte IsMemoryObjectEXT_Lazy(uint memoryObject)
+            private static bool IsMemoryObjectEXT_Lazy(uint memoryObject)
             {
-                _IsMemoryObjectEXT_fnptr = (delegate* unmanaged<uint, byte>)GLLoader.BindingsContext.GetProcAddress("glIsMemoryObjectEXT");
+                _IsMemoryObjectEXT_fnptr = (delegate* unmanaged<uint, bool>)GLLoader.BindingsContext.GetProcAddress("glIsMemoryObjectEXT");
                 return _IsMemoryObjectEXT_fnptr(memoryObject);
             }
             
@@ -24628,14 +24628,14 @@ namespace OpenTK.Graphics.OpenGL
                 _TexStorageMem2DEXT_fnptr(target, levels, internalFormat, width, height, memory, offset);
             }
             
-            private static delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, byte, uint, ulong, void> _TexStorageMem2DMultisampleEXT_fnptr = &TexStorageMem2DMultisampleEXT_Lazy;
+            private static delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, bool, uint, ulong, void> _TexStorageMem2DMultisampleEXT_fnptr = &TexStorageMem2DMultisampleEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_memory_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TexStorageMem2DMultisampleEXT(TextureTarget target, int samples, SizedInternalFormat internalFormat, int width, int height, byte fixedSampleLocations, uint memory, ulong offset) => _TexStorageMem2DMultisampleEXT_fnptr(target, samples, internalFormat, width, height, fixedSampleLocations, memory, offset);
+            public static void TexStorageMem2DMultisampleEXT(TextureTarget target, int samples, SizedInternalFormat internalFormat, int width, int height, bool fixedSampleLocations, uint memory, ulong offset) => _TexStorageMem2DMultisampleEXT_fnptr(target, samples, internalFormat, width, height, fixedSampleLocations, memory, offset);
             [UnmanagedCallersOnly]
-            private static void TexStorageMem2DMultisampleEXT_Lazy(TextureTarget target, int samples, SizedInternalFormat internalFormat, int width, int height, byte fixedSampleLocations, uint memory, ulong offset)
+            private static void TexStorageMem2DMultisampleEXT_Lazy(TextureTarget target, int samples, SizedInternalFormat internalFormat, int width, int height, bool fixedSampleLocations, uint memory, ulong offset)
             {
-                _TexStorageMem2DMultisampleEXT_fnptr = (delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, byte, uint, ulong, void>)GLLoader.BindingsContext.GetProcAddress("glTexStorageMem2DMultisampleEXT");
+                _TexStorageMem2DMultisampleEXT_fnptr = (delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, bool, uint, ulong, void>)GLLoader.BindingsContext.GetProcAddress("glTexStorageMem2DMultisampleEXT");
                 _TexStorageMem2DMultisampleEXT_fnptr(target, samples, internalFormat, width, height, fixedSampleLocations, memory, offset);
             }
             
@@ -24650,14 +24650,14 @@ namespace OpenTK.Graphics.OpenGL
                 _TexStorageMem3DEXT_fnptr(target, levels, internalFormat, width, height, depth, memory, offset);
             }
             
-            private static delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, int, byte, uint, ulong, void> _TexStorageMem3DMultisampleEXT_fnptr = &TexStorageMem3DMultisampleEXT_Lazy;
+            private static delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, int, bool, uint, ulong, void> _TexStorageMem3DMultisampleEXT_fnptr = &TexStorageMem3DMultisampleEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_memory_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TexStorageMem3DMultisampleEXT(TextureTarget target, int samples, SizedInternalFormat internalFormat, int width, int height, int depth, byte fixedSampleLocations, uint memory, ulong offset) => _TexStorageMem3DMultisampleEXT_fnptr(target, samples, internalFormat, width, height, depth, fixedSampleLocations, memory, offset);
+            public static void TexStorageMem3DMultisampleEXT(TextureTarget target, int samples, SizedInternalFormat internalFormat, int width, int height, int depth, bool fixedSampleLocations, uint memory, ulong offset) => _TexStorageMem3DMultisampleEXT_fnptr(target, samples, internalFormat, width, height, depth, fixedSampleLocations, memory, offset);
             [UnmanagedCallersOnly]
-            private static void TexStorageMem3DMultisampleEXT_Lazy(TextureTarget target, int samples, SizedInternalFormat internalFormat, int width, int height, int depth, byte fixedSampleLocations, uint memory, ulong offset)
+            private static void TexStorageMem3DMultisampleEXT_Lazy(TextureTarget target, int samples, SizedInternalFormat internalFormat, int width, int height, int depth, bool fixedSampleLocations, uint memory, ulong offset)
             {
-                _TexStorageMem3DMultisampleEXT_fnptr = (delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, int, byte, uint, ulong, void>)GLLoader.BindingsContext.GetProcAddress("glTexStorageMem3DMultisampleEXT");
+                _TexStorageMem3DMultisampleEXT_fnptr = (delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, int, bool, uint, ulong, void>)GLLoader.BindingsContext.GetProcAddress("glTexStorageMem3DMultisampleEXT");
                 _TexStorageMem3DMultisampleEXT_fnptr(target, samples, internalFormat, width, height, depth, fixedSampleLocations, memory, offset);
             }
             
@@ -24683,14 +24683,14 @@ namespace OpenTK.Graphics.OpenGL
                 _TextureStorageMem2DEXT_fnptr(texture, levels, internalFormat, width, height, memory, offset);
             }
             
-            private static delegate* unmanaged<TextureHandle, int, SizedInternalFormat, int, int, byte, uint, ulong, void> _TextureStorageMem2DMultisampleEXT_fnptr = &TextureStorageMem2DMultisampleEXT_Lazy;
+            private static delegate* unmanaged<TextureHandle, int, SizedInternalFormat, int, int, bool, uint, ulong, void> _TextureStorageMem2DMultisampleEXT_fnptr = &TextureStorageMem2DMultisampleEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_memory_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureStorageMem2DMultisampleEXT(TextureHandle texture, int samples, SizedInternalFormat internalFormat, int width, int height, byte fixedSampleLocations, uint memory, ulong offset) => _TextureStorageMem2DMultisampleEXT_fnptr(texture, samples, internalFormat, width, height, fixedSampleLocations, memory, offset);
+            public static void TextureStorageMem2DMultisampleEXT(TextureHandle texture, int samples, SizedInternalFormat internalFormat, int width, int height, bool fixedSampleLocations, uint memory, ulong offset) => _TextureStorageMem2DMultisampleEXT_fnptr(texture, samples, internalFormat, width, height, fixedSampleLocations, memory, offset);
             [UnmanagedCallersOnly]
-            private static void TextureStorageMem2DMultisampleEXT_Lazy(TextureHandle texture, int samples, SizedInternalFormat internalFormat, int width, int height, byte fixedSampleLocations, uint memory, ulong offset)
+            private static void TextureStorageMem2DMultisampleEXT_Lazy(TextureHandle texture, int samples, SizedInternalFormat internalFormat, int width, int height, bool fixedSampleLocations, uint memory, ulong offset)
             {
-                _TextureStorageMem2DMultisampleEXT_fnptr = (delegate* unmanaged<TextureHandle, int, SizedInternalFormat, int, int, byte, uint, ulong, void>)GLLoader.BindingsContext.GetProcAddress("glTextureStorageMem2DMultisampleEXT");
+                _TextureStorageMem2DMultisampleEXT_fnptr = (delegate* unmanaged<TextureHandle, int, SizedInternalFormat, int, int, bool, uint, ulong, void>)GLLoader.BindingsContext.GetProcAddress("glTextureStorageMem2DMultisampleEXT");
                 _TextureStorageMem2DMultisampleEXT_fnptr(texture, samples, internalFormat, width, height, fixedSampleLocations, memory, offset);
             }
             
@@ -24705,14 +24705,14 @@ namespace OpenTK.Graphics.OpenGL
                 _TextureStorageMem3DEXT_fnptr(texture, levels, internalFormat, width, height, depth, memory, offset);
             }
             
-            private static delegate* unmanaged<TextureHandle, int, SizedInternalFormat, int, int, int, byte, uint, ulong, void> _TextureStorageMem3DMultisampleEXT_fnptr = &TextureStorageMem3DMultisampleEXT_Lazy;
+            private static delegate* unmanaged<TextureHandle, int, SizedInternalFormat, int, int, int, bool, uint, ulong, void> _TextureStorageMem3DMultisampleEXT_fnptr = &TextureStorageMem3DMultisampleEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_memory_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureStorageMem3DMultisampleEXT(TextureHandle texture, int samples, SizedInternalFormat internalFormat, int width, int height, int depth, byte fixedSampleLocations, uint memory, ulong offset) => _TextureStorageMem3DMultisampleEXT_fnptr(texture, samples, internalFormat, width, height, depth, fixedSampleLocations, memory, offset);
+            public static void TextureStorageMem3DMultisampleEXT(TextureHandle texture, int samples, SizedInternalFormat internalFormat, int width, int height, int depth, bool fixedSampleLocations, uint memory, ulong offset) => _TextureStorageMem3DMultisampleEXT_fnptr(texture, samples, internalFormat, width, height, depth, fixedSampleLocations, memory, offset);
             [UnmanagedCallersOnly]
-            private static void TextureStorageMem3DMultisampleEXT_Lazy(TextureHandle texture, int samples, SizedInternalFormat internalFormat, int width, int height, int depth, byte fixedSampleLocations, uint memory, ulong offset)
+            private static void TextureStorageMem3DMultisampleEXT_Lazy(TextureHandle texture, int samples, SizedInternalFormat internalFormat, int width, int height, int depth, bool fixedSampleLocations, uint memory, ulong offset)
             {
-                _TextureStorageMem3DMultisampleEXT_fnptr = (delegate* unmanaged<TextureHandle, int, SizedInternalFormat, int, int, int, byte, uint, ulong, void>)GLLoader.BindingsContext.GetProcAddress("glTextureStorageMem3DMultisampleEXT");
+                _TextureStorageMem3DMultisampleEXT_fnptr = (delegate* unmanaged<TextureHandle, int, SizedInternalFormat, int, int, int, bool, uint, ulong, void>)GLLoader.BindingsContext.GetProcAddress("glTextureStorageMem3DMultisampleEXT");
                 _TextureStorageMem3DMultisampleEXT_fnptr(texture, samples, internalFormat, width, height, depth, fixedSampleLocations, memory, offset);
             }
             
@@ -24804,14 +24804,14 @@ namespace OpenTK.Graphics.OpenGL
                 _MultiDrawElementsEXT_fnptr(mode, count, type, indices, primcount);
             }
             
-            private static delegate* unmanaged<float, byte, void> _SampleMaskEXT_fnptr = &SampleMaskEXT_Lazy;
+            private static delegate* unmanaged<float, bool, void> _SampleMaskEXT_fnptr = &SampleMaskEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_multisample]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void SampleMaskEXT(float value, byte invert) => _SampleMaskEXT_fnptr(value, invert);
+            public static void SampleMaskEXT(float value, bool invert) => _SampleMaskEXT_fnptr(value, invert);
             [UnmanagedCallersOnly]
-            private static void SampleMaskEXT_Lazy(float value, byte invert)
+            private static void SampleMaskEXT_Lazy(float value, bool invert)
             {
-                _SampleMaskEXT_fnptr = (delegate* unmanaged<float, byte, void>)GLLoader.BindingsContext.GetProcAddress("glSampleMaskEXT");
+                _SampleMaskEXT_fnptr = (delegate* unmanaged<float, bool, void>)GLLoader.BindingsContext.GetProcAddress("glSampleMaskEXT");
                 _SampleMaskEXT_fnptr(value, invert);
             }
             
@@ -24991,14 +24991,14 @@ namespace OpenTK.Graphics.OpenGL
                 _ProvokingVertexEXT_fnptr(mode);
             }
             
-            private static delegate* unmanaged<uint, byte, void> _RasterSamplesEXT_fnptr = &RasterSamplesEXT_Lazy;
+            private static delegate* unmanaged<uint, bool, void> _RasterSamplesEXT_fnptr = &RasterSamplesEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_raster_multisample | GL_NV_framebuffer_mixed_samples]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void RasterSamplesEXT(uint samples, byte fixedsamplelocations) => _RasterSamplesEXT_fnptr(samples, fixedsamplelocations);
+            public static void RasterSamplesEXT(uint samples, bool fixedsamplelocations) => _RasterSamplesEXT_fnptr(samples, fixedsamplelocations);
             [UnmanagedCallersOnly]
-            private static void RasterSamplesEXT_Lazy(uint samples, byte fixedsamplelocations)
+            private static void RasterSamplesEXT_Lazy(uint samples, bool fixedsamplelocations)
             {
-                _RasterSamplesEXT_fnptr = (delegate* unmanaged<uint, byte, void>)GLLoader.BindingsContext.GetProcAddress("glRasterSamplesEXT");
+                _RasterSamplesEXT_fnptr = (delegate* unmanaged<uint, bool, void>)GLLoader.BindingsContext.GetProcAddress("glRasterSamplesEXT");
                 _RasterSamplesEXT_fnptr(samples, fixedsamplelocations);
             }
             
@@ -25024,14 +25024,14 @@ namespace OpenTK.Graphics.OpenGL
                 _DeleteSemaphoresEXT_fnptr(n, semaphores);
             }
             
-            private static delegate* unmanaged<uint, byte> _IsSemaphoreEXT_fnptr = &IsSemaphoreEXT_Lazy;
+            private static delegate* unmanaged<uint, bool> _IsSemaphoreEXT_fnptr = &IsSemaphoreEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_semaphore]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsSemaphoreEXT(uint semaphore) => _IsSemaphoreEXT_fnptr(semaphore);
+            public static bool IsSemaphoreEXT(uint semaphore) => _IsSemaphoreEXT_fnptr(semaphore);
             [UnmanagedCallersOnly]
-            private static byte IsSemaphoreEXT_Lazy(uint semaphore)
+            private static bool IsSemaphoreEXT_Lazy(uint semaphore)
             {
-                _IsSemaphoreEXT_fnptr = (delegate* unmanaged<uint, byte>)GLLoader.BindingsContext.GetProcAddress("glIsSemaphoreEXT");
+                _IsSemaphoreEXT_fnptr = (delegate* unmanaged<uint, bool>)GLLoader.BindingsContext.GetProcAddress("glIsSemaphoreEXT");
                 return _IsSemaphoreEXT_fnptr(semaphore);
             }
             
@@ -25409,14 +25409,14 @@ namespace OpenTK.Graphics.OpenGL
                 _GetProgramPipelineivEXT_fnptr(pipeline, pname, parameters);
             }
             
-            private static delegate* unmanaged<ProgramPipelineHandle, byte> _IsProgramPipelineEXT_fnptr = &IsProgramPipelineEXT_Lazy;
+            private static delegate* unmanaged<ProgramPipelineHandle, bool> _IsProgramPipelineEXT_fnptr = &IsProgramPipelineEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsProgramPipelineEXT(ProgramPipelineHandle pipeline) => _IsProgramPipelineEXT_fnptr(pipeline);
+            public static bool IsProgramPipelineEXT(ProgramPipelineHandle pipeline) => _IsProgramPipelineEXT_fnptr(pipeline);
             [UnmanagedCallersOnly]
-            private static byte IsProgramPipelineEXT_Lazy(ProgramPipelineHandle pipeline)
+            private static bool IsProgramPipelineEXT_Lazy(ProgramPipelineHandle pipeline)
             {
-                _IsProgramPipelineEXT_fnptr = (delegate* unmanaged<ProgramPipelineHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsProgramPipelineEXT");
+                _IsProgramPipelineEXT_fnptr = (delegate* unmanaged<ProgramPipelineHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsProgramPipelineEXT");
                 return _IsProgramPipelineEXT_fnptr(pipeline);
             }
             
@@ -25453,14 +25453,14 @@ namespace OpenTK.Graphics.OpenGL
                 _FramebufferFetchBarrierEXT_fnptr();
             }
             
-            private static delegate* unmanaged<uint, TextureHandle, int, byte, int, BufferAccessARB, int, void> _BindImageTextureEXT_fnptr = &BindImageTextureEXT_Lazy;
+            private static delegate* unmanaged<uint, TextureHandle, int, bool, int, BufferAccessARB, int, void> _BindImageTextureEXT_fnptr = &BindImageTextureEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_shader_image_load_store]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void BindImageTextureEXT(uint index, TextureHandle texture, int level, byte layered, int layer, BufferAccessARB access, int format) => _BindImageTextureEXT_fnptr(index, texture, level, layered, layer, access, format);
+            public static void BindImageTextureEXT(uint index, TextureHandle texture, int level, bool layered, int layer, BufferAccessARB access, int format) => _BindImageTextureEXT_fnptr(index, texture, level, layered, layer, access, format);
             [UnmanagedCallersOnly]
-            private static void BindImageTextureEXT_Lazy(uint index, TextureHandle texture, int level, byte layered, int layer, BufferAccessARB access, int format)
+            private static void BindImageTextureEXT_Lazy(uint index, TextureHandle texture, int level, bool layered, int layer, BufferAccessARB access, int format)
             {
-                _BindImageTextureEXT_fnptr = (delegate* unmanaged<uint, TextureHandle, int, byte, int, BufferAccessARB, int, void>)GLLoader.BindingsContext.GetProcAddress("glBindImageTextureEXT");
+                _BindImageTextureEXT_fnptr = (delegate* unmanaged<uint, TextureHandle, int, bool, int, BufferAccessARB, int, void>)GLLoader.BindingsContext.GetProcAddress("glBindImageTextureEXT");
                 _BindImageTextureEXT_fnptr(index, texture, level, layered, layer, access, format);
             }
             
@@ -25629,14 +25629,14 @@ namespace OpenTK.Graphics.OpenGL
                 _ClearColorIuiEXT_fnptr(red, green, blue, alpha);
             }
             
-            private static delegate* unmanaged<int, TextureHandle*, byte*, byte> _AreTexturesResidentEXT_fnptr = &AreTexturesResidentEXT_Lazy;
+            private static delegate* unmanaged<int, TextureHandle*, bool*, bool> _AreTexturesResidentEXT_fnptr = &AreTexturesResidentEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_texture_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte AreTexturesResidentEXT(int n, TextureHandle* textures, byte* residences) => _AreTexturesResidentEXT_fnptr(n, textures, residences);
+            public static bool AreTexturesResidentEXT(int n, TextureHandle* textures, bool* residences) => _AreTexturesResidentEXT_fnptr(n, textures, residences);
             [UnmanagedCallersOnly]
-            private static byte AreTexturesResidentEXT_Lazy(int n, TextureHandle* textures, byte* residences)
+            private static bool AreTexturesResidentEXT_Lazy(int n, TextureHandle* textures, bool* residences)
             {
-                _AreTexturesResidentEXT_fnptr = (delegate* unmanaged<int, TextureHandle*, byte*, byte>)GLLoader.BindingsContext.GetProcAddress("glAreTexturesResidentEXT");
+                _AreTexturesResidentEXT_fnptr = (delegate* unmanaged<int, TextureHandle*, bool*, bool>)GLLoader.BindingsContext.GetProcAddress("glAreTexturesResidentEXT");
                 return _AreTexturesResidentEXT_fnptr(n, textures, residences);
             }
             
@@ -25673,14 +25673,14 @@ namespace OpenTK.Graphics.OpenGL
                 _GenTexturesEXT_fnptr(n, textures);
             }
             
-            private static delegate* unmanaged<TextureHandle, byte> _IsTextureEXT_fnptr = &IsTextureEXT_Lazy;
+            private static delegate* unmanaged<TextureHandle, bool> _IsTextureEXT_fnptr = &IsTextureEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_texture_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsTextureEXT(TextureHandle texture) => _IsTextureEXT_fnptr(texture);
+            public static bool IsTextureEXT(TextureHandle texture) => _IsTextureEXT_fnptr(texture);
             [UnmanagedCallersOnly]
-            private static byte IsTextureEXT_Lazy(TextureHandle texture)
+            private static bool IsTextureEXT_Lazy(TextureHandle texture)
             {
-                _IsTextureEXT_fnptr = (delegate* unmanaged<TextureHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsTextureEXT");
+                _IsTextureEXT_fnptr = (delegate* unmanaged<TextureHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsTextureEXT");
                 return _IsTextureEXT_fnptr(texture);
             }
             
@@ -25871,14 +25871,14 @@ namespace OpenTK.Graphics.OpenGL
                 _DrawArraysEXT_fnptr(mode, first, count);
             }
             
-            private static delegate* unmanaged<int, int, byte*, void> _EdgeFlagPointerEXT_fnptr = &EdgeFlagPointerEXT_Lazy;
+            private static delegate* unmanaged<int, int, bool*, void> _EdgeFlagPointerEXT_fnptr = &EdgeFlagPointerEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_vertex_array]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void EdgeFlagPointerEXT(int stride, int count, byte* pointer) => _EdgeFlagPointerEXT_fnptr(stride, count, pointer);
+            public static void EdgeFlagPointerEXT(int stride, int count, bool* pointer) => _EdgeFlagPointerEXT_fnptr(stride, count, pointer);
             [UnmanagedCallersOnly]
-            private static void EdgeFlagPointerEXT_Lazy(int stride, int count, byte* pointer)
+            private static void EdgeFlagPointerEXT_Lazy(int stride, int count, bool* pointer)
             {
-                _EdgeFlagPointerEXT_fnptr = (delegate* unmanaged<int, int, byte*, void>)GLLoader.BindingsContext.GetProcAddress("glEdgeFlagPointerEXT");
+                _EdgeFlagPointerEXT_fnptr = (delegate* unmanaged<int, int, bool*, void>)GLLoader.BindingsContext.GetProcAddress("glEdgeFlagPointerEXT");
                 _EdgeFlagPointerEXT_fnptr(stride, count, pointer);
             }
             
@@ -26388,25 +26388,25 @@ namespace OpenTK.Graphics.OpenGL
                 return _BindParameterEXT_fnptr(value);
             }
             
-            private static delegate* unmanaged<uint, VariantCapEXT, byte> _IsVariantEnabledEXT_fnptr = &IsVariantEnabledEXT_Lazy;
+            private static delegate* unmanaged<uint, VariantCapEXT, bool> _IsVariantEnabledEXT_fnptr = &IsVariantEnabledEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_vertex_shader]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsVariantEnabledEXT(uint id, VariantCapEXT cap) => _IsVariantEnabledEXT_fnptr(id, cap);
+            public static bool IsVariantEnabledEXT(uint id, VariantCapEXT cap) => _IsVariantEnabledEXT_fnptr(id, cap);
             [UnmanagedCallersOnly]
-            private static byte IsVariantEnabledEXT_Lazy(uint id, VariantCapEXT cap)
+            private static bool IsVariantEnabledEXT_Lazy(uint id, VariantCapEXT cap)
             {
-                _IsVariantEnabledEXT_fnptr = (delegate* unmanaged<uint, VariantCapEXT, byte>)GLLoader.BindingsContext.GetProcAddress("glIsVariantEnabledEXT");
+                _IsVariantEnabledEXT_fnptr = (delegate* unmanaged<uint, VariantCapEXT, bool>)GLLoader.BindingsContext.GetProcAddress("glIsVariantEnabledEXT");
                 return _IsVariantEnabledEXT_fnptr(id, cap);
             }
             
-            private static delegate* unmanaged<uint, GetVariantValueEXT, byte*, void> _GetVariantBooleanvEXT_fnptr = &GetVariantBooleanvEXT_Lazy;
+            private static delegate* unmanaged<uint, GetVariantValueEXT, bool*, void> _GetVariantBooleanvEXT_fnptr = &GetVariantBooleanvEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_vertex_shader]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetVariantBooleanvEXT(uint id, GetVariantValueEXT value, byte* data) => _GetVariantBooleanvEXT_fnptr(id, value, data);
+            public static void GetVariantBooleanvEXT(uint id, GetVariantValueEXT value, bool* data) => _GetVariantBooleanvEXT_fnptr(id, value, data);
             [UnmanagedCallersOnly]
-            private static void GetVariantBooleanvEXT_Lazy(uint id, GetVariantValueEXT value, byte* data)
+            private static void GetVariantBooleanvEXT_Lazy(uint id, GetVariantValueEXT value, bool* data)
             {
-                _GetVariantBooleanvEXT_fnptr = (delegate* unmanaged<uint, GetVariantValueEXT, byte*, void>)GLLoader.BindingsContext.GetProcAddress("glGetVariantBooleanvEXT");
+                _GetVariantBooleanvEXT_fnptr = (delegate* unmanaged<uint, GetVariantValueEXT, bool*, void>)GLLoader.BindingsContext.GetProcAddress("glGetVariantBooleanvEXT");
                 _GetVariantBooleanvEXT_fnptr(id, value, data);
             }
             
@@ -26443,14 +26443,14 @@ namespace OpenTK.Graphics.OpenGL
                 _GetVariantPointervEXT_fnptr(id, value, data);
             }
             
-            private static delegate* unmanaged<uint, GetVariantValueEXT, byte*, void> _GetInvariantBooleanvEXT_fnptr = &GetInvariantBooleanvEXT_Lazy;
+            private static delegate* unmanaged<uint, GetVariantValueEXT, bool*, void> _GetInvariantBooleanvEXT_fnptr = &GetInvariantBooleanvEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_vertex_shader]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetInvariantBooleanvEXT(uint id, GetVariantValueEXT value, byte* data) => _GetInvariantBooleanvEXT_fnptr(id, value, data);
+            public static void GetInvariantBooleanvEXT(uint id, GetVariantValueEXT value, bool* data) => _GetInvariantBooleanvEXT_fnptr(id, value, data);
             [UnmanagedCallersOnly]
-            private static void GetInvariantBooleanvEXT_Lazy(uint id, GetVariantValueEXT value, byte* data)
+            private static void GetInvariantBooleanvEXT_Lazy(uint id, GetVariantValueEXT value, bool* data)
             {
-                _GetInvariantBooleanvEXT_fnptr = (delegate* unmanaged<uint, GetVariantValueEXT, byte*, void>)GLLoader.BindingsContext.GetProcAddress("glGetInvariantBooleanvEXT");
+                _GetInvariantBooleanvEXT_fnptr = (delegate* unmanaged<uint, GetVariantValueEXT, bool*, void>)GLLoader.BindingsContext.GetProcAddress("glGetInvariantBooleanvEXT");
                 _GetInvariantBooleanvEXT_fnptr(id, value, data);
             }
             
@@ -26476,14 +26476,14 @@ namespace OpenTK.Graphics.OpenGL
                 _GetInvariantFloatvEXT_fnptr(id, value, data);
             }
             
-            private static delegate* unmanaged<uint, GetVariantValueEXT, byte*, void> _GetLocalConstantBooleanvEXT_fnptr = &GetLocalConstantBooleanvEXT_Lazy;
+            private static delegate* unmanaged<uint, GetVariantValueEXT, bool*, void> _GetLocalConstantBooleanvEXT_fnptr = &GetLocalConstantBooleanvEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_vertex_shader]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetLocalConstantBooleanvEXT(uint id, GetVariantValueEXT value, byte* data) => _GetLocalConstantBooleanvEXT_fnptr(id, value, data);
+            public static void GetLocalConstantBooleanvEXT(uint id, GetVariantValueEXT value, bool* data) => _GetLocalConstantBooleanvEXT_fnptr(id, value, data);
             [UnmanagedCallersOnly]
-            private static void GetLocalConstantBooleanvEXT_Lazy(uint id, GetVariantValueEXT value, byte* data)
+            private static void GetLocalConstantBooleanvEXT_Lazy(uint id, GetVariantValueEXT value, bool* data)
             {
-                _GetLocalConstantBooleanvEXT_fnptr = (delegate* unmanaged<uint, GetVariantValueEXT, byte*, void>)GLLoader.BindingsContext.GetProcAddress("glGetLocalConstantBooleanvEXT");
+                _GetLocalConstantBooleanvEXT_fnptr = (delegate* unmanaged<uint, GetVariantValueEXT, bool*, void>)GLLoader.BindingsContext.GetProcAddress("glGetLocalConstantBooleanvEXT");
                 _GetLocalConstantBooleanvEXT_fnptr(id, value, data);
             }
             
@@ -26542,25 +26542,25 @@ namespace OpenTK.Graphics.OpenGL
                 _VertexWeightPointerEXT_fnptr(size, type, stride, pointer);
             }
             
-            private static delegate* unmanaged<uint, ulong, uint, byte> _AcquireKeyedMutexWin32EXT_fnptr = &AcquireKeyedMutexWin32EXT_Lazy;
+            private static delegate* unmanaged<uint, ulong, uint, bool> _AcquireKeyedMutexWin32EXT_fnptr = &AcquireKeyedMutexWin32EXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_win32_keyed_mutex]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte AcquireKeyedMutexWin32EXT(uint memory, ulong key, uint timeout) => _AcquireKeyedMutexWin32EXT_fnptr(memory, key, timeout);
+            public static bool AcquireKeyedMutexWin32EXT(uint memory, ulong key, uint timeout) => _AcquireKeyedMutexWin32EXT_fnptr(memory, key, timeout);
             [UnmanagedCallersOnly]
-            private static byte AcquireKeyedMutexWin32EXT_Lazy(uint memory, ulong key, uint timeout)
+            private static bool AcquireKeyedMutexWin32EXT_Lazy(uint memory, ulong key, uint timeout)
             {
-                _AcquireKeyedMutexWin32EXT_fnptr = (delegate* unmanaged<uint, ulong, uint, byte>)GLLoader.BindingsContext.GetProcAddress("glAcquireKeyedMutexWin32EXT");
+                _AcquireKeyedMutexWin32EXT_fnptr = (delegate* unmanaged<uint, ulong, uint, bool>)GLLoader.BindingsContext.GetProcAddress("glAcquireKeyedMutexWin32EXT");
                 return _AcquireKeyedMutexWin32EXT_fnptr(memory, key, timeout);
             }
             
-            private static delegate* unmanaged<uint, ulong, byte> _ReleaseKeyedMutexWin32EXT_fnptr = &ReleaseKeyedMutexWin32EXT_Lazy;
+            private static delegate* unmanaged<uint, ulong, bool> _ReleaseKeyedMutexWin32EXT_fnptr = &ReleaseKeyedMutexWin32EXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_win32_keyed_mutex]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte ReleaseKeyedMutexWin32EXT(uint memory, ulong key) => _ReleaseKeyedMutexWin32EXT_fnptr(memory, key);
+            public static bool ReleaseKeyedMutexWin32EXT(uint memory, ulong key) => _ReleaseKeyedMutexWin32EXT_fnptr(memory, key);
             [UnmanagedCallersOnly]
-            private static byte ReleaseKeyedMutexWin32EXT_Lazy(uint memory, ulong key)
+            private static bool ReleaseKeyedMutexWin32EXT_Lazy(uint memory, ulong key)
             {
-                _ReleaseKeyedMutexWin32EXT_fnptr = (delegate* unmanaged<uint, ulong, byte>)GLLoader.BindingsContext.GetProcAddress("glReleaseKeyedMutexWin32EXT");
+                _ReleaseKeyedMutexWin32EXT_fnptr = (delegate* unmanaged<uint, ulong, bool>)GLLoader.BindingsContext.GetProcAddress("glReleaseKeyedMutexWin32EXT");
                 return _ReleaseKeyedMutexWin32EXT_fnptr(memory, key);
             }
             
@@ -26721,14 +26721,14 @@ namespace OpenTK.Graphics.OpenGL
                 _MakeTextureHandleNonResidentNV_fnptr(handle);
             }
             
-            private static delegate* unmanaged<TextureHandle, int, byte, int, PixelFormat, ulong> _GetImageHandleNV_fnptr = &GetImageHandleNV_Lazy;
+            private static delegate* unmanaged<TextureHandle, int, bool, int, PixelFormat, ulong> _GetImageHandleNV_fnptr = &GetImageHandleNV_Lazy;
             /// <summary> <b>[requires: GL_NV_bindless_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static ulong GetImageHandleNV(TextureHandle texture, int level, byte layered, int layer, PixelFormat format) => _GetImageHandleNV_fnptr(texture, level, layered, layer, format);
+            public static ulong GetImageHandleNV(TextureHandle texture, int level, bool layered, int layer, PixelFormat format) => _GetImageHandleNV_fnptr(texture, level, layered, layer, format);
             [UnmanagedCallersOnly]
-            private static ulong GetImageHandleNV_Lazy(TextureHandle texture, int level, byte layered, int layer, PixelFormat format)
+            private static ulong GetImageHandleNV_Lazy(TextureHandle texture, int level, bool layered, int layer, PixelFormat format)
             {
-                _GetImageHandleNV_fnptr = (delegate* unmanaged<TextureHandle, int, byte, int, PixelFormat, ulong>)GLLoader.BindingsContext.GetProcAddress("glGetImageHandleNV");
+                _GetImageHandleNV_fnptr = (delegate* unmanaged<TextureHandle, int, bool, int, PixelFormat, ulong>)GLLoader.BindingsContext.GetProcAddress("glGetImageHandleNV");
                 return _GetImageHandleNV_fnptr(texture, level, layered, layer, format);
             }
             
@@ -26798,25 +26798,25 @@ namespace OpenTK.Graphics.OpenGL
                 _ProgramUniformHandleui64vNV_fnptr(program, location, count, values);
             }
             
-            private static delegate* unmanaged<ulong, byte> _IsTextureHandleResidentNV_fnptr = &IsTextureHandleResidentNV_Lazy;
+            private static delegate* unmanaged<ulong, bool> _IsTextureHandleResidentNV_fnptr = &IsTextureHandleResidentNV_Lazy;
             /// <summary> <b>[requires: GL_NV_bindless_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsTextureHandleResidentNV(ulong handle) => _IsTextureHandleResidentNV_fnptr(handle);
+            public static bool IsTextureHandleResidentNV(ulong handle) => _IsTextureHandleResidentNV_fnptr(handle);
             [UnmanagedCallersOnly]
-            private static byte IsTextureHandleResidentNV_Lazy(ulong handle)
+            private static bool IsTextureHandleResidentNV_Lazy(ulong handle)
             {
-                _IsTextureHandleResidentNV_fnptr = (delegate* unmanaged<ulong, byte>)GLLoader.BindingsContext.GetProcAddress("glIsTextureHandleResidentNV");
+                _IsTextureHandleResidentNV_fnptr = (delegate* unmanaged<ulong, bool>)GLLoader.BindingsContext.GetProcAddress("glIsTextureHandleResidentNV");
                 return _IsTextureHandleResidentNV_fnptr(handle);
             }
             
-            private static delegate* unmanaged<ulong, byte> _IsImageHandleResidentNV_fnptr = &IsImageHandleResidentNV_Lazy;
+            private static delegate* unmanaged<ulong, bool> _IsImageHandleResidentNV_fnptr = &IsImageHandleResidentNV_Lazy;
             /// <summary> <b>[requires: GL_NV_bindless_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsImageHandleResidentNV(ulong handle) => _IsImageHandleResidentNV_fnptr(handle);
+            public static bool IsImageHandleResidentNV(ulong handle) => _IsImageHandleResidentNV_fnptr(handle);
             [UnmanagedCallersOnly]
-            private static byte IsImageHandleResidentNV_Lazy(ulong handle)
+            private static bool IsImageHandleResidentNV_Lazy(ulong handle)
             {
-                _IsImageHandleResidentNV_fnptr = (delegate* unmanaged<ulong, byte>)GLLoader.BindingsContext.GetProcAddress("glIsImageHandleResidentNV");
+                _IsImageHandleResidentNV_fnptr = (delegate* unmanaged<ulong, bool>)GLLoader.BindingsContext.GetProcAddress("glIsImageHandleResidentNV");
                 return _IsImageHandleResidentNV_fnptr(handle);
             }
             
@@ -26875,14 +26875,14 @@ namespace OpenTK.Graphics.OpenGL
                 _DeleteStatesNV_fnptr(n, states);
             }
             
-            private static delegate* unmanaged<uint, byte> _IsStateNV_fnptr = &IsStateNV_Lazy;
+            private static delegate* unmanaged<uint, bool> _IsStateNV_fnptr = &IsStateNV_Lazy;
             /// <summary> <b>[requires: GL_NV_command_list]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsStateNV(uint state) => _IsStateNV_fnptr(state);
+            public static bool IsStateNV(uint state) => _IsStateNV_fnptr(state);
             [UnmanagedCallersOnly]
-            private static byte IsStateNV_Lazy(uint state)
+            private static bool IsStateNV_Lazy(uint state)
             {
-                _IsStateNV_fnptr = (delegate* unmanaged<uint, byte>)GLLoader.BindingsContext.GetProcAddress("glIsStateNV");
+                _IsStateNV_fnptr = (delegate* unmanaged<uint, bool>)GLLoader.BindingsContext.GetProcAddress("glIsStateNV");
                 return _IsStateNV_fnptr(state);
             }
             
@@ -26985,14 +26985,14 @@ namespace OpenTK.Graphics.OpenGL
                 _DeleteCommandListsNV_fnptr(n, lists);
             }
             
-            private static delegate* unmanaged<uint, byte> _IsCommandListNV_fnptr = &IsCommandListNV_Lazy;
+            private static delegate* unmanaged<uint, bool> _IsCommandListNV_fnptr = &IsCommandListNV_Lazy;
             /// <summary> <b>[requires: GL_NV_command_list]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsCommandListNV(uint list) => _IsCommandListNV_fnptr(list);
+            public static bool IsCommandListNV(uint list) => _IsCommandListNV_fnptr(list);
             [UnmanagedCallersOnly]
-            private static byte IsCommandListNV_Lazy(uint list)
+            private static bool IsCommandListNV_Lazy(uint list)
             {
-                _IsCommandListNV_fnptr = (delegate* unmanaged<uint, byte>)GLLoader.BindingsContext.GetProcAddress("glIsCommandListNV");
+                _IsCommandListNV_fnptr = (delegate* unmanaged<uint, bool>)GLLoader.BindingsContext.GetProcAddress("glIsCommandListNV");
                 return _IsCommandListNV_fnptr(list);
             }
             
@@ -27205,14 +27205,14 @@ namespace OpenTK.Graphics.OpenGL
                 _SignalVkFenceNV_fnptr(vkFence);
             }
             
-            private static delegate* unmanaged<EvalTargetNV, uint, MapTypeNV, int, int, int, int, byte, void*, void> _MapControlPointsNV_fnptr = &MapControlPointsNV_Lazy;
+            private static delegate* unmanaged<EvalTargetNV, uint, MapTypeNV, int, int, int, int, bool, void*, void> _MapControlPointsNV_fnptr = &MapControlPointsNV_Lazy;
             /// <summary> <b>[requires: GL_NV_evaluators]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void MapControlPointsNV(EvalTargetNV target, uint index, MapTypeNV type, int ustride, int vstride, int uorder, int vorder, byte packed, void* points) => _MapControlPointsNV_fnptr(target, index, type, ustride, vstride, uorder, vorder, packed, points);
+            public static void MapControlPointsNV(EvalTargetNV target, uint index, MapTypeNV type, int ustride, int vstride, int uorder, int vorder, bool packed, void* points) => _MapControlPointsNV_fnptr(target, index, type, ustride, vstride, uorder, vorder, packed, points);
             [UnmanagedCallersOnly]
-            private static void MapControlPointsNV_Lazy(EvalTargetNV target, uint index, MapTypeNV type, int ustride, int vstride, int uorder, int vorder, byte packed, void* points)
+            private static void MapControlPointsNV_Lazy(EvalTargetNV target, uint index, MapTypeNV type, int ustride, int vstride, int uorder, int vorder, bool packed, void* points)
             {
-                _MapControlPointsNV_fnptr = (delegate* unmanaged<EvalTargetNV, uint, MapTypeNV, int, int, int, int, byte, void*, void>)GLLoader.BindingsContext.GetProcAddress("glMapControlPointsNV");
+                _MapControlPointsNV_fnptr = (delegate* unmanaged<EvalTargetNV, uint, MapTypeNV, int, int, int, int, bool, void*, void>)GLLoader.BindingsContext.GetProcAddress("glMapControlPointsNV");
                 _MapControlPointsNV_fnptr(target, index, type, ustride, vstride, uorder, vorder, packed, points);
             }
             
@@ -27238,14 +27238,14 @@ namespace OpenTK.Graphics.OpenGL
                 _MapParameterfvNV_fnptr(target, pname, parameters);
             }
             
-            private static delegate* unmanaged<EvalTargetNV, uint, MapTypeNV, int, int, byte, void*, void> _GetMapControlPointsNV_fnptr = &GetMapControlPointsNV_Lazy;
+            private static delegate* unmanaged<EvalTargetNV, uint, MapTypeNV, int, int, bool, void*, void> _GetMapControlPointsNV_fnptr = &GetMapControlPointsNV_Lazy;
             /// <summary> <b>[requires: GL_NV_evaluators]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetMapControlPointsNV(EvalTargetNV target, uint index, MapTypeNV type, int ustride, int vstride, byte packed, void* points) => _GetMapControlPointsNV_fnptr(target, index, type, ustride, vstride, packed, points);
+            public static void GetMapControlPointsNV(EvalTargetNV target, uint index, MapTypeNV type, int ustride, int vstride, bool packed, void* points) => _GetMapControlPointsNV_fnptr(target, index, type, ustride, vstride, packed, points);
             [UnmanagedCallersOnly]
-            private static void GetMapControlPointsNV_Lazy(EvalTargetNV target, uint index, MapTypeNV type, int ustride, int vstride, byte packed, void* points)
+            private static void GetMapControlPointsNV_Lazy(EvalTargetNV target, uint index, MapTypeNV type, int ustride, int vstride, bool packed, void* points)
             {
-                _GetMapControlPointsNV_fnptr = (delegate* unmanaged<EvalTargetNV, uint, MapTypeNV, int, int, byte, void*, void>)GLLoader.BindingsContext.GetProcAddress("glGetMapControlPointsNV");
+                _GetMapControlPointsNV_fnptr = (delegate* unmanaged<EvalTargetNV, uint, MapTypeNV, int, int, bool, void*, void>)GLLoader.BindingsContext.GetProcAddress("glGetMapControlPointsNV");
                 _GetMapControlPointsNV_fnptr(target, index, type, ustride, vstride, packed, points);
             }
             
@@ -27359,25 +27359,25 @@ namespace OpenTK.Graphics.OpenGL
                 _GenFencesNV_fnptr(n, fences);
             }
             
-            private static delegate* unmanaged<uint, byte> _IsFenceNV_fnptr = &IsFenceNV_Lazy;
+            private static delegate* unmanaged<uint, bool> _IsFenceNV_fnptr = &IsFenceNV_Lazy;
             /// <summary> <b>[requires: GL_NV_fence]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsFenceNV(uint fence) => _IsFenceNV_fnptr(fence);
+            public static bool IsFenceNV(uint fence) => _IsFenceNV_fnptr(fence);
             [UnmanagedCallersOnly]
-            private static byte IsFenceNV_Lazy(uint fence)
+            private static bool IsFenceNV_Lazy(uint fence)
             {
-                _IsFenceNV_fnptr = (delegate* unmanaged<uint, byte>)GLLoader.BindingsContext.GetProcAddress("glIsFenceNV");
+                _IsFenceNV_fnptr = (delegate* unmanaged<uint, bool>)GLLoader.BindingsContext.GetProcAddress("glIsFenceNV");
                 return _IsFenceNV_fnptr(fence);
             }
             
-            private static delegate* unmanaged<uint, byte> _TestFenceNV_fnptr = &TestFenceNV_Lazy;
+            private static delegate* unmanaged<uint, bool> _TestFenceNV_fnptr = &TestFenceNV_Lazy;
             /// <summary> <b>[requires: GL_NV_fence]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte TestFenceNV(uint fence) => _TestFenceNV_fnptr(fence);
+            public static bool TestFenceNV(uint fence) => _TestFenceNV_fnptr(fence);
             [UnmanagedCallersOnly]
-            private static byte TestFenceNV_Lazy(uint fence)
+            private static bool TestFenceNV_Lazy(uint fence)
             {
-                _TestFenceNV_fnptr = (delegate* unmanaged<uint, byte>)GLLoader.BindingsContext.GetProcAddress("glTestFenceNV");
+                _TestFenceNV_fnptr = (delegate* unmanaged<uint, bool>)GLLoader.BindingsContext.GetProcAddress("glTestFenceNV");
                 return _TestFenceNV_fnptr(fence);
             }
             
@@ -27491,14 +27491,14 @@ namespace OpenTK.Graphics.OpenGL
                 _GetProgramNamedParameterdvNV_fnptr(id, len, name, parameters);
             }
             
-            private static delegate* unmanaged<uint, byte, void> _RasterSamplesEXT_fnptr = &RasterSamplesEXT_Lazy;
+            private static delegate* unmanaged<uint, bool, void> _RasterSamplesEXT_fnptr = &RasterSamplesEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_raster_multisample | GL_NV_framebuffer_mixed_samples]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void RasterSamplesEXT(uint samples, byte fixedsamplelocations) => _RasterSamplesEXT_fnptr(samples, fixedsamplelocations);
+            public static void RasterSamplesEXT(uint samples, bool fixedsamplelocations) => _RasterSamplesEXT_fnptr(samples, fixedsamplelocations);
             [UnmanagedCallersOnly]
-            private static void RasterSamplesEXT_Lazy(uint samples, byte fixedsamplelocations)
+            private static void RasterSamplesEXT_Lazy(uint samples, bool fixedsamplelocations)
             {
-                _RasterSamplesEXT_fnptr = (delegate* unmanaged<uint, byte, void>)GLLoader.BindingsContext.GetProcAddress("glRasterSamplesEXT");
+                _RasterSamplesEXT_fnptr = (delegate* unmanaged<uint, bool, void>)GLLoader.BindingsContext.GetProcAddress("glRasterSamplesEXT");
                 _RasterSamplesEXT_fnptr(samples, fixedsamplelocations);
             }
             
@@ -28866,47 +28866,47 @@ namespace OpenTK.Graphics.OpenGL
                 _NamedBufferAttachMemoryNV_fnptr(buffer, memory, offset);
             }
             
-            private static delegate* unmanaged<BufferStorageTarget, IntPtr, nint, uint, ulong, byte, void> _BufferPageCommitmentMemNV_fnptr = &BufferPageCommitmentMemNV_Lazy;
+            private static delegate* unmanaged<BufferStorageTarget, IntPtr, nint, uint, ulong, bool, void> _BufferPageCommitmentMemNV_fnptr = &BufferPageCommitmentMemNV_Lazy;
             /// <summary> <b>[requires: GL_NV_memory_object_sparse]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void BufferPageCommitmentMemNV(BufferStorageTarget target, IntPtr offset, nint size, uint memory, ulong memOffset, byte commit) => _BufferPageCommitmentMemNV_fnptr(target, offset, size, memory, memOffset, commit);
+            public static void BufferPageCommitmentMemNV(BufferStorageTarget target, IntPtr offset, nint size, uint memory, ulong memOffset, bool commit) => _BufferPageCommitmentMemNV_fnptr(target, offset, size, memory, memOffset, commit);
             [UnmanagedCallersOnly]
-            private static void BufferPageCommitmentMemNV_Lazy(BufferStorageTarget target, IntPtr offset, nint size, uint memory, ulong memOffset, byte commit)
+            private static void BufferPageCommitmentMemNV_Lazy(BufferStorageTarget target, IntPtr offset, nint size, uint memory, ulong memOffset, bool commit)
             {
-                _BufferPageCommitmentMemNV_fnptr = (delegate* unmanaged<BufferStorageTarget, IntPtr, nint, uint, ulong, byte, void>)GLLoader.BindingsContext.GetProcAddress("glBufferPageCommitmentMemNV");
+                _BufferPageCommitmentMemNV_fnptr = (delegate* unmanaged<BufferStorageTarget, IntPtr, nint, uint, ulong, bool, void>)GLLoader.BindingsContext.GetProcAddress("glBufferPageCommitmentMemNV");
                 _BufferPageCommitmentMemNV_fnptr(target, offset, size, memory, memOffset, commit);
             }
             
-            private static delegate* unmanaged<TextureTarget, int, int, int, int, int, int, int, int, uint, ulong, byte, void> _TexPageCommitmentMemNV_fnptr = &TexPageCommitmentMemNV_Lazy;
+            private static delegate* unmanaged<TextureTarget, int, int, int, int, int, int, int, int, uint, ulong, bool, void> _TexPageCommitmentMemNV_fnptr = &TexPageCommitmentMemNV_Lazy;
             /// <summary> <b>[requires: GL_NV_memory_object_sparse]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TexPageCommitmentMemNV(TextureTarget target, int layer, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, uint memory, ulong offset, byte commit) => _TexPageCommitmentMemNV_fnptr(target, layer, level, xoffset, yoffset, zoffset, width, height, depth, memory, offset, commit);
+            public static void TexPageCommitmentMemNV(TextureTarget target, int layer, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, uint memory, ulong offset, bool commit) => _TexPageCommitmentMemNV_fnptr(target, layer, level, xoffset, yoffset, zoffset, width, height, depth, memory, offset, commit);
             [UnmanagedCallersOnly]
-            private static void TexPageCommitmentMemNV_Lazy(TextureTarget target, int layer, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, uint memory, ulong offset, byte commit)
+            private static void TexPageCommitmentMemNV_Lazy(TextureTarget target, int layer, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, uint memory, ulong offset, bool commit)
             {
-                _TexPageCommitmentMemNV_fnptr = (delegate* unmanaged<TextureTarget, int, int, int, int, int, int, int, int, uint, ulong, byte, void>)GLLoader.BindingsContext.GetProcAddress("glTexPageCommitmentMemNV");
+                _TexPageCommitmentMemNV_fnptr = (delegate* unmanaged<TextureTarget, int, int, int, int, int, int, int, int, uint, ulong, bool, void>)GLLoader.BindingsContext.GetProcAddress("glTexPageCommitmentMemNV");
                 _TexPageCommitmentMemNV_fnptr(target, layer, level, xoffset, yoffset, zoffset, width, height, depth, memory, offset, commit);
             }
             
-            private static delegate* unmanaged<BufferHandle, IntPtr, nint, uint, ulong, byte, void> _NamedBufferPageCommitmentMemNV_fnptr = &NamedBufferPageCommitmentMemNV_Lazy;
+            private static delegate* unmanaged<BufferHandle, IntPtr, nint, uint, ulong, bool, void> _NamedBufferPageCommitmentMemNV_fnptr = &NamedBufferPageCommitmentMemNV_Lazy;
             /// <summary> <b>[requires: GL_NV_memory_object_sparse]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedBufferPageCommitmentMemNV(BufferHandle buffer, IntPtr offset, nint size, uint memory, ulong memOffset, byte commit) => _NamedBufferPageCommitmentMemNV_fnptr(buffer, offset, size, memory, memOffset, commit);
+            public static void NamedBufferPageCommitmentMemNV(BufferHandle buffer, IntPtr offset, nint size, uint memory, ulong memOffset, bool commit) => _NamedBufferPageCommitmentMemNV_fnptr(buffer, offset, size, memory, memOffset, commit);
             [UnmanagedCallersOnly]
-            private static void NamedBufferPageCommitmentMemNV_Lazy(BufferHandle buffer, IntPtr offset, nint size, uint memory, ulong memOffset, byte commit)
+            private static void NamedBufferPageCommitmentMemNV_Lazy(BufferHandle buffer, IntPtr offset, nint size, uint memory, ulong memOffset, bool commit)
             {
-                _NamedBufferPageCommitmentMemNV_fnptr = (delegate* unmanaged<BufferHandle, IntPtr, nint, uint, ulong, byte, void>)GLLoader.BindingsContext.GetProcAddress("glNamedBufferPageCommitmentMemNV");
+                _NamedBufferPageCommitmentMemNV_fnptr = (delegate* unmanaged<BufferHandle, IntPtr, nint, uint, ulong, bool, void>)GLLoader.BindingsContext.GetProcAddress("glNamedBufferPageCommitmentMemNV");
                 _NamedBufferPageCommitmentMemNV_fnptr(buffer, offset, size, memory, memOffset, commit);
             }
             
-            private static delegate* unmanaged<TextureHandle, int, int, int, int, int, int, int, int, uint, ulong, byte, void> _TexturePageCommitmentMemNV_fnptr = &TexturePageCommitmentMemNV_Lazy;
+            private static delegate* unmanaged<TextureHandle, int, int, int, int, int, int, int, int, uint, ulong, bool, void> _TexturePageCommitmentMemNV_fnptr = &TexturePageCommitmentMemNV_Lazy;
             /// <summary> <b>[requires: GL_NV_memory_object_sparse]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TexturePageCommitmentMemNV(TextureHandle texture, int layer, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, uint memory, ulong offset, byte commit) => _TexturePageCommitmentMemNV_fnptr(texture, layer, level, xoffset, yoffset, zoffset, width, height, depth, memory, offset, commit);
+            public static void TexturePageCommitmentMemNV(TextureHandle texture, int layer, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, uint memory, ulong offset, bool commit) => _TexturePageCommitmentMemNV_fnptr(texture, layer, level, xoffset, yoffset, zoffset, width, height, depth, memory, offset, commit);
             [UnmanagedCallersOnly]
-            private static void TexturePageCommitmentMemNV_Lazy(TextureHandle texture, int layer, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, uint memory, ulong offset, byte commit)
+            private static void TexturePageCommitmentMemNV_Lazy(TextureHandle texture, int layer, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, uint memory, ulong offset, bool commit)
             {
-                _TexturePageCommitmentMemNV_fnptr = (delegate* unmanaged<TextureHandle, int, int, int, int, int, int, int, int, uint, ulong, byte, void>)GLLoader.BindingsContext.GetProcAddress("glTexturePageCommitmentMemNV");
+                _TexturePageCommitmentMemNV_fnptr = (delegate* unmanaged<TextureHandle, int, int, int, int, int, int, int, int, uint, ulong, bool, void>)GLLoader.BindingsContext.GetProcAddress("glTexturePageCommitmentMemNV");
                 _TexturePageCommitmentMemNV_fnptr(texture, layer, level, xoffset, yoffset, zoffset, width, height, depth, memory, offset, commit);
             }
             
@@ -28976,14 +28976,14 @@ namespace OpenTK.Graphics.OpenGL
                 _DeleteOcclusionQueriesNV_fnptr(n, ids);
             }
             
-            private static delegate* unmanaged<uint, byte> _IsOcclusionQueryNV_fnptr = &IsOcclusionQueryNV_Lazy;
+            private static delegate* unmanaged<uint, bool> _IsOcclusionQueryNV_fnptr = &IsOcclusionQueryNV_Lazy;
             /// <summary> <b>[requires: GL_NV_occlusion_query]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsOcclusionQueryNV(uint id) => _IsOcclusionQueryNV_fnptr(id);
+            public static bool IsOcclusionQueryNV(uint id) => _IsOcclusionQueryNV_fnptr(id);
             [UnmanagedCallersOnly]
-            private static byte IsOcclusionQueryNV_Lazy(uint id)
+            private static bool IsOcclusionQueryNV_Lazy(uint id)
             {
-                _IsOcclusionQueryNV_fnptr = (delegate* unmanaged<uint, byte>)GLLoader.BindingsContext.GetProcAddress("glIsOcclusionQueryNV");
+                _IsOcclusionQueryNV_fnptr = (delegate* unmanaged<uint, bool>)GLLoader.BindingsContext.GetProcAddress("glIsOcclusionQueryNV");
                 return _IsOcclusionQueryNV_fnptr(id);
             }
             
@@ -29086,14 +29086,14 @@ namespace OpenTK.Graphics.OpenGL
                 _DeletePathsNV_fnptr(path, range);
             }
             
-            private static delegate* unmanaged<uint, byte> _IsPathNV_fnptr = &IsPathNV_Lazy;
+            private static delegate* unmanaged<uint, bool> _IsPathNV_fnptr = &IsPathNV_Lazy;
             /// <summary> <b>[requires: GL_NV_path_rendering]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsPathNV(uint path) => _IsPathNV_fnptr(path);
+            public static bool IsPathNV(uint path) => _IsPathNV_fnptr(path);
             [UnmanagedCallersOnly]
-            private static byte IsPathNV_Lazy(uint path)
+            private static bool IsPathNV_Lazy(uint path)
             {
-                _IsPathNV_fnptr = (delegate* unmanaged<uint, byte>)GLLoader.BindingsContext.GetProcAddress("glIsPathNV");
+                _IsPathNV_fnptr = (delegate* unmanaged<uint, bool>)GLLoader.BindingsContext.GetProcAddress("glIsPathNV");
                 return _IsPathNV_fnptr(path);
             }
             
@@ -29482,25 +29482,25 @@ namespace OpenTK.Graphics.OpenGL
                 _GetPathSpacingNV_fnptr(pathListMode, numPaths, pathNameType, paths, pathBase, advanceScale, kerningScale, transformType, returnedSpacing);
             }
             
-            private static delegate* unmanaged<uint, uint, float, float, byte> _IsPointInFillPathNV_fnptr = &IsPointInFillPathNV_Lazy;
+            private static delegate* unmanaged<uint, uint, float, float, bool> _IsPointInFillPathNV_fnptr = &IsPointInFillPathNV_Lazy;
             /// <summary> <b>[requires: GL_NV_path_rendering]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsPointInFillPathNV(uint path, uint mask, float x, float y) => _IsPointInFillPathNV_fnptr(path, mask, x, y);
+            public static bool IsPointInFillPathNV(uint path, uint mask, float x, float y) => _IsPointInFillPathNV_fnptr(path, mask, x, y);
             [UnmanagedCallersOnly]
-            private static byte IsPointInFillPathNV_Lazy(uint path, uint mask, float x, float y)
+            private static bool IsPointInFillPathNV_Lazy(uint path, uint mask, float x, float y)
             {
-                _IsPointInFillPathNV_fnptr = (delegate* unmanaged<uint, uint, float, float, byte>)GLLoader.BindingsContext.GetProcAddress("glIsPointInFillPathNV");
+                _IsPointInFillPathNV_fnptr = (delegate* unmanaged<uint, uint, float, float, bool>)GLLoader.BindingsContext.GetProcAddress("glIsPointInFillPathNV");
                 return _IsPointInFillPathNV_fnptr(path, mask, x, y);
             }
             
-            private static delegate* unmanaged<uint, float, float, byte> _IsPointInStrokePathNV_fnptr = &IsPointInStrokePathNV_Lazy;
+            private static delegate* unmanaged<uint, float, float, bool> _IsPointInStrokePathNV_fnptr = &IsPointInStrokePathNV_Lazy;
             /// <summary> <b>[requires: GL_NV_path_rendering]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsPointInStrokePathNV(uint path, float x, float y) => _IsPointInStrokePathNV_fnptr(path, x, y);
+            public static bool IsPointInStrokePathNV(uint path, float x, float y) => _IsPointInStrokePathNV_fnptr(path, x, y);
             [UnmanagedCallersOnly]
-            private static byte IsPointInStrokePathNV_Lazy(uint path, float x, float y)
+            private static bool IsPointInStrokePathNV_Lazy(uint path, float x, float y)
             {
-                _IsPointInStrokePathNV_fnptr = (delegate* unmanaged<uint, float, float, byte>)GLLoader.BindingsContext.GetProcAddress("glIsPointInStrokePathNV");
+                _IsPointInStrokePathNV_fnptr = (delegate* unmanaged<uint, float, float, bool>)GLLoader.BindingsContext.GetProcAddress("glIsPointInStrokePathNV");
                 return _IsPointInStrokePathNV_fnptr(path, x, y);
             }
             
@@ -29515,14 +29515,14 @@ namespace OpenTK.Graphics.OpenGL
                 return _GetPathLengthNV_fnptr(path, startSegment, numSegments);
             }
             
-            private static delegate* unmanaged<uint, int, int, float, float*, float*, float*, float*, byte> _PointAlongPathNV_fnptr = &PointAlongPathNV_Lazy;
+            private static delegate* unmanaged<uint, int, int, float, float*, float*, float*, float*, bool> _PointAlongPathNV_fnptr = &PointAlongPathNV_Lazy;
             /// <summary> <b>[requires: GL_NV_path_rendering]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte PointAlongPathNV(uint path, int startSegment, int numSegments, float distance, float* x, float* y, float* tangentX, float* tangentY) => _PointAlongPathNV_fnptr(path, startSegment, numSegments, distance, x, y, tangentX, tangentY);
+            public static bool PointAlongPathNV(uint path, int startSegment, int numSegments, float distance, float* x, float* y, float* tangentX, float* tangentY) => _PointAlongPathNV_fnptr(path, startSegment, numSegments, distance, x, y, tangentX, tangentY);
             [UnmanagedCallersOnly]
-            private static byte PointAlongPathNV_Lazy(uint path, int startSegment, int numSegments, float distance, float* x, float* y, float* tangentX, float* tangentY)
+            private static bool PointAlongPathNV_Lazy(uint path, int startSegment, int numSegments, float distance, float* x, float* y, float* tangentX, float* tangentY)
             {
-                _PointAlongPathNV_fnptr = (delegate* unmanaged<uint, int, int, float, float*, float*, float*, float*, byte>)GLLoader.BindingsContext.GetProcAddress("glPointAlongPathNV");
+                _PointAlongPathNV_fnptr = (delegate* unmanaged<uint, int, int, float, float*, float*, float*, float*, bool>)GLLoader.BindingsContext.GetProcAddress("glPointAlongPathNV");
                 return _PointAlongPathNV_fnptr(path, startSegment, numSegments, distance, x, y, tangentX, tangentY);
             }
             
@@ -30131,14 +30131,14 @@ namespace OpenTK.Graphics.OpenGL
                 _CombinerInputNV_fnptr(stage, portion, variable, input, mapping, componentUsage);
             }
             
-            private static delegate* unmanaged<CombinerStageNV, CombinerPortionNV, CombinerRegisterNV, CombinerRegisterNV, CombinerRegisterNV, CombinerScaleNV, CombinerBiasNV, byte, byte, byte, void> _CombinerOutputNV_fnptr = &CombinerOutputNV_Lazy;
+            private static delegate* unmanaged<CombinerStageNV, CombinerPortionNV, CombinerRegisterNV, CombinerRegisterNV, CombinerRegisterNV, CombinerScaleNV, CombinerBiasNV, bool, bool, bool, void> _CombinerOutputNV_fnptr = &CombinerOutputNV_Lazy;
             /// <summary> <b>[requires: GL_NV_register_combiners]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void CombinerOutputNV(CombinerStageNV stage, CombinerPortionNV portion, CombinerRegisterNV abOutput, CombinerRegisterNV cdOutput, CombinerRegisterNV sumOutput, CombinerScaleNV scale, CombinerBiasNV bias, byte abDotProduct, byte cdDotProduct, byte muxSum) => _CombinerOutputNV_fnptr(stage, portion, abOutput, cdOutput, sumOutput, scale, bias, abDotProduct, cdDotProduct, muxSum);
+            public static void CombinerOutputNV(CombinerStageNV stage, CombinerPortionNV portion, CombinerRegisterNV abOutput, CombinerRegisterNV cdOutput, CombinerRegisterNV sumOutput, CombinerScaleNV scale, CombinerBiasNV bias, bool abDotProduct, bool cdDotProduct, bool muxSum) => _CombinerOutputNV_fnptr(stage, portion, abOutput, cdOutput, sumOutput, scale, bias, abDotProduct, cdDotProduct, muxSum);
             [UnmanagedCallersOnly]
-            private static void CombinerOutputNV_Lazy(CombinerStageNV stage, CombinerPortionNV portion, CombinerRegisterNV abOutput, CombinerRegisterNV cdOutput, CombinerRegisterNV sumOutput, CombinerScaleNV scale, CombinerBiasNV bias, byte abDotProduct, byte cdDotProduct, byte muxSum)
+            private static void CombinerOutputNV_Lazy(CombinerStageNV stage, CombinerPortionNV portion, CombinerRegisterNV abOutput, CombinerRegisterNV cdOutput, CombinerRegisterNV sumOutput, CombinerScaleNV scale, CombinerBiasNV bias, bool abDotProduct, bool cdDotProduct, bool muxSum)
             {
-                _CombinerOutputNV_fnptr = (delegate* unmanaged<CombinerStageNV, CombinerPortionNV, CombinerRegisterNV, CombinerRegisterNV, CombinerRegisterNV, CombinerScaleNV, CombinerBiasNV, byte, byte, byte, void>)GLLoader.BindingsContext.GetProcAddress("glCombinerOutputNV");
+                _CombinerOutputNV_fnptr = (delegate* unmanaged<CombinerStageNV, CombinerPortionNV, CombinerRegisterNV, CombinerRegisterNV, CombinerRegisterNV, CombinerScaleNV, CombinerBiasNV, bool, bool, bool, void>)GLLoader.BindingsContext.GetProcAddress("glCombinerOutputNV");
                 _CombinerOutputNV_fnptr(stage, portion, abOutput, cdOutput, sumOutput, scale, bias, abDotProduct, cdDotProduct, muxSum);
             }
             
@@ -30318,14 +30318,14 @@ namespace OpenTK.Graphics.OpenGL
                 _MakeBufferNonResidentNV_fnptr(target);
             }
             
-            private static delegate* unmanaged<All, byte> _IsBufferResidentNV_fnptr = &IsBufferResidentNV_Lazy;
+            private static delegate* unmanaged<All, bool> _IsBufferResidentNV_fnptr = &IsBufferResidentNV_Lazy;
             /// <summary> <b>[requires: GL_NV_shader_buffer_load]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsBufferResidentNV(All target) => _IsBufferResidentNV_fnptr(target);
+            public static bool IsBufferResidentNV(All target) => _IsBufferResidentNV_fnptr(target);
             [UnmanagedCallersOnly]
-            private static byte IsBufferResidentNV_Lazy(All target)
+            private static bool IsBufferResidentNV_Lazy(All target)
             {
-                _IsBufferResidentNV_fnptr = (delegate* unmanaged<All, byte>)GLLoader.BindingsContext.GetProcAddress("glIsBufferResidentNV");
+                _IsBufferResidentNV_fnptr = (delegate* unmanaged<All, bool>)GLLoader.BindingsContext.GetProcAddress("glIsBufferResidentNV");
                 return _IsBufferResidentNV_fnptr(target);
             }
             
@@ -30351,14 +30351,14 @@ namespace OpenTK.Graphics.OpenGL
                 _MakeNamedBufferNonResidentNV_fnptr(buffer);
             }
             
-            private static delegate* unmanaged<BufferHandle, byte> _IsNamedBufferResidentNV_fnptr = &IsNamedBufferResidentNV_Lazy;
+            private static delegate* unmanaged<BufferHandle, bool> _IsNamedBufferResidentNV_fnptr = &IsNamedBufferResidentNV_Lazy;
             /// <summary> <b>[requires: GL_NV_shader_buffer_load]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsNamedBufferResidentNV(BufferHandle buffer) => _IsNamedBufferResidentNV_fnptr(buffer);
+            public static bool IsNamedBufferResidentNV(BufferHandle buffer) => _IsNamedBufferResidentNV_fnptr(buffer);
             [UnmanagedCallersOnly]
-            private static byte IsNamedBufferResidentNV_Lazy(BufferHandle buffer)
+            private static bool IsNamedBufferResidentNV_Lazy(BufferHandle buffer)
             {
-                _IsNamedBufferResidentNV_fnptr = (delegate* unmanaged<BufferHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsNamedBufferResidentNV");
+                _IsNamedBufferResidentNV_fnptr = (delegate* unmanaged<BufferHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsNamedBufferResidentNV");
                 return _IsNamedBufferResidentNV_fnptr(buffer);
             }
             
@@ -30483,14 +30483,14 @@ namespace OpenTK.Graphics.OpenGL
                 _GetShadingRateSampleLocationivNV_fnptr(rate, samples, index, location);
             }
             
-            private static delegate* unmanaged<byte, void> _ShadingRateImageBarrierNV_fnptr = &ShadingRateImageBarrierNV_Lazy;
+            private static delegate* unmanaged<bool, void> _ShadingRateImageBarrierNV_fnptr = &ShadingRateImageBarrierNV_Lazy;
             /// <summary> <b>[requires: GL_NV_shading_rate_image]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ShadingRateImageBarrierNV(byte synchronize) => _ShadingRateImageBarrierNV_fnptr(synchronize);
+            public static void ShadingRateImageBarrierNV(bool synchronize) => _ShadingRateImageBarrierNV_fnptr(synchronize);
             [UnmanagedCallersOnly]
-            private static void ShadingRateImageBarrierNV_Lazy(byte synchronize)
+            private static void ShadingRateImageBarrierNV_Lazy(bool synchronize)
             {
-                _ShadingRateImageBarrierNV_fnptr = (delegate* unmanaged<byte, void>)GLLoader.BindingsContext.GetProcAddress("glShadingRateImageBarrierNV");
+                _ShadingRateImageBarrierNV_fnptr = (delegate* unmanaged<bool, void>)GLLoader.BindingsContext.GetProcAddress("glShadingRateImageBarrierNV");
                 _ShadingRateImageBarrierNV_fnptr(synchronize);
             }
             
@@ -30538,69 +30538,69 @@ namespace OpenTK.Graphics.OpenGL
                 _TextureBarrierNV_fnptr();
             }
             
-            private static delegate* unmanaged<TextureTarget, int, int, int, int, int, byte, void> _TexImage2DMultisampleCoverageNV_fnptr = &TexImage2DMultisampleCoverageNV_Lazy;
+            private static delegate* unmanaged<TextureTarget, int, int, int, int, int, bool, void> _TexImage2DMultisampleCoverageNV_fnptr = &TexImage2DMultisampleCoverageNV_Lazy;
             /// <summary> <b>[requires: GL_NV_texture_multisample]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TexImage2DMultisampleCoverageNV(TextureTarget target, int coverageSamples, int colorSamples, int internalFormat, int width, int height, byte fixedSampleLocations) => _TexImage2DMultisampleCoverageNV_fnptr(target, coverageSamples, colorSamples, internalFormat, width, height, fixedSampleLocations);
+            public static void TexImage2DMultisampleCoverageNV(TextureTarget target, int coverageSamples, int colorSamples, int internalFormat, int width, int height, bool fixedSampleLocations) => _TexImage2DMultisampleCoverageNV_fnptr(target, coverageSamples, colorSamples, internalFormat, width, height, fixedSampleLocations);
             [UnmanagedCallersOnly]
-            private static void TexImage2DMultisampleCoverageNV_Lazy(TextureTarget target, int coverageSamples, int colorSamples, int internalFormat, int width, int height, byte fixedSampleLocations)
+            private static void TexImage2DMultisampleCoverageNV_Lazy(TextureTarget target, int coverageSamples, int colorSamples, int internalFormat, int width, int height, bool fixedSampleLocations)
             {
-                _TexImage2DMultisampleCoverageNV_fnptr = (delegate* unmanaged<TextureTarget, int, int, int, int, int, byte, void>)GLLoader.BindingsContext.GetProcAddress("glTexImage2DMultisampleCoverageNV");
+                _TexImage2DMultisampleCoverageNV_fnptr = (delegate* unmanaged<TextureTarget, int, int, int, int, int, bool, void>)GLLoader.BindingsContext.GetProcAddress("glTexImage2DMultisampleCoverageNV");
                 _TexImage2DMultisampleCoverageNV_fnptr(target, coverageSamples, colorSamples, internalFormat, width, height, fixedSampleLocations);
             }
             
-            private static delegate* unmanaged<TextureTarget, int, int, int, int, int, int, byte, void> _TexImage3DMultisampleCoverageNV_fnptr = &TexImage3DMultisampleCoverageNV_Lazy;
+            private static delegate* unmanaged<TextureTarget, int, int, int, int, int, int, bool, void> _TexImage3DMultisampleCoverageNV_fnptr = &TexImage3DMultisampleCoverageNV_Lazy;
             /// <summary> <b>[requires: GL_NV_texture_multisample]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TexImage3DMultisampleCoverageNV(TextureTarget target, int coverageSamples, int colorSamples, int internalFormat, int width, int height, int depth, byte fixedSampleLocations) => _TexImage3DMultisampleCoverageNV_fnptr(target, coverageSamples, colorSamples, internalFormat, width, height, depth, fixedSampleLocations);
+            public static void TexImage3DMultisampleCoverageNV(TextureTarget target, int coverageSamples, int colorSamples, int internalFormat, int width, int height, int depth, bool fixedSampleLocations) => _TexImage3DMultisampleCoverageNV_fnptr(target, coverageSamples, colorSamples, internalFormat, width, height, depth, fixedSampleLocations);
             [UnmanagedCallersOnly]
-            private static void TexImage3DMultisampleCoverageNV_Lazy(TextureTarget target, int coverageSamples, int colorSamples, int internalFormat, int width, int height, int depth, byte fixedSampleLocations)
+            private static void TexImage3DMultisampleCoverageNV_Lazy(TextureTarget target, int coverageSamples, int colorSamples, int internalFormat, int width, int height, int depth, bool fixedSampleLocations)
             {
-                _TexImage3DMultisampleCoverageNV_fnptr = (delegate* unmanaged<TextureTarget, int, int, int, int, int, int, byte, void>)GLLoader.BindingsContext.GetProcAddress("glTexImage3DMultisampleCoverageNV");
+                _TexImage3DMultisampleCoverageNV_fnptr = (delegate* unmanaged<TextureTarget, int, int, int, int, int, int, bool, void>)GLLoader.BindingsContext.GetProcAddress("glTexImage3DMultisampleCoverageNV");
                 _TexImage3DMultisampleCoverageNV_fnptr(target, coverageSamples, colorSamples, internalFormat, width, height, depth, fixedSampleLocations);
             }
             
-            private static delegate* unmanaged<TextureHandle, TextureTarget, int, int, int, int, byte, void> _TextureImage2DMultisampleNV_fnptr = &TextureImage2DMultisampleNV_Lazy;
+            private static delegate* unmanaged<TextureHandle, TextureTarget, int, int, int, int, bool, void> _TextureImage2DMultisampleNV_fnptr = &TextureImage2DMultisampleNV_Lazy;
             /// <summary> <b>[requires: GL_NV_texture_multisample]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureImage2DMultisampleNV(TextureHandle texture, TextureTarget target, int samples, int internalFormat, int width, int height, byte fixedSampleLocations) => _TextureImage2DMultisampleNV_fnptr(texture, target, samples, internalFormat, width, height, fixedSampleLocations);
+            public static void TextureImage2DMultisampleNV(TextureHandle texture, TextureTarget target, int samples, int internalFormat, int width, int height, bool fixedSampleLocations) => _TextureImage2DMultisampleNV_fnptr(texture, target, samples, internalFormat, width, height, fixedSampleLocations);
             [UnmanagedCallersOnly]
-            private static void TextureImage2DMultisampleNV_Lazy(TextureHandle texture, TextureTarget target, int samples, int internalFormat, int width, int height, byte fixedSampleLocations)
+            private static void TextureImage2DMultisampleNV_Lazy(TextureHandle texture, TextureTarget target, int samples, int internalFormat, int width, int height, bool fixedSampleLocations)
             {
-                _TextureImage2DMultisampleNV_fnptr = (delegate* unmanaged<TextureHandle, TextureTarget, int, int, int, int, byte, void>)GLLoader.BindingsContext.GetProcAddress("glTextureImage2DMultisampleNV");
+                _TextureImage2DMultisampleNV_fnptr = (delegate* unmanaged<TextureHandle, TextureTarget, int, int, int, int, bool, void>)GLLoader.BindingsContext.GetProcAddress("glTextureImage2DMultisampleNV");
                 _TextureImage2DMultisampleNV_fnptr(texture, target, samples, internalFormat, width, height, fixedSampleLocations);
             }
             
-            private static delegate* unmanaged<TextureHandle, TextureTarget, int, int, int, int, int, byte, void> _TextureImage3DMultisampleNV_fnptr = &TextureImage3DMultisampleNV_Lazy;
+            private static delegate* unmanaged<TextureHandle, TextureTarget, int, int, int, int, int, bool, void> _TextureImage3DMultisampleNV_fnptr = &TextureImage3DMultisampleNV_Lazy;
             /// <summary> <b>[requires: GL_NV_texture_multisample]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureImage3DMultisampleNV(TextureHandle texture, TextureTarget target, int samples, int internalFormat, int width, int height, int depth, byte fixedSampleLocations) => _TextureImage3DMultisampleNV_fnptr(texture, target, samples, internalFormat, width, height, depth, fixedSampleLocations);
+            public static void TextureImage3DMultisampleNV(TextureHandle texture, TextureTarget target, int samples, int internalFormat, int width, int height, int depth, bool fixedSampleLocations) => _TextureImage3DMultisampleNV_fnptr(texture, target, samples, internalFormat, width, height, depth, fixedSampleLocations);
             [UnmanagedCallersOnly]
-            private static void TextureImage3DMultisampleNV_Lazy(TextureHandle texture, TextureTarget target, int samples, int internalFormat, int width, int height, int depth, byte fixedSampleLocations)
+            private static void TextureImage3DMultisampleNV_Lazy(TextureHandle texture, TextureTarget target, int samples, int internalFormat, int width, int height, int depth, bool fixedSampleLocations)
             {
-                _TextureImage3DMultisampleNV_fnptr = (delegate* unmanaged<TextureHandle, TextureTarget, int, int, int, int, int, byte, void>)GLLoader.BindingsContext.GetProcAddress("glTextureImage3DMultisampleNV");
+                _TextureImage3DMultisampleNV_fnptr = (delegate* unmanaged<TextureHandle, TextureTarget, int, int, int, int, int, bool, void>)GLLoader.BindingsContext.GetProcAddress("glTextureImage3DMultisampleNV");
                 _TextureImage3DMultisampleNV_fnptr(texture, target, samples, internalFormat, width, height, depth, fixedSampleLocations);
             }
             
-            private static delegate* unmanaged<TextureHandle, TextureTarget, int, int, int, int, int, byte, void> _TextureImage2DMultisampleCoverageNV_fnptr = &TextureImage2DMultisampleCoverageNV_Lazy;
+            private static delegate* unmanaged<TextureHandle, TextureTarget, int, int, int, int, int, bool, void> _TextureImage2DMultisampleCoverageNV_fnptr = &TextureImage2DMultisampleCoverageNV_Lazy;
             /// <summary> <b>[requires: GL_NV_texture_multisample]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureImage2DMultisampleCoverageNV(TextureHandle texture, TextureTarget target, int coverageSamples, int colorSamples, int internalFormat, int width, int height, byte fixedSampleLocations) => _TextureImage2DMultisampleCoverageNV_fnptr(texture, target, coverageSamples, colorSamples, internalFormat, width, height, fixedSampleLocations);
+            public static void TextureImage2DMultisampleCoverageNV(TextureHandle texture, TextureTarget target, int coverageSamples, int colorSamples, int internalFormat, int width, int height, bool fixedSampleLocations) => _TextureImage2DMultisampleCoverageNV_fnptr(texture, target, coverageSamples, colorSamples, internalFormat, width, height, fixedSampleLocations);
             [UnmanagedCallersOnly]
-            private static void TextureImage2DMultisampleCoverageNV_Lazy(TextureHandle texture, TextureTarget target, int coverageSamples, int colorSamples, int internalFormat, int width, int height, byte fixedSampleLocations)
+            private static void TextureImage2DMultisampleCoverageNV_Lazy(TextureHandle texture, TextureTarget target, int coverageSamples, int colorSamples, int internalFormat, int width, int height, bool fixedSampleLocations)
             {
-                _TextureImage2DMultisampleCoverageNV_fnptr = (delegate* unmanaged<TextureHandle, TextureTarget, int, int, int, int, int, byte, void>)GLLoader.BindingsContext.GetProcAddress("glTextureImage2DMultisampleCoverageNV");
+                _TextureImage2DMultisampleCoverageNV_fnptr = (delegate* unmanaged<TextureHandle, TextureTarget, int, int, int, int, int, bool, void>)GLLoader.BindingsContext.GetProcAddress("glTextureImage2DMultisampleCoverageNV");
                 _TextureImage2DMultisampleCoverageNV_fnptr(texture, target, coverageSamples, colorSamples, internalFormat, width, height, fixedSampleLocations);
             }
             
-            private static delegate* unmanaged<TextureHandle, TextureTarget, int, int, int, int, int, int, byte, void> _TextureImage3DMultisampleCoverageNV_fnptr = &TextureImage3DMultisampleCoverageNV_Lazy;
+            private static delegate* unmanaged<TextureHandle, TextureTarget, int, int, int, int, int, int, bool, void> _TextureImage3DMultisampleCoverageNV_fnptr = &TextureImage3DMultisampleCoverageNV_Lazy;
             /// <summary> <b>[requires: GL_NV_texture_multisample]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureImage3DMultisampleCoverageNV(TextureHandle texture, TextureTarget target, int coverageSamples, int colorSamples, int internalFormat, int width, int height, int depth, byte fixedSampleLocations) => _TextureImage3DMultisampleCoverageNV_fnptr(texture, target, coverageSamples, colorSamples, internalFormat, width, height, depth, fixedSampleLocations);
+            public static void TextureImage3DMultisampleCoverageNV(TextureHandle texture, TextureTarget target, int coverageSamples, int colorSamples, int internalFormat, int width, int height, int depth, bool fixedSampleLocations) => _TextureImage3DMultisampleCoverageNV_fnptr(texture, target, coverageSamples, colorSamples, internalFormat, width, height, depth, fixedSampleLocations);
             [UnmanagedCallersOnly]
-            private static void TextureImage3DMultisampleCoverageNV_Lazy(TextureHandle texture, TextureTarget target, int coverageSamples, int colorSamples, int internalFormat, int width, int height, int depth, byte fixedSampleLocations)
+            private static void TextureImage3DMultisampleCoverageNV_Lazy(TextureHandle texture, TextureTarget target, int coverageSamples, int colorSamples, int internalFormat, int width, int height, int depth, bool fixedSampleLocations)
             {
-                _TextureImage3DMultisampleCoverageNV_fnptr = (delegate* unmanaged<TextureHandle, TextureTarget, int, int, int, int, int, int, byte, void>)GLLoader.BindingsContext.GetProcAddress("glTextureImage3DMultisampleCoverageNV");
+                _TextureImage3DMultisampleCoverageNV_fnptr = (delegate* unmanaged<TextureHandle, TextureTarget, int, int, int, int, int, int, bool, void>)GLLoader.BindingsContext.GetProcAddress("glTextureImage3DMultisampleCoverageNV");
                 _TextureImage3DMultisampleCoverageNV_fnptr(texture, target, coverageSamples, colorSamples, internalFormat, width, height, depth, fixedSampleLocations);
             }
             
@@ -30769,14 +30769,14 @@ namespace OpenTK.Graphics.OpenGL
                 _GenTransformFeedbacksNV_fnptr(n, ids);
             }
             
-            private static delegate* unmanaged<TransformFeedbackHandle, byte> _IsTransformFeedbackNV_fnptr = &IsTransformFeedbackNV_Lazy;
+            private static delegate* unmanaged<TransformFeedbackHandle, bool> _IsTransformFeedbackNV_fnptr = &IsTransformFeedbackNV_Lazy;
             /// <summary> <b>[requires: GL_NV_transform_feedback2]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsTransformFeedbackNV(TransformFeedbackHandle id) => _IsTransformFeedbackNV_fnptr(id);
+            public static bool IsTransformFeedbackNV(TransformFeedbackHandle id) => _IsTransformFeedbackNV_fnptr(id);
             [UnmanagedCallersOnly]
-            private static byte IsTransformFeedbackNV_Lazy(TransformFeedbackHandle id)
+            private static bool IsTransformFeedbackNV_Lazy(TransformFeedbackHandle id)
             {
-                _IsTransformFeedbackNV_fnptr = (delegate* unmanaged<TransformFeedbackHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsTransformFeedbackNV");
+                _IsTransformFeedbackNV_fnptr = (delegate* unmanaged<TransformFeedbackHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsTransformFeedbackNV");
                 return _IsTransformFeedbackNV_fnptr(id);
             }
             
@@ -30857,14 +30857,14 @@ namespace OpenTK.Graphics.OpenGL
                 return _VDPAURegisterOutputSurfaceNV_fnptr(vdpSurface, target, numTextureNames, textureNames);
             }
             
-            private static delegate* unmanaged<IntPtr, byte> _VDPAUIsSurfaceNV_fnptr = &VDPAUIsSurfaceNV_Lazy;
+            private static delegate* unmanaged<IntPtr, bool> _VDPAUIsSurfaceNV_fnptr = &VDPAUIsSurfaceNV_Lazy;
             /// <summary> <b>[requires: GL_NV_vdpau_interop]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte VDPAUIsSurfaceNV(IntPtr surface) => _VDPAUIsSurfaceNV_fnptr(surface);
+            public static bool VDPAUIsSurfaceNV(IntPtr surface) => _VDPAUIsSurfaceNV_fnptr(surface);
             [UnmanagedCallersOnly]
-            private static byte VDPAUIsSurfaceNV_Lazy(IntPtr surface)
+            private static bool VDPAUIsSurfaceNV_Lazy(IntPtr surface)
             {
-                _VDPAUIsSurfaceNV_fnptr = (delegate* unmanaged<IntPtr, byte>)GLLoader.BindingsContext.GetProcAddress("glVDPAUIsSurfaceNV");
+                _VDPAUIsSurfaceNV_fnptr = (delegate* unmanaged<IntPtr, bool>)GLLoader.BindingsContext.GetProcAddress("glVDPAUIsSurfaceNV");
                 return _VDPAUIsSurfaceNV_fnptr(surface);
             }
             
@@ -30923,14 +30923,14 @@ namespace OpenTK.Graphics.OpenGL
                 _VDPAUUnmapSurfacesNV_fnptr(numSurface, surfaces);
             }
             
-            private static delegate* unmanaged<void*, All, int, uint*, byte, IntPtr> _VDPAURegisterVideoSurfaceWithPictureStructureNV_fnptr = &VDPAURegisterVideoSurfaceWithPictureStructureNV_Lazy;
+            private static delegate* unmanaged<void*, All, int, uint*, bool, IntPtr> _VDPAURegisterVideoSurfaceWithPictureStructureNV_fnptr = &VDPAURegisterVideoSurfaceWithPictureStructureNV_Lazy;
             /// <summary> <b>[requires: GL_NV_vdpau_interop2]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static IntPtr VDPAURegisterVideoSurfaceWithPictureStructureNV(void* vdpSurface, All target, int numTextureNames, uint* textureNames, byte isFrameStructure) => _VDPAURegisterVideoSurfaceWithPictureStructureNV_fnptr(vdpSurface, target, numTextureNames, textureNames, isFrameStructure);
+            public static IntPtr VDPAURegisterVideoSurfaceWithPictureStructureNV(void* vdpSurface, All target, int numTextureNames, uint* textureNames, bool isFrameStructure) => _VDPAURegisterVideoSurfaceWithPictureStructureNV_fnptr(vdpSurface, target, numTextureNames, textureNames, isFrameStructure);
             [UnmanagedCallersOnly]
-            private static IntPtr VDPAURegisterVideoSurfaceWithPictureStructureNV_Lazy(void* vdpSurface, All target, int numTextureNames, uint* textureNames, byte isFrameStructure)
+            private static IntPtr VDPAURegisterVideoSurfaceWithPictureStructureNV_Lazy(void* vdpSurface, All target, int numTextureNames, uint* textureNames, bool isFrameStructure)
             {
-                _VDPAURegisterVideoSurfaceWithPictureStructureNV_fnptr = (delegate* unmanaged<void*, All, int, uint*, byte, IntPtr>)GLLoader.BindingsContext.GetProcAddress("glVDPAURegisterVideoSurfaceWithPictureStructureNV");
+                _VDPAURegisterVideoSurfaceWithPictureStructureNV_fnptr = (delegate* unmanaged<void*, All, int, uint*, bool, IntPtr>)GLLoader.BindingsContext.GetProcAddress("glVDPAURegisterVideoSurfaceWithPictureStructureNV");
                 return _VDPAURegisterVideoSurfaceWithPictureStructureNV_fnptr(vdpSurface, target, numTextureNames, textureNames, isFrameStructure);
             }
             
@@ -31264,14 +31264,14 @@ namespace OpenTK.Graphics.OpenGL
                 _FogCoordFormatNV_fnptr(type, stride);
             }
             
-            private static delegate* unmanaged<uint, int, VertexAttribType, byte, int, void> _VertexAttribFormatNV_fnptr = &VertexAttribFormatNV_Lazy;
+            private static delegate* unmanaged<uint, int, VertexAttribType, bool, int, void> _VertexAttribFormatNV_fnptr = &VertexAttribFormatNV_Lazy;
             /// <summary> <b>[requires: GL_NV_vertex_buffer_unified_memory]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void VertexAttribFormatNV(uint index, int size, VertexAttribType type, byte normalized, int stride) => _VertexAttribFormatNV_fnptr(index, size, type, normalized, stride);
+            public static void VertexAttribFormatNV(uint index, int size, VertexAttribType type, bool normalized, int stride) => _VertexAttribFormatNV_fnptr(index, size, type, normalized, stride);
             [UnmanagedCallersOnly]
-            private static void VertexAttribFormatNV_Lazy(uint index, int size, VertexAttribType type, byte normalized, int stride)
+            private static void VertexAttribFormatNV_Lazy(uint index, int size, VertexAttribType type, bool normalized, int stride)
             {
-                _VertexAttribFormatNV_fnptr = (delegate* unmanaged<uint, int, VertexAttribType, byte, int, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribFormatNV");
+                _VertexAttribFormatNV_fnptr = (delegate* unmanaged<uint, int, VertexAttribType, bool, int, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribFormatNV");
                 _VertexAttribFormatNV_fnptr(index, size, type, normalized, stride);
             }
             
@@ -31297,14 +31297,14 @@ namespace OpenTK.Graphics.OpenGL
                 _GetIntegerui64i_vNV_fnptr(value, index, result);
             }
             
-            private static delegate* unmanaged<int, ProgramHandle*, byte*, byte> _AreProgramsResidentNV_fnptr = &AreProgramsResidentNV_Lazy;
+            private static delegate* unmanaged<int, ProgramHandle*, bool*, bool> _AreProgramsResidentNV_fnptr = &AreProgramsResidentNV_Lazy;
             /// <summary> <b>[requires: GL_NV_vertex_program]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte AreProgramsResidentNV(int n, ProgramHandle* programs, byte* residences) => _AreProgramsResidentNV_fnptr(n, programs, residences);
+            public static bool AreProgramsResidentNV(int n, ProgramHandle* programs, bool* residences) => _AreProgramsResidentNV_fnptr(n, programs, residences);
             [UnmanagedCallersOnly]
-            private static byte AreProgramsResidentNV_Lazy(int n, ProgramHandle* programs, byte* residences)
+            private static bool AreProgramsResidentNV_Lazy(int n, ProgramHandle* programs, bool* residences)
             {
-                _AreProgramsResidentNV_fnptr = (delegate* unmanaged<int, ProgramHandle*, byte*, byte>)GLLoader.BindingsContext.GetProcAddress("glAreProgramsResidentNV");
+                _AreProgramsResidentNV_fnptr = (delegate* unmanaged<int, ProgramHandle*, bool*, bool>)GLLoader.BindingsContext.GetProcAddress("glAreProgramsResidentNV");
                 return _AreProgramsResidentNV_fnptr(n, programs, residences);
             }
             
@@ -31451,14 +31451,14 @@ namespace OpenTK.Graphics.OpenGL
                 _GetVertexAttribPointervNV_fnptr(index, pname, pointer);
             }
             
-            private static delegate* unmanaged<ProgramHandle, byte> _IsProgramNV_fnptr = &IsProgramNV_Lazy;
+            private static delegate* unmanaged<ProgramHandle, bool> _IsProgramNV_fnptr = &IsProgramNV_Lazy;
             /// <summary> <b>[requires: GL_NV_vertex_program]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsProgramNV(ProgramHandle id) => _IsProgramNV_fnptr(id);
+            public static bool IsProgramNV(ProgramHandle id) => _IsProgramNV_fnptr(id);
             [UnmanagedCallersOnly]
-            private static byte IsProgramNV_Lazy(ProgramHandle id)
+            private static bool IsProgramNV_Lazy(ProgramHandle id)
             {
-                _IsProgramNV_fnptr = (delegate* unmanaged<ProgramHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsProgramNV");
+                _IsProgramNV_fnptr = (delegate* unmanaged<ProgramHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsProgramNV");
                 return _IsProgramNV_fnptr(id);
             }
             
@@ -32549,14 +32549,14 @@ namespace OpenTK.Graphics.OpenGL
                 _SecondaryColorPointerListIBM_fnptr(size, type, stride, pointer, ptrstride);
             }
             
-            private static delegate* unmanaged<int, byte**, int, void> _EdgeFlagPointerListIBM_fnptr = &EdgeFlagPointerListIBM_Lazy;
+            private static delegate* unmanaged<int, bool**, int, void> _EdgeFlagPointerListIBM_fnptr = &EdgeFlagPointerListIBM_Lazy;
             /// <summary> <b>[requires: GL_IBM_vertex_array_lists]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void EdgeFlagPointerListIBM(int stride, byte** pointer, int ptrstride) => _EdgeFlagPointerListIBM_fnptr(stride, pointer, ptrstride);
+            public static void EdgeFlagPointerListIBM(int stride, bool** pointer, int ptrstride) => _EdgeFlagPointerListIBM_fnptr(stride, pointer, ptrstride);
             [UnmanagedCallersOnly]
-            private static void EdgeFlagPointerListIBM_Lazy(int stride, byte** pointer, int ptrstride)
+            private static void EdgeFlagPointerListIBM_Lazy(int stride, bool** pointer, int ptrstride)
             {
-                _EdgeFlagPointerListIBM_fnptr = (delegate* unmanaged<int, byte**, int, void>)GLLoader.BindingsContext.GetProcAddress("glEdgeFlagPointerListIBM");
+                _EdgeFlagPointerListIBM_fnptr = (delegate* unmanaged<int, bool**, int, void>)GLLoader.BindingsContext.GetProcAddress("glEdgeFlagPointerListIBM");
                 _EdgeFlagPointerListIBM_fnptr(stride, pointer, ptrstride);
             }
             
@@ -32844,7 +32844,7 @@ namespace OpenTK.Graphics.OpenGL
                 _BlendBarrierKHR_fnptr();
             }
             
-            private static delegate* unmanaged<DebugSource, DebugType, DebugSeverity, int, uint*, byte, void> _DebugMessageControl_fnptr = &DebugMessageControl_Lazy;
+            private static delegate* unmanaged<DebugSource, DebugType, DebugSeverity, int, uint*, bool, void> _DebugMessageControl_fnptr = &DebugMessageControl_Lazy;
             /// <summary> <b>[requires: v4.3 | GL_KHR_debug]</b> Control the reporting of debug messages in a debug context. </summary>
             /// <param name="source"> The source of debug messages to enable or disable. </param>
             /// <param name="type"> The type of debug messages to enable or disable. </param>
@@ -32853,11 +32853,11 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="ids"> The address of an array of unsigned integers contianing the ids of the messages to enable or disable. </param>
             /// <param name="enabled"> A Boolean flag determining whether the selected messages should be enabled or disabled. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDebugMessageControl.xhtml" /></remarks>
-            public static void DebugMessageControl(DebugSource source, DebugType type, DebugSeverity severity, int count, uint* ids, byte enabled) => _DebugMessageControl_fnptr(source, type, severity, count, ids, enabled);
+            public static void DebugMessageControl(DebugSource source, DebugType type, DebugSeverity severity, int count, uint* ids, bool enabled) => _DebugMessageControl_fnptr(source, type, severity, count, ids, enabled);
             [UnmanagedCallersOnly]
-            private static void DebugMessageControl_Lazy(DebugSource source, DebugType type, DebugSeverity severity, int count, uint* ids, byte enabled)
+            private static void DebugMessageControl_Lazy(DebugSource source, DebugType type, DebugSeverity severity, int count, uint* ids, bool enabled)
             {
-                _DebugMessageControl_fnptr = (delegate* unmanaged<DebugSource, DebugType, DebugSeverity, int, uint*, byte, void>)GLLoader.BindingsContext.GetProcAddress("glDebugMessageControl");
+                _DebugMessageControl_fnptr = (delegate* unmanaged<DebugSource, DebugType, DebugSeverity, int, uint*, bool, void>)GLLoader.BindingsContext.GetProcAddress("glDebugMessageControl");
                 _DebugMessageControl_fnptr(source, type, severity, count, ids, enabled);
             }
             
@@ -32996,14 +32996,14 @@ namespace OpenTK.Graphics.OpenGL
                 _GetObjectPtrLabel_fnptr(ptr, bufSize, length, label);
             }
             
-            private static delegate* unmanaged<DebugSource, DebugType, DebugSeverity, int, uint*, byte, void> _DebugMessageControlKHR_fnptr = &DebugMessageControlKHR_Lazy;
+            private static delegate* unmanaged<DebugSource, DebugType, DebugSeverity, int, uint*, bool, void> _DebugMessageControlKHR_fnptr = &DebugMessageControlKHR_Lazy;
             /// <summary> <b>[requires: GL_KHR_debug]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void DebugMessageControlKHR(DebugSource source, DebugType type, DebugSeverity severity, int count, uint* ids, byte enabled) => _DebugMessageControlKHR_fnptr(source, type, severity, count, ids, enabled);
+            public static void DebugMessageControlKHR(DebugSource source, DebugType type, DebugSeverity severity, int count, uint* ids, bool enabled) => _DebugMessageControlKHR_fnptr(source, type, severity, count, ids, enabled);
             [UnmanagedCallersOnly]
-            private static void DebugMessageControlKHR_Lazy(DebugSource source, DebugType type, DebugSeverity severity, int count, uint* ids, byte enabled)
+            private static void DebugMessageControlKHR_Lazy(DebugSource source, DebugType type, DebugSeverity severity, int count, uint* ids, bool enabled)
             {
-                _DebugMessageControlKHR_fnptr = (delegate* unmanaged<DebugSource, DebugType, DebugSeverity, int, uint*, byte, void>)GLLoader.BindingsContext.GetProcAddress("glDebugMessageControlKHR");
+                _DebugMessageControlKHR_fnptr = (delegate* unmanaged<DebugSource, DebugType, DebugSeverity, int, uint*, bool, void>)GLLoader.BindingsContext.GetProcAddress("glDebugMessageControlKHR");
                 _DebugMessageControlKHR_fnptr(source, type, severity, count, ids, enabled);
             }
             
@@ -34389,14 +34389,14 @@ namespace OpenTK.Graphics.OpenGL
                 _PointParameterxOES_fnptr(pname, param);
             }
             
-            private static delegate* unmanaged<int, byte, void> _SampleCoveragexOES_fnptr = &SampleCoveragexOES_Lazy;
+            private static delegate* unmanaged<int, bool, void> _SampleCoveragexOES_fnptr = &SampleCoveragexOES_Lazy;
             /// <summary> <b>[requires: GL_OES_fixed_point]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void SampleCoveragexOES(int value, byte invert) => _SampleCoveragexOES_fnptr(value, invert);
+            public static void SampleCoveragexOES(int value, bool invert) => _SampleCoveragexOES_fnptr(value, invert);
             [UnmanagedCallersOnly]
-            private static void SampleCoveragexOES_Lazy(int value, byte invert)
+            private static void SampleCoveragexOES_Lazy(int value, bool invert)
             {
-                _SampleCoveragexOES_fnptr = (delegate* unmanaged<int, byte, void>)GLLoader.BindingsContext.GetProcAddress("glSampleCoveragexOES");
+                _SampleCoveragexOES_fnptr = (delegate* unmanaged<int, bool, void>)GLLoader.BindingsContext.GetProcAddress("glSampleCoveragexOES");
                 _SampleCoveragexOES_fnptr(value, invert);
             }
             
@@ -35300,14 +35300,14 @@ namespace OpenTK.Graphics.OpenGL
                 _GetFogFuncSGIS_fnptr(points);
             }
             
-            private static delegate* unmanaged<float, byte, void> _SampleMaskSGIS_fnptr = &SampleMaskSGIS_Lazy;
+            private static delegate* unmanaged<float, bool, void> _SampleMaskSGIS_fnptr = &SampleMaskSGIS_Lazy;
             /// <summary> <b>[requires: GL_SGIS_multisample]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void SampleMaskSGIS(float value, byte invert) => _SampleMaskSGIS_fnptr(value, invert);
+            public static void SampleMaskSGIS(float value, bool invert) => _SampleMaskSGIS_fnptr(value, invert);
             [UnmanagedCallersOnly]
-            private static void SampleMaskSGIS_Lazy(float value, byte invert)
+            private static void SampleMaskSGIS_Lazy(float value, bool invert)
             {
-                _SampleMaskSGIS_fnptr = (delegate* unmanaged<float, byte, void>)GLLoader.BindingsContext.GetProcAddress("glSampleMaskSGIS");
+                _SampleMaskSGIS_fnptr = (delegate* unmanaged<float, bool, void>)GLLoader.BindingsContext.GetProcAddress("glSampleMaskSGIS");
                 _SampleMaskSGIS_fnptr(value, invert);
             }
             
@@ -35454,14 +35454,14 @@ namespace OpenTK.Graphics.OpenGL
                 _TexSubImage4DSGIS_fnptr(target, level, xoffset, yoffset, zoffset, woffset, width, height, depth, size4d, format, type, pixels);
             }
             
-            private static delegate* unmanaged<byte, byte, byte, byte, void> _TextureColorMaskSGIS_fnptr = &TextureColorMaskSGIS_Lazy;
+            private static delegate* unmanaged<bool, bool, bool, bool, void> _TextureColorMaskSGIS_fnptr = &TextureColorMaskSGIS_Lazy;
             /// <summary> <b>[requires: GL_SGIS_texture_color_mask]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureColorMaskSGIS(byte red, byte green, byte blue, byte alpha) => _TextureColorMaskSGIS_fnptr(red, green, blue, alpha);
+            public static void TextureColorMaskSGIS(bool red, bool green, bool blue, bool alpha) => _TextureColorMaskSGIS_fnptr(red, green, blue, alpha);
             [UnmanagedCallersOnly]
-            private static void TextureColorMaskSGIS_Lazy(byte red, byte green, byte blue, byte alpha)
+            private static void TextureColorMaskSGIS_Lazy(bool red, bool green, bool blue, bool alpha)
             {
-                _TextureColorMaskSGIS_fnptr = (delegate* unmanaged<byte, byte, byte, byte, void>)GLLoader.BindingsContext.GetProcAddress("glTextureColorMaskSGIS");
+                _TextureColorMaskSGIS_fnptr = (delegate* unmanaged<bool, bool, bool, bool, void>)GLLoader.BindingsContext.GetProcAddress("glTextureColorMaskSGIS");
                 _TextureColorMaskSGIS_fnptr(red, green, blue, alpha);
             }
             
@@ -35545,14 +35545,14 @@ namespace OpenTK.Graphics.OpenGL
                 _DeleteAsyncMarkersSGIX_fnptr(marker, range);
             }
             
-            private static delegate* unmanaged<uint, byte> _IsAsyncMarkerSGIX_fnptr = &IsAsyncMarkerSGIX_Lazy;
+            private static delegate* unmanaged<uint, bool> _IsAsyncMarkerSGIX_fnptr = &IsAsyncMarkerSGIX_Lazy;
             /// <summary> <b>[requires: GL_SGIX_async]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsAsyncMarkerSGIX(uint marker) => _IsAsyncMarkerSGIX_fnptr(marker);
+            public static bool IsAsyncMarkerSGIX(uint marker) => _IsAsyncMarkerSGIX_fnptr(marker);
             [UnmanagedCallersOnly]
-            private static byte IsAsyncMarkerSGIX_Lazy(uint marker)
+            private static bool IsAsyncMarkerSGIX_Lazy(uint marker)
             {
-                _IsAsyncMarkerSGIX_fnptr = (delegate* unmanaged<uint, byte>)GLLoader.BindingsContext.GetProcAddress("glIsAsyncMarkerSGIX");
+                _IsAsyncMarkerSGIX_fnptr = (delegate* unmanaged<uint, bool>)GLLoader.BindingsContext.GetProcAddress("glIsAsyncMarkerSGIX");
                 return _IsAsyncMarkerSGIX_fnptr(marker);
             }
             

--- a/src/OpenTK.Graphics/OpenGL/GL.Overloads.cs
+++ b/src/OpenTK.Graphics/OpenGL/GL.Overloads.cs
@@ -172,25 +172,25 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetBooleanv"/>
-        public static unsafe void GetBoolean(GetPName pname, Span<byte> data)
+        public static unsafe void GetBoolean(GetPName pname, Span<bool> data)
         {
-            fixed (byte* data_ptr = data)
+            fixed (bool* data_ptr = data)
             {
                 GetBooleanv(pname, data_ptr);
             }
         }
         /// <inheritdoc cref="GetBooleanv"/>
-        public static unsafe void GetBoolean(GetPName pname, byte[] data)
+        public static unsafe void GetBoolean(GetPName pname, bool[] data)
         {
-            fixed (byte* data_ptr = data)
+            fixed (bool* data_ptr = data)
             {
                 GetBooleanv(pname, data_ptr);
             }
         }
         /// <inheritdoc cref="GetBooleanv"/>
-        public static unsafe void GetBoolean(GetPName pname, ref byte data)
+        public static unsafe void GetBoolean(GetPName pname, ref bool data)
         {
-            fixed (byte* data_ptr = &data)
+            fixed (bool* data_ptr = &data)
             {
                 GetBooleanv(pname, data_ptr);
             }
@@ -3186,25 +3186,25 @@ namespace OpenTK.Graphics.OpenGL
             ColorMaski(index, r_byte, g_byte, b_byte, a_byte);
         }
         /// <inheritdoc cref="GetBooleani_v"/>
-        public static unsafe void GetBoolean(BufferTargetARB target, uint index, Span<byte> data)
+        public static unsafe void GetBoolean(BufferTargetARB target, uint index, Span<bool> data)
         {
-            fixed (byte* data_ptr = data)
+            fixed (bool* data_ptr = data)
             {
                 GetBooleani_v(target, index, data_ptr);
             }
         }
         /// <inheritdoc cref="GetBooleani_v"/>
-        public static unsafe void GetBoolean(BufferTargetARB target, uint index, byte[] data)
+        public static unsafe void GetBoolean(BufferTargetARB target, uint index, bool[] data)
         {
-            fixed (byte* data_ptr = data)
+            fixed (bool* data_ptr = data)
             {
                 GetBooleani_v(target, index, data_ptr);
             }
         }
         /// <inheritdoc cref="GetBooleani_v"/>
-        public static unsafe void GetBoolean(BufferTargetARB target, uint index, ref byte data)
+        public static unsafe void GetBoolean(BufferTargetARB target, uint index, ref bool data)
         {
-            fixed (byte* data_ptr = &data)
+            fixed (bool* data_ptr = &data)
             {
                 GetBooleani_v(target, index, data_ptr);
             }
@@ -19145,9 +19145,9 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="IsNamedStringARB"/>
-            public static unsafe byte IsNamedStringARB(int namelen, string name)
+            public static unsafe bool IsNamedStringARB(int namelen, string name)
             {
-                byte returnValue;
+                bool returnValue;
                 byte* name_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(name);
                 returnValue = IsNamedStringARB(namelen, name_ptr);
                 Marshal.FreeCoTaskMem((IntPtr)name_ptr);
@@ -25079,25 +25079,25 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetBooleanIndexedvEXT"/>
-            public static unsafe void GetBooleanIndexedvEXT(BufferTargetARB target, uint index, Span<byte> data)
+            public static unsafe void GetBooleanIndexedvEXT(BufferTargetARB target, uint index, Span<bool> data)
             {
-                fixed (byte* data_ptr = data)
+                fixed (bool* data_ptr = data)
                 {
                     GetBooleanIndexedvEXT(target, index, data_ptr);
                 }
             }
             /// <inheritdoc cref="GetBooleanIndexedvEXT"/>
-            public static unsafe void GetBooleanIndexedvEXT(BufferTargetARB target, uint index, byte[] data)
+            public static unsafe void GetBooleanIndexedvEXT(BufferTargetARB target, uint index, bool[] data)
             {
-                fixed (byte* data_ptr = data)
+                fixed (bool* data_ptr = data)
                 {
                     GetBooleanIndexedvEXT(target, index, data_ptr);
                 }
             }
             /// <inheritdoc cref="GetBooleanIndexedvEXT"/>
-            public static unsafe void GetBooleanIndexedvEXT(BufferTargetARB target, uint index, ref byte data)
+            public static unsafe void GetBooleanIndexedvEXT(BufferTargetARB target, uint index, ref bool data)
             {
-                fixed (byte* data_ptr = &data)
+                fixed (bool* data_ptr = &data)
                 {
                     GetBooleanIndexedvEXT(target, index, data_ptr);
                 }
@@ -29875,12 +29875,12 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="AreTexturesResidentEXT"/>
-            public static unsafe byte AreTexturesResidentEXT(int n, ReadOnlySpan<TextureHandle> textures, Span<byte> residences)
+            public static unsafe bool AreTexturesResidentEXT(int n, ReadOnlySpan<TextureHandle> textures, Span<bool> residences)
             {
-                byte returnValue;
+                bool returnValue;
                 fixed (TextureHandle* textures_ptr = textures)
                 {
-                    fixed (byte* residences_ptr = residences)
+                    fixed (bool* residences_ptr = residences)
                     {
                         returnValue = AreTexturesResidentEXT(n, textures_ptr, residences_ptr);
                     }
@@ -29888,12 +29888,12 @@ namespace OpenTK.Graphics.OpenGL
                 return returnValue;
             }
             /// <inheritdoc cref="AreTexturesResidentEXT"/>
-            public static unsafe byte AreTexturesResidentEXT(int n, TextureHandle[] textures, byte[] residences)
+            public static unsafe bool AreTexturesResidentEXT(int n, TextureHandle[] textures, bool[] residences)
             {
-                byte returnValue;
+                bool returnValue;
                 fixed (TextureHandle* textures_ptr = textures)
                 {
-                    fixed (byte* residences_ptr = residences)
+                    fixed (bool* residences_ptr = residences)
                     {
                         returnValue = AreTexturesResidentEXT(n, textures_ptr, residences_ptr);
                     }
@@ -29901,11 +29901,11 @@ namespace OpenTK.Graphics.OpenGL
                 return returnValue;
             }
             /// <inheritdoc cref="AreTexturesResidentEXT"/>
-            public static unsafe byte AreTexturesResidentEXT(int n, in TextureHandle textures, ref byte residences)
+            public static unsafe bool AreTexturesResidentEXT(int n, in TextureHandle textures, ref bool residences)
             {
-                byte returnValue;
+                bool returnValue;
                 fixed (TextureHandle* textures_ptr = &textures)
-                fixed (byte* residences_ptr = &residences)
+                fixed (bool* residences_ptr = &residences)
                 {
                     returnValue = AreTexturesResidentEXT(n, textures_ptr, residences_ptr);
                 }
@@ -30176,25 +30176,25 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="EdgeFlagPointerEXT"/>
-            public static unsafe void EdgeFlagPointerEXT(int stride, int count, ReadOnlySpan<byte> pointer)
+            public static unsafe void EdgeFlagPointerEXT(int stride, int count, ReadOnlySpan<bool> pointer)
             {
-                fixed (byte* pointer_ptr = pointer)
+                fixed (bool* pointer_ptr = pointer)
                 {
                     EdgeFlagPointerEXT(stride, count, pointer_ptr);
                 }
             }
             /// <inheritdoc cref="EdgeFlagPointerEXT"/>
-            public static unsafe void EdgeFlagPointerEXT(int stride, int count, byte[] pointer)
+            public static unsafe void EdgeFlagPointerEXT(int stride, int count, bool[] pointer)
             {
-                fixed (byte* pointer_ptr = pointer)
+                fixed (bool* pointer_ptr = pointer)
                 {
                     EdgeFlagPointerEXT(stride, count, pointer_ptr);
                 }
             }
             /// <inheritdoc cref="EdgeFlagPointerEXT"/>
-            public static unsafe void EdgeFlagPointerEXT(int stride, int count, in byte pointer)
+            public static unsafe void EdgeFlagPointerEXT(int stride, int count, in bool pointer)
             {
-                fixed (byte* pointer_ptr = &pointer)
+                fixed (bool* pointer_ptr = &pointer)
                 {
                     EdgeFlagPointerEXT(stride, count, pointer_ptr);
                 }
@@ -30778,25 +30778,25 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetVariantBooleanvEXT"/>
-            public static unsafe void GetVariantBooleanvEXT(uint id, GetVariantValueEXT value, Span<byte> data)
+            public static unsafe void GetVariantBooleanvEXT(uint id, GetVariantValueEXT value, Span<bool> data)
             {
-                fixed (byte* data_ptr = data)
+                fixed (bool* data_ptr = data)
                 {
                     GetVariantBooleanvEXT(id, value, data_ptr);
                 }
             }
             /// <inheritdoc cref="GetVariantBooleanvEXT"/>
-            public static unsafe void GetVariantBooleanvEXT(uint id, GetVariantValueEXT value, byte[] data)
+            public static unsafe void GetVariantBooleanvEXT(uint id, GetVariantValueEXT value, bool[] data)
             {
-                fixed (byte* data_ptr = data)
+                fixed (bool* data_ptr = data)
                 {
                     GetVariantBooleanvEXT(id, value, data_ptr);
                 }
             }
             /// <inheritdoc cref="GetVariantBooleanvEXT"/>
-            public static unsafe void GetVariantBooleanvEXT(uint id, GetVariantValueEXT value, ref byte data)
+            public static unsafe void GetVariantBooleanvEXT(uint id, GetVariantValueEXT value, ref bool data)
             {
-                fixed (byte* data_ptr = &data)
+                fixed (bool* data_ptr = &data)
                 {
                     GetVariantBooleanvEXT(id, value, data_ptr);
                 }
@@ -30850,25 +30850,25 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetInvariantBooleanvEXT"/>
-            public static unsafe void GetInvariantBooleanvEXT(uint id, GetVariantValueEXT value, Span<byte> data)
+            public static unsafe void GetInvariantBooleanvEXT(uint id, GetVariantValueEXT value, Span<bool> data)
             {
-                fixed (byte* data_ptr = data)
+                fixed (bool* data_ptr = data)
                 {
                     GetInvariantBooleanvEXT(id, value, data_ptr);
                 }
             }
             /// <inheritdoc cref="GetInvariantBooleanvEXT"/>
-            public static unsafe void GetInvariantBooleanvEXT(uint id, GetVariantValueEXT value, byte[] data)
+            public static unsafe void GetInvariantBooleanvEXT(uint id, GetVariantValueEXT value, bool[] data)
             {
-                fixed (byte* data_ptr = data)
+                fixed (bool* data_ptr = data)
                 {
                     GetInvariantBooleanvEXT(id, value, data_ptr);
                 }
             }
             /// <inheritdoc cref="GetInvariantBooleanvEXT"/>
-            public static unsafe void GetInvariantBooleanvEXT(uint id, GetVariantValueEXT value, ref byte data)
+            public static unsafe void GetInvariantBooleanvEXT(uint id, GetVariantValueEXT value, ref bool data)
             {
-                fixed (byte* data_ptr = &data)
+                fixed (bool* data_ptr = &data)
                 {
                     GetInvariantBooleanvEXT(id, value, data_ptr);
                 }
@@ -30922,25 +30922,25 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetLocalConstantBooleanvEXT"/>
-            public static unsafe void GetLocalConstantBooleanvEXT(uint id, GetVariantValueEXT value, Span<byte> data)
+            public static unsafe void GetLocalConstantBooleanvEXT(uint id, GetVariantValueEXT value, Span<bool> data)
             {
-                fixed (byte* data_ptr = data)
+                fixed (bool* data_ptr = data)
                 {
                     GetLocalConstantBooleanvEXT(id, value, data_ptr);
                 }
             }
             /// <inheritdoc cref="GetLocalConstantBooleanvEXT"/>
-            public static unsafe void GetLocalConstantBooleanvEXT(uint id, GetVariantValueEXT value, byte[] data)
+            public static unsafe void GetLocalConstantBooleanvEXT(uint id, GetVariantValueEXT value, bool[] data)
             {
-                fixed (byte* data_ptr = data)
+                fixed (bool* data_ptr = data)
                 {
                     GetLocalConstantBooleanvEXT(id, value, data_ptr);
                 }
             }
             /// <inheritdoc cref="GetLocalConstantBooleanvEXT"/>
-            public static unsafe void GetLocalConstantBooleanvEXT(uint id, GetVariantValueEXT value, ref byte data)
+            public static unsafe void GetLocalConstantBooleanvEXT(uint id, GetVariantValueEXT value, ref bool data)
             {
-                fixed (byte* data_ptr = &data)
+                fixed (bool* data_ptr = &data)
                 {
                     GetLocalConstantBooleanvEXT(id, value, data_ptr);
                 }
@@ -34593,9 +34593,9 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="PointAlongPathNV"/>
-            public static unsafe byte PointAlongPathNV(uint path, int startSegment, int numSegments, float distance, Span<float> x, Span<float> y, Span<float> tangentX, Span<float> tangentY)
+            public static unsafe bool PointAlongPathNV(uint path, int startSegment, int numSegments, float distance, Span<float> x, Span<float> y, Span<float> tangentX, Span<float> tangentY)
             {
-                byte returnValue;
+                bool returnValue;
                 fixed (float* x_ptr = x)
                 {
                     fixed (float* y_ptr = y)
@@ -34612,9 +34612,9 @@ namespace OpenTK.Graphics.OpenGL
                 return returnValue;
             }
             /// <inheritdoc cref="PointAlongPathNV"/>
-            public static unsafe byte PointAlongPathNV(uint path, int startSegment, int numSegments, float distance, float[] x, float[] y, float[] tangentX, float[] tangentY)
+            public static unsafe bool PointAlongPathNV(uint path, int startSegment, int numSegments, float distance, float[] x, float[] y, float[] tangentX, float[] tangentY)
             {
-                byte returnValue;
+                bool returnValue;
                 fixed (float* x_ptr = x)
                 {
                     fixed (float* y_ptr = y)
@@ -34631,9 +34631,9 @@ namespace OpenTK.Graphics.OpenGL
                 return returnValue;
             }
             /// <inheritdoc cref="PointAlongPathNV"/>
-            public static unsafe byte PointAlongPathNV(uint path, int startSegment, int numSegments, float distance, ref float x, ref float y, ref float tangentX, ref float tangentY)
+            public static unsafe bool PointAlongPathNV(uint path, int startSegment, int numSegments, float distance, ref float x, ref float y, ref float tangentX, ref float tangentY)
             {
-                byte returnValue;
+                bool returnValue;
                 fixed (float* x_ptr = &x)
                 fixed (float* y_ptr = &y)
                 fixed (float* tangentX_ptr = &tangentX)
@@ -36823,12 +36823,12 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="AreProgramsResidentNV"/>
-            public static unsafe byte AreProgramsResidentNV(int n, ReadOnlySpan<ProgramHandle> programs, Span<byte> residences)
+            public static unsafe bool AreProgramsResidentNV(int n, ReadOnlySpan<ProgramHandle> programs, Span<bool> residences)
             {
-                byte returnValue;
+                bool returnValue;
                 fixed (ProgramHandle* programs_ptr = programs)
                 {
-                    fixed (byte* residences_ptr = residences)
+                    fixed (bool* residences_ptr = residences)
                     {
                         returnValue = AreProgramsResidentNV(n, programs_ptr, residences_ptr);
                     }
@@ -36836,12 +36836,12 @@ namespace OpenTK.Graphics.OpenGL
                 return returnValue;
             }
             /// <inheritdoc cref="AreProgramsResidentNV"/>
-            public static unsafe byte AreProgramsResidentNV(int n, ProgramHandle[] programs, byte[] residences)
+            public static unsafe bool AreProgramsResidentNV(int n, ProgramHandle[] programs, bool[] residences)
             {
-                byte returnValue;
+                bool returnValue;
                 fixed (ProgramHandle* programs_ptr = programs)
                 {
-                    fixed (byte* residences_ptr = residences)
+                    fixed (bool* residences_ptr = residences)
                     {
                         returnValue = AreProgramsResidentNV(n, programs_ptr, residences_ptr);
                     }
@@ -36849,11 +36849,11 @@ namespace OpenTK.Graphics.OpenGL
                 return returnValue;
             }
             /// <inheritdoc cref="AreProgramsResidentNV"/>
-            public static unsafe byte AreProgramsResidentNV(int n, in ProgramHandle programs, ref byte residences)
+            public static unsafe bool AreProgramsResidentNV(int n, in ProgramHandle programs, ref bool residences)
             {
-                byte returnValue;
+                bool returnValue;
                 fixed (ProgramHandle* programs_ptr = &programs)
-                fixed (byte* residences_ptr = &residences)
+                fixed (bool* residences_ptr = &residences)
                 {
                     returnValue = AreProgramsResidentNV(n, programs_ptr, residences_ptr);
                 }

--- a/src/OpenTK.Graphics/OpenGL/GL.Overloads.cs
+++ b/src/OpenTK.Graphics/OpenGL/GL.Overloads.cs
@@ -123,21 +123,6 @@ namespace OpenTK.Graphics.OpenGL
                 TexImage2D(target, level, internalformat, width, height, border, format, type, pixels_ptr);
             }
         }
-        /// <inheritdoc cref="ColorMask"/>
-        public static unsafe void ColorMask(bool red, bool green, bool blue, bool alpha)
-        {
-            byte red_byte = (byte)(red ? 1 : 0);
-            byte green_byte = (byte)(green ? 1 : 0);
-            byte blue_byte = (byte)(blue ? 1 : 0);
-            byte alpha_byte = (byte)(alpha ? 1 : 0);
-            ColorMask(red_byte, green_byte, blue_byte, alpha_byte);
-        }
-        /// <inheritdoc cref="DepthMask"/>
-        public static unsafe void DepthMask(bool flag)
-        {
-            byte flag_byte = (byte)(flag ? 1 : 0);
-            DepthMask(flag_byte);
-        }
         /// <inheritdoc cref="ReadPixels"/>
         public static unsafe void ReadPixels(int x, int y, int width, int height, PixelFormat format, PixelType type, IntPtr pixels)
         {
@@ -643,12 +628,6 @@ namespace OpenTK.Graphics.OpenGL
             {
                 TexSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, pixels_ptr);
             }
-        }
-        /// <inheritdoc cref="SampleCoverage"/>
-        public static unsafe void SampleCoverage(float value, bool invert)
-        {
-            byte invert_byte = (byte)(invert ? 1 : 0);
-            SampleCoverage(value, invert_byte);
         }
         /// <inheritdoc cref="CompressedTexImage3D"/>
         public static unsafe void CompressedTexImage3D(TextureTarget target, int level, InternalFormat internalformat, int width, int height, int depth, int border, int imageSize, IntPtr data)
@@ -2320,8 +2299,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix2* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix2fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix2fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix2fv"/>
@@ -2330,8 +2308,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix2* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix2fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix2fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix2fv"/>
@@ -2340,8 +2317,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix2* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix2fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix2fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix3fv"/>
@@ -2351,8 +2327,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix3* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix3fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix3fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix3fv"/>
@@ -2361,8 +2336,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix3* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix3fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix3fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix3fv"/>
@@ -2371,8 +2345,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix3* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix3fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix3fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix4fv"/>
@@ -2382,8 +2355,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix4* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix4fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix4fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix4fv"/>
@@ -2392,8 +2364,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix4* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix4fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix4fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix4fv"/>
@@ -2402,8 +2373,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix4* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix4fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix4fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="VertexAttrib1dv"/>
@@ -2987,8 +2957,7 @@ namespace OpenTK.Graphics.OpenGL
         public static unsafe void VertexAttribPointer(uint index, int size, VertexAttribPointerType type, bool normalized, int stride, nint offset)
         {
             void* pointer = (void*)offset;
-            byte normalized_byte = (byte)(normalized ? 1 : 0);
-            VertexAttribPointer(index, size, type, normalized_byte, stride, pointer);
+            VertexAttribPointer(index, size, type, normalized, stride, pointer);
         }
         /// <inheritdoc cref="UniformMatrix2x3fv"/>
         public static unsafe void UniformMatrix2x3f(int location, bool transpose, in Matrix2x3 value)
@@ -2997,8 +2966,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix2x3* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix2x3fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix2x3fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix2x3fv"/>
@@ -3007,8 +2975,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix2x3* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix2x3fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix2x3fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix2x3fv"/>
@@ -3017,8 +2984,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix2x3* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix2x3fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix2x3fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix3x2fv"/>
@@ -3028,8 +2994,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix3x2* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix3x2fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix3x2fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix3x2fv"/>
@@ -3038,8 +3003,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix3x2* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix3x2fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix3x2fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix3x2fv"/>
@@ -3048,8 +3012,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix3x2* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix3x2fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix3x2fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix2x4fv"/>
@@ -3059,8 +3022,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix2x4* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix2x4fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix2x4fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix2x4fv"/>
@@ -3069,8 +3031,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix2x4* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix2x4fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix2x4fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix2x4fv"/>
@@ -3079,8 +3040,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix2x4* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix2x4fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix2x4fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix4x2fv"/>
@@ -3090,8 +3050,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix4x2* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix4x2fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix4x2fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix4x2fv"/>
@@ -3100,8 +3059,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix4x2* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix4x2fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix4x2fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix4x2fv"/>
@@ -3110,8 +3068,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix4x2* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix4x2fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix4x2fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix3x4fv"/>
@@ -3121,8 +3078,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix3x4* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix3x4fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix3x4fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix3x4fv"/>
@@ -3131,8 +3087,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix3x4* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix3x4fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix3x4fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix3x4fv"/>
@@ -3141,8 +3096,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix3x4* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix3x4fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix3x4fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix4x3fv"/>
@@ -3152,8 +3106,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix4x3* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix4x3fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix4x3fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix4x3fv"/>
@@ -3162,8 +3115,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix4x3* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix4x3fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix4x3fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix4x3fv"/>
@@ -3172,18 +3124,8 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix4x3* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix4x3fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix4x3fv(location, count, transpose, value_ptr);
             }
-        }
-        /// <inheritdoc cref="ColorMaski"/>
-        public static unsafe void ColorMaski(uint index, bool r, bool g, bool b, bool a)
-        {
-            byte r_byte = (byte)(r ? 1 : 0);
-            byte g_byte = (byte)(g ? 1 : 0);
-            byte b_byte = (byte)(b ? 1 : 0);
-            byte a_byte = (byte)(a ? 1 : 0);
-            ColorMaski(index, r_byte, g_byte, b_byte, a_byte);
         }
         /// <inheritdoc cref="GetBooleani_v"/>
         public static unsafe void GetBoolean(BufferTargetARB target, uint index, Span<bool> data)
@@ -4728,18 +4670,6 @@ namespace OpenTK.Graphics.OpenGL
                 GetBufferParameteri64v(target, pname, parameters_ptr);
             }
         }
-        /// <inheritdoc cref="TexImage2DMultisample"/>
-        public static unsafe void TexImage2DMultisample(TextureTarget target, int samples, InternalFormat internalformat, int width, int height, bool fixedsamplelocations)
-        {
-            byte fixedsamplelocations_byte = (byte)(fixedsamplelocations ? 1 : 0);
-            TexImage2DMultisample(target, samples, internalformat, width, height, fixedsamplelocations_byte);
-        }
-        /// <inheritdoc cref="TexImage3DMultisample"/>
-        public static unsafe void TexImage3DMultisample(TextureTarget target, int samples, InternalFormat internalformat, int width, int height, int depth, bool fixedsamplelocations)
-        {
-            byte fixedsamplelocations_byte = (byte)(fixedsamplelocations ? 1 : 0);
-            TexImage3DMultisample(target, samples, internalformat, width, height, depth, fixedsamplelocations_byte);
-        }
         /// <inheritdoc cref="GetMultisamplefv"/>
         public static unsafe void GetMultisamplef(GetMultisamplePNameNV pname, uint index, Span<float> val)
         {
@@ -5115,19 +5045,12 @@ namespace OpenTK.Graphics.OpenGL
                 GetQueryObjectui64v(id, pname, parameters_ptr);
             }
         }
-        /// <inheritdoc cref="VertexAttribP1ui"/>
-        public static unsafe void VertexAttribP1ui(uint index, VertexAttribPointerType type, bool normalized, uint value)
-        {
-            byte normalized_byte = (byte)(normalized ? 1 : 0);
-            VertexAttribP1ui(index, type, normalized_byte, value);
-        }
         /// <inheritdoc cref="VertexAttribP1uiv"/>
         public static unsafe void VertexAttribP1ui(uint index, VertexAttribPointerType type, bool normalized, ReadOnlySpan<uint> value)
         {
             fixed (uint* value_ptr = value)
             {
-                byte normalized_byte = (byte)(normalized ? 1 : 0);
-                VertexAttribP1uiv(index, type, normalized_byte, value_ptr);
+                VertexAttribP1uiv(index, type, normalized, value_ptr);
             }
         }
         /// <inheritdoc cref="VertexAttribP1uiv"/>
@@ -5135,8 +5058,7 @@ namespace OpenTK.Graphics.OpenGL
         {
             fixed (uint* value_ptr = value)
             {
-                byte normalized_byte = (byte)(normalized ? 1 : 0);
-                VertexAttribP1uiv(index, type, normalized_byte, value_ptr);
+                VertexAttribP1uiv(index, type, normalized, value_ptr);
             }
         }
         /// <inheritdoc cref="VertexAttribP1uiv"/>
@@ -5144,23 +5066,15 @@ namespace OpenTK.Graphics.OpenGL
         {
             fixed (uint* value_ptr = &value)
             {
-                byte normalized_byte = (byte)(normalized ? 1 : 0);
-                VertexAttribP1uiv(index, type, normalized_byte, value_ptr);
+                VertexAttribP1uiv(index, type, normalized, value_ptr);
             }
-        }
-        /// <inheritdoc cref="VertexAttribP2ui"/>
-        public static unsafe void VertexAttribP2ui(uint index, VertexAttribPointerType type, bool normalized, uint value)
-        {
-            byte normalized_byte = (byte)(normalized ? 1 : 0);
-            VertexAttribP2ui(index, type, normalized_byte, value);
         }
         /// <inheritdoc cref="VertexAttribP2uiv"/>
         public static unsafe void VertexAttribP2ui(uint index, VertexAttribPointerType type, bool normalized, ReadOnlySpan<uint> value)
         {
             fixed (uint* value_ptr = value)
             {
-                byte normalized_byte = (byte)(normalized ? 1 : 0);
-                VertexAttribP2uiv(index, type, normalized_byte, value_ptr);
+                VertexAttribP2uiv(index, type, normalized, value_ptr);
             }
         }
         /// <inheritdoc cref="VertexAttribP2uiv"/>
@@ -5168,8 +5082,7 @@ namespace OpenTK.Graphics.OpenGL
         {
             fixed (uint* value_ptr = value)
             {
-                byte normalized_byte = (byte)(normalized ? 1 : 0);
-                VertexAttribP2uiv(index, type, normalized_byte, value_ptr);
+                VertexAttribP2uiv(index, type, normalized, value_ptr);
             }
         }
         /// <inheritdoc cref="VertexAttribP2uiv"/>
@@ -5177,23 +5090,15 @@ namespace OpenTK.Graphics.OpenGL
         {
             fixed (uint* value_ptr = &value)
             {
-                byte normalized_byte = (byte)(normalized ? 1 : 0);
-                VertexAttribP2uiv(index, type, normalized_byte, value_ptr);
+                VertexAttribP2uiv(index, type, normalized, value_ptr);
             }
-        }
-        /// <inheritdoc cref="VertexAttribP3ui"/>
-        public static unsafe void VertexAttribP3ui(uint index, VertexAttribPointerType type, bool normalized, uint value)
-        {
-            byte normalized_byte = (byte)(normalized ? 1 : 0);
-            VertexAttribP3ui(index, type, normalized_byte, value);
         }
         /// <inheritdoc cref="VertexAttribP3uiv"/>
         public static unsafe void VertexAttribP3ui(uint index, VertexAttribPointerType type, bool normalized, ReadOnlySpan<uint> value)
         {
             fixed (uint* value_ptr = value)
             {
-                byte normalized_byte = (byte)(normalized ? 1 : 0);
-                VertexAttribP3uiv(index, type, normalized_byte, value_ptr);
+                VertexAttribP3uiv(index, type, normalized, value_ptr);
             }
         }
         /// <inheritdoc cref="VertexAttribP3uiv"/>
@@ -5201,8 +5106,7 @@ namespace OpenTK.Graphics.OpenGL
         {
             fixed (uint* value_ptr = value)
             {
-                byte normalized_byte = (byte)(normalized ? 1 : 0);
-                VertexAttribP3uiv(index, type, normalized_byte, value_ptr);
+                VertexAttribP3uiv(index, type, normalized, value_ptr);
             }
         }
         /// <inheritdoc cref="VertexAttribP3uiv"/>
@@ -5210,23 +5114,15 @@ namespace OpenTK.Graphics.OpenGL
         {
             fixed (uint* value_ptr = &value)
             {
-                byte normalized_byte = (byte)(normalized ? 1 : 0);
-                VertexAttribP3uiv(index, type, normalized_byte, value_ptr);
+                VertexAttribP3uiv(index, type, normalized, value_ptr);
             }
-        }
-        /// <inheritdoc cref="VertexAttribP4ui"/>
-        public static unsafe void VertexAttribP4ui(uint index, VertexAttribPointerType type, bool normalized, uint value)
-        {
-            byte normalized_byte = (byte)(normalized ? 1 : 0);
-            VertexAttribP4ui(index, type, normalized_byte, value);
         }
         /// <inheritdoc cref="VertexAttribP4uiv"/>
         public static unsafe void VertexAttribP4ui(uint index, VertexAttribPointerType type, bool normalized, ReadOnlySpan<uint> value)
         {
             fixed (uint* value_ptr = value)
             {
-                byte normalized_byte = (byte)(normalized ? 1 : 0);
-                VertexAttribP4uiv(index, type, normalized_byte, value_ptr);
+                VertexAttribP4uiv(index, type, normalized, value_ptr);
             }
         }
         /// <inheritdoc cref="VertexAttribP4uiv"/>
@@ -5234,8 +5130,7 @@ namespace OpenTK.Graphics.OpenGL
         {
             fixed (uint* value_ptr = value)
             {
-                byte normalized_byte = (byte)(normalized ? 1 : 0);
-                VertexAttribP4uiv(index, type, normalized_byte, value_ptr);
+                VertexAttribP4uiv(index, type, normalized, value_ptr);
             }
         }
         /// <inheritdoc cref="VertexAttribP4uiv"/>
@@ -5243,8 +5138,7 @@ namespace OpenTK.Graphics.OpenGL
         {
             fixed (uint* value_ptr = &value)
             {
-                byte normalized_byte = (byte)(normalized ? 1 : 0);
-                VertexAttribP4uiv(index, type, normalized_byte, value_ptr);
+                VertexAttribP4uiv(index, type, normalized, value_ptr);
             }
         }
         /// <inheritdoc cref="DrawArraysIndirect"/>
@@ -5396,8 +5290,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix2d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix2dv(location, count, transpose_byte, value_ptr);
+                UniformMatrix2dv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix2dv"/>
@@ -5406,8 +5299,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix2d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix2dv(location, count, transpose_byte, value_ptr);
+                UniformMatrix2dv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix2dv"/>
@@ -5416,8 +5308,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix2d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix2dv(location, count, transpose_byte, value_ptr);
+                UniformMatrix2dv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix3dv"/>
@@ -5427,8 +5318,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix3d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix3dv(location, count, transpose_byte, value_ptr);
+                UniformMatrix3dv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix3dv"/>
@@ -5437,8 +5327,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix3d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix3dv(location, count, transpose_byte, value_ptr);
+                UniformMatrix3dv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix3dv"/>
@@ -5447,8 +5336,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix3d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix3dv(location, count, transpose_byte, value_ptr);
+                UniformMatrix3dv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix4dv"/>
@@ -5458,8 +5346,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix4d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix4dv(location, count, transpose_byte, value_ptr);
+                UniformMatrix4dv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix4dv"/>
@@ -5468,8 +5355,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix4d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix4dv(location, count, transpose_byte, value_ptr);
+                UniformMatrix4dv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix4dv"/>
@@ -5478,8 +5364,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix4d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix4dv(location, count, transpose_byte, value_ptr);
+                UniformMatrix4dv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix2x3dv"/>
@@ -5489,8 +5374,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix2x3d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix2x3dv(location, count, transpose_byte, value_ptr);
+                UniformMatrix2x3dv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix2x3dv"/>
@@ -5499,8 +5383,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix2x3d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix2x3dv(location, count, transpose_byte, value_ptr);
+                UniformMatrix2x3dv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix2x3dv"/>
@@ -5509,8 +5392,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix2x3d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix2x3dv(location, count, transpose_byte, value_ptr);
+                UniformMatrix2x3dv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix2x4dv"/>
@@ -5520,8 +5402,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix2x4d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix2x4dv(location, count, transpose_byte, value_ptr);
+                UniformMatrix2x4dv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix2x4dv"/>
@@ -5530,8 +5411,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix2x4d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix2x4dv(location, count, transpose_byte, value_ptr);
+                UniformMatrix2x4dv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix2x4dv"/>
@@ -5540,8 +5420,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix2x4d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix2x4dv(location, count, transpose_byte, value_ptr);
+                UniformMatrix2x4dv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix3x2dv"/>
@@ -5551,8 +5430,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix3x2d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix3x2dv(location, count, transpose_byte, value_ptr);
+                UniformMatrix3x2dv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix3x2dv"/>
@@ -5561,8 +5439,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix3x2d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix3x2dv(location, count, transpose_byte, value_ptr);
+                UniformMatrix3x2dv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix3x2dv"/>
@@ -5571,8 +5448,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix3x2d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix3x2dv(location, count, transpose_byte, value_ptr);
+                UniformMatrix3x2dv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix3x4dv"/>
@@ -5582,8 +5458,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix3x4d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix3x4dv(location, count, transpose_byte, value_ptr);
+                UniformMatrix3x4dv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix3x4dv"/>
@@ -5592,8 +5467,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix3x4d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix3x4dv(location, count, transpose_byte, value_ptr);
+                UniformMatrix3x4dv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix3x4dv"/>
@@ -5602,8 +5476,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix3x4d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix3x4dv(location, count, transpose_byte, value_ptr);
+                UniformMatrix3x4dv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix4x2dv"/>
@@ -5613,8 +5486,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix4x2d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix4x2dv(location, count, transpose_byte, value_ptr);
+                UniformMatrix4x2dv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix4x2dv"/>
@@ -5623,8 +5495,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix4x2d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix4x2dv(location, count, transpose_byte, value_ptr);
+                UniformMatrix4x2dv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix4x2dv"/>
@@ -5633,8 +5504,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix4x2d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix4x2dv(location, count, transpose_byte, value_ptr);
+                UniformMatrix4x2dv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix4x3dv"/>
@@ -5644,8 +5514,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix4x3d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix4x3dv(location, count, transpose_byte, value_ptr);
+                UniformMatrix4x3dv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix4x3dv"/>
@@ -5654,8 +5523,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix4x3d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix4x3dv(location, count, transpose_byte, value_ptr);
+                UniformMatrix4x3dv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix4x3dv"/>
@@ -5664,8 +5532,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix4x3d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix4x3dv(location, count, transpose_byte, value_ptr);
+                UniformMatrix4x3dv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="GetUniformdv"/>
@@ -6872,8 +6739,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix2* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix2fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix2fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2fv"/>
@@ -6882,8 +6748,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix2* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix2fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix2fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2fv"/>
@@ -6892,8 +6757,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix2* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix2fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix2fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3fv"/>
@@ -6903,8 +6767,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix3* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix3fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix3fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3fv"/>
@@ -6913,8 +6776,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix3* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix3fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix3fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3fv"/>
@@ -6923,8 +6785,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix3* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix3fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix3fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
@@ -6934,8 +6795,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix4* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix4fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix4fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
@@ -6944,8 +6804,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix4* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix4fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix4fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
@@ -6954,8 +6813,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix4* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix4fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix4fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2dv"/>
@@ -6965,8 +6823,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix2d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix2dv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix2dv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2dv"/>
@@ -6975,8 +6832,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix2d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix2dv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix2dv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2dv"/>
@@ -6985,8 +6841,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix2d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix2dv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix2dv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3dv"/>
@@ -6996,8 +6851,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix3d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix3dv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix3dv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3dv"/>
@@ -7006,8 +6860,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix3d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix3dv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix3dv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3dv"/>
@@ -7016,8 +6869,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix3d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix3dv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix3dv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4dv"/>
@@ -7027,8 +6879,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix4d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix4dv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix4dv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4dv"/>
@@ -7037,8 +6888,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix4d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix4dv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix4dv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4dv"/>
@@ -7047,8 +6897,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix4d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix4dv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix4dv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x3fv"/>
@@ -7058,8 +6907,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix2x3* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix2x3fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix2x3fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x3fv"/>
@@ -7068,8 +6916,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix2x3* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix2x3fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix2x3fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x3fv"/>
@@ -7078,8 +6925,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix2x3* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix2x3fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix2x3fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
@@ -7089,8 +6935,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix3x2* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix3x2fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix3x2fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
@@ -7099,8 +6944,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix3x2* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix3x2fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix3x2fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
@@ -7109,8 +6953,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix3x2* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix3x2fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix3x2fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x4fv"/>
@@ -7120,8 +6963,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix2x4* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix2x4fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix2x4fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x4fv"/>
@@ -7130,8 +6972,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix2x4* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix2x4fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix2x4fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x4fv"/>
@@ -7140,8 +6981,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix2x4* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix2x4fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix2x4fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x2fv"/>
@@ -7151,8 +6991,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix4x2* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix4x2fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix4x2fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x2fv"/>
@@ -7161,8 +7000,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix4x2* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix4x2fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix4x2fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x2fv"/>
@@ -7171,8 +7009,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix4x2* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix4x2fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix4x2fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x4fv"/>
@@ -7182,8 +7019,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix3x4* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix3x4fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix3x4fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x4fv"/>
@@ -7192,8 +7028,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix3x4* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix3x4fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix3x4fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x4fv"/>
@@ -7202,8 +7037,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix3x4* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix3x4fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix3x4fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x3fv"/>
@@ -7213,8 +7047,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix4x3* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix4x3fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix4x3fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x3fv"/>
@@ -7223,8 +7056,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix4x3* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix4x3fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix4x3fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x3fv"/>
@@ -7233,8 +7065,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix4x3* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix4x3fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix4x3fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x3dv"/>
@@ -7244,8 +7075,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix2x3d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix2x3dv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix2x3dv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x3dv"/>
@@ -7254,8 +7084,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix2x3d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix2x3dv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix2x3dv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x3dv"/>
@@ -7264,8 +7093,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix2x3d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix2x3dv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix2x3dv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x2dv"/>
@@ -7275,8 +7103,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix3x2d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix3x2dv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix3x2dv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x2dv"/>
@@ -7285,8 +7112,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix3x2d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix3x2dv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix3x2dv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x2dv"/>
@@ -7295,8 +7121,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix3x2d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix3x2dv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix3x2dv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x4dv"/>
@@ -7306,8 +7131,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix2x4d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix2x4dv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix2x4dv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x4dv"/>
@@ -7316,8 +7140,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix2x4d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix2x4dv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix2x4dv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x4dv"/>
@@ -7326,8 +7149,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix2x4d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix2x4dv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix2x4dv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x2dv"/>
@@ -7337,8 +7159,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix4x2d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix4x2dv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix4x2dv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x2dv"/>
@@ -7347,8 +7168,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix4x2d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix4x2dv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix4x2dv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x2dv"/>
@@ -7357,8 +7177,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix4x2d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix4x2dv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix4x2dv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x4dv"/>
@@ -7368,8 +7187,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix3x4d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix3x4dv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix3x4dv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x4dv"/>
@@ -7378,8 +7196,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix3x4d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix3x4dv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix3x4dv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x4dv"/>
@@ -7388,8 +7205,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix3x4d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix3x4dv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix3x4dv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x3dv"/>
@@ -7399,8 +7215,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix4x3d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix4x3dv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix4x3dv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x3dv"/>
@@ -7409,8 +7224,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix4x3d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix4x3dv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix4x3dv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x3dv"/>
@@ -7419,8 +7233,7 @@ namespace OpenTK.Graphics.OpenGL
             fixed (Matrix4x3d* tmp_vecPtr = value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix4x3dv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix4x3dv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="GetProgramPipelineInfoLog"/>
@@ -7851,12 +7664,6 @@ namespace OpenTK.Graphics.OpenGL
                 GetActiveAtomicCounterBufferiv(program, bufferIndex, pname, parameters_ptr);
             }
         }
-        /// <inheritdoc cref="BindImageTexture"/>
-        public static unsafe void BindImageTexture(uint unit, TextureHandle texture, int level, bool layered, int layer, BufferAccessARB access, InternalFormat format)
-        {
-            byte layered_byte = (byte)(layered ? 1 : 0);
-            BindImageTexture(unit, texture, level, layered_byte, layer, access, format);
-        }
         /// <inheritdoc cref="ClearBufferData"/>
         public static unsafe void ClearBufferData(BufferStorageTarget target, SizedInternalFormat internalformat, PixelFormat format, PixelType type, IntPtr data)
         {
@@ -8256,32 +8063,13 @@ namespace OpenTK.Graphics.OpenGL
             Marshal.FreeCoTaskMem((IntPtr)name_ptr);
             return returnValue;
         }
-        /// <inheritdoc cref="TexStorage2DMultisample"/>
-        public static unsafe void TexStorage2DMultisample(TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, bool fixedsamplelocations)
-        {
-            byte fixedsamplelocations_byte = (byte)(fixedsamplelocations ? 1 : 0);
-            TexStorage2DMultisample(target, samples, internalformat, width, height, fixedsamplelocations_byte);
-        }
-        /// <inheritdoc cref="TexStorage3DMultisample"/>
-        public static unsafe void TexStorage3DMultisample(TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, int depth, bool fixedsamplelocations)
-        {
-            byte fixedsamplelocations_byte = (byte)(fixedsamplelocations ? 1 : 0);
-            TexStorage3DMultisample(target, samples, internalformat, width, height, depth, fixedsamplelocations_byte);
-        }
-        /// <inheritdoc cref="VertexAttribFormat"/>
-        public static unsafe void VertexAttribFormat(uint attribindex, int size, VertexAttribType type, bool normalized, uint relativeoffset)
-        {
-            byte normalized_byte = (byte)(normalized ? 1 : 0);
-            VertexAttribFormat(attribindex, size, type, normalized_byte, relativeoffset);
-        }
         /// <inheritdoc cref="DebugMessageControl"/>
         public static unsafe void DebugMessageControl(DebugSource source, DebugType type, DebugSeverity severity, ReadOnlySpan<uint> ids, bool enabled)
         {
             int count = (int)(ids.Length);
             fixed (uint* ids_ptr = ids)
             {
-                byte enabled_byte = (byte)(enabled ? 1 : 0);
-                DebugMessageControl(source, type, severity, count, ids_ptr, enabled_byte);
+                DebugMessageControl(source, type, severity, count, ids_ptr, enabled);
             }
         }
         /// <inheritdoc cref="DebugMessageControl"/>
@@ -8290,8 +8078,7 @@ namespace OpenTK.Graphics.OpenGL
             int count = (int)(ids.Length);
             fixed (uint* ids_ptr = ids)
             {
-                byte enabled_byte = (byte)(enabled ? 1 : 0);
-                DebugMessageControl(source, type, severity, count, ids_ptr, enabled_byte);
+                DebugMessageControl(source, type, severity, count, ids_ptr, enabled);
             }
         }
         /// <inheritdoc cref="DebugMessageControl"/>
@@ -8299,8 +8086,7 @@ namespace OpenTK.Graphics.OpenGL
         {
             fixed (uint* ids_ptr = &ids)
             {
-                byte enabled_byte = (byte)(enabled ? 1 : 0);
-                DebugMessageControl(source, type, severity, count, ids_ptr, enabled_byte);
+                DebugMessageControl(source, type, severity, count, ids_ptr, enabled);
             }
         }
         /// <inheritdoc cref="DebugMessageInsert"/>
@@ -9500,18 +9286,6 @@ namespace OpenTK.Graphics.OpenGL
                 CreateTextures(target, n, textures_ptr);
             }
         }
-        /// <inheritdoc cref="TextureStorage2DMultisample"/>
-        public static unsafe void TextureStorage2DMultisample(TextureHandle texture, int samples, SizedInternalFormat internalformat, int width, int height, bool fixedsamplelocations)
-        {
-            byte fixedsamplelocations_byte = (byte)(fixedsamplelocations ? 1 : 0);
-            TextureStorage2DMultisample(texture, samples, internalformat, width, height, fixedsamplelocations_byte);
-        }
-        /// <inheritdoc cref="TextureStorage3DMultisample"/>
-        public static unsafe void TextureStorage3DMultisample(TextureHandle texture, int samples, SizedInternalFormat internalformat, int width, int height, int depth, bool fixedsamplelocations)
-        {
-            byte fixedsamplelocations_byte = (byte)(fixedsamplelocations ? 1 : 0);
-            TextureStorage3DMultisample(texture, samples, internalformat, width, height, depth, fixedsamplelocations_byte);
-        }
         /// <inheritdoc cref="TextureSubImage1D"/>
         public static unsafe void TextureSubImage1D(TextureHandle texture, int level, int xoffset, int width, PixelFormat format, PixelType type, IntPtr pixels)
         {
@@ -9781,12 +9555,6 @@ namespace OpenTK.Graphics.OpenGL
             {
                 VertexArrayVertexBuffers(vaobj, first, count, buffers_ptr, offsets_ptr, strides_ptr);
             }
-        }
-        /// <inheritdoc cref="VertexArrayAttribFormat"/>
-        public static unsafe void VertexArrayAttribFormat(VertexArrayHandle vaobj, uint attribindex, int size, VertexAttribType type, bool normalized, uint relativeoffset)
-        {
-            byte normalized_byte = (byte)(normalized ? 1 : 0);
-            VertexArrayAttribFormat(vaobj, attribindex, size, type, normalized_byte, relativeoffset);
         }
         /// <inheritdoc cref="GetVertexArrayiv"/>
         public static unsafe void GetVertexArrayi(VertexArrayHandle vaobj, VertexArrayPName pname, ref int param)
@@ -10303,8 +10071,7 @@ namespace OpenTK.Graphics.OpenGL
                 int count = (int)(ids.Length);
                 fixed (uint* ids_ptr = ids)
                 {
-                    byte enabled_byte = (byte)(enabled ? 1 : 0);
-                    DebugMessageEnableAMD(category, severity, count, ids_ptr, enabled_byte);
+                    DebugMessageEnableAMD(category, severity, count, ids_ptr, enabled);
                 }
             }
             /// <inheritdoc cref="DebugMessageEnableAMD"/>
@@ -10313,8 +10080,7 @@ namespace OpenTK.Graphics.OpenGL
                 int count = (int)(ids.Length);
                 fixed (uint* ids_ptr = ids)
                 {
-                    byte enabled_byte = (byte)(enabled ? 1 : 0);
-                    DebugMessageEnableAMD(category, severity, count, ids_ptr, enabled_byte);
+                    DebugMessageEnableAMD(category, severity, count, ids_ptr, enabled);
                 }
             }
             /// <inheritdoc cref="DebugMessageEnableAMD"/>
@@ -10322,8 +10088,7 @@ namespace OpenTK.Graphics.OpenGL
             {
                 fixed (uint* ids_ptr = &ids)
                 {
-                    byte enabled_byte = (byte)(enabled ? 1 : 0);
-                    DebugMessageEnableAMD(category, severity, count, ids_ptr, enabled_byte);
+                    DebugMessageEnableAMD(category, severity, count, ids_ptr, enabled);
                 }
             }
             /// <inheritdoc cref="DebugMessageInsertAMD"/>
@@ -11332,8 +11097,7 @@ namespace OpenTK.Graphics.OpenGL
                 int numCounters = (int)(counterList.Length);
                 fixed (uint* counterList_ptr = counterList)
                 {
-                    byte enable_byte = (byte)(enable ? 1 : 0);
-                    SelectPerfMonitorCountersAMD(monitor, enable_byte, group, numCounters, counterList_ptr);
+                    SelectPerfMonitorCountersAMD(monitor, enable, group, numCounters, counterList_ptr);
                 }
             }
             /// <inheritdoc cref="SelectPerfMonitorCountersAMD"/>
@@ -11342,8 +11106,7 @@ namespace OpenTK.Graphics.OpenGL
                 int numCounters = (int)(counterList.Length);
                 fixed (uint* counterList_ptr = counterList)
                 {
-                    byte enable_byte = (byte)(enable ? 1 : 0);
-                    SelectPerfMonitorCountersAMD(monitor, enable_byte, group, numCounters, counterList_ptr);
+                    SelectPerfMonitorCountersAMD(monitor, enable, group, numCounters, counterList_ptr);
                 }
             }
             /// <inheritdoc cref="SelectPerfMonitorCountersAMD"/>
@@ -11351,8 +11114,7 @@ namespace OpenTK.Graphics.OpenGL
             {
                 fixed (uint* counterList_ptr = &counterList)
                 {
-                    byte enable_byte = (byte)(enable ? 1 : 0);
-                    SelectPerfMonitorCountersAMD(monitor, enable_byte, group, numCounters, counterList_ptr);
+                    SelectPerfMonitorCountersAMD(monitor, enable, group, numCounters, counterList_ptr);
                 }
             }
             /// <inheritdoc cref="GetPerfMonitorCounterDataAMD"/>
@@ -11952,14 +11714,6 @@ namespace OpenTK.Graphics.OpenGL
                 void* indices = (void*)offset;
                 DrawElementsInstancedBaseVertexBaseInstance(mode, count, type, indices, instancecount, basevertex, baseinstance);
             }
-            /// <inheritdoc cref="GetImageHandleARB"/>
-            public static unsafe ulong GetImageHandleARB(TextureHandle texture, int level, bool layered, int layer, PixelFormat format)
-            {
-                ulong returnValue;
-                byte layered_byte = (byte)(layered ? 1 : 0);
-                returnValue = GetImageHandleARB(texture, level, layered_byte, layer, format);
-                return returnValue;
-            }
             /// <inheritdoc cref="UniformHandleui64vARB"/>
             public static unsafe void UniformHandleui64vARB(int location, ReadOnlySpan<ulong> value)
             {
@@ -12228,8 +11982,7 @@ namespace OpenTK.Graphics.OpenGL
                 int count = (int)(ids.Length);
                 fixed (uint* ids_ptr = ids)
                 {
-                    byte enabled_byte = (byte)(enabled ? 1 : 0);
-                    DebugMessageControlARB(source, type, severity, count, ids_ptr, enabled_byte);
+                    DebugMessageControlARB(source, type, severity, count, ids_ptr, enabled);
                 }
             }
             /// <inheritdoc cref="DebugMessageControlARB"/>
@@ -12238,8 +11991,7 @@ namespace OpenTK.Graphics.OpenGL
                 int count = (int)(ids.Length);
                 fixed (uint* ids_ptr = ids)
                 {
-                    byte enabled_byte = (byte)(enabled ? 1 : 0);
-                    DebugMessageControlARB(source, type, severity, count, ids_ptr, enabled_byte);
+                    DebugMessageControlARB(source, type, severity, count, ids_ptr, enabled);
                 }
             }
             /// <inheritdoc cref="DebugMessageControlARB"/>
@@ -12247,8 +11999,7 @@ namespace OpenTK.Graphics.OpenGL
             {
                 fixed (uint* ids_ptr = &ids)
                 {
-                    byte enabled_byte = (byte)(enabled ? 1 : 0);
-                    DebugMessageControlARB(source, type, severity, count, ids_ptr, enabled_byte);
+                    DebugMessageControlARB(source, type, severity, count, ids_ptr, enabled);
                 }
             }
             /// <inheritdoc cref="DebugMessageInsertARB"/>
@@ -12912,18 +12663,6 @@ namespace OpenTK.Graphics.OpenGL
                     CreateTextures(target, n, textures_ptr);
                 }
             }
-            /// <inheritdoc cref="TextureStorage2DMultisample"/>
-            public static unsafe void TextureStorage2DMultisample(TextureHandle texture, int samples, SizedInternalFormat internalformat, int width, int height, bool fixedsamplelocations)
-            {
-                byte fixedsamplelocations_byte = (byte)(fixedsamplelocations ? 1 : 0);
-                TextureStorage2DMultisample(texture, samples, internalformat, width, height, fixedsamplelocations_byte);
-            }
-            /// <inheritdoc cref="TextureStorage3DMultisample"/>
-            public static unsafe void TextureStorage3DMultisample(TextureHandle texture, int samples, SizedInternalFormat internalformat, int width, int height, int depth, bool fixedsamplelocations)
-            {
-                byte fixedsamplelocations_byte = (byte)(fixedsamplelocations ? 1 : 0);
-                TextureStorage3DMultisample(texture, samples, internalformat, width, height, depth, fixedsamplelocations_byte);
-            }
             /// <inheritdoc cref="TextureSubImage1D"/>
             public static unsafe void TextureSubImage1D(TextureHandle texture, int level, int xoffset, int width, PixelFormat format, PixelType type, IntPtr pixels)
             {
@@ -13193,12 +12932,6 @@ namespace OpenTK.Graphics.OpenGL
                 {
                     VertexArrayVertexBuffers(vaobj, first, count, buffers_ptr, offsets_ptr, strides_ptr);
                 }
-            }
-            /// <inheritdoc cref="VertexArrayAttribFormat"/>
-            public static unsafe void VertexArrayAttribFormat(VertexArrayHandle vaobj, uint attribindex, int size, VertexAttribType type, bool normalized, uint relativeoffset)
-            {
-                byte normalized_byte = (byte)(normalized ? 1 : 0);
-                VertexArrayAttribFormat(vaobj, attribindex, size, type, normalized_byte, relativeoffset);
             }
             /// <inheritdoc cref="GetVertexArrayiv"/>
             public static unsafe void GetVertexArrayi(VertexArrayHandle vaobj, VertexArrayPName pname, ref int param)
@@ -14405,8 +14138,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix2d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix2dv(location, count, transpose_byte, value_ptr);
+                    UniformMatrix2dv(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix2dv"/>
@@ -14415,8 +14147,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix2d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix2dv(location, count, transpose_byte, value_ptr);
+                    UniformMatrix2dv(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix2dv"/>
@@ -14425,8 +14156,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix2d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix2dv(location, count, transpose_byte, value_ptr);
+                    UniformMatrix2dv(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix3dv"/>
@@ -14436,8 +14166,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix3d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix3dv(location, count, transpose_byte, value_ptr);
+                    UniformMatrix3dv(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix3dv"/>
@@ -14446,8 +14175,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix3d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix3dv(location, count, transpose_byte, value_ptr);
+                    UniformMatrix3dv(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix3dv"/>
@@ -14456,8 +14184,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix3d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix3dv(location, count, transpose_byte, value_ptr);
+                    UniformMatrix3dv(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix4dv"/>
@@ -14467,8 +14194,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix4d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix4dv(location, count, transpose_byte, value_ptr);
+                    UniformMatrix4dv(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix4dv"/>
@@ -14477,8 +14203,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix4d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix4dv(location, count, transpose_byte, value_ptr);
+                    UniformMatrix4dv(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix4dv"/>
@@ -14487,8 +14212,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix4d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix4dv(location, count, transpose_byte, value_ptr);
+                    UniformMatrix4dv(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix2x3dv"/>
@@ -14498,8 +14222,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix2x3d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix2x3dv(location, count, transpose_byte, value_ptr);
+                    UniformMatrix2x3dv(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix2x3dv"/>
@@ -14508,8 +14231,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix2x3d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix2x3dv(location, count, transpose_byte, value_ptr);
+                    UniformMatrix2x3dv(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix2x3dv"/>
@@ -14518,8 +14240,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix2x3d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix2x3dv(location, count, transpose_byte, value_ptr);
+                    UniformMatrix2x3dv(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix2x4dv"/>
@@ -14529,8 +14250,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix2x4d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix2x4dv(location, count, transpose_byte, value_ptr);
+                    UniformMatrix2x4dv(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix2x4dv"/>
@@ -14539,8 +14259,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix2x4d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix2x4dv(location, count, transpose_byte, value_ptr);
+                    UniformMatrix2x4dv(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix2x4dv"/>
@@ -14549,8 +14268,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix2x4d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix2x4dv(location, count, transpose_byte, value_ptr);
+                    UniformMatrix2x4dv(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix3x2dv"/>
@@ -14560,8 +14278,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix3x2d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix3x2dv(location, count, transpose_byte, value_ptr);
+                    UniformMatrix3x2dv(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix3x2dv"/>
@@ -14570,8 +14287,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix3x2d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix3x2dv(location, count, transpose_byte, value_ptr);
+                    UniformMatrix3x2dv(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix3x2dv"/>
@@ -14580,8 +14296,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix3x2d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix3x2dv(location, count, transpose_byte, value_ptr);
+                    UniformMatrix3x2dv(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix3x4dv"/>
@@ -14591,8 +14306,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix3x4d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix3x4dv(location, count, transpose_byte, value_ptr);
+                    UniformMatrix3x4dv(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix3x4dv"/>
@@ -14601,8 +14315,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix3x4d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix3x4dv(location, count, transpose_byte, value_ptr);
+                    UniformMatrix3x4dv(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix3x4dv"/>
@@ -14611,8 +14324,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix3x4d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix3x4dv(location, count, transpose_byte, value_ptr);
+                    UniformMatrix3x4dv(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix4x2dv"/>
@@ -14622,8 +14334,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix4x2d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix4x2dv(location, count, transpose_byte, value_ptr);
+                    UniformMatrix4x2dv(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix4x2dv"/>
@@ -14632,8 +14343,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix4x2d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix4x2dv(location, count, transpose_byte, value_ptr);
+                    UniformMatrix4x2dv(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix4x2dv"/>
@@ -14642,8 +14352,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix4x2d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix4x2dv(location, count, transpose_byte, value_ptr);
+                    UniformMatrix4x2dv(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix4x3dv"/>
@@ -14653,8 +14362,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix4x3d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix4x3dv(location, count, transpose_byte, value_ptr);
+                    UniformMatrix4x3dv(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix4x3dv"/>
@@ -14663,8 +14371,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix4x3d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix4x3dv(location, count, transpose_byte, value_ptr);
+                    UniformMatrix4x3dv(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix4x3dv"/>
@@ -14673,8 +14380,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix4x3d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix4x3dv(location, count, transpose_byte, value_ptr);
+                    UniformMatrix4x3dv(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="GetUniformdv"/>
@@ -15707,12 +15413,6 @@ namespace OpenTK.Graphics.OpenGL
                 {
                     MultiDrawElementsIndirect(mode, type, indirect_ptr, drawcount, stride);
                 }
-            }
-            /// <inheritdoc cref="SampleCoverageARB"/>
-            public static unsafe void SampleCoverageARB(float value, bool invert)
-            {
-                byte invert_byte = (byte)(invert ? 1 : 0);
-                SampleCoverageARB(value, invert_byte);
             }
             /// <inheritdoc cref="MultiTexCoord1dvARB"/>
             public static unsafe void MultiTexCoord1dvARB(TextureUnit target, ReadOnlySpan<double> v)
@@ -17490,8 +17190,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix2* tmp_vecPtr = &value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2fv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2fv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2fv"/>
@@ -17500,8 +17199,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix2* tmp_vecPtr = value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2fv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2fv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2fv"/>
@@ -17510,8 +17208,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix2* tmp_vecPtr = value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2fv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2fv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3fv"/>
@@ -17521,8 +17218,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix3* tmp_vecPtr = &value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3fv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3fv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3fv"/>
@@ -17531,8 +17227,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix3* tmp_vecPtr = value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3fv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3fv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3fv"/>
@@ -17541,8 +17236,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix3* tmp_vecPtr = value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3fv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3fv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
@@ -17552,8 +17246,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix4* tmp_vecPtr = &value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4fv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4fv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
@@ -17562,8 +17255,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix4* tmp_vecPtr = value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4fv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4fv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
@@ -17572,8 +17264,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix4* tmp_vecPtr = value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4fv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4fv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2dv"/>
@@ -17583,8 +17274,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix2d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2dv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2dv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2dv"/>
@@ -17593,8 +17283,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix2d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2dv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2dv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2dv"/>
@@ -17603,8 +17292,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix2d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2dv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2dv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3dv"/>
@@ -17614,8 +17302,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix3d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3dv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3dv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3dv"/>
@@ -17624,8 +17311,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix3d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3dv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3dv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3dv"/>
@@ -17634,8 +17320,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix3d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3dv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3dv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4dv"/>
@@ -17645,8 +17330,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix4d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4dv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4dv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4dv"/>
@@ -17655,8 +17339,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix4d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4dv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4dv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4dv"/>
@@ -17665,8 +17348,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix4d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4dv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4dv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x3fv"/>
@@ -17676,8 +17358,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix2x3* tmp_vecPtr = &value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2x3fv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2x3fv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x3fv"/>
@@ -17686,8 +17367,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix2x3* tmp_vecPtr = value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2x3fv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2x3fv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x3fv"/>
@@ -17696,8 +17376,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix2x3* tmp_vecPtr = value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2x3fv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2x3fv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
@@ -17707,8 +17386,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix3x2* tmp_vecPtr = &value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3x2fv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3x2fv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
@@ -17717,8 +17395,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix3x2* tmp_vecPtr = value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3x2fv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3x2fv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
@@ -17727,8 +17404,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix3x2* tmp_vecPtr = value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3x2fv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3x2fv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x4fv"/>
@@ -17738,8 +17414,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix2x4* tmp_vecPtr = &value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2x4fv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2x4fv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x4fv"/>
@@ -17748,8 +17423,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix2x4* tmp_vecPtr = value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2x4fv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2x4fv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x4fv"/>
@@ -17758,8 +17432,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix2x4* tmp_vecPtr = value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2x4fv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2x4fv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x2fv"/>
@@ -17769,8 +17442,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix4x2* tmp_vecPtr = &value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4x2fv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4x2fv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x2fv"/>
@@ -17779,8 +17451,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix4x2* tmp_vecPtr = value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4x2fv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4x2fv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x2fv"/>
@@ -17789,8 +17460,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix4x2* tmp_vecPtr = value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4x2fv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4x2fv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x4fv"/>
@@ -17800,8 +17470,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix3x4* tmp_vecPtr = &value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3x4fv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3x4fv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x4fv"/>
@@ -17810,8 +17479,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix3x4* tmp_vecPtr = value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3x4fv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3x4fv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x4fv"/>
@@ -17820,8 +17488,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix3x4* tmp_vecPtr = value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3x4fv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3x4fv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x3fv"/>
@@ -17831,8 +17498,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix4x3* tmp_vecPtr = &value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4x3fv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4x3fv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x3fv"/>
@@ -17841,8 +17507,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix4x3* tmp_vecPtr = value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4x3fv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4x3fv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x3fv"/>
@@ -17851,8 +17516,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix4x3* tmp_vecPtr = value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4x3fv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4x3fv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x3dv"/>
@@ -17862,8 +17526,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix2x3d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2x3dv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2x3dv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x3dv"/>
@@ -17872,8 +17535,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix2x3d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2x3dv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2x3dv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x3dv"/>
@@ -17882,8 +17544,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix2x3d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2x3dv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2x3dv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2dv"/>
@@ -17893,8 +17554,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix3x2d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3x2dv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3x2dv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2dv"/>
@@ -17903,8 +17563,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix3x2d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3x2dv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3x2dv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2dv"/>
@@ -17913,8 +17572,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix3x2d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3x2dv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3x2dv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x4dv"/>
@@ -17924,8 +17582,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix2x4d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2x4dv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2x4dv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x4dv"/>
@@ -17934,8 +17591,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix2x4d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2x4dv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2x4dv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x4dv"/>
@@ -17944,8 +17600,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix2x4d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2x4dv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2x4dv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x2dv"/>
@@ -17955,8 +17610,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix4x2d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4x2dv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4x2dv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x2dv"/>
@@ -17965,8 +17619,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix4x2d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4x2dv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4x2dv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x2dv"/>
@@ -17975,8 +17628,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix4x2d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4x2dv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4x2dv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x4dv"/>
@@ -17986,8 +17638,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix3x4d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3x4dv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3x4dv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x4dv"/>
@@ -17996,8 +17647,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix3x4d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3x4dv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3x4dv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x4dv"/>
@@ -18006,8 +17656,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix3x4d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3x4dv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3x4dv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x3dv"/>
@@ -18017,8 +17666,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix4x3d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4x3dv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4x3dv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x3dv"/>
@@ -18027,8 +17675,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix4x3d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4x3dv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4x3dv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x3dv"/>
@@ -18037,8 +17684,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (Matrix4x3d* tmp_vecPtr = value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4x3dv(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4x3dv(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="GetProgramPipelineInfoLog"/>
@@ -18136,12 +17782,6 @@ namespace OpenTK.Graphics.OpenGL
                 {
                     GetActiveAtomicCounterBufferiv(program, bufferIndex, pname, parameters_ptr);
                 }
-            }
-            /// <inheritdoc cref="BindImageTexture"/>
-            public static unsafe void BindImageTexture(uint unit, TextureHandle texture, int level, bool layered, int layer, BufferAccessARB access, InternalFormat format)
-            {
-                byte layered_byte = (byte)(layered ? 1 : 0);
-                BindImageTexture(unit, texture, level, layered_byte, layer, access, format);
             }
             /// <inheritdoc cref="ShaderSourceARB"/>
             public static unsafe void ShaderSourceARB(GLHandleARB shaderObj, int count, byte** str, ReadOnlySpan<int> length)
@@ -18381,8 +18021,7 @@ namespace OpenTK.Graphics.OpenGL
                 int count = (int)(value.Length / 4);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix2fvARB(location, count, transpose_byte, value_ptr);
+                    UniformMatrix2fvARB(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix2fvARB"/>
@@ -18391,8 +18030,7 @@ namespace OpenTK.Graphics.OpenGL
                 int count = (int)(value.Length / 4);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix2fvARB(location, count, transpose_byte, value_ptr);
+                    UniformMatrix2fvARB(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix2fvARB"/>
@@ -18400,8 +18038,7 @@ namespace OpenTK.Graphics.OpenGL
             {
                 fixed (float* value_ptr = &value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix2fvARB(location, count, transpose_byte, value_ptr);
+                    UniformMatrix2fvARB(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix3fvARB"/>
@@ -18410,8 +18047,7 @@ namespace OpenTK.Graphics.OpenGL
                 int count = (int)(value.Length / 9);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix3fvARB(location, count, transpose_byte, value_ptr);
+                    UniformMatrix3fvARB(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix3fvARB"/>
@@ -18420,8 +18056,7 @@ namespace OpenTK.Graphics.OpenGL
                 int count = (int)(value.Length / 9);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix3fvARB(location, count, transpose_byte, value_ptr);
+                    UniformMatrix3fvARB(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix3fvARB"/>
@@ -18429,8 +18064,7 @@ namespace OpenTK.Graphics.OpenGL
             {
                 fixed (float* value_ptr = &value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix3fvARB(location, count, transpose_byte, value_ptr);
+                    UniformMatrix3fvARB(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix4fvARB"/>
@@ -18439,8 +18073,7 @@ namespace OpenTK.Graphics.OpenGL
                 int count = (int)(value.Length / 16);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix4fvARB(location, count, transpose_byte, value_ptr);
+                    UniformMatrix4fvARB(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix4fvARB"/>
@@ -18449,8 +18082,7 @@ namespace OpenTK.Graphics.OpenGL
                 int count = (int)(value.Length / 16);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix4fvARB(location, count, transpose_byte, value_ptr);
+                    UniformMatrix4fvARB(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix4fvARB"/>
@@ -18458,8 +18090,7 @@ namespace OpenTK.Graphics.OpenGL
             {
                 fixed (float* value_ptr = &value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix4fvARB(location, count, transpose_byte, value_ptr);
+                    UniformMatrix4fvARB(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="GetObjectParameterfvARB"/>
@@ -19267,30 +18898,6 @@ namespace OpenTK.Graphics.OpenGL
                     Marshal.FreeCoTaskMem((IntPtr)name_ptr);
                 }
             }
-            /// <inheritdoc cref="BufferPageCommitmentARB"/>
-            public static unsafe void BufferPageCommitmentARB(All target, IntPtr offset, nint size, bool commit)
-            {
-                byte commit_byte = (byte)(commit ? 1 : 0);
-                BufferPageCommitmentARB(target, offset, size, commit_byte);
-            }
-            /// <inheritdoc cref="NamedBufferPageCommitmentEXT"/>
-            public static unsafe void NamedBufferPageCommitmentEXT(BufferHandle buffer, IntPtr offset, nint size, bool commit)
-            {
-                byte commit_byte = (byte)(commit ? 1 : 0);
-                NamedBufferPageCommitmentEXT(buffer, offset, size, commit_byte);
-            }
-            /// <inheritdoc cref="NamedBufferPageCommitmentARB"/>
-            public static unsafe void NamedBufferPageCommitmentARB(BufferHandle buffer, IntPtr offset, nint size, bool commit)
-            {
-                byte commit_byte = (byte)(commit ? 1 : 0);
-                NamedBufferPageCommitmentARB(buffer, offset, size, commit_byte);
-            }
-            /// <inheritdoc cref="TexPageCommitmentARB"/>
-            public static unsafe void TexPageCommitmentARB(All target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, bool commit)
-            {
-                byte commit_byte = (byte)(commit ? 1 : 0);
-                TexPageCommitmentARB(target, level, xoffset, yoffset, zoffset, width, height, depth, commit_byte);
-            }
             /// <inheritdoc cref="GetInteger64v"/>
             public static unsafe void GetInteger64(GetPName pname, Span<long> data)
             {
@@ -19615,18 +19222,6 @@ namespace OpenTK.Graphics.OpenGL
                     GetCompressedTexImageARB(target, level, img_ptr);
                 }
             }
-            /// <inheritdoc cref="TexImage2DMultisample"/>
-            public static unsafe void TexImage2DMultisample(TextureTarget target, int samples, InternalFormat internalformat, int width, int height, bool fixedsamplelocations)
-            {
-                byte fixedsamplelocations_byte = (byte)(fixedsamplelocations ? 1 : 0);
-                TexImage2DMultisample(target, samples, internalformat, width, height, fixedsamplelocations_byte);
-            }
-            /// <inheritdoc cref="TexImage3DMultisample"/>
-            public static unsafe void TexImage3DMultisample(TextureTarget target, int samples, InternalFormat internalformat, int width, int height, int depth, bool fixedsamplelocations)
-            {
-                byte fixedsamplelocations_byte = (byte)(fixedsamplelocations ? 1 : 0);
-                TexImage3DMultisample(target, samples, internalformat, width, height, depth, fixedsamplelocations_byte);
-            }
             /// <inheritdoc cref="GetMultisamplefv"/>
             public static unsafe void GetMultisamplef(GetMultisamplePNameNV pname, uint index, Span<float> val)
             {
@@ -19650,18 +19245,6 @@ namespace OpenTK.Graphics.OpenGL
                 {
                     GetMultisamplefv(pname, index, val_ptr);
                 }
-            }
-            /// <inheritdoc cref="TexStorage2DMultisample"/>
-            public static unsafe void TexStorage2DMultisample(TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, bool fixedsamplelocations)
-            {
-                byte fixedsamplelocations_byte = (byte)(fixedsamplelocations ? 1 : 0);
-                TexStorage2DMultisample(target, samples, internalformat, width, height, fixedsamplelocations_byte);
-            }
-            /// <inheritdoc cref="TexStorage3DMultisample"/>
-            public static unsafe void TexStorage3DMultisample(TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, int depth, bool fixedsamplelocations)
-            {
-                byte fixedsamplelocations_byte = (byte)(fixedsamplelocations ? 1 : 0);
-                TexStorage3DMultisample(target, samples, internalformat, width, height, depth, fixedsamplelocations_byte);
             }
             /// <inheritdoc cref="GetQueryObjecti64v"/>
             public static unsafe void GetQueryObjecti64(QueryHandle id, QueryObjectParameterName pname, Span<long> parameters)
@@ -20404,12 +19987,6 @@ namespace OpenTK.Graphics.OpenGL
                 {
                     GetVertexAttribLdv(index, pname, parameters_ptr);
                 }
-            }
-            /// <inheritdoc cref="VertexAttribFormat"/>
-            public static unsafe void VertexAttribFormat(uint attribindex, int size, VertexAttribType type, bool normalized, uint relativeoffset)
-            {
-                byte normalized_byte = (byte)(normalized ? 1 : 0);
-                VertexAttribFormat(attribindex, size, type, normalized_byte, relativeoffset);
             }
             /// <inheritdoc cref="WeightbvARB"/>
             public static unsafe void WeightbvARB(ReadOnlySpan<sbyte> weights)
@@ -21389,8 +20966,7 @@ namespace OpenTK.Graphics.OpenGL
             public static unsafe void VertexAttribPointerARB(uint index, int size, VertexAttribPointerType type, bool normalized, int stride, IntPtr pointer)
             {
                 void* pointer_vptr = (void*)pointer;
-                byte normalized_byte = (byte)(normalized ? 1 : 0);
-                VertexAttribPointerARB(index, size, type, normalized_byte, stride, pointer_vptr);
+                VertexAttribPointerARB(index, size, type, normalized, stride, pointer_vptr);
             }
             /// <inheritdoc cref="VertexAttribPointerARB"/>
             public static unsafe void VertexAttribPointerARB<T1>(uint index, int size, VertexAttribPointerType type, bool normalized, int stride, ReadOnlySpan<T1> pointer)
@@ -21398,8 +20974,7 @@ namespace OpenTK.Graphics.OpenGL
             {
                 fixed (void* pointer_ptr = pointer)
                 {
-                    byte normalized_byte = (byte)(normalized ? 1 : 0);
-                    VertexAttribPointerARB(index, size, type, normalized_byte, stride, pointer_ptr);
+                    VertexAttribPointerARB(index, size, type, normalized, stride, pointer_ptr);
                 }
             }
             /// <inheritdoc cref="VertexAttribPointerARB"/>
@@ -21408,8 +20983,7 @@ namespace OpenTK.Graphics.OpenGL
             {
                 fixed (void* pointer_ptr = pointer)
                 {
-                    byte normalized_byte = (byte)(normalized ? 1 : 0);
-                    VertexAttribPointerARB(index, size, type, normalized_byte, stride, pointer_ptr);
+                    VertexAttribPointerARB(index, size, type, normalized, stride, pointer_ptr);
                 }
             }
             /// <inheritdoc cref="VertexAttribPointerARB"/>
@@ -21418,8 +20992,7 @@ namespace OpenTK.Graphics.OpenGL
             {
                 fixed (void* pointer_ptr = &pointer)
                 {
-                    byte normalized_byte = (byte)(normalized ? 1 : 0);
-                    VertexAttribPointerARB(index, size, type, normalized_byte, stride, pointer_ptr);
+                    VertexAttribPointerARB(index, size, type, normalized, stride, pointer_ptr);
                 }
             }
             /// <inheritdoc cref="GetVertexAttribdvARB"/>
@@ -21610,19 +21183,12 @@ namespace OpenTK.Graphics.OpenGL
                 Marshal.FreeCoTaskMem((IntPtr)name_ptr);
                 return returnValue;
             }
-            /// <inheritdoc cref="VertexAttribP1ui"/>
-            public static unsafe void VertexAttribP1ui(uint index, VertexAttribPointerType type, bool normalized, uint value)
-            {
-                byte normalized_byte = (byte)(normalized ? 1 : 0);
-                VertexAttribP1ui(index, type, normalized_byte, value);
-            }
             /// <inheritdoc cref="VertexAttribP1uiv"/>
             public static unsafe void VertexAttribP1ui(uint index, VertexAttribPointerType type, bool normalized, ReadOnlySpan<uint> value)
             {
                 fixed (uint* value_ptr = value)
                 {
-                    byte normalized_byte = (byte)(normalized ? 1 : 0);
-                    VertexAttribP1uiv(index, type, normalized_byte, value_ptr);
+                    VertexAttribP1uiv(index, type, normalized, value_ptr);
                 }
             }
             /// <inheritdoc cref="VertexAttribP1uiv"/>
@@ -21630,8 +21196,7 @@ namespace OpenTK.Graphics.OpenGL
             {
                 fixed (uint* value_ptr = value)
                 {
-                    byte normalized_byte = (byte)(normalized ? 1 : 0);
-                    VertexAttribP1uiv(index, type, normalized_byte, value_ptr);
+                    VertexAttribP1uiv(index, type, normalized, value_ptr);
                 }
             }
             /// <inheritdoc cref="VertexAttribP1uiv"/>
@@ -21639,23 +21204,15 @@ namespace OpenTK.Graphics.OpenGL
             {
                 fixed (uint* value_ptr = &value)
                 {
-                    byte normalized_byte = (byte)(normalized ? 1 : 0);
-                    VertexAttribP1uiv(index, type, normalized_byte, value_ptr);
+                    VertexAttribP1uiv(index, type, normalized, value_ptr);
                 }
-            }
-            /// <inheritdoc cref="VertexAttribP2ui"/>
-            public static unsafe void VertexAttribP2ui(uint index, VertexAttribPointerType type, bool normalized, uint value)
-            {
-                byte normalized_byte = (byte)(normalized ? 1 : 0);
-                VertexAttribP2ui(index, type, normalized_byte, value);
             }
             /// <inheritdoc cref="VertexAttribP2uiv"/>
             public static unsafe void VertexAttribP2ui(uint index, VertexAttribPointerType type, bool normalized, ReadOnlySpan<uint> value)
             {
                 fixed (uint* value_ptr = value)
                 {
-                    byte normalized_byte = (byte)(normalized ? 1 : 0);
-                    VertexAttribP2uiv(index, type, normalized_byte, value_ptr);
+                    VertexAttribP2uiv(index, type, normalized, value_ptr);
                 }
             }
             /// <inheritdoc cref="VertexAttribP2uiv"/>
@@ -21663,8 +21220,7 @@ namespace OpenTK.Graphics.OpenGL
             {
                 fixed (uint* value_ptr = value)
                 {
-                    byte normalized_byte = (byte)(normalized ? 1 : 0);
-                    VertexAttribP2uiv(index, type, normalized_byte, value_ptr);
+                    VertexAttribP2uiv(index, type, normalized, value_ptr);
                 }
             }
             /// <inheritdoc cref="VertexAttribP2uiv"/>
@@ -21672,23 +21228,15 @@ namespace OpenTK.Graphics.OpenGL
             {
                 fixed (uint* value_ptr = &value)
                 {
-                    byte normalized_byte = (byte)(normalized ? 1 : 0);
-                    VertexAttribP2uiv(index, type, normalized_byte, value_ptr);
+                    VertexAttribP2uiv(index, type, normalized, value_ptr);
                 }
-            }
-            /// <inheritdoc cref="VertexAttribP3ui"/>
-            public static unsafe void VertexAttribP3ui(uint index, VertexAttribPointerType type, bool normalized, uint value)
-            {
-                byte normalized_byte = (byte)(normalized ? 1 : 0);
-                VertexAttribP3ui(index, type, normalized_byte, value);
             }
             /// <inheritdoc cref="VertexAttribP3uiv"/>
             public static unsafe void VertexAttribP3ui(uint index, VertexAttribPointerType type, bool normalized, ReadOnlySpan<uint> value)
             {
                 fixed (uint* value_ptr = value)
                 {
-                    byte normalized_byte = (byte)(normalized ? 1 : 0);
-                    VertexAttribP3uiv(index, type, normalized_byte, value_ptr);
+                    VertexAttribP3uiv(index, type, normalized, value_ptr);
                 }
             }
             /// <inheritdoc cref="VertexAttribP3uiv"/>
@@ -21696,8 +21244,7 @@ namespace OpenTK.Graphics.OpenGL
             {
                 fixed (uint* value_ptr = value)
                 {
-                    byte normalized_byte = (byte)(normalized ? 1 : 0);
-                    VertexAttribP3uiv(index, type, normalized_byte, value_ptr);
+                    VertexAttribP3uiv(index, type, normalized, value_ptr);
                 }
             }
             /// <inheritdoc cref="VertexAttribP3uiv"/>
@@ -21705,23 +21252,15 @@ namespace OpenTK.Graphics.OpenGL
             {
                 fixed (uint* value_ptr = &value)
                 {
-                    byte normalized_byte = (byte)(normalized ? 1 : 0);
-                    VertexAttribP3uiv(index, type, normalized_byte, value_ptr);
+                    VertexAttribP3uiv(index, type, normalized, value_ptr);
                 }
-            }
-            /// <inheritdoc cref="VertexAttribP4ui"/>
-            public static unsafe void VertexAttribP4ui(uint index, VertexAttribPointerType type, bool normalized, uint value)
-            {
-                byte normalized_byte = (byte)(normalized ? 1 : 0);
-                VertexAttribP4ui(index, type, normalized_byte, value);
             }
             /// <inheritdoc cref="VertexAttribP4uiv"/>
             public static unsafe void VertexAttribP4ui(uint index, VertexAttribPointerType type, bool normalized, ReadOnlySpan<uint> value)
             {
                 fixed (uint* value_ptr = value)
                 {
-                    byte normalized_byte = (byte)(normalized ? 1 : 0);
-                    VertexAttribP4uiv(index, type, normalized_byte, value_ptr);
+                    VertexAttribP4uiv(index, type, normalized, value_ptr);
                 }
             }
             /// <inheritdoc cref="VertexAttribP4uiv"/>
@@ -21729,8 +21268,7 @@ namespace OpenTK.Graphics.OpenGL
             {
                 fixed (uint* value_ptr = value)
                 {
-                    byte normalized_byte = (byte)(normalized ? 1 : 0);
-                    VertexAttribP4uiv(index, type, normalized_byte, value_ptr);
+                    VertexAttribP4uiv(index, type, normalized, value_ptr);
                 }
             }
             /// <inheritdoc cref="VertexAttribP4uiv"/>
@@ -21738,8 +21276,7 @@ namespace OpenTK.Graphics.OpenGL
             {
                 fixed (uint* value_ptr = &value)
                 {
-                    byte normalized_byte = (byte)(normalized ? 1 : 0);
-                    VertexAttribP4uiv(index, type, normalized_byte, value_ptr);
+                    VertexAttribP4uiv(index, type, normalized, value_ptr);
                 }
             }
             /// <inheritdoc cref="ViewportArrayv"/>
@@ -22513,12 +22050,6 @@ namespace OpenTK.Graphics.OpenGL
                 {
                     GetVariantArrayObjectivATI(id, pname, parameters_ptr);
                 }
-            }
-            /// <inheritdoc cref="VertexAttribArrayObjectATI"/>
-            public static unsafe void VertexAttribArrayObjectATI(uint index, int size, VertexAttribPointerType type, bool normalized, int stride, BufferHandle buffer, uint offset)
-            {
-                byte normalized_byte = (byte)(normalized ? 1 : 0);
-                VertexAttribArrayObjectATI(index, size, type, normalized_byte, stride, buffer, offset);
             }
             /// <inheritdoc cref="GetVertexAttribArrayObjectfvATI"/>
             public static unsafe void GetVertexAttribArrayObjectfvATI(uint index, ArrayObjectPNameATI pname, Span<float> parameters)
@@ -26021,8 +25552,7 @@ namespace OpenTK.Graphics.OpenGL
                 int count = (int)(value.Length / 4);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2fvEXT"/>
@@ -26031,8 +25561,7 @@ namespace OpenTK.Graphics.OpenGL
                 int count = (int)(value.Length / 4);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2fvEXT"/>
@@ -26040,8 +25569,7 @@ namespace OpenTK.Graphics.OpenGL
             {
                 fixed (float* value_ptr = &value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3fvEXT"/>
@@ -26050,8 +25578,7 @@ namespace OpenTK.Graphics.OpenGL
                 int count = (int)(value.Length / 9);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3fvEXT"/>
@@ -26060,8 +25587,7 @@ namespace OpenTK.Graphics.OpenGL
                 int count = (int)(value.Length / 9);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3fvEXT"/>
@@ -26069,8 +25595,7 @@ namespace OpenTK.Graphics.OpenGL
             {
                 fixed (float* value_ptr = &value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4fvEXT"/>
@@ -26079,8 +25604,7 @@ namespace OpenTK.Graphics.OpenGL
                 int count = (int)(value.Length / 16);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4fvEXT"/>
@@ -26089,8 +25613,7 @@ namespace OpenTK.Graphics.OpenGL
                 int count = (int)(value.Length / 16);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4fvEXT"/>
@@ -26098,8 +25621,7 @@ namespace OpenTK.Graphics.OpenGL
             {
                 fixed (float* value_ptr = &value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x3fvEXT"/>
@@ -26108,8 +25630,7 @@ namespace OpenTK.Graphics.OpenGL
                 int count = (int)(value.Length / 6);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2x3fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2x3fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x3fvEXT"/>
@@ -26118,8 +25639,7 @@ namespace OpenTK.Graphics.OpenGL
                 int count = (int)(value.Length / 6);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2x3fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2x3fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x3fvEXT"/>
@@ -26127,8 +25647,7 @@ namespace OpenTK.Graphics.OpenGL
             {
                 fixed (float* value_ptr = &value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2x3fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2x3fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2fvEXT"/>
@@ -26137,8 +25656,7 @@ namespace OpenTK.Graphics.OpenGL
                 int count = (int)(value.Length / 6);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3x2fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3x2fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2fvEXT"/>
@@ -26147,8 +25665,7 @@ namespace OpenTK.Graphics.OpenGL
                 int count = (int)(value.Length / 6);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3x2fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3x2fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2fvEXT"/>
@@ -26156,8 +25673,7 @@ namespace OpenTK.Graphics.OpenGL
             {
                 fixed (float* value_ptr = &value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3x2fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3x2fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x4fvEXT"/>
@@ -26166,8 +25682,7 @@ namespace OpenTK.Graphics.OpenGL
                 int count = (int)(value.Length / 8);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2x4fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2x4fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x4fvEXT"/>
@@ -26176,8 +25691,7 @@ namespace OpenTK.Graphics.OpenGL
                 int count = (int)(value.Length / 8);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2x4fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2x4fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x4fvEXT"/>
@@ -26185,8 +25699,7 @@ namespace OpenTK.Graphics.OpenGL
             {
                 fixed (float* value_ptr = &value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2x4fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2x4fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x2fvEXT"/>
@@ -26195,8 +25708,7 @@ namespace OpenTK.Graphics.OpenGL
                 int count = (int)(value.Length / 8);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4x2fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4x2fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x2fvEXT"/>
@@ -26205,8 +25717,7 @@ namespace OpenTK.Graphics.OpenGL
                 int count = (int)(value.Length / 8);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4x2fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4x2fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x2fvEXT"/>
@@ -26214,8 +25725,7 @@ namespace OpenTK.Graphics.OpenGL
             {
                 fixed (float* value_ptr = &value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4x2fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4x2fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x4fvEXT"/>
@@ -26224,8 +25734,7 @@ namespace OpenTK.Graphics.OpenGL
                 int count = (int)(value.Length / 12);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3x4fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3x4fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x4fvEXT"/>
@@ -26234,8 +25743,7 @@ namespace OpenTK.Graphics.OpenGL
                 int count = (int)(value.Length / 12);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3x4fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3x4fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x4fvEXT"/>
@@ -26243,8 +25751,7 @@ namespace OpenTK.Graphics.OpenGL
             {
                 fixed (float* value_ptr = &value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3x4fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3x4fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x3fvEXT"/>
@@ -26253,8 +25760,7 @@ namespace OpenTK.Graphics.OpenGL
                 int count = (int)(value.Length / 12);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4x3fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4x3fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x3fvEXT"/>
@@ -26263,8 +25769,7 @@ namespace OpenTK.Graphics.OpenGL
                 int count = (int)(value.Length / 12);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4x3fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4x3fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x3fvEXT"/>
@@ -26272,8 +25777,7 @@ namespace OpenTK.Graphics.OpenGL
             {
                 fixed (float* value_ptr = &value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4x3fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4x3fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="TextureParameterIivEXT"/>
@@ -27080,12 +26584,6 @@ namespace OpenTK.Graphics.OpenGL
                     GetFramebufferParameterivEXT(framebuffer, pname, parameters_ptr);
                 }
             }
-            /// <inheritdoc cref="VertexArrayVertexAttribOffsetEXT"/>
-            public static unsafe void VertexArrayVertexAttribOffsetEXT(VertexArrayHandle vaobj, BufferHandle buffer, uint index, int size, VertexAttribPointerType type, bool normalized, int stride, IntPtr offset)
-            {
-                byte normalized_byte = (byte)(normalized ? 1 : 0);
-                VertexArrayVertexAttribOffsetEXT(vaobj, buffer, index, size, type, normalized_byte, stride, offset);
-            }
             /// <inheritdoc cref="GetVertexArrayIntegervEXT"/>
             public static unsafe void GetVertexArrayIntegervEXT(VertexArrayHandle vaobj, VertexArrayPName pname, ref int param)
             {
@@ -27337,8 +26835,7 @@ namespace OpenTK.Graphics.OpenGL
                 int count = (int)(value.Length / 4);
                 fixed (double* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2dvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2dvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2dvEXT"/>
@@ -27347,8 +26844,7 @@ namespace OpenTK.Graphics.OpenGL
                 int count = (int)(value.Length / 4);
                 fixed (double* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2dvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2dvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2dvEXT"/>
@@ -27356,8 +26852,7 @@ namespace OpenTK.Graphics.OpenGL
             {
                 fixed (double* value_ptr = &value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2dvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2dvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3dvEXT"/>
@@ -27366,8 +26861,7 @@ namespace OpenTK.Graphics.OpenGL
                 int count = (int)(value.Length / 9);
                 fixed (double* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3dvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3dvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3dvEXT"/>
@@ -27376,8 +26870,7 @@ namespace OpenTK.Graphics.OpenGL
                 int count = (int)(value.Length / 9);
                 fixed (double* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3dvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3dvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3dvEXT"/>
@@ -27385,8 +26878,7 @@ namespace OpenTK.Graphics.OpenGL
             {
                 fixed (double* value_ptr = &value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3dvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3dvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4dvEXT"/>
@@ -27395,8 +26887,7 @@ namespace OpenTK.Graphics.OpenGL
                 int count = (int)(value.Length / 16);
                 fixed (double* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4dvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4dvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4dvEXT"/>
@@ -27405,8 +26896,7 @@ namespace OpenTK.Graphics.OpenGL
                 int count = (int)(value.Length / 16);
                 fixed (double* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4dvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4dvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4dvEXT"/>
@@ -27414,8 +26904,7 @@ namespace OpenTK.Graphics.OpenGL
             {
                 fixed (double* value_ptr = &value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4dvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4dvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x3dvEXT"/>
@@ -27424,8 +26913,7 @@ namespace OpenTK.Graphics.OpenGL
                 int count = (int)(value.Length / 6);
                 fixed (double* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2x3dvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2x3dvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x3dvEXT"/>
@@ -27434,8 +26922,7 @@ namespace OpenTK.Graphics.OpenGL
                 int count = (int)(value.Length / 6);
                 fixed (double* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2x3dvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2x3dvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x3dvEXT"/>
@@ -27443,8 +26930,7 @@ namespace OpenTK.Graphics.OpenGL
             {
                 fixed (double* value_ptr = &value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2x3dvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2x3dvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x4dvEXT"/>
@@ -27453,8 +26939,7 @@ namespace OpenTK.Graphics.OpenGL
                 int count = (int)(value.Length / 8);
                 fixed (double* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2x4dvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2x4dvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x4dvEXT"/>
@@ -27463,8 +26948,7 @@ namespace OpenTK.Graphics.OpenGL
                 int count = (int)(value.Length / 8);
                 fixed (double* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2x4dvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2x4dvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x4dvEXT"/>
@@ -27472,8 +26956,7 @@ namespace OpenTK.Graphics.OpenGL
             {
                 fixed (double* value_ptr = &value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2x4dvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2x4dvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2dvEXT"/>
@@ -27482,8 +26965,7 @@ namespace OpenTK.Graphics.OpenGL
                 int count = (int)(value.Length / 6);
                 fixed (double* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3x2dvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3x2dvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2dvEXT"/>
@@ -27492,8 +26974,7 @@ namespace OpenTK.Graphics.OpenGL
                 int count = (int)(value.Length / 6);
                 fixed (double* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3x2dvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3x2dvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2dvEXT"/>
@@ -27501,8 +26982,7 @@ namespace OpenTK.Graphics.OpenGL
             {
                 fixed (double* value_ptr = &value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3x2dvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3x2dvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x4dvEXT"/>
@@ -27511,8 +26991,7 @@ namespace OpenTK.Graphics.OpenGL
                 int count = (int)(value.Length / 12);
                 fixed (double* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3x4dvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3x4dvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x4dvEXT"/>
@@ -27521,8 +27000,7 @@ namespace OpenTK.Graphics.OpenGL
                 int count = (int)(value.Length / 12);
                 fixed (double* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3x4dvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3x4dvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x4dvEXT"/>
@@ -27530,8 +27008,7 @@ namespace OpenTK.Graphics.OpenGL
             {
                 fixed (double* value_ptr = &value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3x4dvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3x4dvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x2dvEXT"/>
@@ -27540,8 +27017,7 @@ namespace OpenTK.Graphics.OpenGL
                 int count = (int)(value.Length / 8);
                 fixed (double* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4x2dvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4x2dvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x2dvEXT"/>
@@ -27550,8 +27026,7 @@ namespace OpenTK.Graphics.OpenGL
                 int count = (int)(value.Length / 8);
                 fixed (double* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4x2dvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4x2dvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x2dvEXT"/>
@@ -27559,8 +27034,7 @@ namespace OpenTK.Graphics.OpenGL
             {
                 fixed (double* value_ptr = &value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4x2dvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4x2dvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x3dvEXT"/>
@@ -27569,8 +27043,7 @@ namespace OpenTK.Graphics.OpenGL
                 int count = (int)(value.Length / 12);
                 fixed (double* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4x3dvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4x3dvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x3dvEXT"/>
@@ -27579,8 +27052,7 @@ namespace OpenTK.Graphics.OpenGL
                 int count = (int)(value.Length / 12);
                 fixed (double* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4x3dvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4x3dvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x3dvEXT"/>
@@ -27588,42 +27060,8 @@ namespace OpenTK.Graphics.OpenGL
             {
                 fixed (double* value_ptr = &value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4x3dvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4x3dvEXT(program, location, count, transpose, value_ptr);
                 }
-            }
-            /// <inheritdoc cref="TextureStorage2DMultisampleEXT"/>
-            public static unsafe void TextureStorage2DMultisampleEXT(TextureHandle texture, TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, bool fixedsamplelocations)
-            {
-                byte fixedsamplelocations_byte = (byte)(fixedsamplelocations ? 1 : 0);
-                TextureStorage2DMultisampleEXT(texture, target, samples, internalformat, width, height, fixedsamplelocations_byte);
-            }
-            /// <inheritdoc cref="TextureStorage3DMultisampleEXT"/>
-            public static unsafe void TextureStorage3DMultisampleEXT(TextureHandle texture, All target, int samples, SizedInternalFormat internalformat, int width, int height, int depth, bool fixedsamplelocations)
-            {
-                byte fixedsamplelocations_byte = (byte)(fixedsamplelocations ? 1 : 0);
-                TextureStorage3DMultisampleEXT(texture, target, samples, internalformat, width, height, depth, fixedsamplelocations_byte);
-            }
-            /// <inheritdoc cref="VertexArrayVertexAttribFormatEXT"/>
-            public static unsafe void VertexArrayVertexAttribFormatEXT(VertexArrayHandle vaobj, uint attribindex, int size, VertexAttribType type, bool normalized, uint relativeoffset)
-            {
-                byte normalized_byte = (byte)(normalized ? 1 : 0);
-                VertexArrayVertexAttribFormatEXT(vaobj, attribindex, size, type, normalized_byte, relativeoffset);
-            }
-            /// <inheritdoc cref="TexturePageCommitmentEXT"/>
-            public static unsafe void TexturePageCommitmentEXT(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, bool commit)
-            {
-                byte commit_byte = (byte)(commit ? 1 : 0);
-                TexturePageCommitmentEXT(texture, level, xoffset, yoffset, zoffset, width, height, depth, commit_byte);
-            }
-            /// <inheritdoc cref="ColorMaskIndexedEXT"/>
-            public static unsafe void ColorMaskIndexedEXT(uint index, bool r, bool g, bool b, bool a)
-            {
-                byte r_byte = (byte)(r ? 1 : 0);
-                byte g_byte = (byte)(g ? 1 : 0);
-                byte b_byte = (byte)(b ? 1 : 0);
-                byte a_byte = (byte)(a ? 1 : 0);
-                ColorMaskIndexedEXT(index, r_byte, g_byte, b_byte, a_byte);
             }
             /// <inheritdoc cref="DrawElementsInstancedEXT"/>
             public static unsafe void DrawElementsInstancedEXT(PrimitiveType mode, int count, DrawElementsType type, nint offset, int primcount)
@@ -28469,8 +27907,7 @@ namespace OpenTK.Graphics.OpenGL
             public static unsafe void GetHistogramEXT(HistogramTargetEXT target, bool reset, PixelFormat format, PixelType type, IntPtr values)
             {
                 void* values_vptr = (void*)values;
-                byte reset_byte = (byte)(reset ? 1 : 0);
-                GetHistogramEXT(target, reset_byte, format, type, values_vptr);
+                GetHistogramEXT(target, reset, format, type, values_vptr);
             }
             /// <inheritdoc cref="GetHistogramEXT"/>
             public static unsafe void GetHistogramEXT<T1>(HistogramTargetEXT target, bool reset, PixelFormat format, PixelType type, Span<T1> values)
@@ -28478,8 +27915,7 @@ namespace OpenTK.Graphics.OpenGL
             {
                 fixed (void* values_ptr = values)
                 {
-                    byte reset_byte = (byte)(reset ? 1 : 0);
-                    GetHistogramEXT(target, reset_byte, format, type, values_ptr);
+                    GetHistogramEXT(target, reset, format, type, values_ptr);
                 }
             }
             /// <inheritdoc cref="GetHistogramEXT"/>
@@ -28488,8 +27924,7 @@ namespace OpenTK.Graphics.OpenGL
             {
                 fixed (void* values_ptr = values)
                 {
-                    byte reset_byte = (byte)(reset ? 1 : 0);
-                    GetHistogramEXT(target, reset_byte, format, type, values_ptr);
+                    GetHistogramEXT(target, reset, format, type, values_ptr);
                 }
             }
             /// <inheritdoc cref="GetHistogramEXT"/>
@@ -28498,8 +27933,7 @@ namespace OpenTK.Graphics.OpenGL
             {
                 fixed (void* values_ptr = &values)
                 {
-                    byte reset_byte = (byte)(reset ? 1 : 0);
-                    GetHistogramEXT(target, reset_byte, format, type, values_ptr);
+                    GetHistogramEXT(target, reset, format, type, values_ptr);
                 }
             }
             /// <inheritdoc cref="GetHistogramParameterfvEXT"/>
@@ -28554,8 +27988,7 @@ namespace OpenTK.Graphics.OpenGL
             public static unsafe void GetMinmaxEXT(MinmaxTargetEXT target, bool reset, PixelFormat format, PixelType type, IntPtr values)
             {
                 void* values_vptr = (void*)values;
-                byte reset_byte = (byte)(reset ? 1 : 0);
-                GetMinmaxEXT(target, reset_byte, format, type, values_vptr);
+                GetMinmaxEXT(target, reset, format, type, values_vptr);
             }
             /// <inheritdoc cref="GetMinmaxEXT"/>
             public static unsafe void GetMinmaxEXT<T1>(MinmaxTargetEXT target, bool reset, PixelFormat format, PixelType type, Span<T1> values)
@@ -28563,8 +27996,7 @@ namespace OpenTK.Graphics.OpenGL
             {
                 fixed (void* values_ptr = values)
                 {
-                    byte reset_byte = (byte)(reset ? 1 : 0);
-                    GetMinmaxEXT(target, reset_byte, format, type, values_ptr);
+                    GetMinmaxEXT(target, reset, format, type, values_ptr);
                 }
             }
             /// <inheritdoc cref="GetMinmaxEXT"/>
@@ -28573,8 +28005,7 @@ namespace OpenTK.Graphics.OpenGL
             {
                 fixed (void* values_ptr = values)
                 {
-                    byte reset_byte = (byte)(reset ? 1 : 0);
-                    GetMinmaxEXT(target, reset_byte, format, type, values_ptr);
+                    GetMinmaxEXT(target, reset, format, type, values_ptr);
                 }
             }
             /// <inheritdoc cref="GetMinmaxEXT"/>
@@ -28583,8 +28014,7 @@ namespace OpenTK.Graphics.OpenGL
             {
                 fixed (void* values_ptr = &values)
                 {
-                    byte reset_byte = (byte)(reset ? 1 : 0);
-                    GetMinmaxEXT(target, reset_byte, format, type, values_ptr);
+                    GetMinmaxEXT(target, reset, format, type, values_ptr);
                 }
             }
             /// <inheritdoc cref="GetMinmaxParameterfvEXT"/>
@@ -28634,18 +28064,6 @@ namespace OpenTK.Graphics.OpenGL
                 {
                     GetMinmaxParameterivEXT(target, pname, parameters_ptr);
                 }
-            }
-            /// <inheritdoc cref="HistogramEXT"/>
-            public static unsafe void HistogramEXT(HistogramTargetEXT target, int width, InternalFormat internalformat, bool sink)
-            {
-                byte sink_byte = (byte)(sink ? 1 : 0);
-                HistogramEXT(target, width, internalformat, sink_byte);
-            }
-            /// <inheritdoc cref="MinmaxEXT"/>
-            public static unsafe void MinmaxEXT(MinmaxTargetEXT target, InternalFormat internalformat, bool sink)
-            {
-                byte sink_byte = (byte)(sink ? 1 : 0);
-                MinmaxEXT(target, internalformat, sink_byte);
             }
             /// <inheritdoc cref="GetUnsignedBytevEXT"/>
             public static unsafe void GetUnsignedBytevEXT(GetPName pname, Span<byte> data)
@@ -28745,30 +28163,6 @@ namespace OpenTK.Graphics.OpenGL
                     GetMemoryObjectParameterivEXT(memoryObject, pname, parameters_ptr);
                 }
             }
-            /// <inheritdoc cref="TexStorageMem2DMultisampleEXT"/>
-            public static unsafe void TexStorageMem2DMultisampleEXT(TextureTarget target, int samples, SizedInternalFormat internalFormat, int width, int height, bool fixedSampleLocations, uint memory, ulong offset)
-            {
-                byte fixedSampleLocations_byte = (byte)(fixedSampleLocations ? 1 : 0);
-                TexStorageMem2DMultisampleEXT(target, samples, internalFormat, width, height, fixedSampleLocations_byte, memory, offset);
-            }
-            /// <inheritdoc cref="TexStorageMem3DMultisampleEXT"/>
-            public static unsafe void TexStorageMem3DMultisampleEXT(TextureTarget target, int samples, SizedInternalFormat internalFormat, int width, int height, int depth, bool fixedSampleLocations, uint memory, ulong offset)
-            {
-                byte fixedSampleLocations_byte = (byte)(fixedSampleLocations ? 1 : 0);
-                TexStorageMem3DMultisampleEXT(target, samples, internalFormat, width, height, depth, fixedSampleLocations_byte, memory, offset);
-            }
-            /// <inheritdoc cref="TextureStorageMem2DMultisampleEXT"/>
-            public static unsafe void TextureStorageMem2DMultisampleEXT(TextureHandle texture, int samples, SizedInternalFormat internalFormat, int width, int height, bool fixedSampleLocations, uint memory, ulong offset)
-            {
-                byte fixedSampleLocations_byte = (byte)(fixedSampleLocations ? 1 : 0);
-                TextureStorageMem2DMultisampleEXT(texture, samples, internalFormat, width, height, fixedSampleLocations_byte, memory, offset);
-            }
-            /// <inheritdoc cref="TextureStorageMem3DMultisampleEXT"/>
-            public static unsafe void TextureStorageMem3DMultisampleEXT(TextureHandle texture, int samples, SizedInternalFormat internalFormat, int width, int height, int depth, bool fixedSampleLocations, uint memory, ulong offset)
-            {
-                byte fixedSampleLocations_byte = (byte)(fixedSampleLocations ? 1 : 0);
-                TextureStorageMem3DMultisampleEXT(texture, samples, internalFormat, width, height, depth, fixedSampleLocations_byte, memory, offset);
-            }
             /// <inheritdoc cref="ImportMemoryWin32HandleEXT"/>
             public static unsafe void ImportMemoryWin32HandleEXT(uint memory, ulong size, ExternalHandleType handleType, IntPtr handle)
             {
@@ -28853,12 +28247,6 @@ namespace OpenTK.Graphics.OpenGL
                 {
                     MultiDrawElementsEXT(mode, count_ptr, type, indices, primcount);
                 }
-            }
-            /// <inheritdoc cref="SampleMaskEXT"/>
-            public static unsafe void SampleMaskEXT(float value, bool invert)
-            {
-                byte invert_byte = (byte)(invert ? 1 : 0);
-                SampleMaskEXT(value, invert_byte);
             }
             /// <inheritdoc cref="ColorTableEXT"/>
             public static unsafe void ColorTableEXT(ColorTableTarget target, InternalFormat internalFormat, int width, PixelFormat format, PixelType type, IntPtr table)
@@ -29093,12 +28481,6 @@ namespace OpenTK.Graphics.OpenGL
                 {
                     PointParameterfvEXT(pname, parameters_ptr);
                 }
-            }
-            /// <inheritdoc cref="RasterSamplesEXT"/>
-            public static unsafe void RasterSamplesEXT(uint samples, bool fixedsamplelocations)
-            {
-                byte fixedsamplelocations_byte = (byte)(fixedsamplelocations ? 1 : 0);
-                RasterSamplesEXT(samples, fixedsamplelocations_byte);
             }
             /// <inheritdoc cref="GenSemaphoresEXT"/>
             public static unsafe void GenSemaphoresEXT(Span<uint> semaphores)
@@ -29639,12 +29021,6 @@ namespace OpenTK.Graphics.OpenGL
                 {
                     GetProgramPipelineivEXT(pipeline, pname, parameters_ptr);
                 }
-            }
-            /// <inheritdoc cref="BindImageTextureEXT"/>
-            public static unsafe void BindImageTextureEXT(uint index, TextureHandle texture, int level, bool layered, int layer, BufferAccessARB access, int format)
-            {
-                byte layered_byte = (byte)(layered ? 1 : 0);
-                BindImageTextureEXT(index, texture, level, layered_byte, layer, access, format);
             }
             /// <inheritdoc cref="TexSubImage1DEXT"/>
             public static unsafe void TexSubImage1DEXT(TextureTarget target, int level, int xoffset, int width, PixelFormat format, PixelType type, IntPtr pixels)
@@ -31179,14 +30555,6 @@ namespace OpenTK.Graphics.OpenGL
                     MultiDrawElementsIndirectBindlessCountNV(mode, type, indirect_ptr, drawCount, maxDrawCount, stride, vertexBufferCount);
                 }
             }
-            /// <inheritdoc cref="GetImageHandleNV"/>
-            public static unsafe ulong GetImageHandleNV(TextureHandle texture, int level, bool layered, int layer, PixelFormat format)
-            {
-                ulong returnValue;
-                byte layered_byte = (byte)(layered ? 1 : 0);
-                returnValue = GetImageHandleNV(texture, level, layered_byte, layer, format);
-                return returnValue;
-            }
             /// <inheritdoc cref="UniformHandleui64vNV"/>
             public static unsafe void UniformHandleui64vNV(int location, ReadOnlySpan<ulong> value)
             {
@@ -31434,8 +30802,7 @@ namespace OpenTK.Graphics.OpenGL
             public static unsafe void MapControlPointsNV(EvalTargetNV target, uint index, MapTypeNV type, int ustride, int vstride, int uorder, int vorder, bool packed, IntPtr points)
             {
                 void* points_vptr = (void*)points;
-                byte packed_byte = (byte)(packed ? 1 : 0);
-                MapControlPointsNV(target, index, type, ustride, vstride, uorder, vorder, packed_byte, points_vptr);
+                MapControlPointsNV(target, index, type, ustride, vstride, uorder, vorder, packed, points_vptr);
             }
             /// <inheritdoc cref="MapControlPointsNV"/>
             public static unsafe void MapControlPointsNV<T1>(EvalTargetNV target, uint index, MapTypeNV type, int ustride, int vstride, int uorder, int vorder, bool packed, ReadOnlySpan<T1> points)
@@ -31443,8 +30810,7 @@ namespace OpenTK.Graphics.OpenGL
             {
                 fixed (void* points_ptr = points)
                 {
-                    byte packed_byte = (byte)(packed ? 1 : 0);
-                    MapControlPointsNV(target, index, type, ustride, vstride, uorder, vorder, packed_byte, points_ptr);
+                    MapControlPointsNV(target, index, type, ustride, vstride, uorder, vorder, packed, points_ptr);
                 }
             }
             /// <inheritdoc cref="MapControlPointsNV"/>
@@ -31453,8 +30819,7 @@ namespace OpenTK.Graphics.OpenGL
             {
                 fixed (void* points_ptr = points)
                 {
-                    byte packed_byte = (byte)(packed ? 1 : 0);
-                    MapControlPointsNV(target, index, type, ustride, vstride, uorder, vorder, packed_byte, points_ptr);
+                    MapControlPointsNV(target, index, type, ustride, vstride, uorder, vorder, packed, points_ptr);
                 }
             }
             /// <inheritdoc cref="MapControlPointsNV"/>
@@ -31463,8 +30828,7 @@ namespace OpenTK.Graphics.OpenGL
             {
                 fixed (void* points_ptr = &points)
                 {
-                    byte packed_byte = (byte)(packed ? 1 : 0);
-                    MapControlPointsNV(target, index, type, ustride, vstride, uorder, vorder, packed_byte, points_ptr);
+                    MapControlPointsNV(target, index, type, ustride, vstride, uorder, vorder, packed, points_ptr);
                 }
             }
             /// <inheritdoc cref="MapParameterivNV"/>
@@ -31519,8 +30883,7 @@ namespace OpenTK.Graphics.OpenGL
             public static unsafe void GetMapControlPointsNV(EvalTargetNV target, uint index, MapTypeNV type, int ustride, int vstride, bool packed, IntPtr points)
             {
                 void* points_vptr = (void*)points;
-                byte packed_byte = (byte)(packed ? 1 : 0);
-                GetMapControlPointsNV(target, index, type, ustride, vstride, packed_byte, points_vptr);
+                GetMapControlPointsNV(target, index, type, ustride, vstride, packed, points_vptr);
             }
             /// <inheritdoc cref="GetMapControlPointsNV"/>
             public static unsafe void GetMapControlPointsNV<T1>(EvalTargetNV target, uint index, MapTypeNV type, int ustride, int vstride, bool packed, Span<T1> points)
@@ -31528,8 +30891,7 @@ namespace OpenTK.Graphics.OpenGL
             {
                 fixed (void* points_ptr = points)
                 {
-                    byte packed_byte = (byte)(packed ? 1 : 0);
-                    GetMapControlPointsNV(target, index, type, ustride, vstride, packed_byte, points_ptr);
+                    GetMapControlPointsNV(target, index, type, ustride, vstride, packed, points_ptr);
                 }
             }
             /// <inheritdoc cref="GetMapControlPointsNV"/>
@@ -31538,8 +30900,7 @@ namespace OpenTK.Graphics.OpenGL
             {
                 fixed (void* points_ptr = points)
                 {
-                    byte packed_byte = (byte)(packed ? 1 : 0);
-                    GetMapControlPointsNV(target, index, type, ustride, vstride, packed_byte, points_ptr);
+                    GetMapControlPointsNV(target, index, type, ustride, vstride, packed, points_ptr);
                 }
             }
             /// <inheritdoc cref="GetMapControlPointsNV"/>
@@ -31548,8 +30909,7 @@ namespace OpenTK.Graphics.OpenGL
             {
                 fixed (void* points_ptr = &points)
                 {
-                    byte packed_byte = (byte)(packed ? 1 : 0);
-                    GetMapControlPointsNV(target, index, type, ustride, vstride, packed_byte, points_ptr);
+                    GetMapControlPointsNV(target, index, type, ustride, vstride, packed, points_ptr);
                 }
             }
             /// <inheritdoc cref="GetMapParameterivNV"/>
@@ -31919,12 +31279,6 @@ namespace OpenTK.Graphics.OpenGL
                 {
                     GetProgramNamedParameterdvNV(id, len, name_ptr, parameters_ptr);
                 }
-            }
-            /// <inheritdoc cref="RasterSamplesEXT"/>
-            public static unsafe void RasterSamplesEXT(uint samples, bool fixedsamplelocations)
-            {
-                byte fixedsamplelocations_byte = (byte)(fixedsamplelocations ? 1 : 0);
-                RasterSamplesEXT(samples, fixedsamplelocations_byte);
             }
             /// <inheritdoc cref="CoverageModulationTableNV"/>
             public static unsafe void CoverageModulationTableNV(ReadOnlySpan<float> v)
@@ -33442,30 +32796,6 @@ namespace OpenTK.Graphics.OpenGL
                 {
                     GetMemoryObjectDetachedResourcesuivNV(memory, pname, first, count, parameters_ptr);
                 }
-            }
-            /// <inheritdoc cref="BufferPageCommitmentMemNV"/>
-            public static unsafe void BufferPageCommitmentMemNV(BufferStorageTarget target, IntPtr offset, nint size, uint memory, ulong memOffset, bool commit)
-            {
-                byte commit_byte = (byte)(commit ? 1 : 0);
-                BufferPageCommitmentMemNV(target, offset, size, memory, memOffset, commit_byte);
-            }
-            /// <inheritdoc cref="TexPageCommitmentMemNV"/>
-            public static unsafe void TexPageCommitmentMemNV(TextureTarget target, int layer, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, uint memory, ulong offset, bool commit)
-            {
-                byte commit_byte = (byte)(commit ? 1 : 0);
-                TexPageCommitmentMemNV(target, layer, level, xoffset, yoffset, zoffset, width, height, depth, memory, offset, commit_byte);
-            }
-            /// <inheritdoc cref="NamedBufferPageCommitmentMemNV"/>
-            public static unsafe void NamedBufferPageCommitmentMemNV(BufferHandle buffer, IntPtr offset, nint size, uint memory, ulong memOffset, bool commit)
-            {
-                byte commit_byte = (byte)(commit ? 1 : 0);
-                NamedBufferPageCommitmentMemNV(buffer, offset, size, memory, memOffset, commit_byte);
-            }
-            /// <inheritdoc cref="TexturePageCommitmentMemNV"/>
-            public static unsafe void TexturePageCommitmentMemNV(TextureHandle texture, int layer, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, uint memory, ulong offset, bool commit)
-            {
-                byte commit_byte = (byte)(commit ? 1 : 0);
-                TexturePageCommitmentMemNV(texture, layer, level, xoffset, yoffset, zoffset, width, height, depth, memory, offset, commit_byte);
             }
             /// <inheritdoc cref="GenOcclusionQueriesNV"/>
             public static unsafe void GenOcclusionQueriesNV(Span<uint> ids)
@@ -35374,14 +34704,6 @@ namespace OpenTK.Graphics.OpenGL
                     CombinerParameterivNV(pname, parameters_ptr);
                 }
             }
-            /// <inheritdoc cref="CombinerOutputNV"/>
-            public static unsafe void CombinerOutputNV(CombinerStageNV stage, CombinerPortionNV portion, CombinerRegisterNV abOutput, CombinerRegisterNV cdOutput, CombinerRegisterNV sumOutput, CombinerScaleNV scale, CombinerBiasNV bias, bool abDotProduct, bool cdDotProduct, bool muxSum)
-            {
-                byte abDotProduct_byte = (byte)(abDotProduct ? 1 : 0);
-                byte cdDotProduct_byte = (byte)(cdDotProduct ? 1 : 0);
-                byte muxSum_byte = (byte)(muxSum ? 1 : 0);
-                CombinerOutputNV(stage, portion, abOutput, cdOutput, sumOutput, scale, bias, abDotProduct_byte, cdDotProduct_byte, muxSum_byte);
-            }
             /// <inheritdoc cref="GetCombinerInputParameterfvNV"/>
             public static unsafe void GetCombinerInputParameterfvNV(CombinerStageNV stage, CombinerPortionNV portion, CombinerVariableNV variable, CombinerParameterNV pname, Span<float> parameters)
             {
@@ -35810,12 +35132,6 @@ namespace OpenTK.Graphics.OpenGL
                     GetShadingRateSampleLocationivNV(rate, samples, index, location_ptr);
                 }
             }
-            /// <inheritdoc cref="ShadingRateImageBarrierNV"/>
-            public static unsafe void ShadingRateImageBarrierNV(bool synchronize)
-            {
-                byte synchronize_byte = (byte)(synchronize ? 1 : 0);
-                ShadingRateImageBarrierNV(synchronize_byte);
-            }
             /// <inheritdoc cref="ShadingRateImagePaletteNV"/>
             public static unsafe void ShadingRateImagePaletteNV(uint viewport, uint first, ReadOnlySpan<All> rates)
             {
@@ -35865,42 +35181,6 @@ namespace OpenTK.Graphics.OpenGL
                 {
                     ShadingRateSampleOrderCustomNV(rate, samples, locations_ptr);
                 }
-            }
-            /// <inheritdoc cref="TexImage2DMultisampleCoverageNV"/>
-            public static unsafe void TexImage2DMultisampleCoverageNV(TextureTarget target, int coverageSamples, int colorSamples, int internalFormat, int width, int height, bool fixedSampleLocations)
-            {
-                byte fixedSampleLocations_byte = (byte)(fixedSampleLocations ? 1 : 0);
-                TexImage2DMultisampleCoverageNV(target, coverageSamples, colorSamples, internalFormat, width, height, fixedSampleLocations_byte);
-            }
-            /// <inheritdoc cref="TexImage3DMultisampleCoverageNV"/>
-            public static unsafe void TexImage3DMultisampleCoverageNV(TextureTarget target, int coverageSamples, int colorSamples, int internalFormat, int width, int height, int depth, bool fixedSampleLocations)
-            {
-                byte fixedSampleLocations_byte = (byte)(fixedSampleLocations ? 1 : 0);
-                TexImage3DMultisampleCoverageNV(target, coverageSamples, colorSamples, internalFormat, width, height, depth, fixedSampleLocations_byte);
-            }
-            /// <inheritdoc cref="TextureImage2DMultisampleNV"/>
-            public static unsafe void TextureImage2DMultisampleNV(TextureHandle texture, TextureTarget target, int samples, int internalFormat, int width, int height, bool fixedSampleLocations)
-            {
-                byte fixedSampleLocations_byte = (byte)(fixedSampleLocations ? 1 : 0);
-                TextureImage2DMultisampleNV(texture, target, samples, internalFormat, width, height, fixedSampleLocations_byte);
-            }
-            /// <inheritdoc cref="TextureImage3DMultisampleNV"/>
-            public static unsafe void TextureImage3DMultisampleNV(TextureHandle texture, TextureTarget target, int samples, int internalFormat, int width, int height, int depth, bool fixedSampleLocations)
-            {
-                byte fixedSampleLocations_byte = (byte)(fixedSampleLocations ? 1 : 0);
-                TextureImage3DMultisampleNV(texture, target, samples, internalFormat, width, height, depth, fixedSampleLocations_byte);
-            }
-            /// <inheritdoc cref="TextureImage2DMultisampleCoverageNV"/>
-            public static unsafe void TextureImage2DMultisampleCoverageNV(TextureHandle texture, TextureTarget target, int coverageSamples, int colorSamples, int internalFormat, int width, int height, bool fixedSampleLocations)
-            {
-                byte fixedSampleLocations_byte = (byte)(fixedSampleLocations ? 1 : 0);
-                TextureImage2DMultisampleCoverageNV(texture, target, coverageSamples, colorSamples, internalFormat, width, height, fixedSampleLocations_byte);
-            }
-            /// <inheritdoc cref="TextureImage3DMultisampleCoverageNV"/>
-            public static unsafe void TextureImage3DMultisampleCoverageNV(TextureHandle texture, TextureTarget target, int coverageSamples, int colorSamples, int internalFormat, int width, int height, int depth, bool fixedSampleLocations)
-            {
-                byte fixedSampleLocations_byte = (byte)(fixedSampleLocations ? 1 : 0);
-                TextureImage3DMultisampleCoverageNV(texture, target, coverageSamples, colorSamples, internalFormat, width, height, depth, fixedSampleLocations_byte);
             }
             /// <inheritdoc cref="TransformFeedbackAttribsNV"/>
             public static unsafe void TransformFeedbackAttribsNV(int count, ReadOnlySpan<int> attribs, All bufferMode)
@@ -36444,8 +35724,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (uint* textureNames_ptr = textureNames)
                 {
                     void* vdpSurface_vptr = (void*)vdpSurface;
-                    byte isFrameStructure_byte = (byte)(isFrameStructure ? 1 : 0);
-                    returnValue = VDPAURegisterVideoSurfaceWithPictureStructureNV(vdpSurface_vptr, target, numTextureNames, textureNames_ptr, isFrameStructure_byte);
+                    returnValue = VDPAURegisterVideoSurfaceWithPictureStructureNV(vdpSurface_vptr, target, numTextureNames, textureNames_ptr, isFrameStructure);
                 }
                 return returnValue;
             }
@@ -36457,8 +35736,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (uint* textureNames_ptr = textureNames)
                 {
                     void* vdpSurface_vptr = (void*)vdpSurface;
-                    byte isFrameStructure_byte = (byte)(isFrameStructure ? 1 : 0);
-                    returnValue = VDPAURegisterVideoSurfaceWithPictureStructureNV(vdpSurface_vptr, target, numTextureNames, textureNames_ptr, isFrameStructure_byte);
+                    returnValue = VDPAURegisterVideoSurfaceWithPictureStructureNV(vdpSurface_vptr, target, numTextureNames, textureNames_ptr, isFrameStructure);
                 }
                 return returnValue;
             }
@@ -36469,8 +35747,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (uint* textureNames_ptr = &textureNames)
                 {
                     void* vdpSurface_vptr = (void*)vdpSurface;
-                    byte isFrameStructure_byte = (byte)(isFrameStructure ? 1 : 0);
-                    returnValue = VDPAURegisterVideoSurfaceWithPictureStructureNV(vdpSurface_vptr, target, numTextureNames, textureNames_ptr, isFrameStructure_byte);
+                    returnValue = VDPAURegisterVideoSurfaceWithPictureStructureNV(vdpSurface_vptr, target, numTextureNames, textureNames_ptr, isFrameStructure);
                 }
                 return returnValue;
             }
@@ -36484,8 +35761,7 @@ namespace OpenTK.Graphics.OpenGL
                     int numTextureNames = (int)(textureNames.Length);
                     fixed (uint* textureNames_ptr = textureNames)
                     {
-                        byte isFrameStructure_byte = (byte)(isFrameStructure ? 1 : 0);
-                        returnValue = VDPAURegisterVideoSurfaceWithPictureStructureNV(vdpSurface_ptr, target, numTextureNames, textureNames_ptr, isFrameStructure_byte);
+                        returnValue = VDPAURegisterVideoSurfaceWithPictureStructureNV(vdpSurface_ptr, target, numTextureNames, textureNames_ptr, isFrameStructure);
                     }
                 }
                 return returnValue;
@@ -36500,8 +35776,7 @@ namespace OpenTK.Graphics.OpenGL
                     int numTextureNames = (int)(textureNames.Length);
                     fixed (uint* textureNames_ptr = textureNames)
                     {
-                        byte isFrameStructure_byte = (byte)(isFrameStructure ? 1 : 0);
-                        returnValue = VDPAURegisterVideoSurfaceWithPictureStructureNV(vdpSurface_ptr, target, numTextureNames, textureNames_ptr, isFrameStructure_byte);
+                        returnValue = VDPAURegisterVideoSurfaceWithPictureStructureNV(vdpSurface_ptr, target, numTextureNames, textureNames_ptr, isFrameStructure);
                     }
                 }
                 return returnValue;
@@ -36514,8 +35789,7 @@ namespace OpenTK.Graphics.OpenGL
                 fixed (void* vdpSurface_ptr = &vdpSurface)
                 fixed (uint* textureNames_ptr = &textureNames)
                 {
-                    byte isFrameStructure_byte = (byte)(isFrameStructure ? 1 : 0);
-                    returnValue = VDPAURegisterVideoSurfaceWithPictureStructureNV(vdpSurface_ptr, target, numTextureNames, textureNames_ptr, isFrameStructure_byte);
+                    returnValue = VDPAURegisterVideoSurfaceWithPictureStructureNV(vdpSurface_ptr, target, numTextureNames, textureNames_ptr, isFrameStructure);
                 }
                 return returnValue;
             }
@@ -36791,12 +36065,6 @@ namespace OpenTK.Graphics.OpenGL
                 {
                     GetVertexAttribLui64vNV(index, pname, parameters_ptr);
                 }
-            }
-            /// <inheritdoc cref="VertexAttribFormatNV"/>
-            public static unsafe void VertexAttribFormatNV(uint index, int size, VertexAttribType type, bool normalized, int stride)
-            {
-                byte normalized_byte = (byte)(normalized ? 1 : 0);
-                VertexAttribFormatNV(index, size, type, normalized_byte, stride);
             }
             /// <inheritdoc cref="GetIntegerui64i_vNV"/>
             public static unsafe void GetIntegerui64i_vNV(All value, uint index, Span<ulong> result)
@@ -38870,8 +38138,7 @@ namespace OpenTK.Graphics.OpenGL
                 int count = (int)(ids.Length);
                 fixed (uint* ids_ptr = ids)
                 {
-                    byte enabled_byte = (byte)(enabled ? 1 : 0);
-                    DebugMessageControl(source, type, severity, count, ids_ptr, enabled_byte);
+                    DebugMessageControl(source, type, severity, count, ids_ptr, enabled);
                 }
             }
             /// <inheritdoc cref="DebugMessageControl"/>
@@ -38880,8 +38147,7 @@ namespace OpenTK.Graphics.OpenGL
                 int count = (int)(ids.Length);
                 fixed (uint* ids_ptr = ids)
                 {
-                    byte enabled_byte = (byte)(enabled ? 1 : 0);
-                    DebugMessageControl(source, type, severity, count, ids_ptr, enabled_byte);
+                    DebugMessageControl(source, type, severity, count, ids_ptr, enabled);
                 }
             }
             /// <inheritdoc cref="DebugMessageControl"/>
@@ -38889,8 +38155,7 @@ namespace OpenTK.Graphics.OpenGL
             {
                 fixed (uint* ids_ptr = &ids)
                 {
-                    byte enabled_byte = (byte)(enabled ? 1 : 0);
-                    DebugMessageControl(source, type, severity, count, ids_ptr, enabled_byte);
+                    DebugMessageControl(source, type, severity, count, ids_ptr, enabled);
                 }
             }
             /// <inheritdoc cref="DebugMessageInsert"/>
@@ -39264,8 +38529,7 @@ namespace OpenTK.Graphics.OpenGL
             {
                 fixed (uint* ids_ptr = &ids)
                 {
-                    byte enabled_byte = (byte)(enabled ? 1 : 0);
-                    DebugMessageControlKHR(source, type, severity, count, ids_ptr, enabled_byte);
+                    DebugMessageControlKHR(source, type, severity, count, ids_ptr, enabled);
                 }
             }
             /// <inheritdoc cref="DebugMessageInsertKHR"/>
@@ -41039,12 +40303,6 @@ namespace OpenTK.Graphics.OpenGL
                     GetMaterialxvOES(face, pname, parameters_ptr);
                 }
             }
-            /// <inheritdoc cref="SampleCoveragexOES"/>
-            public static unsafe void SampleCoveragexOES(int value, bool invert)
-            {
-                byte invert_byte = (byte)(invert ? 1 : 0);
-                SampleCoveragexOES(value, invert_byte);
-            }
             /// <inheritdoc cref="BitmapxOES"/>
             public static unsafe void BitmapxOES(int width, int height, int xorig, int yorig, int xmove, int ymove, ReadOnlySpan<byte> bitmap)
             {
@@ -42123,12 +41381,6 @@ namespace OpenTK.Graphics.OpenGL
                     GetFogFuncSGIS(points_ptr);
                 }
             }
-            /// <inheritdoc cref="SampleMaskSGIS"/>
-            public static unsafe void SampleMaskSGIS(float value, bool invert)
-            {
-                byte invert_byte = (byte)(invert ? 1 : 0);
-                SampleMaskSGIS(value, invert_byte);
-            }
             /// <inheritdoc cref="PixelTexGenParameterivSGIS"/>
             public static unsafe void PixelTexGenParameterivSGIS(PixelTexGenParameterNameSGIS pname, ReadOnlySpan<int> parameters)
             {
@@ -42364,15 +41616,6 @@ namespace OpenTK.Graphics.OpenGL
                 {
                     TexSubImage4DSGIS(target, level, xoffset, yoffset, zoffset, woffset, width, height, depth, size4d, format, type, pixels_ptr);
                 }
-            }
-            /// <inheritdoc cref="TextureColorMaskSGIS"/>
-            public static unsafe void TextureColorMaskSGIS(bool red, bool green, bool blue, bool alpha)
-            {
-                byte red_byte = (byte)(red ? 1 : 0);
-                byte green_byte = (byte)(green ? 1 : 0);
-                byte blue_byte = (byte)(blue ? 1 : 0);
-                byte alpha_byte = (byte)(alpha ? 1 : 0);
-                TextureColorMaskSGIS(red_byte, green_byte, blue_byte, alpha_byte);
             }
             /// <inheritdoc cref="GetTexFilterFuncSGIS"/>
             public static unsafe void GetTexFilterFuncSGIS(TextureTarget target, TextureFilterSGIS filter, Span<float> weights)

--- a/src/OpenTK.Graphics/OpenGLES1/GL.Native.cs
+++ b/src/OpenTK.Graphics/OpenGLES1/GL.Native.cs
@@ -696,18 +696,18 @@ namespace OpenTK.Graphics.OpenGLES1
             _Color4x_fnptr(red, green, blue, alpha);
         }
         
-        private static delegate* unmanaged<byte, byte, byte, byte, void> _ColorMask_fnptr = &ColorMask_Lazy;
+        private static delegate* unmanaged<bool, bool, bool, bool, void> _ColorMask_fnptr = &ColorMask_Lazy;
         /// <summary> <b>[requires: v1.0]</b> Enable and disable writing of color buffer        components. </summary>
         /// <param name="red">Specify whether red, green, blue, and alpha can or cannot be written into the color buffer. The initial values are all GL_TRUE, indicating that all color components can be written.</param>
         /// <param name="green">Specify whether red, green, blue, and alpha can or cannot be written into the color buffer. The initial values are all GL_TRUE, indicating that all color components can be written.</param>
         /// <param name="blue">Specify whether red, green, blue, and alpha can or cannot be written into the color buffer. The initial values are all GL_TRUE, indicating that all color components can be written.</param>
         /// <param name="alpha">Specify whether red, green, blue, and alpha can or cannot be written into the color buffer. The initial values are all GL_TRUE, indicating that all color components can be written.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es1.1/xhtml/glColorMask.xml" /></remarks>
-        public static void ColorMask(byte red, byte green, byte blue, byte alpha) => _ColorMask_fnptr(red, green, blue, alpha);
+        public static void ColorMask(bool red, bool green, bool blue, bool alpha) => _ColorMask_fnptr(red, green, blue, alpha);
         [UnmanagedCallersOnly]
-        private static void ColorMask_Lazy(byte red, byte green, byte blue, byte alpha)
+        private static void ColorMask_Lazy(bool red, bool green, bool blue, bool alpha)
         {
-            _ColorMask_fnptr = (delegate* unmanaged<byte, byte, byte, byte, void>)GLLoader.BindingsContext.GetProcAddress("glColorMask");
+            _ColorMask_fnptr = (delegate* unmanaged<bool, bool, bool, bool, void>)GLLoader.BindingsContext.GetProcAddress("glColorMask");
             _ColorMask_fnptr(red, green, blue, alpha);
         }
         
@@ -853,15 +853,15 @@ namespace OpenTK.Graphics.OpenGLES1
             _DepthFunc_fnptr(func);
         }
         
-        private static delegate* unmanaged<byte, void> _DepthMask_fnptr = &DepthMask_Lazy;
+        private static delegate* unmanaged<bool, void> _DepthMask_fnptr = &DepthMask_Lazy;
         /// <summary> <b>[requires: v1.0]</b> Enable or disable writing into the depth buffer. </summary>
         /// <param name="flag">Specifies whether the depth buffer is enabled for writing. If flag is GL_FALSE, depth buffer writing is disabled, otherwise it is enabled. The initial value is GL_TRUE.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es1.1/xhtml/glDepthMask.xml" /></remarks>
-        public static void DepthMask(byte flag) => _DepthMask_fnptr(flag);
+        public static void DepthMask(bool flag) => _DepthMask_fnptr(flag);
         [UnmanagedCallersOnly]
-        private static void DepthMask_Lazy(byte flag)
+        private static void DepthMask_Lazy(bool flag)
         {
-            _DepthMask_fnptr = (delegate* unmanaged<byte, void>)GLLoader.BindingsContext.GetProcAddress("glDepthMask");
+            _DepthMask_fnptr = (delegate* unmanaged<bool, void>)GLLoader.BindingsContext.GetProcAddress("glDepthMask");
             _DepthMask_fnptr(flag);
         }
         
@@ -1028,16 +1028,16 @@ namespace OpenTK.Graphics.OpenGLES1
             _Frustumx_fnptr(l, r, b, t, n, f);
         }
         
-        private static delegate* unmanaged<GetPName, byte*, void> _GetBooleanv_fnptr = &GetBooleanv_Lazy;
+        private static delegate* unmanaged<GetPName, bool*, void> _GetBooleanv_fnptr = &GetBooleanv_Lazy;
         /// <summary> <b>[requires: v1.0]</b> Return the value or values of a selected parameter. </summary>
         /// <param name="pname">Specifies the parameter value to be returned. The symbolic constants in the list below are accepted.</param>
         /// <param name="parameters">Returns the value or values of the specified parameter.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es1.1/xhtml/glGet.xml" /></remarks>
-        public static void GetBooleanv(GetPName pname, byte* data) => _GetBooleanv_fnptr(pname, data);
+        public static void GetBooleanv(GetPName pname, bool* data) => _GetBooleanv_fnptr(pname, data);
         [UnmanagedCallersOnly]
-        private static void GetBooleanv_Lazy(GetPName pname, byte* data)
+        private static void GetBooleanv_Lazy(GetPName pname, bool* data)
         {
-            _GetBooleanv_fnptr = (delegate* unmanaged<GetPName, byte*, void>)GLLoader.BindingsContext.GetProcAddress("glGetBooleanv");
+            _GetBooleanv_fnptr = (delegate* unmanaged<GetPName, bool*, void>)GLLoader.BindingsContext.GetProcAddress("glGetBooleanv");
             _GetBooleanv_fnptr(pname, data);
         }
         
@@ -1253,39 +1253,39 @@ namespace OpenTK.Graphics.OpenGLES1
             _Hint_fnptr(target, mode);
         }
         
-        private static delegate* unmanaged<BufferHandle, byte> _IsBuffer_fnptr = &IsBuffer_Lazy;
+        private static delegate* unmanaged<BufferHandle, bool> _IsBuffer_fnptr = &IsBuffer_Lazy;
         /// <summary> <b>[requires: v1.0]</b> Determine if a name corresponds to a buffer object. </summary>
         /// <param name="buffer"> Specifies a value that may be the name of a buffer object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es1.1/xhtml/glIsBuffer.xml" /></remarks>
-        public static byte IsBuffer(BufferHandle buffer) => _IsBuffer_fnptr(buffer);
+        public static bool IsBuffer(BufferHandle buffer) => _IsBuffer_fnptr(buffer);
         [UnmanagedCallersOnly]
-        private static byte IsBuffer_Lazy(BufferHandle buffer)
+        private static bool IsBuffer_Lazy(BufferHandle buffer)
         {
-            _IsBuffer_fnptr = (delegate* unmanaged<BufferHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsBuffer");
+            _IsBuffer_fnptr = (delegate* unmanaged<BufferHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsBuffer");
             return _IsBuffer_fnptr(buffer);
         }
         
-        private static delegate* unmanaged<EnableCap, byte> _IsEnabled_fnptr = &IsEnabled_Lazy;
+        private static delegate* unmanaged<EnableCap, bool> _IsEnabled_fnptr = &IsEnabled_Lazy;
         /// <summary> <b>[requires: v1.0]</b> Test whether a capability is enabled. </summary>
         /// <param name="cap"> Specifies a symbolic constant indicating a GL capability. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es1.1/xhtml/glIsEnabled.xml" /></remarks>
-        public static byte IsEnabled(EnableCap cap) => _IsEnabled_fnptr(cap);
+        public static bool IsEnabled(EnableCap cap) => _IsEnabled_fnptr(cap);
         [UnmanagedCallersOnly]
-        private static byte IsEnabled_Lazy(EnableCap cap)
+        private static bool IsEnabled_Lazy(EnableCap cap)
         {
-            _IsEnabled_fnptr = (delegate* unmanaged<EnableCap, byte>)GLLoader.BindingsContext.GetProcAddress("glIsEnabled");
+            _IsEnabled_fnptr = (delegate* unmanaged<EnableCap, bool>)GLLoader.BindingsContext.GetProcAddress("glIsEnabled");
             return _IsEnabled_fnptr(cap);
         }
         
-        private static delegate* unmanaged<TextureHandle, byte> _IsTexture_fnptr = &IsTexture_Lazy;
+        private static delegate* unmanaged<TextureHandle, bool> _IsTexture_fnptr = &IsTexture_Lazy;
         /// <summary> <b>[requires: v1.0]</b> Determine if a name corresponds to a texture. </summary>
         /// <param name="texture"> Specifies a value that may be the name of a texture. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es1.1/xhtml/glIsTexture.xml" /></remarks>
-        public static byte IsTexture(TextureHandle texture) => _IsTexture_fnptr(texture);
+        public static bool IsTexture(TextureHandle texture) => _IsTexture_fnptr(texture);
         [UnmanagedCallersOnly]
-        private static byte IsTexture_Lazy(TextureHandle texture)
+        private static bool IsTexture_Lazy(TextureHandle texture)
         {
-            _IsTexture_fnptr = (delegate* unmanaged<TextureHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsTexture");
+            _IsTexture_fnptr = (delegate* unmanaged<TextureHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsTexture");
             return _IsTexture_fnptr(texture);
         }
         
@@ -1604,29 +1604,29 @@ namespace OpenTK.Graphics.OpenGLES1
             _Rotatex_fnptr(angle, x, y, z);
         }
         
-        private static delegate* unmanaged<float, byte, void> _SampleCoverage_fnptr = &SampleCoverage_Lazy;
+        private static delegate* unmanaged<float, bool, void> _SampleCoverage_fnptr = &SampleCoverage_Lazy;
         /// <summary> <b>[requires: v1.0]</b> Specify mask to modify multisampled pixel fragments. </summary>
         /// <param name="value">Specifies the coverage of the modification mask. The value is clamped to the range [0, 1], where 0 represents no coverage and 1 full coverage. The initial value is 1.</param>
         /// <param name="invert">Specifies whether the modification mask implied by value is inverted or not. The initial value is GL_FALSE. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es1.1/xhtml/glSampleCoverage.xml" /></remarks>
-        public static void SampleCoverage(float value, byte invert) => _SampleCoverage_fnptr(value, invert);
+        public static void SampleCoverage(float value, bool invert) => _SampleCoverage_fnptr(value, invert);
         [UnmanagedCallersOnly]
-        private static void SampleCoverage_Lazy(float value, byte invert)
+        private static void SampleCoverage_Lazy(float value, bool invert)
         {
-            _SampleCoverage_fnptr = (delegate* unmanaged<float, byte, void>)GLLoader.BindingsContext.GetProcAddress("glSampleCoverage");
+            _SampleCoverage_fnptr = (delegate* unmanaged<float, bool, void>)GLLoader.BindingsContext.GetProcAddress("glSampleCoverage");
             _SampleCoverage_fnptr(value, invert);
         }
         
-        private static delegate* unmanaged<int, byte, void> _SampleCoveragex_fnptr = &SampleCoveragex_Lazy;
+        private static delegate* unmanaged<int, bool, void> _SampleCoveragex_fnptr = &SampleCoveragex_Lazy;
         /// <summary> <b>[requires: v1.0]</b> Specify mask to modify multisampled pixel fragments. </summary>
         /// <param name="value">Specifies the coverage of the modification mask. The value is clamped to the range [0, 1], where 0 represents no coverage and 1 full coverage. The initial value is 1.</param>
         /// <param name="invert">Specifies whether the modification mask implied by value is inverted or not. The initial value is GL_FALSE. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es1.1/xhtml/glSampleCoverage.xml" /></remarks>
-        public static void SampleCoveragex(int value, byte invert) => _SampleCoveragex_fnptr(value, invert);
+        public static void SampleCoveragex(int value, bool invert) => _SampleCoveragex_fnptr(value, invert);
         [UnmanagedCallersOnly]
-        private static void SampleCoveragex_Lazy(int value, byte invert)
+        private static void SampleCoveragex_Lazy(int value, bool invert)
         {
-            _SampleCoveragex_fnptr = (delegate* unmanaged<int, byte, void>)GLLoader.BindingsContext.GetProcAddress("glSampleCoveragex");
+            _SampleCoveragex_fnptr = (delegate* unmanaged<int, bool, void>)GLLoader.BindingsContext.GetProcAddress("glSampleCoveragex");
             _SampleCoveragex_fnptr(value, invert);
         }
         
@@ -1948,14 +1948,14 @@ namespace OpenTK.Graphics.OpenGLES1
                 return _FenceSyncAPPLE_fnptr(condition, flags);
             }
             
-            private static delegate* unmanaged<GLSync, byte> _IsSyncAPPLE_fnptr = &IsSyncAPPLE_Lazy;
+            private static delegate* unmanaged<GLSync, bool> _IsSyncAPPLE_fnptr = &IsSyncAPPLE_Lazy;
             /// <summary> <b>[requires: GL_APPLE_sync]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsSyncAPPLE(GLSync sync) => _IsSyncAPPLE_fnptr(sync);
+            public static bool IsSyncAPPLE(GLSync sync) => _IsSyncAPPLE_fnptr(sync);
             [UnmanagedCallersOnly]
-            private static byte IsSyncAPPLE_Lazy(GLSync sync)
+            private static bool IsSyncAPPLE_Lazy(GLSync sync)
             {
-                _IsSyncAPPLE_fnptr = (delegate* unmanaged<GLSync, byte>)GLLoader.BindingsContext.GetProcAddress("glIsSyncAPPLE");
+                _IsSyncAPPLE_fnptr = (delegate* unmanaged<GLSync, bool>)GLLoader.BindingsContext.GetProcAddress("glIsSyncAPPLE");
                 return _IsSyncAPPLE_fnptr(sync);
             }
             
@@ -2298,14 +2298,14 @@ namespace OpenTK.Graphics.OpenGLES1
         }
         public static unsafe partial class KHR
         {
-            private static delegate* unmanaged<DebugSource, DebugType, DebugSeverity, int, uint*, byte, void> _DebugMessageControl_fnptr = &DebugMessageControl_Lazy;
+            private static delegate* unmanaged<DebugSource, DebugType, DebugSeverity, int, uint*, bool, void> _DebugMessageControl_fnptr = &DebugMessageControl_Lazy;
             /// <summary> <b>[requires: GL_KHR_debug]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void DebugMessageControl(DebugSource source, DebugType type, DebugSeverity severity, int count, uint* ids, byte enabled) => _DebugMessageControl_fnptr(source, type, severity, count, ids, enabled);
+            public static void DebugMessageControl(DebugSource source, DebugType type, DebugSeverity severity, int count, uint* ids, bool enabled) => _DebugMessageControl_fnptr(source, type, severity, count, ids, enabled);
             [UnmanagedCallersOnly]
-            private static void DebugMessageControl_Lazy(DebugSource source, DebugType type, DebugSeverity severity, int count, uint* ids, byte enabled)
+            private static void DebugMessageControl_Lazy(DebugSource source, DebugType type, DebugSeverity severity, int count, uint* ids, bool enabled)
             {
-                _DebugMessageControl_fnptr = (delegate* unmanaged<DebugSource, DebugType, DebugSeverity, int, uint*, byte, void>)GLLoader.BindingsContext.GetProcAddress("glDebugMessageControl");
+                _DebugMessageControl_fnptr = (delegate* unmanaged<DebugSource, DebugType, DebugSeverity, int, uint*, bool, void>)GLLoader.BindingsContext.GetProcAddress("glDebugMessageControl");
                 _DebugMessageControl_fnptr(source, type, severity, count, ids, enabled);
             }
             
@@ -2421,14 +2421,14 @@ namespace OpenTK.Graphics.OpenGLES1
                 _GetPointerv_fnptr(pname, parameters);
             }
             
-            private static delegate* unmanaged<DebugSource, DebugType, DebugSeverity, int, uint*, byte, void> _DebugMessageControlKHR_fnptr = &DebugMessageControlKHR_Lazy;
+            private static delegate* unmanaged<DebugSource, DebugType, DebugSeverity, int, uint*, bool, void> _DebugMessageControlKHR_fnptr = &DebugMessageControlKHR_Lazy;
             /// <summary> <b>[requires: GL_KHR_debug]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void DebugMessageControlKHR(DebugSource source, DebugType type, DebugSeverity severity, int count, uint* ids, byte enabled) => _DebugMessageControlKHR_fnptr(source, type, severity, count, ids, enabled);
+            public static void DebugMessageControlKHR(DebugSource source, DebugType type, DebugSeverity severity, int count, uint* ids, bool enabled) => _DebugMessageControlKHR_fnptr(source, type, severity, count, ids, enabled);
             [UnmanagedCallersOnly]
-            private static void DebugMessageControlKHR_Lazy(DebugSource source, DebugType type, DebugSeverity severity, int count, uint* ids, byte enabled)
+            private static void DebugMessageControlKHR_Lazy(DebugSource source, DebugType type, DebugSeverity severity, int count, uint* ids, bool enabled)
             {
-                _DebugMessageControlKHR_fnptr = (delegate* unmanaged<DebugSource, DebugType, DebugSeverity, int, uint*, byte, void>)GLLoader.BindingsContext.GetProcAddress("glDebugMessageControlKHR");
+                _DebugMessageControlKHR_fnptr = (delegate* unmanaged<DebugSource, DebugType, DebugSeverity, int, uint*, bool, void>)GLLoader.BindingsContext.GetProcAddress("glDebugMessageControlKHR");
                 _DebugMessageControlKHR_fnptr(source, type, severity, count, ids, enabled);
             }
             
@@ -2567,25 +2567,25 @@ namespace OpenTK.Graphics.OpenGLES1
                 _GenFencesNV_fnptr(n, fences);
             }
             
-            private static delegate* unmanaged<uint, byte> _IsFenceNV_fnptr = &IsFenceNV_Lazy;
+            private static delegate* unmanaged<uint, bool> _IsFenceNV_fnptr = &IsFenceNV_Lazy;
             /// <summary> <b>[requires: GL_NV_fence]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsFenceNV(uint fence) => _IsFenceNV_fnptr(fence);
+            public static bool IsFenceNV(uint fence) => _IsFenceNV_fnptr(fence);
             [UnmanagedCallersOnly]
-            private static byte IsFenceNV_Lazy(uint fence)
+            private static bool IsFenceNV_Lazy(uint fence)
             {
-                _IsFenceNV_fnptr = (delegate* unmanaged<uint, byte>)GLLoader.BindingsContext.GetProcAddress("glIsFenceNV");
+                _IsFenceNV_fnptr = (delegate* unmanaged<uint, bool>)GLLoader.BindingsContext.GetProcAddress("glIsFenceNV");
                 return _IsFenceNV_fnptr(fence);
             }
             
-            private static delegate* unmanaged<uint, byte> _TestFenceNV_fnptr = &TestFenceNV_Lazy;
+            private static delegate* unmanaged<uint, bool> _TestFenceNV_fnptr = &TestFenceNV_Lazy;
             /// <summary> <b>[requires: GL_NV_fence]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte TestFenceNV(uint fence) => _TestFenceNV_fnptr(fence);
+            public static bool TestFenceNV(uint fence) => _TestFenceNV_fnptr(fence);
             [UnmanagedCallersOnly]
-            private static byte TestFenceNV_Lazy(uint fence)
+            private static bool TestFenceNV_Lazy(uint fence)
             {
-                _TestFenceNV_fnptr = (delegate* unmanaged<uint, byte>)GLLoader.BindingsContext.GetProcAddress("glTestFenceNV");
+                _TestFenceNV_fnptr = (delegate* unmanaged<uint, bool>)GLLoader.BindingsContext.GetProcAddress("glTestFenceNV");
                 return _TestFenceNV_fnptr(fence);
             }
             
@@ -3448,14 +3448,14 @@ namespace OpenTK.Graphics.OpenGLES1
                 _PointParameterxOES_fnptr(pname, param);
             }
             
-            private static delegate* unmanaged<int, byte, void> _SampleCoveragexOES_fnptr = &SampleCoveragexOES_Lazy;
+            private static delegate* unmanaged<int, bool, void> _SampleCoveragexOES_fnptr = &SampleCoveragexOES_Lazy;
             /// <summary> <b>[requires: GL_OES_fixed_point]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void SampleCoveragexOES(int value, byte invert) => _SampleCoveragexOES_fnptr(value, invert);
+            public static void SampleCoveragexOES(int value, bool invert) => _SampleCoveragexOES_fnptr(value, invert);
             [UnmanagedCallersOnly]
-            private static void SampleCoveragexOES_Lazy(int value, byte invert)
+            private static void SampleCoveragexOES_Lazy(int value, bool invert)
             {
-                _SampleCoveragexOES_fnptr = (delegate* unmanaged<int, byte, void>)GLLoader.BindingsContext.GetProcAddress("glSampleCoveragexOES");
+                _SampleCoveragexOES_fnptr = (delegate* unmanaged<int, bool, void>)GLLoader.BindingsContext.GetProcAddress("glSampleCoveragexOES");
                 _SampleCoveragexOES_fnptr(value, invert);
             }
             
@@ -4207,14 +4207,14 @@ namespace OpenTK.Graphics.OpenGLES1
                 _Vertex4xvOES_fnptr(coords);
             }
             
-            private static delegate* unmanaged<RenderbufferHandle, byte> _IsRenderbufferOES_fnptr = &IsRenderbufferOES_Lazy;
+            private static delegate* unmanaged<RenderbufferHandle, bool> _IsRenderbufferOES_fnptr = &IsRenderbufferOES_Lazy;
             /// <summary> <b>[requires: GL_OES_framebuffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsRenderbufferOES(RenderbufferHandle renderbuffer) => _IsRenderbufferOES_fnptr(renderbuffer);
+            public static bool IsRenderbufferOES(RenderbufferHandle renderbuffer) => _IsRenderbufferOES_fnptr(renderbuffer);
             [UnmanagedCallersOnly]
-            private static byte IsRenderbufferOES_Lazy(RenderbufferHandle renderbuffer)
+            private static bool IsRenderbufferOES_Lazy(RenderbufferHandle renderbuffer)
             {
-                _IsRenderbufferOES_fnptr = (delegate* unmanaged<RenderbufferHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsRenderbufferOES");
+                _IsRenderbufferOES_fnptr = (delegate* unmanaged<RenderbufferHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsRenderbufferOES");
                 return _IsRenderbufferOES_fnptr(renderbuffer);
             }
             
@@ -4273,14 +4273,14 @@ namespace OpenTK.Graphics.OpenGLES1
                 _GetRenderbufferParameterivOES_fnptr(target, pname, parameters);
             }
             
-            private static delegate* unmanaged<FramebufferHandle, byte> _IsFramebufferOES_fnptr = &IsFramebufferOES_Lazy;
+            private static delegate* unmanaged<FramebufferHandle, bool> _IsFramebufferOES_fnptr = &IsFramebufferOES_Lazy;
             /// <summary> <b>[requires: GL_OES_framebuffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsFramebufferOES(FramebufferHandle framebuffer) => _IsFramebufferOES_fnptr(framebuffer);
+            public static bool IsFramebufferOES(FramebufferHandle framebuffer) => _IsFramebufferOES_fnptr(framebuffer);
             [UnmanagedCallersOnly]
-            private static byte IsFramebufferOES_Lazy(FramebufferHandle framebuffer)
+            private static bool IsFramebufferOES_Lazy(FramebufferHandle framebuffer)
             {
-                _IsFramebufferOES_fnptr = (delegate* unmanaged<FramebufferHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsFramebufferOES");
+                _IsFramebufferOES_fnptr = (delegate* unmanaged<FramebufferHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsFramebufferOES");
                 return _IsFramebufferOES_fnptr(framebuffer);
             }
             
@@ -4383,14 +4383,14 @@ namespace OpenTK.Graphics.OpenGLES1
                 return _MapBufferOES_fnptr(target, access);
             }
             
-            private static delegate* unmanaged<All, byte> _UnmapBufferOES_fnptr = &UnmapBufferOES_Lazy;
+            private static delegate* unmanaged<All, bool> _UnmapBufferOES_fnptr = &UnmapBufferOES_Lazy;
             /// <summary> <b>[requires: GL_OES_mapbuffer]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte UnmapBufferOES(All target) => _UnmapBufferOES_fnptr(target);
+            public static bool UnmapBufferOES(All target) => _UnmapBufferOES_fnptr(target);
             [UnmanagedCallersOnly]
-            private static byte UnmapBufferOES_Lazy(All target)
+            private static bool UnmapBufferOES_Lazy(All target)
             {
-                _UnmapBufferOES_fnptr = (delegate* unmanaged<All, byte>)GLLoader.BindingsContext.GetProcAddress("glUnmapBufferOES");
+                _UnmapBufferOES_fnptr = (delegate* unmanaged<All, bool>)GLLoader.BindingsContext.GetProcAddress("glUnmapBufferOES");
                 return _UnmapBufferOES_fnptr(target);
             }
             
@@ -4650,14 +4650,14 @@ namespace OpenTK.Graphics.OpenGLES1
                 _GenVertexArraysOES_fnptr(n, arrays);
             }
             
-            private static delegate* unmanaged<VertexArrayHandle, byte> _IsVertexArrayOES_fnptr = &IsVertexArrayOES_Lazy;
+            private static delegate* unmanaged<VertexArrayHandle, bool> _IsVertexArrayOES_fnptr = &IsVertexArrayOES_Lazy;
             /// <summary> <b>[requires: GL_OES_vertex_array_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsVertexArrayOES(VertexArrayHandle array) => _IsVertexArrayOES_fnptr(array);
+            public static bool IsVertexArrayOES(VertexArrayHandle array) => _IsVertexArrayOES_fnptr(array);
             [UnmanagedCallersOnly]
-            private static byte IsVertexArrayOES_Lazy(VertexArrayHandle array)
+            private static bool IsVertexArrayOES_Lazy(VertexArrayHandle array)
             {
-                _IsVertexArrayOES_fnptr = (delegate* unmanaged<VertexArrayHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsVertexArrayOES");
+                _IsVertexArrayOES_fnptr = (delegate* unmanaged<VertexArrayHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsVertexArrayOES");
                 return _IsVertexArrayOES_fnptr(array);
             }
             
@@ -4818,14 +4818,14 @@ namespace OpenTK.Graphics.OpenGLES1
                 _ExtGetProgramsQCOM_fnptr(programs, maxPrograms, numPrograms);
             }
             
-            private static delegate* unmanaged<ProgramHandle, byte> _ExtIsProgramBinaryQCOM_fnptr = &ExtIsProgramBinaryQCOM_Lazy;
+            private static delegate* unmanaged<ProgramHandle, bool> _ExtIsProgramBinaryQCOM_fnptr = &ExtIsProgramBinaryQCOM_Lazy;
             /// <summary> <b>[requires: GL_QCOM_extended_get2]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte ExtIsProgramBinaryQCOM(ProgramHandle program) => _ExtIsProgramBinaryQCOM_fnptr(program);
+            public static bool ExtIsProgramBinaryQCOM(ProgramHandle program) => _ExtIsProgramBinaryQCOM_fnptr(program);
             [UnmanagedCallersOnly]
-            private static byte ExtIsProgramBinaryQCOM_Lazy(ProgramHandle program)
+            private static bool ExtIsProgramBinaryQCOM_Lazy(ProgramHandle program)
             {
-                _ExtIsProgramBinaryQCOM_fnptr = (delegate* unmanaged<ProgramHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glExtIsProgramBinaryQCOM");
+                _ExtIsProgramBinaryQCOM_fnptr = (delegate* unmanaged<ProgramHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glExtIsProgramBinaryQCOM");
                 return _ExtIsProgramBinaryQCOM_fnptr(program);
             }
             

--- a/src/OpenTK.Graphics/OpenGLES1/GL.Overloads.cs
+++ b/src/OpenTK.Graphics/OpenGLES1/GL.Overloads.cs
@@ -711,25 +711,25 @@ namespace OpenTK.Graphics.OpenGLES1
             }
         }
         /// <inheritdoc cref="GetBooleanv"/>
-        public static unsafe void GetBoolean(GetPName pname, Span<byte> data)
+        public static unsafe void GetBoolean(GetPName pname, Span<bool> data)
         {
-            fixed (byte* data_ptr = data)
+            fixed (bool* data_ptr = data)
             {
                 GetBooleanv(pname, data_ptr);
             }
         }
         /// <inheritdoc cref="GetBooleanv"/>
-        public static unsafe void GetBoolean(GetPName pname, byte[] data)
+        public static unsafe void GetBoolean(GetPName pname, bool[] data)
         {
-            fixed (byte* data_ptr = data)
+            fixed (bool* data_ptr = data)
             {
                 GetBooleanv(pname, data_ptr);
             }
         }
         /// <inheritdoc cref="GetBooleanv"/>
-        public static unsafe void GetBoolean(GetPName pname, ref byte data)
+        public static unsafe void GetBoolean(GetPName pname, ref bool data)
         {
-            fixed (byte* data_ptr = &data)
+            fixed (bool* data_ptr = &data)
             {
                 GetBooleanv(pname, data_ptr);
             }

--- a/src/OpenTK.Graphics/OpenGLES1/GL.Overloads.cs
+++ b/src/OpenTK.Graphics/OpenGLES1/GL.Overloads.cs
@@ -492,15 +492,6 @@ namespace OpenTK.Graphics.OpenGLES1
         {
             Color4ub(red, green, blue, alpha);
         }
-        /// <inheritdoc cref="ColorMask"/>
-        public static unsafe void ColorMask(bool red, bool green, bool blue, bool alpha)
-        {
-            byte red_byte = (byte)(red ? 1 : 0);
-            byte green_byte = (byte)(green ? 1 : 0);
-            byte blue_byte = (byte)(blue ? 1 : 0);
-            byte alpha_byte = (byte)(alpha ? 1 : 0);
-            ColorMask(red_byte, green_byte, blue_byte, alpha_byte);
-        }
         /// <inheritdoc cref="ColorPointer"/>
         public static unsafe void ColorPointer(int size, ColorPointerType type, int stride, IntPtr pointer)
         {
@@ -673,12 +664,6 @@ namespace OpenTK.Graphics.OpenGLES1
             {
                 DeleteTextures(n, textures_ptr);
             }
-        }
-        /// <inheritdoc cref="DepthMask"/>
-        public static unsafe void DepthMask(bool flag)
-        {
-            byte flag_byte = (byte)(flag ? 1 : 0);
-            DepthMask(flag_byte);
         }
         /// <inheritdoc cref="DrawElements"/>
         public static unsafe void DrawElements(PrimitiveType mode, int count, DrawElementsType type, nint offset)
@@ -1302,18 +1287,6 @@ namespace OpenTK.Graphics.OpenGLES1
                 ReadPixels(x, y, width, height, format, type, pixels_ptr);
             }
         }
-        /// <inheritdoc cref="SampleCoverage"/>
-        public static unsafe void SampleCoverage(float value, bool invert)
-        {
-            byte invert_byte = (byte)(invert ? 1 : 0);
-            SampleCoverage(value, invert_byte);
-        }
-        /// <inheritdoc cref="SampleCoveragex"/>
-        public static unsafe void SampleCoveragex(int value, bool invert)
-        {
-            byte invert_byte = (byte)(invert ? 1 : 0);
-            SampleCoveragex(value, invert_byte);
-        }
         /// <inheritdoc cref="TexCoordPointer"/>
         public static unsafe void TexCoordPointer(int size, TexCoordPointerType type, int stride, IntPtr pointer)
         {
@@ -1830,8 +1803,7 @@ namespace OpenTK.Graphics.OpenGLES1
                 int count = (int)(ids.Length);
                 fixed (uint* ids_ptr = ids)
                 {
-                    byte enabled_byte = (byte)(enabled ? 1 : 0);
-                    DebugMessageControl(source, type, severity, count, ids_ptr, enabled_byte);
+                    DebugMessageControl(source, type, severity, count, ids_ptr, enabled);
                 }
             }
             /// <inheritdoc cref="DebugMessageControl"/>
@@ -1840,8 +1812,7 @@ namespace OpenTK.Graphics.OpenGLES1
                 int count = (int)(ids.Length);
                 fixed (uint* ids_ptr = ids)
                 {
-                    byte enabled_byte = (byte)(enabled ? 1 : 0);
-                    DebugMessageControl(source, type, severity, count, ids_ptr, enabled_byte);
+                    DebugMessageControl(source, type, severity, count, ids_ptr, enabled);
                 }
             }
             /// <inheritdoc cref="DebugMessageControl"/>
@@ -1849,8 +1820,7 @@ namespace OpenTK.Graphics.OpenGLES1
             {
                 fixed (uint* ids_ptr = &ids)
                 {
-                    byte enabled_byte = (byte)(enabled ? 1 : 0);
-                    DebugMessageControl(source, type, severity, count, ids_ptr, enabled_byte);
+                    DebugMessageControl(source, type, severity, count, ids_ptr, enabled);
                 }
             }
             /// <inheritdoc cref="DebugMessageInsert"/>
@@ -2229,8 +2199,7 @@ namespace OpenTK.Graphics.OpenGLES1
             {
                 fixed (uint* ids_ptr = &ids)
                 {
-                    byte enabled_byte = (byte)(enabled ? 1 : 0);
-                    DebugMessageControlKHR(source, type, severity, count, ids_ptr, enabled_byte);
+                    DebugMessageControlKHR(source, type, severity, count, ids_ptr, enabled);
                 }
             }
             /// <inheritdoc cref="DebugMessageInsertKHR"/>
@@ -3406,12 +3375,6 @@ namespace OpenTK.Graphics.OpenGLES1
                 {
                     GetMaterialxvOES(face, pname, parameters_ptr);
                 }
-            }
-            /// <inheritdoc cref="SampleCoveragexOES"/>
-            public static unsafe void SampleCoveragexOES(int value, bool invert)
-            {
-                byte invert_byte = (byte)(invert ? 1 : 0);
-                SampleCoveragexOES(value, invert_byte);
             }
             /// <inheritdoc cref="BitmapxOES"/>
             public static unsafe void BitmapxOES(int width, int height, int xorig, int yorig, int xmove, int ymove, ReadOnlySpan<byte> bitmap)

--- a/src/OpenTK.Graphics/OpenGLES3/GL.Native.cs
+++ b/src/OpenTK.Graphics/OpenGLES3/GL.Native.cs
@@ -259,18 +259,18 @@ namespace OpenTK.Graphics.OpenGLES3
             _ClearStencil_fnptr(s);
         }
         
-        private static delegate* unmanaged<byte, byte, byte, byte, void> _ColorMask_fnptr = &ColorMask_Lazy;
+        private static delegate* unmanaged<bool, bool, bool, bool, void> _ColorMask_fnptr = &ColorMask_Lazy;
         /// <summary> <b>[requires: v2.0]</b> Enable and disable writing of frame buffer color components. </summary>
         /// <param name="red"> Specify whether red, green, blue, and alpha are to be written into the frame buffer. The initial values are all GL_TRUE, indicating that the color components are written. </param>
         /// <param name="green"> Specify whether red, green, blue, and alpha are to be written into the frame buffer. The initial values are all GL_TRUE, indicating that the color components are written. </param>
         /// <param name="blue"> Specify whether red, green, blue, and alpha are to be written into the frame buffer. The initial values are all GL_TRUE, indicating that the color components are written. </param>
         /// <param name="alpha"> Specify whether red, green, blue, and alpha are to be written into the frame buffer. The initial values are all GL_TRUE, indicating that the color components are written. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglColorMask.xhtml" /></remarks>
-        public static void ColorMask(byte red, byte green, byte blue, byte alpha) => _ColorMask_fnptr(red, green, blue, alpha);
+        public static void ColorMask(bool red, bool green, bool blue, bool alpha) => _ColorMask_fnptr(red, green, blue, alpha);
         [UnmanagedCallersOnly]
-        private static void ColorMask_Lazy(byte red, byte green, byte blue, byte alpha)
+        private static void ColorMask_Lazy(bool red, bool green, bool blue, bool alpha)
         {
-            _ColorMask_fnptr = (delegate* unmanaged<byte, byte, byte, byte, void>)GLLoader.BindingsContext.GetProcAddress("glColorMask");
+            _ColorMask_fnptr = (delegate* unmanaged<bool, bool, bool, bool, void>)GLLoader.BindingsContext.GetProcAddress("glColorMask");
             _ColorMask_fnptr(red, green, blue, alpha);
         }
         
@@ -486,15 +486,15 @@ namespace OpenTK.Graphics.OpenGLES3
             _DepthFunc_fnptr(func);
         }
         
-        private static delegate* unmanaged<byte, void> _DepthMask_fnptr = &DepthMask_Lazy;
+        private static delegate* unmanaged<bool, void> _DepthMask_fnptr = &DepthMask_Lazy;
         /// <summary> <b>[requires: v2.0]</b> Enable or disable writing into the depth buffer. </summary>
         /// <param name="flag"> Specifies whether the depth buffer is enabled for writing. If flag is GL_FALSE, depth buffer writing is disabled. Otherwise, it is enabled. Initially, depth buffer writing is enabled. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglDepthMask.xhtml" /></remarks>
-        public static void DepthMask(byte flag) => _DepthMask_fnptr(flag);
+        public static void DepthMask(bool flag) => _DepthMask_fnptr(flag);
         [UnmanagedCallersOnly]
-        private static void DepthMask_Lazy(byte flag)
+        private static void DepthMask_Lazy(bool flag)
         {
-            _DepthMask_fnptr = (delegate* unmanaged<byte, void>)GLLoader.BindingsContext.GetProcAddress("glDepthMask");
+            _DepthMask_fnptr = (delegate* unmanaged<bool, void>)GLLoader.BindingsContext.GetProcAddress("glDepthMask");
             _DepthMask_fnptr(flag);
         }
         
@@ -794,16 +794,16 @@ namespace OpenTK.Graphics.OpenGLES3
             return _GetAttribLocation_fnptr(program, name);
         }
         
-        private static delegate* unmanaged<GetPName, byte*, void> _GetBooleanv_fnptr = &GetBooleanv_Lazy;
+        private static delegate* unmanaged<GetPName, bool*, void> _GetBooleanv_fnptr = &GetBooleanv_Lazy;
         /// <summary> <b>[requires: v2.0]</b> Return the value or values of a selected parameter. </summary>
         /// <param name="pname"> Specifies the parameter value to be returned. The symbolic constants in the list below are accepted. </param>
         /// <param name="data"> Returns the value or values of the specified parameter. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglGet.xhtml" /></remarks>
-        public static void GetBooleanv(GetPName pname, byte* data) => _GetBooleanv_fnptr(pname, data);
+        public static void GetBooleanv(GetPName pname, bool* data) => _GetBooleanv_fnptr(pname, data);
         [UnmanagedCallersOnly]
-        private static void GetBooleanv_Lazy(GetPName pname, byte* data)
+        private static void GetBooleanv_Lazy(GetPName pname, bool* data)
         {
-            _GetBooleanv_fnptr = (delegate* unmanaged<GetPName, byte*, void>)GLLoader.BindingsContext.GetProcAddress("glGetBooleanv");
+            _GetBooleanv_fnptr = (delegate* unmanaged<GetPName, bool*, void>)GLLoader.BindingsContext.GetProcAddress("glGetBooleanv");
             _GetBooleanv_fnptr(pname, data);
         }
         
@@ -1111,87 +1111,87 @@ namespace OpenTK.Graphics.OpenGLES3
             _Hint_fnptr(target, mode);
         }
         
-        private static delegate* unmanaged<BufferHandle, byte> _IsBuffer_fnptr = &IsBuffer_Lazy;
+        private static delegate* unmanaged<BufferHandle, bool> _IsBuffer_fnptr = &IsBuffer_Lazy;
         /// <summary> <b>[requires: v2.0]</b> Determine if a name corresponds to a buffer object. </summary>
         /// <param name="buffer"> Specifies a value that may be the name of a buffer object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglIsBuffer.xhtml" /></remarks>
-        public static byte IsBuffer(BufferHandle buffer) => _IsBuffer_fnptr(buffer);
+        public static bool IsBuffer(BufferHandle buffer) => _IsBuffer_fnptr(buffer);
         [UnmanagedCallersOnly]
-        private static byte IsBuffer_Lazy(BufferHandle buffer)
+        private static bool IsBuffer_Lazy(BufferHandle buffer)
         {
-            _IsBuffer_fnptr = (delegate* unmanaged<BufferHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsBuffer");
+            _IsBuffer_fnptr = (delegate* unmanaged<BufferHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsBuffer");
             return _IsBuffer_fnptr(buffer);
         }
         
-        private static delegate* unmanaged<EnableCap, byte> _IsEnabled_fnptr = &IsEnabled_Lazy;
+        private static delegate* unmanaged<EnableCap, bool> _IsEnabled_fnptr = &IsEnabled_Lazy;
         /// <summary> <b>[requires: v2.0]</b> Test whether a capability is enabled. </summary>
         /// <param name="cap"> Specifies a symbolic constant indicating a GL capability. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglIsEnabled.xhtml" /></remarks>
-        public static byte IsEnabled(EnableCap cap) => _IsEnabled_fnptr(cap);
+        public static bool IsEnabled(EnableCap cap) => _IsEnabled_fnptr(cap);
         [UnmanagedCallersOnly]
-        private static byte IsEnabled_Lazy(EnableCap cap)
+        private static bool IsEnabled_Lazy(EnableCap cap)
         {
-            _IsEnabled_fnptr = (delegate* unmanaged<EnableCap, byte>)GLLoader.BindingsContext.GetProcAddress("glIsEnabled");
+            _IsEnabled_fnptr = (delegate* unmanaged<EnableCap, bool>)GLLoader.BindingsContext.GetProcAddress("glIsEnabled");
             return _IsEnabled_fnptr(cap);
         }
         
-        private static delegate* unmanaged<FramebufferHandle, byte> _IsFramebuffer_fnptr = &IsFramebuffer_Lazy;
+        private static delegate* unmanaged<FramebufferHandle, bool> _IsFramebuffer_fnptr = &IsFramebuffer_Lazy;
         /// <summary> <b>[requires: v2.0]</b> Determine if a name corresponds to a framebuffer object. </summary>
         /// <param name="framebuffer"> Specifies a value that may be the name of a framebuffer object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglIsFramebuffer.xhtml" /></remarks>
-        public static byte IsFramebuffer(FramebufferHandle framebuffer) => _IsFramebuffer_fnptr(framebuffer);
+        public static bool IsFramebuffer(FramebufferHandle framebuffer) => _IsFramebuffer_fnptr(framebuffer);
         [UnmanagedCallersOnly]
-        private static byte IsFramebuffer_Lazy(FramebufferHandle framebuffer)
+        private static bool IsFramebuffer_Lazy(FramebufferHandle framebuffer)
         {
-            _IsFramebuffer_fnptr = (delegate* unmanaged<FramebufferHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsFramebuffer");
+            _IsFramebuffer_fnptr = (delegate* unmanaged<FramebufferHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsFramebuffer");
             return _IsFramebuffer_fnptr(framebuffer);
         }
         
-        private static delegate* unmanaged<ProgramHandle, byte> _IsProgram_fnptr = &IsProgram_Lazy;
+        private static delegate* unmanaged<ProgramHandle, bool> _IsProgram_fnptr = &IsProgram_Lazy;
         /// <summary> <b>[requires: v2.0]</b> Determines if a name corresponds to a program object. </summary>
         /// <param name="program">Specifies a potential program object.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglIsProgram.xhtml" /></remarks>
-        public static byte IsProgram(ProgramHandle program) => _IsProgram_fnptr(program);
+        public static bool IsProgram(ProgramHandle program) => _IsProgram_fnptr(program);
         [UnmanagedCallersOnly]
-        private static byte IsProgram_Lazy(ProgramHandle program)
+        private static bool IsProgram_Lazy(ProgramHandle program)
         {
-            _IsProgram_fnptr = (delegate* unmanaged<ProgramHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsProgram");
+            _IsProgram_fnptr = (delegate* unmanaged<ProgramHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsProgram");
             return _IsProgram_fnptr(program);
         }
         
-        private static delegate* unmanaged<RenderbufferHandle, byte> _IsRenderbuffer_fnptr = &IsRenderbuffer_Lazy;
+        private static delegate* unmanaged<RenderbufferHandle, bool> _IsRenderbuffer_fnptr = &IsRenderbuffer_Lazy;
         /// <summary> <b>[requires: v2.0]</b> Determine if a name corresponds to a renderbuffer object. </summary>
         /// <param name="renderbuffer"> Specifies a value that may be the name of a renderbuffer object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglIsRenderbuffer.xhtml" /></remarks>
-        public static byte IsRenderbuffer(RenderbufferHandle renderbuffer) => _IsRenderbuffer_fnptr(renderbuffer);
+        public static bool IsRenderbuffer(RenderbufferHandle renderbuffer) => _IsRenderbuffer_fnptr(renderbuffer);
         [UnmanagedCallersOnly]
-        private static byte IsRenderbuffer_Lazy(RenderbufferHandle renderbuffer)
+        private static bool IsRenderbuffer_Lazy(RenderbufferHandle renderbuffer)
         {
-            _IsRenderbuffer_fnptr = (delegate* unmanaged<RenderbufferHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsRenderbuffer");
+            _IsRenderbuffer_fnptr = (delegate* unmanaged<RenderbufferHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsRenderbuffer");
             return _IsRenderbuffer_fnptr(renderbuffer);
         }
         
-        private static delegate* unmanaged<ShaderHandle, byte> _IsShader_fnptr = &IsShader_Lazy;
+        private static delegate* unmanaged<ShaderHandle, bool> _IsShader_fnptr = &IsShader_Lazy;
         /// <summary> <b>[requires: v2.0]</b> Determines if a name corresponds to a shader object. </summary>
         /// <param name="shader">Specifies a potential shader object.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglIsShader.xhtml" /></remarks>
-        public static byte IsShader(ShaderHandle shader) => _IsShader_fnptr(shader);
+        public static bool IsShader(ShaderHandle shader) => _IsShader_fnptr(shader);
         [UnmanagedCallersOnly]
-        private static byte IsShader_Lazy(ShaderHandle shader)
+        private static bool IsShader_Lazy(ShaderHandle shader)
         {
-            _IsShader_fnptr = (delegate* unmanaged<ShaderHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsShader");
+            _IsShader_fnptr = (delegate* unmanaged<ShaderHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsShader");
             return _IsShader_fnptr(shader);
         }
         
-        private static delegate* unmanaged<TextureHandle, byte> _IsTexture_fnptr = &IsTexture_Lazy;
+        private static delegate* unmanaged<TextureHandle, bool> _IsTexture_fnptr = &IsTexture_Lazy;
         /// <summary> <b>[requires: v2.0]</b> Determine if a name corresponds to a texture. </summary>
         /// <param name="texture"> Specifies a value that may be the name of a texture. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglIsTexture.xhtml" /></remarks>
-        public static byte IsTexture(TextureHandle texture) => _IsTexture_fnptr(texture);
+        public static bool IsTexture(TextureHandle texture) => _IsTexture_fnptr(texture);
         [UnmanagedCallersOnly]
-        private static byte IsTexture_Lazy(TextureHandle texture)
+        private static bool IsTexture_Lazy(TextureHandle texture)
         {
-            _IsTexture_fnptr = (delegate* unmanaged<TextureHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsTexture");
+            _IsTexture_fnptr = (delegate* unmanaged<TextureHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsTexture");
             return _IsTexture_fnptr(texture);
         }
         
@@ -1289,16 +1289,16 @@ namespace OpenTK.Graphics.OpenGLES3
             _RenderbufferStorage_fnptr(target, internalformat, width, height);
         }
         
-        private static delegate* unmanaged<float, byte, void> _SampleCoverage_fnptr = &SampleCoverage_Lazy;
+        private static delegate* unmanaged<float, bool, void> _SampleCoverage_fnptr = &SampleCoverage_Lazy;
         /// <summary> <b>[requires: v2.0]</b> Specify multisample coverage parameters. </summary>
         /// <param name="value"> Specify a single floating-point sample coverage value. The value is clamped to the range 0 1 . The initial value is 1.0. </param>
         /// <param name="invert"> Specify a single boolean value representing if the coverage masks should be inverted. GL_TRUE and GL_FALSE are accepted. The initial value is GL_FALSE. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglSampleCoverage.xhtml" /></remarks>
-        public static void SampleCoverage(float value, byte invert) => _SampleCoverage_fnptr(value, invert);
+        public static void SampleCoverage(float value, bool invert) => _SampleCoverage_fnptr(value, invert);
         [UnmanagedCallersOnly]
-        private static void SampleCoverage_Lazy(float value, byte invert)
+        private static void SampleCoverage_Lazy(float value, bool invert)
         {
-            _SampleCoverage_fnptr = (delegate* unmanaged<float, byte, void>)GLLoader.BindingsContext.GetProcAddress("glSampleCoverage");
+            _SampleCoverage_fnptr = (delegate* unmanaged<float, bool, void>)GLLoader.BindingsContext.GetProcAddress("glSampleCoverage");
             _SampleCoverage_fnptr(value, invert);
         }
         
@@ -1755,48 +1755,48 @@ namespace OpenTK.Graphics.OpenGLES3
             _Uniform4iv_fnptr(location, count, value);
         }
         
-        private static delegate* unmanaged<int, int, byte, float*, void> _UniformMatrix2fv_fnptr = &UniformMatrix2fv_Lazy;
+        private static delegate* unmanaged<int, int, bool, float*, void> _UniformMatrix2fv_fnptr = &UniformMatrix2fv_Lazy;
         /// <summary> <b>[requires: v2.0]</b> Specify the value of a uniform variable for the current program object. </summary>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
         /// <param name="count"> For the vector (glUniform*v) commands, specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglUniform.xhtml" /></remarks>
-        public static void UniformMatrix2fv(int location, int count, byte transpose, float* value) => _UniformMatrix2fv_fnptr(location, count, transpose, value);
+        public static void UniformMatrix2fv(int location, int count, bool transpose, float* value) => _UniformMatrix2fv_fnptr(location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void UniformMatrix2fv_Lazy(int location, int count, byte transpose, float* value)
+        private static void UniformMatrix2fv_Lazy(int location, int count, bool transpose, float* value)
         {
-            _UniformMatrix2fv_fnptr = (delegate* unmanaged<int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix2fv");
+            _UniformMatrix2fv_fnptr = (delegate* unmanaged<int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix2fv");
             _UniformMatrix2fv_fnptr(location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<int, int, byte, float*, void> _UniformMatrix3fv_fnptr = &UniformMatrix3fv_Lazy;
+        private static delegate* unmanaged<int, int, bool, float*, void> _UniformMatrix3fv_fnptr = &UniformMatrix3fv_Lazy;
         /// <summary> <b>[requires: v2.0]</b> Specify the value of a uniform variable for the current program object. </summary>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
         /// <param name="count"> For the vector (glUniform*v) commands, specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglUniform.xhtml" /></remarks>
-        public static void UniformMatrix3fv(int location, int count, byte transpose, float* value) => _UniformMatrix3fv_fnptr(location, count, transpose, value);
+        public static void UniformMatrix3fv(int location, int count, bool transpose, float* value) => _UniformMatrix3fv_fnptr(location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void UniformMatrix3fv_Lazy(int location, int count, byte transpose, float* value)
+        private static void UniformMatrix3fv_Lazy(int location, int count, bool transpose, float* value)
         {
-            _UniformMatrix3fv_fnptr = (delegate* unmanaged<int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix3fv");
+            _UniformMatrix3fv_fnptr = (delegate* unmanaged<int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix3fv");
             _UniformMatrix3fv_fnptr(location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<int, int, byte, float*, void> _UniformMatrix4fv_fnptr = &UniformMatrix4fv_Lazy;
+        private static delegate* unmanaged<int, int, bool, float*, void> _UniformMatrix4fv_fnptr = &UniformMatrix4fv_Lazy;
         /// <summary> <b>[requires: v2.0]</b> Specify the value of a uniform variable for the current program object. </summary>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
         /// <param name="count"> For the vector (glUniform*v) commands, specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglUniform.xhtml" /></remarks>
-        public static void UniformMatrix4fv(int location, int count, byte transpose, float* value) => _UniformMatrix4fv_fnptr(location, count, transpose, value);
+        public static void UniformMatrix4fv(int location, int count, bool transpose, float* value) => _UniformMatrix4fv_fnptr(location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void UniformMatrix4fv_Lazy(int location, int count, byte transpose, float* value)
+        private static void UniformMatrix4fv_Lazy(int location, int count, bool transpose, float* value)
         {
-            _UniformMatrix4fv_fnptr = (delegate* unmanaged<int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix4fv");
+            _UniformMatrix4fv_fnptr = (delegate* unmanaged<int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix4fv");
             _UniformMatrix4fv_fnptr(location, count, transpose, value);
         }
         
@@ -1934,7 +1934,7 @@ namespace OpenTK.Graphics.OpenGLES3
             _VertexAttrib4fv_fnptr(index, v);
         }
         
-        private static delegate* unmanaged<uint, int, VertexAttribPointerType, byte, int, void*, void> _VertexAttribPointer_fnptr = &VertexAttribPointer_Lazy;
+        private static delegate* unmanaged<uint, int, VertexAttribPointerType, bool, int, void*, void> _VertexAttribPointer_fnptr = &VertexAttribPointer_Lazy;
         /// <summary> <b>[requires: v2.0]</b> Define an array of generic vertex attribute data. </summary>
         /// <param name="index">Specifies the index of the generic vertex attribute to be modified.</param>
         /// <param name="size">Specifies the number of components per generic vertex attribute. Must be 1, 2, 3, 4. The initial value is 4.</param>
@@ -1943,11 +1943,11 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="stride"> Specifies the byte offset between consecutive generic vertex attributes. If stride is 0, the generic vertex attributes are understood to be tightly packed in the array. The initial value is 0. </param>
         /// <param name="pointer"> Specifies a pointer to the first generic vertex attribute in the array. If a non-zero buffer is currently bound to the GL_ARRAY_BUFFER target, pointer specifies an offset of into the array in the data store of that buffer. The initial value is 0. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglVertexAttribPointer.xhtml" /></remarks>
-        public static void VertexAttribPointer(uint index, int size, VertexAttribPointerType type, byte normalized, int stride, void* pointer) => _VertexAttribPointer_fnptr(index, size, type, normalized, stride, pointer);
+        public static void VertexAttribPointer(uint index, int size, VertexAttribPointerType type, bool normalized, int stride, void* pointer) => _VertexAttribPointer_fnptr(index, size, type, normalized, stride, pointer);
         [UnmanagedCallersOnly]
-        private static void VertexAttribPointer_Lazy(uint index, int size, VertexAttribPointerType type, byte normalized, int stride, void* pointer)
+        private static void VertexAttribPointer_Lazy(uint index, int size, VertexAttribPointerType type, bool normalized, int stride, void* pointer)
         {
-            _VertexAttribPointer_fnptr = (delegate* unmanaged<uint, int, VertexAttribPointerType, byte, int, void*, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribPointer");
+            _VertexAttribPointer_fnptr = (delegate* unmanaged<uint, int, VertexAttribPointerType, bool, int, void*, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribPointer");
             _VertexAttribPointer_fnptr(index, size, type, normalized, stride, pointer);
         }
         
@@ -2126,15 +2126,15 @@ namespace OpenTK.Graphics.OpenGLES3
             _DeleteQueries_fnptr(n, ids);
         }
         
-        private static delegate* unmanaged<QueryHandle, byte> _IsQuery_fnptr = &IsQuery_Lazy;
+        private static delegate* unmanaged<QueryHandle, bool> _IsQuery_fnptr = &IsQuery_Lazy;
         /// <summary> <b>[requires: v3.0]</b> Determine if a name corresponds to a query object. </summary>
         /// <param name="id"> Specifies a value that may be the name of a query object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglIsQuery.xhtml" /></remarks>
-        public static byte IsQuery(QueryHandle id) => _IsQuery_fnptr(id);
+        public static bool IsQuery(QueryHandle id) => _IsQuery_fnptr(id);
         [UnmanagedCallersOnly]
-        private static byte IsQuery_Lazy(QueryHandle id)
+        private static bool IsQuery_Lazy(QueryHandle id)
         {
-            _IsQuery_fnptr = (delegate* unmanaged<QueryHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsQuery");
+            _IsQuery_fnptr = (delegate* unmanaged<QueryHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsQuery");
             return _IsQuery_fnptr(id);
         }
         
@@ -2191,15 +2191,15 @@ namespace OpenTK.Graphics.OpenGLES3
             _GetQueryObjectuiv_fnptr(id, pname, parameters);
         }
         
-        private static delegate* unmanaged<BufferTargetARB, byte> _UnmapBuffer_fnptr = &UnmapBuffer_Lazy;
+        private static delegate* unmanaged<BufferTargetARB, bool> _UnmapBuffer_fnptr = &UnmapBuffer_Lazy;
         /// <summary> <b>[requires: v3.0]</b> Map a section of a buffer object's data store. </summary>
         /// <param name="target"> Specifies the target to which the buffer object is bound for glMapBufferRange, which must be one of the buffer binding targets in the following table: </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglMapBufferRange.xhtml" /></remarks>
-        public static byte UnmapBuffer(BufferTargetARB target) => _UnmapBuffer_fnptr(target);
+        public static bool UnmapBuffer(BufferTargetARB target) => _UnmapBuffer_fnptr(target);
         [UnmanagedCallersOnly]
-        private static byte UnmapBuffer_Lazy(BufferTargetARB target)
+        private static bool UnmapBuffer_Lazy(BufferTargetARB target)
         {
-            _UnmapBuffer_fnptr = (delegate* unmanaged<BufferTargetARB, byte>)GLLoader.BindingsContext.GetProcAddress("glUnmapBuffer");
+            _UnmapBuffer_fnptr = (delegate* unmanaged<BufferTargetARB, bool>)GLLoader.BindingsContext.GetProcAddress("glUnmapBuffer");
             return _UnmapBuffer_fnptr(target);
         }
         
@@ -2230,93 +2230,93 @@ namespace OpenTK.Graphics.OpenGLES3
             _DrawBuffers_fnptr(n, bufs);
         }
         
-        private static delegate* unmanaged<int, int, byte, float*, void> _UniformMatrix2x3fv_fnptr = &UniformMatrix2x3fv_Lazy;
+        private static delegate* unmanaged<int, int, bool, float*, void> _UniformMatrix2x3fv_fnptr = &UniformMatrix2x3fv_Lazy;
         /// <summary> <b>[requires: v3.0]</b> Specify the value of a uniform variable for the current program object. </summary>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
         /// <param name="count"> For the vector (glUniform*v) commands, specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglUniform.xhtml" /></remarks>
-        public static void UniformMatrix2x3fv(int location, int count, byte transpose, float* value) => _UniformMatrix2x3fv_fnptr(location, count, transpose, value);
+        public static void UniformMatrix2x3fv(int location, int count, bool transpose, float* value) => _UniformMatrix2x3fv_fnptr(location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void UniformMatrix2x3fv_Lazy(int location, int count, byte transpose, float* value)
+        private static void UniformMatrix2x3fv_Lazy(int location, int count, bool transpose, float* value)
         {
-            _UniformMatrix2x3fv_fnptr = (delegate* unmanaged<int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix2x3fv");
+            _UniformMatrix2x3fv_fnptr = (delegate* unmanaged<int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix2x3fv");
             _UniformMatrix2x3fv_fnptr(location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<int, int, byte, float*, void> _UniformMatrix3x2fv_fnptr = &UniformMatrix3x2fv_Lazy;
+        private static delegate* unmanaged<int, int, bool, float*, void> _UniformMatrix3x2fv_fnptr = &UniformMatrix3x2fv_Lazy;
         /// <summary> <b>[requires: v3.0]</b> Specify the value of a uniform variable for the current program object. </summary>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
         /// <param name="count"> For the vector (glUniform*v) commands, specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglUniform.xhtml" /></remarks>
-        public static void UniformMatrix3x2fv(int location, int count, byte transpose, float* value) => _UniformMatrix3x2fv_fnptr(location, count, transpose, value);
+        public static void UniformMatrix3x2fv(int location, int count, bool transpose, float* value) => _UniformMatrix3x2fv_fnptr(location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void UniformMatrix3x2fv_Lazy(int location, int count, byte transpose, float* value)
+        private static void UniformMatrix3x2fv_Lazy(int location, int count, bool transpose, float* value)
         {
-            _UniformMatrix3x2fv_fnptr = (delegate* unmanaged<int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix3x2fv");
+            _UniformMatrix3x2fv_fnptr = (delegate* unmanaged<int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix3x2fv");
             _UniformMatrix3x2fv_fnptr(location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<int, int, byte, float*, void> _UniformMatrix2x4fv_fnptr = &UniformMatrix2x4fv_Lazy;
+        private static delegate* unmanaged<int, int, bool, float*, void> _UniformMatrix2x4fv_fnptr = &UniformMatrix2x4fv_Lazy;
         /// <summary> <b>[requires: v3.0]</b> Specify the value of a uniform variable for the current program object. </summary>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
         /// <param name="count"> For the vector (glUniform*v) commands, specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglUniform.xhtml" /></remarks>
-        public static void UniformMatrix2x4fv(int location, int count, byte transpose, float* value) => _UniformMatrix2x4fv_fnptr(location, count, transpose, value);
+        public static void UniformMatrix2x4fv(int location, int count, bool transpose, float* value) => _UniformMatrix2x4fv_fnptr(location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void UniformMatrix2x4fv_Lazy(int location, int count, byte transpose, float* value)
+        private static void UniformMatrix2x4fv_Lazy(int location, int count, bool transpose, float* value)
         {
-            _UniformMatrix2x4fv_fnptr = (delegate* unmanaged<int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix2x4fv");
+            _UniformMatrix2x4fv_fnptr = (delegate* unmanaged<int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix2x4fv");
             _UniformMatrix2x4fv_fnptr(location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<int, int, byte, float*, void> _UniformMatrix4x2fv_fnptr = &UniformMatrix4x2fv_Lazy;
+        private static delegate* unmanaged<int, int, bool, float*, void> _UniformMatrix4x2fv_fnptr = &UniformMatrix4x2fv_Lazy;
         /// <summary> <b>[requires: v3.0]</b> Specify the value of a uniform variable for the current program object. </summary>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
         /// <param name="count"> For the vector (glUniform*v) commands, specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglUniform.xhtml" /></remarks>
-        public static void UniformMatrix4x2fv(int location, int count, byte transpose, float* value) => _UniformMatrix4x2fv_fnptr(location, count, transpose, value);
+        public static void UniformMatrix4x2fv(int location, int count, bool transpose, float* value) => _UniformMatrix4x2fv_fnptr(location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void UniformMatrix4x2fv_Lazy(int location, int count, byte transpose, float* value)
+        private static void UniformMatrix4x2fv_Lazy(int location, int count, bool transpose, float* value)
         {
-            _UniformMatrix4x2fv_fnptr = (delegate* unmanaged<int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix4x2fv");
+            _UniformMatrix4x2fv_fnptr = (delegate* unmanaged<int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix4x2fv");
             _UniformMatrix4x2fv_fnptr(location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<int, int, byte, float*, void> _UniformMatrix3x4fv_fnptr = &UniformMatrix3x4fv_Lazy;
+        private static delegate* unmanaged<int, int, bool, float*, void> _UniformMatrix3x4fv_fnptr = &UniformMatrix3x4fv_Lazy;
         /// <summary> <b>[requires: v3.0]</b> Specify the value of a uniform variable for the current program object. </summary>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
         /// <param name="count"> For the vector (glUniform*v) commands, specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglUniform.xhtml" /></remarks>
-        public static void UniformMatrix3x4fv(int location, int count, byte transpose, float* value) => _UniformMatrix3x4fv_fnptr(location, count, transpose, value);
+        public static void UniformMatrix3x4fv(int location, int count, bool transpose, float* value) => _UniformMatrix3x4fv_fnptr(location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void UniformMatrix3x4fv_Lazy(int location, int count, byte transpose, float* value)
+        private static void UniformMatrix3x4fv_Lazy(int location, int count, bool transpose, float* value)
         {
-            _UniformMatrix3x4fv_fnptr = (delegate* unmanaged<int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix3x4fv");
+            _UniformMatrix3x4fv_fnptr = (delegate* unmanaged<int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix3x4fv");
             _UniformMatrix3x4fv_fnptr(location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<int, int, byte, float*, void> _UniformMatrix4x3fv_fnptr = &UniformMatrix4x3fv_Lazy;
+        private static delegate* unmanaged<int, int, bool, float*, void> _UniformMatrix4x3fv_fnptr = &UniformMatrix4x3fv_Lazy;
         /// <summary> <b>[requires: v3.0]</b> Specify the value of a uniform variable for the current program object. </summary>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
         /// <param name="count"> For the vector (glUniform*v) commands, specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglUniform.xhtml" /></remarks>
-        public static void UniformMatrix4x3fv(int location, int count, byte transpose, float* value) => _UniformMatrix4x3fv_fnptr(location, count, transpose, value);
+        public static void UniformMatrix4x3fv(int location, int count, bool transpose, float* value) => _UniformMatrix4x3fv_fnptr(location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void UniformMatrix4x3fv_Lazy(int location, int count, byte transpose, float* value)
+        private static void UniformMatrix4x3fv_Lazy(int location, int count, bool transpose, float* value)
         {
-            _UniformMatrix4x3fv_fnptr = (delegate* unmanaged<int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix4x3fv");
+            _UniformMatrix4x3fv_fnptr = (delegate* unmanaged<int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix4x3fv");
             _UniformMatrix4x3fv_fnptr(location, count, transpose, value);
         }
         
@@ -2440,15 +2440,15 @@ namespace OpenTK.Graphics.OpenGLES3
             _GenVertexArrays_fnptr(n, arrays);
         }
         
-        private static delegate* unmanaged<VertexArrayHandle, byte> _IsVertexArray_fnptr = &IsVertexArray_Lazy;
+        private static delegate* unmanaged<VertexArrayHandle, bool> _IsVertexArray_fnptr = &IsVertexArray_Lazy;
         /// <summary> <b>[requires: v3.0]</b> Determine if a name corresponds to a vertex array object. </summary>
         /// <param name="array"> Specifies a value that may be the name of a vertex array object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglIsVertexArray.xhtml" /></remarks>
-        public static byte IsVertexArray(VertexArrayHandle array) => _IsVertexArray_fnptr(array);
+        public static bool IsVertexArray(VertexArrayHandle array) => _IsVertexArray_fnptr(array);
         [UnmanagedCallersOnly]
-        private static byte IsVertexArray_Lazy(VertexArrayHandle array)
+        private static bool IsVertexArray_Lazy(VertexArrayHandle array)
         {
-            _IsVertexArray_fnptr = (delegate* unmanaged<VertexArrayHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsVertexArray");
+            _IsVertexArray_fnptr = (delegate* unmanaged<VertexArrayHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsVertexArray");
             return _IsVertexArray_fnptr(array);
         }
         
@@ -3014,15 +3014,15 @@ namespace OpenTK.Graphics.OpenGLES3
             return _FenceSync_fnptr(condition, flags);
         }
         
-        private static delegate* unmanaged<GLSync, byte> _IsSync_fnptr = &IsSync_Lazy;
+        private static delegate* unmanaged<GLSync, bool> _IsSync_fnptr = &IsSync_Lazy;
         /// <summary> <b>[requires: v3.0]</b> Determine if a name corresponds to a sync object. </summary>
         /// <param name="sync"> Specifies a value that may be the name of a sync object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglIsSync.xhtml" /></remarks>
-        public static byte IsSync(GLSync sync) => _IsSync_fnptr(sync);
+        public static bool IsSync(GLSync sync) => _IsSync_fnptr(sync);
         [UnmanagedCallersOnly]
-        private static byte IsSync_Lazy(GLSync sync)
+        private static bool IsSync_Lazy(GLSync sync)
         {
-            _IsSync_fnptr = (delegate* unmanaged<GLSync, byte>)GLLoader.BindingsContext.GetProcAddress("glIsSync");
+            _IsSync_fnptr = (delegate* unmanaged<GLSync, bool>)GLLoader.BindingsContext.GetProcAddress("glIsSync");
             return _IsSync_fnptr(sync);
         }
         
@@ -3149,15 +3149,15 @@ namespace OpenTK.Graphics.OpenGLES3
             _DeleteSamplers_fnptr(count, samplers);
         }
         
-        private static delegate* unmanaged<SamplerHandle, byte> _IsSampler_fnptr = &IsSampler_Lazy;
+        private static delegate* unmanaged<SamplerHandle, bool> _IsSampler_fnptr = &IsSampler_Lazy;
         /// <summary> <b>[requires: v3.0]</b> Determine if a name corresponds to a sampler object. </summary>
         /// <param name="id"> Specifies a value that may be the name of a sampler object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglIsSampler.xhtml" /></remarks>
-        public static byte IsSampler(SamplerHandle sampler) => _IsSampler_fnptr(sampler);
+        public static bool IsSampler(SamplerHandle sampler) => _IsSampler_fnptr(sampler);
         [UnmanagedCallersOnly]
-        private static byte IsSampler_Lazy(SamplerHandle sampler)
+        private static bool IsSampler_Lazy(SamplerHandle sampler)
         {
-            _IsSampler_fnptr = (delegate* unmanaged<SamplerHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsSampler");
+            _IsSampler_fnptr = (delegate* unmanaged<SamplerHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsSampler");
             return _IsSampler_fnptr(sampler);
         }
         
@@ -3310,15 +3310,15 @@ namespace OpenTK.Graphics.OpenGLES3
             _GenTransformFeedbacks_fnptr(n, ids);
         }
         
-        private static delegate* unmanaged<TransformFeedbackHandle, byte> _IsTransformFeedback_fnptr = &IsTransformFeedback_Lazy;
+        private static delegate* unmanaged<TransformFeedbackHandle, bool> _IsTransformFeedback_fnptr = &IsTransformFeedback_Lazy;
         /// <summary> <b>[requires: v3.0]</b> Determine if a name corresponds to a transform feedback object. </summary>
         /// <param name="id"> Specifies a value that may be the name of a transform feedback object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglIsTransformFeedback.xhtml" /></remarks>
-        public static byte IsTransformFeedback(TransformFeedbackHandle id) => _IsTransformFeedback_fnptr(id);
+        public static bool IsTransformFeedback(TransformFeedbackHandle id) => _IsTransformFeedback_fnptr(id);
         [UnmanagedCallersOnly]
-        private static byte IsTransformFeedback_Lazy(TransformFeedbackHandle id)
+        private static bool IsTransformFeedback_Lazy(TransformFeedbackHandle id)
         {
-            _IsTransformFeedback_fnptr = (delegate* unmanaged<TransformFeedbackHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsTransformFeedback");
+            _IsTransformFeedback_fnptr = (delegate* unmanaged<TransformFeedbackHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsTransformFeedback");
             return _IsTransformFeedback_fnptr(id);
         }
         
@@ -3709,15 +3709,15 @@ namespace OpenTK.Graphics.OpenGLES3
             _GenProgramPipelines_fnptr(n, pipelines);
         }
         
-        private static delegate* unmanaged<ProgramPipelineHandle, byte> _IsProgramPipeline_fnptr = &IsProgramPipeline_Lazy;
+        private static delegate* unmanaged<ProgramPipelineHandle, bool> _IsProgramPipeline_fnptr = &IsProgramPipeline_Lazy;
         /// <summary> <b>[requires: v3.1]</b> Determine if a name corresponds to a program pipeline object. </summary>
         /// <param name="pipeline"> Specifies a value that may be the name of a program pipeline object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglIsProgramPipeline.xhtml" /></remarks>
-        public static byte IsProgramPipeline(ProgramPipelineHandle pipeline) => _IsProgramPipeline_fnptr(pipeline);
+        public static bool IsProgramPipeline(ProgramPipelineHandle pipeline) => _IsProgramPipeline_fnptr(pipeline);
         [UnmanagedCallersOnly]
-        private static byte IsProgramPipeline_Lazy(ProgramPipelineHandle pipeline)
+        private static bool IsProgramPipeline_Lazy(ProgramPipelineHandle pipeline)
         {
-            _IsProgramPipeline_fnptr = (delegate* unmanaged<ProgramPipelineHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsProgramPipeline");
+            _IsProgramPipeline_fnptr = (delegate* unmanaged<ProgramPipelineHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsProgramPipeline");
             return _IsProgramPipeline_fnptr(pipeline);
         }
         
@@ -4101,7 +4101,7 @@ namespace OpenTK.Graphics.OpenGLES3
             _ProgramUniform4fv_fnptr(program, location, count, value);
         }
         
-        private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix2fv_fnptr = &ProgramUniformMatrix2fv_Lazy;
+        private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix2fv_fnptr = &ProgramUniformMatrix2fv_Lazy;
         /// <summary> <b>[requires: v3.1]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
@@ -4109,15 +4109,15 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniformMatrix2fv(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix2fv_fnptr(program, location, count, transpose, value);
+        public static void ProgramUniformMatrix2fv(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix2fv_fnptr(program, location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void ProgramUniformMatrix2fv_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+        private static void ProgramUniformMatrix2fv_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
         {
-            _ProgramUniformMatrix2fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2fv");
+            _ProgramUniformMatrix2fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2fv");
             _ProgramUniformMatrix2fv_fnptr(program, location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix3fv_fnptr = &ProgramUniformMatrix3fv_Lazy;
+        private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix3fv_fnptr = &ProgramUniformMatrix3fv_Lazy;
         /// <summary> <b>[requires: v3.1]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
@@ -4125,15 +4125,15 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniformMatrix3fv(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix3fv_fnptr(program, location, count, transpose, value);
+        public static void ProgramUniformMatrix3fv(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix3fv_fnptr(program, location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void ProgramUniformMatrix3fv_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+        private static void ProgramUniformMatrix3fv_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
         {
-            _ProgramUniformMatrix3fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3fv");
+            _ProgramUniformMatrix3fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3fv");
             _ProgramUniformMatrix3fv_fnptr(program, location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix4fv_fnptr = &ProgramUniformMatrix4fv_Lazy;
+        private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix4fv_fnptr = &ProgramUniformMatrix4fv_Lazy;
         /// <summary> <b>[requires: v3.1]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
@@ -4141,15 +4141,15 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniformMatrix4fv(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix4fv_fnptr(program, location, count, transpose, value);
+        public static void ProgramUniformMatrix4fv(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix4fv_fnptr(program, location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void ProgramUniformMatrix4fv_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+        private static void ProgramUniformMatrix4fv_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
         {
-            _ProgramUniformMatrix4fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4fv");
+            _ProgramUniformMatrix4fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4fv");
             _ProgramUniformMatrix4fv_fnptr(program, location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix2x3fv_fnptr = &ProgramUniformMatrix2x3fv_Lazy;
+        private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix2x3fv_fnptr = &ProgramUniformMatrix2x3fv_Lazy;
         /// <summary> <b>[requires: v3.1]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
@@ -4157,15 +4157,15 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniformMatrix2x3fv(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix2x3fv_fnptr(program, location, count, transpose, value);
+        public static void ProgramUniformMatrix2x3fv(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix2x3fv_fnptr(program, location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void ProgramUniformMatrix2x3fv_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+        private static void ProgramUniformMatrix2x3fv_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
         {
-            _ProgramUniformMatrix2x3fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2x3fv");
+            _ProgramUniformMatrix2x3fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2x3fv");
             _ProgramUniformMatrix2x3fv_fnptr(program, location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix3x2fv_fnptr = &ProgramUniformMatrix3x2fv_Lazy;
+        private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix3x2fv_fnptr = &ProgramUniformMatrix3x2fv_Lazy;
         /// <summary> <b>[requires: v3.1]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
@@ -4173,15 +4173,15 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniformMatrix3x2fv(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix3x2fv_fnptr(program, location, count, transpose, value);
+        public static void ProgramUniformMatrix3x2fv(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix3x2fv_fnptr(program, location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void ProgramUniformMatrix3x2fv_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+        private static void ProgramUniformMatrix3x2fv_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
         {
-            _ProgramUniformMatrix3x2fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3x2fv");
+            _ProgramUniformMatrix3x2fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3x2fv");
             _ProgramUniformMatrix3x2fv_fnptr(program, location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix2x4fv_fnptr = &ProgramUniformMatrix2x4fv_Lazy;
+        private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix2x4fv_fnptr = &ProgramUniformMatrix2x4fv_Lazy;
         /// <summary> <b>[requires: v3.1]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
@@ -4189,15 +4189,15 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniformMatrix2x4fv(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix2x4fv_fnptr(program, location, count, transpose, value);
+        public static void ProgramUniformMatrix2x4fv(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix2x4fv_fnptr(program, location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void ProgramUniformMatrix2x4fv_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+        private static void ProgramUniformMatrix2x4fv_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
         {
-            _ProgramUniformMatrix2x4fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2x4fv");
+            _ProgramUniformMatrix2x4fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2x4fv");
             _ProgramUniformMatrix2x4fv_fnptr(program, location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix4x2fv_fnptr = &ProgramUniformMatrix4x2fv_Lazy;
+        private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix4x2fv_fnptr = &ProgramUniformMatrix4x2fv_Lazy;
         /// <summary> <b>[requires: v3.1]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
@@ -4205,15 +4205,15 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniformMatrix4x2fv(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix4x2fv_fnptr(program, location, count, transpose, value);
+        public static void ProgramUniformMatrix4x2fv(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix4x2fv_fnptr(program, location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void ProgramUniformMatrix4x2fv_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+        private static void ProgramUniformMatrix4x2fv_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
         {
-            _ProgramUniformMatrix4x2fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4x2fv");
+            _ProgramUniformMatrix4x2fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4x2fv");
             _ProgramUniformMatrix4x2fv_fnptr(program, location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix3x4fv_fnptr = &ProgramUniformMatrix3x4fv_Lazy;
+        private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix3x4fv_fnptr = &ProgramUniformMatrix3x4fv_Lazy;
         /// <summary> <b>[requires: v3.1]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
@@ -4221,15 +4221,15 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniformMatrix3x4fv(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix3x4fv_fnptr(program, location, count, transpose, value);
+        public static void ProgramUniformMatrix3x4fv(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix3x4fv_fnptr(program, location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void ProgramUniformMatrix3x4fv_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+        private static void ProgramUniformMatrix3x4fv_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
         {
-            _ProgramUniformMatrix3x4fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3x4fv");
+            _ProgramUniformMatrix3x4fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3x4fv");
             _ProgramUniformMatrix3x4fv_fnptr(program, location, count, transpose, value);
         }
         
-        private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix4x3fv_fnptr = &ProgramUniformMatrix4x3fv_Lazy;
+        private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix4x3fv_fnptr = &ProgramUniformMatrix4x3fv_Lazy;
         /// <summary> <b>[requires: v3.1]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
@@ -4237,11 +4237,11 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniformMatrix4x3fv(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix4x3fv_fnptr(program, location, count, transpose, value);
+        public static void ProgramUniformMatrix4x3fv(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix4x3fv_fnptr(program, location, count, transpose, value);
         [UnmanagedCallersOnly]
-        private static void ProgramUniformMatrix4x3fv_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+        private static void ProgramUniformMatrix4x3fv_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
         {
-            _ProgramUniformMatrix4x3fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4x3fv");
+            _ProgramUniformMatrix4x3fv_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4x3fv");
             _ProgramUniformMatrix4x3fv_fnptr(program, location, count, transpose, value);
         }
         
@@ -4272,7 +4272,7 @@ namespace OpenTK.Graphics.OpenGLES3
             _GetProgramPipelineInfoLog_fnptr(pipeline, bufSize, length, infoLog);
         }
         
-        private static delegate* unmanaged<uint, TextureHandle, int, byte, int, BufferAccessARB, InternalFormat, void> _BindImageTexture_fnptr = &BindImageTexture_Lazy;
+        private static delegate* unmanaged<uint, TextureHandle, int, bool, int, BufferAccessARB, InternalFormat, void> _BindImageTexture_fnptr = &BindImageTexture_Lazy;
         /// <summary> <b>[requires: v3.1]</b> Bind a level of a texture to an image unit. </summary>
         /// <param name="unit"> Specifies the index of the image unit to which to bind the texture </param>
         /// <param name="texture"> Specifies the name of the texture to bind to the image unit. </param>
@@ -4282,25 +4282,25 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="access"> Specifies a token indicating the type of access that will be performed on the image. </param>
         /// <param name="format"> Specifies the format that the elements of the image will be treated as for the purposes of formatted loads and stores. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglBindImageTexture.xhtml" /></remarks>
-        public static void BindImageTexture(uint unit, TextureHandle texture, int level, byte layered, int layer, BufferAccessARB access, InternalFormat format) => _BindImageTexture_fnptr(unit, texture, level, layered, layer, access, format);
+        public static void BindImageTexture(uint unit, TextureHandle texture, int level, bool layered, int layer, BufferAccessARB access, InternalFormat format) => _BindImageTexture_fnptr(unit, texture, level, layered, layer, access, format);
         [UnmanagedCallersOnly]
-        private static void BindImageTexture_Lazy(uint unit, TextureHandle texture, int level, byte layered, int layer, BufferAccessARB access, InternalFormat format)
+        private static void BindImageTexture_Lazy(uint unit, TextureHandle texture, int level, bool layered, int layer, BufferAccessARB access, InternalFormat format)
         {
-            _BindImageTexture_fnptr = (delegate* unmanaged<uint, TextureHandle, int, byte, int, BufferAccessARB, InternalFormat, void>)GLLoader.BindingsContext.GetProcAddress("glBindImageTexture");
+            _BindImageTexture_fnptr = (delegate* unmanaged<uint, TextureHandle, int, bool, int, BufferAccessARB, InternalFormat, void>)GLLoader.BindingsContext.GetProcAddress("glBindImageTexture");
             _BindImageTexture_fnptr(unit, texture, level, layered, layer, access, format);
         }
         
-        private static delegate* unmanaged<BufferTargetARB, uint, byte*, void> _GetBooleani_v_fnptr = &GetBooleani_v_Lazy;
+        private static delegate* unmanaged<BufferTargetARB, uint, bool*, void> _GetBooleani_v_fnptr = &GetBooleani_v_Lazy;
         /// <summary> <b>[requires: v3.1]</b> Return the value or values of a selected parameter. </summary>
         /// <param name="target"> Specifies the parameter value to be returned for indexed versions of glGet. The symbolic constants in the list below are accepted. </param>
         /// <param name="index"> Specifies the index of the particular element being queried. </param>
         /// <param name="data"> Returns the value or values of the specified parameter. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglGet.xhtml" /></remarks>
-        public static void GetBooleani_v(BufferTargetARB target, uint index, byte* data) => _GetBooleani_v_fnptr(target, index, data);
+        public static void GetBooleani_v(BufferTargetARB target, uint index, bool* data) => _GetBooleani_v_fnptr(target, index, data);
         [UnmanagedCallersOnly]
-        private static void GetBooleani_v_Lazy(BufferTargetARB target, uint index, byte* data)
+        private static void GetBooleani_v_Lazy(BufferTargetARB target, uint index, bool* data)
         {
-            _GetBooleani_v_fnptr = (delegate* unmanaged<BufferTargetARB, uint, byte*, void>)GLLoader.BindingsContext.GetProcAddress("glGetBooleani_v");
+            _GetBooleani_v_fnptr = (delegate* unmanaged<BufferTargetARB, uint, bool*, void>)GLLoader.BindingsContext.GetProcAddress("glGetBooleani_v");
             _GetBooleani_v_fnptr(target, index, data);
         }
         
@@ -4328,7 +4328,7 @@ namespace OpenTK.Graphics.OpenGLES3
             _MemoryBarrierByRegion_fnptr(barriers);
         }
         
-        private static delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, byte, void> _TexStorage2DMultisample_fnptr = &TexStorage2DMultisample_Lazy;
+        private static delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, bool, void> _TexStorage2DMultisample_fnptr = &TexStorage2DMultisample_Lazy;
         /// <summary> <b>[requires: v3.1]</b> Specify storage for a two-dimensional multisample texture. </summary>
         /// <param name="target"> Specify the target of the operation. target must be GL_TEXTURE_2D_MULTISAMPLE. </param>
         /// <param name="samples"> Specify the number of samples in the texture. </param>
@@ -4337,11 +4337,11 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="height"> Specifies the height of the texture, in texels. </param>
         /// <param name="fixedsamplelocations"> Specifies whether the image will use identical sample locations and the same number of samples for all texels in the image, and the sample locations will not depend on the internal format or size of the image. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglTexStorage2DMultisample.xhtml" /></remarks>
-        public static void TexStorage2DMultisample(TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, byte fixedsamplelocations) => _TexStorage2DMultisample_fnptr(target, samples, internalformat, width, height, fixedsamplelocations);
+        public static void TexStorage2DMultisample(TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, bool fixedsamplelocations) => _TexStorage2DMultisample_fnptr(target, samples, internalformat, width, height, fixedsamplelocations);
         [UnmanagedCallersOnly]
-        private static void TexStorage2DMultisample_Lazy(TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, byte fixedsamplelocations)
+        private static void TexStorage2DMultisample_Lazy(TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, bool fixedsamplelocations)
         {
-            _TexStorage2DMultisample_fnptr = (delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, byte, void>)GLLoader.BindingsContext.GetProcAddress("glTexStorage2DMultisample");
+            _TexStorage2DMultisample_fnptr = (delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, bool, void>)GLLoader.BindingsContext.GetProcAddress("glTexStorage2DMultisample");
             _TexStorage2DMultisample_fnptr(target, samples, internalformat, width, height, fixedsamplelocations);
         }
         
@@ -4417,7 +4417,7 @@ namespace OpenTK.Graphics.OpenGLES3
             _BindVertexBuffer_fnptr(bindingindex, buffer, offset, stride);
         }
         
-        private static delegate* unmanaged<uint, int, VertexAttribType, byte, uint, void> _VertexAttribFormat_fnptr = &VertexAttribFormat_Lazy;
+        private static delegate* unmanaged<uint, int, VertexAttribType, bool, uint, void> _VertexAttribFormat_fnptr = &VertexAttribFormat_Lazy;
         /// <summary> <b>[requires: v3.1]</b> Specify the organization of vertex arrays. </summary>
         /// <param name="attribindex"> The generic vertex attribute array being described. </param>
         /// <param name="size"> The number of values per vertex that are stored in the array. </param>
@@ -4425,11 +4425,11 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="normalized"> Specifies whether fixed-point data values should be normalized (GL_TRUE) or converted directly as fixed-point values (GL_FALSE) when they are accessed. This parameter is ignored if type is GL_FIXED. </param>
         /// <param name="relativeoffset"> An offset to the first element relative to the start of the vertex buffer binding. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglVertexAttribFormat.xhtml" /></remarks>
-        public static void VertexAttribFormat(uint attribindex, int size, VertexAttribType type, byte normalized, uint relativeoffset) => _VertexAttribFormat_fnptr(attribindex, size, type, normalized, relativeoffset);
+        public static void VertexAttribFormat(uint attribindex, int size, VertexAttribType type, bool normalized, uint relativeoffset) => _VertexAttribFormat_fnptr(attribindex, size, type, normalized, relativeoffset);
         [UnmanagedCallersOnly]
-        private static void VertexAttribFormat_Lazy(uint attribindex, int size, VertexAttribType type, byte normalized, uint relativeoffset)
+        private static void VertexAttribFormat_Lazy(uint attribindex, int size, VertexAttribType type, bool normalized, uint relativeoffset)
         {
-            _VertexAttribFormat_fnptr = (delegate* unmanaged<uint, int, VertexAttribType, byte, uint, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribFormat");
+            _VertexAttribFormat_fnptr = (delegate* unmanaged<uint, int, VertexAttribType, bool, uint, void>)GLLoader.BindingsContext.GetProcAddress("glVertexAttribFormat");
             _VertexAttribFormat_fnptr(attribindex, size, type, normalized, relativeoffset);
         }
         
@@ -4511,7 +4511,7 @@ namespace OpenTK.Graphics.OpenGLES3
             _CopyImageSubData_fnptr(srcName, srcTarget, srcLevel, srcX, srcY, srcZ, dstName, dstTarget, dstLevel, dstX, dstY, dstZ, srcWidth, srcHeight, srcDepth);
         }
         
-        private static delegate* unmanaged<DebugSource, DebugType, DebugSeverity, int, uint*, byte, void> _DebugMessageControl_fnptr = &DebugMessageControl_Lazy;
+        private static delegate* unmanaged<DebugSource, DebugType, DebugSeverity, int, uint*, bool, void> _DebugMessageControl_fnptr = &DebugMessageControl_Lazy;
         /// <summary> <b>[requires: v3.2 | GL_KHR_debug]</b> Control the reporting of debug messages in a debug context. </summary>
         /// <param name="source"> The source of debug messages to enable or disable. </param>
         /// <param name="type"> The type of debug messages to enable or disable. </param>
@@ -4520,11 +4520,11 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="ids"> The address of an array of unsigned integers contianing the ids of the messages to enable or disable. </param>
         /// <param name="enabled"> A Boolean flag determining whether the selected messages should be enabled or disabled. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglDebugMessageControl.xhtml" /></remarks>
-        public static void DebugMessageControl(DebugSource source, DebugType type, DebugSeverity severity, int count, uint* ids, byte enabled) => _DebugMessageControl_fnptr(source, type, severity, count, ids, enabled);
+        public static void DebugMessageControl(DebugSource source, DebugType type, DebugSeverity severity, int count, uint* ids, bool enabled) => _DebugMessageControl_fnptr(source, type, severity, count, ids, enabled);
         [UnmanagedCallersOnly]
-        private static void DebugMessageControl_Lazy(DebugSource source, DebugType type, DebugSeverity severity, int count, uint* ids, byte enabled)
+        private static void DebugMessageControl_Lazy(DebugSource source, DebugType type, DebugSeverity severity, int count, uint* ids, bool enabled)
         {
-            _DebugMessageControl_fnptr = (delegate* unmanaged<DebugSource, DebugType, DebugSeverity, int, uint*, byte, void>)GLLoader.BindingsContext.GetProcAddress("glDebugMessageControl");
+            _DebugMessageControl_fnptr = (delegate* unmanaged<DebugSource, DebugType, DebugSeverity, int, uint*, bool, void>)GLLoader.BindingsContext.GetProcAddress("glDebugMessageControl");
             _DebugMessageControl_fnptr(source, type, severity, count, ids, enabled);
         }
         
@@ -4759,7 +4759,7 @@ namespace OpenTK.Graphics.OpenGLES3
             _BlendFuncSeparatei_fnptr(buf, srcRGB, dstRGB, srcAlpha, dstAlpha);
         }
         
-        private static delegate* unmanaged<uint, byte, byte, byte, byte, void> _ColorMaski_fnptr = &ColorMaski_Lazy;
+        private static delegate* unmanaged<uint, bool, bool, bool, bool, void> _ColorMaski_fnptr = &ColorMaski_Lazy;
         /// <summary> <b>[requires: v3.2]</b> Enable and disable writing of frame buffer color components. </summary>
         /// <param name="buf"> For glColorMaski, specifies the index of the draw buffer whose color mask to set. </param>
         /// <param name="red"> Specify whether red, green, blue, and alpha are to be written into the frame buffer. The initial values are all GL_TRUE, indicating that the color components are written. </param>
@@ -4767,24 +4767,24 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="blue"> Specify whether red, green, blue, and alpha are to be written into the frame buffer. The initial values are all GL_TRUE, indicating that the color components are written. </param>
         /// <param name="alpha"> Specify whether red, green, blue, and alpha are to be written into the frame buffer. The initial values are all GL_TRUE, indicating that the color components are written. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglColorMask.xhtml" /></remarks>
-        public static void ColorMaski(uint index, byte r, byte g, byte b, byte a) => _ColorMaski_fnptr(index, r, g, b, a);
+        public static void ColorMaski(uint index, bool r, bool g, bool b, bool a) => _ColorMaski_fnptr(index, r, g, b, a);
         [UnmanagedCallersOnly]
-        private static void ColorMaski_Lazy(uint index, byte r, byte g, byte b, byte a)
+        private static void ColorMaski_Lazy(uint index, bool r, bool g, bool b, bool a)
         {
-            _ColorMaski_fnptr = (delegate* unmanaged<uint, byte, byte, byte, byte, void>)GLLoader.BindingsContext.GetProcAddress("glColorMaski");
+            _ColorMaski_fnptr = (delegate* unmanaged<uint, bool, bool, bool, bool, void>)GLLoader.BindingsContext.GetProcAddress("glColorMaski");
             _ColorMaski_fnptr(index, r, g, b, a);
         }
         
-        private static delegate* unmanaged<EnableCap, uint, byte> _IsEnabledi_fnptr = &IsEnabledi_Lazy;
+        private static delegate* unmanaged<EnableCap, uint, bool> _IsEnabledi_fnptr = &IsEnabledi_Lazy;
         /// <summary> <b>[requires: v3.2]</b> Test whether a capability is enabled. </summary>
         /// <param name="cap"> Specifies a symbolic constant indicating a GL capability. </param>
         /// <param name="index"> Specifies the index of the capability. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglIsEnabled.xhtml" /></remarks>
-        public static byte IsEnabledi(EnableCap target, uint index) => _IsEnabledi_fnptr(target, index);
+        public static bool IsEnabledi(EnableCap target, uint index) => _IsEnabledi_fnptr(target, index);
         [UnmanagedCallersOnly]
-        private static byte IsEnabledi_Lazy(EnableCap target, uint index)
+        private static bool IsEnabledi_Lazy(EnableCap target, uint index)
         {
-            _IsEnabledi_fnptr = (delegate* unmanaged<EnableCap, uint, byte>)GLLoader.BindingsContext.GetProcAddress("glIsEnabledi");
+            _IsEnabledi_fnptr = (delegate* unmanaged<EnableCap, uint, bool>)GLLoader.BindingsContext.GetProcAddress("glIsEnabledi");
             return _IsEnabledi_fnptr(target, index);
         }
         
@@ -5115,7 +5115,7 @@ namespace OpenTK.Graphics.OpenGLES3
             _TexBufferRange_fnptr(target, internalformat, buffer, offset, size);
         }
         
-        private static delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, int, byte, void> _TexStorage3DMultisample_fnptr = &TexStorage3DMultisample_Lazy;
+        private static delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, int, bool, void> _TexStorage3DMultisample_fnptr = &TexStorage3DMultisample_Lazy;
         /// <summary> <b>[requires: v3.2]</b> Specify storage for a two-dimensional multisample array texture. </summary>
         /// <param name="target"> Specifies the target to which the texture object is bound for glTexStorage3DMultisample. Must be GL_TEXTURE_2D_MULTISAMPLE_ARRAY. </param>
         /// <param name="samples"> Specify the number of samples in the texture. </param>
@@ -5125,11 +5125,11 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="depth"> Specifies the depth of the texture, in layers. </param>
         /// <param name="fixedsamplelocations"> Specifies whether the image will use identical sample locations and the same number of samples for all texels in the image, and the sample locations will not depend on the internal format or size of the image. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglTexStorage3DMultisample.xhtml" /></remarks>
-        public static void TexStorage3DMultisample(TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, int depth, byte fixedsamplelocations) => _TexStorage3DMultisample_fnptr(target, samples, internalformat, width, height, depth, fixedsamplelocations);
+        public static void TexStorage3DMultisample(TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, int depth, bool fixedsamplelocations) => _TexStorage3DMultisample_fnptr(target, samples, internalformat, width, height, depth, fixedsamplelocations);
         [UnmanagedCallersOnly]
-        private static void TexStorage3DMultisample_Lazy(TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, int depth, byte fixedsamplelocations)
+        private static void TexStorage3DMultisample_Lazy(TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, int depth, bool fixedsamplelocations)
         {
-            _TexStorage3DMultisample_fnptr = (delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, int, byte, void>)GLLoader.BindingsContext.GetProcAddress("glTexStorage3DMultisample");
+            _TexStorage3DMultisample_fnptr = (delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, int, bool, void>)GLLoader.BindingsContext.GetProcAddress("glTexStorage3DMultisample");
             _TexStorage3DMultisample_fnptr(target, samples, internalformat, width, height, depth, fixedsamplelocations);
         }
         
@@ -5234,14 +5234,14 @@ namespace OpenTK.Graphics.OpenGLES3
                 _DeletePerfMonitorsAMD_fnptr(n, monitors);
             }
             
-            private static delegate* unmanaged<uint, byte, uint, int, uint*, void> _SelectPerfMonitorCountersAMD_fnptr = &SelectPerfMonitorCountersAMD_Lazy;
+            private static delegate* unmanaged<uint, bool, uint, int, uint*, void> _SelectPerfMonitorCountersAMD_fnptr = &SelectPerfMonitorCountersAMD_Lazy;
             /// <summary> <b>[requires: GL_AMD_performance_monitor]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void SelectPerfMonitorCountersAMD(uint monitor, byte enable, uint group, int numCounters, uint* counterList) => _SelectPerfMonitorCountersAMD_fnptr(monitor, enable, group, numCounters, counterList);
+            public static void SelectPerfMonitorCountersAMD(uint monitor, bool enable, uint group, int numCounters, uint* counterList) => _SelectPerfMonitorCountersAMD_fnptr(monitor, enable, group, numCounters, counterList);
             [UnmanagedCallersOnly]
-            private static void SelectPerfMonitorCountersAMD_Lazy(uint monitor, byte enable, uint group, int numCounters, uint* counterList)
+            private static void SelectPerfMonitorCountersAMD_Lazy(uint monitor, bool enable, uint group, int numCounters, uint* counterList)
             {
-                _SelectPerfMonitorCountersAMD_fnptr = (delegate* unmanaged<uint, byte, uint, int, uint*, void>)GLLoader.BindingsContext.GetProcAddress("glSelectPerfMonitorCountersAMD");
+                _SelectPerfMonitorCountersAMD_fnptr = (delegate* unmanaged<uint, bool, uint, int, uint*, void>)GLLoader.BindingsContext.GetProcAddress("glSelectPerfMonitorCountersAMD");
                 _SelectPerfMonitorCountersAMD_fnptr(monitor, enable, group, numCounters, counterList);
             }
             
@@ -5394,14 +5394,14 @@ namespace OpenTK.Graphics.OpenGLES3
                 return _FenceSyncAPPLE_fnptr(condition, flags);
             }
             
-            private static delegate* unmanaged<GLSync, byte> _IsSyncAPPLE_fnptr = &IsSyncAPPLE_Lazy;
+            private static delegate* unmanaged<GLSync, bool> _IsSyncAPPLE_fnptr = &IsSyncAPPLE_Lazy;
             /// <summary> <b>[requires: GL_APPLE_sync]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsSyncAPPLE(GLSync sync) => _IsSyncAPPLE_fnptr(sync);
+            public static bool IsSyncAPPLE(GLSync sync) => _IsSyncAPPLE_fnptr(sync);
             [UnmanagedCallersOnly]
-            private static byte IsSyncAPPLE_Lazy(GLSync sync)
+            private static bool IsSyncAPPLE_Lazy(GLSync sync)
             {
-                _IsSyncAPPLE_fnptr = (delegate* unmanaged<GLSync, byte>)GLLoader.BindingsContext.GetProcAddress("glIsSyncAPPLE");
+                _IsSyncAPPLE_fnptr = (delegate* unmanaged<GLSync, bool>)GLLoader.BindingsContext.GetProcAddress("glIsSyncAPPLE");
                 return _IsSyncAPPLE_fnptr(sync);
             }
             
@@ -5716,14 +5716,14 @@ namespace OpenTK.Graphics.OpenGLES3
                 _DeleteQueriesEXT_fnptr(n, ids);
             }
             
-            private static delegate* unmanaged<QueryHandle, byte> _IsQueryEXT_fnptr = &IsQueryEXT_Lazy;
+            private static delegate* unmanaged<QueryHandle, bool> _IsQueryEXT_fnptr = &IsQueryEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_disjoint_timer_query | GL_EXT_occlusion_query_boolean]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsQueryEXT(QueryHandle id) => _IsQueryEXT_fnptr(id);
+            public static bool IsQueryEXT(QueryHandle id) => _IsQueryEXT_fnptr(id);
             [UnmanagedCallersOnly]
-            private static byte IsQueryEXT_Lazy(QueryHandle id)
+            private static bool IsQueryEXT_Lazy(QueryHandle id)
             {
-                _IsQueryEXT_fnptr = (delegate* unmanaged<QueryHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsQueryEXT");
+                _IsQueryEXT_fnptr = (delegate* unmanaged<QueryHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsQueryEXT");
                 return _IsQueryEXT_fnptr(id);
             }
             
@@ -5903,25 +5903,25 @@ namespace OpenTK.Graphics.OpenGLES3
                 _BlendFuncSeparateiEXT_fnptr(buf, srcRGB, dstRGB, srcAlpha, dstAlpha);
             }
             
-            private static delegate* unmanaged<uint, byte, byte, byte, byte, void> _ColorMaskiEXT_fnptr = &ColorMaskiEXT_Lazy;
+            private static delegate* unmanaged<uint, bool, bool, bool, bool, void> _ColorMaskiEXT_fnptr = &ColorMaskiEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_draw_buffers_indexed]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ColorMaskiEXT(uint index, byte r, byte g, byte b, byte a) => _ColorMaskiEXT_fnptr(index, r, g, b, a);
+            public static void ColorMaskiEXT(uint index, bool r, bool g, bool b, bool a) => _ColorMaskiEXT_fnptr(index, r, g, b, a);
             [UnmanagedCallersOnly]
-            private static void ColorMaskiEXT_Lazy(uint index, byte r, byte g, byte b, byte a)
+            private static void ColorMaskiEXT_Lazy(uint index, bool r, bool g, bool b, bool a)
             {
-                _ColorMaskiEXT_fnptr = (delegate* unmanaged<uint, byte, byte, byte, byte, void>)GLLoader.BindingsContext.GetProcAddress("glColorMaskiEXT");
+                _ColorMaskiEXT_fnptr = (delegate* unmanaged<uint, bool, bool, bool, bool, void>)GLLoader.BindingsContext.GetProcAddress("glColorMaskiEXT");
                 _ColorMaskiEXT_fnptr(index, r, g, b, a);
             }
             
-            private static delegate* unmanaged<EnableCap, uint, byte> _IsEnablediEXT_fnptr = &IsEnablediEXT_Lazy;
+            private static delegate* unmanaged<EnableCap, uint, bool> _IsEnablediEXT_fnptr = &IsEnablediEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_draw_buffers_indexed]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsEnablediEXT(EnableCap target, uint index) => _IsEnablediEXT_fnptr(target, index);
+            public static bool IsEnablediEXT(EnableCap target, uint index) => _IsEnablediEXT_fnptr(target, index);
             [UnmanagedCallersOnly]
-            private static byte IsEnablediEXT_Lazy(EnableCap target, uint index)
+            private static bool IsEnablediEXT_Lazy(EnableCap target, uint index)
             {
-                _IsEnablediEXT_fnptr = (delegate* unmanaged<EnableCap, uint, byte>)GLLoader.BindingsContext.GetProcAddress("glIsEnablediEXT");
+                _IsEnablediEXT_fnptr = (delegate* unmanaged<EnableCap, uint, bool>)GLLoader.BindingsContext.GetProcAddress("glIsEnablediEXT");
                 return _IsEnablediEXT_fnptr(target, index);
             }
             
@@ -6112,14 +6112,14 @@ namespace OpenTK.Graphics.OpenGLES3
                 _DeleteMemoryObjectsEXT_fnptr(n, memoryObjects);
             }
             
-            private static delegate* unmanaged<uint, byte> _IsMemoryObjectEXT_fnptr = &IsMemoryObjectEXT_Lazy;
+            private static delegate* unmanaged<uint, bool> _IsMemoryObjectEXT_fnptr = &IsMemoryObjectEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_memory_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsMemoryObjectEXT(uint memoryObject) => _IsMemoryObjectEXT_fnptr(memoryObject);
+            public static bool IsMemoryObjectEXT(uint memoryObject) => _IsMemoryObjectEXT_fnptr(memoryObject);
             [UnmanagedCallersOnly]
-            private static byte IsMemoryObjectEXT_Lazy(uint memoryObject)
+            private static bool IsMemoryObjectEXT_Lazy(uint memoryObject)
             {
-                _IsMemoryObjectEXT_fnptr = (delegate* unmanaged<uint, byte>)GLLoader.BindingsContext.GetProcAddress("glIsMemoryObjectEXT");
+                _IsMemoryObjectEXT_fnptr = (delegate* unmanaged<uint, bool>)GLLoader.BindingsContext.GetProcAddress("glIsMemoryObjectEXT");
                 return _IsMemoryObjectEXT_fnptr(memoryObject);
             }
             
@@ -6167,14 +6167,14 @@ namespace OpenTK.Graphics.OpenGLES3
                 _TexStorageMem2DEXT_fnptr(target, levels, internalFormat, width, height, memory, offset);
             }
             
-            private static delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, byte, uint, ulong, void> _TexStorageMem2DMultisampleEXT_fnptr = &TexStorageMem2DMultisampleEXT_Lazy;
+            private static delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, bool, uint, ulong, void> _TexStorageMem2DMultisampleEXT_fnptr = &TexStorageMem2DMultisampleEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_memory_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TexStorageMem2DMultisampleEXT(TextureTarget target, int samples, SizedInternalFormat internalFormat, int width, int height, byte fixedSampleLocations, uint memory, ulong offset) => _TexStorageMem2DMultisampleEXT_fnptr(target, samples, internalFormat, width, height, fixedSampleLocations, memory, offset);
+            public static void TexStorageMem2DMultisampleEXT(TextureTarget target, int samples, SizedInternalFormat internalFormat, int width, int height, bool fixedSampleLocations, uint memory, ulong offset) => _TexStorageMem2DMultisampleEXT_fnptr(target, samples, internalFormat, width, height, fixedSampleLocations, memory, offset);
             [UnmanagedCallersOnly]
-            private static void TexStorageMem2DMultisampleEXT_Lazy(TextureTarget target, int samples, SizedInternalFormat internalFormat, int width, int height, byte fixedSampleLocations, uint memory, ulong offset)
+            private static void TexStorageMem2DMultisampleEXT_Lazy(TextureTarget target, int samples, SizedInternalFormat internalFormat, int width, int height, bool fixedSampleLocations, uint memory, ulong offset)
             {
-                _TexStorageMem2DMultisampleEXT_fnptr = (delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, byte, uint, ulong, void>)GLLoader.BindingsContext.GetProcAddress("glTexStorageMem2DMultisampleEXT");
+                _TexStorageMem2DMultisampleEXT_fnptr = (delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, bool, uint, ulong, void>)GLLoader.BindingsContext.GetProcAddress("glTexStorageMem2DMultisampleEXT");
                 _TexStorageMem2DMultisampleEXT_fnptr(target, samples, internalFormat, width, height, fixedSampleLocations, memory, offset);
             }
             
@@ -6189,14 +6189,14 @@ namespace OpenTK.Graphics.OpenGLES3
                 _TexStorageMem3DEXT_fnptr(target, levels, internalFormat, width, height, depth, memory, offset);
             }
             
-            private static delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, int, byte, uint, ulong, void> _TexStorageMem3DMultisampleEXT_fnptr = &TexStorageMem3DMultisampleEXT_Lazy;
+            private static delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, int, bool, uint, ulong, void> _TexStorageMem3DMultisampleEXT_fnptr = &TexStorageMem3DMultisampleEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_memory_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TexStorageMem3DMultisampleEXT(TextureTarget target, int samples, SizedInternalFormat internalFormat, int width, int height, int depth, byte fixedSampleLocations, uint memory, ulong offset) => _TexStorageMem3DMultisampleEXT_fnptr(target, samples, internalFormat, width, height, depth, fixedSampleLocations, memory, offset);
+            public static void TexStorageMem3DMultisampleEXT(TextureTarget target, int samples, SizedInternalFormat internalFormat, int width, int height, int depth, bool fixedSampleLocations, uint memory, ulong offset) => _TexStorageMem3DMultisampleEXT_fnptr(target, samples, internalFormat, width, height, depth, fixedSampleLocations, memory, offset);
             [UnmanagedCallersOnly]
-            private static void TexStorageMem3DMultisampleEXT_Lazy(TextureTarget target, int samples, SizedInternalFormat internalFormat, int width, int height, int depth, byte fixedSampleLocations, uint memory, ulong offset)
+            private static void TexStorageMem3DMultisampleEXT_Lazy(TextureTarget target, int samples, SizedInternalFormat internalFormat, int width, int height, int depth, bool fixedSampleLocations, uint memory, ulong offset)
             {
-                _TexStorageMem3DMultisampleEXT_fnptr = (delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, int, byte, uint, ulong, void>)GLLoader.BindingsContext.GetProcAddress("glTexStorageMem3DMultisampleEXT");
+                _TexStorageMem3DMultisampleEXT_fnptr = (delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, int, bool, uint, ulong, void>)GLLoader.BindingsContext.GetProcAddress("glTexStorageMem3DMultisampleEXT");
                 _TexStorageMem3DMultisampleEXT_fnptr(target, samples, internalFormat, width, height, depth, fixedSampleLocations, memory, offset);
             }
             
@@ -6222,14 +6222,14 @@ namespace OpenTK.Graphics.OpenGLES3
                 _TextureStorageMem2DEXT_fnptr(texture, levels, internalFormat, width, height, memory, offset);
             }
             
-            private static delegate* unmanaged<TextureHandle, int, SizedInternalFormat, int, int, byte, uint, ulong, void> _TextureStorageMem2DMultisampleEXT_fnptr = &TextureStorageMem2DMultisampleEXT_Lazy;
+            private static delegate* unmanaged<TextureHandle, int, SizedInternalFormat, int, int, bool, uint, ulong, void> _TextureStorageMem2DMultisampleEXT_fnptr = &TextureStorageMem2DMultisampleEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_memory_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureStorageMem2DMultisampleEXT(TextureHandle texture, int samples, SizedInternalFormat internalFormat, int width, int height, byte fixedSampleLocations, uint memory, ulong offset) => _TextureStorageMem2DMultisampleEXT_fnptr(texture, samples, internalFormat, width, height, fixedSampleLocations, memory, offset);
+            public static void TextureStorageMem2DMultisampleEXT(TextureHandle texture, int samples, SizedInternalFormat internalFormat, int width, int height, bool fixedSampleLocations, uint memory, ulong offset) => _TextureStorageMem2DMultisampleEXT_fnptr(texture, samples, internalFormat, width, height, fixedSampleLocations, memory, offset);
             [UnmanagedCallersOnly]
-            private static void TextureStorageMem2DMultisampleEXT_Lazy(TextureHandle texture, int samples, SizedInternalFormat internalFormat, int width, int height, byte fixedSampleLocations, uint memory, ulong offset)
+            private static void TextureStorageMem2DMultisampleEXT_Lazy(TextureHandle texture, int samples, SizedInternalFormat internalFormat, int width, int height, bool fixedSampleLocations, uint memory, ulong offset)
             {
-                _TextureStorageMem2DMultisampleEXT_fnptr = (delegate* unmanaged<TextureHandle, int, SizedInternalFormat, int, int, byte, uint, ulong, void>)GLLoader.BindingsContext.GetProcAddress("glTextureStorageMem2DMultisampleEXT");
+                _TextureStorageMem2DMultisampleEXT_fnptr = (delegate* unmanaged<TextureHandle, int, SizedInternalFormat, int, int, bool, uint, ulong, void>)GLLoader.BindingsContext.GetProcAddress("glTextureStorageMem2DMultisampleEXT");
                 _TextureStorageMem2DMultisampleEXT_fnptr(texture, samples, internalFormat, width, height, fixedSampleLocations, memory, offset);
             }
             
@@ -6244,14 +6244,14 @@ namespace OpenTK.Graphics.OpenGLES3
                 _TextureStorageMem3DEXT_fnptr(texture, levels, internalFormat, width, height, depth, memory, offset);
             }
             
-            private static delegate* unmanaged<TextureHandle, int, SizedInternalFormat, int, int, int, byte, uint, ulong, void> _TextureStorageMem3DMultisampleEXT_fnptr = &TextureStorageMem3DMultisampleEXT_Lazy;
+            private static delegate* unmanaged<TextureHandle, int, SizedInternalFormat, int, int, int, bool, uint, ulong, void> _TextureStorageMem3DMultisampleEXT_fnptr = &TextureStorageMem3DMultisampleEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_memory_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureStorageMem3DMultisampleEXT(TextureHandle texture, int samples, SizedInternalFormat internalFormat, int width, int height, int depth, byte fixedSampleLocations, uint memory, ulong offset) => _TextureStorageMem3DMultisampleEXT_fnptr(texture, samples, internalFormat, width, height, depth, fixedSampleLocations, memory, offset);
+            public static void TextureStorageMem3DMultisampleEXT(TextureHandle texture, int samples, SizedInternalFormat internalFormat, int width, int height, int depth, bool fixedSampleLocations, uint memory, ulong offset) => _TextureStorageMem3DMultisampleEXT_fnptr(texture, samples, internalFormat, width, height, depth, fixedSampleLocations, memory, offset);
             [UnmanagedCallersOnly]
-            private static void TextureStorageMem3DMultisampleEXT_Lazy(TextureHandle texture, int samples, SizedInternalFormat internalFormat, int width, int height, int depth, byte fixedSampleLocations, uint memory, ulong offset)
+            private static void TextureStorageMem3DMultisampleEXT_Lazy(TextureHandle texture, int samples, SizedInternalFormat internalFormat, int width, int height, int depth, bool fixedSampleLocations, uint memory, ulong offset)
             {
-                _TextureStorageMem3DMultisampleEXT_fnptr = (delegate* unmanaged<TextureHandle, int, SizedInternalFormat, int, int, int, byte, uint, ulong, void>)GLLoader.BindingsContext.GetProcAddress("glTextureStorageMem3DMultisampleEXT");
+                _TextureStorageMem3DMultisampleEXT_fnptr = (delegate* unmanaged<TextureHandle, int, SizedInternalFormat, int, int, int, bool, uint, ulong, void>)GLLoader.BindingsContext.GetProcAddress("glTextureStorageMem3DMultisampleEXT");
                 _TextureStorageMem3DMultisampleEXT_fnptr(texture, samples, internalFormat, width, height, depth, fixedSampleLocations, memory, offset);
             }
             
@@ -6442,14 +6442,14 @@ namespace OpenTK.Graphics.OpenGLES3
                 _PrimitiveBoundingBoxEXT_fnptr(minX, minY, minZ, minW, maxX, maxY, maxZ, maxW);
             }
             
-            private static delegate* unmanaged<uint, byte, void> _RasterSamplesEXT_fnptr = &RasterSamplesEXT_Lazy;
+            private static delegate* unmanaged<uint, bool, void> _RasterSamplesEXT_fnptr = &RasterSamplesEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_raster_multisample | GL_NV_framebuffer_mixed_samples]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void RasterSamplesEXT(uint samples, byte fixedsamplelocations) => _RasterSamplesEXT_fnptr(samples, fixedsamplelocations);
+            public static void RasterSamplesEXT(uint samples, bool fixedsamplelocations) => _RasterSamplesEXT_fnptr(samples, fixedsamplelocations);
             [UnmanagedCallersOnly]
-            private static void RasterSamplesEXT_Lazy(uint samples, byte fixedsamplelocations)
+            private static void RasterSamplesEXT_Lazy(uint samples, bool fixedsamplelocations)
             {
-                _RasterSamplesEXT_fnptr = (delegate* unmanaged<uint, byte, void>)GLLoader.BindingsContext.GetProcAddress("glRasterSamplesEXT");
+                _RasterSamplesEXT_fnptr = (delegate* unmanaged<uint, bool, void>)GLLoader.BindingsContext.GetProcAddress("glRasterSamplesEXT");
                 _RasterSamplesEXT_fnptr(samples, fixedsamplelocations);
             }
             
@@ -6519,14 +6519,14 @@ namespace OpenTK.Graphics.OpenGLES3
                 _DeleteSemaphoresEXT_fnptr(n, semaphores);
             }
             
-            private static delegate* unmanaged<uint, byte> _IsSemaphoreEXT_fnptr = &IsSemaphoreEXT_Lazy;
+            private static delegate* unmanaged<uint, bool> _IsSemaphoreEXT_fnptr = &IsSemaphoreEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_semaphore]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsSemaphoreEXT(uint semaphore) => _IsSemaphoreEXT_fnptr(semaphore);
+            public static bool IsSemaphoreEXT(uint semaphore) => _IsSemaphoreEXT_fnptr(semaphore);
             [UnmanagedCallersOnly]
-            private static byte IsSemaphoreEXT_Lazy(uint semaphore)
+            private static bool IsSemaphoreEXT_Lazy(uint semaphore)
             {
-                _IsSemaphoreEXT_fnptr = (delegate* unmanaged<uint, byte>)GLLoader.BindingsContext.GetProcAddress("glIsSemaphoreEXT");
+                _IsSemaphoreEXT_fnptr = (delegate* unmanaged<uint, bool>)GLLoader.BindingsContext.GetProcAddress("glIsSemaphoreEXT");
                 return _IsSemaphoreEXT_fnptr(semaphore);
             }
             
@@ -6717,14 +6717,14 @@ namespace OpenTK.Graphics.OpenGLES3
                 _GetProgramPipelineivEXT_fnptr(pipeline, pname, parameters);
             }
             
-            private static delegate* unmanaged<ProgramPipelineHandle, byte> _IsProgramPipelineEXT_fnptr = &IsProgramPipelineEXT_Lazy;
+            private static delegate* unmanaged<ProgramPipelineHandle, bool> _IsProgramPipelineEXT_fnptr = &IsProgramPipelineEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsProgramPipelineEXT(ProgramPipelineHandle pipeline) => _IsProgramPipelineEXT_fnptr(pipeline);
+            public static bool IsProgramPipelineEXT(ProgramPipelineHandle pipeline) => _IsProgramPipelineEXT_fnptr(pipeline);
             [UnmanagedCallersOnly]
-            private static byte IsProgramPipelineEXT_Lazy(ProgramPipelineHandle pipeline)
+            private static bool IsProgramPipelineEXT_Lazy(ProgramPipelineHandle pipeline)
             {
-                _IsProgramPipelineEXT_fnptr = (delegate* unmanaged<ProgramPipelineHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsProgramPipelineEXT");
+                _IsProgramPipelineEXT_fnptr = (delegate* unmanaged<ProgramPipelineHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsProgramPipelineEXT");
                 return _IsProgramPipelineEXT_fnptr(pipeline);
             }
             
@@ -6915,36 +6915,36 @@ namespace OpenTK.Graphics.OpenGLES3
                 _ProgramUniform4ivEXT_fnptr(program, location, count, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix2fvEXT_fnptr = &ProgramUniformMatrix2fvEXT_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix2fvEXT_fnptr = &ProgramUniformMatrix2fvEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix2fvEXT(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix2fvEXT_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix2fvEXT(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix2fvEXT_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix2fvEXT_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+            private static void ProgramUniformMatrix2fvEXT_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
             {
-                _ProgramUniformMatrix2fvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2fvEXT");
+                _ProgramUniformMatrix2fvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2fvEXT");
                 _ProgramUniformMatrix2fvEXT_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix3fvEXT_fnptr = &ProgramUniformMatrix3fvEXT_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix3fvEXT_fnptr = &ProgramUniformMatrix3fvEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix3fvEXT(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix3fvEXT_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix3fvEXT(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix3fvEXT_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix3fvEXT_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+            private static void ProgramUniformMatrix3fvEXT_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
             {
-                _ProgramUniformMatrix3fvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3fvEXT");
+                _ProgramUniformMatrix3fvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3fvEXT");
                 _ProgramUniformMatrix3fvEXT_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix4fvEXT_fnptr = &ProgramUniformMatrix4fvEXT_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix4fvEXT_fnptr = &ProgramUniformMatrix4fvEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix4fvEXT(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix4fvEXT_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix4fvEXT(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix4fvEXT_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix4fvEXT_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+            private static void ProgramUniformMatrix4fvEXT_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
             {
-                _ProgramUniformMatrix4fvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4fvEXT");
+                _ProgramUniformMatrix4fvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4fvEXT");
                 _ProgramUniformMatrix4fvEXT_fnptr(program, location, count, transpose, value);
             }
             
@@ -7058,69 +7058,69 @@ namespace OpenTK.Graphics.OpenGLES3
                 _ProgramUniform4uivEXT_fnptr(program, location, count, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix2x3fvEXT_fnptr = &ProgramUniformMatrix2x3fvEXT_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix2x3fvEXT_fnptr = &ProgramUniformMatrix2x3fvEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix2x3fvEXT(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix2x3fvEXT_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix2x3fvEXT(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix2x3fvEXT_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix2x3fvEXT_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+            private static void ProgramUniformMatrix2x3fvEXT_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
             {
-                _ProgramUniformMatrix2x3fvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2x3fvEXT");
+                _ProgramUniformMatrix2x3fvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2x3fvEXT");
                 _ProgramUniformMatrix2x3fvEXT_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix3x2fvEXT_fnptr = &ProgramUniformMatrix3x2fvEXT_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix3x2fvEXT_fnptr = &ProgramUniformMatrix3x2fvEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix3x2fvEXT(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix3x2fvEXT_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix3x2fvEXT(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix3x2fvEXT_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix3x2fvEXT_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+            private static void ProgramUniformMatrix3x2fvEXT_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
             {
-                _ProgramUniformMatrix3x2fvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3x2fvEXT");
+                _ProgramUniformMatrix3x2fvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3x2fvEXT");
                 _ProgramUniformMatrix3x2fvEXT_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix2x4fvEXT_fnptr = &ProgramUniformMatrix2x4fvEXT_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix2x4fvEXT_fnptr = &ProgramUniformMatrix2x4fvEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix2x4fvEXT(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix2x4fvEXT_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix2x4fvEXT(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix2x4fvEXT_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix2x4fvEXT_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+            private static void ProgramUniformMatrix2x4fvEXT_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
             {
-                _ProgramUniformMatrix2x4fvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2x4fvEXT");
+                _ProgramUniformMatrix2x4fvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix2x4fvEXT");
                 _ProgramUniformMatrix2x4fvEXT_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix4x2fvEXT_fnptr = &ProgramUniformMatrix4x2fvEXT_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix4x2fvEXT_fnptr = &ProgramUniformMatrix4x2fvEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix4x2fvEXT(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix4x2fvEXT_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix4x2fvEXT(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix4x2fvEXT_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix4x2fvEXT_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+            private static void ProgramUniformMatrix4x2fvEXT_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
             {
-                _ProgramUniformMatrix4x2fvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4x2fvEXT");
+                _ProgramUniformMatrix4x2fvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4x2fvEXT");
                 _ProgramUniformMatrix4x2fvEXT_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix3x4fvEXT_fnptr = &ProgramUniformMatrix3x4fvEXT_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix3x4fvEXT_fnptr = &ProgramUniformMatrix3x4fvEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix3x4fvEXT(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix3x4fvEXT_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix3x4fvEXT(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix3x4fvEXT_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix3x4fvEXT_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+            private static void ProgramUniformMatrix3x4fvEXT_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
             {
-                _ProgramUniformMatrix3x4fvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3x4fvEXT");
+                _ProgramUniformMatrix3x4fvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix3x4fvEXT");
                 _ProgramUniformMatrix3x4fvEXT_fnptr(program, location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<ProgramHandle, int, int, byte, float*, void> _ProgramUniformMatrix4x3fvEXT_fnptr = &ProgramUniformMatrix4x3fvEXT_Lazy;
+            private static delegate* unmanaged<ProgramHandle, int, int, bool, float*, void> _ProgramUniformMatrix4x3fvEXT_fnptr = &ProgramUniformMatrix4x3fvEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix4x3fvEXT(ProgramHandle program, int location, int count, byte transpose, float* value) => _ProgramUniformMatrix4x3fvEXT_fnptr(program, location, count, transpose, value);
+            public static void ProgramUniformMatrix4x3fvEXT(ProgramHandle program, int location, int count, bool transpose, float* value) => _ProgramUniformMatrix4x3fvEXT_fnptr(program, location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void ProgramUniformMatrix4x3fvEXT_Lazy(ProgramHandle program, int location, int count, byte transpose, float* value)
+            private static void ProgramUniformMatrix4x3fvEXT_Lazy(ProgramHandle program, int location, int count, bool transpose, float* value)
             {
-                _ProgramUniformMatrix4x3fvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4x3fvEXT");
+                _ProgramUniformMatrix4x3fvEXT_fnptr = (delegate* unmanaged<ProgramHandle, int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glProgramUniformMatrix4x3fvEXT");
                 _ProgramUniformMatrix4x3fvEXT_fnptr(program, location, count, transpose, value);
             }
             
@@ -7168,14 +7168,14 @@ namespace OpenTK.Graphics.OpenGLES3
                 _ClearPixelLocalStorageuiEXT_fnptr(offset, n, values);
             }
             
-            private static delegate* unmanaged<All, int, int, int, int, int, int, int, byte, void> _TexPageCommitmentEXT_fnptr = &TexPageCommitmentEXT_Lazy;
+            private static delegate* unmanaged<All, int, int, int, int, int, int, int, bool, void> _TexPageCommitmentEXT_fnptr = &TexPageCommitmentEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_sparse_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TexPageCommitmentEXT(All target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, byte commit) => _TexPageCommitmentEXT_fnptr(target, level, xoffset, yoffset, zoffset, width, height, depth, commit);
+            public static void TexPageCommitmentEXT(All target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, bool commit) => _TexPageCommitmentEXT_fnptr(target, level, xoffset, yoffset, zoffset, width, height, depth, commit);
             [UnmanagedCallersOnly]
-            private static void TexPageCommitmentEXT_Lazy(All target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, byte commit)
+            private static void TexPageCommitmentEXT_Lazy(All target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, bool commit)
             {
-                _TexPageCommitmentEXT_fnptr = (delegate* unmanaged<All, int, int, int, int, int, int, int, byte, void>)GLLoader.BindingsContext.GetProcAddress("glTexPageCommitmentEXT");
+                _TexPageCommitmentEXT_fnptr = (delegate* unmanaged<All, int, int, int, int, int, int, int, bool, void>)GLLoader.BindingsContext.GetProcAddress("glTexPageCommitmentEXT");
                 _TexPageCommitmentEXT_fnptr(target, level, xoffset, yoffset, zoffset, width, height, depth, commit);
             }
             
@@ -7399,25 +7399,25 @@ namespace OpenTK.Graphics.OpenGLES3
                 _TextureViewEXT_fnptr(texture, target, origtexture, internalformat, minlevel, numlevels, minlayer, numlayers);
             }
             
-            private static delegate* unmanaged<uint, ulong, uint, byte> _AcquireKeyedMutexWin32EXT_fnptr = &AcquireKeyedMutexWin32EXT_Lazy;
+            private static delegate* unmanaged<uint, ulong, uint, bool> _AcquireKeyedMutexWin32EXT_fnptr = &AcquireKeyedMutexWin32EXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_win32_keyed_mutex]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte AcquireKeyedMutexWin32EXT(uint memory, ulong key, uint timeout) => _AcquireKeyedMutexWin32EXT_fnptr(memory, key, timeout);
+            public static bool AcquireKeyedMutexWin32EXT(uint memory, ulong key, uint timeout) => _AcquireKeyedMutexWin32EXT_fnptr(memory, key, timeout);
             [UnmanagedCallersOnly]
-            private static byte AcquireKeyedMutexWin32EXT_Lazy(uint memory, ulong key, uint timeout)
+            private static bool AcquireKeyedMutexWin32EXT_Lazy(uint memory, ulong key, uint timeout)
             {
-                _AcquireKeyedMutexWin32EXT_fnptr = (delegate* unmanaged<uint, ulong, uint, byte>)GLLoader.BindingsContext.GetProcAddress("glAcquireKeyedMutexWin32EXT");
+                _AcquireKeyedMutexWin32EXT_fnptr = (delegate* unmanaged<uint, ulong, uint, bool>)GLLoader.BindingsContext.GetProcAddress("glAcquireKeyedMutexWin32EXT");
                 return _AcquireKeyedMutexWin32EXT_fnptr(memory, key, timeout);
             }
             
-            private static delegate* unmanaged<uint, ulong, byte> _ReleaseKeyedMutexWin32EXT_fnptr = &ReleaseKeyedMutexWin32EXT_Lazy;
+            private static delegate* unmanaged<uint, ulong, bool> _ReleaseKeyedMutexWin32EXT_fnptr = &ReleaseKeyedMutexWin32EXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_win32_keyed_mutex]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte ReleaseKeyedMutexWin32EXT(uint memory, ulong key) => _ReleaseKeyedMutexWin32EXT_fnptr(memory, key);
+            public static bool ReleaseKeyedMutexWin32EXT(uint memory, ulong key) => _ReleaseKeyedMutexWin32EXT_fnptr(memory, key);
             [UnmanagedCallersOnly]
-            private static byte ReleaseKeyedMutexWin32EXT_Lazy(uint memory, ulong key)
+            private static bool ReleaseKeyedMutexWin32EXT_Lazy(uint memory, ulong key)
             {
-                _ReleaseKeyedMutexWin32EXT_fnptr = (delegate* unmanaged<uint, ulong, byte>)GLLoader.BindingsContext.GetProcAddress("glReleaseKeyedMutexWin32EXT");
+                _ReleaseKeyedMutexWin32EXT_fnptr = (delegate* unmanaged<uint, ulong, bool>)GLLoader.BindingsContext.GetProcAddress("glReleaseKeyedMutexWin32EXT");
                 return _ReleaseKeyedMutexWin32EXT_fnptr(memory, key);
             }
             
@@ -7512,14 +7512,14 @@ namespace OpenTK.Graphics.OpenGLES3
                 _MakeTextureHandleNonResidentNV_fnptr(handle);
             }
             
-            private static delegate* unmanaged<TextureHandle, int, byte, int, PixelFormat, ulong> _GetImageHandleNV_fnptr = &GetImageHandleNV_Lazy;
+            private static delegate* unmanaged<TextureHandle, int, bool, int, PixelFormat, ulong> _GetImageHandleNV_fnptr = &GetImageHandleNV_Lazy;
             /// <summary> <b>[requires: GL_NV_bindless_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static ulong GetImageHandleNV(TextureHandle texture, int level, byte layered, int layer, PixelFormat format) => _GetImageHandleNV_fnptr(texture, level, layered, layer, format);
+            public static ulong GetImageHandleNV(TextureHandle texture, int level, bool layered, int layer, PixelFormat format) => _GetImageHandleNV_fnptr(texture, level, layered, layer, format);
             [UnmanagedCallersOnly]
-            private static ulong GetImageHandleNV_Lazy(TextureHandle texture, int level, byte layered, int layer, PixelFormat format)
+            private static ulong GetImageHandleNV_Lazy(TextureHandle texture, int level, bool layered, int layer, PixelFormat format)
             {
-                _GetImageHandleNV_fnptr = (delegate* unmanaged<TextureHandle, int, byte, int, PixelFormat, ulong>)GLLoader.BindingsContext.GetProcAddress("glGetImageHandleNV");
+                _GetImageHandleNV_fnptr = (delegate* unmanaged<TextureHandle, int, bool, int, PixelFormat, ulong>)GLLoader.BindingsContext.GetProcAddress("glGetImageHandleNV");
                 return _GetImageHandleNV_fnptr(texture, level, layered, layer, format);
             }
             
@@ -7589,25 +7589,25 @@ namespace OpenTK.Graphics.OpenGLES3
                 _ProgramUniformHandleui64vNV_fnptr(program, location, count, values);
             }
             
-            private static delegate* unmanaged<ulong, byte> _IsTextureHandleResidentNV_fnptr = &IsTextureHandleResidentNV_Lazy;
+            private static delegate* unmanaged<ulong, bool> _IsTextureHandleResidentNV_fnptr = &IsTextureHandleResidentNV_Lazy;
             /// <summary> <b>[requires: GL_NV_bindless_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsTextureHandleResidentNV(ulong handle) => _IsTextureHandleResidentNV_fnptr(handle);
+            public static bool IsTextureHandleResidentNV(ulong handle) => _IsTextureHandleResidentNV_fnptr(handle);
             [UnmanagedCallersOnly]
-            private static byte IsTextureHandleResidentNV_Lazy(ulong handle)
+            private static bool IsTextureHandleResidentNV_Lazy(ulong handle)
             {
-                _IsTextureHandleResidentNV_fnptr = (delegate* unmanaged<ulong, byte>)GLLoader.BindingsContext.GetProcAddress("glIsTextureHandleResidentNV");
+                _IsTextureHandleResidentNV_fnptr = (delegate* unmanaged<ulong, bool>)GLLoader.BindingsContext.GetProcAddress("glIsTextureHandleResidentNV");
                 return _IsTextureHandleResidentNV_fnptr(handle);
             }
             
-            private static delegate* unmanaged<ulong, byte> _IsImageHandleResidentNV_fnptr = &IsImageHandleResidentNV_Lazy;
+            private static delegate* unmanaged<ulong, bool> _IsImageHandleResidentNV_fnptr = &IsImageHandleResidentNV_Lazy;
             /// <summary> <b>[requires: GL_NV_bindless_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsImageHandleResidentNV(ulong handle) => _IsImageHandleResidentNV_fnptr(handle);
+            public static bool IsImageHandleResidentNV(ulong handle) => _IsImageHandleResidentNV_fnptr(handle);
             [UnmanagedCallersOnly]
-            private static byte IsImageHandleResidentNV_Lazy(ulong handle)
+            private static bool IsImageHandleResidentNV_Lazy(ulong handle)
             {
-                _IsImageHandleResidentNV_fnptr = (delegate* unmanaged<ulong, byte>)GLLoader.BindingsContext.GetProcAddress("glIsImageHandleResidentNV");
+                _IsImageHandleResidentNV_fnptr = (delegate* unmanaged<ulong, bool>)GLLoader.BindingsContext.GetProcAddress("glIsImageHandleResidentNV");
                 return _IsImageHandleResidentNV_fnptr(handle);
             }
             
@@ -7699,14 +7699,14 @@ namespace OpenTK.Graphics.OpenGLES3
                 _CopyBufferSubDataNV_fnptr(readTarget, writeTarget, readOffset, writeOffset, size);
             }
             
-            private static delegate* unmanaged<byte, void> _CoverageMaskNV_fnptr = &CoverageMaskNV_Lazy;
+            private static delegate* unmanaged<bool, void> _CoverageMaskNV_fnptr = &CoverageMaskNV_Lazy;
             /// <summary> <b>[requires: GL_NV_coverage_sample]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void CoverageMaskNV(byte mask) => _CoverageMaskNV_fnptr(mask);
+            public static void CoverageMaskNV(bool mask) => _CoverageMaskNV_fnptr(mask);
             [UnmanagedCallersOnly]
-            private static void CoverageMaskNV_Lazy(byte mask)
+            private static void CoverageMaskNV_Lazy(bool mask)
             {
-                _CoverageMaskNV_fnptr = (delegate* unmanaged<byte, void>)GLLoader.BindingsContext.GetProcAddress("glCoverageMaskNV");
+                _CoverageMaskNV_fnptr = (delegate* unmanaged<bool, void>)GLLoader.BindingsContext.GetProcAddress("glCoverageMaskNV");
                 _CoverageMaskNV_fnptr(mask);
             }
             
@@ -7831,25 +7831,25 @@ namespace OpenTK.Graphics.OpenGLES3
                 _GenFencesNV_fnptr(n, fences);
             }
             
-            private static delegate* unmanaged<uint, byte> _IsFenceNV_fnptr = &IsFenceNV_Lazy;
+            private static delegate* unmanaged<uint, bool> _IsFenceNV_fnptr = &IsFenceNV_Lazy;
             /// <summary> <b>[requires: GL_NV_fence]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsFenceNV(uint fence) => _IsFenceNV_fnptr(fence);
+            public static bool IsFenceNV(uint fence) => _IsFenceNV_fnptr(fence);
             [UnmanagedCallersOnly]
-            private static byte IsFenceNV_Lazy(uint fence)
+            private static bool IsFenceNV_Lazy(uint fence)
             {
-                _IsFenceNV_fnptr = (delegate* unmanaged<uint, byte>)GLLoader.BindingsContext.GetProcAddress("glIsFenceNV");
+                _IsFenceNV_fnptr = (delegate* unmanaged<uint, bool>)GLLoader.BindingsContext.GetProcAddress("glIsFenceNV");
                 return _IsFenceNV_fnptr(fence);
             }
             
-            private static delegate* unmanaged<uint, byte> _TestFenceNV_fnptr = &TestFenceNV_Lazy;
+            private static delegate* unmanaged<uint, bool> _TestFenceNV_fnptr = &TestFenceNV_Lazy;
             /// <summary> <b>[requires: GL_NV_fence]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte TestFenceNV(uint fence) => _TestFenceNV_fnptr(fence);
+            public static bool TestFenceNV(uint fence) => _TestFenceNV_fnptr(fence);
             [UnmanagedCallersOnly]
-            private static byte TestFenceNV_Lazy(uint fence)
+            private static bool TestFenceNV_Lazy(uint fence)
             {
-                _TestFenceNV_fnptr = (delegate* unmanaged<uint, byte>)GLLoader.BindingsContext.GetProcAddress("glTestFenceNV");
+                _TestFenceNV_fnptr = (delegate* unmanaged<uint, bool>)GLLoader.BindingsContext.GetProcAddress("glTestFenceNV");
                 return _TestFenceNV_fnptr(fence);
             }
             
@@ -7908,14 +7908,14 @@ namespace OpenTK.Graphics.OpenGLES3
                 _BlitFramebufferNV_fnptr(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
             }
             
-            private static delegate* unmanaged<uint, byte, void> _RasterSamplesEXT_fnptr = &RasterSamplesEXT_Lazy;
+            private static delegate* unmanaged<uint, bool, void> _RasterSamplesEXT_fnptr = &RasterSamplesEXT_Lazy;
             /// <summary> <b>[requires: GL_EXT_raster_multisample | GL_NV_framebuffer_mixed_samples]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void RasterSamplesEXT(uint samples, byte fixedsamplelocations) => _RasterSamplesEXT_fnptr(samples, fixedsamplelocations);
+            public static void RasterSamplesEXT(uint samples, bool fixedsamplelocations) => _RasterSamplesEXT_fnptr(samples, fixedsamplelocations);
             [UnmanagedCallersOnly]
-            private static void RasterSamplesEXT_Lazy(uint samples, byte fixedsamplelocations)
+            private static void RasterSamplesEXT_Lazy(uint samples, bool fixedsamplelocations)
             {
-                _RasterSamplesEXT_fnptr = (delegate* unmanaged<uint, byte, void>)GLLoader.BindingsContext.GetProcAddress("glRasterSamplesEXT");
+                _RasterSamplesEXT_fnptr = (delegate* unmanaged<uint, bool, void>)GLLoader.BindingsContext.GetProcAddress("glRasterSamplesEXT");
                 _RasterSamplesEXT_fnptr(samples, fixedsamplelocations);
             }
             
@@ -8414,47 +8414,47 @@ namespace OpenTK.Graphics.OpenGLES3
                 _NamedBufferAttachMemoryNV_fnptr(buffer, memory, offset);
             }
             
-            private static delegate* unmanaged<BufferStorageTarget, IntPtr, nint, uint, ulong, byte, void> _BufferPageCommitmentMemNV_fnptr = &BufferPageCommitmentMemNV_Lazy;
+            private static delegate* unmanaged<BufferStorageTarget, IntPtr, nint, uint, ulong, bool, void> _BufferPageCommitmentMemNV_fnptr = &BufferPageCommitmentMemNV_Lazy;
             /// <summary> <b>[requires: GL_NV_memory_object_sparse]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void BufferPageCommitmentMemNV(BufferStorageTarget target, IntPtr offset, nint size, uint memory, ulong memOffset, byte commit) => _BufferPageCommitmentMemNV_fnptr(target, offset, size, memory, memOffset, commit);
+            public static void BufferPageCommitmentMemNV(BufferStorageTarget target, IntPtr offset, nint size, uint memory, ulong memOffset, bool commit) => _BufferPageCommitmentMemNV_fnptr(target, offset, size, memory, memOffset, commit);
             [UnmanagedCallersOnly]
-            private static void BufferPageCommitmentMemNV_Lazy(BufferStorageTarget target, IntPtr offset, nint size, uint memory, ulong memOffset, byte commit)
+            private static void BufferPageCommitmentMemNV_Lazy(BufferStorageTarget target, IntPtr offset, nint size, uint memory, ulong memOffset, bool commit)
             {
-                _BufferPageCommitmentMemNV_fnptr = (delegate* unmanaged<BufferStorageTarget, IntPtr, nint, uint, ulong, byte, void>)GLLoader.BindingsContext.GetProcAddress("glBufferPageCommitmentMemNV");
+                _BufferPageCommitmentMemNV_fnptr = (delegate* unmanaged<BufferStorageTarget, IntPtr, nint, uint, ulong, bool, void>)GLLoader.BindingsContext.GetProcAddress("glBufferPageCommitmentMemNV");
                 _BufferPageCommitmentMemNV_fnptr(target, offset, size, memory, memOffset, commit);
             }
             
-            private static delegate* unmanaged<TextureTarget, int, int, int, int, int, int, int, int, uint, ulong, byte, void> _TexPageCommitmentMemNV_fnptr = &TexPageCommitmentMemNV_Lazy;
+            private static delegate* unmanaged<TextureTarget, int, int, int, int, int, int, int, int, uint, ulong, bool, void> _TexPageCommitmentMemNV_fnptr = &TexPageCommitmentMemNV_Lazy;
             /// <summary> <b>[requires: GL_NV_memory_object_sparse]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TexPageCommitmentMemNV(TextureTarget target, int layer, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, uint memory, ulong offset, byte commit) => _TexPageCommitmentMemNV_fnptr(target, layer, level, xoffset, yoffset, zoffset, width, height, depth, memory, offset, commit);
+            public static void TexPageCommitmentMemNV(TextureTarget target, int layer, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, uint memory, ulong offset, bool commit) => _TexPageCommitmentMemNV_fnptr(target, layer, level, xoffset, yoffset, zoffset, width, height, depth, memory, offset, commit);
             [UnmanagedCallersOnly]
-            private static void TexPageCommitmentMemNV_Lazy(TextureTarget target, int layer, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, uint memory, ulong offset, byte commit)
+            private static void TexPageCommitmentMemNV_Lazy(TextureTarget target, int layer, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, uint memory, ulong offset, bool commit)
             {
-                _TexPageCommitmentMemNV_fnptr = (delegate* unmanaged<TextureTarget, int, int, int, int, int, int, int, int, uint, ulong, byte, void>)GLLoader.BindingsContext.GetProcAddress("glTexPageCommitmentMemNV");
+                _TexPageCommitmentMemNV_fnptr = (delegate* unmanaged<TextureTarget, int, int, int, int, int, int, int, int, uint, ulong, bool, void>)GLLoader.BindingsContext.GetProcAddress("glTexPageCommitmentMemNV");
                 _TexPageCommitmentMemNV_fnptr(target, layer, level, xoffset, yoffset, zoffset, width, height, depth, memory, offset, commit);
             }
             
-            private static delegate* unmanaged<BufferHandle, IntPtr, nint, uint, ulong, byte, void> _NamedBufferPageCommitmentMemNV_fnptr = &NamedBufferPageCommitmentMemNV_Lazy;
+            private static delegate* unmanaged<BufferHandle, IntPtr, nint, uint, ulong, bool, void> _NamedBufferPageCommitmentMemNV_fnptr = &NamedBufferPageCommitmentMemNV_Lazy;
             /// <summary> <b>[requires: GL_NV_memory_object_sparse]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedBufferPageCommitmentMemNV(BufferHandle buffer, IntPtr offset, nint size, uint memory, ulong memOffset, byte commit) => _NamedBufferPageCommitmentMemNV_fnptr(buffer, offset, size, memory, memOffset, commit);
+            public static void NamedBufferPageCommitmentMemNV(BufferHandle buffer, IntPtr offset, nint size, uint memory, ulong memOffset, bool commit) => _NamedBufferPageCommitmentMemNV_fnptr(buffer, offset, size, memory, memOffset, commit);
             [UnmanagedCallersOnly]
-            private static void NamedBufferPageCommitmentMemNV_Lazy(BufferHandle buffer, IntPtr offset, nint size, uint memory, ulong memOffset, byte commit)
+            private static void NamedBufferPageCommitmentMemNV_Lazy(BufferHandle buffer, IntPtr offset, nint size, uint memory, ulong memOffset, bool commit)
             {
-                _NamedBufferPageCommitmentMemNV_fnptr = (delegate* unmanaged<BufferHandle, IntPtr, nint, uint, ulong, byte, void>)GLLoader.BindingsContext.GetProcAddress("glNamedBufferPageCommitmentMemNV");
+                _NamedBufferPageCommitmentMemNV_fnptr = (delegate* unmanaged<BufferHandle, IntPtr, nint, uint, ulong, bool, void>)GLLoader.BindingsContext.GetProcAddress("glNamedBufferPageCommitmentMemNV");
                 _NamedBufferPageCommitmentMemNV_fnptr(buffer, offset, size, memory, memOffset, commit);
             }
             
-            private static delegate* unmanaged<TextureHandle, int, int, int, int, int, int, int, int, uint, ulong, byte, void> _TexturePageCommitmentMemNV_fnptr = &TexturePageCommitmentMemNV_Lazy;
+            private static delegate* unmanaged<TextureHandle, int, int, int, int, int, int, int, int, uint, ulong, bool, void> _TexturePageCommitmentMemNV_fnptr = &TexturePageCommitmentMemNV_Lazy;
             /// <summary> <b>[requires: GL_NV_memory_object_sparse]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TexturePageCommitmentMemNV(TextureHandle texture, int layer, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, uint memory, ulong offset, byte commit) => _TexturePageCommitmentMemNV_fnptr(texture, layer, level, xoffset, yoffset, zoffset, width, height, depth, memory, offset, commit);
+            public static void TexturePageCommitmentMemNV(TextureHandle texture, int layer, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, uint memory, ulong offset, bool commit) => _TexturePageCommitmentMemNV_fnptr(texture, layer, level, xoffset, yoffset, zoffset, width, height, depth, memory, offset, commit);
             [UnmanagedCallersOnly]
-            private static void TexturePageCommitmentMemNV_Lazy(TextureHandle texture, int layer, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, uint memory, ulong offset, byte commit)
+            private static void TexturePageCommitmentMemNV_Lazy(TextureHandle texture, int layer, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, uint memory, ulong offset, bool commit)
             {
-                _TexturePageCommitmentMemNV_fnptr = (delegate* unmanaged<TextureHandle, int, int, int, int, int, int, int, int, uint, ulong, byte, void>)GLLoader.BindingsContext.GetProcAddress("glTexturePageCommitmentMemNV");
+                _TexturePageCommitmentMemNV_fnptr = (delegate* unmanaged<TextureHandle, int, int, int, int, int, int, int, int, uint, ulong, bool, void>)GLLoader.BindingsContext.GetProcAddress("glTexturePageCommitmentMemNV");
                 _TexturePageCommitmentMemNV_fnptr(texture, layer, level, xoffset, yoffset, zoffset, width, height, depth, memory, offset, commit);
             }
             
@@ -8502,69 +8502,69 @@ namespace OpenTK.Graphics.OpenGLES3
                 _MultiDrawMeshTasksIndirectCountNV_fnptr(indirect, drawcount, maxdrawcount, stride);
             }
             
-            private static delegate* unmanaged<int, int, byte, float*, void> _UniformMatrix2x3fvNV_fnptr = &UniformMatrix2x3fvNV_Lazy;
+            private static delegate* unmanaged<int, int, bool, float*, void> _UniformMatrix2x3fvNV_fnptr = &UniformMatrix2x3fvNV_Lazy;
             /// <summary> <b>[requires: GL_NV_non_square_matrices]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void UniformMatrix2x3fvNV(int location, int count, byte transpose, float* value) => _UniformMatrix2x3fvNV_fnptr(location, count, transpose, value);
+            public static void UniformMatrix2x3fvNV(int location, int count, bool transpose, float* value) => _UniformMatrix2x3fvNV_fnptr(location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void UniformMatrix2x3fvNV_Lazy(int location, int count, byte transpose, float* value)
+            private static void UniformMatrix2x3fvNV_Lazy(int location, int count, bool transpose, float* value)
             {
-                _UniformMatrix2x3fvNV_fnptr = (delegate* unmanaged<int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix2x3fvNV");
+                _UniformMatrix2x3fvNV_fnptr = (delegate* unmanaged<int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix2x3fvNV");
                 _UniformMatrix2x3fvNV_fnptr(location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<int, int, byte, float*, void> _UniformMatrix3x2fvNV_fnptr = &UniformMatrix3x2fvNV_Lazy;
+            private static delegate* unmanaged<int, int, bool, float*, void> _UniformMatrix3x2fvNV_fnptr = &UniformMatrix3x2fvNV_Lazy;
             /// <summary> <b>[requires: GL_NV_non_square_matrices]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void UniformMatrix3x2fvNV(int location, int count, byte transpose, float* value) => _UniformMatrix3x2fvNV_fnptr(location, count, transpose, value);
+            public static void UniformMatrix3x2fvNV(int location, int count, bool transpose, float* value) => _UniformMatrix3x2fvNV_fnptr(location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void UniformMatrix3x2fvNV_Lazy(int location, int count, byte transpose, float* value)
+            private static void UniformMatrix3x2fvNV_Lazy(int location, int count, bool transpose, float* value)
             {
-                _UniformMatrix3x2fvNV_fnptr = (delegate* unmanaged<int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix3x2fvNV");
+                _UniformMatrix3x2fvNV_fnptr = (delegate* unmanaged<int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix3x2fvNV");
                 _UniformMatrix3x2fvNV_fnptr(location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<int, int, byte, float*, void> _UniformMatrix2x4fvNV_fnptr = &UniformMatrix2x4fvNV_Lazy;
+            private static delegate* unmanaged<int, int, bool, float*, void> _UniformMatrix2x4fvNV_fnptr = &UniformMatrix2x4fvNV_Lazy;
             /// <summary> <b>[requires: GL_NV_non_square_matrices]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void UniformMatrix2x4fvNV(int location, int count, byte transpose, float* value) => _UniformMatrix2x4fvNV_fnptr(location, count, transpose, value);
+            public static void UniformMatrix2x4fvNV(int location, int count, bool transpose, float* value) => _UniformMatrix2x4fvNV_fnptr(location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void UniformMatrix2x4fvNV_Lazy(int location, int count, byte transpose, float* value)
+            private static void UniformMatrix2x4fvNV_Lazy(int location, int count, bool transpose, float* value)
             {
-                _UniformMatrix2x4fvNV_fnptr = (delegate* unmanaged<int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix2x4fvNV");
+                _UniformMatrix2x4fvNV_fnptr = (delegate* unmanaged<int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix2x4fvNV");
                 _UniformMatrix2x4fvNV_fnptr(location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<int, int, byte, float*, void> _UniformMatrix4x2fvNV_fnptr = &UniformMatrix4x2fvNV_Lazy;
+            private static delegate* unmanaged<int, int, bool, float*, void> _UniformMatrix4x2fvNV_fnptr = &UniformMatrix4x2fvNV_Lazy;
             /// <summary> <b>[requires: GL_NV_non_square_matrices]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void UniformMatrix4x2fvNV(int location, int count, byte transpose, float* value) => _UniformMatrix4x2fvNV_fnptr(location, count, transpose, value);
+            public static void UniformMatrix4x2fvNV(int location, int count, bool transpose, float* value) => _UniformMatrix4x2fvNV_fnptr(location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void UniformMatrix4x2fvNV_Lazy(int location, int count, byte transpose, float* value)
+            private static void UniformMatrix4x2fvNV_Lazy(int location, int count, bool transpose, float* value)
             {
-                _UniformMatrix4x2fvNV_fnptr = (delegate* unmanaged<int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix4x2fvNV");
+                _UniformMatrix4x2fvNV_fnptr = (delegate* unmanaged<int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix4x2fvNV");
                 _UniformMatrix4x2fvNV_fnptr(location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<int, int, byte, float*, void> _UniformMatrix3x4fvNV_fnptr = &UniformMatrix3x4fvNV_Lazy;
+            private static delegate* unmanaged<int, int, bool, float*, void> _UniformMatrix3x4fvNV_fnptr = &UniformMatrix3x4fvNV_Lazy;
             /// <summary> <b>[requires: GL_NV_non_square_matrices]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void UniformMatrix3x4fvNV(int location, int count, byte transpose, float* value) => _UniformMatrix3x4fvNV_fnptr(location, count, transpose, value);
+            public static void UniformMatrix3x4fvNV(int location, int count, bool transpose, float* value) => _UniformMatrix3x4fvNV_fnptr(location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void UniformMatrix3x4fvNV_Lazy(int location, int count, byte transpose, float* value)
+            private static void UniformMatrix3x4fvNV_Lazy(int location, int count, bool transpose, float* value)
             {
-                _UniformMatrix3x4fvNV_fnptr = (delegate* unmanaged<int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix3x4fvNV");
+                _UniformMatrix3x4fvNV_fnptr = (delegate* unmanaged<int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix3x4fvNV");
                 _UniformMatrix3x4fvNV_fnptr(location, count, transpose, value);
             }
             
-            private static delegate* unmanaged<int, int, byte, float*, void> _UniformMatrix4x3fvNV_fnptr = &UniformMatrix4x3fvNV_Lazy;
+            private static delegate* unmanaged<int, int, bool, float*, void> _UniformMatrix4x3fvNV_fnptr = &UniformMatrix4x3fvNV_Lazy;
             /// <summary> <b>[requires: GL_NV_non_square_matrices]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void UniformMatrix4x3fvNV(int location, int count, byte transpose, float* value) => _UniformMatrix4x3fvNV_fnptr(location, count, transpose, value);
+            public static void UniformMatrix4x3fvNV(int location, int count, bool transpose, float* value) => _UniformMatrix4x3fvNV_fnptr(location, count, transpose, value);
             [UnmanagedCallersOnly]
-            private static void UniformMatrix4x3fvNV_Lazy(int location, int count, byte transpose, float* value)
+            private static void UniformMatrix4x3fvNV_Lazy(int location, int count, bool transpose, float* value)
             {
-                _UniformMatrix4x3fvNV_fnptr = (delegate* unmanaged<int, int, byte, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix4x3fvNV");
+                _UniformMatrix4x3fvNV_fnptr = (delegate* unmanaged<int, int, bool, float*, void>)GLLoader.BindingsContext.GetProcAddress("glUniformMatrix4x3fvNV");
                 _UniformMatrix4x3fvNV_fnptr(location, count, transpose, value);
             }
             
@@ -8590,14 +8590,14 @@ namespace OpenTK.Graphics.OpenGLES3
                 _DeletePathsNV_fnptr(path, range);
             }
             
-            private static delegate* unmanaged<uint, byte> _IsPathNV_fnptr = &IsPathNV_Lazy;
+            private static delegate* unmanaged<uint, bool> _IsPathNV_fnptr = &IsPathNV_Lazy;
             /// <summary> <b>[requires: GL_NV_path_rendering]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsPathNV(uint path) => _IsPathNV_fnptr(path);
+            public static bool IsPathNV(uint path) => _IsPathNV_fnptr(path);
             [UnmanagedCallersOnly]
-            private static byte IsPathNV_Lazy(uint path)
+            private static bool IsPathNV_Lazy(uint path)
             {
-                _IsPathNV_fnptr = (delegate* unmanaged<uint, byte>)GLLoader.BindingsContext.GetProcAddress("glIsPathNV");
+                _IsPathNV_fnptr = (delegate* unmanaged<uint, bool>)GLLoader.BindingsContext.GetProcAddress("glIsPathNV");
                 return _IsPathNV_fnptr(path);
             }
             
@@ -8986,25 +8986,25 @@ namespace OpenTK.Graphics.OpenGLES3
                 _GetPathSpacingNV_fnptr(pathListMode, numPaths, pathNameType, paths, pathBase, advanceScale, kerningScale, transformType, returnedSpacing);
             }
             
-            private static delegate* unmanaged<uint, uint, float, float, byte> _IsPointInFillPathNV_fnptr = &IsPointInFillPathNV_Lazy;
+            private static delegate* unmanaged<uint, uint, float, float, bool> _IsPointInFillPathNV_fnptr = &IsPointInFillPathNV_Lazy;
             /// <summary> <b>[requires: GL_NV_path_rendering]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsPointInFillPathNV(uint path, uint mask, float x, float y) => _IsPointInFillPathNV_fnptr(path, mask, x, y);
+            public static bool IsPointInFillPathNV(uint path, uint mask, float x, float y) => _IsPointInFillPathNV_fnptr(path, mask, x, y);
             [UnmanagedCallersOnly]
-            private static byte IsPointInFillPathNV_Lazy(uint path, uint mask, float x, float y)
+            private static bool IsPointInFillPathNV_Lazy(uint path, uint mask, float x, float y)
             {
-                _IsPointInFillPathNV_fnptr = (delegate* unmanaged<uint, uint, float, float, byte>)GLLoader.BindingsContext.GetProcAddress("glIsPointInFillPathNV");
+                _IsPointInFillPathNV_fnptr = (delegate* unmanaged<uint, uint, float, float, bool>)GLLoader.BindingsContext.GetProcAddress("glIsPointInFillPathNV");
                 return _IsPointInFillPathNV_fnptr(path, mask, x, y);
             }
             
-            private static delegate* unmanaged<uint, float, float, byte> _IsPointInStrokePathNV_fnptr = &IsPointInStrokePathNV_Lazy;
+            private static delegate* unmanaged<uint, float, float, bool> _IsPointInStrokePathNV_fnptr = &IsPointInStrokePathNV_Lazy;
             /// <summary> <b>[requires: GL_NV_path_rendering]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsPointInStrokePathNV(uint path, float x, float y) => _IsPointInStrokePathNV_fnptr(path, x, y);
+            public static bool IsPointInStrokePathNV(uint path, float x, float y) => _IsPointInStrokePathNV_fnptr(path, x, y);
             [UnmanagedCallersOnly]
-            private static byte IsPointInStrokePathNV_Lazy(uint path, float x, float y)
+            private static bool IsPointInStrokePathNV_Lazy(uint path, float x, float y)
             {
-                _IsPointInStrokePathNV_fnptr = (delegate* unmanaged<uint, float, float, byte>)GLLoader.BindingsContext.GetProcAddress("glIsPointInStrokePathNV");
+                _IsPointInStrokePathNV_fnptr = (delegate* unmanaged<uint, float, float, bool>)GLLoader.BindingsContext.GetProcAddress("glIsPointInStrokePathNV");
                 return _IsPointInStrokePathNV_fnptr(path, x, y);
             }
             
@@ -9019,14 +9019,14 @@ namespace OpenTK.Graphics.OpenGLES3
                 return _GetPathLengthNV_fnptr(path, startSegment, numSegments);
             }
             
-            private static delegate* unmanaged<uint, int, int, float, float*, float*, float*, float*, byte> _PointAlongPathNV_fnptr = &PointAlongPathNV_Lazy;
+            private static delegate* unmanaged<uint, int, int, float, float*, float*, float*, float*, bool> _PointAlongPathNV_fnptr = &PointAlongPathNV_Lazy;
             /// <summary> <b>[requires: GL_NV_path_rendering]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte PointAlongPathNV(uint path, int startSegment, int numSegments, float distance, float* x, float* y, float* tangentX, float* tangentY) => _PointAlongPathNV_fnptr(path, startSegment, numSegments, distance, x, y, tangentX, tangentY);
+            public static bool PointAlongPathNV(uint path, int startSegment, int numSegments, float distance, float* x, float* y, float* tangentX, float* tangentY) => _PointAlongPathNV_fnptr(path, startSegment, numSegments, distance, x, y, tangentX, tangentY);
             [UnmanagedCallersOnly]
-            private static byte PointAlongPathNV_Lazy(uint path, int startSegment, int numSegments, float distance, float* x, float* y, float* tangentX, float* tangentY)
+            private static bool PointAlongPathNV_Lazy(uint path, int startSegment, int numSegments, float distance, float* x, float* y, float* tangentX, float* tangentY)
             {
-                _PointAlongPathNV_fnptr = (delegate* unmanaged<uint, int, int, float, float*, float*, float*, float*, byte>)GLLoader.BindingsContext.GetProcAddress("glPointAlongPathNV");
+                _PointAlongPathNV_fnptr = (delegate* unmanaged<uint, int, int, float, float*, float*, float*, float*, bool>)GLLoader.BindingsContext.GetProcAddress("glPointAlongPathNV");
                 return _PointAlongPathNV_fnptr(path, startSegment, numSegments, distance, x, y, tangentX, tangentY);
             }
             
@@ -9514,14 +9514,14 @@ namespace OpenTK.Graphics.OpenGLES3
                 _GetShadingRateSampleLocationivNV_fnptr(rate, samples, index, location);
             }
             
-            private static delegate* unmanaged<byte, void> _ShadingRateImageBarrierNV_fnptr = &ShadingRateImageBarrierNV_Lazy;
+            private static delegate* unmanaged<bool, void> _ShadingRateImageBarrierNV_fnptr = &ShadingRateImageBarrierNV_Lazy;
             /// <summary> <b>[requires: GL_NV_shading_rate_image]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ShadingRateImageBarrierNV(byte synchronize) => _ShadingRateImageBarrierNV_fnptr(synchronize);
+            public static void ShadingRateImageBarrierNV(bool synchronize) => _ShadingRateImageBarrierNV_fnptr(synchronize);
             [UnmanagedCallersOnly]
-            private static void ShadingRateImageBarrierNV_Lazy(byte synchronize)
+            private static void ShadingRateImageBarrierNV_Lazy(bool synchronize)
             {
-                _ShadingRateImageBarrierNV_fnptr = (delegate* unmanaged<byte, void>)GLLoader.BindingsContext.GetProcAddress("glShadingRateImageBarrierNV");
+                _ShadingRateImageBarrierNV_fnptr = (delegate* unmanaged<bool, void>)GLLoader.BindingsContext.GetProcAddress("glShadingRateImageBarrierNV");
                 _ShadingRateImageBarrierNV_fnptr(synchronize);
             }
             
@@ -9679,14 +9679,14 @@ namespace OpenTK.Graphics.OpenGLES3
                 _DisableiNV_fnptr(target, index);
             }
             
-            private static delegate* unmanaged<EnableCap, uint, byte> _IsEnablediNV_fnptr = &IsEnablediNV_Lazy;
+            private static delegate* unmanaged<EnableCap, uint, bool> _IsEnablediNV_fnptr = &IsEnablediNV_Lazy;
             /// <summary> <b>[requires: GL_NV_viewport_array]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsEnablediNV(EnableCap target, uint index) => _IsEnablediNV_fnptr(target, index);
+            public static bool IsEnablediNV(EnableCap target, uint index) => _IsEnablediNV_fnptr(target, index);
             [UnmanagedCallersOnly]
-            private static byte IsEnablediNV_Lazy(EnableCap target, uint index)
+            private static bool IsEnablediNV_Lazy(EnableCap target, uint index)
             {
-                _IsEnablediNV_fnptr = (delegate* unmanaged<EnableCap, uint, byte>)GLLoader.BindingsContext.GetProcAddress("glIsEnablediNV");
+                _IsEnablediNV_fnptr = (delegate* unmanaged<EnableCap, uint, bool>)GLLoader.BindingsContext.GetProcAddress("glIsEnablediNV");
                 return _IsEnablediNV_fnptr(target, index);
             }
             
@@ -9952,7 +9952,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 _BlendBarrierKHR_fnptr();
             }
             
-            private static delegate* unmanaged<DebugSource, DebugType, DebugSeverity, int, uint*, byte, void> _DebugMessageControl_fnptr = &DebugMessageControl_Lazy;
+            private static delegate* unmanaged<DebugSource, DebugType, DebugSeverity, int, uint*, bool, void> _DebugMessageControl_fnptr = &DebugMessageControl_Lazy;
             /// <summary> <b>[requires: v3.2 | GL_KHR_debug]</b> Control the reporting of debug messages in a debug context. </summary>
             /// <param name="source"> The source of debug messages to enable or disable. </param>
             /// <param name="type"> The type of debug messages to enable or disable. </param>
@@ -9961,11 +9961,11 @@ namespace OpenTK.Graphics.OpenGLES3
             /// <param name="ids"> The address of an array of unsigned integers contianing the ids of the messages to enable or disable. </param>
             /// <param name="enabled"> A Boolean flag determining whether the selected messages should be enabled or disabled. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglDebugMessageControl.xhtml" /></remarks>
-            public static void DebugMessageControl(DebugSource source, DebugType type, DebugSeverity severity, int count, uint* ids, byte enabled) => _DebugMessageControl_fnptr(source, type, severity, count, ids, enabled);
+            public static void DebugMessageControl(DebugSource source, DebugType type, DebugSeverity severity, int count, uint* ids, bool enabled) => _DebugMessageControl_fnptr(source, type, severity, count, ids, enabled);
             [UnmanagedCallersOnly]
-            private static void DebugMessageControl_Lazy(DebugSource source, DebugType type, DebugSeverity severity, int count, uint* ids, byte enabled)
+            private static void DebugMessageControl_Lazy(DebugSource source, DebugType type, DebugSeverity severity, int count, uint* ids, bool enabled)
             {
-                _DebugMessageControl_fnptr = (delegate* unmanaged<DebugSource, DebugType, DebugSeverity, int, uint*, byte, void>)GLLoader.BindingsContext.GetProcAddress("glDebugMessageControl");
+                _DebugMessageControl_fnptr = (delegate* unmanaged<DebugSource, DebugType, DebugSeverity, int, uint*, bool, void>)GLLoader.BindingsContext.GetProcAddress("glDebugMessageControl");
                 _DebugMessageControl_fnptr(source, type, severity, count, ids, enabled);
             }
             
@@ -10117,14 +10117,14 @@ namespace OpenTK.Graphics.OpenGLES3
                 _GetPointerv_fnptr(pname, parameters);
             }
             
-            private static delegate* unmanaged<DebugSource, DebugType, DebugSeverity, int, uint*, byte, void> _DebugMessageControlKHR_fnptr = &DebugMessageControlKHR_Lazy;
+            private static delegate* unmanaged<DebugSource, DebugType, DebugSeverity, int, uint*, bool, void> _DebugMessageControlKHR_fnptr = &DebugMessageControlKHR_Lazy;
             /// <summary> <b>[requires: GL_KHR_debug]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void DebugMessageControlKHR(DebugSource source, DebugType type, DebugSeverity severity, int count, uint* ids, byte enabled) => _DebugMessageControlKHR_fnptr(source, type, severity, count, ids, enabled);
+            public static void DebugMessageControlKHR(DebugSource source, DebugType type, DebugSeverity severity, int count, uint* ids, bool enabled) => _DebugMessageControlKHR_fnptr(source, type, severity, count, ids, enabled);
             [UnmanagedCallersOnly]
-            private static void DebugMessageControlKHR_Lazy(DebugSource source, DebugType type, DebugSeverity severity, int count, uint* ids, byte enabled)
+            private static void DebugMessageControlKHR_Lazy(DebugSource source, DebugType type, DebugSeverity severity, int count, uint* ids, bool enabled)
             {
-                _DebugMessageControlKHR_fnptr = (delegate* unmanaged<DebugSource, DebugType, DebugSeverity, int, uint*, byte, void>)GLLoader.BindingsContext.GetProcAddress("glDebugMessageControlKHR");
+                _DebugMessageControlKHR_fnptr = (delegate* unmanaged<DebugSource, DebugType, DebugSeverity, int, uint*, bool, void>)GLLoader.BindingsContext.GetProcAddress("glDebugMessageControlKHR");
                 _DebugMessageControlKHR_fnptr(source, type, severity, count, ids, enabled);
             }
             
@@ -10506,25 +10506,25 @@ namespace OpenTK.Graphics.OpenGLES3
                 _BlendFuncSeparateiOES_fnptr(buf, srcRGB, dstRGB, srcAlpha, dstAlpha);
             }
             
-            private static delegate* unmanaged<uint, byte, byte, byte, byte, void> _ColorMaskiOES_fnptr = &ColorMaskiOES_Lazy;
+            private static delegate* unmanaged<uint, bool, bool, bool, bool, void> _ColorMaskiOES_fnptr = &ColorMaskiOES_Lazy;
             /// <summary> <b>[requires: GL_OES_draw_buffers_indexed]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ColorMaskiOES(uint index, byte r, byte g, byte b, byte a) => _ColorMaskiOES_fnptr(index, r, g, b, a);
+            public static void ColorMaskiOES(uint index, bool r, bool g, bool b, bool a) => _ColorMaskiOES_fnptr(index, r, g, b, a);
             [UnmanagedCallersOnly]
-            private static void ColorMaskiOES_Lazy(uint index, byte r, byte g, byte b, byte a)
+            private static void ColorMaskiOES_Lazy(uint index, bool r, bool g, bool b, bool a)
             {
-                _ColorMaskiOES_fnptr = (delegate* unmanaged<uint, byte, byte, byte, byte, void>)GLLoader.BindingsContext.GetProcAddress("glColorMaskiOES");
+                _ColorMaskiOES_fnptr = (delegate* unmanaged<uint, bool, bool, bool, bool, void>)GLLoader.BindingsContext.GetProcAddress("glColorMaskiOES");
                 _ColorMaskiOES_fnptr(index, r, g, b, a);
             }
             
-            private static delegate* unmanaged<EnableCap, uint, byte> _IsEnablediOES_fnptr = &IsEnablediOES_Lazy;
+            private static delegate* unmanaged<EnableCap, uint, bool> _IsEnablediOES_fnptr = &IsEnablediOES_Lazy;
             /// <summary> <b>[requires: GL_OES_draw_buffers_indexed | GL_OES_viewport_array]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsEnablediOES(EnableCap target, uint index) => _IsEnablediOES_fnptr(target, index);
+            public static bool IsEnablediOES(EnableCap target, uint index) => _IsEnablediOES_fnptr(target, index);
             [UnmanagedCallersOnly]
-            private static byte IsEnablediOES_Lazy(EnableCap target, uint index)
+            private static bool IsEnablediOES_Lazy(EnableCap target, uint index)
             {
-                _IsEnablediOES_fnptr = (delegate* unmanaged<EnableCap, uint, byte>)GLLoader.BindingsContext.GetProcAddress("glIsEnablediOES");
+                _IsEnablediOES_fnptr = (delegate* unmanaged<EnableCap, uint, bool>)GLLoader.BindingsContext.GetProcAddress("glIsEnablediOES");
                 return _IsEnablediOES_fnptr(target, index);
             }
             
@@ -10616,14 +10616,14 @@ namespace OpenTK.Graphics.OpenGLES3
                 return _MapBufferOES_fnptr(target, access);
             }
             
-            private static delegate* unmanaged<All, byte> _UnmapBufferOES_fnptr = &UnmapBufferOES_Lazy;
+            private static delegate* unmanaged<All, bool> _UnmapBufferOES_fnptr = &UnmapBufferOES_Lazy;
             /// <summary> <b>[requires: GL_OES_mapbuffer]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte UnmapBufferOES(All target) => _UnmapBufferOES_fnptr(target);
+            public static bool UnmapBufferOES(All target) => _UnmapBufferOES_fnptr(target);
             [UnmanagedCallersOnly]
-            private static byte UnmapBufferOES_Lazy(All target)
+            private static bool UnmapBufferOES_Lazy(All target)
             {
-                _UnmapBufferOES_fnptr = (delegate* unmanaged<All, byte>)GLLoader.BindingsContext.GetProcAddress("glUnmapBufferOES");
+                _UnmapBufferOES_fnptr = (delegate* unmanaged<All, bool>)GLLoader.BindingsContext.GetProcAddress("glUnmapBufferOES");
                 return _UnmapBufferOES_fnptr(target);
             }
             
@@ -10847,14 +10847,14 @@ namespace OpenTK.Graphics.OpenGLES3
                 _TexBufferRangeOES_fnptr(target, internalformat, buffer, offset, size);
             }
             
-            private static delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, int, byte, void> _TexStorage3DMultisampleOES_fnptr = &TexStorage3DMultisampleOES_Lazy;
+            private static delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, int, bool, void> _TexStorage3DMultisampleOES_fnptr = &TexStorage3DMultisampleOES_Lazy;
             /// <summary> <b>[requires: GL_OES_texture_storage_multisample_2d_array]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TexStorage3DMultisampleOES(TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, int depth, byte fixedsamplelocations) => _TexStorage3DMultisampleOES_fnptr(target, samples, internalformat, width, height, depth, fixedsamplelocations);
+            public static void TexStorage3DMultisampleOES(TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, int depth, bool fixedsamplelocations) => _TexStorage3DMultisampleOES_fnptr(target, samples, internalformat, width, height, depth, fixedsamplelocations);
             [UnmanagedCallersOnly]
-            private static void TexStorage3DMultisampleOES_Lazy(TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, int depth, byte fixedsamplelocations)
+            private static void TexStorage3DMultisampleOES_Lazy(TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, int depth, bool fixedsamplelocations)
             {
-                _TexStorage3DMultisampleOES_fnptr = (delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, int, byte, void>)GLLoader.BindingsContext.GetProcAddress("glTexStorage3DMultisampleOES");
+                _TexStorage3DMultisampleOES_fnptr = (delegate* unmanaged<TextureTarget, int, SizedInternalFormat, int, int, int, bool, void>)GLLoader.BindingsContext.GetProcAddress("glTexStorage3DMultisampleOES");
                 _TexStorage3DMultisampleOES_fnptr(target, samples, internalformat, width, height, depth, fixedsamplelocations);
             }
             
@@ -10902,14 +10902,14 @@ namespace OpenTK.Graphics.OpenGLES3
                 _GenVertexArraysOES_fnptr(n, arrays);
             }
             
-            private static delegate* unmanaged<VertexArrayHandle, byte> _IsVertexArrayOES_fnptr = &IsVertexArrayOES_Lazy;
+            private static delegate* unmanaged<VertexArrayHandle, bool> _IsVertexArrayOES_fnptr = &IsVertexArrayOES_Lazy;
             /// <summary> <b>[requires: GL_OES_vertex_array_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte IsVertexArrayOES(VertexArrayHandle array) => _IsVertexArrayOES_fnptr(array);
+            public static bool IsVertexArrayOES(VertexArrayHandle array) => _IsVertexArrayOES_fnptr(array);
             [UnmanagedCallersOnly]
-            private static byte IsVertexArrayOES_Lazy(VertexArrayHandle array)
+            private static bool IsVertexArrayOES_Lazy(VertexArrayHandle array)
             {
-                _IsVertexArrayOES_fnptr = (delegate* unmanaged<VertexArrayHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glIsVertexArrayOES");
+                _IsVertexArrayOES_fnptr = (delegate* unmanaged<VertexArrayHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glIsVertexArrayOES");
                 return _IsVertexArrayOES_fnptr(array);
             }
             
@@ -11205,14 +11205,14 @@ namespace OpenTK.Graphics.OpenGLES3
                 _ExtGetProgramsQCOM_fnptr(programs, maxPrograms, numPrograms);
             }
             
-            private static delegate* unmanaged<ProgramHandle, byte> _ExtIsProgramBinaryQCOM_fnptr = &ExtIsProgramBinaryQCOM_Lazy;
+            private static delegate* unmanaged<ProgramHandle, bool> _ExtIsProgramBinaryQCOM_fnptr = &ExtIsProgramBinaryQCOM_Lazy;
             /// <summary> <b>[requires: GL_QCOM_extended_get2]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static byte ExtIsProgramBinaryQCOM(ProgramHandle program) => _ExtIsProgramBinaryQCOM_fnptr(program);
+            public static bool ExtIsProgramBinaryQCOM(ProgramHandle program) => _ExtIsProgramBinaryQCOM_fnptr(program);
             [UnmanagedCallersOnly]
-            private static byte ExtIsProgramBinaryQCOM_Lazy(ProgramHandle program)
+            private static bool ExtIsProgramBinaryQCOM_Lazy(ProgramHandle program)
             {
-                _ExtIsProgramBinaryQCOM_fnptr = (delegate* unmanaged<ProgramHandle, byte>)GLLoader.BindingsContext.GetProcAddress("glExtIsProgramBinaryQCOM");
+                _ExtIsProgramBinaryQCOM_fnptr = (delegate* unmanaged<ProgramHandle, bool>)GLLoader.BindingsContext.GetProcAddress("glExtIsProgramBinaryQCOM");
                 return _ExtIsProgramBinaryQCOM_fnptr(program);
             }
             

--- a/src/OpenTK.Graphics/OpenGLES3/GL.Overloads.cs
+++ b/src/OpenTK.Graphics/OpenGLES3/GL.Overloads.cs
@@ -800,25 +800,25 @@ namespace OpenTK.Graphics.OpenGLES3
             return returnValue;
         }
         /// <inheritdoc cref="GetBooleanv"/>
-        public static unsafe void GetBoolean(GetPName pname, Span<byte> data)
+        public static unsafe void GetBoolean(GetPName pname, Span<bool> data)
         {
-            fixed (byte* data_ptr = data)
+            fixed (bool* data_ptr = data)
             {
                 GetBooleanv(pname, data_ptr);
             }
         }
         /// <inheritdoc cref="GetBooleanv"/>
-        public static unsafe void GetBoolean(GetPName pname, byte[] data)
+        public static unsafe void GetBoolean(GetPName pname, bool[] data)
         {
-            fixed (byte* data_ptr = data)
+            fixed (bool* data_ptr = data)
             {
                 GetBooleanv(pname, data_ptr);
             }
         }
         /// <inheritdoc cref="GetBooleanv"/>
-        public static unsafe void GetBoolean(GetPName pname, ref byte data)
+        public static unsafe void GetBoolean(GetPName pname, ref bool data)
         {
-            fixed (byte* data_ptr = &data)
+            fixed (bool* data_ptr = &data)
             {
                 GetBooleanv(pname, data_ptr);
             }
@@ -4882,25 +4882,25 @@ namespace OpenTK.Graphics.OpenGLES3
             BindImageTexture(unit, texture, level, layered_byte, layer, access, format);
         }
         /// <inheritdoc cref="GetBooleani_v"/>
-        public static unsafe void GetBoolean(BufferTargetARB target, uint index, Span<byte> data)
+        public static unsafe void GetBoolean(BufferTargetARB target, uint index, Span<bool> data)
         {
-            fixed (byte* data_ptr = data)
+            fixed (bool* data_ptr = data)
             {
                 GetBooleani_v(target, index, data_ptr);
             }
         }
         /// <inheritdoc cref="GetBooleani_v"/>
-        public static unsafe void GetBoolean(BufferTargetARB target, uint index, byte[] data)
+        public static unsafe void GetBoolean(BufferTargetARB target, uint index, bool[] data)
         {
-            fixed (byte* data_ptr = data)
+            fixed (bool* data_ptr = data)
             {
                 GetBooleani_v(target, index, data_ptr);
             }
         }
         /// <inheritdoc cref="GetBooleani_v"/>
-        public static unsafe void GetBoolean(BufferTargetARB target, uint index, ref byte data)
+        public static unsafe void GetBoolean(BufferTargetARB target, uint index, ref bool data)
         {
-            fixed (byte* data_ptr = &data)
+            fixed (bool* data_ptr = &data)
             {
                 GetBooleani_v(target, index, data_ptr);
             }
@@ -10284,9 +10284,9 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="PointAlongPathNV"/>
-            public static unsafe byte PointAlongPathNV(uint path, int startSegment, int numSegments, float distance, Span<float> x, Span<float> y, Span<float> tangentX, Span<float> tangentY)
+            public static unsafe bool PointAlongPathNV(uint path, int startSegment, int numSegments, float distance, Span<float> x, Span<float> y, Span<float> tangentX, Span<float> tangentY)
             {
-                byte returnValue;
+                bool returnValue;
                 fixed (float* x_ptr = x)
                 {
                     fixed (float* y_ptr = y)
@@ -10303,9 +10303,9 @@ namespace OpenTK.Graphics.OpenGLES3
                 return returnValue;
             }
             /// <inheritdoc cref="PointAlongPathNV"/>
-            public static unsafe byte PointAlongPathNV(uint path, int startSegment, int numSegments, float distance, float[] x, float[] y, float[] tangentX, float[] tangentY)
+            public static unsafe bool PointAlongPathNV(uint path, int startSegment, int numSegments, float distance, float[] x, float[] y, float[] tangentX, float[] tangentY)
             {
-                byte returnValue;
+                bool returnValue;
                 fixed (float* x_ptr = x)
                 {
                     fixed (float* y_ptr = y)
@@ -10322,9 +10322,9 @@ namespace OpenTK.Graphics.OpenGLES3
                 return returnValue;
             }
             /// <inheritdoc cref="PointAlongPathNV"/>
-            public static unsafe byte PointAlongPathNV(uint path, int startSegment, int numSegments, float distance, ref float x, ref float y, ref float tangentX, ref float tangentY)
+            public static unsafe bool PointAlongPathNV(uint path, int startSegment, int numSegments, float distance, ref float x, ref float y, ref float tangentX, ref float tangentY)
             {
-                byte returnValue;
+                bool returnValue;
                 fixed (float* x_ptr = &x)
                 fixed (float* y_ptr = &y)
                 fixed (float* tangentX_ptr = &tangentX)

--- a/src/OpenTK.Graphics/OpenGLES3/GL.Overloads.cs
+++ b/src/OpenTK.Graphics/OpenGLES3/GL.Overloads.cs
@@ -86,15 +86,6 @@ namespace OpenTK.Graphics.OpenGLES3
                 BufferSubData(target, offset, size, data_ptr);
             }
         }
-        /// <inheritdoc cref="ColorMask"/>
-        public static unsafe void ColorMask(bool red, bool green, bool blue, bool alpha)
-        {
-            byte red_byte = (byte)(red ? 1 : 0);
-            byte green_byte = (byte)(green ? 1 : 0);
-            byte blue_byte = (byte)(blue ? 1 : 0);
-            byte alpha_byte = (byte)(alpha ? 1 : 0);
-            ColorMask(red_byte, green_byte, blue_byte, alpha_byte);
-        }
         /// <inheritdoc cref="CompressedTexImage2D"/>
         public static unsafe void CompressedTexImage2D(TextureTarget target, int level, InternalFormat internalformat, int width, int height, int border, int imageSize, IntPtr data)
         {
@@ -304,12 +295,6 @@ namespace OpenTK.Graphics.OpenGLES3
             {
                 DeleteTextures(n, textures_ptr);
             }
-        }
-        /// <inheritdoc cref="DepthMask"/>
-        public static unsafe void DepthMask(bool flag)
-        {
-            byte flag_byte = (byte)(flag ? 1 : 0);
-            DepthMask(flag_byte);
         }
         /// <inheritdoc cref="DrawElements"/>
         public static unsafe void DrawElements(PrimitiveType mode, int count, DrawElementsType type, nint offset)
@@ -1438,12 +1423,6 @@ namespace OpenTK.Graphics.OpenGLES3
                 ReadPixels(x, y, width, height, format, type, pixels_ptr);
             }
         }
-        /// <inheritdoc cref="SampleCoverage"/>
-        public static unsafe void SampleCoverage(float value, bool invert)
-        {
-            byte invert_byte = (byte)(invert ? 1 : 0);
-            SampleCoverage(value, invert_byte);
-        }
         /// <inheritdoc cref="ShaderBinary"/>
         public static unsafe void ShaderBinary(ReadOnlySpan<ShaderHandle> shaders, ShaderBinaryFormat binaryFormat, IntPtr binary, int length)
         {
@@ -1880,8 +1859,7 @@ namespace OpenTK.Graphics.OpenGLES3
             fixed (Matrix2* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix2fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix2fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix2fv"/>
@@ -1890,8 +1868,7 @@ namespace OpenTK.Graphics.OpenGLES3
             fixed (Matrix2* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix2fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix2fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix2fv"/>
@@ -1900,8 +1877,7 @@ namespace OpenTK.Graphics.OpenGLES3
             fixed (Matrix2* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix2fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix2fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix3fv"/>
@@ -1911,8 +1887,7 @@ namespace OpenTK.Graphics.OpenGLES3
             fixed (Matrix3* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix3fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix3fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix3fv"/>
@@ -1921,8 +1896,7 @@ namespace OpenTK.Graphics.OpenGLES3
             fixed (Matrix3* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix3fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix3fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix3fv"/>
@@ -1931,8 +1905,7 @@ namespace OpenTK.Graphics.OpenGLES3
             fixed (Matrix3* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix3fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix3fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix4fv"/>
@@ -1942,8 +1915,7 @@ namespace OpenTK.Graphics.OpenGLES3
             fixed (Matrix4* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix4fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix4fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix4fv"/>
@@ -1952,8 +1924,7 @@ namespace OpenTK.Graphics.OpenGLES3
             fixed (Matrix4* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix4fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix4fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix4fv"/>
@@ -1962,8 +1933,7 @@ namespace OpenTK.Graphics.OpenGLES3
             fixed (Matrix4* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix4fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix4fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="VertexAttrib1fv"/>
@@ -2066,8 +2036,7 @@ namespace OpenTK.Graphics.OpenGLES3
         public static unsafe void VertexAttribPointer(uint index, int size, VertexAttribPointerType type, bool normalized, int stride, nint offset)
         {
             void* pointer = (void*)offset;
-            byte normalized_byte = (byte)(normalized ? 1 : 0);
-            VertexAttribPointer(index, size, type, normalized_byte, stride, pointer);
+            VertexAttribPointer(index, size, type, normalized, stride, pointer);
         }
         /// <inheritdoc cref="DrawRangeElements"/>
         public static unsafe void DrawRangeElements(PrimitiveType mode, uint start, uint end, int count, DrawElementsType type, nint offset)
@@ -2392,8 +2361,7 @@ namespace OpenTK.Graphics.OpenGLES3
             fixed (Matrix2x3* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix2x3fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix2x3fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix2x3fv"/>
@@ -2402,8 +2370,7 @@ namespace OpenTK.Graphics.OpenGLES3
             fixed (Matrix2x3* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix2x3fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix2x3fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix2x3fv"/>
@@ -2412,8 +2379,7 @@ namespace OpenTK.Graphics.OpenGLES3
             fixed (Matrix2x3* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix2x3fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix2x3fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix3x2fv"/>
@@ -2423,8 +2389,7 @@ namespace OpenTK.Graphics.OpenGLES3
             fixed (Matrix3x2* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix3x2fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix3x2fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix3x2fv"/>
@@ -2433,8 +2398,7 @@ namespace OpenTK.Graphics.OpenGLES3
             fixed (Matrix3x2* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix3x2fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix3x2fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix3x2fv"/>
@@ -2443,8 +2407,7 @@ namespace OpenTK.Graphics.OpenGLES3
             fixed (Matrix3x2* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix3x2fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix3x2fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix2x4fv"/>
@@ -2454,8 +2417,7 @@ namespace OpenTK.Graphics.OpenGLES3
             fixed (Matrix2x4* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix2x4fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix2x4fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix2x4fv"/>
@@ -2464,8 +2426,7 @@ namespace OpenTK.Graphics.OpenGLES3
             fixed (Matrix2x4* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix2x4fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix2x4fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix2x4fv"/>
@@ -2474,8 +2435,7 @@ namespace OpenTK.Graphics.OpenGLES3
             fixed (Matrix2x4* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix2x4fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix2x4fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix4x2fv"/>
@@ -2485,8 +2445,7 @@ namespace OpenTK.Graphics.OpenGLES3
             fixed (Matrix4x2* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix4x2fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix4x2fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix4x2fv"/>
@@ -2495,8 +2454,7 @@ namespace OpenTK.Graphics.OpenGLES3
             fixed (Matrix4x2* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix4x2fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix4x2fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix4x2fv"/>
@@ -2505,8 +2463,7 @@ namespace OpenTK.Graphics.OpenGLES3
             fixed (Matrix4x2* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix4x2fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix4x2fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix3x4fv"/>
@@ -2516,8 +2473,7 @@ namespace OpenTK.Graphics.OpenGLES3
             fixed (Matrix3x4* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix3x4fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix3x4fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix3x4fv"/>
@@ -2526,8 +2482,7 @@ namespace OpenTK.Graphics.OpenGLES3
             fixed (Matrix3x4* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix3x4fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix3x4fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix3x4fv"/>
@@ -2536,8 +2491,7 @@ namespace OpenTK.Graphics.OpenGLES3
             fixed (Matrix3x4* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix3x4fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix3x4fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix4x3fv"/>
@@ -2547,8 +2501,7 @@ namespace OpenTK.Graphics.OpenGLES3
             fixed (Matrix4x3* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix4x3fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix4x3fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix4x3fv"/>
@@ -2557,8 +2510,7 @@ namespace OpenTK.Graphics.OpenGLES3
             fixed (Matrix4x3* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix4x3fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix4x3fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="UniformMatrix4x3fv"/>
@@ -2567,8 +2519,7 @@ namespace OpenTK.Graphics.OpenGLES3
             fixed (Matrix4x3* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                UniformMatrix4x3fv(location, count, transpose_byte, value_ptr);
+                UniformMatrix4x3fv(location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="DeleteVertexArrays"/>
@@ -4531,8 +4482,7 @@ namespace OpenTK.Graphics.OpenGLES3
             fixed (Matrix2* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix2fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix2fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2fv"/>
@@ -4541,8 +4491,7 @@ namespace OpenTK.Graphics.OpenGLES3
             fixed (Matrix2* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix2fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix2fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2fv"/>
@@ -4551,8 +4500,7 @@ namespace OpenTK.Graphics.OpenGLES3
             fixed (Matrix2* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix2fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix2fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3fv"/>
@@ -4562,8 +4510,7 @@ namespace OpenTK.Graphics.OpenGLES3
             fixed (Matrix3* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix3fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix3fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3fv"/>
@@ -4572,8 +4519,7 @@ namespace OpenTK.Graphics.OpenGLES3
             fixed (Matrix3* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix3fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix3fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3fv"/>
@@ -4582,8 +4528,7 @@ namespace OpenTK.Graphics.OpenGLES3
             fixed (Matrix3* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix3fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix3fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
@@ -4593,8 +4538,7 @@ namespace OpenTK.Graphics.OpenGLES3
             fixed (Matrix4* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix4fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix4fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
@@ -4603,8 +4547,7 @@ namespace OpenTK.Graphics.OpenGLES3
             fixed (Matrix4* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix4fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix4fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
@@ -4613,8 +4556,7 @@ namespace OpenTK.Graphics.OpenGLES3
             fixed (Matrix4* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix4fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix4fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x3fv"/>
@@ -4624,8 +4566,7 @@ namespace OpenTK.Graphics.OpenGLES3
             fixed (Matrix2x3* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix2x3fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix2x3fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x3fv"/>
@@ -4634,8 +4575,7 @@ namespace OpenTK.Graphics.OpenGLES3
             fixed (Matrix2x3* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix2x3fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix2x3fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x3fv"/>
@@ -4644,8 +4584,7 @@ namespace OpenTK.Graphics.OpenGLES3
             fixed (Matrix2x3* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix2x3fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix2x3fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
@@ -4655,8 +4594,7 @@ namespace OpenTK.Graphics.OpenGLES3
             fixed (Matrix3x2* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix3x2fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix3x2fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
@@ -4665,8 +4603,7 @@ namespace OpenTK.Graphics.OpenGLES3
             fixed (Matrix3x2* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix3x2fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix3x2fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
@@ -4675,8 +4612,7 @@ namespace OpenTK.Graphics.OpenGLES3
             fixed (Matrix3x2* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix3x2fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix3x2fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x4fv"/>
@@ -4686,8 +4622,7 @@ namespace OpenTK.Graphics.OpenGLES3
             fixed (Matrix2x4* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix2x4fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix2x4fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x4fv"/>
@@ -4696,8 +4631,7 @@ namespace OpenTK.Graphics.OpenGLES3
             fixed (Matrix2x4* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix2x4fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix2x4fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x4fv"/>
@@ -4706,8 +4640,7 @@ namespace OpenTK.Graphics.OpenGLES3
             fixed (Matrix2x4* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix2x4fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix2x4fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x2fv"/>
@@ -4717,8 +4650,7 @@ namespace OpenTK.Graphics.OpenGLES3
             fixed (Matrix4x2* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix4x2fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix4x2fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x2fv"/>
@@ -4727,8 +4659,7 @@ namespace OpenTK.Graphics.OpenGLES3
             fixed (Matrix4x2* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix4x2fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix4x2fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x2fv"/>
@@ -4737,8 +4668,7 @@ namespace OpenTK.Graphics.OpenGLES3
             fixed (Matrix4x2* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix4x2fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix4x2fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x4fv"/>
@@ -4748,8 +4678,7 @@ namespace OpenTK.Graphics.OpenGLES3
             fixed (Matrix3x4* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix3x4fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix3x4fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x4fv"/>
@@ -4758,8 +4687,7 @@ namespace OpenTK.Graphics.OpenGLES3
             fixed (Matrix3x4* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix3x4fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix3x4fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x4fv"/>
@@ -4768,8 +4696,7 @@ namespace OpenTK.Graphics.OpenGLES3
             fixed (Matrix3x4* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix3x4fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix3x4fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x3fv"/>
@@ -4779,8 +4706,7 @@ namespace OpenTK.Graphics.OpenGLES3
             fixed (Matrix4x3* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix4x3fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix4x3fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x3fv"/>
@@ -4789,8 +4715,7 @@ namespace OpenTK.Graphics.OpenGLES3
             fixed (Matrix4x3* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix4x3fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix4x3fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x3fv"/>
@@ -4799,8 +4724,7 @@ namespace OpenTK.Graphics.OpenGLES3
             fixed (Matrix4x3* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
-                byte transpose_byte = (byte)(transpose ? 1 : 0);
-                ProgramUniformMatrix4x3fv(program, location, count, transpose_byte, value_ptr);
+                ProgramUniformMatrix4x3fv(program, location, count, transpose, value_ptr);
             }
         }
         /// <inheritdoc cref="GetProgramPipelineInfoLog"/>
@@ -4875,12 +4799,6 @@ namespace OpenTK.Graphics.OpenGLES3
                 Marshal.FreeCoTaskMem((IntPtr)infoLog_ptr);
             }
         }
-        /// <inheritdoc cref="BindImageTexture"/>
-        public static unsafe void BindImageTexture(uint unit, TextureHandle texture, int level, bool layered, int layer, BufferAccessARB access, InternalFormat format)
-        {
-            byte layered_byte = (byte)(layered ? 1 : 0);
-            BindImageTexture(unit, texture, level, layered_byte, layer, access, format);
-        }
         /// <inheritdoc cref="GetBooleani_v"/>
         public static unsafe void GetBoolean(BufferTargetARB target, uint index, Span<bool> data)
         {
@@ -4904,12 +4822,6 @@ namespace OpenTK.Graphics.OpenGLES3
             {
                 GetBooleani_v(target, index, data_ptr);
             }
-        }
-        /// <inheritdoc cref="TexStorage2DMultisample"/>
-        public static unsafe void TexStorage2DMultisample(TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, bool fixedsamplelocations)
-        {
-            byte fixedsamplelocations_byte = (byte)(fixedsamplelocations ? 1 : 0);
-            TexStorage2DMultisample(target, samples, internalformat, width, height, fixedsamplelocations_byte);
         }
         /// <inheritdoc cref="GetMultisamplefv"/>
         public static unsafe void GetMultisamplef(GetMultisamplePNameNV pname, uint index, Span<float> val)
@@ -4983,20 +4895,13 @@ namespace OpenTK.Graphics.OpenGLES3
                 GetTexLevelParameterfv(target, level, pname, parameters_ptr);
             }
         }
-        /// <inheritdoc cref="VertexAttribFormat"/>
-        public static unsafe void VertexAttribFormat(uint attribindex, int size, VertexAttribType type, bool normalized, uint relativeoffset)
-        {
-            byte normalized_byte = (byte)(normalized ? 1 : 0);
-            VertexAttribFormat(attribindex, size, type, normalized_byte, relativeoffset);
-        }
         /// <inheritdoc cref="DebugMessageControl"/>
         public static unsafe void DebugMessageControl(DebugSource source, DebugType type, DebugSeverity severity, ReadOnlySpan<uint> ids, bool enabled)
         {
             int count = (int)(ids.Length);
             fixed (uint* ids_ptr = ids)
             {
-                byte enabled_byte = (byte)(enabled ? 1 : 0);
-                DebugMessageControl(source, type, severity, count, ids_ptr, enabled_byte);
+                DebugMessageControl(source, type, severity, count, ids_ptr, enabled);
             }
         }
         /// <inheritdoc cref="DebugMessageControl"/>
@@ -5005,8 +4910,7 @@ namespace OpenTK.Graphics.OpenGLES3
             int count = (int)(ids.Length);
             fixed (uint* ids_ptr = ids)
             {
-                byte enabled_byte = (byte)(enabled ? 1 : 0);
-                DebugMessageControl(source, type, severity, count, ids_ptr, enabled_byte);
+                DebugMessageControl(source, type, severity, count, ids_ptr, enabled);
             }
         }
         /// <inheritdoc cref="DebugMessageControl"/>
@@ -5014,8 +4918,7 @@ namespace OpenTK.Graphics.OpenGLES3
         {
             fixed (uint* ids_ptr = &ids)
             {
-                byte enabled_byte = (byte)(enabled ? 1 : 0);
-                DebugMessageControl(source, type, severity, count, ids_ptr, enabled_byte);
+                DebugMessageControl(source, type, severity, count, ids_ptr, enabled);
             }
         }
         /// <inheritdoc cref="DebugMessageInsert"/>
@@ -5389,15 +5292,6 @@ namespace OpenTK.Graphics.OpenGLES3
         {
             GetPointerv(pname, parameters);
         }
-        /// <inheritdoc cref="ColorMaski"/>
-        public static unsafe void ColorMaski(uint index, bool r, bool g, bool b, bool a)
-        {
-            byte r_byte = (byte)(r ? 1 : 0);
-            byte g_byte = (byte)(g ? 1 : 0);
-            byte b_byte = (byte)(b ? 1 : 0);
-            byte a_byte = (byte)(a ? 1 : 0);
-            ColorMaski(index, r_byte, g_byte, b_byte, a_byte);
-        }
         /// <inheritdoc cref="DrawElementsBaseVertex"/>
         public static unsafe void DrawElementsBaseVertex(PrimitiveType mode, int count, DrawElementsType type, nint offset, int basevertex)
         {
@@ -5721,12 +5615,6 @@ namespace OpenTK.Graphics.OpenGLES3
                 GetSamplerParameterIuiv(sampler, pname, parameters_ptr);
             }
         }
-        /// <inheritdoc cref="TexStorage3DMultisample"/>
-        public static unsafe void TexStorage3DMultisample(TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, int depth, bool fixedsamplelocations)
-        {
-            byte fixedsamplelocations_byte = (byte)(fixedsamplelocations ? 1 : 0);
-            TexStorage3DMultisample(target, samples, internalformat, width, height, depth, fixedsamplelocations_byte);
-        }
         public static unsafe partial class AMD
         {
             /// <inheritdoc cref="GetPerfMonitorGroupsAMD"/>
@@ -6037,8 +5925,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 int numCounters = (int)(counterList.Length);
                 fixed (uint* counterList_ptr = counterList)
                 {
-                    byte enable_byte = (byte)(enable ? 1 : 0);
-                    SelectPerfMonitorCountersAMD(monitor, enable_byte, group, numCounters, counterList_ptr);
+                    SelectPerfMonitorCountersAMD(monitor, enable, group, numCounters, counterList_ptr);
                 }
             }
             /// <inheritdoc cref="SelectPerfMonitorCountersAMD"/>
@@ -6047,8 +5934,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 int numCounters = (int)(counterList.Length);
                 fixed (uint* counterList_ptr = counterList)
                 {
-                    byte enable_byte = (byte)(enable ? 1 : 0);
-                    SelectPerfMonitorCountersAMD(monitor, enable_byte, group, numCounters, counterList_ptr);
+                    SelectPerfMonitorCountersAMD(monitor, enable, group, numCounters, counterList_ptr);
                 }
             }
             /// <inheritdoc cref="SelectPerfMonitorCountersAMD"/>
@@ -6056,8 +5942,7 @@ namespace OpenTK.Graphics.OpenGLES3
             {
                 fixed (uint* counterList_ptr = &counterList)
                 {
-                    byte enable_byte = (byte)(enable ? 1 : 0);
-                    SelectPerfMonitorCountersAMD(monitor, enable_byte, group, numCounters, counterList_ptr);
+                    SelectPerfMonitorCountersAMD(monitor, enable, group, numCounters, counterList_ptr);
                 }
             }
             /// <inheritdoc cref="GetPerfMonitorCounterDataAMD"/>
@@ -6745,15 +6630,6 @@ namespace OpenTK.Graphics.OpenGLES3
                     DrawBuffersEXT(n, bufs_ptr);
                 }
             }
-            /// <inheritdoc cref="ColorMaskiEXT"/>
-            public static unsafe void ColorMaskiEXT(uint index, bool r, bool g, bool b, bool a)
-            {
-                byte r_byte = (byte)(r ? 1 : 0);
-                byte g_byte = (byte)(g ? 1 : 0);
-                byte b_byte = (byte)(b ? 1 : 0);
-                byte a_byte = (byte)(a ? 1 : 0);
-                ColorMaskiEXT(index, r_byte, g_byte, b_byte, a_byte);
-            }
             /// <inheritdoc cref="DrawElementsBaseVertexEXT"/>
             public static unsafe void DrawElementsBaseVertexEXT(PrimitiveType mode, int count, DrawElementsType type, nint offset, int basevertex)
             {
@@ -6936,30 +6812,6 @@ namespace OpenTK.Graphics.OpenGLES3
                 {
                     GetMemoryObjectParameterivEXT(memoryObject, pname, parameters_ptr);
                 }
-            }
-            /// <inheritdoc cref="TexStorageMem2DMultisampleEXT"/>
-            public static unsafe void TexStorageMem2DMultisampleEXT(TextureTarget target, int samples, SizedInternalFormat internalFormat, int width, int height, bool fixedSampleLocations, uint memory, ulong offset)
-            {
-                byte fixedSampleLocations_byte = (byte)(fixedSampleLocations ? 1 : 0);
-                TexStorageMem2DMultisampleEXT(target, samples, internalFormat, width, height, fixedSampleLocations_byte, memory, offset);
-            }
-            /// <inheritdoc cref="TexStorageMem3DMultisampleEXT"/>
-            public static unsafe void TexStorageMem3DMultisampleEXT(TextureTarget target, int samples, SizedInternalFormat internalFormat, int width, int height, int depth, bool fixedSampleLocations, uint memory, ulong offset)
-            {
-                byte fixedSampleLocations_byte = (byte)(fixedSampleLocations ? 1 : 0);
-                TexStorageMem3DMultisampleEXT(target, samples, internalFormat, width, height, depth, fixedSampleLocations_byte, memory, offset);
-            }
-            /// <inheritdoc cref="TextureStorageMem2DMultisampleEXT"/>
-            public static unsafe void TextureStorageMem2DMultisampleEXT(TextureHandle texture, int samples, SizedInternalFormat internalFormat, int width, int height, bool fixedSampleLocations, uint memory, ulong offset)
-            {
-                byte fixedSampleLocations_byte = (byte)(fixedSampleLocations ? 1 : 0);
-                TextureStorageMem2DMultisampleEXT(texture, samples, internalFormat, width, height, fixedSampleLocations_byte, memory, offset);
-            }
-            /// <inheritdoc cref="TextureStorageMem3DMultisampleEXT"/>
-            public static unsafe void TextureStorageMem3DMultisampleEXT(TextureHandle texture, int samples, SizedInternalFormat internalFormat, int width, int height, int depth, bool fixedSampleLocations, uint memory, ulong offset)
-            {
-                byte fixedSampleLocations_byte = (byte)(fixedSampleLocations ? 1 : 0);
-                TextureStorageMem3DMultisampleEXT(texture, samples, internalFormat, width, height, depth, fixedSampleLocations_byte, memory, offset);
             }
             /// <inheritdoc cref="ImportMemoryWin32HandleEXT"/>
             public static unsafe void ImportMemoryWin32HandleEXT(uint memory, ulong size, ExternalHandleType handleType, IntPtr handle)
@@ -7150,12 +7002,6 @@ namespace OpenTK.Graphics.OpenGLES3
                 {
                     GetIntegeri_vEXT(target, index, data_ptr);
                 }
-            }
-            /// <inheritdoc cref="RasterSamplesEXT"/>
-            public static unsafe void RasterSamplesEXT(uint samples, bool fixedsamplelocations)
-            {
-                byte fixedsamplelocations_byte = (byte)(fixedsamplelocations ? 1 : 0);
-                RasterSamplesEXT(samples, fixedsamplelocations_byte);
             }
             /// <inheritdoc cref="ReadnPixelsEXT"/>
             public static unsafe void ReadnPixelsEXT(int x, int y, int width, int height, PixelFormat format, PixelType type, int bufSize, IntPtr data)
@@ -7773,8 +7619,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 int count = (int)(value.Length / 4);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2fvEXT"/>
@@ -7783,8 +7628,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 int count = (int)(value.Length / 4);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2fvEXT"/>
@@ -7792,8 +7636,7 @@ namespace OpenTK.Graphics.OpenGLES3
             {
                 fixed (float* value_ptr = &value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3fvEXT"/>
@@ -7802,8 +7645,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 int count = (int)(value.Length / 9);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3fvEXT"/>
@@ -7812,8 +7654,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 int count = (int)(value.Length / 9);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3fvEXT"/>
@@ -7821,8 +7662,7 @@ namespace OpenTK.Graphics.OpenGLES3
             {
                 fixed (float* value_ptr = &value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4fvEXT"/>
@@ -7831,8 +7671,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 int count = (int)(value.Length / 16);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4fvEXT"/>
@@ -7841,8 +7680,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 int count = (int)(value.Length / 16);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4fvEXT"/>
@@ -7850,8 +7688,7 @@ namespace OpenTK.Graphics.OpenGLES3
             {
                 fixed (float* value_ptr = &value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniform1uivEXT"/>
@@ -7964,8 +7801,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 int count = (int)(value.Length / 6);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2x3fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2x3fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x3fvEXT"/>
@@ -7974,8 +7810,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 int count = (int)(value.Length / 6);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2x3fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2x3fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x3fvEXT"/>
@@ -7983,8 +7818,7 @@ namespace OpenTK.Graphics.OpenGLES3
             {
                 fixed (float* value_ptr = &value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2x3fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2x3fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2fvEXT"/>
@@ -7993,8 +7827,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 int count = (int)(value.Length / 6);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3x2fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3x2fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2fvEXT"/>
@@ -8003,8 +7836,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 int count = (int)(value.Length / 6);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3x2fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3x2fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2fvEXT"/>
@@ -8012,8 +7844,7 @@ namespace OpenTK.Graphics.OpenGLES3
             {
                 fixed (float* value_ptr = &value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3x2fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3x2fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x4fvEXT"/>
@@ -8022,8 +7853,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 int count = (int)(value.Length / 8);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2x4fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2x4fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x4fvEXT"/>
@@ -8032,8 +7862,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 int count = (int)(value.Length / 8);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2x4fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2x4fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x4fvEXT"/>
@@ -8041,8 +7870,7 @@ namespace OpenTK.Graphics.OpenGLES3
             {
                 fixed (float* value_ptr = &value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix2x4fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix2x4fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x2fvEXT"/>
@@ -8051,8 +7879,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 int count = (int)(value.Length / 8);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4x2fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4x2fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x2fvEXT"/>
@@ -8061,8 +7888,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 int count = (int)(value.Length / 8);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4x2fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4x2fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x2fvEXT"/>
@@ -8070,8 +7896,7 @@ namespace OpenTK.Graphics.OpenGLES3
             {
                 fixed (float* value_ptr = &value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4x2fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4x2fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x4fvEXT"/>
@@ -8080,8 +7905,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 int count = (int)(value.Length / 12);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3x4fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3x4fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x4fvEXT"/>
@@ -8090,8 +7914,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 int count = (int)(value.Length / 12);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3x4fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3x4fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x4fvEXT"/>
@@ -8099,8 +7922,7 @@ namespace OpenTK.Graphics.OpenGLES3
             {
                 fixed (float* value_ptr = &value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix3x4fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix3x4fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x3fvEXT"/>
@@ -8109,8 +7931,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 int count = (int)(value.Length / 12);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4x3fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4x3fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x3fvEXT"/>
@@ -8119,8 +7940,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 int count = (int)(value.Length / 12);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4x3fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4x3fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x3fvEXT"/>
@@ -8128,8 +7948,7 @@ namespace OpenTK.Graphics.OpenGLES3
             {
                 fixed (float* value_ptr = &value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    ProgramUniformMatrix4x3fvEXT(program, location, count, transpose_byte, value_ptr);
+                    ProgramUniformMatrix4x3fvEXT(program, location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="ClearPixelLocalStorageuiEXT"/>
@@ -8157,12 +7976,6 @@ namespace OpenTK.Graphics.OpenGLES3
                 {
                     ClearPixelLocalStorageuiEXT(offset, n, values_ptr);
                 }
-            }
-            /// <inheritdoc cref="TexPageCommitmentEXT"/>
-            public static unsafe void TexPageCommitmentEXT(All target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, bool commit)
-            {
-                byte commit_byte = (byte)(commit ? 1 : 0);
-                TexPageCommitmentEXT(target, level, xoffset, yoffset, zoffset, width, height, depth, commit_byte);
             }
             /// <inheritdoc cref="TexParameterIivEXT"/>
             public static unsafe void TexParameterIivEXT(TextureTarget target, TextureParameterName pname, ReadOnlySpan<int> parameters)
@@ -8441,14 +8254,6 @@ namespace OpenTK.Graphics.OpenGLES3
                     GetSemaphoreParameterivNV(semaphore, pname, parameters_ptr);
                 }
             }
-            /// <inheritdoc cref="GetImageHandleNV"/>
-            public static unsafe ulong GetImageHandleNV(TextureHandle texture, int level, bool layered, int layer, PixelFormat format)
-            {
-                ulong returnValue;
-                byte layered_byte = (byte)(layered ? 1 : 0);
-                returnValue = GetImageHandleNV(texture, level, layered_byte, layer, format);
-                return returnValue;
-            }
             /// <inheritdoc cref="UniformHandleui64vNV"/>
             public static unsafe void UniformHandleui64vNV(int location, ReadOnlySpan<ulong> value)
             {
@@ -8500,12 +8305,6 @@ namespace OpenTK.Graphics.OpenGLES3
                 {
                     ProgramUniformHandleui64vNV(program, location, count, values_ptr);
                 }
-            }
-            /// <inheritdoc cref="CoverageMaskNV"/>
-            public static unsafe void CoverageMaskNV(bool mask)
-            {
-                byte mask_byte = (byte)(mask ? 1 : 0);
-                CoverageMaskNV(mask_byte);
             }
             /// <inheritdoc cref="DrawBuffersNV"/>
             public static unsafe void DrawBuffersNV(ReadOnlySpan<All> bufs)
@@ -8623,12 +8422,6 @@ namespace OpenTK.Graphics.OpenGLES3
                 {
                     GetFenceivNV(fence, pname, parameters_ptr);
                 }
-            }
-            /// <inheritdoc cref="RasterSamplesEXT"/>
-            public static unsafe void RasterSamplesEXT(uint samples, bool fixedsamplelocations)
-            {
-                byte fixedsamplelocations_byte = (byte)(fixedsamplelocations ? 1 : 0);
-                RasterSamplesEXT(samples, fixedsamplelocations_byte);
             }
             /// <inheritdoc cref="CoverageModulationTableNV"/>
             public static unsafe void CoverageModulationTableNV(ReadOnlySpan<float> v)
@@ -9138,38 +8931,13 @@ namespace OpenTK.Graphics.OpenGLES3
                     GetMemoryObjectDetachedResourcesuivNV(memory, pname, first, count, parameters_ptr);
                 }
             }
-            /// <inheritdoc cref="BufferPageCommitmentMemNV"/>
-            public static unsafe void BufferPageCommitmentMemNV(BufferStorageTarget target, IntPtr offset, nint size, uint memory, ulong memOffset, bool commit)
-            {
-                byte commit_byte = (byte)(commit ? 1 : 0);
-                BufferPageCommitmentMemNV(target, offset, size, memory, memOffset, commit_byte);
-            }
-            /// <inheritdoc cref="TexPageCommitmentMemNV"/>
-            public static unsafe void TexPageCommitmentMemNV(TextureTarget target, int layer, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, uint memory, ulong offset, bool commit)
-            {
-                byte commit_byte = (byte)(commit ? 1 : 0);
-                TexPageCommitmentMemNV(target, layer, level, xoffset, yoffset, zoffset, width, height, depth, memory, offset, commit_byte);
-            }
-            /// <inheritdoc cref="NamedBufferPageCommitmentMemNV"/>
-            public static unsafe void NamedBufferPageCommitmentMemNV(BufferHandle buffer, IntPtr offset, nint size, uint memory, ulong memOffset, bool commit)
-            {
-                byte commit_byte = (byte)(commit ? 1 : 0);
-                NamedBufferPageCommitmentMemNV(buffer, offset, size, memory, memOffset, commit_byte);
-            }
-            /// <inheritdoc cref="TexturePageCommitmentMemNV"/>
-            public static unsafe void TexturePageCommitmentMemNV(TextureHandle texture, int layer, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, uint memory, ulong offset, bool commit)
-            {
-                byte commit_byte = (byte)(commit ? 1 : 0);
-                TexturePageCommitmentMemNV(texture, layer, level, xoffset, yoffset, zoffset, width, height, depth, memory, offset, commit_byte);
-            }
             /// <inheritdoc cref="UniformMatrix2x3fvNV"/>
             public static unsafe void UniformMatrix2x3fvNV(int location, bool transpose, ReadOnlySpan<float> value)
             {
                 int count = (int)(value.Length / 6);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix2x3fvNV(location, count, transpose_byte, value_ptr);
+                    UniformMatrix2x3fvNV(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix2x3fvNV"/>
@@ -9178,8 +8946,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 int count = (int)(value.Length / 6);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix2x3fvNV(location, count, transpose_byte, value_ptr);
+                    UniformMatrix2x3fvNV(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix2x3fvNV"/>
@@ -9187,8 +8954,7 @@ namespace OpenTK.Graphics.OpenGLES3
             {
                 fixed (float* value_ptr = &value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix2x3fvNV(location, count, transpose_byte, value_ptr);
+                    UniformMatrix2x3fvNV(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix3x2fvNV"/>
@@ -9197,8 +8963,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 int count = (int)(value.Length / 6);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix3x2fvNV(location, count, transpose_byte, value_ptr);
+                    UniformMatrix3x2fvNV(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix3x2fvNV"/>
@@ -9207,8 +8972,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 int count = (int)(value.Length / 6);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix3x2fvNV(location, count, transpose_byte, value_ptr);
+                    UniformMatrix3x2fvNV(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix3x2fvNV"/>
@@ -9216,8 +8980,7 @@ namespace OpenTK.Graphics.OpenGLES3
             {
                 fixed (float* value_ptr = &value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix3x2fvNV(location, count, transpose_byte, value_ptr);
+                    UniformMatrix3x2fvNV(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix2x4fvNV"/>
@@ -9226,8 +8989,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 int count = (int)(value.Length / 8);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix2x4fvNV(location, count, transpose_byte, value_ptr);
+                    UniformMatrix2x4fvNV(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix2x4fvNV"/>
@@ -9236,8 +8998,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 int count = (int)(value.Length / 8);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix2x4fvNV(location, count, transpose_byte, value_ptr);
+                    UniformMatrix2x4fvNV(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix2x4fvNV"/>
@@ -9245,8 +9006,7 @@ namespace OpenTK.Graphics.OpenGLES3
             {
                 fixed (float* value_ptr = &value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix2x4fvNV(location, count, transpose_byte, value_ptr);
+                    UniformMatrix2x4fvNV(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix4x2fvNV"/>
@@ -9255,8 +9015,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 int count = (int)(value.Length / 8);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix4x2fvNV(location, count, transpose_byte, value_ptr);
+                    UniformMatrix4x2fvNV(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix4x2fvNV"/>
@@ -9265,8 +9024,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 int count = (int)(value.Length / 8);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix4x2fvNV(location, count, transpose_byte, value_ptr);
+                    UniformMatrix4x2fvNV(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix4x2fvNV"/>
@@ -9274,8 +9032,7 @@ namespace OpenTK.Graphics.OpenGLES3
             {
                 fixed (float* value_ptr = &value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix4x2fvNV(location, count, transpose_byte, value_ptr);
+                    UniformMatrix4x2fvNV(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix3x4fvNV"/>
@@ -9284,8 +9041,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 int count = (int)(value.Length / 12);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix3x4fvNV(location, count, transpose_byte, value_ptr);
+                    UniformMatrix3x4fvNV(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix3x4fvNV"/>
@@ -9294,8 +9050,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 int count = (int)(value.Length / 12);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix3x4fvNV(location, count, transpose_byte, value_ptr);
+                    UniformMatrix3x4fvNV(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix3x4fvNV"/>
@@ -9303,8 +9058,7 @@ namespace OpenTK.Graphics.OpenGLES3
             {
                 fixed (float* value_ptr = &value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix3x4fvNV(location, count, transpose_byte, value_ptr);
+                    UniformMatrix3x4fvNV(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix4x3fvNV"/>
@@ -9313,8 +9067,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 int count = (int)(value.Length / 12);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix4x3fvNV(location, count, transpose_byte, value_ptr);
+                    UniformMatrix4x3fvNV(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix4x3fvNV"/>
@@ -9323,8 +9076,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 int count = (int)(value.Length / 12);
                 fixed (float* value_ptr = value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix4x3fvNV(location, count, transpose_byte, value_ptr);
+                    UniformMatrix4x3fvNV(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="UniformMatrix4x3fvNV"/>
@@ -9332,8 +9084,7 @@ namespace OpenTK.Graphics.OpenGLES3
             {
                 fixed (float* value_ptr = &value)
                 {
-                    byte transpose_byte = (byte)(transpose ? 1 : 0);
-                    UniformMatrix4x3fvNV(location, count, transpose_byte, value_ptr);
+                    UniformMatrix4x3fvNV(location, count, transpose, value_ptr);
                 }
             }
             /// <inheritdoc cref="PathCommandsNV"/>
@@ -10859,12 +10610,6 @@ namespace OpenTK.Graphics.OpenGLES3
                     GetShadingRateSampleLocationivNV(rate, samples, index, location_ptr);
                 }
             }
-            /// <inheritdoc cref="ShadingRateImageBarrierNV"/>
-            public static unsafe void ShadingRateImageBarrierNV(bool synchronize)
-            {
-                byte synchronize_byte = (byte)(synchronize ? 1 : 0);
-                ShadingRateImageBarrierNV(synchronize_byte);
-            }
             /// <inheritdoc cref="ShadingRateImagePaletteNV"/>
             public static unsafe void ShadingRateImagePaletteNV(uint viewport, uint first, ReadOnlySpan<All> rates)
             {
@@ -11209,8 +10954,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 int count = (int)(ids.Length);
                 fixed (uint* ids_ptr = ids)
                 {
-                    byte enabled_byte = (byte)(enabled ? 1 : 0);
-                    DebugMessageControl(source, type, severity, count, ids_ptr, enabled_byte);
+                    DebugMessageControl(source, type, severity, count, ids_ptr, enabled);
                 }
             }
             /// <inheritdoc cref="DebugMessageControl"/>
@@ -11219,8 +10963,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 int count = (int)(ids.Length);
                 fixed (uint* ids_ptr = ids)
                 {
-                    byte enabled_byte = (byte)(enabled ? 1 : 0);
-                    DebugMessageControl(source, type, severity, count, ids_ptr, enabled_byte);
+                    DebugMessageControl(source, type, severity, count, ids_ptr, enabled);
                 }
             }
             /// <inheritdoc cref="DebugMessageControl"/>
@@ -11228,8 +10971,7 @@ namespace OpenTK.Graphics.OpenGLES3
             {
                 fixed (uint* ids_ptr = &ids)
                 {
-                    byte enabled_byte = (byte)(enabled ? 1 : 0);
-                    DebugMessageControl(source, type, severity, count, ids_ptr, enabled_byte);
+                    DebugMessageControl(source, type, severity, count, ids_ptr, enabled);
                 }
             }
             /// <inheritdoc cref="DebugMessageInsert"/>
@@ -11608,8 +11350,7 @@ namespace OpenTK.Graphics.OpenGLES3
             {
                 fixed (uint* ids_ptr = &ids)
                 {
-                    byte enabled_byte = (byte)(enabled ? 1 : 0);
-                    DebugMessageControlKHR(source, type, severity, count, ids_ptr, enabled_byte);
+                    DebugMessageControlKHR(source, type, severity, count, ids_ptr, enabled);
                 }
             }
             /// <inheritdoc cref="DebugMessageInsertKHR"/>
@@ -12216,15 +11957,6 @@ namespace OpenTK.Graphics.OpenGLES3
                     EGLImageTargetRenderbufferStorageOES(target, image_ptr);
                 }
             }
-            /// <inheritdoc cref="ColorMaskiOES"/>
-            public static unsafe void ColorMaskiOES(uint index, bool r, bool g, bool b, bool a)
-            {
-                byte r_byte = (byte)(r ? 1 : 0);
-                byte g_byte = (byte)(g ? 1 : 0);
-                byte b_byte = (byte)(b ? 1 : 0);
-                byte a_byte = (byte)(a ? 1 : 0);
-                ColorMaskiOES(index, r_byte, g_byte, b_byte, a_byte);
-            }
             /// <inheritdoc cref="DrawElementsBaseVertexOES"/>
             public static unsafe void DrawElementsBaseVertexOES(PrimitiveType mode, int count, DrawElementsType type, nint offset, int basevertex)
             {
@@ -12713,12 +12445,6 @@ namespace OpenTK.Graphics.OpenGLES3
                 {
                     GetSamplerParameterIuivOES(sampler, pname, parameters_ptr);
                 }
-            }
-            /// <inheritdoc cref="TexStorage3DMultisampleOES"/>
-            public static unsafe void TexStorage3DMultisampleOES(TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, int depth, bool fixedsamplelocations)
-            {
-                byte fixedsamplelocations_byte = (byte)(fixedsamplelocations ? 1 : 0);
-                TexStorage3DMultisampleOES(target, samples, internalformat, width, height, depth, fixedsamplelocations_byte);
             }
             /// <inheritdoc cref="DeleteVertexArraysOES"/>
             public static unsafe void DeleteVertexArraysOES(ReadOnlySpan<VertexArrayHandle> arrays)


### PR DESCRIPTION
### Purpose of this PR

Changes `GLboolean` to be generated as `bool` instead of ``byte`.

### Testing status

Generated code is not tested, but the abi for bools and bytes should be the same for all supported platforms.