### PR TITLE
IFormattable implementations for vectors

### DIFF
--- a/src/OpenTK.Mathematics/Data/Color4.cs
+++ b/src/OpenTK.Mathematics/Data/Color4.cs
@@ -36,7 +36,7 @@ namespace OpenTK.Mathematics
     /// </summary>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
-    public struct Color4 : IEquatable<Color4>
+    public struct Color4 : IEquatable<Color4>, IFormattable
     {
         /// <summary>
         /// The red component of this Color4 structure.
@@ -195,8 +195,31 @@ namespace OpenTK.Mathematics
         /// <returns>A System.String that describes this Color4 structure.</returns>
         public override string ToString()
         {
-            var ls = MathHelper.ListSeparator;
-            return $"{{(R{ls} G{ls} B{ls} A) = ({R}{ls} {G}{ls} {B}{ls} {A})}}";
+            return ToString(null, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(string format)
+        {
+            return ToString(format, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(IFormatProvider formatProvider)
+        {
+            return ToString(null, formatProvider);
+        }
+
+        /// <inheritdoc/>
+        public string ToString(string format, IFormatProvider formatProvider)
+        {
+            var ls = MathHelper.GetListSeparator(formatProvider);
+            var r = R.ToString(format, formatProvider);
+            var g = G.ToString(format, formatProvider);
+            var b = B.ToString(format, formatProvider);
+            var a = A.ToString(format, formatProvider);
+
+            return $"{{(R{ls} G{ls} B{ls} A) = ({r}{ls} {g}{ls} {b}{ls} {a})}}";
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Data/Half.cs
+++ b/src/OpenTK.Mathematics/Data/Half.cs
@@ -537,7 +537,19 @@ namespace OpenTK.Mathematics
         /// <returns>The string representation of this instance.</returns>
         public override string ToString()
         {
-            return ToSingle().ToString();
+            return ToString(null, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(string format)
+        {
+            return ToString(format, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(IFormatProvider formatProvider)
+        {
+            return ToString(null, formatProvider);
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Data/Quaternion.cs
+++ b/src/OpenTK.Mathematics/Data/Quaternion.cs
@@ -31,7 +31,7 @@ namespace OpenTK.Mathematics
     /// Represents a Quaternion.
     /// </summary>
     [Serializable, StructLayout(LayoutKind.Sequential)]
-    public struct Quaternion : IEquatable<Quaternion>
+    public struct Quaternion : IEquatable<Quaternion>, IFormattable
     {
         /// <summary>
         /// The X, Y and Z components of this instance.
@@ -828,7 +828,28 @@ namespace OpenTK.Mathematics
         /// <returns>A human-readable representation of the quaternion.</returns>
         public override string ToString()
         {
-            return $"V: {Xyz}{MathHelper.ListSeparator} W: {W}";
+            return ToString(null, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(string format)
+        {
+            return ToString(format, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(IFormatProvider formatProvider)
+        {
+            return ToString(null, formatProvider);
+        }
+
+        /// <inheritdoc/>
+        public string ToString(string format, IFormatProvider formatProvider)
+        {
+            var ls = MathHelper.GetListSeparator(formatProvider);
+            var xyz = Xyz.ToString(format, formatProvider);
+            var w = W.ToString(format, formatProvider);
+            return $"V: {xyz}{ls} W: {w}";
         }
     }
 }

--- a/src/OpenTK.Mathematics/Data/Quaterniond.cs
+++ b/src/OpenTK.Mathematics/Data/Quaterniond.cs
@@ -31,7 +31,7 @@ namespace OpenTK.Mathematics
     /// Represents a double-precision Quaternion.
     /// </summary>
     [Serializable, StructLayout(LayoutKind.Sequential)]
-    public struct Quaterniond : IEquatable<Quaterniond>
+    public struct Quaterniond : IEquatable<Quaterniond>, IFormattable
     {
         /// <summary>
         /// The X, Y and Z components of this instance.
@@ -818,7 +818,28 @@ namespace OpenTK.Mathematics
         /// <returns>A human-readable representation of the quaternion.</returns>
         public override string ToString()
         {
-            return $"V: {Xyz}{MathHelper.ListSeparator} W: {W}";
+            return ToString(null, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(string format)
+        {
+            return ToString(format, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(IFormatProvider formatProvider)
+        {
+            return ToString(null, formatProvider);
+        }
+
+        /// <inheritdoc/>
+        public string ToString(string format, IFormatProvider formatProvider)
+        {
+            var ls = MathHelper.GetListSeparator(formatProvider);
+            var xyz = Xyz.ToString(format, formatProvider);
+            var w = W.ToString(format, formatProvider);
+            return $"V: {xyz}{ls} W: {w}";
         }
     }
 }

--- a/src/OpenTK.Mathematics/Geometry/Box2.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box2.cs
@@ -20,7 +20,7 @@ namespace OpenTK.Mathematics
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     [Serializable]
-    public struct Box2 : IEquatable<Box2>
+    public struct Box2 : IEquatable<Box2>, IFormattable
     {
         private Vector2 _min;
 
@@ -326,7 +326,25 @@ namespace OpenTK.Mathematics
         /// <inheritdoc/>
         public override string ToString()
         {
-            return $"{Min} - {Max}";
+            return ToString(null, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(string format)
+        {
+            return ToString(format, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(IFormatProvider formatProvider)
+        {
+            return ToString(null, formatProvider);
+        }
+
+        /// <inheritdoc/>
+        public string ToString(string format, IFormatProvider formatProvider)
+        {
+            return $"{Min.ToString(format, formatProvider)} - {Max.ToString(format, formatProvider)}";
         }
     }
 }

--- a/src/OpenTK.Mathematics/Geometry/Box2d.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box2d.cs
@@ -20,7 +20,7 @@ namespace OpenTK.Mathematics
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     [Serializable]
-    public struct Box2d : IEquatable<Box2d>
+    public struct Box2d : IEquatable<Box2d>, IFormattable
     {
         private Vector2d _min;
 
@@ -326,7 +326,25 @@ namespace OpenTK.Mathematics
         /// <inheritdoc/>
         public override string ToString()
         {
-            return $"{Min} - {Max}";
+            return ToString(null, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(string format)
+        {
+            return ToString(format, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(IFormatProvider formatProvider)
+        {
+            return ToString(null, formatProvider);
+        }
+
+        /// <inheritdoc/>
+        public string ToString(string format, IFormatProvider formatProvider)
+        {
+            return $"{Min.ToString(format, formatProvider)} - {Max.ToString(format, formatProvider)}";
         }
     }
 }

--- a/src/OpenTK.Mathematics/Geometry/Box2i.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box2i.cs
@@ -20,7 +20,7 @@ namespace OpenTK.Mathematics
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     [Serializable]
-    public struct Box2i : IEquatable<Box2i>
+    public struct Box2i : IEquatable<Box2i>, IFormattable
     {
         /// <summary>
         /// An empty box with Min (0, 0) and Max (0, 0).
@@ -336,7 +336,25 @@ namespace OpenTK.Mathematics
         /// <inheritdoc/>
         public override string ToString()
         {
-            return $"{Min} - {Max}";
+            return ToString(null, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(string format)
+        {
+            return ToString(format, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(IFormatProvider formatProvider)
+        {
+            return ToString(null, formatProvider);
+        }
+
+        /// <inheritdoc/>
+        public string ToString(string format, IFormatProvider formatProvider)
+        {
+            return $"{Min.ToString(format, formatProvider)} - {Max.ToString(format, formatProvider)}";
         }
     }
 }

--- a/src/OpenTK.Mathematics/Geometry/Box3.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box3.cs
@@ -20,7 +20,7 @@ namespace OpenTK.Mathematics
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     [Serializable]
-    public struct Box3 : IEquatable<Box3>
+    public struct Box3 : IEquatable<Box3>, IFormattable
     {
         private Vector3 _min;
 
@@ -341,7 +341,25 @@ namespace OpenTK.Mathematics
         /// <inheritdoc/>
         public override string ToString()
         {
-            return $"{Min} - {Max}";
+            return ToString(null, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(string format)
+        {
+            return ToString(format, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(IFormatProvider formatProvider)
+        {
+            return ToString(null, formatProvider);
+        }
+
+        /// <inheritdoc/>
+        public string ToString(string format, IFormatProvider formatProvider)
+        {
+            return $"{Min.ToString(format, formatProvider)} - {Max.ToString(format, formatProvider)}";
         }
     }
 }

--- a/src/OpenTK.Mathematics/Geometry/Box3d.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box3d.cs
@@ -20,7 +20,7 @@ namespace OpenTK.Mathematics
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     [Serializable]
-    public struct Box3d : IEquatable<Box3d>
+    public struct Box3d : IEquatable<Box3d>, IFormattable
     {
         private Vector3d _min;
 
@@ -341,7 +341,25 @@ namespace OpenTK.Mathematics
         /// <inheritdoc/>
         public override string ToString()
         {
-            return $"{Min} - {Max}";
+            return ToString(null, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(string format)
+        {
+            return ToString(format, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(IFormatProvider formatProvider)
+        {
+            return ToString(null, formatProvider);
+        }
+
+        /// <inheritdoc/>
+        public string ToString(string format, IFormatProvider formatProvider)
+        {
+            return $"{Min.ToString(format, formatProvider)} - {Max.ToString(format, formatProvider)}";
         }
     }
 }

--- a/src/OpenTK.Mathematics/Geometry/Box3i.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box3i.cs
@@ -20,7 +20,7 @@ namespace OpenTK.Mathematics
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     [Serializable]
-    public struct Box3i : IEquatable<Box3i>
+    public struct Box3i : IEquatable<Box3i>, IFormattable
     {
         /// <summary>
         /// An empty box with Min (0, 0, 0) and Max (0, 0, 0).
@@ -321,7 +321,25 @@ namespace OpenTK.Mathematics
         /// <inheritdoc/>
         public override string ToString()
         {
-            return $"{Min} - {Max}";
+            return ToString(null, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(string format)
+        {
+            return ToString(format, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(IFormatProvider formatProvider)
+        {
+            return ToString(null, formatProvider);
+        }
+
+        /// <inheritdoc/>
+        public string ToString(string format, IFormatProvider formatProvider)
+        {
+            return $"{Min.ToString(format, formatProvider)} - {Max.ToString(format, formatProvider)}";
         }
     }
 }

--- a/src/OpenTK.Mathematics/MathHelper.cs
+++ b/src/OpenTK.Mathematics/MathHelper.cs
@@ -1325,9 +1325,17 @@ namespace OpenTK.Mathematics
 
         internal static string GetListSeparator(IFormatProvider formatProvider)
         {
-            return formatProvider is CultureInfo cultureInfo
-                ? cultureInfo.TextInfo.ListSeparator
-                : ListSeparator;
+            if (formatProvider is CultureInfo cultureInfo)
+            {
+                return cultureInfo.TextInfo.ListSeparator;
+            }
+
+            if (formatProvider.GetFormat(typeof(TextInfo)) is TextInfo textInfo)
+            {
+                return textInfo.ListSeparator;
+            }
+
+            return ListSeparator;
         }
     }
 }

--- a/src/OpenTK.Mathematics/MathHelper.cs
+++ b/src/OpenTK.Mathematics/MathHelper.cs
@@ -1322,5 +1322,12 @@ namespace OpenTK.Mathematics
         }
 
         internal static readonly string ListSeparator = CultureInfo.CurrentCulture.TextInfo.ListSeparator;
+
+        internal static string GetListSeparator(IFormatProvider formatProvider)
+        {
+            return formatProvider is CultureInfo cultureInfo
+                ? cultureInfo.TextInfo.ListSeparator
+                : ListSeparator;
+        }
     }
 }

--- a/src/OpenTK.Mathematics/MathHelper.cs
+++ b/src/OpenTK.Mathematics/MathHelper.cs
@@ -1321,8 +1321,6 @@ namespace OpenTK.Mathematics
             return angle;
         }
 
-        internal static string ListSeparator => CultureInfo.CurrentCulture.TextInfo.ListSeparator;
-
         internal static string GetListSeparator(IFormatProvider formatProvider)
         {
             if (formatProvider is CultureInfo cultureInfo)
@@ -1335,7 +1333,7 @@ namespace OpenTK.Mathematics
                 return textInfo.ListSeparator;
             }
 
-            return ListSeparator;
+            return CultureInfo.CurrentCulture.TextInfo.ListSeparator;
         }
     }
 }

--- a/src/OpenTK.Mathematics/Matrix/Matrix2.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix2.cs
@@ -32,7 +32,7 @@ namespace OpenTK.Mathematics
     /// </summary>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
-    public struct Matrix2 : IEquatable<Matrix2>
+    public struct Matrix2 : IEquatable<Matrix2>, IFormattable
     {
         /// <summary>
         /// Top row of the matrix.
@@ -724,7 +724,27 @@ namespace OpenTK.Mathematics
         /// <returns>The string representation of the matrix.</returns>
         public override string ToString()
         {
-            return $"{Row0}\n{Row1}";
+            return ToString(null, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(string format)
+        {
+            return ToString(format, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(IFormatProvider formatProvider)
+        {
+            return ToString(null, formatProvider);
+        }
+
+        /// <inheritdoc/>
+        public string ToString(string format, IFormatProvider formatProvider)
+        {
+            var row0 = Row0.ToString(format, formatProvider);
+            var row1 = Row1.ToString(format, formatProvider);
+            return $"{row0}\n{row1}";
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Matrix/Matrix2d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix2d.cs
@@ -32,7 +32,7 @@ namespace OpenTK.Mathematics
     /// </summary>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
-    public struct Matrix2d : IEquatable<Matrix2d>
+    public struct Matrix2d : IEquatable<Matrix2d>, IFormattable
     {
         /// <summary>
         /// Top row of the matrix.
@@ -724,7 +724,27 @@ namespace OpenTK.Mathematics
         /// <returns>The string representation of the matrix.</returns>
         public override string ToString()
         {
-            return $"{Row0}\n{Row1}";
+            return ToString(null, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(string format)
+        {
+            return ToString(format, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(IFormatProvider formatProvider)
+        {
+            return ToString(null, formatProvider);
+        }
+
+        /// <inheritdoc/>
+        public string ToString(string format, IFormatProvider formatProvider)
+        {
+            var row0 = Row0.ToString(format, formatProvider);
+            var row1 = Row1.ToString(format, formatProvider);
+            return $"{row0}\n{row1}";
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Matrix/Matrix2x3.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix2x3.cs
@@ -32,7 +32,7 @@ namespace OpenTK.Mathematics
     /// </summary>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
-    public struct Matrix2x3 : IEquatable<Matrix2x3>
+    public struct Matrix2x3 : IEquatable<Matrix2x3>, IFormattable
     {
         /// <summary>
         /// Top row of the matrix.
@@ -708,7 +708,27 @@ namespace OpenTK.Mathematics
         /// <returns>The string representation of the matrix.</returns>
         public override string ToString()
         {
-            return $"{Row0}\n{Row1}";
+            return ToString(null, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(string format)
+        {
+            return ToString(format, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(IFormatProvider formatProvider)
+        {
+            return ToString(null, formatProvider);
+        }
+
+        /// <inheritdoc/>
+        public string ToString(string format, IFormatProvider formatProvider)
+        {
+            var row0 = Row0.ToString(format, formatProvider);
+            var row1 = Row1.ToString(format, formatProvider);
+            return $"{row0}\n{row1}";
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Matrix/Matrix2x3d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix2x3d.cs
@@ -32,7 +32,7 @@ namespace OpenTK.Mathematics
     /// </summary>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
-    public struct Matrix2x3d : IEquatable<Matrix2x3d>
+    public struct Matrix2x3d : IEquatable<Matrix2x3d>, IFormattable
     {
         /// <summary>
         /// Top row of the matrix.
@@ -708,7 +708,27 @@ namespace OpenTK.Mathematics
         /// <returns>The string representation of the matrix.</returns>
         public override string ToString()
         {
-            return $"{Row0}\n{Row1}";
+            return ToString(null, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(string format)
+        {
+            return ToString(format, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(IFormatProvider formatProvider)
+        {
+            return ToString(null, formatProvider);
+        }
+
+        /// <inheritdoc/>
+        public string ToString(string format, IFormatProvider formatProvider)
+        {
+            var row0 = Row0.ToString(format, formatProvider);
+            var row1 = Row1.ToString(format, formatProvider);
+            return $"{row0}\n{row1}";
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Matrix/Matrix2x4.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix2x4.cs
@@ -32,7 +32,7 @@ namespace OpenTK.Mathematics
     /// </summary>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
-    public struct Matrix2x4 : IEquatable<Matrix2x4>
+    public struct Matrix2x4 : IEquatable<Matrix2x4>, IFormattable
     {
         /// <summary>
         /// Top row of the matrix.
@@ -773,7 +773,27 @@ namespace OpenTK.Mathematics
         /// <returns>The string representation of the matrix.</returns>
         public override string ToString()
         {
-            return $"{Row0}\n{Row1}";
+            return ToString(null, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(string format)
+        {
+            return ToString(format, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(IFormatProvider formatProvider)
+        {
+            return ToString(null, formatProvider);
+        }
+
+        /// <inheritdoc/>
+        public string ToString(string format, IFormatProvider formatProvider)
+        {
+            var row0 = Row0.ToString(format, formatProvider);
+            var row1 = Row1.ToString(format, formatProvider);
+            return $"{row0}\n{row1}";
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Matrix/Matrix2x4d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix2x4d.cs
@@ -32,7 +32,7 @@ namespace OpenTK.Mathematics
     /// </summary>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
-    public struct Matrix2x4d : IEquatable<Matrix2x4d>
+    public struct Matrix2x4d : IEquatable<Matrix2x4d>, IFormattable
     {
         /// <summary>
         /// Top row of the matrix.
@@ -773,7 +773,27 @@ namespace OpenTK.Mathematics
         /// <returns>The string representation of the matrix.</returns>
         public override string ToString()
         {
-            return $"{Row0}\n{Row1}";
+            return ToString(null, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(string format)
+        {
+            return ToString(format, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(IFormatProvider formatProvider)
+        {
+            return ToString(null, formatProvider);
+        }
+
+        /// <inheritdoc/>
+        public string ToString(string format, IFormatProvider formatProvider)
+        {
+            var row0 = Row0.ToString(format, formatProvider);
+            var row1 = Row1.ToString(format, formatProvider);
+            return $"{row0}\n{row1}";
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Matrix/Matrix3.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix3.cs
@@ -32,7 +32,7 @@ namespace OpenTK.Mathematics
     /// </summary>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
-    public struct Matrix3 : IEquatable<Matrix3>
+    public struct Matrix3 : IEquatable<Matrix3>, IFormattable
     {
         /// <summary>
         /// First row of the matrix.
@@ -938,7 +938,28 @@ namespace OpenTK.Mathematics
         /// <returns>The string representation of the matrix.</returns>
         public override string ToString()
         {
-            return $"{Row0}\n{Row1}\n{Row2}";
+            return ToString(null, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(string format)
+        {
+            return ToString(format, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(IFormatProvider formatProvider)
+        {
+            return ToString(null, formatProvider);
+        }
+
+        /// <inheritdoc/>
+        public string ToString(string format, IFormatProvider formatProvider)
+        {
+            var row0 = Row0.ToString(format, formatProvider);
+            var row1 = Row1.ToString(format, formatProvider);
+            var row2 = Row2.ToString(format, formatProvider);
+            return $"{row0}\n{row1}\n{row2}";
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Matrix/Matrix3d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix3d.cs
@@ -32,7 +32,7 @@ namespace OpenTK.Mathematics
     /// </summary>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
-    public struct Matrix3d : IEquatable<Matrix3d>
+    public struct Matrix3d : IEquatable<Matrix3d>, IFormattable
     {
         /// <summary>
         /// First row of the matrix.
@@ -928,7 +928,28 @@ namespace OpenTK.Mathematics
         /// <returns>The string representation of the matrix.</returns>
         public override string ToString()
         {
-            return $"{Row0}\n{Row1}\n{Row2}";
+            return ToString(null, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(string format)
+        {
+            return ToString(format, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(IFormatProvider formatProvider)
+        {
+            return ToString(null, formatProvider);
+        }
+
+        /// <inheritdoc/>
+        public string ToString(string format, IFormatProvider formatProvider)
+        {
+            var row0 = Row0.ToString(format, formatProvider);
+            var row1 = Row1.ToString(format, formatProvider);
+            var row2 = Row2.ToString(format, formatProvider);
+            return $"{row0}\n{row1}\n{row2}";
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Matrix/Matrix3x2.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix3x2.cs
@@ -32,7 +32,7 @@ namespace OpenTK.Mathematics
     /// </summary>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
-    public struct Matrix3x2 : IEquatable<Matrix3x2>
+    public struct Matrix3x2 : IEquatable<Matrix3x2>, IFormattable
     {
         /// <summary>
         /// Top row of the matrix.
@@ -716,7 +716,28 @@ namespace OpenTK.Mathematics
         /// <returns>The string representation of the matrix.</returns>
         public override string ToString()
         {
-            return $"{Row0}\n{Row1}\n{Row2}";
+            return ToString(null, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(string format)
+        {
+            return ToString(format, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(IFormatProvider formatProvider)
+        {
+            return ToString(null, formatProvider);
+        }
+
+        /// <inheritdoc/>
+        public string ToString(string format, IFormatProvider formatProvider)
+        {
+            var row0 = Row0.ToString(format, formatProvider);
+            var row1 = Row1.ToString(format, formatProvider);
+            var row2 = Row2.ToString(format, formatProvider);
+            return $"{row0}\n{row1}\n{row2}";
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Matrix/Matrix3x2d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix3x2d.cs
@@ -32,7 +32,7 @@ namespace OpenTK.Mathematics
     /// </summary>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
-    public struct Matrix3x2d : IEquatable<Matrix3x2d>
+    public struct Matrix3x2d : IEquatable<Matrix3x2d>, IFormattable
     {
         /// <summary>
         /// Top row of the matrix.
@@ -716,7 +716,28 @@ namespace OpenTK.Mathematics
         /// <returns>The string representation of the matrix.</returns>
         public override string ToString()
         {
-            return $"{Row0}\n{Row1}\n{Row2}";
+            return ToString(null, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(string format)
+        {
+            return ToString(format, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(IFormatProvider formatProvider)
+        {
+            return ToString(null, formatProvider);
+        }
+
+        /// <inheritdoc/>
+        public string ToString(string format, IFormatProvider formatProvider)
+        {
+            var row0 = Row0.ToString(format, formatProvider);
+            var row1 = Row1.ToString(format, formatProvider);
+            var row2 = Row2.ToString(format, formatProvider);
+            return $"{row0}\n{row1}\n{row2}";
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Matrix/Matrix3x4.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix3x4.cs
@@ -32,7 +32,7 @@ namespace OpenTK.Mathematics
     /// </summary>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
-    public struct Matrix3x4 : IEquatable<Matrix3x4>
+    public struct Matrix3x4 : IEquatable<Matrix3x4>, IFormattable
     {
         /// <summary>
         /// Top row of the matrix.
@@ -972,7 +972,28 @@ namespace OpenTK.Mathematics
         /// <returns>The string representation of the matrix.</returns>
         public override string ToString()
         {
-            return $"{Row0}\n{Row1}\n{Row2}";
+            return ToString(null, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(string format)
+        {
+            return ToString(format, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(IFormatProvider formatProvider)
+        {
+            return ToString(null, formatProvider);
+        }
+
+        /// <inheritdoc/>
+        public string ToString(string format, IFormatProvider formatProvider)
+        {
+            var row0 = Row0.ToString(format, formatProvider);
+            var row1 = Row1.ToString(format, formatProvider);
+            var row2 = Row2.ToString(format, formatProvider);
+            return $"{row0}\n{row1}\n{row2}";
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Matrix/Matrix3x4d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix3x4d.cs
@@ -32,7 +32,7 @@ namespace OpenTK.Mathematics
     /// </summary>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
-    public struct Matrix3x4d : IEquatable<Matrix3x4d>
+    public struct Matrix3x4d : IEquatable<Matrix3x4d>, IFormattable
     {
         /// <summary>
         /// Top row of the matrix.
@@ -972,7 +972,28 @@ namespace OpenTK.Mathematics
         /// <returns>The string representation of the matrix.</returns>
         public override string ToString()
         {
-            return $"{Row0}\n{Row1}\n{Row2}";
+            return ToString(null, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(string format)
+        {
+            return ToString(format, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(IFormatProvider formatProvider)
+        {
+            return ToString(null, formatProvider);
+        }
+
+        /// <inheritdoc/>
+        public string ToString(string format, IFormatProvider formatProvider)
+        {
+            var row0 = Row0.ToString(format, formatProvider);
+            var row1 = Row1.ToString(format, formatProvider);
+            var row2 = Row2.ToString(format, formatProvider);
+            return $"{row0}\n{row1}\n{row2}";
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Matrix/Matrix4.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix4.cs
@@ -43,7 +43,7 @@ namespace OpenTK.Mathematics
     /// <seealso cref="Matrix4d"/>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
-    public struct Matrix4 : IEquatable<Matrix4>
+    public struct Matrix4 : IEquatable<Matrix4>, IFormattable
     {
         /// <summary>
         /// Top row of the matrix.
@@ -1921,7 +1921,29 @@ namespace OpenTK.Mathematics
         /// <returns>The string representation of the matrix.</returns>
         public override string ToString()
         {
-            return $"{Row0}\n{Row1}\n{Row2}\n{Row3}";
+            return ToString(null, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(string format)
+        {
+            return ToString(format, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(IFormatProvider formatProvider)
+        {
+            return ToString(null, formatProvider);
+        }
+
+        /// <inheritdoc/>
+        public string ToString(string format, IFormatProvider formatProvider)
+        {
+            var row0 = Row0.ToString(format, formatProvider);
+            var row1 = Row1.ToString(format, formatProvider);
+            var row2 = Row2.ToString(format, formatProvider);
+            var row3 = Row3.ToString(format, formatProvider);
+            return $"{row0}\n{row1}\n{row2}\n{row3}";
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Matrix/Matrix4d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix4d.cs
@@ -33,7 +33,7 @@ namespace OpenTK.Mathematics
     /// <seealso cref="Matrix4"/>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
-    public struct Matrix4d : IEquatable<Matrix4d>
+    public struct Matrix4d : IEquatable<Matrix4d>, IFormattable
     {
         /// <summary>
         /// Top row of the matrix.
@@ -1759,7 +1759,29 @@ namespace OpenTK.Mathematics
         /// <inheritdoc />
         public override string ToString()
         {
-            return $"{Row0}\n{Row1}\n{Row2}\n{Row3}";
+            return ToString(null, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(string format)
+        {
+            return ToString(format, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(IFormatProvider formatProvider)
+        {
+            return ToString(null, formatProvider);
+        }
+
+        /// <inheritdoc/>
+        public string ToString(string format, IFormatProvider formatProvider)
+        {
+            var row0 = Row0.ToString(format, formatProvider);
+            var row1 = Row1.ToString(format, formatProvider);
+            var row2 = Row2.ToString(format, formatProvider);
+            var row3 = Row3.ToString(format, formatProvider);
+            return $"{row0}\n{row1}\n{row2}\n{row3}";
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Matrix/Matrix4x2.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix4x2.cs
@@ -32,7 +32,7 @@ namespace OpenTK.Mathematics
     /// </summary>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
-    public struct Matrix4x2 : IEquatable<Matrix4x2>
+    public struct Matrix4x2 : IEquatable<Matrix4x2>, IFormattable
     {
         /// <summary>
         /// Top row of the matrix.
@@ -787,7 +787,29 @@ namespace OpenTK.Mathematics
         /// <returns>The string representation of the matrix.</returns>
         public override string ToString()
         {
-            return $"{Row0}\n{Row1}\n{Row2}\n{Row3}";
+            return ToString(null, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(string format)
+        {
+            return ToString(format, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(IFormatProvider formatProvider)
+        {
+            return ToString(null, formatProvider);
+        }
+
+        /// <inheritdoc/>
+        public string ToString(string format, IFormatProvider formatProvider)
+        {
+            var row0 = Row0.ToString(format, formatProvider);
+            var row1 = Row1.ToString(format, formatProvider);
+            var row2 = Row2.ToString(format, formatProvider);
+            var row3 = Row3.ToString(format, formatProvider);
+            return $"{row0}\n{row1}\n{row2}\n{row3}";
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Matrix/Matrix4x2d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix4x2d.cs
@@ -32,7 +32,7 @@ namespace OpenTK.Mathematics
     /// </summary>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
-    public struct Matrix4x2d : IEquatable<Matrix4x2d>
+    public struct Matrix4x2d : IEquatable<Matrix4x2d>, IFormattable
     {
         /// <summary>
         /// Top row of the matrix.
@@ -793,7 +793,29 @@ namespace OpenTK.Mathematics
         /// <returns>The string representation of the matrix.</returns>
         public override string ToString()
         {
-            return $"{Row0}\n{Row1}\n{Row2}\n{Row3}";
+            return ToString(null, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(string format)
+        {
+            return ToString(format, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(IFormatProvider formatProvider)
+        {
+            return ToString(null, formatProvider);
+        }
+
+        /// <inheritdoc/>
+        public string ToString(string format, IFormatProvider formatProvider)
+        {
+            var row0 = Row0.ToString(format, formatProvider);
+            var row1 = Row1.ToString(format, formatProvider);
+            var row2 = Row2.ToString(format, formatProvider);
+            var row3 = Row3.ToString(format, formatProvider);
+            return $"{row0}\n{row1}\n{row2}\n{row3}";
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Matrix/Matrix4x3.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix4x3.cs
@@ -32,7 +32,7 @@ namespace OpenTK.Mathematics
     /// </summary>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
-    public struct Matrix4x3 : IEquatable<Matrix4x3>
+    public struct Matrix4x3 : IEquatable<Matrix4x3>, IFormattable
     {
         /// <summary>
         /// Top row of the matrix.
@@ -1003,7 +1003,29 @@ namespace OpenTK.Mathematics
         /// <returns>The string representation of the matrix.</returns>
         public override string ToString()
         {
-            return $"{Row0}\n{Row1}\n{Row2}\n{Row3}";
+            return ToString(null, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(string format)
+        {
+            return ToString(format, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(IFormatProvider formatProvider)
+        {
+            return ToString(null, formatProvider);
+        }
+
+        /// <inheritdoc/>
+        public string ToString(string format, IFormatProvider formatProvider)
+        {
+            var row0 = Row0.ToString(format, formatProvider);
+            var row1 = Row1.ToString(format, formatProvider);
+            var row2 = Row2.ToString(format, formatProvider);
+            var row3 = Row3.ToString(format, formatProvider);
+            return $"{row0}\n{row1}\n{row2}\n{row3}";
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Matrix/Matrix4x3d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix4x3d.cs
@@ -32,7 +32,7 @@ namespace OpenTK.Mathematics
     /// </summary>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
-    public struct Matrix4x3d : IEquatable<Matrix4x3d>
+    public struct Matrix4x3d : IEquatable<Matrix4x3d>, IFormattable
     {
         /// <summary>
         /// Top row of the matrix.
@@ -1002,7 +1002,29 @@ namespace OpenTK.Mathematics
         /// <returns>The string representation of the matrix.</returns>
         public override string ToString()
         {
-            return $"{Row0}\n{Row1}\n{Row2}\n{Row3}";
+            return ToString(null, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(string format)
+        {
+            return ToString(format, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(IFormatProvider formatProvider)
+        {
+            return ToString(null, formatProvider);
+        }
+
+        /// <inheritdoc/>
+        public string ToString(string format, IFormatProvider formatProvider)
+        {
+            var row0 = Row0.ToString(format, formatProvider);
+            var row1 = Row1.ToString(format, formatProvider);
+            var row2 = Row2.ToString(format, formatProvider);
+            var row3 = Row3.ToString(format, formatProvider);
+            return $"{row0}\n{row1}\n{row2}\n{row3}";
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Vector/Vector2.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2.cs
@@ -37,7 +37,7 @@ namespace OpenTK.Mathematics
     /// </remarks>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
-    public struct Vector2 : IEquatable<Vector2>
+    public struct Vector2 : IEquatable<Vector2>, IFormattable
     {
         /// <summary>
         /// The X component of the Vector2.
@@ -1033,6 +1033,12 @@ namespace OpenTK.Mathematics
         public override string ToString()
         {
             return string.Format("({0}{2} {1})", X, Y, MathHelper.ListSeparator);
+        }
+
+        /// <inheritdoc/>
+        public string ToString(string format, IFormatProvider formatProvider)
+        {
+            throw new NotImplementedException();
         }
 
         /// <inheritdoc/>

--- a/src/OpenTK.Mathematics/Vector/Vector2.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2.cs
@@ -1054,7 +1054,7 @@ namespace OpenTK.Mathematics
                 "({0}{2} {1})",
                 X.ToString(format, formatProvider),
                 Y.ToString(format, formatProvider),
-                MathHelper.ListSeparator);
+                MathHelper.GetListSeparator(formatProvider));
         }
 
         /// <inheritdoc/>

--- a/src/OpenTK.Mathematics/Vector/Vector2.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2.cs
@@ -1038,7 +1038,11 @@ namespace OpenTK.Mathematics
         /// <inheritdoc/>
         public string ToString(string format, IFormatProvider formatProvider)
         {
-            throw new NotImplementedException();
+            return string.Format(
+                "({0}{2} {1})",
+                X.ToString(format, formatProvider),
+                Y.ToString(format, formatProvider),
+                MathHelper.ListSeparator);
         }
 
         /// <inheritdoc/>

--- a/src/OpenTK.Mathematics/Vector/Vector2.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2.cs
@@ -1032,7 +1032,7 @@ namespace OpenTK.Mathematics
         /// <inheritdoc/>
         public override string ToString()
         {
-            return string.Format("({0}{2} {1})", X, Y, MathHelper.ListSeparator);
+            return ToString(null, null);
         }
 
         /// <inheritdoc/>

--- a/src/OpenTK.Mathematics/Vector/Vector2.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2.cs
@@ -1035,6 +1035,18 @@ namespace OpenTK.Mathematics
             return ToString(null, null);
         }
 
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(string format)
+        {
+            return ToString(format, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(IFormatProvider formatProvider)
+        {
+            return ToString(null, formatProvider);
+        }
+
         /// <inheritdoc/>
         public string ToString(string format, IFormatProvider formatProvider)
         {

--- a/src/OpenTK.Mathematics/Vector/Vector2d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2d.cs
@@ -34,7 +34,7 @@ namespace OpenTK.Mathematics
     /// </summary>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
-    public struct Vector2d : IEquatable<Vector2d>
+    public struct Vector2d : IEquatable<Vector2d>, IFormattable
     {
         /// <summary>
         /// The X coordinate of this instance.
@@ -982,6 +982,16 @@ namespace OpenTK.Mathematics
         public override string ToString()
         {
             return string.Format("({0}{2} {1})", X, Y, MathHelper.ListSeparator);
+        }
+
+        /// <inheritdoc/>
+        public string ToString(string format, IFormatProvider formatProvider)
+        {
+            return string.Format(
+                "({0}{2} {1})",
+                X.ToString(format, formatProvider),
+                Y.ToString(format, formatProvider),
+                MathHelper.ListSeparator);
         }
 
         /// <inheritdoc/>

--- a/src/OpenTK.Mathematics/Vector/Vector2d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2d.cs
@@ -1009,7 +1009,19 @@ namespace OpenTK.Mathematics
         /// <inheritdoc/>
         public override string ToString()
         {
-            return string.Format("({0}{2} {1})", X, Y, MathHelper.ListSeparator);
+            return ToString(null, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(string format)
+        {
+            return ToString(format, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(IFormatProvider formatProvider)
+        {
+            return ToString(null, formatProvider);
         }
 
         /// <inheritdoc/>
@@ -1019,7 +1031,7 @@ namespace OpenTK.Mathematics
                 "({0}{2} {1})",
                 X.ToString(format, formatProvider),
                 Y.ToString(format, formatProvider),
-                MathHelper.ListSeparator);
+                MathHelper.GetListSeparator(formatProvider));
         }
 
         /// <inheritdoc/>

--- a/src/OpenTK.Mathematics/Vector/Vector2h.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2h.cs
@@ -36,7 +36,7 @@ namespace OpenTK.Mathematics
     /// </summary>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
-    public struct Vector2h : ISerializable, IEquatable<Vector2h>
+    public struct Vector2h : ISerializable, IEquatable<Vector2h>, IFormattable
     {
         /// <summary>
         /// The X component of the Half2.
@@ -332,6 +332,16 @@ namespace OpenTK.Mathematics
         public override string ToString()
         {
             return string.Format("({0}{2} {1})", X, Y, MathHelper.ListSeparator);
+        }
+
+        /// <inheritdoc/>
+        public string ToString(string format, IFormatProvider formatProvider)
+        {
+            return string.Format(
+                "({0}{2} {1})",
+                X.ToString(format, formatProvider),
+                Y.ToString(format, formatProvider),
+                MathHelper.ListSeparator);
         }
 
         /// <inheritdoc/>

--- a/src/OpenTK.Mathematics/Vector/Vector2h.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2h.cs
@@ -331,7 +331,19 @@ namespace OpenTK.Mathematics
         /// <inheritdoc/>
         public override string ToString()
         {
-            return string.Format("({0}{2} {1})", X, Y, MathHelper.ListSeparator);
+            return ToString(null, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(string format)
+        {
+            return ToString(format, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(IFormatProvider formatProvider)
+        {
+            return ToString(null, formatProvider);
         }
 
         /// <inheritdoc/>
@@ -341,7 +353,7 @@ namespace OpenTK.Mathematics
                 "({0}{2} {1})",
                 X.ToString(format, formatProvider),
                 Y.ToString(format, formatProvider),
-                MathHelper.ListSeparator);
+                MathHelper.GetListSeparator(formatProvider));
         }
 
         /// <inheritdoc/>

--- a/src/OpenTK.Mathematics/Vector/Vector2i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2i.cs
@@ -586,7 +586,19 @@ namespace OpenTK.Mathematics
         /// <inheritdoc/>
         public override string ToString()
         {
-            return string.Format("({0}{2} {1})", X, Y, MathHelper.ListSeparator);
+            return ToString(null, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(string format)
+        {
+            return ToString(format, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(IFormatProvider formatProvider)
+        {
+            return ToString(null, formatProvider);
         }
 
         /// <inheritdoc />
@@ -596,7 +608,7 @@ namespace OpenTK.Mathematics
                 "({0}{2} {1})",
                 X.ToString(format, formatProvider),
                 Y.ToString(format, formatProvider),
-                MathHelper.ListSeparator);
+                MathHelper.GetListSeparator(formatProvider));
         }
 
         /// <inheritdoc/>

--- a/src/OpenTK.Mathematics/Vector/Vector2i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2i.cs
@@ -24,7 +24,7 @@ namespace OpenTK.Mathematics
     /// </remarks>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
-    public struct Vector2i : IEquatable<Vector2i>
+    public struct Vector2i : IEquatable<Vector2i>, IFormattable
     {
         /// <summary>
         /// The X component of the Vector2i.
@@ -587,6 +587,16 @@ namespace OpenTK.Mathematics
         public override string ToString()
         {
             return string.Format("({0}{2} {1})", X, Y, MathHelper.ListSeparator);
+        }
+
+        /// <inheritdoc />
+        public string ToString(string format, IFormatProvider formatProvider)
+        {
+            return string.Format(
+                "({0}{2} {1})",
+                X.ToString(format, formatProvider),
+                Y.ToString(format, formatProvider),
+                MathHelper.ListSeparator);
         }
 
         /// <inheritdoc/>

--- a/src/OpenTK.Mathematics/Vector/Vector3.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3.cs
@@ -1614,10 +1614,22 @@ namespace OpenTK.Mathematics
             return new Vector3(values.X, values.Y, values.Z);
         }
 
-        /// <inheritdoc />
+        /// <inheritdoc/>
         public override string ToString()
         {
-            return string.Format("({0}{3} {1}{3} {2})", X, Y, Z, MathHelper.ListSeparator);
+            return ToString(null, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(string format)
+        {
+            return ToString(format, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(IFormatProvider formatProvider)
+        {
+            return ToString(null, formatProvider);
         }
 
         /// <inheritdoc />
@@ -1628,7 +1640,7 @@ namespace OpenTK.Mathematics
                 X.ToString(format, formatProvider),
                 Y.ToString(format, formatProvider),
                 Z.ToString(format, formatProvider),
-                MathHelper.ListSeparator);
+                MathHelper.GetListSeparator(formatProvider));
         }
 
         /// <inheritdoc />

--- a/src/OpenTK.Mathematics/Vector/Vector3.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3.cs
@@ -37,7 +37,7 @@ namespace OpenTK.Mathematics
     /// </remarks>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
-    public struct Vector3 : IEquatable<Vector3>
+    public struct Vector3 : IEquatable<Vector3>, IFormattable
     {
         /// <summary>
         /// The X component of the Vector3.
@@ -1588,6 +1588,17 @@ namespace OpenTK.Mathematics
         public override string ToString()
         {
             return string.Format("({0}{3} {1}{3} {2})", X, Y, Z, MathHelper.ListSeparator);
+        }
+
+        /// <inheritdoc />
+        public string ToString(string format, IFormatProvider formatProvider)
+        {
+            return string.Format(
+                "({0}{3} {1}{3} {2})",
+                X.ToString(format, formatProvider),
+                Y.ToString(format, formatProvider),
+                Z.ToString(format, formatProvider),
+                MathHelper.ListSeparator);
         }
 
         /// <inheritdoc />

--- a/src/OpenTK.Mathematics/Vector/Vector3d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3d.cs
@@ -34,7 +34,7 @@ namespace OpenTK.Mathematics
     /// </summary>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
-    public struct Vector3d : IEquatable<Vector3d>
+    public struct Vector3d : IEquatable<Vector3d>, IFormattable
     {
         /// <summary>
         /// The X component of the Vector3.
@@ -1454,6 +1454,17 @@ namespace OpenTK.Mathematics
         public override string ToString()
         {
             return string.Format("({0}{3} {1}{3} {2})", X, Y, Z, MathHelper.ListSeparator);
+        }
+
+        /// <inheritdoc />
+        public string ToString(string format, IFormatProvider formatProvider)
+        {
+            return string.Format(
+                "({0}{3} {1}{3} {2})",
+                X.ToString(format, formatProvider),
+                Y.ToString(format, formatProvider),
+                Z.ToString(format, formatProvider),
+                MathHelper.ListSeparator);
         }
 
         /// <inheritdoc />

--- a/src/OpenTK.Mathematics/Vector/Vector3d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3d.cs
@@ -1480,10 +1480,22 @@ namespace OpenTK.Mathematics
             return new Vector3d(values.X, values.Y, values.Z);
         }
 
-        /// <inheritdoc />
+        /// <inheritdoc/>
         public override string ToString()
         {
-            return string.Format("({0}{3} {1}{3} {2})", X, Y, Z, MathHelper.ListSeparator);
+            return ToString(null, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(string format)
+        {
+            return ToString(format, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(IFormatProvider formatProvider)
+        {
+            return ToString(null, formatProvider);
         }
 
         /// <inheritdoc />
@@ -1494,7 +1506,7 @@ namespace OpenTK.Mathematics
                 X.ToString(format, formatProvider),
                 Y.ToString(format, formatProvider),
                 Z.ToString(format, formatProvider),
-                MathHelper.ListSeparator);
+                MathHelper.GetListSeparator(formatProvider));
         }
 
         /// <inheritdoc />

--- a/src/OpenTK.Mathematics/Vector/Vector3h.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3h.cs
@@ -504,7 +504,19 @@ namespace OpenTK.Mathematics
         /// <inheritdoc/>
         public override string ToString()
         {
-            return string.Format("({0}{3} {1}{3} {2})", X.ToString(), Y.ToString(), Z.ToString(), MathHelper.ListSeparator);
+            return ToString(null, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(string format)
+        {
+            return ToString(format, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(IFormatProvider formatProvider)
+        {
+            return ToString(null, formatProvider);
         }
 
         /// <inheritdoc />
@@ -515,7 +527,7 @@ namespace OpenTK.Mathematics
                 X.ToString(format, formatProvider),
                 Y.ToString(format, formatProvider),
                 Z.ToString(format, formatProvider),
-                MathHelper.ListSeparator);
+                MathHelper.GetListSeparator(formatProvider));
         }
 
         /// <inheritdoc/>

--- a/src/OpenTK.Mathematics/Vector/Vector3h.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3h.cs
@@ -36,7 +36,7 @@ namespace OpenTK.Mathematics
     /// </summary>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
-    public struct Vector3h : ISerializable, IEquatable<Vector3h>
+    public struct Vector3h : ISerializable, IEquatable<Vector3h>, IFormattable
     {
         /// <summary>
         /// The X component of the Half3.
@@ -505,6 +505,17 @@ namespace OpenTK.Mathematics
         public override string ToString()
         {
             return string.Format("({0}{3} {1}{3} {2})", X.ToString(), Y.ToString(), Z.ToString(), MathHelper.ListSeparator);
+        }
+
+        /// <inheritdoc />
+        public string ToString(string format, IFormatProvider formatProvider)
+        {
+            return string.Format(
+                "({0}{3} {1}{3} {2})",
+                X.ToString(format, formatProvider),
+                Y.ToString(format, formatProvider),
+                Z.ToString(format, formatProvider),
+                MathHelper.ListSeparator);
         }
 
         /// <inheritdoc/>

--- a/src/OpenTK.Mathematics/Vector/Vector3i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3i.cs
@@ -24,7 +24,7 @@ namespace OpenTK.Mathematics
     /// </remarks>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
-    public struct Vector3i : IEquatable<Vector3i>
+    public struct Vector3i : IEquatable<Vector3i>, IFormattable
     {
         /// <summary>
         /// The X component of the Vector3i.
@@ -791,6 +791,17 @@ namespace OpenTK.Mathematics
         public override string ToString()
         {
             return string.Format("({0}{3} {1}{3} {2})", X, Y, Z, MathHelper.ListSeparator);
+        }
+
+        /// <inheritdoc />
+        public string ToString(string format, IFormatProvider formatProvider)
+        {
+            return string.Format(
+                "({0}{3} {1}{3} {2})",
+                X.ToString(format, formatProvider),
+                Y.ToString(format, formatProvider),
+                Z.ToString(format, formatProvider),
+                MathHelper.ListSeparator);
         }
 
         /// <inheritdoc />

--- a/src/OpenTK.Mathematics/Vector/Vector3i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3i.cs
@@ -787,10 +787,22 @@ namespace OpenTK.Mathematics
             return new Vector3i(values.X, values.Y, values.Z);
         }
 
-        /// <inheritdoc />
+        /// <inheritdoc/>
         public override string ToString()
         {
-            return string.Format("({0}{3} {1}{3} {2})", X, Y, Z, MathHelper.ListSeparator);
+            return ToString(null, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(string format)
+        {
+            return ToString(format, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(IFormatProvider formatProvider)
+        {
+            return ToString(null, formatProvider);
         }
 
         /// <inheritdoc />
@@ -801,7 +813,7 @@ namespace OpenTK.Mathematics
                 X.ToString(format, formatProvider),
                 Y.ToString(format, formatProvider),
                 Z.ToString(format, formatProvider),
-                MathHelper.ListSeparator);
+                MathHelper.GetListSeparator(formatProvider));
         }
 
         /// <inheritdoc />

--- a/src/OpenTK.Mathematics/Vector/Vector4.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4.cs
@@ -2120,10 +2120,22 @@ namespace OpenTK.Mathematics
             return new Vector4(values.X, values.Y, values.Z, values.W);
         }
 
-        /// <inheritdoc />
+        /// <inheritdoc/>
         public override string ToString()
         {
-            return string.Format("({0}{4} {1}{4} {2}{4} {3})", X, Y, Z, W, MathHelper.ListSeparator);
+            return ToString(null, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(string format)
+        {
+            return ToString(format, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(IFormatProvider formatProvider)
+        {
+            return ToString(null, formatProvider);
         }
 
         /// <inheritdoc />
@@ -2135,7 +2147,7 @@ namespace OpenTK.Mathematics
                 Y.ToString(format, formatProvider),
                 Z.ToString(format, formatProvider),
                 W.ToString(format, formatProvider),
-                MathHelper.ListSeparator);
+                MathHelper.GetListSeparator(formatProvider));
         }
 
         /// <inheritdoc />

--- a/src/OpenTK.Mathematics/Vector/Vector4.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4.cs
@@ -37,7 +37,7 @@ namespace OpenTK.Mathematics
     /// </remarks>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
-    public struct Vector4 : IEquatable<Vector4>
+    public struct Vector4 : IEquatable<Vector4>, IFormattable
     {
         /// <summary>
         /// The X component of the Vector4.
@@ -2092,6 +2092,18 @@ namespace OpenTK.Mathematics
         public override string ToString()
         {
             return string.Format("({0}{4} {1}{4} {2}{4} {3})", X, Y, Z, W, MathHelper.ListSeparator);
+        }
+
+        /// <inheritdoc />
+        public string ToString(string format, IFormatProvider formatProvider)
+        {
+            return string.Format(
+                "({0}{4} {1}{4} {2}{4} {3})",
+                X.ToString(format, formatProvider),
+                Y.ToString(format, formatProvider),
+                Z.ToString(format, formatProvider),
+                W.ToString(format, formatProvider),
+                MathHelper.ListSeparator);
         }
 
         /// <inheritdoc />

--- a/src/OpenTK.Mathematics/Vector/Vector4d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4d.cs
@@ -37,7 +37,7 @@ namespace OpenTK.Mathematics
     /// </remarks>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
-    public struct Vector4d : IEquatable<Vector4d>
+    public struct Vector4d : IEquatable<Vector4d>, IFormattable
     {
         /// <summary>
         /// The X component of the Vector4d.
@@ -2075,6 +2075,18 @@ namespace OpenTK.Mathematics
         public override string ToString()
         {
             return string.Format("({0}{4} {1}{4} {2}{4} {3})", X, Y, Z, W, MathHelper.ListSeparator);
+        }
+
+        /// <inheritdoc />
+        public string ToString(string format, IFormatProvider formatProvider)
+        {
+            return string.Format(
+                "({0}{4} {1}{4} {2}{4} {3})",
+                X.ToString(format, formatProvider),
+                Y.ToString(format, formatProvider),
+                Z.ToString(format, formatProvider),
+                W.ToString(format, formatProvider),
+                MathHelper.ListSeparator);
         }
 
         /// <inheritdoc />

--- a/src/OpenTK.Mathematics/Vector/Vector4d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4d.cs
@@ -2103,10 +2103,22 @@ namespace OpenTK.Mathematics
             return new Vector4d(values.X, values.Y, values.Z, values.W);
         }
 
-        /// <inheritdoc />
+        /// <inheritdoc/>
         public override string ToString()
         {
-            return string.Format("({0}{4} {1}{4} {2}{4} {3})", X, Y, Z, W, MathHelper.ListSeparator);
+            return ToString(null, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(string format)
+        {
+            return ToString(format, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(IFormatProvider formatProvider)
+        {
+            return ToString(null, formatProvider);
         }
 
         /// <inheritdoc />
@@ -2118,7 +2130,7 @@ namespace OpenTK.Mathematics
                 Y.ToString(format, formatProvider),
                 Z.ToString(format, formatProvider),
                 W.ToString(format, formatProvider),
-                MathHelper.ListSeparator);
+                MathHelper.GetListSeparator(formatProvider));
         }
 
         /// <inheritdoc />

--- a/src/OpenTK.Mathematics/Vector/Vector4h.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4h.cs
@@ -36,7 +36,7 @@ namespace OpenTK.Mathematics
     /// </summary>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
-    public struct Vector4h : ISerializable, IEquatable<Vector4h>
+    public struct Vector4h : ISerializable, IEquatable<Vector4h>, IFormattable
     {
         /// <summary>
         /// The X component of the Half4.
@@ -1358,6 +1358,18 @@ namespace OpenTK.Mathematics
                 W.ToString(),
                 MathHelper.ListSeparator
             );
+        }
+
+        /// <inheritdoc />
+        public string ToString(string format, IFormatProvider formatProvider)
+        {
+            return string.Format(
+                "({0}{4} {1}{4} {2}{4} {3})",
+                X.ToString(format, formatProvider),
+                Y.ToString(format, formatProvider),
+                Z.ToString(format, formatProvider),
+                W.ToString(format, formatProvider),
+                MathHelper.ListSeparator);
         }
 
         /// <inheritdoc/>

--- a/src/OpenTK.Mathematics/Vector/Vector4h.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4h.cs
@@ -1349,15 +1349,19 @@ namespace OpenTK.Mathematics
         /// <inheritdoc/>
         public override string ToString()
         {
-            return string.Format
-            (
-                "({0}{4} {1}{4} {2}{4} {3})",
-                X.ToString(),
-                Y.ToString(),
-                Z.ToString(),
-                W.ToString(),
-                MathHelper.ListSeparator
-            );
+            return ToString(null, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(string format)
+        {
+            return ToString(format, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(IFormatProvider formatProvider)
+        {
+            return ToString(null, formatProvider);
         }
 
         /// <inheritdoc />
@@ -1369,7 +1373,7 @@ namespace OpenTK.Mathematics
                 Y.ToString(format, formatProvider),
                 Z.ToString(format, formatProvider),
                 W.ToString(format, formatProvider),
-                MathHelper.ListSeparator);
+                MathHelper.GetListSeparator(formatProvider));
         }
 
         /// <inheritdoc/>

--- a/src/OpenTK.Mathematics/Vector/Vector4i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4i.cs
@@ -24,7 +24,7 @@ namespace OpenTK.Mathematics
     /// </remarks>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
-    public struct Vector4i : IEquatable<Vector4i>
+    public struct Vector4i : IEquatable<Vector4i>, IFormattable
     {
         /// <summary>
         /// The X component of the Vector4i.
@@ -1687,6 +1687,18 @@ namespace OpenTK.Mathematics
         public override string ToString()
         {
             return string.Format("({0}{4} {1}{4} {2}{4} {3})", X, Y, Z, W, MathHelper.ListSeparator);
+        }
+
+        /// <inheritdoc />
+        public string ToString(string format, IFormatProvider formatProvider)
+        {
+            return string.Format(
+                "({0}{4} {1}{4} {2}{4} {3})",
+                X.ToString(format, formatProvider),
+                Y.ToString(format, formatProvider),
+                Z.ToString(format, formatProvider),
+                W.ToString(format, formatProvider),
+                MathHelper.ListSeparator);
         }
 
         /// <inheritdoc />

--- a/src/OpenTK.Mathematics/Vector/Vector4i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4i.cs
@@ -1683,10 +1683,22 @@ namespace OpenTK.Mathematics
             return new Vector4i(values.X, values.Y, values.Z, values.W);
         }
 
-        /// <inheritdoc />
+        /// <inheritdoc/>
         public override string ToString()
         {
-            return string.Format("({0}{4} {1}{4} {2}{4} {3})", X, Y, Z, W, MathHelper.ListSeparator);
+            return ToString(null, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(string format)
+        {
+            return ToString(format, null);
+        }
+
+        /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
+        public string ToString(IFormatProvider formatProvider)
+        {
+            return ToString(null, formatProvider);
         }
 
         /// <inheritdoc />
@@ -1698,7 +1710,7 @@ namespace OpenTK.Mathematics
                 Y.ToString(format, formatProvider),
                 Z.ToString(format, formatProvider),
                 W.ToString(format, formatProvider),
-                MathHelper.ListSeparator);
+                MathHelper.GetListSeparator(formatProvider));
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
### Purpose of this PR

Fixes #1481.
Implements the changes wanted in #1481 by implementing the IFormattable interface for all vectors. The implementation delegates the actual formatting to the vectors scalar type, passing on the `format` and `formatProvider` parameters.

### Testing status

Manual testing has been done.

### Comments

You can @ me in the Discord server if you have any questions.