### PR TITLE
Fix: Separator used by vectors does not change when CurrentCulture changes.

### DIFF
--- a/src/OpenTK.Mathematics/MathHelper.cs
+++ b/src/OpenTK.Mathematics/MathHelper.cs
@@ -1321,6 +1321,6 @@ namespace OpenTK.Mathematics
             return angle;
         }
 
-        internal static readonly string ListSeparator = CultureInfo.CurrentCulture.TextInfo.ListSeparator;
+        internal static string ListSeparator => CultureInfo.CurrentCulture.TextInfo.ListSeparator;
     }
 }

--- a/src/OpenTK.Mathematics/Vector/Vector2.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2.cs
@@ -1027,8 +1027,6 @@ namespace OpenTK.Mathematics
             return new Vector2i((int)vec.X, (int)vec.Y);
         }
 
-        private static readonly string ListSeparator = CultureInfo.CurrentCulture.TextInfo.ListSeparator;
-
         /// <inheritdoc/>
         public override string ToString()
         {


### PR DESCRIPTION
### Purpose of this PR

Fixes #1517 by applying the fix I suggested there.

### Testing status

Manual testing has been done.

### Comments

This chnage also impacts the quaternions and Color4 which also used the `ListSeparator` field of `MathHelper`. There might be a performance impact to repeatedly getting CurrentCulture instead of caching it, for which I did not test. You can @ me in the Discord server if you have any questions.
