### PR TITLE
Add OpenAL platform detection for FreeBSD

### DIFF
--- a/src/OpenAL/OpenTK.OpenAL/OpenALLibraryNameContainer.cs
+++ b/src/OpenAL/OpenTK.OpenAL/OpenALLibraryNameContainer.cs
@@ -55,6 +55,10 @@ namespace OpenTK.Audio.OpenAL
                     return Linux;
                 }
             }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.FreeBSD))
+            {
+                return Linux;
+            }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 return Windows;


### PR DESCRIPTION
### Purpose of this PR
This PR adds FreeBSD platform detection for the OpenAL module (FreeBSD has actually been a valid OSPlatform [since Core 3.0](https://docs.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.osplatform.freebsd?view=net-6.0#system-runtime-interopservices-osplatform-freebsd)). Right now this is only used to determine the shared library name that it should load, which is actually just Linux's shared library name.

### Testing status
Tested locally myself on FreeBSD 13-x64. With this change, dependent apps can now play OGG Vorbis (and presumably other formats) on FreeBSD.

### Comments
N/A