### PR TITLE
[3.x] Update test projects to net framework 4.6.1

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,5 +1,5 @@
 @echo off
-cls
+::cls
 
 .paket\paket.bootstrapper.exe
 if errorlevel 1 (

--- a/src/OpenTK.GLWidget/OpenTK.GLWidget.csproj
+++ b/src/OpenTK.GLWidget/OpenTK.GLWidget.csproj
@@ -39,7 +39,7 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <TargetFrameworkProfile />
     <Deterministic>true</Deterministic>
     <LangVersion>7</LangVersion>

--- a/tests/OpenTK.Tests.Generators/OpenTK.Tests.Generators.fsproj
+++ b/tests/OpenTK.Tests.Generators/OpenTK.Tests.Generators.fsproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>OpenTK.Tests.Generators</RootNamespace>
     <AssemblyName>OpenTK.Tests.Generators</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <TargetFSharpCoreVersion>4.4.0.0</TargetFSharpCoreVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>

--- a/tests/OpenTK.Tests.Integration/App.config
+++ b/tests/OpenTK.Tests.Integration/App.config
@@ -12,6 +12,6 @@
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
     </startup>-->
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
   </startup>
 </configuration>

--- a/tests/OpenTK.Tests.Integration/OpenTK.Tests.Integration.fsproj
+++ b/tests/OpenTK.Tests.Integration/OpenTK.Tests.Integration.fsproj
@@ -9,7 +9,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>OpenTK.Tests.Integration</RootNamespace>
     <AssemblyName>OpenTK.Tests.Integration</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <TargetFSharpCoreVersion>4.4.0.0</TargetFSharpCoreVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Name>OpenTK.Tests.Integration</Name>

--- a/tests/OpenTK.Tests.Math/OpenTK.Tests.Math.csproj
+++ b/tests/OpenTK.Tests.Math/OpenTK.Tests.Math.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>OpenTK.Tests.Math</RootNamespace>
     <AssemblyName>OpenTK.Tests.Math</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/tests/OpenTK.Tests/OpenTK.Tests.fsproj
+++ b/tests/OpenTK.Tests/OpenTK.Tests.fsproj
@@ -9,7 +9,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>OpenTK.Tests</RootNamespace>
     <AssemblyName>OpenTK.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <TargetFSharpCoreVersion>4.4.0.0</TargetFSharpCoreVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Name>OpenTK.Tests</Name>
@@ -51,6 +51,7 @@
       </PropertyGroup>
     </Otherwise>
   </Choose>
+
   <Import Project="$(FSharpTargetsPath)" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
### Purpose of this PR

Updates all projects (except the ones targeting `net20`) to `net461`.

### Testing status
