### PR TITLE
Update to GLFW 3.3.8

### DIFF
--- a/src/OpenTK.Windowing.GraphicsLibraryFramework/OpenTK.Windowing.GraphicsLibraryFramework.csproj
+++ b/src/OpenTK.Windowing.GraphicsLibraryFramework/OpenTK.Windowing.GraphicsLibraryFramework.csproj
@@ -18,7 +18,7 @@
         <PrivateAssets>all</PrivateAssets>
       </PackageReference>
       <PackageReference Condition="'$(TargetFramework)' == 'net472'" Include="System.Memory" Version="4.5" />
-      <PackageReference Include="OpenTK.redist.glfw" Version="3.3.7.25" />
+      <PackageReference Include="OpenTK.redist.glfw" Version="3.3.8.30" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/OpenTK.Windowing.GraphicsLibraryFramework/paket
+++ b/src/OpenTK.Windowing.GraphicsLibraryFramework/paket
@@ -5,7 +5,7 @@ description
 dependencies
     framework: netcoreapp3.1
         OpenTK.Core ~> #VERSION#
-        OpenTK.redist.glfw >= 3.3.7.27
+        OpenTK.redist.glfw >= 3.3.8.30
 files
     bin\Release\netcoreapp3.1\OpenTK.Windowing.GraphicsLibraryFramework.dll ==> lib\netcoreapp3.1
     bin\Release\netcoreapp3.1\OpenTK.Windowing.GraphicsLibraryFramework.xml ==> lib\netcoreapp3.1


### PR DESCRIPTION
### Purpose of this PR

Updates OpenTK to GLFW 3.3.8 by updating the `OpenTK.redist.glfw` package to `3.3.8.30`

### Testing status

Built locally.