### PR TITLE
[5.0] Add System.Numerics overloads

### DIFF
--- a/src/Generator/Parsing/SpecificationData.cs
+++ b/src/Generator/Parsing/SpecificationData.cs
@@ -66,6 +66,7 @@ namespace Generator.Parsing
 
     public record GLParameter(
         PType Type,
+        string[] Kinds,
         string Name,
         Expression? Length);
 

--- a/src/Generator/Parsing/SpecificationParser.cs
+++ b/src/Generator/Parsing/SpecificationParser.cs
@@ -59,13 +59,14 @@ namespace Generator.Parsing
                 string? paramName = element.Element("name")?.Value;
                 PType? ptype = ParsePType(element);
 
+                string[] kind = element.Attribute("kind")?.Value?.Split(',') ?? Array.Empty<string>();
+
                 if (paramName == null) throw new Exception("Missing parameter name!");
 
                 string? length = element.Attribute("len")?.Value;
                 Expression? paramLength = length == null ? null : ParseExpression(length);
 
-                //isGLhandleArb |= ptype.Name == PlatformSpecificGlHandleArbFlag;
-                parameterList.Add(new GLParameter(ptype, paramName, paramLength));
+                parameterList.Add(new GLParameter(ptype, kind, paramName, paramLength));
             }
 
             PType? returnType = ParsePType(proto);

--- a/src/Generator/Process/OutputData.cs
+++ b/src/Generator/Process/OutputData.cs
@@ -50,6 +50,8 @@ namespace Generator.Writing
 
     public record Parameter(
         BaseCSType Type,
+        // FIXME: Should we expose this exactly like it's exposed in gl.xml?
+        string[] Kinds,
         string Name,
         Expression? Length);
 

--- a/src/Generator/Process/Processor.cs
+++ b/src/Generator/Process/Processor.cs
@@ -472,7 +472,8 @@ namespace Generator.Process
             foreach (GLParameter parameter in command.Parameters)
             {
                 BaseCSType type = MakeCSType(parameter.Type.Type, parameter.Type.Handle, parameter.Type.Group);
-                parameters.Add(new Parameter(type, NameMangler.MangleParameterName(parameter.Name), parameter.Length));
+                // FIXME: Maybe we want to do some kind of processing on parameter.Kind to not pass it directly as it is in gl.xml
+                parameters.Add(new Parameter(type, parameter.Kinds, NameMangler.MangleParameterName(parameter.Name), parameter.Length));
                 if (parameter.Type.Group != null)
                 {
                     referencedEnumGroups.Add(parameter.Type.Group);

--- a/src/Generator/SpecificationFiles/gl.xml
+++ b/src/Generator/SpecificationFiles/gl.xml
@@ -80,6 +80,17 @@ typedef unsigned int GLhandleARB;
         <kind name="String" desc="This parameter represents a string of characters. A GLubyte parameter should be treated as GLchar." />
         <kind name="DrawBufferIndex" desc="This parameter represents an index to a draw buffer in the range 0 to the value of GL_MAX_COLOR_ATTACHMENTS" />
         
+        <kind name="Matrix2x2" desc="This parameter represents a 2x2 matrix." />
+        <kind name="Matrix2x3" desc="This parameter represents a 2x3 matrix." />
+        <kind name="Matrix2x4" desc="This parameter represents a 2x4 matrix." />
+
+        <kind name="Matrix3x2" desc="This parameter represents a 3x2 matrix." />
+        <kind name="Matrix3x3" desc="This parameter represents a 3x3 matrix." />
+        <kind name="Matrix3x4" desc="This parameter represents a 3x4 matrix." />>
+
+        <kind name="Matrix4x2" desc="This parameter represents a 4x2 matrix." />>
+        <kind name="Matrix4x3" desc="This parameter represents a 4x3 matrix." />>
+        <kind name="Matrix4x4" desc="This parameter represents a 4x4 matrix." />>
 
         <!-- Applicable to legacy OpenGL functions -->
         <kind name="ColorIndexValue" desc="This parameter represents a color in the color index." />
@@ -17785,16 +17796,16 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glMinSampleShading</name></proto>
-            <param kind="Color"><ptype>GLfloat</ptype> <name>value</name></param>
+            <param kind="Clamped[0; 1]"><ptype>GLfloat</ptype> <name>value</name></param>
         </command>
         <command>
             <proto>void <name>glMinSampleShadingARB</name></proto>
-            <param kind="Color"><ptype>GLfloat</ptype> <name>value</name></param>
+            <param kind="Clamped[0; 1]"><ptype>GLfloat</ptype> <name>value</name></param>
             <alias name="glMinSampleShading"/>
         </command>
         <command>
             <proto>void <name>glMinSampleShadingOES</name></proto>
-            <param kind="Color"><ptype>GLfloat</ptype> <name>value</name></param>
+            <param kind="Clamped[0; 1]"><ptype>GLfloat</ptype> <name>value</name></param>
             <alias name="glMinSampleShading"/>
         </command>
         <command>
@@ -21551,7 +21562,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*4">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix2x2" len="count*4">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix2fvEXT</name></proto>
@@ -21559,7 +21570,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*4">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix2x2" len="count*4">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glProgramUniformMatrix2fv"/>
         </command>
         <command>
@@ -21568,7 +21579,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*6">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix2x3" len="count*6">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix2x3dvEXT</name></proto>
@@ -21576,7 +21587,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*6">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix2x3" len="count*6">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix2x3fv</name></proto>
@@ -21584,7 +21595,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*6">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix2x3" len="count*6">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix2x3fvEXT</name></proto>
@@ -21592,7 +21603,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*6">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix2x3" len="count*6">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glProgramUniformMatrix2x3fv"/>
         </command>
         <command>
@@ -21601,7 +21612,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*8">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix2x4" len="count*8">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix2x4dvEXT</name></proto>
@@ -21609,7 +21620,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*8">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix2x4" len="count*8">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix2x4fv</name></proto>
@@ -21617,7 +21628,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*8">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix2x4" len="count*8">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix2x4fvEXT</name></proto>
@@ -21625,7 +21636,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*8">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix2x4" len="count*8">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glProgramUniformMatrix2x4fv"/>
         </command>
         <command>
@@ -21634,7 +21645,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*9">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix3x3" len="count*9">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix3dvEXT</name></proto>
@@ -21642,7 +21653,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*9">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix3x3" len="count*9">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix3fv</name></proto>
@@ -21650,7 +21661,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*9">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix3x3" len="count*9">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix3fvEXT</name></proto>
@@ -21658,7 +21669,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*9">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix3x3" len="count*9">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glProgramUniformMatrix3fv"/>
         </command>
         <command>
@@ -21667,7 +21678,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*6">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix3x2" len="count*6">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix3x2dvEXT</name></proto>
@@ -21675,7 +21686,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*6">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix3x2" len="count*6">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix3x2fv</name></proto>
@@ -21683,7 +21694,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*6">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix3x2" len="count*6">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix3x2fvEXT</name></proto>
@@ -21700,7 +21711,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*12">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix3x4" len="count*12">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix3x4dvEXT</name></proto>
@@ -21708,7 +21719,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*12">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix3x4" len="count*12">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix3x4fv</name></proto>
@@ -21716,7 +21727,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*12">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix3x4" len="count*12">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix3x4fvEXT</name></proto>
@@ -21724,7 +21735,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*12">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix3x4" len="count*12">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glProgramUniformMatrix3x4fv"/>
         </command>
         <command>
@@ -21733,7 +21744,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*16">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix4x4" len="count*16">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix4dvEXT</name></proto>
@@ -21741,7 +21752,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*16">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix4x4" len="count*16">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix4fv</name></proto>
@@ -21749,7 +21760,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*16">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix4x4" len="count*16">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix4fvEXT</name></proto>
@@ -21757,7 +21768,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*16">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix4x4" len="count*16">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glProgramUniformMatrix4fv"/>
         </command>
         <command>
@@ -21766,7 +21777,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*8">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix4x2" len="count*8">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix4x2dvEXT</name></proto>
@@ -21774,7 +21785,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*8">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix4x2" len="count*8">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix4x2fv</name></proto>
@@ -21782,7 +21793,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*8">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix4x2" len="count*8">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix4x2fvEXT</name></proto>
@@ -21790,7 +21801,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*8">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix4x2" len="count*8">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glProgramUniformMatrix4x2fv"/>
         </command>
         <command>
@@ -21799,7 +21810,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*12">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix4x3" len="count*12">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix4x3dvEXT</name></proto>
@@ -21807,7 +21818,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*12">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix4x3" len="count*12">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix4x3fv</name></proto>
@@ -21815,7 +21826,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*12">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix4x3" len="count*12">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix4x3fvEXT</name></proto>
@@ -21823,7 +21834,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*12">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix4x3" len="count*12">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glProgramUniformMatrix4x3fv"/>
         </command>
         <command>
@@ -26169,14 +26180,14 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*4">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix2x2" len="count*4">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniformMatrix2fvARB</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*4">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix2x2" len="count*4">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glUniformMatrix2fv"/>
         </command>
         <command>
@@ -26184,14 +26195,14 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*6">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix2x3" len="count*6">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniformMatrix2x3fv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*6">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix2x3" len="count*6">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <glx type="render" opcode="305"/>
         </command>
         <command>
@@ -26199,7 +26210,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*6">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix2x3" len="count*6">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glUniformMatrix2x3fv"/>
         </command>
         <command>
@@ -26207,14 +26218,14 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*8">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix2x4" len="count*8">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniformMatrix2x4fv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*8">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix2x4" len="count*8">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <glx type="render" opcode="307"/>
         </command>
         <command>
@@ -26222,7 +26233,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*8">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix2x4" len="count*8">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glUniformMatrix2x4fv"/>
         </command>
         <command>
@@ -26230,21 +26241,21 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*9">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix3x3" len="count*9">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniformMatrix3fv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*9">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix3x3" len="count*9">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniformMatrix3fvARB</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*9">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix3x3" len="count*9">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glUniformMatrix3fv"/>
         </command>
         <command>
@@ -26252,14 +26263,14 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*6">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix3x2" len="count*6">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniformMatrix3x2fv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*6">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix3x2" len="count*6">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <glx type="render" opcode="306"/>
         </command>
         <command>
@@ -26267,7 +26278,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*6">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix3x2" len="count*6">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glUniformMatrix3x2fv"/>
         </command>
         <command>
@@ -26275,14 +26286,14 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*12">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix3x4" len="count*12">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniformMatrix3x4fv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*12">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix3x4" len="count*12">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <glx type="render" opcode="309"/>
         </command>
         <command>
@@ -26290,7 +26301,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*12">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix3x4" len="count*12">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glUniformMatrix3x4fv"/>
         </command>
         <command>
@@ -26298,21 +26309,21 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*16">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix4x4" len="count*16">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniformMatrix4fv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*16">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix4x4" len="count*16">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniformMatrix4fvARB</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*16">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix4x4" len="count*16">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glUniformMatrix4fv"/>
         </command>
         <command>
@@ -26320,14 +26331,14 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*8">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix4x2" len="count*8">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniformMatrix4x2fv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*8">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix4x2" len="count*8">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <glx type="render" opcode="308"/>
         </command>
         <command>
@@ -26335,7 +26346,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*8">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix4x2" len="count*8">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glUniformMatrix4x2fv"/>
         </command>
         <command>
@@ -26343,14 +26354,14 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*12">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix4x3" len="count*12">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniformMatrix4x3fv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*12">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix4x3" len="count*12">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <glx type="render" opcode="310"/>
         </command>
         <command>
@@ -26358,7 +26369,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*12">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix4x3" len="count*12">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glUniformMatrix4x3fv"/>
         </command>
         <command>

--- a/src/OpenTK.Graphics/OpenGL/Compatibility/GL.Overloads.cs
+++ b/src/OpenTK.Graphics/OpenGL/Compatibility/GL.Overloads.cs
@@ -6575,6 +6575,34 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 Uniform2fv(location, count, value_ptr);
             }
         }
+        /// <inheritdoc cref="Uniform2fv"/>
+        public static unsafe void Uniform2f(int location, in System.Numerics.Vector2 value)
+        {
+            int count = 1;
+            fixed (System.Numerics.Vector2* tmp_vecPtr = &value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                Uniform2fv(location, count, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="Uniform2fv"/>
+        public static unsafe void Uniform2f(int location, int count, ReadOnlySpan<System.Numerics.Vector2> value)
+        {
+            fixed (System.Numerics.Vector2* tmp_vecPtr = value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                Uniform2fv(location, count, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="Uniform2fv"/>
+        public static unsafe void Uniform2f(int location, int count, System.Numerics.Vector2[] value)
+        {
+            fixed (System.Numerics.Vector2* tmp_vecPtr = value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                Uniform2fv(location, count, value_ptr);
+            }
+        }
         /// <inheritdoc cref="Uniform3fv"/>
         public static unsafe void Uniform3f(int location, in Vector3 value)
         {
@@ -6603,6 +6631,34 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 Uniform3fv(location, count, value_ptr);
             }
         }
+        /// <inheritdoc cref="Uniform3fv"/>
+        public static unsafe void Uniform3f(int location, in System.Numerics.Vector3 value)
+        {
+            int count = 1;
+            fixed (System.Numerics.Vector3* tmp_vecPtr = &value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                Uniform3fv(location, count, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="Uniform3fv"/>
+        public static unsafe void Uniform3f(int location, int count, ReadOnlySpan<System.Numerics.Vector3> value)
+        {
+            fixed (System.Numerics.Vector3* tmp_vecPtr = value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                Uniform3fv(location, count, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="Uniform3fv"/>
+        public static unsafe void Uniform3f(int location, int count, System.Numerics.Vector3[] value)
+        {
+            fixed (System.Numerics.Vector3* tmp_vecPtr = value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                Uniform3fv(location, count, value_ptr);
+            }
+        }
         /// <inheritdoc cref="Uniform4fv"/>
         public static unsafe void Uniform4f(int location, in Vector4 value)
         {
@@ -6626,6 +6682,34 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         public static unsafe void Uniform4f(int location, int count, Vector4[] value)
         {
             fixed (Vector4* tmp_vecPtr = value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                Uniform4fv(location, count, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="Uniform4fv"/>
+        public static unsafe void Uniform4f(int location, in System.Numerics.Vector4 value)
+        {
+            int count = 1;
+            fixed (System.Numerics.Vector4* tmp_vecPtr = &value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                Uniform4fv(location, count, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="Uniform4fv"/>
+        public static unsafe void Uniform4f(int location, int count, ReadOnlySpan<System.Numerics.Vector4> value)
+        {
+            fixed (System.Numerics.Vector4* tmp_vecPtr = value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                Uniform4fv(location, count, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="Uniform4fv"/>
+        public static unsafe void Uniform4f(int location, int count, System.Numerics.Vector4[] value)
+        {
+            fixed (System.Numerics.Vector4* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
                 Uniform4fv(location, count, value_ptr);
@@ -6822,6 +6906,34 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         public static unsafe void UniformMatrix4f(int location, int count, bool transpose, Matrix4[] value)
         {
             fixed (Matrix4* tmp_vecPtr = value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                UniformMatrix4fv(location, count, transpose, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="UniformMatrix4fv"/>
+        public static unsafe void UniformMatrix4f(int location, bool transpose, in System.Numerics.Matrix4x4 value)
+        {
+            int count = 1;
+            fixed (System.Numerics.Matrix4x4* tmp_vecPtr = &value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                UniformMatrix4fv(location, count, transpose, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="UniformMatrix4fv"/>
+        public static unsafe void UniformMatrix4f(int location, int count, bool transpose, ReadOnlySpan<System.Numerics.Matrix4x4> value)
+        {
+            fixed (System.Numerics.Matrix4x4* tmp_vecPtr = value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                UniformMatrix4fv(location, count, transpose, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="UniformMatrix4fv"/>
+        public static unsafe void UniformMatrix4f(int location, int count, bool transpose, System.Numerics.Matrix4x4[] value)
+        {
+            fixed (System.Numerics.Matrix4x4* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
                 UniformMatrix4fv(location, count, transpose, value_ptr);
@@ -7461,6 +7573,34 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         public static unsafe void UniformMatrix3x2f(int location, int count, bool transpose, Matrix3x2[] value)
         {
             fixed (Matrix3x2* tmp_vecPtr = value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                UniformMatrix3x2fv(location, count, transpose, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="UniformMatrix3x2fv"/>
+        public static unsafe void UniformMatrix3x2f(int location, bool transpose, in System.Numerics.Matrix3x2 value)
+        {
+            int count = 1;
+            fixed (System.Numerics.Matrix3x2* tmp_vecPtr = &value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                UniformMatrix3x2fv(location, count, transpose, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="UniformMatrix3x2fv"/>
+        public static unsafe void UniformMatrix3x2f(int location, int count, bool transpose, ReadOnlySpan<System.Numerics.Matrix3x2> value)
+        {
+            fixed (System.Numerics.Matrix3x2* tmp_vecPtr = value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                UniformMatrix3x2fv(location, count, transpose, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="UniformMatrix3x2fv"/>
+        public static unsafe void UniformMatrix3x2f(int location, int count, bool transpose, System.Numerics.Matrix3x2[] value)
+        {
+            fixed (System.Numerics.Matrix3x2* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
                 UniformMatrix3x2fv(location, count, transpose, value_ptr);
@@ -11269,6 +11409,34 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 ProgramUniform2fv(program, location, count, value_ptr);
             }
         }
+        /// <inheritdoc cref="ProgramUniform2fv"/>
+        public static unsafe void ProgramUniform2f(ProgramHandle program, int location, in System.Numerics.Vector2 value)
+        {
+            int count = 1;
+            fixed (System.Numerics.Vector2* tmp_vecPtr = &value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                ProgramUniform2fv(program, location, count, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="ProgramUniform2fv"/>
+        public static unsafe void ProgramUniform2f(ProgramHandle program, int location, int count, ReadOnlySpan<System.Numerics.Vector2> value)
+        {
+            fixed (System.Numerics.Vector2* tmp_vecPtr = value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                ProgramUniform2fv(program, location, count, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="ProgramUniform2fv"/>
+        public static unsafe void ProgramUniform2f(ProgramHandle program, int location, int count, System.Numerics.Vector2[] value)
+        {
+            fixed (System.Numerics.Vector2* tmp_vecPtr = value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                ProgramUniform2fv(program, location, count, value_ptr);
+            }
+        }
         /// <inheritdoc cref="ProgramUniform2dv"/>
         public static unsafe void ProgramUniform2d(ProgramHandle program, int location, in Vector2d value)
         {
@@ -11379,6 +11547,34 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 ProgramUniform3fv(program, location, count, value_ptr);
             }
         }
+        /// <inheritdoc cref="ProgramUniform3fv"/>
+        public static unsafe void ProgramUniform3f(ProgramHandle program, int location, in System.Numerics.Vector3 value)
+        {
+            int count = 1;
+            fixed (System.Numerics.Vector3* tmp_vecPtr = &value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                ProgramUniform3fv(program, location, count, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="ProgramUniform3fv"/>
+        public static unsafe void ProgramUniform3f(ProgramHandle program, int location, int count, ReadOnlySpan<System.Numerics.Vector3> value)
+        {
+            fixed (System.Numerics.Vector3* tmp_vecPtr = value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                ProgramUniform3fv(program, location, count, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="ProgramUniform3fv"/>
+        public static unsafe void ProgramUniform3f(ProgramHandle program, int location, int count, System.Numerics.Vector3[] value)
+        {
+            fixed (System.Numerics.Vector3* tmp_vecPtr = value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                ProgramUniform3fv(program, location, count, value_ptr);
+            }
+        }
         /// <inheritdoc cref="ProgramUniform3dv"/>
         public static unsafe void ProgramUniform3d(ProgramHandle program, int location, in Vector3d value)
         {
@@ -11484,6 +11680,34 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         public static unsafe void ProgramUniform4f(ProgramHandle program, int location, int count, Vector4[] value)
         {
             fixed (Vector4* tmp_vecPtr = value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                ProgramUniform4fv(program, location, count, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="ProgramUniform4fv"/>
+        public static unsafe void ProgramUniform4f(ProgramHandle program, int location, in System.Numerics.Vector4 value)
+        {
+            int count = 1;
+            fixed (System.Numerics.Vector4* tmp_vecPtr = &value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                ProgramUniform4fv(program, location, count, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="ProgramUniform4fv"/>
+        public static unsafe void ProgramUniform4f(ProgramHandle program, int location, int count, ReadOnlySpan<System.Numerics.Vector4> value)
+        {
+            fixed (System.Numerics.Vector4* tmp_vecPtr = value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                ProgramUniform4fv(program, location, count, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="ProgramUniform4fv"/>
+        public static unsafe void ProgramUniform4f(ProgramHandle program, int location, int count, System.Numerics.Vector4[] value)
+        {
+            fixed (System.Numerics.Vector4* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
                 ProgramUniform4fv(program, location, count, value_ptr);
@@ -11627,6 +11851,34 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 ProgramUniformMatrix4fv(program, location, count, transpose, value_ptr);
             }
         }
+        /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
+        public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, bool transpose, in System.Numerics.Matrix4x4 value)
+        {
+            int count = 1;
+            fixed (System.Numerics.Matrix4x4* tmp_vecPtr = &value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                ProgramUniformMatrix4fv(program, location, count, transpose, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
+        public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<System.Numerics.Matrix4x4> value)
+        {
+            fixed (System.Numerics.Matrix4x4* tmp_vecPtr = value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                ProgramUniformMatrix4fv(program, location, count, transpose, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
+        public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, int count, bool transpose, System.Numerics.Matrix4x4[] value)
+        {
+            fixed (System.Numerics.Matrix4x4* tmp_vecPtr = value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                ProgramUniformMatrix4fv(program, location, count, transpose, value_ptr);
+            }
+        }
         /// <inheritdoc cref="ProgramUniformMatrix2dv"/>
         public static unsafe void ProgramUniformMatrix2d(ProgramHandle program, int location, bool transpose, in Matrix2d value)
         {
@@ -11762,6 +12014,34 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, int count, bool transpose, Matrix3x2[] value)
         {
             fixed (Matrix3x2* tmp_vecPtr = value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                ProgramUniformMatrix3x2fv(program, location, count, transpose, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
+        public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, bool transpose, in System.Numerics.Matrix3x2 value)
+        {
+            int count = 1;
+            fixed (System.Numerics.Matrix3x2* tmp_vecPtr = &value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                ProgramUniformMatrix3x2fv(program, location, count, transpose, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
+        public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<System.Numerics.Matrix3x2> value)
+        {
+            fixed (System.Numerics.Matrix3x2* tmp_vecPtr = value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                ProgramUniformMatrix3x2fv(program, location, count, transpose, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
+        public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, int count, bool transpose, System.Numerics.Matrix3x2[] value)
+        {
+            fixed (System.Numerics.Matrix3x2* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
                 ProgramUniformMatrix3x2fv(program, location, count, transpose, value_ptr);
@@ -23711,6 +23991,34 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                     ProgramUniform2fv(program, location, count, value_ptr);
                 }
             }
+            /// <inheritdoc cref="ProgramUniform2fv"/>
+            public static unsafe void ProgramUniform2f(ProgramHandle program, int location, in System.Numerics.Vector2 value)
+            {
+                int count = 1;
+                fixed (System.Numerics.Vector2* tmp_vecPtr = &value)
+                {
+                    float* value_ptr = (float*)tmp_vecPtr;
+                    ProgramUniform2fv(program, location, count, value_ptr);
+                }
+            }
+            /// <inheritdoc cref="ProgramUniform2fv"/>
+            public static unsafe void ProgramUniform2f(ProgramHandle program, int location, int count, ReadOnlySpan<System.Numerics.Vector2> value)
+            {
+                fixed (System.Numerics.Vector2* tmp_vecPtr = value)
+                {
+                    float* value_ptr = (float*)tmp_vecPtr;
+                    ProgramUniform2fv(program, location, count, value_ptr);
+                }
+            }
+            /// <inheritdoc cref="ProgramUniform2fv"/>
+            public static unsafe void ProgramUniform2f(ProgramHandle program, int location, int count, System.Numerics.Vector2[] value)
+            {
+                fixed (System.Numerics.Vector2* tmp_vecPtr = value)
+                {
+                    float* value_ptr = (float*)tmp_vecPtr;
+                    ProgramUniform2fv(program, location, count, value_ptr);
+                }
+            }
             /// <inheritdoc cref="ProgramUniform2dv"/>
             public static unsafe void ProgramUniform2d(ProgramHandle program, int location, in Vector2d value)
             {
@@ -23821,6 +24129,34 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                     ProgramUniform3fv(program, location, count, value_ptr);
                 }
             }
+            /// <inheritdoc cref="ProgramUniform3fv"/>
+            public static unsafe void ProgramUniform3f(ProgramHandle program, int location, in System.Numerics.Vector3 value)
+            {
+                int count = 1;
+                fixed (System.Numerics.Vector3* tmp_vecPtr = &value)
+                {
+                    float* value_ptr = (float*)tmp_vecPtr;
+                    ProgramUniform3fv(program, location, count, value_ptr);
+                }
+            }
+            /// <inheritdoc cref="ProgramUniform3fv"/>
+            public static unsafe void ProgramUniform3f(ProgramHandle program, int location, int count, ReadOnlySpan<System.Numerics.Vector3> value)
+            {
+                fixed (System.Numerics.Vector3* tmp_vecPtr = value)
+                {
+                    float* value_ptr = (float*)tmp_vecPtr;
+                    ProgramUniform3fv(program, location, count, value_ptr);
+                }
+            }
+            /// <inheritdoc cref="ProgramUniform3fv"/>
+            public static unsafe void ProgramUniform3f(ProgramHandle program, int location, int count, System.Numerics.Vector3[] value)
+            {
+                fixed (System.Numerics.Vector3* tmp_vecPtr = value)
+                {
+                    float* value_ptr = (float*)tmp_vecPtr;
+                    ProgramUniform3fv(program, location, count, value_ptr);
+                }
+            }
             /// <inheritdoc cref="ProgramUniform3dv"/>
             public static unsafe void ProgramUniform3d(ProgramHandle program, int location, in Vector3d value)
             {
@@ -23926,6 +24262,34 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             public static unsafe void ProgramUniform4f(ProgramHandle program, int location, int count, Vector4[] value)
             {
                 fixed (Vector4* tmp_vecPtr = value)
+                {
+                    float* value_ptr = (float*)tmp_vecPtr;
+                    ProgramUniform4fv(program, location, count, value_ptr);
+                }
+            }
+            /// <inheritdoc cref="ProgramUniform4fv"/>
+            public static unsafe void ProgramUniform4f(ProgramHandle program, int location, in System.Numerics.Vector4 value)
+            {
+                int count = 1;
+                fixed (System.Numerics.Vector4* tmp_vecPtr = &value)
+                {
+                    float* value_ptr = (float*)tmp_vecPtr;
+                    ProgramUniform4fv(program, location, count, value_ptr);
+                }
+            }
+            /// <inheritdoc cref="ProgramUniform4fv"/>
+            public static unsafe void ProgramUniform4f(ProgramHandle program, int location, int count, ReadOnlySpan<System.Numerics.Vector4> value)
+            {
+                fixed (System.Numerics.Vector4* tmp_vecPtr = value)
+                {
+                    float* value_ptr = (float*)tmp_vecPtr;
+                    ProgramUniform4fv(program, location, count, value_ptr);
+                }
+            }
+            /// <inheritdoc cref="ProgramUniform4fv"/>
+            public static unsafe void ProgramUniform4f(ProgramHandle program, int location, int count, System.Numerics.Vector4[] value)
+            {
+                fixed (System.Numerics.Vector4* tmp_vecPtr = value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
                     ProgramUniform4fv(program, location, count, value_ptr);
@@ -24069,6 +24433,34 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                     ProgramUniformMatrix4fv(program, location, count, transpose, value_ptr);
                 }
             }
+            /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
+            public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, bool transpose, in System.Numerics.Matrix4x4 value)
+            {
+                int count = 1;
+                fixed (System.Numerics.Matrix4x4* tmp_vecPtr = &value)
+                {
+                    float* value_ptr = (float*)tmp_vecPtr;
+                    ProgramUniformMatrix4fv(program, location, count, transpose, value_ptr);
+                }
+            }
+            /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
+            public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<System.Numerics.Matrix4x4> value)
+            {
+                fixed (System.Numerics.Matrix4x4* tmp_vecPtr = value)
+                {
+                    float* value_ptr = (float*)tmp_vecPtr;
+                    ProgramUniformMatrix4fv(program, location, count, transpose, value_ptr);
+                }
+            }
+            /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
+            public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, int count, bool transpose, System.Numerics.Matrix4x4[] value)
+            {
+                fixed (System.Numerics.Matrix4x4* tmp_vecPtr = value)
+                {
+                    float* value_ptr = (float*)tmp_vecPtr;
+                    ProgramUniformMatrix4fv(program, location, count, transpose, value_ptr);
+                }
+            }
             /// <inheritdoc cref="ProgramUniformMatrix2dv"/>
             public static unsafe void ProgramUniformMatrix2d(ProgramHandle program, int location, bool transpose, in Matrix2d value)
             {
@@ -24204,6 +24596,34 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, int count, bool transpose, Matrix3x2[] value)
             {
                 fixed (Matrix3x2* tmp_vecPtr = value)
+                {
+                    float* value_ptr = (float*)tmp_vecPtr;
+                    ProgramUniformMatrix3x2fv(program, location, count, transpose, value_ptr);
+                }
+            }
+            /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
+            public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, bool transpose, in System.Numerics.Matrix3x2 value)
+            {
+                int count = 1;
+                fixed (System.Numerics.Matrix3x2* tmp_vecPtr = &value)
+                {
+                    float* value_ptr = (float*)tmp_vecPtr;
+                    ProgramUniformMatrix3x2fv(program, location, count, transpose, value_ptr);
+                }
+            }
+            /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
+            public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<System.Numerics.Matrix3x2> value)
+            {
+                fixed (System.Numerics.Matrix3x2* tmp_vecPtr = value)
+                {
+                    float* value_ptr = (float*)tmp_vecPtr;
+                    ProgramUniformMatrix3x2fv(program, location, count, transpose, value_ptr);
+                }
+            }
+            /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
+            public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, int count, bool transpose, System.Numerics.Matrix3x2[] value)
+            {
+                fixed (System.Numerics.Matrix3x2* tmp_vecPtr = value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
                     ProgramUniformMatrix3x2fv(program, location, count, transpose, value_ptr);

--- a/src/OpenTK.Graphics/OpenGL/Compatibility/GL.Overloads.cs
+++ b/src/OpenTK.Graphics/OpenGL/Compatibility/GL.Overloads.cs
@@ -478,74 +478,29 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="Color3dv"/>
-        public static unsafe void Color3dv(ReadOnlySpan<double> v)
+        public static unsafe void Color3d(in Vector3d v)
         {
-            fixed (double* v_ptr = v)
+            fixed (Vector3d* tmp_vecPtr = &v)
             {
-                Color3dv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="Color3dv"/>
-        public static unsafe void Color3dv(double[] v)
-        {
-            fixed (double* v_ptr = v)
-            {
-                Color3dv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="Color3dv"/>
-        public static unsafe void Color3dv(in double v)
-        {
-            fixed (double* v_ptr = &v)
-            {
+                double* v_ptr = (double*)tmp_vecPtr;
                 Color3dv(v_ptr);
             }
         }
         /// <inheritdoc cref="Color3fv"/>
-        public static unsafe void Color3fv(ReadOnlySpan<float> v)
+        public static unsafe void Color3f(in Color3<Rgb> v)
         {
-            fixed (float* v_ptr = v)
+            fixed (Color3<Rgb>* tmp_v = &v)
             {
-                Color3fv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="Color3fv"/>
-        public static unsafe void Color3fv(float[] v)
-        {
-            fixed (float* v_ptr = v)
-            {
-                Color3fv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="Color3fv"/>
-        public static unsafe void Color3fv(in float v)
-        {
-            fixed (float* v_ptr = &v)
-            {
+                float* v_ptr = (float*)tmp_v;
                 Color3fv(v_ptr);
             }
         }
         /// <inheritdoc cref="Color3iv"/>
-        public static unsafe void Color3iv(ReadOnlySpan<int> v)
+        public static unsafe void Color3i(in Vector3i v)
         {
-            fixed (int* v_ptr = v)
+            fixed (Vector3i* tmp_vecPtr = &v)
             {
-                Color3iv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="Color3iv"/>
-        public static unsafe void Color3iv(int[] v)
-        {
-            fixed (int* v_ptr = v)
-            {
-                Color3iv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="Color3iv"/>
-        public static unsafe void Color3iv(in int v)
-        {
-            fixed (int* v_ptr = &v)
-            {
+                int* v_ptr = (int*)tmp_vecPtr;
                 Color3iv(v_ptr);
             }
         }
@@ -690,74 +645,29 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="Color4dv"/>
-        public static unsafe void Color4dv(ReadOnlySpan<double> v)
+        public static unsafe void Color4d(in Vector4d v)
         {
-            fixed (double* v_ptr = v)
+            fixed (Vector4d* tmp_vecPtr = &v)
             {
-                Color4dv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="Color4dv"/>
-        public static unsafe void Color4dv(double[] v)
-        {
-            fixed (double* v_ptr = v)
-            {
-                Color4dv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="Color4dv"/>
-        public static unsafe void Color4dv(in double v)
-        {
-            fixed (double* v_ptr = &v)
-            {
+                double* v_ptr = (double*)tmp_vecPtr;
                 Color4dv(v_ptr);
             }
         }
         /// <inheritdoc cref="Color4fv"/>
-        public static unsafe void Color4fv(ReadOnlySpan<float> v)
+        public static unsafe void Color4f(in Color4<Rgba> v)
         {
-            fixed (float* v_ptr = v)
+            fixed (Color4<Rgba>* tmp_v = &v)
             {
-                Color4fv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="Color4fv"/>
-        public static unsafe void Color4fv(float[] v)
-        {
-            fixed (float* v_ptr = v)
-            {
-                Color4fv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="Color4fv"/>
-        public static unsafe void Color4fv(in float v)
-        {
-            fixed (float* v_ptr = &v)
-            {
+                float* v_ptr = (float*)tmp_v;
                 Color4fv(v_ptr);
             }
         }
         /// <inheritdoc cref="Color4iv"/>
-        public static unsafe void Color4iv(ReadOnlySpan<int> v)
+        public static unsafe void Color4i(in Vector4i v)
         {
-            fixed (int* v_ptr = v)
+            fixed (Vector4i* tmp_vecPtr = &v)
             {
-                Color4iv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="Color4iv"/>
-        public static unsafe void Color4iv(int[] v)
-        {
-            fixed (int* v_ptr = v)
-            {
-                Color4iv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="Color4iv"/>
-        public static unsafe void Color4iv(in int v)
-        {
-            fixed (int* v_ptr = &v)
-            {
+                int* v_ptr = (int*)tmp_vecPtr;
                 Color4iv(v_ptr);
             }
         }
@@ -1027,74 +937,38 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="Normal3dv"/>
-        public static unsafe void Normal3dv(ReadOnlySpan<double> v)
+        public static unsafe void Normal3d(in Vector3d v)
         {
-            fixed (double* v_ptr = v)
+            fixed (Vector3d* tmp_vecPtr = &v)
             {
-                Normal3dv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="Normal3dv"/>
-        public static unsafe void Normal3dv(double[] v)
-        {
-            fixed (double* v_ptr = v)
-            {
-                Normal3dv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="Normal3dv"/>
-        public static unsafe void Normal3dv(in double v)
-        {
-            fixed (double* v_ptr = &v)
-            {
+                double* v_ptr = (double*)tmp_vecPtr;
                 Normal3dv(v_ptr);
             }
         }
         /// <inheritdoc cref="Normal3fv"/>
-        public static unsafe void Normal3fv(ReadOnlySpan<float> v)
+        public static unsafe void Normal3f(in Vector3 v)
         {
-            fixed (float* v_ptr = v)
+            fixed (Vector3* tmp_vecPtr = &v)
             {
+                float* v_ptr = (float*)tmp_vecPtr;
                 Normal3fv(v_ptr);
             }
         }
         /// <inheritdoc cref="Normal3fv"/>
-        public static unsafe void Normal3fv(float[] v)
+        public static unsafe void Normal3f(in System.Numerics.Vector3 v)
         {
-            fixed (float* v_ptr = v)
+            fixed (System.Numerics.Vector3* tmp_vecPtr = &v)
             {
-                Normal3fv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="Normal3fv"/>
-        public static unsafe void Normal3fv(in float v)
-        {
-            fixed (float* v_ptr = &v)
-            {
+                float* v_ptr = (float*)tmp_vecPtr;
                 Normal3fv(v_ptr);
             }
         }
         /// <inheritdoc cref="Normal3iv"/>
-        public static unsafe void Normal3iv(ReadOnlySpan<int> v)
+        public static unsafe void Normal3i(in Vector3i v)
         {
-            fixed (int* v_ptr = v)
+            fixed (Vector3i* tmp_vecPtr = &v)
             {
-                Normal3iv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="Normal3iv"/>
-        public static unsafe void Normal3iv(int[] v)
-        {
-            fixed (int* v_ptr = v)
-            {
-                Normal3iv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="Normal3iv"/>
-        public static unsafe void Normal3iv(in int v)
-        {
-            fixed (int* v_ptr = &v)
-            {
+                int* v_ptr = (int*)tmp_vecPtr;
                 Normal3iv(v_ptr);
             }
         }
@@ -1128,74 +1002,38 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="RasterPos2dv"/>
-        public static unsafe void RasterPos2dv(ReadOnlySpan<double> v)
+        public static unsafe void RasterPos2d(in Vector2d v)
         {
-            fixed (double* v_ptr = v)
+            fixed (Vector2d* tmp_vecPtr = &v)
             {
-                RasterPos2dv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="RasterPos2dv"/>
-        public static unsafe void RasterPos2dv(double[] v)
-        {
-            fixed (double* v_ptr = v)
-            {
-                RasterPos2dv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="RasterPos2dv"/>
-        public static unsafe void RasterPos2dv(in double v)
-        {
-            fixed (double* v_ptr = &v)
-            {
+                double* v_ptr = (double*)tmp_vecPtr;
                 RasterPos2dv(v_ptr);
             }
         }
         /// <inheritdoc cref="RasterPos2fv"/>
-        public static unsafe void RasterPos2fv(ReadOnlySpan<float> v)
+        public static unsafe void RasterPos2f(in Vector2 v)
         {
-            fixed (float* v_ptr = v)
+            fixed (Vector2* tmp_vecPtr = &v)
             {
+                float* v_ptr = (float*)tmp_vecPtr;
                 RasterPos2fv(v_ptr);
             }
         }
         /// <inheritdoc cref="RasterPos2fv"/>
-        public static unsafe void RasterPos2fv(float[] v)
+        public static unsafe void RasterPos2f(in System.Numerics.Vector2 v)
         {
-            fixed (float* v_ptr = v)
+            fixed (System.Numerics.Vector2* tmp_vecPtr = &v)
             {
-                RasterPos2fv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="RasterPos2fv"/>
-        public static unsafe void RasterPos2fv(in float v)
-        {
-            fixed (float* v_ptr = &v)
-            {
+                float* v_ptr = (float*)tmp_vecPtr;
                 RasterPos2fv(v_ptr);
             }
         }
         /// <inheritdoc cref="RasterPos2iv"/>
-        public static unsafe void RasterPos2iv(ReadOnlySpan<int> v)
+        public static unsafe void RasterPos2i(in Vector2i v)
         {
-            fixed (int* v_ptr = v)
+            fixed (Vector2i* tmp_vecPtr = &v)
             {
-                RasterPos2iv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="RasterPos2iv"/>
-        public static unsafe void RasterPos2iv(int[] v)
-        {
-            fixed (int* v_ptr = v)
-            {
-                RasterPos2iv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="RasterPos2iv"/>
-        public static unsafe void RasterPos2iv(in int v)
-        {
-            fixed (int* v_ptr = &v)
-            {
+                int* v_ptr = (int*)tmp_vecPtr;
                 RasterPos2iv(v_ptr);
             }
         }
@@ -1229,74 +1067,38 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="RasterPos3dv"/>
-        public static unsafe void RasterPos3dv(ReadOnlySpan<double> v)
+        public static unsafe void RasterPos3d(in Vector3d v)
         {
-            fixed (double* v_ptr = v)
+            fixed (Vector3d* tmp_vecPtr = &v)
             {
-                RasterPos3dv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="RasterPos3dv"/>
-        public static unsafe void RasterPos3dv(double[] v)
-        {
-            fixed (double* v_ptr = v)
-            {
-                RasterPos3dv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="RasterPos3dv"/>
-        public static unsafe void RasterPos3dv(in double v)
-        {
-            fixed (double* v_ptr = &v)
-            {
+                double* v_ptr = (double*)tmp_vecPtr;
                 RasterPos3dv(v_ptr);
             }
         }
         /// <inheritdoc cref="RasterPos3fv"/>
-        public static unsafe void RasterPos3fv(ReadOnlySpan<float> v)
+        public static unsafe void RasterPos3f(in Vector3 v)
         {
-            fixed (float* v_ptr = v)
+            fixed (Vector3* tmp_vecPtr = &v)
             {
+                float* v_ptr = (float*)tmp_vecPtr;
                 RasterPos3fv(v_ptr);
             }
         }
         /// <inheritdoc cref="RasterPos3fv"/>
-        public static unsafe void RasterPos3fv(float[] v)
+        public static unsafe void RasterPos3f(in System.Numerics.Vector3 v)
         {
-            fixed (float* v_ptr = v)
+            fixed (System.Numerics.Vector3* tmp_vecPtr = &v)
             {
-                RasterPos3fv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="RasterPos3fv"/>
-        public static unsafe void RasterPos3fv(in float v)
-        {
-            fixed (float* v_ptr = &v)
-            {
+                float* v_ptr = (float*)tmp_vecPtr;
                 RasterPos3fv(v_ptr);
             }
         }
         /// <inheritdoc cref="RasterPos3iv"/>
-        public static unsafe void RasterPos3iv(ReadOnlySpan<int> v)
+        public static unsafe void RasterPos3i(in Vector3i v)
         {
-            fixed (int* v_ptr = v)
+            fixed (Vector3i* tmp_vecPtr = &v)
             {
-                RasterPos3iv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="RasterPos3iv"/>
-        public static unsafe void RasterPos3iv(int[] v)
-        {
-            fixed (int* v_ptr = v)
-            {
-                RasterPos3iv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="RasterPos3iv"/>
-        public static unsafe void RasterPos3iv(in int v)
-        {
-            fixed (int* v_ptr = &v)
-            {
+                int* v_ptr = (int*)tmp_vecPtr;
                 RasterPos3iv(v_ptr);
             }
         }
@@ -1330,74 +1132,38 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="RasterPos4dv"/>
-        public static unsafe void RasterPos4dv(ReadOnlySpan<double> v)
+        public static unsafe void RasterPos4d(in Vector4d v)
         {
-            fixed (double* v_ptr = v)
+            fixed (Vector4d* tmp_vecPtr = &v)
             {
-                RasterPos4dv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="RasterPos4dv"/>
-        public static unsafe void RasterPos4dv(double[] v)
-        {
-            fixed (double* v_ptr = v)
-            {
-                RasterPos4dv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="RasterPos4dv"/>
-        public static unsafe void RasterPos4dv(in double v)
-        {
-            fixed (double* v_ptr = &v)
-            {
+                double* v_ptr = (double*)tmp_vecPtr;
                 RasterPos4dv(v_ptr);
             }
         }
         /// <inheritdoc cref="RasterPos4fv"/>
-        public static unsafe void RasterPos4fv(ReadOnlySpan<float> v)
+        public static unsafe void RasterPos4f(in Vector4 v)
         {
-            fixed (float* v_ptr = v)
+            fixed (Vector4* tmp_vecPtr = &v)
             {
+                float* v_ptr = (float*)tmp_vecPtr;
                 RasterPos4fv(v_ptr);
             }
         }
         /// <inheritdoc cref="RasterPos4fv"/>
-        public static unsafe void RasterPos4fv(float[] v)
+        public static unsafe void RasterPos4f(in System.Numerics.Vector4 v)
         {
-            fixed (float* v_ptr = v)
+            fixed (System.Numerics.Vector4* tmp_vecPtr = &v)
             {
-                RasterPos4fv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="RasterPos4fv"/>
-        public static unsafe void RasterPos4fv(in float v)
-        {
-            fixed (float* v_ptr = &v)
-            {
+                float* v_ptr = (float*)tmp_vecPtr;
                 RasterPos4fv(v_ptr);
             }
         }
         /// <inheritdoc cref="RasterPos4iv"/>
-        public static unsafe void RasterPos4iv(ReadOnlySpan<int> v)
+        public static unsafe void RasterPos4i(in Vector4i v)
         {
-            fixed (int* v_ptr = v)
+            fixed (Vector4i* tmp_vecPtr = &v)
             {
-                RasterPos4iv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="RasterPos4iv"/>
-        public static unsafe void RasterPos4iv(int[] v)
-        {
-            fixed (int* v_ptr = v)
-            {
-                RasterPos4iv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="RasterPos4iv"/>
-        public static unsafe void RasterPos4iv(in int v)
-        {
-            fixed (int* v_ptr = &v)
-            {
+                int* v_ptr = (int*)tmp_vecPtr;
                 RasterPos4iv(v_ptr);
             }
         }
@@ -1555,74 +1321,29 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="TexCoord1dv"/>
-        public static unsafe void TexCoord1dv(ReadOnlySpan<double> v)
+        public static unsafe void TexCoord1d(in double v)
         {
-            fixed (double* v_ptr = v)
+            fixed (double* tmp_vecPtr = &v)
             {
-                TexCoord1dv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="TexCoord1dv"/>
-        public static unsafe void TexCoord1dv(double[] v)
-        {
-            fixed (double* v_ptr = v)
-            {
-                TexCoord1dv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="TexCoord1dv"/>
-        public static unsafe void TexCoord1dv(in double v)
-        {
-            fixed (double* v_ptr = &v)
-            {
+                double* v_ptr = (double*)tmp_vecPtr;
                 TexCoord1dv(v_ptr);
             }
         }
         /// <inheritdoc cref="TexCoord1fv"/>
-        public static unsafe void TexCoord1fv(ReadOnlySpan<float> v)
+        public static unsafe void TexCoord1f(in float v)
         {
-            fixed (float* v_ptr = v)
+            fixed (float* tmp_vecPtr = &v)
             {
-                TexCoord1fv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="TexCoord1fv"/>
-        public static unsafe void TexCoord1fv(float[] v)
-        {
-            fixed (float* v_ptr = v)
-            {
-                TexCoord1fv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="TexCoord1fv"/>
-        public static unsafe void TexCoord1fv(in float v)
-        {
-            fixed (float* v_ptr = &v)
-            {
+                float* v_ptr = (float*)tmp_vecPtr;
                 TexCoord1fv(v_ptr);
             }
         }
         /// <inheritdoc cref="TexCoord1iv"/>
-        public static unsafe void TexCoord1iv(ReadOnlySpan<int> v)
+        public static unsafe void TexCoord1i(in int v)
         {
-            fixed (int* v_ptr = v)
+            fixed (int* tmp_vecPtr = &v)
             {
-                TexCoord1iv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="TexCoord1iv"/>
-        public static unsafe void TexCoord1iv(int[] v)
-        {
-            fixed (int* v_ptr = v)
-            {
-                TexCoord1iv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="TexCoord1iv"/>
-        public static unsafe void TexCoord1iv(in int v)
-        {
-            fixed (int* v_ptr = &v)
-            {
+                int* v_ptr = (int*)tmp_vecPtr;
                 TexCoord1iv(v_ptr);
             }
         }
@@ -1656,74 +1377,38 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="TexCoord2dv"/>
-        public static unsafe void TexCoord2dv(ReadOnlySpan<double> v)
+        public static unsafe void TexCoord2d(in Vector2d v)
         {
-            fixed (double* v_ptr = v)
+            fixed (Vector2d* tmp_vecPtr = &v)
             {
-                TexCoord2dv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="TexCoord2dv"/>
-        public static unsafe void TexCoord2dv(double[] v)
-        {
-            fixed (double* v_ptr = v)
-            {
-                TexCoord2dv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="TexCoord2dv"/>
-        public static unsafe void TexCoord2dv(in double v)
-        {
-            fixed (double* v_ptr = &v)
-            {
+                double* v_ptr = (double*)tmp_vecPtr;
                 TexCoord2dv(v_ptr);
             }
         }
         /// <inheritdoc cref="TexCoord2fv"/>
-        public static unsafe void TexCoord2fv(ReadOnlySpan<float> v)
+        public static unsafe void TexCoord2f(in Vector2 v)
         {
-            fixed (float* v_ptr = v)
+            fixed (Vector2* tmp_vecPtr = &v)
             {
+                float* v_ptr = (float*)tmp_vecPtr;
                 TexCoord2fv(v_ptr);
             }
         }
         /// <inheritdoc cref="TexCoord2fv"/>
-        public static unsafe void TexCoord2fv(float[] v)
+        public static unsafe void TexCoord2f(in System.Numerics.Vector2 v)
         {
-            fixed (float* v_ptr = v)
+            fixed (System.Numerics.Vector2* tmp_vecPtr = &v)
             {
-                TexCoord2fv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="TexCoord2fv"/>
-        public static unsafe void TexCoord2fv(in float v)
-        {
-            fixed (float* v_ptr = &v)
-            {
+                float* v_ptr = (float*)tmp_vecPtr;
                 TexCoord2fv(v_ptr);
             }
         }
         /// <inheritdoc cref="TexCoord2iv"/>
-        public static unsafe void TexCoord2iv(ReadOnlySpan<int> v)
+        public static unsafe void TexCoord2i(in Vector2i v)
         {
-            fixed (int* v_ptr = v)
+            fixed (Vector2i* tmp_vecPtr = &v)
             {
-                TexCoord2iv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="TexCoord2iv"/>
-        public static unsafe void TexCoord2iv(int[] v)
-        {
-            fixed (int* v_ptr = v)
-            {
-                TexCoord2iv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="TexCoord2iv"/>
-        public static unsafe void TexCoord2iv(in int v)
-        {
-            fixed (int* v_ptr = &v)
-            {
+                int* v_ptr = (int*)tmp_vecPtr;
                 TexCoord2iv(v_ptr);
             }
         }
@@ -1757,74 +1442,38 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="TexCoord3dv"/>
-        public static unsafe void TexCoord3dv(ReadOnlySpan<double> v)
+        public static unsafe void TexCoord3d(in Vector3d v)
         {
-            fixed (double* v_ptr = v)
+            fixed (Vector3d* tmp_vecPtr = &v)
             {
-                TexCoord3dv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="TexCoord3dv"/>
-        public static unsafe void TexCoord3dv(double[] v)
-        {
-            fixed (double* v_ptr = v)
-            {
-                TexCoord3dv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="TexCoord3dv"/>
-        public static unsafe void TexCoord3dv(in double v)
-        {
-            fixed (double* v_ptr = &v)
-            {
+                double* v_ptr = (double*)tmp_vecPtr;
                 TexCoord3dv(v_ptr);
             }
         }
         /// <inheritdoc cref="TexCoord3fv"/>
-        public static unsafe void TexCoord3fv(ReadOnlySpan<float> v)
+        public static unsafe void TexCoord3f(in Vector3 v)
         {
-            fixed (float* v_ptr = v)
+            fixed (Vector3* tmp_vecPtr = &v)
             {
+                float* v_ptr = (float*)tmp_vecPtr;
                 TexCoord3fv(v_ptr);
             }
         }
         /// <inheritdoc cref="TexCoord3fv"/>
-        public static unsafe void TexCoord3fv(float[] v)
+        public static unsafe void TexCoord3f(in System.Numerics.Vector3 v)
         {
-            fixed (float* v_ptr = v)
+            fixed (System.Numerics.Vector3* tmp_vecPtr = &v)
             {
-                TexCoord3fv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="TexCoord3fv"/>
-        public static unsafe void TexCoord3fv(in float v)
-        {
-            fixed (float* v_ptr = &v)
-            {
+                float* v_ptr = (float*)tmp_vecPtr;
                 TexCoord3fv(v_ptr);
             }
         }
         /// <inheritdoc cref="TexCoord3iv"/>
-        public static unsafe void TexCoord3iv(ReadOnlySpan<int> v)
+        public static unsafe void TexCoord3i(in Vector3i v)
         {
-            fixed (int* v_ptr = v)
+            fixed (Vector3i* tmp_vecPtr = &v)
             {
-                TexCoord3iv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="TexCoord3iv"/>
-        public static unsafe void TexCoord3iv(int[] v)
-        {
-            fixed (int* v_ptr = v)
-            {
-                TexCoord3iv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="TexCoord3iv"/>
-        public static unsafe void TexCoord3iv(in int v)
-        {
-            fixed (int* v_ptr = &v)
-            {
+                int* v_ptr = (int*)tmp_vecPtr;
                 TexCoord3iv(v_ptr);
             }
         }
@@ -1858,74 +1507,38 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="TexCoord4dv"/>
-        public static unsafe void TexCoord4dv(ReadOnlySpan<double> v)
+        public static unsafe void TexCoord4d(in Vector4d v)
         {
-            fixed (double* v_ptr = v)
+            fixed (Vector4d* tmp_vecPtr = &v)
             {
-                TexCoord4dv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="TexCoord4dv"/>
-        public static unsafe void TexCoord4dv(double[] v)
-        {
-            fixed (double* v_ptr = v)
-            {
-                TexCoord4dv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="TexCoord4dv"/>
-        public static unsafe void TexCoord4dv(in double v)
-        {
-            fixed (double* v_ptr = &v)
-            {
+                double* v_ptr = (double*)tmp_vecPtr;
                 TexCoord4dv(v_ptr);
             }
         }
         /// <inheritdoc cref="TexCoord4fv"/>
-        public static unsafe void TexCoord4fv(ReadOnlySpan<float> v)
+        public static unsafe void TexCoord4f(in Vector4 v)
         {
-            fixed (float* v_ptr = v)
+            fixed (Vector4* tmp_vecPtr = &v)
             {
+                float* v_ptr = (float*)tmp_vecPtr;
                 TexCoord4fv(v_ptr);
             }
         }
         /// <inheritdoc cref="TexCoord4fv"/>
-        public static unsafe void TexCoord4fv(float[] v)
+        public static unsafe void TexCoord4f(in System.Numerics.Vector4 v)
         {
-            fixed (float* v_ptr = v)
+            fixed (System.Numerics.Vector4* tmp_vecPtr = &v)
             {
-                TexCoord4fv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="TexCoord4fv"/>
-        public static unsafe void TexCoord4fv(in float v)
-        {
-            fixed (float* v_ptr = &v)
-            {
+                float* v_ptr = (float*)tmp_vecPtr;
                 TexCoord4fv(v_ptr);
             }
         }
         /// <inheritdoc cref="TexCoord4iv"/>
-        public static unsafe void TexCoord4iv(ReadOnlySpan<int> v)
+        public static unsafe void TexCoord4i(in Vector4i v)
         {
-            fixed (int* v_ptr = v)
+            fixed (Vector4i* tmp_vecPtr = &v)
             {
-                TexCoord4iv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="TexCoord4iv"/>
-        public static unsafe void TexCoord4iv(int[] v)
-        {
-            fixed (int* v_ptr = v)
-            {
-                TexCoord4iv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="TexCoord4iv"/>
-        public static unsafe void TexCoord4iv(in int v)
-        {
-            fixed (int* v_ptr = &v)
-            {
+                int* v_ptr = (int*)tmp_vecPtr;
                 TexCoord4iv(v_ptr);
             }
         }
@@ -1959,74 +1572,38 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="Vertex2dv"/>
-        public static unsafe void Vertex2dv(ReadOnlySpan<double> v)
+        public static unsafe void Vertex2d(in Vector2d v)
         {
-            fixed (double* v_ptr = v)
+            fixed (Vector2d* tmp_vecPtr = &v)
             {
-                Vertex2dv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="Vertex2dv"/>
-        public static unsafe void Vertex2dv(double[] v)
-        {
-            fixed (double* v_ptr = v)
-            {
-                Vertex2dv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="Vertex2dv"/>
-        public static unsafe void Vertex2dv(in double v)
-        {
-            fixed (double* v_ptr = &v)
-            {
+                double* v_ptr = (double*)tmp_vecPtr;
                 Vertex2dv(v_ptr);
             }
         }
         /// <inheritdoc cref="Vertex2fv"/>
-        public static unsafe void Vertex2fv(ReadOnlySpan<float> v)
+        public static unsafe void Vertex2f(in Vector2 v)
         {
-            fixed (float* v_ptr = v)
+            fixed (Vector2* tmp_vecPtr = &v)
             {
+                float* v_ptr = (float*)tmp_vecPtr;
                 Vertex2fv(v_ptr);
             }
         }
         /// <inheritdoc cref="Vertex2fv"/>
-        public static unsafe void Vertex2fv(float[] v)
+        public static unsafe void Vertex2f(in System.Numerics.Vector2 v)
         {
-            fixed (float* v_ptr = v)
+            fixed (System.Numerics.Vector2* tmp_vecPtr = &v)
             {
-                Vertex2fv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="Vertex2fv"/>
-        public static unsafe void Vertex2fv(in float v)
-        {
-            fixed (float* v_ptr = &v)
-            {
+                float* v_ptr = (float*)tmp_vecPtr;
                 Vertex2fv(v_ptr);
             }
         }
         /// <inheritdoc cref="Vertex2iv"/>
-        public static unsafe void Vertex2iv(ReadOnlySpan<int> v)
+        public static unsafe void Vertex2i(in Vector2i v)
         {
-            fixed (int* v_ptr = v)
+            fixed (Vector2i* tmp_vecPtr = &v)
             {
-                Vertex2iv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="Vertex2iv"/>
-        public static unsafe void Vertex2iv(int[] v)
-        {
-            fixed (int* v_ptr = v)
-            {
-                Vertex2iv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="Vertex2iv"/>
-        public static unsafe void Vertex2iv(in int v)
-        {
-            fixed (int* v_ptr = &v)
-            {
+                int* v_ptr = (int*)tmp_vecPtr;
                 Vertex2iv(v_ptr);
             }
         }
@@ -2060,74 +1637,38 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="Vertex3dv"/>
-        public static unsafe void Vertex3dv(ReadOnlySpan<double> v)
+        public static unsafe void Vertex3d(in Vector3d v)
         {
-            fixed (double* v_ptr = v)
+            fixed (Vector3d* tmp_vecPtr = &v)
             {
-                Vertex3dv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="Vertex3dv"/>
-        public static unsafe void Vertex3dv(double[] v)
-        {
-            fixed (double* v_ptr = v)
-            {
-                Vertex3dv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="Vertex3dv"/>
-        public static unsafe void Vertex3dv(in double v)
-        {
-            fixed (double* v_ptr = &v)
-            {
+                double* v_ptr = (double*)tmp_vecPtr;
                 Vertex3dv(v_ptr);
             }
         }
         /// <inheritdoc cref="Vertex3fv"/>
-        public static unsafe void Vertex3fv(ReadOnlySpan<float> v)
+        public static unsafe void Vertex3f(in Vector3 v)
         {
-            fixed (float* v_ptr = v)
+            fixed (Vector3* tmp_vecPtr = &v)
             {
+                float* v_ptr = (float*)tmp_vecPtr;
                 Vertex3fv(v_ptr);
             }
         }
         /// <inheritdoc cref="Vertex3fv"/>
-        public static unsafe void Vertex3fv(float[] v)
+        public static unsafe void Vertex3f(in System.Numerics.Vector3 v)
         {
-            fixed (float* v_ptr = v)
+            fixed (System.Numerics.Vector3* tmp_vecPtr = &v)
             {
-                Vertex3fv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="Vertex3fv"/>
-        public static unsafe void Vertex3fv(in float v)
-        {
-            fixed (float* v_ptr = &v)
-            {
+                float* v_ptr = (float*)tmp_vecPtr;
                 Vertex3fv(v_ptr);
             }
         }
         /// <inheritdoc cref="Vertex3iv"/>
-        public static unsafe void Vertex3iv(ReadOnlySpan<int> v)
+        public static unsafe void Vertex3i(in Vector3i v)
         {
-            fixed (int* v_ptr = v)
+            fixed (Vector3i* tmp_vecPtr = &v)
             {
-                Vertex3iv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="Vertex3iv"/>
-        public static unsafe void Vertex3iv(int[] v)
-        {
-            fixed (int* v_ptr = v)
-            {
-                Vertex3iv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="Vertex3iv"/>
-        public static unsafe void Vertex3iv(in int v)
-        {
-            fixed (int* v_ptr = &v)
-            {
+                int* v_ptr = (int*)tmp_vecPtr;
                 Vertex3iv(v_ptr);
             }
         }
@@ -2161,74 +1702,38 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="Vertex4dv"/>
-        public static unsafe void Vertex4dv(ReadOnlySpan<double> v)
+        public static unsafe void Vertex4d(in Vector4d v)
         {
-            fixed (double* v_ptr = v)
+            fixed (Vector4d* tmp_vecPtr = &v)
             {
-                Vertex4dv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="Vertex4dv"/>
-        public static unsafe void Vertex4dv(double[] v)
-        {
-            fixed (double* v_ptr = v)
-            {
-                Vertex4dv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="Vertex4dv"/>
-        public static unsafe void Vertex4dv(in double v)
-        {
-            fixed (double* v_ptr = &v)
-            {
+                double* v_ptr = (double*)tmp_vecPtr;
                 Vertex4dv(v_ptr);
             }
         }
         /// <inheritdoc cref="Vertex4fv"/>
-        public static unsafe void Vertex4fv(ReadOnlySpan<float> v)
+        public static unsafe void Vertex4f(in Vector4 v)
         {
-            fixed (float* v_ptr = v)
+            fixed (Vector4* tmp_vecPtr = &v)
             {
+                float* v_ptr = (float*)tmp_vecPtr;
                 Vertex4fv(v_ptr);
             }
         }
         /// <inheritdoc cref="Vertex4fv"/>
-        public static unsafe void Vertex4fv(float[] v)
+        public static unsafe void Vertex4f(in System.Numerics.Vector4 v)
         {
-            fixed (float* v_ptr = v)
+            fixed (System.Numerics.Vector4* tmp_vecPtr = &v)
             {
-                Vertex4fv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="Vertex4fv"/>
-        public static unsafe void Vertex4fv(in float v)
-        {
-            fixed (float* v_ptr = &v)
-            {
+                float* v_ptr = (float*)tmp_vecPtr;
                 Vertex4fv(v_ptr);
             }
         }
         /// <inheritdoc cref="Vertex4iv"/>
-        public static unsafe void Vertex4iv(ReadOnlySpan<int> v)
+        public static unsafe void Vertex4i(in Vector4i v)
         {
-            fixed (int* v_ptr = v)
+            fixed (Vector4i* tmp_vecPtr = &v)
             {
-                Vertex4iv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="Vertex4iv"/>
-        public static unsafe void Vertex4iv(int[] v)
-        {
-            fixed (int* v_ptr = v)
-            {
-                Vertex4iv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="Vertex4iv"/>
-        public static unsafe void Vertex4iv(in int v)
-        {
-            fixed (int* v_ptr = &v)
-            {
+                int* v_ptr = (int*)tmp_vecPtr;
                 Vertex4iv(v_ptr);
             }
         }
@@ -2770,98 +2275,47 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="EvalCoord1dv"/>
-        public static unsafe void EvalCoord1dv(ReadOnlySpan<double> u)
+        public static unsafe void EvalCoord1d(in double u)
         {
-            fixed (double* u_ptr = u)
+            fixed (double* tmp_vecPtr = &u)
             {
-                EvalCoord1dv(u_ptr);
-            }
-        }
-        /// <inheritdoc cref="EvalCoord1dv"/>
-        public static unsafe void EvalCoord1dv(double[] u)
-        {
-            fixed (double* u_ptr = u)
-            {
-                EvalCoord1dv(u_ptr);
-            }
-        }
-        /// <inheritdoc cref="EvalCoord1dv"/>
-        public static unsafe void EvalCoord1dv(in double u)
-        {
-            fixed (double* u_ptr = &u)
-            {
+                double* u_ptr = (double*)tmp_vecPtr;
                 EvalCoord1dv(u_ptr);
             }
         }
         /// <inheritdoc cref="EvalCoord1fv"/>
-        public static unsafe void EvalCoord1fv(ReadOnlySpan<float> u)
+        public static unsafe void EvalCoord1f(in float u)
         {
-            fixed (float* u_ptr = u)
+            fixed (float* tmp_vecPtr = &u)
             {
-                EvalCoord1fv(u_ptr);
-            }
-        }
-        /// <inheritdoc cref="EvalCoord1fv"/>
-        public static unsafe void EvalCoord1fv(float[] u)
-        {
-            fixed (float* u_ptr = u)
-            {
-                EvalCoord1fv(u_ptr);
-            }
-        }
-        /// <inheritdoc cref="EvalCoord1fv"/>
-        public static unsafe void EvalCoord1fv(in float u)
-        {
-            fixed (float* u_ptr = &u)
-            {
+                float* u_ptr = (float*)tmp_vecPtr;
                 EvalCoord1fv(u_ptr);
             }
         }
         /// <inheritdoc cref="EvalCoord2dv"/>
-        public static unsafe void EvalCoord2dv(ReadOnlySpan<double> u)
+        public static unsafe void EvalCoord2d(in Vector2d u)
         {
-            fixed (double* u_ptr = u)
+            fixed (Vector2d* tmp_vecPtr = &u)
             {
-                EvalCoord2dv(u_ptr);
-            }
-        }
-        /// <inheritdoc cref="EvalCoord2dv"/>
-        public static unsafe void EvalCoord2dv(double[] u)
-        {
-            fixed (double* u_ptr = u)
-            {
-                EvalCoord2dv(u_ptr);
-            }
-        }
-        /// <inheritdoc cref="EvalCoord2dv"/>
-        public static unsafe void EvalCoord2dv(in double u)
-        {
-            fixed (double* u_ptr = &u)
-            {
+                double* u_ptr = (double*)tmp_vecPtr;
                 EvalCoord2dv(u_ptr);
             }
         }
         /// <inheritdoc cref="EvalCoord2fv"/>
-        public static unsafe void EvalCoord2fv(ReadOnlySpan<float> u)
+        public static unsafe void EvalCoord2f(in Vector2 u)
         {
-            fixed (float* u_ptr = u)
+            fixed (Vector2* tmp_vecPtr = &u)
             {
+                float* u_ptr = (float*)tmp_vecPtr;
                 EvalCoord2fv(u_ptr);
             }
         }
         /// <inheritdoc cref="EvalCoord2fv"/>
-        public static unsafe void EvalCoord2fv(float[] u)
+        public static unsafe void EvalCoord2f(in System.Numerics.Vector2 u)
         {
-            fixed (float* u_ptr = u)
+            fixed (System.Numerics.Vector2* tmp_vecPtr = &u)
             {
-                EvalCoord2fv(u_ptr);
-            }
-        }
-        /// <inheritdoc cref="EvalCoord2fv"/>
-        public static unsafe void EvalCoord2fv(in float u)
-        {
-            fixed (float* u_ptr = &u)
-            {
+                float* u_ptr = (float*)tmp_vecPtr;
                 EvalCoord2fv(u_ptr);
             }
         }
@@ -4296,74 +3750,29 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="MultiTexCoord1dv"/>
-        public static unsafe void MultiTexCoord1dv(TextureUnit target, ReadOnlySpan<double> v)
+        public static unsafe void MultiTexCoord1d(TextureUnit target, in double v)
         {
-            fixed (double* v_ptr = v)
+            fixed (double* tmp_vecPtr = &v)
             {
-                MultiTexCoord1dv(target, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="MultiTexCoord1dv"/>
-        public static unsafe void MultiTexCoord1dv(TextureUnit target, double[] v)
-        {
-            fixed (double* v_ptr = v)
-            {
-                MultiTexCoord1dv(target, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="MultiTexCoord1dv"/>
-        public static unsafe void MultiTexCoord1dv(TextureUnit target, in double v)
-        {
-            fixed (double* v_ptr = &v)
-            {
+                double* v_ptr = (double*)tmp_vecPtr;
                 MultiTexCoord1dv(target, v_ptr);
             }
         }
         /// <inheritdoc cref="MultiTexCoord1fv"/>
-        public static unsafe void MultiTexCoord1fv(TextureUnit target, ReadOnlySpan<float> v)
+        public static unsafe void MultiTexCoord1f(TextureUnit target, in float v)
         {
-            fixed (float* v_ptr = v)
+            fixed (float* tmp_vecPtr = &v)
             {
-                MultiTexCoord1fv(target, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="MultiTexCoord1fv"/>
-        public static unsafe void MultiTexCoord1fv(TextureUnit target, float[] v)
-        {
-            fixed (float* v_ptr = v)
-            {
-                MultiTexCoord1fv(target, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="MultiTexCoord1fv"/>
-        public static unsafe void MultiTexCoord1fv(TextureUnit target, in float v)
-        {
-            fixed (float* v_ptr = &v)
-            {
+                float* v_ptr = (float*)tmp_vecPtr;
                 MultiTexCoord1fv(target, v_ptr);
             }
         }
         /// <inheritdoc cref="MultiTexCoord1iv"/>
-        public static unsafe void MultiTexCoord1iv(TextureUnit target, ReadOnlySpan<int> v)
+        public static unsafe void MultiTexCoord1i(TextureUnit target, in int v)
         {
-            fixed (int* v_ptr = v)
+            fixed (int* tmp_vecPtr = &v)
             {
-                MultiTexCoord1iv(target, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="MultiTexCoord1iv"/>
-        public static unsafe void MultiTexCoord1iv(TextureUnit target, int[] v)
-        {
-            fixed (int* v_ptr = v)
-            {
-                MultiTexCoord1iv(target, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="MultiTexCoord1iv"/>
-        public static unsafe void MultiTexCoord1iv(TextureUnit target, in int v)
-        {
-            fixed (int* v_ptr = &v)
-            {
+                int* v_ptr = (int*)tmp_vecPtr;
                 MultiTexCoord1iv(target, v_ptr);
             }
         }
@@ -4397,74 +3806,38 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="MultiTexCoord2dv"/>
-        public static unsafe void MultiTexCoord2dv(TextureUnit target, ReadOnlySpan<double> v)
+        public static unsafe void MultiTexCoord2d(TextureUnit target, in Vector2d v)
         {
-            fixed (double* v_ptr = v)
+            fixed (Vector2d* tmp_vecPtr = &v)
             {
-                MultiTexCoord2dv(target, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="MultiTexCoord2dv"/>
-        public static unsafe void MultiTexCoord2dv(TextureUnit target, double[] v)
-        {
-            fixed (double* v_ptr = v)
-            {
-                MultiTexCoord2dv(target, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="MultiTexCoord2dv"/>
-        public static unsafe void MultiTexCoord2dv(TextureUnit target, in double v)
-        {
-            fixed (double* v_ptr = &v)
-            {
+                double* v_ptr = (double*)tmp_vecPtr;
                 MultiTexCoord2dv(target, v_ptr);
             }
         }
         /// <inheritdoc cref="MultiTexCoord2fv"/>
-        public static unsafe void MultiTexCoord2fv(TextureUnit target, ReadOnlySpan<float> v)
+        public static unsafe void MultiTexCoord2f(TextureUnit target, in Vector2 v)
         {
-            fixed (float* v_ptr = v)
+            fixed (Vector2* tmp_vecPtr = &v)
             {
+                float* v_ptr = (float*)tmp_vecPtr;
                 MultiTexCoord2fv(target, v_ptr);
             }
         }
         /// <inheritdoc cref="MultiTexCoord2fv"/>
-        public static unsafe void MultiTexCoord2fv(TextureUnit target, float[] v)
+        public static unsafe void MultiTexCoord2f(TextureUnit target, in System.Numerics.Vector2 v)
         {
-            fixed (float* v_ptr = v)
+            fixed (System.Numerics.Vector2* tmp_vecPtr = &v)
             {
-                MultiTexCoord2fv(target, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="MultiTexCoord2fv"/>
-        public static unsafe void MultiTexCoord2fv(TextureUnit target, in float v)
-        {
-            fixed (float* v_ptr = &v)
-            {
+                float* v_ptr = (float*)tmp_vecPtr;
                 MultiTexCoord2fv(target, v_ptr);
             }
         }
         /// <inheritdoc cref="MultiTexCoord2iv"/>
-        public static unsafe void MultiTexCoord2iv(TextureUnit target, ReadOnlySpan<int> v)
+        public static unsafe void MultiTexCoord2i(TextureUnit target, in Vector2i v)
         {
-            fixed (int* v_ptr = v)
+            fixed (Vector2i* tmp_vecPtr = &v)
             {
-                MultiTexCoord2iv(target, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="MultiTexCoord2iv"/>
-        public static unsafe void MultiTexCoord2iv(TextureUnit target, int[] v)
-        {
-            fixed (int* v_ptr = v)
-            {
-                MultiTexCoord2iv(target, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="MultiTexCoord2iv"/>
-        public static unsafe void MultiTexCoord2iv(TextureUnit target, in int v)
-        {
-            fixed (int* v_ptr = &v)
-            {
+                int* v_ptr = (int*)tmp_vecPtr;
                 MultiTexCoord2iv(target, v_ptr);
             }
         }
@@ -4498,74 +3871,38 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="MultiTexCoord3dv"/>
-        public static unsafe void MultiTexCoord3dv(TextureUnit target, ReadOnlySpan<double> v)
+        public static unsafe void MultiTexCoord3d(TextureUnit target, in Vector3d v)
         {
-            fixed (double* v_ptr = v)
+            fixed (Vector3d* tmp_vecPtr = &v)
             {
-                MultiTexCoord3dv(target, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="MultiTexCoord3dv"/>
-        public static unsafe void MultiTexCoord3dv(TextureUnit target, double[] v)
-        {
-            fixed (double* v_ptr = v)
-            {
-                MultiTexCoord3dv(target, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="MultiTexCoord3dv"/>
-        public static unsafe void MultiTexCoord3dv(TextureUnit target, in double v)
-        {
-            fixed (double* v_ptr = &v)
-            {
+                double* v_ptr = (double*)tmp_vecPtr;
                 MultiTexCoord3dv(target, v_ptr);
             }
         }
         /// <inheritdoc cref="MultiTexCoord3fv"/>
-        public static unsafe void MultiTexCoord3fv(TextureUnit target, ReadOnlySpan<float> v)
+        public static unsafe void MultiTexCoord3f(TextureUnit target, in Vector3 v)
         {
-            fixed (float* v_ptr = v)
+            fixed (Vector3* tmp_vecPtr = &v)
             {
+                float* v_ptr = (float*)tmp_vecPtr;
                 MultiTexCoord3fv(target, v_ptr);
             }
         }
         /// <inheritdoc cref="MultiTexCoord3fv"/>
-        public static unsafe void MultiTexCoord3fv(TextureUnit target, float[] v)
+        public static unsafe void MultiTexCoord3f(TextureUnit target, in System.Numerics.Vector3 v)
         {
-            fixed (float* v_ptr = v)
+            fixed (System.Numerics.Vector3* tmp_vecPtr = &v)
             {
-                MultiTexCoord3fv(target, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="MultiTexCoord3fv"/>
-        public static unsafe void MultiTexCoord3fv(TextureUnit target, in float v)
-        {
-            fixed (float* v_ptr = &v)
-            {
+                float* v_ptr = (float*)tmp_vecPtr;
                 MultiTexCoord3fv(target, v_ptr);
             }
         }
         /// <inheritdoc cref="MultiTexCoord3iv"/>
-        public static unsafe void MultiTexCoord3iv(TextureUnit target, ReadOnlySpan<int> v)
+        public static unsafe void MultiTexCoord3i(TextureUnit target, in Vector3i v)
         {
-            fixed (int* v_ptr = v)
+            fixed (Vector3i* tmp_vecPtr = &v)
             {
-                MultiTexCoord3iv(target, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="MultiTexCoord3iv"/>
-        public static unsafe void MultiTexCoord3iv(TextureUnit target, int[] v)
-        {
-            fixed (int* v_ptr = v)
-            {
-                MultiTexCoord3iv(target, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="MultiTexCoord3iv"/>
-        public static unsafe void MultiTexCoord3iv(TextureUnit target, in int v)
-        {
-            fixed (int* v_ptr = &v)
-            {
+                int* v_ptr = (int*)tmp_vecPtr;
                 MultiTexCoord3iv(target, v_ptr);
             }
         }
@@ -4599,74 +3936,38 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="MultiTexCoord4dv"/>
-        public static unsafe void MultiTexCoord4dv(TextureUnit target, ReadOnlySpan<double> v)
+        public static unsafe void MultiTexCoord4d(TextureUnit target, in Vector4d v)
         {
-            fixed (double* v_ptr = v)
+            fixed (Vector4d* tmp_vecPtr = &v)
             {
-                MultiTexCoord4dv(target, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="MultiTexCoord4dv"/>
-        public static unsafe void MultiTexCoord4dv(TextureUnit target, double[] v)
-        {
-            fixed (double* v_ptr = v)
-            {
-                MultiTexCoord4dv(target, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="MultiTexCoord4dv"/>
-        public static unsafe void MultiTexCoord4dv(TextureUnit target, in double v)
-        {
-            fixed (double* v_ptr = &v)
-            {
+                double* v_ptr = (double*)tmp_vecPtr;
                 MultiTexCoord4dv(target, v_ptr);
             }
         }
         /// <inheritdoc cref="MultiTexCoord4fv"/>
-        public static unsafe void MultiTexCoord4fv(TextureUnit target, ReadOnlySpan<float> v)
+        public static unsafe void MultiTexCoord4f(TextureUnit target, in Vector4 v)
         {
-            fixed (float* v_ptr = v)
+            fixed (Vector4* tmp_vecPtr = &v)
             {
+                float* v_ptr = (float*)tmp_vecPtr;
                 MultiTexCoord4fv(target, v_ptr);
             }
         }
         /// <inheritdoc cref="MultiTexCoord4fv"/>
-        public static unsafe void MultiTexCoord4fv(TextureUnit target, float[] v)
+        public static unsafe void MultiTexCoord4f(TextureUnit target, in System.Numerics.Vector4 v)
         {
-            fixed (float* v_ptr = v)
+            fixed (System.Numerics.Vector4* tmp_vecPtr = &v)
             {
-                MultiTexCoord4fv(target, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="MultiTexCoord4fv"/>
-        public static unsafe void MultiTexCoord4fv(TextureUnit target, in float v)
-        {
-            fixed (float* v_ptr = &v)
-            {
+                float* v_ptr = (float*)tmp_vecPtr;
                 MultiTexCoord4fv(target, v_ptr);
             }
         }
         /// <inheritdoc cref="MultiTexCoord4iv"/>
-        public static unsafe void MultiTexCoord4iv(TextureUnit target, ReadOnlySpan<int> v)
+        public static unsafe void MultiTexCoord4i(TextureUnit target, in Vector4i v)
         {
-            fixed (int* v_ptr = v)
+            fixed (Vector4i* tmp_vecPtr = &v)
             {
-                MultiTexCoord4iv(target, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="MultiTexCoord4iv"/>
-        public static unsafe void MultiTexCoord4iv(TextureUnit target, int[] v)
-        {
-            fixed (int* v_ptr = v)
-            {
-                MultiTexCoord4iv(target, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="MultiTexCoord4iv"/>
-        public static unsafe void MultiTexCoord4iv(TextureUnit target, in int v)
-        {
-            fixed (int* v_ptr = &v)
-            {
+                int* v_ptr = (int*)tmp_vecPtr;
                 MultiTexCoord4iv(target, v_ptr);
             }
         }
@@ -5009,74 +4310,29 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="SecondaryColor3dv"/>
-        public static unsafe void SecondaryColor3dv(ReadOnlySpan<double> v)
+        public static unsafe void SecondaryColor3d(in Vector3d v)
         {
-            fixed (double* v_ptr = v)
+            fixed (Vector3d* tmp_vecPtr = &v)
             {
-                SecondaryColor3dv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="SecondaryColor3dv"/>
-        public static unsafe void SecondaryColor3dv(double[] v)
-        {
-            fixed (double* v_ptr = v)
-            {
-                SecondaryColor3dv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="SecondaryColor3dv"/>
-        public static unsafe void SecondaryColor3dv(in double v)
-        {
-            fixed (double* v_ptr = &v)
-            {
+                double* v_ptr = (double*)tmp_vecPtr;
                 SecondaryColor3dv(v_ptr);
             }
         }
         /// <inheritdoc cref="SecondaryColor3fv"/>
-        public static unsafe void SecondaryColor3fv(ReadOnlySpan<float> v)
+        public static unsafe void SecondaryColor3f(in Color3<Rgb> v)
         {
-            fixed (float* v_ptr = v)
+            fixed (Color3<Rgb>* tmp_v = &v)
             {
-                SecondaryColor3fv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="SecondaryColor3fv"/>
-        public static unsafe void SecondaryColor3fv(float[] v)
-        {
-            fixed (float* v_ptr = v)
-            {
-                SecondaryColor3fv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="SecondaryColor3fv"/>
-        public static unsafe void SecondaryColor3fv(in float v)
-        {
-            fixed (float* v_ptr = &v)
-            {
+                float* v_ptr = (float*)tmp_v;
                 SecondaryColor3fv(v_ptr);
             }
         }
         /// <inheritdoc cref="SecondaryColor3iv"/>
-        public static unsafe void SecondaryColor3iv(ReadOnlySpan<int> v)
+        public static unsafe void SecondaryColor3i(in Vector3i v)
         {
-            fixed (int* v_ptr = v)
+            fixed (Vector3i* tmp_vecPtr = &v)
             {
-                SecondaryColor3iv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="SecondaryColor3iv"/>
-        public static unsafe void SecondaryColor3iv(int[] v)
-        {
-            fixed (int* v_ptr = v)
-            {
-                SecondaryColor3iv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="SecondaryColor3iv"/>
-        public static unsafe void SecondaryColor3iv(in int v)
-        {
-            fixed (int* v_ptr = &v)
-            {
+                int* v_ptr = (int*)tmp_vecPtr;
                 SecondaryColor3iv(v_ptr);
             }
         }
@@ -5225,74 +4481,38 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="WindowPos2dv"/>
-        public static unsafe void WindowPos2dv(ReadOnlySpan<double> v)
+        public static unsafe void WindowPos2d(in Vector2d v)
         {
-            fixed (double* v_ptr = v)
+            fixed (Vector2d* tmp_vecPtr = &v)
             {
-                WindowPos2dv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="WindowPos2dv"/>
-        public static unsafe void WindowPos2dv(double[] v)
-        {
-            fixed (double* v_ptr = v)
-            {
-                WindowPos2dv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="WindowPos2dv"/>
-        public static unsafe void WindowPos2dv(in double v)
-        {
-            fixed (double* v_ptr = &v)
-            {
+                double* v_ptr = (double*)tmp_vecPtr;
                 WindowPos2dv(v_ptr);
             }
         }
         /// <inheritdoc cref="WindowPos2fv"/>
-        public static unsafe void WindowPos2fv(ReadOnlySpan<float> v)
+        public static unsafe void WindowPos2f(in Vector2 v)
         {
-            fixed (float* v_ptr = v)
+            fixed (Vector2* tmp_vecPtr = &v)
             {
+                float* v_ptr = (float*)tmp_vecPtr;
                 WindowPos2fv(v_ptr);
             }
         }
         /// <inheritdoc cref="WindowPos2fv"/>
-        public static unsafe void WindowPos2fv(float[] v)
+        public static unsafe void WindowPos2f(in System.Numerics.Vector2 v)
         {
-            fixed (float* v_ptr = v)
+            fixed (System.Numerics.Vector2* tmp_vecPtr = &v)
             {
-                WindowPos2fv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="WindowPos2fv"/>
-        public static unsafe void WindowPos2fv(in float v)
-        {
-            fixed (float* v_ptr = &v)
-            {
+                float* v_ptr = (float*)tmp_vecPtr;
                 WindowPos2fv(v_ptr);
             }
         }
         /// <inheritdoc cref="WindowPos2iv"/>
-        public static unsafe void WindowPos2iv(ReadOnlySpan<int> v)
+        public static unsafe void WindowPos2i(in Vector2i v)
         {
-            fixed (int* v_ptr = v)
+            fixed (Vector2i* tmp_vecPtr = &v)
             {
-                WindowPos2iv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="WindowPos2iv"/>
-        public static unsafe void WindowPos2iv(int[] v)
-        {
-            fixed (int* v_ptr = v)
-            {
-                WindowPos2iv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="WindowPos2iv"/>
-        public static unsafe void WindowPos2iv(in int v)
-        {
-            fixed (int* v_ptr = &v)
-            {
+                int* v_ptr = (int*)tmp_vecPtr;
                 WindowPos2iv(v_ptr);
             }
         }
@@ -5326,74 +4546,38 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="WindowPos3dv"/>
-        public static unsafe void WindowPos3dv(ReadOnlySpan<double> v)
+        public static unsafe void WindowPos3d(in Vector3d v)
         {
-            fixed (double* v_ptr = v)
+            fixed (Vector3d* tmp_vecPtr = &v)
             {
-                WindowPos3dv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="WindowPos3dv"/>
-        public static unsafe void WindowPos3dv(double[] v)
-        {
-            fixed (double* v_ptr = v)
-            {
-                WindowPos3dv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="WindowPos3dv"/>
-        public static unsafe void WindowPos3dv(in double v)
-        {
-            fixed (double* v_ptr = &v)
-            {
+                double* v_ptr = (double*)tmp_vecPtr;
                 WindowPos3dv(v_ptr);
             }
         }
         /// <inheritdoc cref="WindowPos3fv"/>
-        public static unsafe void WindowPos3fv(ReadOnlySpan<float> v)
+        public static unsafe void WindowPos3f(in Vector3 v)
         {
-            fixed (float* v_ptr = v)
+            fixed (Vector3* tmp_vecPtr = &v)
             {
+                float* v_ptr = (float*)tmp_vecPtr;
                 WindowPos3fv(v_ptr);
             }
         }
         /// <inheritdoc cref="WindowPos3fv"/>
-        public static unsafe void WindowPos3fv(float[] v)
+        public static unsafe void WindowPos3f(in System.Numerics.Vector3 v)
         {
-            fixed (float* v_ptr = v)
+            fixed (System.Numerics.Vector3* tmp_vecPtr = &v)
             {
-                WindowPos3fv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="WindowPos3fv"/>
-        public static unsafe void WindowPos3fv(in float v)
-        {
-            fixed (float* v_ptr = &v)
-            {
+                float* v_ptr = (float*)tmp_vecPtr;
                 WindowPos3fv(v_ptr);
             }
         }
         /// <inheritdoc cref="WindowPos3iv"/>
-        public static unsafe void WindowPos3iv(ReadOnlySpan<int> v)
+        public static unsafe void WindowPos3i(in Vector3i v)
         {
-            fixed (int* v_ptr = v)
+            fixed (Vector3i* tmp_vecPtr = &v)
             {
-                WindowPos3iv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="WindowPos3iv"/>
-        public static unsafe void WindowPos3iv(int[] v)
-        {
-            fixed (int* v_ptr = v)
-            {
-                WindowPos3iv(v_ptr);
-            }
-        }
-        /// <inheritdoc cref="WindowPos3iv"/>
-        public static unsafe void WindowPos3iv(in int v)
-        {
-            fixed (int* v_ptr = &v)
-            {
+                int* v_ptr = (int*)tmp_vecPtr;
                 WindowPos3iv(v_ptr);
             }
         }
@@ -6520,9 +5704,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="Uniform1fv"/>
-        public static unsafe void Uniform1f(int location, in float value)
+        public static unsafe void Uniform1f(int location, int count, in float value)
         {
-            int count = 1;
             fixed (float* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -6548,9 +5731,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="Uniform2fv"/>
-        public static unsafe void Uniform2f(int location, in Vector2 value)
+        public static unsafe void Uniform2f(int location, int count, in Vector2 value)
         {
-            int count = 1;
             fixed (Vector2* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -6576,9 +5758,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="Uniform2fv"/>
-        public static unsafe void Uniform2f(int location, in System.Numerics.Vector2 value)
+        public static unsafe void Uniform2f(int location, int count, in System.Numerics.Vector2 value)
         {
-            int count = 1;
             fixed (System.Numerics.Vector2* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -6604,9 +5785,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="Uniform3fv"/>
-        public static unsafe void Uniform3f(int location, in Vector3 value)
+        public static unsafe void Uniform3f(int location, int count, in Vector3 value)
         {
-            int count = 1;
             fixed (Vector3* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -6632,9 +5812,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="Uniform3fv"/>
-        public static unsafe void Uniform3f(int location, in System.Numerics.Vector3 value)
+        public static unsafe void Uniform3f(int location, int count, in System.Numerics.Vector3 value)
         {
-            int count = 1;
             fixed (System.Numerics.Vector3* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -6660,9 +5839,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="Uniform4fv"/>
-        public static unsafe void Uniform4f(int location, in Vector4 value)
+        public static unsafe void Uniform4f(int location, int count, in Vector4 value)
         {
-            int count = 1;
             fixed (Vector4* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -6688,9 +5866,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="Uniform4fv"/>
-        public static unsafe void Uniform4f(int location, in System.Numerics.Vector4 value)
+        public static unsafe void Uniform4f(int location, int count, in System.Numerics.Vector4 value)
         {
-            int count = 1;
             fixed (System.Numerics.Vector4* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -6716,9 +5893,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="Uniform1iv"/>
-        public static unsafe void Uniform1i(int location, in int value)
+        public static unsafe void Uniform1i(int location, int count, in int value)
         {
-            int count = 1;
             fixed (int* tmp_vecPtr = &value)
             {
                 int* value_ptr = (int*)tmp_vecPtr;
@@ -6744,9 +5920,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="Uniform2iv"/>
-        public static unsafe void Uniform2i(int location, in Vector2i value)
+        public static unsafe void Uniform2i(int location, int count, in Vector2i value)
         {
-            int count = 1;
             fixed (Vector2i* tmp_vecPtr = &value)
             {
                 int* value_ptr = (int*)tmp_vecPtr;
@@ -6772,9 +5947,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="Uniform3iv"/>
-        public static unsafe void Uniform3i(int location, in Vector3i value)
+        public static unsafe void Uniform3i(int location, int count, in Vector3i value)
         {
-            int count = 1;
             fixed (Vector3i* tmp_vecPtr = &value)
             {
                 int* value_ptr = (int*)tmp_vecPtr;
@@ -6800,9 +5974,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="Uniform4iv"/>
-        public static unsafe void Uniform4i(int location, in Vector4i value)
+        public static unsafe void Uniform4i(int location, int count, in Vector4i value)
         {
-            int count = 1;
             fixed (Vector4i* tmp_vecPtr = &value)
             {
                 int* value_ptr = (int*)tmp_vecPtr;
@@ -6828,9 +6001,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="UniformMatrix2fv"/>
-        public static unsafe void UniformMatrix2f(int location, bool transpose, in Matrix2 value)
+        public static unsafe void UniformMatrix2f(int location, int count, bool transpose, in Matrix2 value)
         {
-            int count = 1;
             fixed (Matrix2* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -6856,9 +6028,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="UniformMatrix3fv"/>
-        public static unsafe void UniformMatrix3f(int location, bool transpose, in Matrix3 value)
+        public static unsafe void UniformMatrix3f(int location, int count, bool transpose, in Matrix3 value)
         {
-            int count = 1;
             fixed (Matrix3* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -6884,9 +6055,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="UniformMatrix4fv"/>
-        public static unsafe void UniformMatrix4f(int location, bool transpose, in Matrix4 value)
+        public static unsafe void UniformMatrix4f(int location, int count, bool transpose, in Matrix4 value)
         {
-            int count = 1;
             fixed (Matrix4* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -6912,9 +6082,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="UniformMatrix4fv"/>
-        public static unsafe void UniformMatrix4f(int location, bool transpose, in System.Numerics.Matrix4x4 value)
+        public static unsafe void UniformMatrix4f(int location, int count, bool transpose, in System.Numerics.Matrix4x4 value)
         {
-            int count = 1;
             fixed (System.Numerics.Matrix4x4* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -6940,50 +6109,20 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="VertexAttrib1dv"/>
-        public static unsafe void VertexAttrib1dv(uint index, ReadOnlySpan<double> v)
+        public static unsafe void VertexAttrib1d(uint index, in double v)
         {
-            fixed (double* v_ptr = v)
+            fixed (double* tmp_vecPtr = &v)
             {
-                VertexAttrib1dv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttrib1dv"/>
-        public static unsafe void VertexAttrib1dv(uint index, double[] v)
-        {
-            fixed (double* v_ptr = v)
-            {
-                VertexAttrib1dv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttrib1dv"/>
-        public static unsafe void VertexAttrib1dv(uint index, in double v)
-        {
-            fixed (double* v_ptr = &v)
-            {
+                double* v_ptr = (double*)tmp_vecPtr;
                 VertexAttrib1dv(index, v_ptr);
             }
         }
         /// <inheritdoc cref="VertexAttrib1fv"/>
-        public static unsafe void VertexAttrib1fv(uint index, ReadOnlySpan<float> v)
+        public static unsafe void VertexAttrib1f(uint index, in float v)
         {
-            fixed (float* v_ptr = v)
+            fixed (float* tmp_vecPtr = &v)
             {
-                VertexAttrib1fv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttrib1fv"/>
-        public static unsafe void VertexAttrib1fv(uint index, float[] v)
-        {
-            fixed (float* v_ptr = v)
-            {
-                VertexAttrib1fv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttrib1fv"/>
-        public static unsafe void VertexAttrib1fv(uint index, in float v)
-        {
-            fixed (float* v_ptr = &v)
-            {
+                float* v_ptr = (float*)tmp_vecPtr;
                 VertexAttrib1fv(index, v_ptr);
             }
         }
@@ -7017,50 +6156,29 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="VertexAttrib2dv"/>
-        public static unsafe void VertexAttrib2dv(uint index, ReadOnlySpan<double> v)
+        public static unsafe void VertexAttrib2d(uint index, in Vector2d v)
         {
-            fixed (double* v_ptr = v)
+            fixed (Vector2d* tmp_vecPtr = &v)
             {
-                VertexAttrib2dv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttrib2dv"/>
-        public static unsafe void VertexAttrib2dv(uint index, double[] v)
-        {
-            fixed (double* v_ptr = v)
-            {
-                VertexAttrib2dv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttrib2dv"/>
-        public static unsafe void VertexAttrib2dv(uint index, in double v)
-        {
-            fixed (double* v_ptr = &v)
-            {
+                double* v_ptr = (double*)tmp_vecPtr;
                 VertexAttrib2dv(index, v_ptr);
             }
         }
         /// <inheritdoc cref="VertexAttrib2fv"/>
-        public static unsafe void VertexAttrib2fv(uint index, ReadOnlySpan<float> v)
+        public static unsafe void VertexAttrib2f(uint index, in Vector2 v)
         {
-            fixed (float* v_ptr = v)
+            fixed (Vector2* tmp_vecPtr = &v)
             {
+                float* v_ptr = (float*)tmp_vecPtr;
                 VertexAttrib2fv(index, v_ptr);
             }
         }
         /// <inheritdoc cref="VertexAttrib2fv"/>
-        public static unsafe void VertexAttrib2fv(uint index, float[] v)
+        public static unsafe void VertexAttrib2f(uint index, in System.Numerics.Vector2 v)
         {
-            fixed (float* v_ptr = v)
+            fixed (System.Numerics.Vector2* tmp_vecPtr = &v)
             {
-                VertexAttrib2fv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttrib2fv"/>
-        public static unsafe void VertexAttrib2fv(uint index, in float v)
-        {
-            fixed (float* v_ptr = &v)
-            {
+                float* v_ptr = (float*)tmp_vecPtr;
                 VertexAttrib2fv(index, v_ptr);
             }
         }
@@ -7094,50 +6212,29 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="VertexAttrib3dv"/>
-        public static unsafe void VertexAttrib3dv(uint index, ReadOnlySpan<double> v)
+        public static unsafe void VertexAttrib3d(uint index, in Vector3d v)
         {
-            fixed (double* v_ptr = v)
+            fixed (Vector3d* tmp_vecPtr = &v)
             {
-                VertexAttrib3dv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttrib3dv"/>
-        public static unsafe void VertexAttrib3dv(uint index, double[] v)
-        {
-            fixed (double* v_ptr = v)
-            {
-                VertexAttrib3dv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttrib3dv"/>
-        public static unsafe void VertexAttrib3dv(uint index, in double v)
-        {
-            fixed (double* v_ptr = &v)
-            {
+                double* v_ptr = (double*)tmp_vecPtr;
                 VertexAttrib3dv(index, v_ptr);
             }
         }
         /// <inheritdoc cref="VertexAttrib3fv"/>
-        public static unsafe void VertexAttrib3fv(uint index, ReadOnlySpan<float> v)
+        public static unsafe void VertexAttrib3f(uint index, in Vector3 v)
         {
-            fixed (float* v_ptr = v)
+            fixed (Vector3* tmp_vecPtr = &v)
             {
+                float* v_ptr = (float*)tmp_vecPtr;
                 VertexAttrib3fv(index, v_ptr);
             }
         }
         /// <inheritdoc cref="VertexAttrib3fv"/>
-        public static unsafe void VertexAttrib3fv(uint index, float[] v)
+        public static unsafe void VertexAttrib3f(uint index, in System.Numerics.Vector3 v)
         {
-            fixed (float* v_ptr = v)
+            fixed (System.Numerics.Vector3* tmp_vecPtr = &v)
             {
-                VertexAttrib3fv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttrib3fv"/>
-        public static unsafe void VertexAttrib3fv(uint index, in float v)
-        {
-            fixed (float* v_ptr = &v)
-            {
+                float* v_ptr = (float*)tmp_vecPtr;
                 VertexAttrib3fv(index, v_ptr);
             }
         }
@@ -7344,74 +6441,38 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="VertexAttrib4dv"/>
-        public static unsafe void VertexAttrib4dv(uint index, ReadOnlySpan<double> v)
+        public static unsafe void VertexAttrib4d(uint index, in Vector4d v)
         {
-            fixed (double* v_ptr = v)
+            fixed (Vector4d* tmp_vecPtr = &v)
             {
-                VertexAttrib4dv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttrib4dv"/>
-        public static unsafe void VertexAttrib4dv(uint index, double[] v)
-        {
-            fixed (double* v_ptr = v)
-            {
-                VertexAttrib4dv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttrib4dv"/>
-        public static unsafe void VertexAttrib4dv(uint index, in double v)
-        {
-            fixed (double* v_ptr = &v)
-            {
+                double* v_ptr = (double*)tmp_vecPtr;
                 VertexAttrib4dv(index, v_ptr);
             }
         }
         /// <inheritdoc cref="VertexAttrib4fv"/>
-        public static unsafe void VertexAttrib4fv(uint index, ReadOnlySpan<float> v)
+        public static unsafe void VertexAttrib4f(uint index, in Vector4 v)
         {
-            fixed (float* v_ptr = v)
+            fixed (Vector4* tmp_vecPtr = &v)
             {
+                float* v_ptr = (float*)tmp_vecPtr;
                 VertexAttrib4fv(index, v_ptr);
             }
         }
         /// <inheritdoc cref="VertexAttrib4fv"/>
-        public static unsafe void VertexAttrib4fv(uint index, float[] v)
+        public static unsafe void VertexAttrib4f(uint index, in System.Numerics.Vector4 v)
         {
-            fixed (float* v_ptr = v)
+            fixed (System.Numerics.Vector4* tmp_vecPtr = &v)
             {
-                VertexAttrib4fv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttrib4fv"/>
-        public static unsafe void VertexAttrib4fv(uint index, in float v)
-        {
-            fixed (float* v_ptr = &v)
-            {
+                float* v_ptr = (float*)tmp_vecPtr;
                 VertexAttrib4fv(index, v_ptr);
             }
         }
         /// <inheritdoc cref="VertexAttrib4iv"/>
-        public static unsafe void VertexAttrib4iv(uint index, ReadOnlySpan<int> v)
+        public static unsafe void VertexAttrib4i(uint index, in Vector4i v)
         {
-            fixed (int* v_ptr = v)
+            fixed (Vector4i* tmp_vecPtr = &v)
             {
-                VertexAttrib4iv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttrib4iv"/>
-        public static unsafe void VertexAttrib4iv(uint index, int[] v)
-        {
-            fixed (int* v_ptr = v)
-            {
-                VertexAttrib4iv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttrib4iv"/>
-        public static unsafe void VertexAttrib4iv(uint index, in int v)
-        {
-            fixed (int* v_ptr = &v)
-            {
+                int* v_ptr = (int*)tmp_vecPtr;
                 VertexAttrib4iv(index, v_ptr);
             }
         }
@@ -7523,9 +6584,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             VertexAttribPointer(index, size, type, normalized, stride, pointer);
         }
         /// <inheritdoc cref="UniformMatrix2x3fv"/>
-        public static unsafe void UniformMatrix2x3f(int location, bool transpose, in Matrix2x3 value)
+        public static unsafe void UniformMatrix2x3f(int location, int count, bool transpose, in Matrix2x3 value)
         {
-            int count = 1;
             fixed (Matrix2x3* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -7551,9 +6611,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="UniformMatrix3x2fv"/>
-        public static unsafe void UniformMatrix3x2f(int location, bool transpose, in Matrix3x2 value)
+        public static unsafe void UniformMatrix3x2f(int location, int count, bool transpose, in Matrix3x2 value)
         {
-            int count = 1;
             fixed (Matrix3x2* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -7579,9 +6638,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="UniformMatrix3x2fv"/>
-        public static unsafe void UniformMatrix3x2f(int location, bool transpose, in System.Numerics.Matrix3x2 value)
+        public static unsafe void UniformMatrix3x2f(int location, int count, bool transpose, in System.Numerics.Matrix3x2 value)
         {
-            int count = 1;
             fixed (System.Numerics.Matrix3x2* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -7607,9 +6665,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="UniformMatrix2x4fv"/>
-        public static unsafe void UniformMatrix2x4f(int location, bool transpose, in Matrix2x4 value)
+        public static unsafe void UniformMatrix2x4f(int location, int count, bool transpose, in Matrix2x4 value)
         {
-            int count = 1;
             fixed (Matrix2x4* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -7635,9 +6692,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="UniformMatrix4x2fv"/>
-        public static unsafe void UniformMatrix4x2f(int location, bool transpose, in Matrix4x2 value)
+        public static unsafe void UniformMatrix4x2f(int location, int count, bool transpose, in Matrix4x2 value)
         {
-            int count = 1;
             fixed (Matrix4x2* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -7663,9 +6719,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="UniformMatrix3x4fv"/>
-        public static unsafe void UniformMatrix3x4f(int location, bool transpose, in Matrix3x4 value)
+        public static unsafe void UniformMatrix3x4f(int location, int count, bool transpose, in Matrix3x4 value)
         {
-            int count = 1;
             fixed (Matrix3x4* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -7691,9 +6746,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="UniformMatrix4x3fv"/>
-        public static unsafe void UniformMatrix4x3f(int location, bool transpose, in Matrix4x3 value)
+        public static unsafe void UniformMatrix4x3f(int location, int count, bool transpose, in Matrix4x3 value)
         {
-            int count = 1;
             fixed (Matrix4x3* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -7921,98 +6975,38 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="VertexAttribI1iv"/>
-        public static unsafe void VertexAttribI1iv(uint index, ReadOnlySpan<int> v)
+        public static unsafe void VertexAttribI1i(uint index, in int v)
         {
-            fixed (int* v_ptr = v)
+            fixed (int* tmp_vecPtr = &v)
             {
-                VertexAttribI1iv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttribI1iv"/>
-        public static unsafe void VertexAttribI1iv(uint index, int[] v)
-        {
-            fixed (int* v_ptr = v)
-            {
-                VertexAttribI1iv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttribI1iv"/>
-        public static unsafe void VertexAttribI1iv(uint index, in int v)
-        {
-            fixed (int* v_ptr = &v)
-            {
+                int* v_ptr = (int*)tmp_vecPtr;
                 VertexAttribI1iv(index, v_ptr);
             }
         }
         /// <inheritdoc cref="VertexAttribI2iv"/>
-        public static unsafe void VertexAttribI2iv(uint index, ReadOnlySpan<int> v)
+        public static unsafe void VertexAttribI2i(uint index, in Vector2i v)
         {
-            fixed (int* v_ptr = v)
+            fixed (Vector2i* tmp_vecPtr = &v)
             {
-                VertexAttribI2iv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttribI2iv"/>
-        public static unsafe void VertexAttribI2iv(uint index, int[] v)
-        {
-            fixed (int* v_ptr = v)
-            {
-                VertexAttribI2iv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttribI2iv"/>
-        public static unsafe void VertexAttribI2iv(uint index, in int v)
-        {
-            fixed (int* v_ptr = &v)
-            {
+                int* v_ptr = (int*)tmp_vecPtr;
                 VertexAttribI2iv(index, v_ptr);
             }
         }
         /// <inheritdoc cref="VertexAttribI3iv"/>
-        public static unsafe void VertexAttribI3iv(uint index, ReadOnlySpan<int> v)
+        public static unsafe void VertexAttribI3i(uint index, in Vector3i v)
         {
-            fixed (int* v_ptr = v)
+            fixed (Vector3i* tmp_vecPtr = &v)
             {
-                VertexAttribI3iv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttribI3iv"/>
-        public static unsafe void VertexAttribI3iv(uint index, int[] v)
-        {
-            fixed (int* v_ptr = v)
-            {
-                VertexAttribI3iv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttribI3iv"/>
-        public static unsafe void VertexAttribI3iv(uint index, in int v)
-        {
-            fixed (int* v_ptr = &v)
-            {
+                int* v_ptr = (int*)tmp_vecPtr;
                 VertexAttribI3iv(index, v_ptr);
             }
         }
         /// <inheritdoc cref="VertexAttribI4iv"/>
-        public static unsafe void VertexAttribI4iv(uint index, ReadOnlySpan<int> v)
+        public static unsafe void VertexAttribI4i(uint index, in Vector4i v)
         {
-            fixed (int* v_ptr = v)
+            fixed (Vector4i* tmp_vecPtr = &v)
             {
-                VertexAttribI4iv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttribI4iv"/>
-        public static unsafe void VertexAttribI4iv(uint index, int[] v)
-        {
-            fixed (int* v_ptr = v)
-            {
-                VertexAttribI4iv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttribI4iv"/>
-        public static unsafe void VertexAttribI4iv(uint index, in int v)
-        {
-            fixed (int* v_ptr = &v)
-            {
+                int* v_ptr = (int*)tmp_vecPtr;
                 VertexAttribI4iv(index, v_ptr);
             }
         }
@@ -10123,9 +9117,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="Uniform1dv"/>
-        public static unsafe void Uniform1d(int location, in double value)
+        public static unsafe void Uniform1d(int location, int count, in double value)
         {
-            int count = 1;
             fixed (double* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
@@ -10151,9 +9144,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="Uniform2dv"/>
-        public static unsafe void Uniform2d(int location, in Vector2d value)
+        public static unsafe void Uniform2d(int location, int count, in Vector2d value)
         {
-            int count = 1;
             fixed (Vector2d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
@@ -10179,9 +9171,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="Uniform3dv"/>
-        public static unsafe void Uniform3d(int location, in Vector3d value)
+        public static unsafe void Uniform3d(int location, int count, in Vector3d value)
         {
-            int count = 1;
             fixed (Vector3d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
@@ -10207,9 +9198,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="Uniform4dv"/>
-        public static unsafe void Uniform4d(int location, in Vector4d value)
+        public static unsafe void Uniform4d(int location, int count, in Vector4d value)
         {
-            int count = 1;
             fixed (Vector4d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
@@ -10235,9 +9225,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="UniformMatrix2dv"/>
-        public static unsafe void UniformMatrix2d(int location, bool transpose, in Matrix2d value)
+        public static unsafe void UniformMatrix2d(int location, int count, bool transpose, in Matrix2d value)
         {
-            int count = 1;
             fixed (Matrix2d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
@@ -10263,9 +9252,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="UniformMatrix3dv"/>
-        public static unsafe void UniformMatrix3d(int location, bool transpose, in Matrix3d value)
+        public static unsafe void UniformMatrix3d(int location, int count, bool transpose, in Matrix3d value)
         {
-            int count = 1;
             fixed (Matrix3d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
@@ -10291,9 +9279,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="UniformMatrix4dv"/>
-        public static unsafe void UniformMatrix4d(int location, bool transpose, in Matrix4d value)
+        public static unsafe void UniformMatrix4d(int location, int count, bool transpose, in Matrix4d value)
         {
-            int count = 1;
             fixed (Matrix4d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
@@ -10319,9 +9306,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="UniformMatrix2x3dv"/>
-        public static unsafe void UniformMatrix2x3d(int location, bool transpose, in Matrix2x3d value)
+        public static unsafe void UniformMatrix2x3d(int location, int count, bool transpose, in Matrix2x3d value)
         {
-            int count = 1;
             fixed (Matrix2x3d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
@@ -10347,9 +9333,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="UniformMatrix2x4dv"/>
-        public static unsafe void UniformMatrix2x4d(int location, bool transpose, in Matrix2x4d value)
+        public static unsafe void UniformMatrix2x4d(int location, int count, bool transpose, in Matrix2x4d value)
         {
-            int count = 1;
             fixed (Matrix2x4d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
@@ -10375,9 +9360,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="UniformMatrix3x2dv"/>
-        public static unsafe void UniformMatrix3x2d(int location, bool transpose, in Matrix3x2d value)
+        public static unsafe void UniformMatrix3x2d(int location, int count, bool transpose, in Matrix3x2d value)
         {
-            int count = 1;
             fixed (Matrix3x2d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
@@ -10403,9 +9387,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="UniformMatrix3x4dv"/>
-        public static unsafe void UniformMatrix3x4d(int location, bool transpose, in Matrix3x4d value)
+        public static unsafe void UniformMatrix3x4d(int location, int count, bool transpose, in Matrix3x4d value)
         {
-            int count = 1;
             fixed (Matrix3x4d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
@@ -10431,9 +9414,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="UniformMatrix4x2dv"/>
-        public static unsafe void UniformMatrix4x2d(int location, bool transpose, in Matrix4x2d value)
+        public static unsafe void UniformMatrix4x2d(int location, int count, bool transpose, in Matrix4x2d value)
         {
-            int count = 1;
             fixed (Matrix4x2d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
@@ -10459,9 +9441,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="UniformMatrix4x3dv"/>
-        public static unsafe void UniformMatrix4x3d(int location, bool transpose, in Matrix4x3d value)
+        public static unsafe void UniformMatrix4x3d(int location, int count, bool transpose, in Matrix4x3d value)
         {
-            int count = 1;
             fixed (Matrix4x3d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
@@ -11354,9 +10335,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform2iv"/>
-        public static unsafe void ProgramUniform2i(ProgramHandle program, int location, in Vector2i value)
+        public static unsafe void ProgramUniform2i(ProgramHandle program, int location, int count, in Vector2i value)
         {
-            int count = 1;
             fixed (Vector2i* tmp_vecPtr = &value)
             {
                 int* value_ptr = (int*)tmp_vecPtr;
@@ -11382,9 +10362,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform2fv"/>
-        public static unsafe void ProgramUniform2f(ProgramHandle program, int location, in Vector2 value)
+        public static unsafe void ProgramUniform2f(ProgramHandle program, int location, int count, in Vector2 value)
         {
-            int count = 1;
             fixed (Vector2* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -11410,9 +10389,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform2fv"/>
-        public static unsafe void ProgramUniform2f(ProgramHandle program, int location, in System.Numerics.Vector2 value)
+        public static unsafe void ProgramUniform2f(ProgramHandle program, int location, int count, in System.Numerics.Vector2 value)
         {
-            int count = 1;
             fixed (System.Numerics.Vector2* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -11438,9 +10416,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform2dv"/>
-        public static unsafe void ProgramUniform2d(ProgramHandle program, int location, in Vector2d value)
+        public static unsafe void ProgramUniform2d(ProgramHandle program, int location, int count, in Vector2d value)
         {
-            int count = 1;
             fixed (Vector2d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
@@ -11492,9 +10469,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform3iv"/>
-        public static unsafe void ProgramUniform3i(ProgramHandle program, int location, in Vector3i value)
+        public static unsafe void ProgramUniform3i(ProgramHandle program, int location, int count, in Vector3i value)
         {
-            int count = 1;
             fixed (Vector3i* tmp_vecPtr = &value)
             {
                 int* value_ptr = (int*)tmp_vecPtr;
@@ -11520,9 +10496,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform3fv"/>
-        public static unsafe void ProgramUniform3f(ProgramHandle program, int location, in Vector3 value)
+        public static unsafe void ProgramUniform3f(ProgramHandle program, int location, int count, in Vector3 value)
         {
-            int count = 1;
             fixed (Vector3* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -11548,9 +10523,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform3fv"/>
-        public static unsafe void ProgramUniform3f(ProgramHandle program, int location, in System.Numerics.Vector3 value)
+        public static unsafe void ProgramUniform3f(ProgramHandle program, int location, int count, in System.Numerics.Vector3 value)
         {
-            int count = 1;
             fixed (System.Numerics.Vector3* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -11576,9 +10550,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform3dv"/>
-        public static unsafe void ProgramUniform3d(ProgramHandle program, int location, in Vector3d value)
+        public static unsafe void ProgramUniform3d(ProgramHandle program, int location, int count, in Vector3d value)
         {
-            int count = 1;
             fixed (Vector3d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
@@ -11630,9 +10603,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform4iv"/>
-        public static unsafe void ProgramUniform4i(ProgramHandle program, int location, in Vector4i value)
+        public static unsafe void ProgramUniform4i(ProgramHandle program, int location, int count, in Vector4i value)
         {
-            int count = 1;
             fixed (Vector4i* tmp_vecPtr = &value)
             {
                 int* value_ptr = (int*)tmp_vecPtr;
@@ -11658,9 +10630,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform4fv"/>
-        public static unsafe void ProgramUniform4f(ProgramHandle program, int location, in Vector4 value)
+        public static unsafe void ProgramUniform4f(ProgramHandle program, int location, int count, in Vector4 value)
         {
-            int count = 1;
             fixed (Vector4* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -11686,9 +10657,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform4fv"/>
-        public static unsafe void ProgramUniform4f(ProgramHandle program, int location, in System.Numerics.Vector4 value)
+        public static unsafe void ProgramUniform4f(ProgramHandle program, int location, int count, in System.Numerics.Vector4 value)
         {
-            int count = 1;
             fixed (System.Numerics.Vector4* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -11714,9 +10684,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform4dv"/>
-        public static unsafe void ProgramUniform4d(ProgramHandle program, int location, in Vector4d value)
+        public static unsafe void ProgramUniform4d(ProgramHandle program, int location, int count, in Vector4d value)
         {
-            int count = 1;
             fixed (Vector4d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
@@ -11768,9 +10737,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2fv"/>
-        public static unsafe void ProgramUniformMatrix2f(ProgramHandle program, int location, bool transpose, in Matrix2 value)
+        public static unsafe void ProgramUniformMatrix2f(ProgramHandle program, int location, int count, bool transpose, in Matrix2 value)
         {
-            int count = 1;
             fixed (Matrix2* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -11796,9 +10764,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3fv"/>
-        public static unsafe void ProgramUniformMatrix3f(ProgramHandle program, int location, bool transpose, in Matrix3 value)
+        public static unsafe void ProgramUniformMatrix3f(ProgramHandle program, int location, int count, bool transpose, in Matrix3 value)
         {
-            int count = 1;
             fixed (Matrix3* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -11824,9 +10791,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
-        public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, bool transpose, in Matrix4 value)
+        public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, int count, bool transpose, in Matrix4 value)
         {
-            int count = 1;
             fixed (Matrix4* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -11852,9 +10818,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
-        public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, bool transpose, in System.Numerics.Matrix4x4 value)
+        public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, int count, bool transpose, in System.Numerics.Matrix4x4 value)
         {
-            int count = 1;
             fixed (System.Numerics.Matrix4x4* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -11880,9 +10845,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2dv"/>
-        public static unsafe void ProgramUniformMatrix2d(ProgramHandle program, int location, bool transpose, in Matrix2d value)
+        public static unsafe void ProgramUniformMatrix2d(ProgramHandle program, int location, int count, bool transpose, in Matrix2d value)
         {
-            int count = 1;
             fixed (Matrix2d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
@@ -11908,9 +10872,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3dv"/>
-        public static unsafe void ProgramUniformMatrix3d(ProgramHandle program, int location, bool transpose, in Matrix3d value)
+        public static unsafe void ProgramUniformMatrix3d(ProgramHandle program, int location, int count, bool transpose, in Matrix3d value)
         {
-            int count = 1;
             fixed (Matrix3d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
@@ -11936,9 +10899,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4dv"/>
-        public static unsafe void ProgramUniformMatrix4d(ProgramHandle program, int location, bool transpose, in Matrix4d value)
+        public static unsafe void ProgramUniformMatrix4d(ProgramHandle program, int location, int count, bool transpose, in Matrix4d value)
         {
-            int count = 1;
             fixed (Matrix4d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
@@ -11964,9 +10926,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x3fv"/>
-        public static unsafe void ProgramUniformMatrix2x3f(ProgramHandle program, int location, bool transpose, in Matrix2x3 value)
+        public static unsafe void ProgramUniformMatrix2x3f(ProgramHandle program, int location, int count, bool transpose, in Matrix2x3 value)
         {
-            int count = 1;
             fixed (Matrix2x3* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -11992,9 +10953,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
-        public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, bool transpose, in Matrix3x2 value)
+        public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, int count, bool transpose, in Matrix3x2 value)
         {
-            int count = 1;
             fixed (Matrix3x2* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -12020,9 +10980,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
-        public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, bool transpose, in System.Numerics.Matrix3x2 value)
+        public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, int count, bool transpose, in System.Numerics.Matrix3x2 value)
         {
-            int count = 1;
             fixed (System.Numerics.Matrix3x2* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -12048,9 +11007,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x4fv"/>
-        public static unsafe void ProgramUniformMatrix2x4f(ProgramHandle program, int location, bool transpose, in Matrix2x4 value)
+        public static unsafe void ProgramUniformMatrix2x4f(ProgramHandle program, int location, int count, bool transpose, in Matrix2x4 value)
         {
-            int count = 1;
             fixed (Matrix2x4* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -12076,9 +11034,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x2fv"/>
-        public static unsafe void ProgramUniformMatrix4x2f(ProgramHandle program, int location, bool transpose, in Matrix4x2 value)
+        public static unsafe void ProgramUniformMatrix4x2f(ProgramHandle program, int location, int count, bool transpose, in Matrix4x2 value)
         {
-            int count = 1;
             fixed (Matrix4x2* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -12104,9 +11061,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x4fv"/>
-        public static unsafe void ProgramUniformMatrix3x4f(ProgramHandle program, int location, bool transpose, in Matrix3x4 value)
+        public static unsafe void ProgramUniformMatrix3x4f(ProgramHandle program, int location, int count, bool transpose, in Matrix3x4 value)
         {
-            int count = 1;
             fixed (Matrix3x4* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -12132,9 +11088,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x3fv"/>
-        public static unsafe void ProgramUniformMatrix4x3f(ProgramHandle program, int location, bool transpose, in Matrix4x3 value)
+        public static unsafe void ProgramUniformMatrix4x3f(ProgramHandle program, int location, int count, bool transpose, in Matrix4x3 value)
         {
-            int count = 1;
             fixed (Matrix4x3* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -12160,9 +11115,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x3dv"/>
-        public static unsafe void ProgramUniformMatrix2x3d(ProgramHandle program, int location, bool transpose, in Matrix2x3d value)
+        public static unsafe void ProgramUniformMatrix2x3d(ProgramHandle program, int location, int count, bool transpose, in Matrix2x3d value)
         {
-            int count = 1;
             fixed (Matrix2x3d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
@@ -12188,9 +11142,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x2dv"/>
-        public static unsafe void ProgramUniformMatrix3x2d(ProgramHandle program, int location, bool transpose, in Matrix3x2d value)
+        public static unsafe void ProgramUniformMatrix3x2d(ProgramHandle program, int location, int count, bool transpose, in Matrix3x2d value)
         {
-            int count = 1;
             fixed (Matrix3x2d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
@@ -12216,9 +11169,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x4dv"/>
-        public static unsafe void ProgramUniformMatrix2x4d(ProgramHandle program, int location, bool transpose, in Matrix2x4d value)
+        public static unsafe void ProgramUniformMatrix2x4d(ProgramHandle program, int location, int count, bool transpose, in Matrix2x4d value)
         {
-            int count = 1;
             fixed (Matrix2x4d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
@@ -12244,9 +11196,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x2dv"/>
-        public static unsafe void ProgramUniformMatrix4x2d(ProgramHandle program, int location, bool transpose, in Matrix4x2d value)
+        public static unsafe void ProgramUniformMatrix4x2d(ProgramHandle program, int location, int count, bool transpose, in Matrix4x2d value)
         {
-            int count = 1;
             fixed (Matrix4x2d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
@@ -12272,9 +11223,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x4dv"/>
-        public static unsafe void ProgramUniformMatrix3x4d(ProgramHandle program, int location, bool transpose, in Matrix3x4d value)
+        public static unsafe void ProgramUniformMatrix3x4d(ProgramHandle program, int location, int count, bool transpose, in Matrix3x4d value)
         {
-            int count = 1;
             fixed (Matrix3x4d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
@@ -12300,9 +11250,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x3dv"/>
-        public static unsafe void ProgramUniformMatrix4x3d(ProgramHandle program, int location, bool transpose, in Matrix4x3d value)
+        public static unsafe void ProgramUniformMatrix4x3d(ProgramHandle program, int location, int count, bool transpose, in Matrix4x3d value)
         {
-            int count = 1;
             fixed (Matrix4x3d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
@@ -12400,98 +11349,38 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="VertexAttribL1dv"/>
-        public static unsafe void VertexAttribL1dv(uint index, ReadOnlySpan<double> v)
+        public static unsafe void VertexAttribL1d(uint index, in double v)
         {
-            fixed (double* v_ptr = v)
+            fixed (double* tmp_vecPtr = &v)
             {
-                VertexAttribL1dv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttribL1dv"/>
-        public static unsafe void VertexAttribL1dv(uint index, double[] v)
-        {
-            fixed (double* v_ptr = v)
-            {
-                VertexAttribL1dv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttribL1dv"/>
-        public static unsafe void VertexAttribL1dv(uint index, in double v)
-        {
-            fixed (double* v_ptr = &v)
-            {
+                double* v_ptr = (double*)tmp_vecPtr;
                 VertexAttribL1dv(index, v_ptr);
             }
         }
         /// <inheritdoc cref="VertexAttribL2dv"/>
-        public static unsafe void VertexAttribL2dv(uint index, ReadOnlySpan<double> v)
+        public static unsafe void VertexAttribL2d(uint index, in Vector2d v)
         {
-            fixed (double* v_ptr = v)
+            fixed (Vector2d* tmp_vecPtr = &v)
             {
-                VertexAttribL2dv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttribL2dv"/>
-        public static unsafe void VertexAttribL2dv(uint index, double[] v)
-        {
-            fixed (double* v_ptr = v)
-            {
-                VertexAttribL2dv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttribL2dv"/>
-        public static unsafe void VertexAttribL2dv(uint index, in double v)
-        {
-            fixed (double* v_ptr = &v)
-            {
+                double* v_ptr = (double*)tmp_vecPtr;
                 VertexAttribL2dv(index, v_ptr);
             }
         }
         /// <inheritdoc cref="VertexAttribL3dv"/>
-        public static unsafe void VertexAttribL3dv(uint index, ReadOnlySpan<double> v)
+        public static unsafe void VertexAttribL3d(uint index, in Vector3d v)
         {
-            fixed (double* v_ptr = v)
+            fixed (Vector3d* tmp_vecPtr = &v)
             {
-                VertexAttribL3dv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttribL3dv"/>
-        public static unsafe void VertexAttribL3dv(uint index, double[] v)
-        {
-            fixed (double* v_ptr = v)
-            {
-                VertexAttribL3dv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttribL3dv"/>
-        public static unsafe void VertexAttribL3dv(uint index, in double v)
-        {
-            fixed (double* v_ptr = &v)
-            {
+                double* v_ptr = (double*)tmp_vecPtr;
                 VertexAttribL3dv(index, v_ptr);
             }
         }
         /// <inheritdoc cref="VertexAttribL4dv"/>
-        public static unsafe void VertexAttribL4dv(uint index, ReadOnlySpan<double> v)
+        public static unsafe void VertexAttribL4d(uint index, in Vector4d v)
         {
-            fixed (double* v_ptr = v)
+            fixed (Vector4d* tmp_vecPtr = &v)
             {
-                VertexAttribL4dv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttribL4dv"/>
-        public static unsafe void VertexAttribL4dv(uint index, double[] v)
-        {
-            fixed (double* v_ptr = v)
-            {
-                VertexAttribL4dv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttribL4dv"/>
-        public static unsafe void VertexAttribL4dv(uint index, in double v)
-        {
-            fixed (double* v_ptr = &v)
-            {
+                double* v_ptr = (double*)tmp_vecPtr;
                 VertexAttribL4dv(index, v_ptr);
             }
         }
@@ -20070,9 +18959,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="Uniform1dv"/>
-            public static unsafe void Uniform1d(int location, in double value)
+            public static unsafe void Uniform1d(int location, int count, in double value)
             {
-                int count = 1;
                 fixed (double* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
@@ -20098,9 +18986,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="Uniform2dv"/>
-            public static unsafe void Uniform2d(int location, in Vector2d value)
+            public static unsafe void Uniform2d(int location, int count, in Vector2d value)
             {
-                int count = 1;
                 fixed (Vector2d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
@@ -20126,9 +19013,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="Uniform3dv"/>
-            public static unsafe void Uniform3d(int location, in Vector3d value)
+            public static unsafe void Uniform3d(int location, int count, in Vector3d value)
             {
-                int count = 1;
                 fixed (Vector3d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
@@ -20154,9 +19040,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="Uniform4dv"/>
-            public static unsafe void Uniform4d(int location, in Vector4d value)
+            public static unsafe void Uniform4d(int location, int count, in Vector4d value)
             {
-                int count = 1;
                 fixed (Vector4d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
@@ -20182,9 +19067,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="UniformMatrix2dv"/>
-            public static unsafe void UniformMatrix2d(int location, bool transpose, in Matrix2d value)
+            public static unsafe void UniformMatrix2d(int location, int count, bool transpose, in Matrix2d value)
             {
-                int count = 1;
                 fixed (Matrix2d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
@@ -20210,9 +19094,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="UniformMatrix3dv"/>
-            public static unsafe void UniformMatrix3d(int location, bool transpose, in Matrix3d value)
+            public static unsafe void UniformMatrix3d(int location, int count, bool transpose, in Matrix3d value)
             {
-                int count = 1;
                 fixed (Matrix3d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
@@ -20238,9 +19121,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="UniformMatrix4dv"/>
-            public static unsafe void UniformMatrix4d(int location, bool transpose, in Matrix4d value)
+            public static unsafe void UniformMatrix4d(int location, int count, bool transpose, in Matrix4d value)
             {
-                int count = 1;
                 fixed (Matrix4d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
@@ -20266,9 +19148,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="UniformMatrix2x3dv"/>
-            public static unsafe void UniformMatrix2x3d(int location, bool transpose, in Matrix2x3d value)
+            public static unsafe void UniformMatrix2x3d(int location, int count, bool transpose, in Matrix2x3d value)
             {
-                int count = 1;
                 fixed (Matrix2x3d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
@@ -20294,9 +19175,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="UniformMatrix2x4dv"/>
-            public static unsafe void UniformMatrix2x4d(int location, bool transpose, in Matrix2x4d value)
+            public static unsafe void UniformMatrix2x4d(int location, int count, bool transpose, in Matrix2x4d value)
             {
-                int count = 1;
                 fixed (Matrix2x4d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
@@ -20322,9 +19202,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="UniformMatrix3x2dv"/>
-            public static unsafe void UniformMatrix3x2d(int location, bool transpose, in Matrix3x2d value)
+            public static unsafe void UniformMatrix3x2d(int location, int count, bool transpose, in Matrix3x2d value)
             {
-                int count = 1;
                 fixed (Matrix3x2d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
@@ -20350,9 +19229,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="UniformMatrix3x4dv"/>
-            public static unsafe void UniformMatrix3x4d(int location, bool transpose, in Matrix3x4d value)
+            public static unsafe void UniformMatrix3x4d(int location, int count, bool transpose, in Matrix3x4d value)
             {
-                int count = 1;
                 fixed (Matrix3x4d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
@@ -20378,9 +19256,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="UniformMatrix4x2dv"/>
-            public static unsafe void UniformMatrix4x2d(int location, bool transpose, in Matrix4x2d value)
+            public static unsafe void UniformMatrix4x2d(int location, int count, bool transpose, in Matrix4x2d value)
             {
-                int count = 1;
                 fixed (Matrix4x2d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
@@ -20406,9 +19283,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="UniformMatrix4x3dv"/>
-            public static unsafe void UniformMatrix4x3d(int location, bool transpose, in Matrix4x3d value)
+            public static unsafe void UniformMatrix4x3d(int location, int count, bool transpose, in Matrix4x3d value)
             {
-                int count = 1;
                 fixed (Matrix4x3d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
@@ -23936,9 +22812,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform2iv"/>
-            public static unsafe void ProgramUniform2i(ProgramHandle program, int location, in Vector2i value)
+            public static unsafe void ProgramUniform2i(ProgramHandle program, int location, int count, in Vector2i value)
             {
-                int count = 1;
                 fixed (Vector2i* tmp_vecPtr = &value)
                 {
                     int* value_ptr = (int*)tmp_vecPtr;
@@ -23964,9 +22839,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform2fv"/>
-            public static unsafe void ProgramUniform2f(ProgramHandle program, int location, in Vector2 value)
+            public static unsafe void ProgramUniform2f(ProgramHandle program, int location, int count, in Vector2 value)
             {
-                int count = 1;
                 fixed (Vector2* tmp_vecPtr = &value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
@@ -23992,9 +22866,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform2fv"/>
-            public static unsafe void ProgramUniform2f(ProgramHandle program, int location, in System.Numerics.Vector2 value)
+            public static unsafe void ProgramUniform2f(ProgramHandle program, int location, int count, in System.Numerics.Vector2 value)
             {
-                int count = 1;
                 fixed (System.Numerics.Vector2* tmp_vecPtr = &value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
@@ -24020,9 +22893,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform2dv"/>
-            public static unsafe void ProgramUniform2d(ProgramHandle program, int location, in Vector2d value)
+            public static unsafe void ProgramUniform2d(ProgramHandle program, int location, int count, in Vector2d value)
             {
-                int count = 1;
                 fixed (Vector2d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
@@ -24074,9 +22946,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform3iv"/>
-            public static unsafe void ProgramUniform3i(ProgramHandle program, int location, in Vector3i value)
+            public static unsafe void ProgramUniform3i(ProgramHandle program, int location, int count, in Vector3i value)
             {
-                int count = 1;
                 fixed (Vector3i* tmp_vecPtr = &value)
                 {
                     int* value_ptr = (int*)tmp_vecPtr;
@@ -24102,9 +22973,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform3fv"/>
-            public static unsafe void ProgramUniform3f(ProgramHandle program, int location, in Vector3 value)
+            public static unsafe void ProgramUniform3f(ProgramHandle program, int location, int count, in Vector3 value)
             {
-                int count = 1;
                 fixed (Vector3* tmp_vecPtr = &value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
@@ -24130,9 +23000,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform3fv"/>
-            public static unsafe void ProgramUniform3f(ProgramHandle program, int location, in System.Numerics.Vector3 value)
+            public static unsafe void ProgramUniform3f(ProgramHandle program, int location, int count, in System.Numerics.Vector3 value)
             {
-                int count = 1;
                 fixed (System.Numerics.Vector3* tmp_vecPtr = &value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
@@ -24158,9 +23027,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform3dv"/>
-            public static unsafe void ProgramUniform3d(ProgramHandle program, int location, in Vector3d value)
+            public static unsafe void ProgramUniform3d(ProgramHandle program, int location, int count, in Vector3d value)
             {
-                int count = 1;
                 fixed (Vector3d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
@@ -24212,9 +23080,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform4iv"/>
-            public static unsafe void ProgramUniform4i(ProgramHandle program, int location, in Vector4i value)
+            public static unsafe void ProgramUniform4i(ProgramHandle program, int location, int count, in Vector4i value)
             {
-                int count = 1;
                 fixed (Vector4i* tmp_vecPtr = &value)
                 {
                     int* value_ptr = (int*)tmp_vecPtr;
@@ -24240,9 +23107,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform4fv"/>
-            public static unsafe void ProgramUniform4f(ProgramHandle program, int location, in Vector4 value)
+            public static unsafe void ProgramUniform4f(ProgramHandle program, int location, int count, in Vector4 value)
             {
-                int count = 1;
                 fixed (Vector4* tmp_vecPtr = &value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
@@ -24268,9 +23134,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform4fv"/>
-            public static unsafe void ProgramUniform4f(ProgramHandle program, int location, in System.Numerics.Vector4 value)
+            public static unsafe void ProgramUniform4f(ProgramHandle program, int location, int count, in System.Numerics.Vector4 value)
             {
-                int count = 1;
                 fixed (System.Numerics.Vector4* tmp_vecPtr = &value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
@@ -24296,9 +23161,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform4dv"/>
-            public static unsafe void ProgramUniform4d(ProgramHandle program, int location, in Vector4d value)
+            public static unsafe void ProgramUniform4d(ProgramHandle program, int location, int count, in Vector4d value)
             {
-                int count = 1;
                 fixed (Vector4d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
@@ -24350,9 +23214,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2fv"/>
-            public static unsafe void ProgramUniformMatrix2f(ProgramHandle program, int location, bool transpose, in Matrix2 value)
+            public static unsafe void ProgramUniformMatrix2f(ProgramHandle program, int location, int count, bool transpose, in Matrix2 value)
             {
-                int count = 1;
                 fixed (Matrix2* tmp_vecPtr = &value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
@@ -24378,9 +23241,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3fv"/>
-            public static unsafe void ProgramUniformMatrix3f(ProgramHandle program, int location, bool transpose, in Matrix3 value)
+            public static unsafe void ProgramUniformMatrix3f(ProgramHandle program, int location, int count, bool transpose, in Matrix3 value)
             {
-                int count = 1;
                 fixed (Matrix3* tmp_vecPtr = &value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
@@ -24406,9 +23268,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
-            public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, bool transpose, in Matrix4 value)
+            public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, int count, bool transpose, in Matrix4 value)
             {
-                int count = 1;
                 fixed (Matrix4* tmp_vecPtr = &value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
@@ -24434,9 +23295,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
-            public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, bool transpose, in System.Numerics.Matrix4x4 value)
+            public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, int count, bool transpose, in System.Numerics.Matrix4x4 value)
             {
-                int count = 1;
                 fixed (System.Numerics.Matrix4x4* tmp_vecPtr = &value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
@@ -24462,9 +23322,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2dv"/>
-            public static unsafe void ProgramUniformMatrix2d(ProgramHandle program, int location, bool transpose, in Matrix2d value)
+            public static unsafe void ProgramUniformMatrix2d(ProgramHandle program, int location, int count, bool transpose, in Matrix2d value)
             {
-                int count = 1;
                 fixed (Matrix2d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
@@ -24490,9 +23349,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3dv"/>
-            public static unsafe void ProgramUniformMatrix3d(ProgramHandle program, int location, bool transpose, in Matrix3d value)
+            public static unsafe void ProgramUniformMatrix3d(ProgramHandle program, int location, int count, bool transpose, in Matrix3d value)
             {
-                int count = 1;
                 fixed (Matrix3d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
@@ -24518,9 +23376,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4dv"/>
-            public static unsafe void ProgramUniformMatrix4d(ProgramHandle program, int location, bool transpose, in Matrix4d value)
+            public static unsafe void ProgramUniformMatrix4d(ProgramHandle program, int location, int count, bool transpose, in Matrix4d value)
             {
-                int count = 1;
                 fixed (Matrix4d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
@@ -24546,9 +23403,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x3fv"/>
-            public static unsafe void ProgramUniformMatrix2x3f(ProgramHandle program, int location, bool transpose, in Matrix2x3 value)
+            public static unsafe void ProgramUniformMatrix2x3f(ProgramHandle program, int location, int count, bool transpose, in Matrix2x3 value)
             {
-                int count = 1;
                 fixed (Matrix2x3* tmp_vecPtr = &value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
@@ -24574,9 +23430,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
-            public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, bool transpose, in Matrix3x2 value)
+            public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, int count, bool transpose, in Matrix3x2 value)
             {
-                int count = 1;
                 fixed (Matrix3x2* tmp_vecPtr = &value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
@@ -24602,9 +23457,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
-            public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, bool transpose, in System.Numerics.Matrix3x2 value)
+            public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, int count, bool transpose, in System.Numerics.Matrix3x2 value)
             {
-                int count = 1;
                 fixed (System.Numerics.Matrix3x2* tmp_vecPtr = &value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
@@ -24630,9 +23484,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x4fv"/>
-            public static unsafe void ProgramUniformMatrix2x4f(ProgramHandle program, int location, bool transpose, in Matrix2x4 value)
+            public static unsafe void ProgramUniformMatrix2x4f(ProgramHandle program, int location, int count, bool transpose, in Matrix2x4 value)
             {
-                int count = 1;
                 fixed (Matrix2x4* tmp_vecPtr = &value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
@@ -24658,9 +23511,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x2fv"/>
-            public static unsafe void ProgramUniformMatrix4x2f(ProgramHandle program, int location, bool transpose, in Matrix4x2 value)
+            public static unsafe void ProgramUniformMatrix4x2f(ProgramHandle program, int location, int count, bool transpose, in Matrix4x2 value)
             {
-                int count = 1;
                 fixed (Matrix4x2* tmp_vecPtr = &value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
@@ -24686,9 +23538,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x4fv"/>
-            public static unsafe void ProgramUniformMatrix3x4f(ProgramHandle program, int location, bool transpose, in Matrix3x4 value)
+            public static unsafe void ProgramUniformMatrix3x4f(ProgramHandle program, int location, int count, bool transpose, in Matrix3x4 value)
             {
-                int count = 1;
                 fixed (Matrix3x4* tmp_vecPtr = &value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
@@ -24714,9 +23565,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x3fv"/>
-            public static unsafe void ProgramUniformMatrix4x3f(ProgramHandle program, int location, bool transpose, in Matrix4x3 value)
+            public static unsafe void ProgramUniformMatrix4x3f(ProgramHandle program, int location, int count, bool transpose, in Matrix4x3 value)
             {
-                int count = 1;
                 fixed (Matrix4x3* tmp_vecPtr = &value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
@@ -24742,9 +23592,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x3dv"/>
-            public static unsafe void ProgramUniformMatrix2x3d(ProgramHandle program, int location, bool transpose, in Matrix2x3d value)
+            public static unsafe void ProgramUniformMatrix2x3d(ProgramHandle program, int location, int count, bool transpose, in Matrix2x3d value)
             {
-                int count = 1;
                 fixed (Matrix2x3d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
@@ -24770,9 +23619,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2dv"/>
-            public static unsafe void ProgramUniformMatrix3x2d(ProgramHandle program, int location, bool transpose, in Matrix3x2d value)
+            public static unsafe void ProgramUniformMatrix3x2d(ProgramHandle program, int location, int count, bool transpose, in Matrix3x2d value)
             {
-                int count = 1;
                 fixed (Matrix3x2d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
@@ -24798,9 +23646,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x4dv"/>
-            public static unsafe void ProgramUniformMatrix2x4d(ProgramHandle program, int location, bool transpose, in Matrix2x4d value)
+            public static unsafe void ProgramUniformMatrix2x4d(ProgramHandle program, int location, int count, bool transpose, in Matrix2x4d value)
             {
-                int count = 1;
                 fixed (Matrix2x4d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
@@ -24826,9 +23673,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x2dv"/>
-            public static unsafe void ProgramUniformMatrix4x2d(ProgramHandle program, int location, bool transpose, in Matrix4x2d value)
+            public static unsafe void ProgramUniformMatrix4x2d(ProgramHandle program, int location, int count, bool transpose, in Matrix4x2d value)
             {
-                int count = 1;
                 fixed (Matrix4x2d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
@@ -24854,9 +23700,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x4dv"/>
-            public static unsafe void ProgramUniformMatrix3x4d(ProgramHandle program, int location, bool transpose, in Matrix3x4d value)
+            public static unsafe void ProgramUniformMatrix3x4d(ProgramHandle program, int location, int count, bool transpose, in Matrix3x4d value)
             {
-                int count = 1;
                 fixed (Matrix3x4d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
@@ -24882,9 +23727,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x3dv"/>
-            public static unsafe void ProgramUniformMatrix4x3d(ProgramHandle program, int location, bool transpose, in Matrix4x3d value)
+            public static unsafe void ProgramUniformMatrix4x3d(ProgramHandle program, int location, int count, bool transpose, in Matrix4x3d value)
             {
-                int count = 1;
                 fixed (Matrix4x3d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
@@ -27085,98 +25929,38 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="VertexAttribL1dv"/>
-            public static unsafe void VertexAttribL1dv(uint index, ReadOnlySpan<double> v)
+            public static unsafe void VertexAttribL1d(uint index, in double v)
             {
-                fixed (double* v_ptr = v)
+                fixed (double* tmp_vecPtr = &v)
                 {
-                    VertexAttribL1dv(index, v_ptr);
-                }
-            }
-            /// <inheritdoc cref="VertexAttribL1dv"/>
-            public static unsafe void VertexAttribL1dv(uint index, double[] v)
-            {
-                fixed (double* v_ptr = v)
-                {
-                    VertexAttribL1dv(index, v_ptr);
-                }
-            }
-            /// <inheritdoc cref="VertexAttribL1dv"/>
-            public static unsafe void VertexAttribL1dv(uint index, in double v)
-            {
-                fixed (double* v_ptr = &v)
-                {
+                    double* v_ptr = (double*)tmp_vecPtr;
                     VertexAttribL1dv(index, v_ptr);
                 }
             }
             /// <inheritdoc cref="VertexAttribL2dv"/>
-            public static unsafe void VertexAttribL2dv(uint index, ReadOnlySpan<double> v)
+            public static unsafe void VertexAttribL2d(uint index, in Vector2d v)
             {
-                fixed (double* v_ptr = v)
+                fixed (Vector2d* tmp_vecPtr = &v)
                 {
-                    VertexAttribL2dv(index, v_ptr);
-                }
-            }
-            /// <inheritdoc cref="VertexAttribL2dv"/>
-            public static unsafe void VertexAttribL2dv(uint index, double[] v)
-            {
-                fixed (double* v_ptr = v)
-                {
-                    VertexAttribL2dv(index, v_ptr);
-                }
-            }
-            /// <inheritdoc cref="VertexAttribL2dv"/>
-            public static unsafe void VertexAttribL2dv(uint index, in double v)
-            {
-                fixed (double* v_ptr = &v)
-                {
+                    double* v_ptr = (double*)tmp_vecPtr;
                     VertexAttribL2dv(index, v_ptr);
                 }
             }
             /// <inheritdoc cref="VertexAttribL3dv"/>
-            public static unsafe void VertexAttribL3dv(uint index, ReadOnlySpan<double> v)
+            public static unsafe void VertexAttribL3d(uint index, in Vector3d v)
             {
-                fixed (double* v_ptr = v)
+                fixed (Vector3d* tmp_vecPtr = &v)
                 {
-                    VertexAttribL3dv(index, v_ptr);
-                }
-            }
-            /// <inheritdoc cref="VertexAttribL3dv"/>
-            public static unsafe void VertexAttribL3dv(uint index, double[] v)
-            {
-                fixed (double* v_ptr = v)
-                {
-                    VertexAttribL3dv(index, v_ptr);
-                }
-            }
-            /// <inheritdoc cref="VertexAttribL3dv"/>
-            public static unsafe void VertexAttribL3dv(uint index, in double v)
-            {
-                fixed (double* v_ptr = &v)
-                {
+                    double* v_ptr = (double*)tmp_vecPtr;
                     VertexAttribL3dv(index, v_ptr);
                 }
             }
             /// <inheritdoc cref="VertexAttribL4dv"/>
-            public static unsafe void VertexAttribL4dv(uint index, ReadOnlySpan<double> v)
+            public static unsafe void VertexAttribL4d(uint index, in Vector4d v)
             {
-                fixed (double* v_ptr = v)
+                fixed (Vector4d* tmp_vecPtr = &v)
                 {
-                    VertexAttribL4dv(index, v_ptr);
-                }
-            }
-            /// <inheritdoc cref="VertexAttribL4dv"/>
-            public static unsafe void VertexAttribL4dv(uint index, double[] v)
-            {
-                fixed (double* v_ptr = v)
-                {
-                    VertexAttribL4dv(index, v_ptr);
-                }
-            }
-            /// <inheritdoc cref="VertexAttribL4dv"/>
-            public static unsafe void VertexAttribL4dv(uint index, in double v)
-            {
-                fixed (double* v_ptr = &v)
-                {
+                    double* v_ptr = (double*)tmp_vecPtr;
                     VertexAttribL4dv(index, v_ptr);
                 }
             }

--- a/src/OpenTK.Graphics/OpenGL/Compatibility/GL.Overloads.cs
+++ b/src/OpenTK.Graphics/OpenGL/Compatibility/GL.Overloads.cs
@@ -487,7 +487,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="Color3fv"/>
-        public static unsafe void Color3f(in Color3<Rgb> v)
+        public static unsafe void Color3fv(in Color3<Rgb> v)
         {
             fixed (Color3<Rgb>* tmp_v = &v)
             {
@@ -654,7 +654,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="Color4fv"/>
-        public static unsafe void Color4f(in Color4<Rgba> v)
+        public static unsafe void Color4fv(in Color4<Rgba> v)
         {
             fixed (Color4<Rgba>* tmp_v = &v)
             {
@@ -4319,7 +4319,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="SecondaryColor3fv"/>
-        public static unsafe void SecondaryColor3f(in Color3<Rgb> v)
+        public static unsafe void SecondaryColor3fv(in Color3<Rgb> v)
         {
             fixed (Color3<Rgb>* tmp_v = &v)
             {
@@ -35071,26 +35071,11 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="SecondaryColor3fvEXT"/>
-            public static unsafe void SecondaryColor3fvEXT(ReadOnlySpan<float> v)
+            public static unsafe void SecondaryColor3fvEXT(in Color3<Rgb> v)
             {
-                fixed (float* v_ptr = v)
+                fixed (Color3<Rgb>* tmp_v = &v)
                 {
-                    SecondaryColor3fvEXT(v_ptr);
-                }
-            }
-            /// <inheritdoc cref="SecondaryColor3fvEXT"/>
-            public static unsafe void SecondaryColor3fvEXT(float[] v)
-            {
-                fixed (float* v_ptr = v)
-                {
-                    SecondaryColor3fvEXT(v_ptr);
-                }
-            }
-            /// <inheritdoc cref="SecondaryColor3fvEXT"/>
-            public static unsafe void SecondaryColor3fvEXT(in float v)
-            {
-                fixed (float* v_ptr = &v)
-                {
+                    float* v_ptr = (float*)tmp_v;
                     SecondaryColor3fvEXT(v_ptr);
                 }
             }
@@ -49180,34 +49165,39 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="Color3fVertex3fvSUN"/>
-            public static unsafe void Color3fVertex3fvSUN(ReadOnlySpan<float> c, ReadOnlySpan<float> v)
+            public static unsafe void Color3fVertex3fvSUN(in Color3<Rgb> c, ReadOnlySpan<float> v)
             {
-                fixed (float* c_ptr = c)
+                fixed (float* v_ptr = v)
                 {
-                    fixed (float* v_ptr = v)
+                    fixed (Color3<Rgb>* tmp_c = &c)
                     {
+                        float* c_ptr = (float*)tmp_c;
                         Color3fVertex3fvSUN(c_ptr, v_ptr);
                     }
                 }
             }
             /// <inheritdoc cref="Color3fVertex3fvSUN"/>
-            public static unsafe void Color3fVertex3fvSUN(float[] c, float[] v)
+            public static unsafe void Color3fVertex3fvSUN(in Color3<Rgb> c, float[] v)
             {
-                fixed (float* c_ptr = c)
+                fixed (float* v_ptr = v)
                 {
-                    fixed (float* v_ptr = v)
+                    fixed (Color3<Rgb>* tmp_c = &c)
                     {
+                        float* c_ptr = (float*)tmp_c;
                         Color3fVertex3fvSUN(c_ptr, v_ptr);
                     }
                 }
             }
             /// <inheritdoc cref="Color3fVertex3fvSUN"/>
-            public static unsafe void Color3fVertex3fvSUN(in float c, in float v)
+            public static unsafe void Color3fVertex3fvSUN(in Color3<Rgb> c, in float v)
             {
-                fixed (float* c_ptr = &c)
                 fixed (float* v_ptr = &v)
                 {
-                    Color3fVertex3fvSUN(c_ptr, v_ptr);
+                    fixed (Color3<Rgb>* tmp_c = &c)
+                    {
+                        float* c_ptr = (float*)tmp_c;
+                        Color3fVertex3fvSUN(c_ptr, v_ptr);
+                    }
                 }
             }
             /// <inheritdoc cref="Normal3fVertex3fvSUN"/>
@@ -49242,41 +49232,46 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="Color4fNormal3fVertex3fvSUN"/>
-            public static unsafe void Color4fNormal3fVertex3fvSUN(ReadOnlySpan<float> c, ReadOnlySpan<float> n, ReadOnlySpan<float> v)
+            public static unsafe void Color4fNormal3fVertex3fvSUN(in Color4<Rgba> c, ReadOnlySpan<float> n, ReadOnlySpan<float> v)
             {
-                fixed (float* c_ptr = c)
+                fixed (float* n_ptr = n)
                 {
-                    fixed (float* n_ptr = n)
+                    fixed (float* v_ptr = v)
                     {
-                        fixed (float* v_ptr = v)
+                        fixed (Color4<Rgba>* tmp_c = &c)
                         {
+                            float* c_ptr = (float*)tmp_c;
                             Color4fNormal3fVertex3fvSUN(c_ptr, n_ptr, v_ptr);
                         }
                     }
                 }
             }
             /// <inheritdoc cref="Color4fNormal3fVertex3fvSUN"/>
-            public static unsafe void Color4fNormal3fVertex3fvSUN(float[] c, float[] n, float[] v)
+            public static unsafe void Color4fNormal3fVertex3fvSUN(in Color4<Rgba> c, float[] n, float[] v)
             {
-                fixed (float* c_ptr = c)
+                fixed (float* n_ptr = n)
                 {
-                    fixed (float* n_ptr = n)
+                    fixed (float* v_ptr = v)
                     {
-                        fixed (float* v_ptr = v)
+                        fixed (Color4<Rgba>* tmp_c = &c)
                         {
+                            float* c_ptr = (float*)tmp_c;
                             Color4fNormal3fVertex3fvSUN(c_ptr, n_ptr, v_ptr);
                         }
                     }
                 }
             }
             /// <inheritdoc cref="Color4fNormal3fVertex3fvSUN"/>
-            public static unsafe void Color4fNormal3fVertex3fvSUN(in float c, in float n, in float v)
+            public static unsafe void Color4fNormal3fVertex3fvSUN(in Color4<Rgba> c, in float n, in float v)
             {
-                fixed (float* c_ptr = &c)
                 fixed (float* n_ptr = &n)
                 fixed (float* v_ptr = &v)
                 {
-                    Color4fNormal3fVertex3fvSUN(c_ptr, n_ptr, v_ptr);
+                    fixed (Color4<Rgba>* tmp_c = &c)
+                    {
+                        float* c_ptr = (float*)tmp_c;
+                        Color4fNormal3fVertex3fvSUN(c_ptr, n_ptr, v_ptr);
+                    }
                 }
             }
             /// <inheritdoc cref="TexCoord2fVertex3fvSUN"/>
@@ -49380,41 +49375,46 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="TexCoord2fColor3fVertex3fvSUN"/>
-            public static unsafe void TexCoord2fColor3fVertex3fvSUN(ReadOnlySpan<float> tc, ReadOnlySpan<float> c, ReadOnlySpan<float> v)
+            public static unsafe void TexCoord2fColor3fVertex3fvSUN(ReadOnlySpan<float> tc, in Color3<Rgb> c, ReadOnlySpan<float> v)
             {
                 fixed (float* tc_ptr = tc)
                 {
-                    fixed (float* c_ptr = c)
+                    fixed (float* v_ptr = v)
                     {
-                        fixed (float* v_ptr = v)
+                        fixed (Color3<Rgb>* tmp_c = &c)
                         {
+                            float* c_ptr = (float*)tmp_c;
                             TexCoord2fColor3fVertex3fvSUN(tc_ptr, c_ptr, v_ptr);
                         }
                     }
                 }
             }
             /// <inheritdoc cref="TexCoord2fColor3fVertex3fvSUN"/>
-            public static unsafe void TexCoord2fColor3fVertex3fvSUN(float[] tc, float[] c, float[] v)
+            public static unsafe void TexCoord2fColor3fVertex3fvSUN(float[] tc, in Color3<Rgb> c, float[] v)
             {
                 fixed (float* tc_ptr = tc)
                 {
-                    fixed (float* c_ptr = c)
+                    fixed (float* v_ptr = v)
                     {
-                        fixed (float* v_ptr = v)
+                        fixed (Color3<Rgb>* tmp_c = &c)
                         {
+                            float* c_ptr = (float*)tmp_c;
                             TexCoord2fColor3fVertex3fvSUN(tc_ptr, c_ptr, v_ptr);
                         }
                     }
                 }
             }
             /// <inheritdoc cref="TexCoord2fColor3fVertex3fvSUN"/>
-            public static unsafe void TexCoord2fColor3fVertex3fvSUN(in float tc, in float c, in float v)
+            public static unsafe void TexCoord2fColor3fVertex3fvSUN(in float tc, in Color3<Rgb> c, in float v)
             {
                 fixed (float* tc_ptr = &tc)
-                fixed (float* c_ptr = &c)
                 fixed (float* v_ptr = &v)
                 {
-                    TexCoord2fColor3fVertex3fvSUN(tc_ptr, c_ptr, v_ptr);
+                    fixed (Color3<Rgb>* tmp_c = &c)
+                    {
+                        float* c_ptr = (float*)tmp_c;
+                        TexCoord2fColor3fVertex3fvSUN(tc_ptr, c_ptr, v_ptr);
+                    }
                 }
             }
             /// <inheritdoc cref="TexCoord2fNormal3fVertex3fvSUN"/>
@@ -49456,16 +49456,17 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="TexCoord2fColor4fNormal3fVertex3fvSUN"/>
-            public static unsafe void TexCoord2fColor4fNormal3fVertex3fvSUN(ReadOnlySpan<float> tc, ReadOnlySpan<float> c, ReadOnlySpan<float> n, ReadOnlySpan<float> v)
+            public static unsafe void TexCoord2fColor4fNormal3fVertex3fvSUN(ReadOnlySpan<float> tc, in Color4<Rgba> c, ReadOnlySpan<float> n, ReadOnlySpan<float> v)
             {
                 fixed (float* tc_ptr = tc)
                 {
-                    fixed (float* c_ptr = c)
+                    fixed (float* n_ptr = n)
                     {
-                        fixed (float* n_ptr = n)
+                        fixed (float* v_ptr = v)
                         {
-                            fixed (float* v_ptr = v)
+                            fixed (Color4<Rgba>* tmp_c = &c)
                             {
+                                float* c_ptr = (float*)tmp_c;
                                 TexCoord2fColor4fNormal3fVertex3fvSUN(tc_ptr, c_ptr, n_ptr, v_ptr);
                             }
                         }
@@ -49473,16 +49474,17 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="TexCoord2fColor4fNormal3fVertex3fvSUN"/>
-            public static unsafe void TexCoord2fColor4fNormal3fVertex3fvSUN(float[] tc, float[] c, float[] n, float[] v)
+            public static unsafe void TexCoord2fColor4fNormal3fVertex3fvSUN(float[] tc, in Color4<Rgba> c, float[] n, float[] v)
             {
                 fixed (float* tc_ptr = tc)
                 {
-                    fixed (float* c_ptr = c)
+                    fixed (float* n_ptr = n)
                     {
-                        fixed (float* n_ptr = n)
+                        fixed (float* v_ptr = v)
                         {
-                            fixed (float* v_ptr = v)
+                            fixed (Color4<Rgba>* tmp_c = &c)
                             {
+                                float* c_ptr = (float*)tmp_c;
                                 TexCoord2fColor4fNormal3fVertex3fvSUN(tc_ptr, c_ptr, n_ptr, v_ptr);
                             }
                         }
@@ -49490,27 +49492,31 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="TexCoord2fColor4fNormal3fVertex3fvSUN"/>
-            public static unsafe void TexCoord2fColor4fNormal3fVertex3fvSUN(in float tc, in float c, in float n, in float v)
+            public static unsafe void TexCoord2fColor4fNormal3fVertex3fvSUN(in float tc, in Color4<Rgba> c, in float n, in float v)
             {
                 fixed (float* tc_ptr = &tc)
-                fixed (float* c_ptr = &c)
                 fixed (float* n_ptr = &n)
                 fixed (float* v_ptr = &v)
                 {
-                    TexCoord2fColor4fNormal3fVertex3fvSUN(tc_ptr, c_ptr, n_ptr, v_ptr);
+                    fixed (Color4<Rgba>* tmp_c = &c)
+                    {
+                        float* c_ptr = (float*)tmp_c;
+                        TexCoord2fColor4fNormal3fVertex3fvSUN(tc_ptr, c_ptr, n_ptr, v_ptr);
+                    }
                 }
             }
             /// <inheritdoc cref="TexCoord4fColor4fNormal3fVertex4fvSUN"/>
-            public static unsafe void TexCoord4fColor4fNormal3fVertex4fvSUN(ReadOnlySpan<float> tc, ReadOnlySpan<float> c, ReadOnlySpan<float> n, ReadOnlySpan<float> v)
+            public static unsafe void TexCoord4fColor4fNormal3fVertex4fvSUN(ReadOnlySpan<float> tc, in Color4<Rgba> c, ReadOnlySpan<float> n, ReadOnlySpan<float> v)
             {
                 fixed (float* tc_ptr = tc)
                 {
-                    fixed (float* c_ptr = c)
+                    fixed (float* n_ptr = n)
                     {
-                        fixed (float* n_ptr = n)
+                        fixed (float* v_ptr = v)
                         {
-                            fixed (float* v_ptr = v)
+                            fixed (Color4<Rgba>* tmp_c = &c)
                             {
+                                float* c_ptr = (float*)tmp_c;
                                 TexCoord4fColor4fNormal3fVertex4fvSUN(tc_ptr, c_ptr, n_ptr, v_ptr);
                             }
                         }
@@ -49518,16 +49524,17 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="TexCoord4fColor4fNormal3fVertex4fvSUN"/>
-            public static unsafe void TexCoord4fColor4fNormal3fVertex4fvSUN(float[] tc, float[] c, float[] n, float[] v)
+            public static unsafe void TexCoord4fColor4fNormal3fVertex4fvSUN(float[] tc, in Color4<Rgba> c, float[] n, float[] v)
             {
                 fixed (float* tc_ptr = tc)
                 {
-                    fixed (float* c_ptr = c)
+                    fixed (float* n_ptr = n)
                     {
-                        fixed (float* n_ptr = n)
+                        fixed (float* v_ptr = v)
                         {
-                            fixed (float* v_ptr = v)
+                            fixed (Color4<Rgba>* tmp_c = &c)
                             {
+                                float* c_ptr = (float*)tmp_c;
                                 TexCoord4fColor4fNormal3fVertex4fvSUN(tc_ptr, c_ptr, n_ptr, v_ptr);
                             }
                         }
@@ -49535,14 +49542,17 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="TexCoord4fColor4fNormal3fVertex4fvSUN"/>
-            public static unsafe void TexCoord4fColor4fNormal3fVertex4fvSUN(in float tc, in float c, in float n, in float v)
+            public static unsafe void TexCoord4fColor4fNormal3fVertex4fvSUN(in float tc, in Color4<Rgba> c, in float n, in float v)
             {
                 fixed (float* tc_ptr = &tc)
-                fixed (float* c_ptr = &c)
                 fixed (float* n_ptr = &n)
                 fixed (float* v_ptr = &v)
                 {
-                    TexCoord4fColor4fNormal3fVertex4fvSUN(tc_ptr, c_ptr, n_ptr, v_ptr);
+                    fixed (Color4<Rgba>* tmp_c = &c)
+                    {
+                        float* c_ptr = (float*)tmp_c;
+                        TexCoord4fColor4fNormal3fVertex4fvSUN(tc_ptr, c_ptr, n_ptr, v_ptr);
+                    }
                 }
             }
             /// <inheritdoc cref="ReplacementCodeuiVertex3fvSUN"/>
@@ -49615,41 +49625,46 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ReplacementCodeuiColor3fVertex3fvSUN"/>
-            public static unsafe void ReplacementCodeuiColor3fVertex3fvSUN(ReadOnlySpan<TriangleListSUN> rc, ReadOnlySpan<float> c, ReadOnlySpan<float> v)
+            public static unsafe void ReplacementCodeuiColor3fVertex3fvSUN(ReadOnlySpan<TriangleListSUN> rc, in Color3<Rgb> c, ReadOnlySpan<float> v)
             {
                 fixed (TriangleListSUN* rc_ptr = rc)
                 {
-                    fixed (float* c_ptr = c)
+                    fixed (float* v_ptr = v)
                     {
-                        fixed (float* v_ptr = v)
+                        fixed (Color3<Rgb>* tmp_c = &c)
                         {
+                            float* c_ptr = (float*)tmp_c;
                             ReplacementCodeuiColor3fVertex3fvSUN(rc_ptr, c_ptr, v_ptr);
                         }
                     }
                 }
             }
             /// <inheritdoc cref="ReplacementCodeuiColor3fVertex3fvSUN"/>
-            public static unsafe void ReplacementCodeuiColor3fVertex3fvSUN(TriangleListSUN[] rc, float[] c, float[] v)
+            public static unsafe void ReplacementCodeuiColor3fVertex3fvSUN(TriangleListSUN[] rc, in Color3<Rgb> c, float[] v)
             {
                 fixed (TriangleListSUN* rc_ptr = rc)
                 {
-                    fixed (float* c_ptr = c)
+                    fixed (float* v_ptr = v)
                     {
-                        fixed (float* v_ptr = v)
+                        fixed (Color3<Rgb>* tmp_c = &c)
                         {
+                            float* c_ptr = (float*)tmp_c;
                             ReplacementCodeuiColor3fVertex3fvSUN(rc_ptr, c_ptr, v_ptr);
                         }
                     }
                 }
             }
             /// <inheritdoc cref="ReplacementCodeuiColor3fVertex3fvSUN"/>
-            public static unsafe void ReplacementCodeuiColor3fVertex3fvSUN(in TriangleListSUN rc, in float c, in float v)
+            public static unsafe void ReplacementCodeuiColor3fVertex3fvSUN(in TriangleListSUN rc, in Color3<Rgb> c, in float v)
             {
                 fixed (TriangleListSUN* rc_ptr = &rc)
-                fixed (float* c_ptr = &c)
                 fixed (float* v_ptr = &v)
                 {
-                    ReplacementCodeuiColor3fVertex3fvSUN(rc_ptr, c_ptr, v_ptr);
+                    fixed (Color3<Rgb>* tmp_c = &c)
+                    {
+                        float* c_ptr = (float*)tmp_c;
+                        ReplacementCodeuiColor3fVertex3fvSUN(rc_ptr, c_ptr, v_ptr);
+                    }
                 }
             }
             /// <inheritdoc cref="ReplacementCodeuiNormal3fVertex3fvSUN"/>
@@ -49691,16 +49706,17 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ReplacementCodeuiColor4fNormal3fVertex3fvSUN"/>
-            public static unsafe void ReplacementCodeuiColor4fNormal3fVertex3fvSUN(ReadOnlySpan<TriangleListSUN> rc, ReadOnlySpan<float> c, ReadOnlySpan<float> n, ReadOnlySpan<float> v)
+            public static unsafe void ReplacementCodeuiColor4fNormal3fVertex3fvSUN(ReadOnlySpan<TriangleListSUN> rc, in Color4<Rgba> c, ReadOnlySpan<float> n, ReadOnlySpan<float> v)
             {
                 fixed (TriangleListSUN* rc_ptr = rc)
                 {
-                    fixed (float* c_ptr = c)
+                    fixed (float* n_ptr = n)
                     {
-                        fixed (float* n_ptr = n)
+                        fixed (float* v_ptr = v)
                         {
-                            fixed (float* v_ptr = v)
+                            fixed (Color4<Rgba>* tmp_c = &c)
                             {
+                                float* c_ptr = (float*)tmp_c;
                                 ReplacementCodeuiColor4fNormal3fVertex3fvSUN(rc_ptr, c_ptr, n_ptr, v_ptr);
                             }
                         }
@@ -49708,16 +49724,17 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ReplacementCodeuiColor4fNormal3fVertex3fvSUN"/>
-            public static unsafe void ReplacementCodeuiColor4fNormal3fVertex3fvSUN(TriangleListSUN[] rc, float[] c, float[] n, float[] v)
+            public static unsafe void ReplacementCodeuiColor4fNormal3fVertex3fvSUN(TriangleListSUN[] rc, in Color4<Rgba> c, float[] n, float[] v)
             {
                 fixed (TriangleListSUN* rc_ptr = rc)
                 {
-                    fixed (float* c_ptr = c)
+                    fixed (float* n_ptr = n)
                     {
-                        fixed (float* n_ptr = n)
+                        fixed (float* v_ptr = v)
                         {
-                            fixed (float* v_ptr = v)
+                            fixed (Color4<Rgba>* tmp_c = &c)
                             {
+                                float* c_ptr = (float*)tmp_c;
                                 ReplacementCodeuiColor4fNormal3fVertex3fvSUN(rc_ptr, c_ptr, n_ptr, v_ptr);
                             }
                         }
@@ -49725,14 +49742,17 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ReplacementCodeuiColor4fNormal3fVertex3fvSUN"/>
-            public static unsafe void ReplacementCodeuiColor4fNormal3fVertex3fvSUN(in TriangleListSUN rc, in float c, in float n, in float v)
+            public static unsafe void ReplacementCodeuiColor4fNormal3fVertex3fvSUN(in TriangleListSUN rc, in Color4<Rgba> c, in float n, in float v)
             {
                 fixed (TriangleListSUN* rc_ptr = &rc)
-                fixed (float* c_ptr = &c)
                 fixed (float* n_ptr = &n)
                 fixed (float* v_ptr = &v)
                 {
-                    ReplacementCodeuiColor4fNormal3fVertex3fvSUN(rc_ptr, c_ptr, n_ptr, v_ptr);
+                    fixed (Color4<Rgba>* tmp_c = &c)
+                    {
+                        float* c_ptr = (float*)tmp_c;
+                        ReplacementCodeuiColor4fNormal3fVertex3fvSUN(rc_ptr, c_ptr, n_ptr, v_ptr);
+                    }
                 }
             }
             /// <inheritdoc cref="ReplacementCodeuiTexCoord2fVertex3fvSUN"/>
@@ -49819,18 +49839,19 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ReplacementCodeuiTexCoord2fColor4fNormal3fVertex3fvSUN"/>
-            public static unsafe void ReplacementCodeuiTexCoord2fColor4fNormal3fVertex3fvSUN(ReadOnlySpan<TriangleListSUN> rc, ReadOnlySpan<float> tc, ReadOnlySpan<float> c, ReadOnlySpan<float> n, ReadOnlySpan<float> v)
+            public static unsafe void ReplacementCodeuiTexCoord2fColor4fNormal3fVertex3fvSUN(ReadOnlySpan<TriangleListSUN> rc, ReadOnlySpan<float> tc, in Color4<Rgba> c, ReadOnlySpan<float> n, ReadOnlySpan<float> v)
             {
                 fixed (TriangleListSUN* rc_ptr = rc)
                 {
                     fixed (float* tc_ptr = tc)
                     {
-                        fixed (float* c_ptr = c)
+                        fixed (float* n_ptr = n)
                         {
-                            fixed (float* n_ptr = n)
+                            fixed (float* v_ptr = v)
                             {
-                                fixed (float* v_ptr = v)
+                                fixed (Color4<Rgba>* tmp_c = &c)
                                 {
+                                    float* c_ptr = (float*)tmp_c;
                                     ReplacementCodeuiTexCoord2fColor4fNormal3fVertex3fvSUN(rc_ptr, tc_ptr, c_ptr, n_ptr, v_ptr);
                                 }
                             }
@@ -49839,18 +49860,19 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ReplacementCodeuiTexCoord2fColor4fNormal3fVertex3fvSUN"/>
-            public static unsafe void ReplacementCodeuiTexCoord2fColor4fNormal3fVertex3fvSUN(TriangleListSUN[] rc, float[] tc, float[] c, float[] n, float[] v)
+            public static unsafe void ReplacementCodeuiTexCoord2fColor4fNormal3fVertex3fvSUN(TriangleListSUN[] rc, float[] tc, in Color4<Rgba> c, float[] n, float[] v)
             {
                 fixed (TriangleListSUN* rc_ptr = rc)
                 {
                     fixed (float* tc_ptr = tc)
                     {
-                        fixed (float* c_ptr = c)
+                        fixed (float* n_ptr = n)
                         {
-                            fixed (float* n_ptr = n)
+                            fixed (float* v_ptr = v)
                             {
-                                fixed (float* v_ptr = v)
+                                fixed (Color4<Rgba>* tmp_c = &c)
                                 {
+                                    float* c_ptr = (float*)tmp_c;
                                     ReplacementCodeuiTexCoord2fColor4fNormal3fVertex3fvSUN(rc_ptr, tc_ptr, c_ptr, n_ptr, v_ptr);
                                 }
                             }
@@ -49859,15 +49881,18 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ReplacementCodeuiTexCoord2fColor4fNormal3fVertex3fvSUN"/>
-            public static unsafe void ReplacementCodeuiTexCoord2fColor4fNormal3fVertex3fvSUN(in TriangleListSUN rc, in float tc, in float c, in float n, in float v)
+            public static unsafe void ReplacementCodeuiTexCoord2fColor4fNormal3fVertex3fvSUN(in TriangleListSUN rc, in float tc, in Color4<Rgba> c, in float n, in float v)
             {
                 fixed (TriangleListSUN* rc_ptr = &rc)
                 fixed (float* tc_ptr = &tc)
-                fixed (float* c_ptr = &c)
                 fixed (float* n_ptr = &n)
                 fixed (float* v_ptr = &v)
                 {
-                    ReplacementCodeuiTexCoord2fColor4fNormal3fVertex3fvSUN(rc_ptr, tc_ptr, c_ptr, n_ptr, v_ptr);
+                    fixed (Color4<Rgba>* tmp_c = &c)
+                    {
+                        float* c_ptr = (float*)tmp_c;
+                        ReplacementCodeuiTexCoord2fColor4fNormal3fVertex3fvSUN(rc_ptr, tc_ptr, c_ptr, n_ptr, v_ptr);
+                    }
                 }
             }
         }

--- a/src/OpenTK.Graphics/OpenGL/GL.Overloads.cs
+++ b/src/OpenTK.Graphics/OpenGL/GL.Overloads.cs
@@ -2070,9 +2070,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="Uniform1fv"/>
-        public static unsafe void Uniform1f(int location, in float value)
+        public static unsafe void Uniform1f(int location, int count, in float value)
         {
-            int count = 1;
             fixed (float* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -2098,9 +2097,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="Uniform2fv"/>
-        public static unsafe void Uniform2f(int location, in Vector2 value)
+        public static unsafe void Uniform2f(int location, int count, in Vector2 value)
         {
-            int count = 1;
             fixed (Vector2* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -2126,9 +2124,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="Uniform2fv"/>
-        public static unsafe void Uniform2f(int location, in System.Numerics.Vector2 value)
+        public static unsafe void Uniform2f(int location, int count, in System.Numerics.Vector2 value)
         {
-            int count = 1;
             fixed (System.Numerics.Vector2* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -2154,9 +2151,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="Uniform3fv"/>
-        public static unsafe void Uniform3f(int location, in Vector3 value)
+        public static unsafe void Uniform3f(int location, int count, in Vector3 value)
         {
-            int count = 1;
             fixed (Vector3* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -2182,9 +2178,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="Uniform3fv"/>
-        public static unsafe void Uniform3f(int location, in System.Numerics.Vector3 value)
+        public static unsafe void Uniform3f(int location, int count, in System.Numerics.Vector3 value)
         {
-            int count = 1;
             fixed (System.Numerics.Vector3* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -2210,9 +2205,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="Uniform4fv"/>
-        public static unsafe void Uniform4f(int location, in Vector4 value)
+        public static unsafe void Uniform4f(int location, int count, in Vector4 value)
         {
-            int count = 1;
             fixed (Vector4* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -2238,9 +2232,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="Uniform4fv"/>
-        public static unsafe void Uniform4f(int location, in System.Numerics.Vector4 value)
+        public static unsafe void Uniform4f(int location, int count, in System.Numerics.Vector4 value)
         {
-            int count = 1;
             fixed (System.Numerics.Vector4* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -2266,9 +2259,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="Uniform1iv"/>
-        public static unsafe void Uniform1i(int location, in int value)
+        public static unsafe void Uniform1i(int location, int count, in int value)
         {
-            int count = 1;
             fixed (int* tmp_vecPtr = &value)
             {
                 int* value_ptr = (int*)tmp_vecPtr;
@@ -2294,9 +2286,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="Uniform2iv"/>
-        public static unsafe void Uniform2i(int location, in Vector2i value)
+        public static unsafe void Uniform2i(int location, int count, in Vector2i value)
         {
-            int count = 1;
             fixed (Vector2i* tmp_vecPtr = &value)
             {
                 int* value_ptr = (int*)tmp_vecPtr;
@@ -2322,9 +2313,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="Uniform3iv"/>
-        public static unsafe void Uniform3i(int location, in Vector3i value)
+        public static unsafe void Uniform3i(int location, int count, in Vector3i value)
         {
-            int count = 1;
             fixed (Vector3i* tmp_vecPtr = &value)
             {
                 int* value_ptr = (int*)tmp_vecPtr;
@@ -2350,9 +2340,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="Uniform4iv"/>
-        public static unsafe void Uniform4i(int location, in Vector4i value)
+        public static unsafe void Uniform4i(int location, int count, in Vector4i value)
         {
-            int count = 1;
             fixed (Vector4i* tmp_vecPtr = &value)
             {
                 int* value_ptr = (int*)tmp_vecPtr;
@@ -2378,9 +2367,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="UniformMatrix2fv"/>
-        public static unsafe void UniformMatrix2f(int location, bool transpose, in Matrix2 value)
+        public static unsafe void UniformMatrix2f(int location, int count, bool transpose, in Matrix2 value)
         {
-            int count = 1;
             fixed (Matrix2* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -2406,9 +2394,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="UniformMatrix3fv"/>
-        public static unsafe void UniformMatrix3f(int location, bool transpose, in Matrix3 value)
+        public static unsafe void UniformMatrix3f(int location, int count, bool transpose, in Matrix3 value)
         {
-            int count = 1;
             fixed (Matrix3* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -2434,9 +2421,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="UniformMatrix4fv"/>
-        public static unsafe void UniformMatrix4f(int location, bool transpose, in Matrix4 value)
+        public static unsafe void UniformMatrix4f(int location, int count, bool transpose, in Matrix4 value)
         {
-            int count = 1;
             fixed (Matrix4* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -2462,9 +2448,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="UniformMatrix4fv"/>
-        public static unsafe void UniformMatrix4f(int location, bool transpose, in System.Numerics.Matrix4x4 value)
+        public static unsafe void UniformMatrix4f(int location, int count, bool transpose, in System.Numerics.Matrix4x4 value)
         {
-            int count = 1;
             fixed (System.Numerics.Matrix4x4* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -2490,50 +2475,20 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="VertexAttrib1dv"/>
-        public static unsafe void VertexAttrib1dv(uint index, ReadOnlySpan<double> v)
+        public static unsafe void VertexAttrib1d(uint index, in double v)
         {
-            fixed (double* v_ptr = v)
+            fixed (double* tmp_vecPtr = &v)
             {
-                VertexAttrib1dv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttrib1dv"/>
-        public static unsafe void VertexAttrib1dv(uint index, double[] v)
-        {
-            fixed (double* v_ptr = v)
-            {
-                VertexAttrib1dv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttrib1dv"/>
-        public static unsafe void VertexAttrib1dv(uint index, in double v)
-        {
-            fixed (double* v_ptr = &v)
-            {
+                double* v_ptr = (double*)tmp_vecPtr;
                 VertexAttrib1dv(index, v_ptr);
             }
         }
         /// <inheritdoc cref="VertexAttrib1fv"/>
-        public static unsafe void VertexAttrib1fv(uint index, ReadOnlySpan<float> v)
+        public static unsafe void VertexAttrib1f(uint index, in float v)
         {
-            fixed (float* v_ptr = v)
+            fixed (float* tmp_vecPtr = &v)
             {
-                VertexAttrib1fv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttrib1fv"/>
-        public static unsafe void VertexAttrib1fv(uint index, float[] v)
-        {
-            fixed (float* v_ptr = v)
-            {
-                VertexAttrib1fv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttrib1fv"/>
-        public static unsafe void VertexAttrib1fv(uint index, in float v)
-        {
-            fixed (float* v_ptr = &v)
-            {
+                float* v_ptr = (float*)tmp_vecPtr;
                 VertexAttrib1fv(index, v_ptr);
             }
         }
@@ -2567,50 +2522,29 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="VertexAttrib2dv"/>
-        public static unsafe void VertexAttrib2dv(uint index, ReadOnlySpan<double> v)
+        public static unsafe void VertexAttrib2d(uint index, in Vector2d v)
         {
-            fixed (double* v_ptr = v)
+            fixed (Vector2d* tmp_vecPtr = &v)
             {
-                VertexAttrib2dv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttrib2dv"/>
-        public static unsafe void VertexAttrib2dv(uint index, double[] v)
-        {
-            fixed (double* v_ptr = v)
-            {
-                VertexAttrib2dv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttrib2dv"/>
-        public static unsafe void VertexAttrib2dv(uint index, in double v)
-        {
-            fixed (double* v_ptr = &v)
-            {
+                double* v_ptr = (double*)tmp_vecPtr;
                 VertexAttrib2dv(index, v_ptr);
             }
         }
         /// <inheritdoc cref="VertexAttrib2fv"/>
-        public static unsafe void VertexAttrib2fv(uint index, ReadOnlySpan<float> v)
+        public static unsafe void VertexAttrib2f(uint index, in Vector2 v)
         {
-            fixed (float* v_ptr = v)
+            fixed (Vector2* tmp_vecPtr = &v)
             {
+                float* v_ptr = (float*)tmp_vecPtr;
                 VertexAttrib2fv(index, v_ptr);
             }
         }
         /// <inheritdoc cref="VertexAttrib2fv"/>
-        public static unsafe void VertexAttrib2fv(uint index, float[] v)
+        public static unsafe void VertexAttrib2f(uint index, in System.Numerics.Vector2 v)
         {
-            fixed (float* v_ptr = v)
+            fixed (System.Numerics.Vector2* tmp_vecPtr = &v)
             {
-                VertexAttrib2fv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttrib2fv"/>
-        public static unsafe void VertexAttrib2fv(uint index, in float v)
-        {
-            fixed (float* v_ptr = &v)
-            {
+                float* v_ptr = (float*)tmp_vecPtr;
                 VertexAttrib2fv(index, v_ptr);
             }
         }
@@ -2644,50 +2578,29 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="VertexAttrib3dv"/>
-        public static unsafe void VertexAttrib3dv(uint index, ReadOnlySpan<double> v)
+        public static unsafe void VertexAttrib3d(uint index, in Vector3d v)
         {
-            fixed (double* v_ptr = v)
+            fixed (Vector3d* tmp_vecPtr = &v)
             {
-                VertexAttrib3dv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttrib3dv"/>
-        public static unsafe void VertexAttrib3dv(uint index, double[] v)
-        {
-            fixed (double* v_ptr = v)
-            {
-                VertexAttrib3dv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttrib3dv"/>
-        public static unsafe void VertexAttrib3dv(uint index, in double v)
-        {
-            fixed (double* v_ptr = &v)
-            {
+                double* v_ptr = (double*)tmp_vecPtr;
                 VertexAttrib3dv(index, v_ptr);
             }
         }
         /// <inheritdoc cref="VertexAttrib3fv"/>
-        public static unsafe void VertexAttrib3fv(uint index, ReadOnlySpan<float> v)
+        public static unsafe void VertexAttrib3f(uint index, in Vector3 v)
         {
-            fixed (float* v_ptr = v)
+            fixed (Vector3* tmp_vecPtr = &v)
             {
+                float* v_ptr = (float*)tmp_vecPtr;
                 VertexAttrib3fv(index, v_ptr);
             }
         }
         /// <inheritdoc cref="VertexAttrib3fv"/>
-        public static unsafe void VertexAttrib3fv(uint index, float[] v)
+        public static unsafe void VertexAttrib3f(uint index, in System.Numerics.Vector3 v)
         {
-            fixed (float* v_ptr = v)
+            fixed (System.Numerics.Vector3* tmp_vecPtr = &v)
             {
-                VertexAttrib3fv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttrib3fv"/>
-        public static unsafe void VertexAttrib3fv(uint index, in float v)
-        {
-            fixed (float* v_ptr = &v)
-            {
+                float* v_ptr = (float*)tmp_vecPtr;
                 VertexAttrib3fv(index, v_ptr);
             }
         }
@@ -2894,74 +2807,38 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="VertexAttrib4dv"/>
-        public static unsafe void VertexAttrib4dv(uint index, ReadOnlySpan<double> v)
+        public static unsafe void VertexAttrib4d(uint index, in Vector4d v)
         {
-            fixed (double* v_ptr = v)
+            fixed (Vector4d* tmp_vecPtr = &v)
             {
-                VertexAttrib4dv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttrib4dv"/>
-        public static unsafe void VertexAttrib4dv(uint index, double[] v)
-        {
-            fixed (double* v_ptr = v)
-            {
-                VertexAttrib4dv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttrib4dv"/>
-        public static unsafe void VertexAttrib4dv(uint index, in double v)
-        {
-            fixed (double* v_ptr = &v)
-            {
+                double* v_ptr = (double*)tmp_vecPtr;
                 VertexAttrib4dv(index, v_ptr);
             }
         }
         /// <inheritdoc cref="VertexAttrib4fv"/>
-        public static unsafe void VertexAttrib4fv(uint index, ReadOnlySpan<float> v)
+        public static unsafe void VertexAttrib4f(uint index, in Vector4 v)
         {
-            fixed (float* v_ptr = v)
+            fixed (Vector4* tmp_vecPtr = &v)
             {
+                float* v_ptr = (float*)tmp_vecPtr;
                 VertexAttrib4fv(index, v_ptr);
             }
         }
         /// <inheritdoc cref="VertexAttrib4fv"/>
-        public static unsafe void VertexAttrib4fv(uint index, float[] v)
+        public static unsafe void VertexAttrib4f(uint index, in System.Numerics.Vector4 v)
         {
-            fixed (float* v_ptr = v)
+            fixed (System.Numerics.Vector4* tmp_vecPtr = &v)
             {
-                VertexAttrib4fv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttrib4fv"/>
-        public static unsafe void VertexAttrib4fv(uint index, in float v)
-        {
-            fixed (float* v_ptr = &v)
-            {
+                float* v_ptr = (float*)tmp_vecPtr;
                 VertexAttrib4fv(index, v_ptr);
             }
         }
         /// <inheritdoc cref="VertexAttrib4iv"/>
-        public static unsafe void VertexAttrib4iv(uint index, ReadOnlySpan<int> v)
+        public static unsafe void VertexAttrib4i(uint index, in Vector4i v)
         {
-            fixed (int* v_ptr = v)
+            fixed (Vector4i* tmp_vecPtr = &v)
             {
-                VertexAttrib4iv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttrib4iv"/>
-        public static unsafe void VertexAttrib4iv(uint index, int[] v)
-        {
-            fixed (int* v_ptr = v)
-            {
-                VertexAttrib4iv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttrib4iv"/>
-        public static unsafe void VertexAttrib4iv(uint index, in int v)
-        {
-            fixed (int* v_ptr = &v)
-            {
+                int* v_ptr = (int*)tmp_vecPtr;
                 VertexAttrib4iv(index, v_ptr);
             }
         }
@@ -3073,9 +2950,8 @@ namespace OpenTK.Graphics.OpenGL
             VertexAttribPointer(index, size, type, normalized, stride, pointer);
         }
         /// <inheritdoc cref="UniformMatrix2x3fv"/>
-        public static unsafe void UniformMatrix2x3f(int location, bool transpose, in Matrix2x3 value)
+        public static unsafe void UniformMatrix2x3f(int location, int count, bool transpose, in Matrix2x3 value)
         {
-            int count = 1;
             fixed (Matrix2x3* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -3101,9 +2977,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="UniformMatrix3x2fv"/>
-        public static unsafe void UniformMatrix3x2f(int location, bool transpose, in Matrix3x2 value)
+        public static unsafe void UniformMatrix3x2f(int location, int count, bool transpose, in Matrix3x2 value)
         {
-            int count = 1;
             fixed (Matrix3x2* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -3129,9 +3004,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="UniformMatrix3x2fv"/>
-        public static unsafe void UniformMatrix3x2f(int location, bool transpose, in System.Numerics.Matrix3x2 value)
+        public static unsafe void UniformMatrix3x2f(int location, int count, bool transpose, in System.Numerics.Matrix3x2 value)
         {
-            int count = 1;
             fixed (System.Numerics.Matrix3x2* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -3157,9 +3031,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="UniformMatrix2x4fv"/>
-        public static unsafe void UniformMatrix2x4f(int location, bool transpose, in Matrix2x4 value)
+        public static unsafe void UniformMatrix2x4f(int location, int count, bool transpose, in Matrix2x4 value)
         {
-            int count = 1;
             fixed (Matrix2x4* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -3185,9 +3058,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="UniformMatrix4x2fv"/>
-        public static unsafe void UniformMatrix4x2f(int location, bool transpose, in Matrix4x2 value)
+        public static unsafe void UniformMatrix4x2f(int location, int count, bool transpose, in Matrix4x2 value)
         {
-            int count = 1;
             fixed (Matrix4x2* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -3213,9 +3085,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="UniformMatrix3x4fv"/>
-        public static unsafe void UniformMatrix3x4f(int location, bool transpose, in Matrix3x4 value)
+        public static unsafe void UniformMatrix3x4f(int location, int count, bool transpose, in Matrix3x4 value)
         {
-            int count = 1;
             fixed (Matrix3x4* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -3241,9 +3112,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="UniformMatrix4x3fv"/>
-        public static unsafe void UniformMatrix4x3f(int location, bool transpose, in Matrix4x3 value)
+        public static unsafe void UniformMatrix4x3f(int location, int count, bool transpose, in Matrix4x3 value)
         {
-            int count = 1;
             fixed (Matrix4x3* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -3471,98 +3341,38 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="VertexAttribI1iv"/>
-        public static unsafe void VertexAttribI1iv(uint index, ReadOnlySpan<int> v)
+        public static unsafe void VertexAttribI1i(uint index, in int v)
         {
-            fixed (int* v_ptr = v)
+            fixed (int* tmp_vecPtr = &v)
             {
-                VertexAttribI1iv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttribI1iv"/>
-        public static unsafe void VertexAttribI1iv(uint index, int[] v)
-        {
-            fixed (int* v_ptr = v)
-            {
-                VertexAttribI1iv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttribI1iv"/>
-        public static unsafe void VertexAttribI1iv(uint index, in int v)
-        {
-            fixed (int* v_ptr = &v)
-            {
+                int* v_ptr = (int*)tmp_vecPtr;
                 VertexAttribI1iv(index, v_ptr);
             }
         }
         /// <inheritdoc cref="VertexAttribI2iv"/>
-        public static unsafe void VertexAttribI2iv(uint index, ReadOnlySpan<int> v)
+        public static unsafe void VertexAttribI2i(uint index, in Vector2i v)
         {
-            fixed (int* v_ptr = v)
+            fixed (Vector2i* tmp_vecPtr = &v)
             {
-                VertexAttribI2iv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttribI2iv"/>
-        public static unsafe void VertexAttribI2iv(uint index, int[] v)
-        {
-            fixed (int* v_ptr = v)
-            {
-                VertexAttribI2iv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttribI2iv"/>
-        public static unsafe void VertexAttribI2iv(uint index, in int v)
-        {
-            fixed (int* v_ptr = &v)
-            {
+                int* v_ptr = (int*)tmp_vecPtr;
                 VertexAttribI2iv(index, v_ptr);
             }
         }
         /// <inheritdoc cref="VertexAttribI3iv"/>
-        public static unsafe void VertexAttribI3iv(uint index, ReadOnlySpan<int> v)
+        public static unsafe void VertexAttribI3i(uint index, in Vector3i v)
         {
-            fixed (int* v_ptr = v)
+            fixed (Vector3i* tmp_vecPtr = &v)
             {
-                VertexAttribI3iv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttribI3iv"/>
-        public static unsafe void VertexAttribI3iv(uint index, int[] v)
-        {
-            fixed (int* v_ptr = v)
-            {
-                VertexAttribI3iv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttribI3iv"/>
-        public static unsafe void VertexAttribI3iv(uint index, in int v)
-        {
-            fixed (int* v_ptr = &v)
-            {
+                int* v_ptr = (int*)tmp_vecPtr;
                 VertexAttribI3iv(index, v_ptr);
             }
         }
         /// <inheritdoc cref="VertexAttribI4iv"/>
-        public static unsafe void VertexAttribI4iv(uint index, ReadOnlySpan<int> v)
+        public static unsafe void VertexAttribI4i(uint index, in Vector4i v)
         {
-            fixed (int* v_ptr = v)
+            fixed (Vector4i* tmp_vecPtr = &v)
             {
-                VertexAttribI4iv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttribI4iv"/>
-        public static unsafe void VertexAttribI4iv(uint index, int[] v)
-        {
-            fixed (int* v_ptr = v)
-            {
-                VertexAttribI4iv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttribI4iv"/>
-        public static unsafe void VertexAttribI4iv(uint index, in int v)
-        {
-            fixed (int* v_ptr = &v)
-            {
+                int* v_ptr = (int*)tmp_vecPtr;
                 VertexAttribI4iv(index, v_ptr);
             }
         }
@@ -5313,9 +5123,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="Uniform1dv"/>
-        public static unsafe void Uniform1d(int location, in double value)
+        public static unsafe void Uniform1d(int location, int count, in double value)
         {
-            int count = 1;
             fixed (double* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
@@ -5341,9 +5150,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="Uniform2dv"/>
-        public static unsafe void Uniform2d(int location, in Vector2d value)
+        public static unsafe void Uniform2d(int location, int count, in Vector2d value)
         {
-            int count = 1;
             fixed (Vector2d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
@@ -5369,9 +5177,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="Uniform3dv"/>
-        public static unsafe void Uniform3d(int location, in Vector3d value)
+        public static unsafe void Uniform3d(int location, int count, in Vector3d value)
         {
-            int count = 1;
             fixed (Vector3d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
@@ -5397,9 +5204,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="Uniform4dv"/>
-        public static unsafe void Uniform4d(int location, in Vector4d value)
+        public static unsafe void Uniform4d(int location, int count, in Vector4d value)
         {
-            int count = 1;
             fixed (Vector4d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
@@ -5425,9 +5231,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="UniformMatrix2dv"/>
-        public static unsafe void UniformMatrix2d(int location, bool transpose, in Matrix2d value)
+        public static unsafe void UniformMatrix2d(int location, int count, bool transpose, in Matrix2d value)
         {
-            int count = 1;
             fixed (Matrix2d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
@@ -5453,9 +5258,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="UniformMatrix3dv"/>
-        public static unsafe void UniformMatrix3d(int location, bool transpose, in Matrix3d value)
+        public static unsafe void UniformMatrix3d(int location, int count, bool transpose, in Matrix3d value)
         {
-            int count = 1;
             fixed (Matrix3d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
@@ -5481,9 +5285,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="UniformMatrix4dv"/>
-        public static unsafe void UniformMatrix4d(int location, bool transpose, in Matrix4d value)
+        public static unsafe void UniformMatrix4d(int location, int count, bool transpose, in Matrix4d value)
         {
-            int count = 1;
             fixed (Matrix4d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
@@ -5509,9 +5312,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="UniformMatrix2x3dv"/>
-        public static unsafe void UniformMatrix2x3d(int location, bool transpose, in Matrix2x3d value)
+        public static unsafe void UniformMatrix2x3d(int location, int count, bool transpose, in Matrix2x3d value)
         {
-            int count = 1;
             fixed (Matrix2x3d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
@@ -5537,9 +5339,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="UniformMatrix2x4dv"/>
-        public static unsafe void UniformMatrix2x4d(int location, bool transpose, in Matrix2x4d value)
+        public static unsafe void UniformMatrix2x4d(int location, int count, bool transpose, in Matrix2x4d value)
         {
-            int count = 1;
             fixed (Matrix2x4d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
@@ -5565,9 +5366,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="UniformMatrix3x2dv"/>
-        public static unsafe void UniformMatrix3x2d(int location, bool transpose, in Matrix3x2d value)
+        public static unsafe void UniformMatrix3x2d(int location, int count, bool transpose, in Matrix3x2d value)
         {
-            int count = 1;
             fixed (Matrix3x2d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
@@ -5593,9 +5393,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="UniformMatrix3x4dv"/>
-        public static unsafe void UniformMatrix3x4d(int location, bool transpose, in Matrix3x4d value)
+        public static unsafe void UniformMatrix3x4d(int location, int count, bool transpose, in Matrix3x4d value)
         {
-            int count = 1;
             fixed (Matrix3x4d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
@@ -5621,9 +5420,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="UniformMatrix4x2dv"/>
-        public static unsafe void UniformMatrix4x2d(int location, bool transpose, in Matrix4x2d value)
+        public static unsafe void UniformMatrix4x2d(int location, int count, bool transpose, in Matrix4x2d value)
         {
-            int count = 1;
             fixed (Matrix4x2d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
@@ -5649,9 +5447,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="UniformMatrix4x3dv"/>
-        public static unsafe void UniformMatrix4x3d(int location, bool transpose, in Matrix4x3d value)
+        public static unsafe void UniformMatrix4x3d(int location, int count, bool transpose, in Matrix4x3d value)
         {
-            int count = 1;
             fixed (Matrix4x3d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
@@ -6544,9 +6341,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform2iv"/>
-        public static unsafe void ProgramUniform2i(ProgramHandle program, int location, in Vector2i value)
+        public static unsafe void ProgramUniform2i(ProgramHandle program, int location, int count, in Vector2i value)
         {
-            int count = 1;
             fixed (Vector2i* tmp_vecPtr = &value)
             {
                 int* value_ptr = (int*)tmp_vecPtr;
@@ -6572,9 +6368,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform2fv"/>
-        public static unsafe void ProgramUniform2f(ProgramHandle program, int location, in Vector2 value)
+        public static unsafe void ProgramUniform2f(ProgramHandle program, int location, int count, in Vector2 value)
         {
-            int count = 1;
             fixed (Vector2* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -6600,9 +6395,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform2fv"/>
-        public static unsafe void ProgramUniform2f(ProgramHandle program, int location, in System.Numerics.Vector2 value)
+        public static unsafe void ProgramUniform2f(ProgramHandle program, int location, int count, in System.Numerics.Vector2 value)
         {
-            int count = 1;
             fixed (System.Numerics.Vector2* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -6628,9 +6422,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform2dv"/>
-        public static unsafe void ProgramUniform2d(ProgramHandle program, int location, in Vector2d value)
+        public static unsafe void ProgramUniform2d(ProgramHandle program, int location, int count, in Vector2d value)
         {
-            int count = 1;
             fixed (Vector2d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
@@ -6682,9 +6475,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform3iv"/>
-        public static unsafe void ProgramUniform3i(ProgramHandle program, int location, in Vector3i value)
+        public static unsafe void ProgramUniform3i(ProgramHandle program, int location, int count, in Vector3i value)
         {
-            int count = 1;
             fixed (Vector3i* tmp_vecPtr = &value)
             {
                 int* value_ptr = (int*)tmp_vecPtr;
@@ -6710,9 +6502,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform3fv"/>
-        public static unsafe void ProgramUniform3f(ProgramHandle program, int location, in Vector3 value)
+        public static unsafe void ProgramUniform3f(ProgramHandle program, int location, int count, in Vector3 value)
         {
-            int count = 1;
             fixed (Vector3* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -6738,9 +6529,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform3fv"/>
-        public static unsafe void ProgramUniform3f(ProgramHandle program, int location, in System.Numerics.Vector3 value)
+        public static unsafe void ProgramUniform3f(ProgramHandle program, int location, int count, in System.Numerics.Vector3 value)
         {
-            int count = 1;
             fixed (System.Numerics.Vector3* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -6766,9 +6556,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform3dv"/>
-        public static unsafe void ProgramUniform3d(ProgramHandle program, int location, in Vector3d value)
+        public static unsafe void ProgramUniform3d(ProgramHandle program, int location, int count, in Vector3d value)
         {
-            int count = 1;
             fixed (Vector3d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
@@ -6820,9 +6609,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform4iv"/>
-        public static unsafe void ProgramUniform4i(ProgramHandle program, int location, in Vector4i value)
+        public static unsafe void ProgramUniform4i(ProgramHandle program, int location, int count, in Vector4i value)
         {
-            int count = 1;
             fixed (Vector4i* tmp_vecPtr = &value)
             {
                 int* value_ptr = (int*)tmp_vecPtr;
@@ -6848,9 +6636,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform4fv"/>
-        public static unsafe void ProgramUniform4f(ProgramHandle program, int location, in Vector4 value)
+        public static unsafe void ProgramUniform4f(ProgramHandle program, int location, int count, in Vector4 value)
         {
-            int count = 1;
             fixed (Vector4* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -6876,9 +6663,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform4fv"/>
-        public static unsafe void ProgramUniform4f(ProgramHandle program, int location, in System.Numerics.Vector4 value)
+        public static unsafe void ProgramUniform4f(ProgramHandle program, int location, int count, in System.Numerics.Vector4 value)
         {
-            int count = 1;
             fixed (System.Numerics.Vector4* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -6904,9 +6690,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform4dv"/>
-        public static unsafe void ProgramUniform4d(ProgramHandle program, int location, in Vector4d value)
+        public static unsafe void ProgramUniform4d(ProgramHandle program, int location, int count, in Vector4d value)
         {
-            int count = 1;
             fixed (Vector4d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
@@ -6958,9 +6743,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2fv"/>
-        public static unsafe void ProgramUniformMatrix2f(ProgramHandle program, int location, bool transpose, in Matrix2 value)
+        public static unsafe void ProgramUniformMatrix2f(ProgramHandle program, int location, int count, bool transpose, in Matrix2 value)
         {
-            int count = 1;
             fixed (Matrix2* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -6986,9 +6770,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3fv"/>
-        public static unsafe void ProgramUniformMatrix3f(ProgramHandle program, int location, bool transpose, in Matrix3 value)
+        public static unsafe void ProgramUniformMatrix3f(ProgramHandle program, int location, int count, bool transpose, in Matrix3 value)
         {
-            int count = 1;
             fixed (Matrix3* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -7014,9 +6797,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
-        public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, bool transpose, in Matrix4 value)
+        public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, int count, bool transpose, in Matrix4 value)
         {
-            int count = 1;
             fixed (Matrix4* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -7042,9 +6824,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
-        public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, bool transpose, in System.Numerics.Matrix4x4 value)
+        public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, int count, bool transpose, in System.Numerics.Matrix4x4 value)
         {
-            int count = 1;
             fixed (System.Numerics.Matrix4x4* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -7070,9 +6851,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2dv"/>
-        public static unsafe void ProgramUniformMatrix2d(ProgramHandle program, int location, bool transpose, in Matrix2d value)
+        public static unsafe void ProgramUniformMatrix2d(ProgramHandle program, int location, int count, bool transpose, in Matrix2d value)
         {
-            int count = 1;
             fixed (Matrix2d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
@@ -7098,9 +6878,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3dv"/>
-        public static unsafe void ProgramUniformMatrix3d(ProgramHandle program, int location, bool transpose, in Matrix3d value)
+        public static unsafe void ProgramUniformMatrix3d(ProgramHandle program, int location, int count, bool transpose, in Matrix3d value)
         {
-            int count = 1;
             fixed (Matrix3d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
@@ -7126,9 +6905,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4dv"/>
-        public static unsafe void ProgramUniformMatrix4d(ProgramHandle program, int location, bool transpose, in Matrix4d value)
+        public static unsafe void ProgramUniformMatrix4d(ProgramHandle program, int location, int count, bool transpose, in Matrix4d value)
         {
-            int count = 1;
             fixed (Matrix4d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
@@ -7154,9 +6932,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x3fv"/>
-        public static unsafe void ProgramUniformMatrix2x3f(ProgramHandle program, int location, bool transpose, in Matrix2x3 value)
+        public static unsafe void ProgramUniformMatrix2x3f(ProgramHandle program, int location, int count, bool transpose, in Matrix2x3 value)
         {
-            int count = 1;
             fixed (Matrix2x3* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -7182,9 +6959,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
-        public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, bool transpose, in Matrix3x2 value)
+        public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, int count, bool transpose, in Matrix3x2 value)
         {
-            int count = 1;
             fixed (Matrix3x2* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -7210,9 +6986,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
-        public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, bool transpose, in System.Numerics.Matrix3x2 value)
+        public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, int count, bool transpose, in System.Numerics.Matrix3x2 value)
         {
-            int count = 1;
             fixed (System.Numerics.Matrix3x2* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -7238,9 +7013,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x4fv"/>
-        public static unsafe void ProgramUniformMatrix2x4f(ProgramHandle program, int location, bool transpose, in Matrix2x4 value)
+        public static unsafe void ProgramUniformMatrix2x4f(ProgramHandle program, int location, int count, bool transpose, in Matrix2x4 value)
         {
-            int count = 1;
             fixed (Matrix2x4* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -7266,9 +7040,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x2fv"/>
-        public static unsafe void ProgramUniformMatrix4x2f(ProgramHandle program, int location, bool transpose, in Matrix4x2 value)
+        public static unsafe void ProgramUniformMatrix4x2f(ProgramHandle program, int location, int count, bool transpose, in Matrix4x2 value)
         {
-            int count = 1;
             fixed (Matrix4x2* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -7294,9 +7067,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x4fv"/>
-        public static unsafe void ProgramUniformMatrix3x4f(ProgramHandle program, int location, bool transpose, in Matrix3x4 value)
+        public static unsafe void ProgramUniformMatrix3x4f(ProgramHandle program, int location, int count, bool transpose, in Matrix3x4 value)
         {
-            int count = 1;
             fixed (Matrix3x4* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -7322,9 +7094,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x3fv"/>
-        public static unsafe void ProgramUniformMatrix4x3f(ProgramHandle program, int location, bool transpose, in Matrix4x3 value)
+        public static unsafe void ProgramUniformMatrix4x3f(ProgramHandle program, int location, int count, bool transpose, in Matrix4x3 value)
         {
-            int count = 1;
             fixed (Matrix4x3* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -7350,9 +7121,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x3dv"/>
-        public static unsafe void ProgramUniformMatrix2x3d(ProgramHandle program, int location, bool transpose, in Matrix2x3d value)
+        public static unsafe void ProgramUniformMatrix2x3d(ProgramHandle program, int location, int count, bool transpose, in Matrix2x3d value)
         {
-            int count = 1;
             fixed (Matrix2x3d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
@@ -7378,9 +7148,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x2dv"/>
-        public static unsafe void ProgramUniformMatrix3x2d(ProgramHandle program, int location, bool transpose, in Matrix3x2d value)
+        public static unsafe void ProgramUniformMatrix3x2d(ProgramHandle program, int location, int count, bool transpose, in Matrix3x2d value)
         {
-            int count = 1;
             fixed (Matrix3x2d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
@@ -7406,9 +7175,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x4dv"/>
-        public static unsafe void ProgramUniformMatrix2x4d(ProgramHandle program, int location, bool transpose, in Matrix2x4d value)
+        public static unsafe void ProgramUniformMatrix2x4d(ProgramHandle program, int location, int count, bool transpose, in Matrix2x4d value)
         {
-            int count = 1;
             fixed (Matrix2x4d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
@@ -7434,9 +7202,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x2dv"/>
-        public static unsafe void ProgramUniformMatrix4x2d(ProgramHandle program, int location, bool transpose, in Matrix4x2d value)
+        public static unsafe void ProgramUniformMatrix4x2d(ProgramHandle program, int location, int count, bool transpose, in Matrix4x2d value)
         {
-            int count = 1;
             fixed (Matrix4x2d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
@@ -7462,9 +7229,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x4dv"/>
-        public static unsafe void ProgramUniformMatrix3x4d(ProgramHandle program, int location, bool transpose, in Matrix3x4d value)
+        public static unsafe void ProgramUniformMatrix3x4d(ProgramHandle program, int location, int count, bool transpose, in Matrix3x4d value)
         {
-            int count = 1;
             fixed (Matrix3x4d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
@@ -7490,9 +7256,8 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x3dv"/>
-        public static unsafe void ProgramUniformMatrix4x3d(ProgramHandle program, int location, bool transpose, in Matrix4x3d value)
+        public static unsafe void ProgramUniformMatrix4x3d(ProgramHandle program, int location, int count, bool transpose, in Matrix4x3d value)
         {
-            int count = 1;
             fixed (Matrix4x3d* tmp_vecPtr = &value)
             {
                 double* value_ptr = (double*)tmp_vecPtr;
@@ -7590,98 +7355,38 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="VertexAttribL1dv"/>
-        public static unsafe void VertexAttribL1dv(uint index, ReadOnlySpan<double> v)
+        public static unsafe void VertexAttribL1d(uint index, in double v)
         {
-            fixed (double* v_ptr = v)
+            fixed (double* tmp_vecPtr = &v)
             {
-                VertexAttribL1dv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttribL1dv"/>
-        public static unsafe void VertexAttribL1dv(uint index, double[] v)
-        {
-            fixed (double* v_ptr = v)
-            {
-                VertexAttribL1dv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttribL1dv"/>
-        public static unsafe void VertexAttribL1dv(uint index, in double v)
-        {
-            fixed (double* v_ptr = &v)
-            {
+                double* v_ptr = (double*)tmp_vecPtr;
                 VertexAttribL1dv(index, v_ptr);
             }
         }
         /// <inheritdoc cref="VertexAttribL2dv"/>
-        public static unsafe void VertexAttribL2dv(uint index, ReadOnlySpan<double> v)
+        public static unsafe void VertexAttribL2d(uint index, in Vector2d v)
         {
-            fixed (double* v_ptr = v)
+            fixed (Vector2d* tmp_vecPtr = &v)
             {
-                VertexAttribL2dv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttribL2dv"/>
-        public static unsafe void VertexAttribL2dv(uint index, double[] v)
-        {
-            fixed (double* v_ptr = v)
-            {
-                VertexAttribL2dv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttribL2dv"/>
-        public static unsafe void VertexAttribL2dv(uint index, in double v)
-        {
-            fixed (double* v_ptr = &v)
-            {
+                double* v_ptr = (double*)tmp_vecPtr;
                 VertexAttribL2dv(index, v_ptr);
             }
         }
         /// <inheritdoc cref="VertexAttribL3dv"/>
-        public static unsafe void VertexAttribL3dv(uint index, ReadOnlySpan<double> v)
+        public static unsafe void VertexAttribL3d(uint index, in Vector3d v)
         {
-            fixed (double* v_ptr = v)
+            fixed (Vector3d* tmp_vecPtr = &v)
             {
-                VertexAttribL3dv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttribL3dv"/>
-        public static unsafe void VertexAttribL3dv(uint index, double[] v)
-        {
-            fixed (double* v_ptr = v)
-            {
-                VertexAttribL3dv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttribL3dv"/>
-        public static unsafe void VertexAttribL3dv(uint index, in double v)
-        {
-            fixed (double* v_ptr = &v)
-            {
+                double* v_ptr = (double*)tmp_vecPtr;
                 VertexAttribL3dv(index, v_ptr);
             }
         }
         /// <inheritdoc cref="VertexAttribL4dv"/>
-        public static unsafe void VertexAttribL4dv(uint index, ReadOnlySpan<double> v)
+        public static unsafe void VertexAttribL4d(uint index, in Vector4d v)
         {
-            fixed (double* v_ptr = v)
+            fixed (Vector4d* tmp_vecPtr = &v)
             {
-                VertexAttribL4dv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttribL4dv"/>
-        public static unsafe void VertexAttribL4dv(uint index, double[] v)
-        {
-            fixed (double* v_ptr = v)
-            {
-                VertexAttribL4dv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttribL4dv"/>
-        public static unsafe void VertexAttribL4dv(uint index, in double v)
-        {
-            fixed (double* v_ptr = &v)
-            {
+                double* v_ptr = (double*)tmp_vecPtr;
                 VertexAttribL4dv(index, v_ptr);
             }
         }
@@ -14955,9 +14660,8 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="Uniform1dv"/>
-            public static unsafe void Uniform1d(int location, in double value)
+            public static unsafe void Uniform1d(int location, int count, in double value)
             {
-                int count = 1;
                 fixed (double* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
@@ -14983,9 +14687,8 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="Uniform2dv"/>
-            public static unsafe void Uniform2d(int location, in Vector2d value)
+            public static unsafe void Uniform2d(int location, int count, in Vector2d value)
             {
-                int count = 1;
                 fixed (Vector2d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
@@ -15011,9 +14714,8 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="Uniform3dv"/>
-            public static unsafe void Uniform3d(int location, in Vector3d value)
+            public static unsafe void Uniform3d(int location, int count, in Vector3d value)
             {
-                int count = 1;
                 fixed (Vector3d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
@@ -15039,9 +14741,8 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="Uniform4dv"/>
-            public static unsafe void Uniform4d(int location, in Vector4d value)
+            public static unsafe void Uniform4d(int location, int count, in Vector4d value)
             {
-                int count = 1;
                 fixed (Vector4d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
@@ -15067,9 +14768,8 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="UniformMatrix2dv"/>
-            public static unsafe void UniformMatrix2d(int location, bool transpose, in Matrix2d value)
+            public static unsafe void UniformMatrix2d(int location, int count, bool transpose, in Matrix2d value)
             {
-                int count = 1;
                 fixed (Matrix2d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
@@ -15095,9 +14795,8 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="UniformMatrix3dv"/>
-            public static unsafe void UniformMatrix3d(int location, bool transpose, in Matrix3d value)
+            public static unsafe void UniformMatrix3d(int location, int count, bool transpose, in Matrix3d value)
             {
-                int count = 1;
                 fixed (Matrix3d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
@@ -15123,9 +14822,8 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="UniformMatrix4dv"/>
-            public static unsafe void UniformMatrix4d(int location, bool transpose, in Matrix4d value)
+            public static unsafe void UniformMatrix4d(int location, int count, bool transpose, in Matrix4d value)
             {
-                int count = 1;
                 fixed (Matrix4d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
@@ -15151,9 +14849,8 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="UniformMatrix2x3dv"/>
-            public static unsafe void UniformMatrix2x3d(int location, bool transpose, in Matrix2x3d value)
+            public static unsafe void UniformMatrix2x3d(int location, int count, bool transpose, in Matrix2x3d value)
             {
-                int count = 1;
                 fixed (Matrix2x3d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
@@ -15179,9 +14876,8 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="UniformMatrix2x4dv"/>
-            public static unsafe void UniformMatrix2x4d(int location, bool transpose, in Matrix2x4d value)
+            public static unsafe void UniformMatrix2x4d(int location, int count, bool transpose, in Matrix2x4d value)
             {
-                int count = 1;
                 fixed (Matrix2x4d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
@@ -15207,9 +14903,8 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="UniformMatrix3x2dv"/>
-            public static unsafe void UniformMatrix3x2d(int location, bool transpose, in Matrix3x2d value)
+            public static unsafe void UniformMatrix3x2d(int location, int count, bool transpose, in Matrix3x2d value)
             {
-                int count = 1;
                 fixed (Matrix3x2d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
@@ -15235,9 +14930,8 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="UniformMatrix3x4dv"/>
-            public static unsafe void UniformMatrix3x4d(int location, bool transpose, in Matrix3x4d value)
+            public static unsafe void UniformMatrix3x4d(int location, int count, bool transpose, in Matrix3x4d value)
             {
-                int count = 1;
                 fixed (Matrix3x4d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
@@ -15263,9 +14957,8 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="UniformMatrix4x2dv"/>
-            public static unsafe void UniformMatrix4x2d(int location, bool transpose, in Matrix4x2d value)
+            public static unsafe void UniformMatrix4x2d(int location, int count, bool transpose, in Matrix4x2d value)
             {
-                int count = 1;
                 fixed (Matrix4x2d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
@@ -15291,9 +14984,8 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="UniformMatrix4x3dv"/>
-            public static unsafe void UniformMatrix4x3d(int location, bool transpose, in Matrix4x3d value)
+            public static unsafe void UniformMatrix4x3d(int location, int count, bool transpose, in Matrix4x3d value)
             {
-                int count = 1;
                 fixed (Matrix4x3d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
@@ -17789,9 +17481,8 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform2iv"/>
-            public static unsafe void ProgramUniform2i(ProgramHandle program, int location, in Vector2i value)
+            public static unsafe void ProgramUniform2i(ProgramHandle program, int location, int count, in Vector2i value)
             {
-                int count = 1;
                 fixed (Vector2i* tmp_vecPtr = &value)
                 {
                     int* value_ptr = (int*)tmp_vecPtr;
@@ -17817,9 +17508,8 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform2fv"/>
-            public static unsafe void ProgramUniform2f(ProgramHandle program, int location, in Vector2 value)
+            public static unsafe void ProgramUniform2f(ProgramHandle program, int location, int count, in Vector2 value)
             {
-                int count = 1;
                 fixed (Vector2* tmp_vecPtr = &value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
@@ -17845,9 +17535,8 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform2fv"/>
-            public static unsafe void ProgramUniform2f(ProgramHandle program, int location, in System.Numerics.Vector2 value)
+            public static unsafe void ProgramUniform2f(ProgramHandle program, int location, int count, in System.Numerics.Vector2 value)
             {
-                int count = 1;
                 fixed (System.Numerics.Vector2* tmp_vecPtr = &value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
@@ -17873,9 +17562,8 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform2dv"/>
-            public static unsafe void ProgramUniform2d(ProgramHandle program, int location, in Vector2d value)
+            public static unsafe void ProgramUniform2d(ProgramHandle program, int location, int count, in Vector2d value)
             {
-                int count = 1;
                 fixed (Vector2d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
@@ -17927,9 +17615,8 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform3iv"/>
-            public static unsafe void ProgramUniform3i(ProgramHandle program, int location, in Vector3i value)
+            public static unsafe void ProgramUniform3i(ProgramHandle program, int location, int count, in Vector3i value)
             {
-                int count = 1;
                 fixed (Vector3i* tmp_vecPtr = &value)
                 {
                     int* value_ptr = (int*)tmp_vecPtr;
@@ -17955,9 +17642,8 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform3fv"/>
-            public static unsafe void ProgramUniform3f(ProgramHandle program, int location, in Vector3 value)
+            public static unsafe void ProgramUniform3f(ProgramHandle program, int location, int count, in Vector3 value)
             {
-                int count = 1;
                 fixed (Vector3* tmp_vecPtr = &value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
@@ -17983,9 +17669,8 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform3fv"/>
-            public static unsafe void ProgramUniform3f(ProgramHandle program, int location, in System.Numerics.Vector3 value)
+            public static unsafe void ProgramUniform3f(ProgramHandle program, int location, int count, in System.Numerics.Vector3 value)
             {
-                int count = 1;
                 fixed (System.Numerics.Vector3* tmp_vecPtr = &value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
@@ -18011,9 +17696,8 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform3dv"/>
-            public static unsafe void ProgramUniform3d(ProgramHandle program, int location, in Vector3d value)
+            public static unsafe void ProgramUniform3d(ProgramHandle program, int location, int count, in Vector3d value)
             {
-                int count = 1;
                 fixed (Vector3d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
@@ -18065,9 +17749,8 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform4iv"/>
-            public static unsafe void ProgramUniform4i(ProgramHandle program, int location, in Vector4i value)
+            public static unsafe void ProgramUniform4i(ProgramHandle program, int location, int count, in Vector4i value)
             {
-                int count = 1;
                 fixed (Vector4i* tmp_vecPtr = &value)
                 {
                     int* value_ptr = (int*)tmp_vecPtr;
@@ -18093,9 +17776,8 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform4fv"/>
-            public static unsafe void ProgramUniform4f(ProgramHandle program, int location, in Vector4 value)
+            public static unsafe void ProgramUniform4f(ProgramHandle program, int location, int count, in Vector4 value)
             {
-                int count = 1;
                 fixed (Vector4* tmp_vecPtr = &value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
@@ -18121,9 +17803,8 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform4fv"/>
-            public static unsafe void ProgramUniform4f(ProgramHandle program, int location, in System.Numerics.Vector4 value)
+            public static unsafe void ProgramUniform4f(ProgramHandle program, int location, int count, in System.Numerics.Vector4 value)
             {
-                int count = 1;
                 fixed (System.Numerics.Vector4* tmp_vecPtr = &value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
@@ -18149,9 +17830,8 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform4dv"/>
-            public static unsafe void ProgramUniform4d(ProgramHandle program, int location, in Vector4d value)
+            public static unsafe void ProgramUniform4d(ProgramHandle program, int location, int count, in Vector4d value)
             {
-                int count = 1;
                 fixed (Vector4d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
@@ -18203,9 +17883,8 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2fv"/>
-            public static unsafe void ProgramUniformMatrix2f(ProgramHandle program, int location, bool transpose, in Matrix2 value)
+            public static unsafe void ProgramUniformMatrix2f(ProgramHandle program, int location, int count, bool transpose, in Matrix2 value)
             {
-                int count = 1;
                 fixed (Matrix2* tmp_vecPtr = &value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
@@ -18231,9 +17910,8 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3fv"/>
-            public static unsafe void ProgramUniformMatrix3f(ProgramHandle program, int location, bool transpose, in Matrix3 value)
+            public static unsafe void ProgramUniformMatrix3f(ProgramHandle program, int location, int count, bool transpose, in Matrix3 value)
             {
-                int count = 1;
                 fixed (Matrix3* tmp_vecPtr = &value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
@@ -18259,9 +17937,8 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
-            public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, bool transpose, in Matrix4 value)
+            public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, int count, bool transpose, in Matrix4 value)
             {
-                int count = 1;
                 fixed (Matrix4* tmp_vecPtr = &value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
@@ -18287,9 +17964,8 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
-            public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, bool transpose, in System.Numerics.Matrix4x4 value)
+            public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, int count, bool transpose, in System.Numerics.Matrix4x4 value)
             {
-                int count = 1;
                 fixed (System.Numerics.Matrix4x4* tmp_vecPtr = &value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
@@ -18315,9 +17991,8 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2dv"/>
-            public static unsafe void ProgramUniformMatrix2d(ProgramHandle program, int location, bool transpose, in Matrix2d value)
+            public static unsafe void ProgramUniformMatrix2d(ProgramHandle program, int location, int count, bool transpose, in Matrix2d value)
             {
-                int count = 1;
                 fixed (Matrix2d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
@@ -18343,9 +18018,8 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3dv"/>
-            public static unsafe void ProgramUniformMatrix3d(ProgramHandle program, int location, bool transpose, in Matrix3d value)
+            public static unsafe void ProgramUniformMatrix3d(ProgramHandle program, int location, int count, bool transpose, in Matrix3d value)
             {
-                int count = 1;
                 fixed (Matrix3d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
@@ -18371,9 +18045,8 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4dv"/>
-            public static unsafe void ProgramUniformMatrix4d(ProgramHandle program, int location, bool transpose, in Matrix4d value)
+            public static unsafe void ProgramUniformMatrix4d(ProgramHandle program, int location, int count, bool transpose, in Matrix4d value)
             {
-                int count = 1;
                 fixed (Matrix4d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
@@ -18399,9 +18072,8 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x3fv"/>
-            public static unsafe void ProgramUniformMatrix2x3f(ProgramHandle program, int location, bool transpose, in Matrix2x3 value)
+            public static unsafe void ProgramUniformMatrix2x3f(ProgramHandle program, int location, int count, bool transpose, in Matrix2x3 value)
             {
-                int count = 1;
                 fixed (Matrix2x3* tmp_vecPtr = &value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
@@ -18427,9 +18099,8 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
-            public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, bool transpose, in Matrix3x2 value)
+            public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, int count, bool transpose, in Matrix3x2 value)
             {
-                int count = 1;
                 fixed (Matrix3x2* tmp_vecPtr = &value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
@@ -18455,9 +18126,8 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
-            public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, bool transpose, in System.Numerics.Matrix3x2 value)
+            public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, int count, bool transpose, in System.Numerics.Matrix3x2 value)
             {
-                int count = 1;
                 fixed (System.Numerics.Matrix3x2* tmp_vecPtr = &value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
@@ -18483,9 +18153,8 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x4fv"/>
-            public static unsafe void ProgramUniformMatrix2x4f(ProgramHandle program, int location, bool transpose, in Matrix2x4 value)
+            public static unsafe void ProgramUniformMatrix2x4f(ProgramHandle program, int location, int count, bool transpose, in Matrix2x4 value)
             {
-                int count = 1;
                 fixed (Matrix2x4* tmp_vecPtr = &value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
@@ -18511,9 +18180,8 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x2fv"/>
-            public static unsafe void ProgramUniformMatrix4x2f(ProgramHandle program, int location, bool transpose, in Matrix4x2 value)
+            public static unsafe void ProgramUniformMatrix4x2f(ProgramHandle program, int location, int count, bool transpose, in Matrix4x2 value)
             {
-                int count = 1;
                 fixed (Matrix4x2* tmp_vecPtr = &value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
@@ -18539,9 +18207,8 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x4fv"/>
-            public static unsafe void ProgramUniformMatrix3x4f(ProgramHandle program, int location, bool transpose, in Matrix3x4 value)
+            public static unsafe void ProgramUniformMatrix3x4f(ProgramHandle program, int location, int count, bool transpose, in Matrix3x4 value)
             {
-                int count = 1;
                 fixed (Matrix3x4* tmp_vecPtr = &value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
@@ -18567,9 +18234,8 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x3fv"/>
-            public static unsafe void ProgramUniformMatrix4x3f(ProgramHandle program, int location, bool transpose, in Matrix4x3 value)
+            public static unsafe void ProgramUniformMatrix4x3f(ProgramHandle program, int location, int count, bool transpose, in Matrix4x3 value)
             {
-                int count = 1;
                 fixed (Matrix4x3* tmp_vecPtr = &value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
@@ -18595,9 +18261,8 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x3dv"/>
-            public static unsafe void ProgramUniformMatrix2x3d(ProgramHandle program, int location, bool transpose, in Matrix2x3d value)
+            public static unsafe void ProgramUniformMatrix2x3d(ProgramHandle program, int location, int count, bool transpose, in Matrix2x3d value)
             {
-                int count = 1;
                 fixed (Matrix2x3d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
@@ -18623,9 +18288,8 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2dv"/>
-            public static unsafe void ProgramUniformMatrix3x2d(ProgramHandle program, int location, bool transpose, in Matrix3x2d value)
+            public static unsafe void ProgramUniformMatrix3x2d(ProgramHandle program, int location, int count, bool transpose, in Matrix3x2d value)
             {
-                int count = 1;
                 fixed (Matrix3x2d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
@@ -18651,9 +18315,8 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x4dv"/>
-            public static unsafe void ProgramUniformMatrix2x4d(ProgramHandle program, int location, bool transpose, in Matrix2x4d value)
+            public static unsafe void ProgramUniformMatrix2x4d(ProgramHandle program, int location, int count, bool transpose, in Matrix2x4d value)
             {
-                int count = 1;
                 fixed (Matrix2x4d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
@@ -18679,9 +18342,8 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x2dv"/>
-            public static unsafe void ProgramUniformMatrix4x2d(ProgramHandle program, int location, bool transpose, in Matrix4x2d value)
+            public static unsafe void ProgramUniformMatrix4x2d(ProgramHandle program, int location, int count, bool transpose, in Matrix4x2d value)
             {
-                int count = 1;
                 fixed (Matrix4x2d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
@@ -18707,9 +18369,8 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x4dv"/>
-            public static unsafe void ProgramUniformMatrix3x4d(ProgramHandle program, int location, bool transpose, in Matrix3x4d value)
+            public static unsafe void ProgramUniformMatrix3x4d(ProgramHandle program, int location, int count, bool transpose, in Matrix3x4d value)
             {
-                int count = 1;
                 fixed (Matrix3x4d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
@@ -18735,9 +18396,8 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x3dv"/>
-            public static unsafe void ProgramUniformMatrix4x3d(ProgramHandle program, int location, bool transpose, in Matrix4x3d value)
+            public static unsafe void ProgramUniformMatrix4x3d(ProgramHandle program, int location, int count, bool transpose, in Matrix4x3d value)
             {
-                int count = 1;
                 fixed (Matrix4x3d* tmp_vecPtr = &value)
                 {
                     double* value_ptr = (double*)tmp_vecPtr;
@@ -20938,98 +20598,38 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="VertexAttribL1dv"/>
-            public static unsafe void VertexAttribL1dv(uint index, ReadOnlySpan<double> v)
+            public static unsafe void VertexAttribL1d(uint index, in double v)
             {
-                fixed (double* v_ptr = v)
+                fixed (double* tmp_vecPtr = &v)
                 {
-                    VertexAttribL1dv(index, v_ptr);
-                }
-            }
-            /// <inheritdoc cref="VertexAttribL1dv"/>
-            public static unsafe void VertexAttribL1dv(uint index, double[] v)
-            {
-                fixed (double* v_ptr = v)
-                {
-                    VertexAttribL1dv(index, v_ptr);
-                }
-            }
-            /// <inheritdoc cref="VertexAttribL1dv"/>
-            public static unsafe void VertexAttribL1dv(uint index, in double v)
-            {
-                fixed (double* v_ptr = &v)
-                {
+                    double* v_ptr = (double*)tmp_vecPtr;
                     VertexAttribL1dv(index, v_ptr);
                 }
             }
             /// <inheritdoc cref="VertexAttribL2dv"/>
-            public static unsafe void VertexAttribL2dv(uint index, ReadOnlySpan<double> v)
+            public static unsafe void VertexAttribL2d(uint index, in Vector2d v)
             {
-                fixed (double* v_ptr = v)
+                fixed (Vector2d* tmp_vecPtr = &v)
                 {
-                    VertexAttribL2dv(index, v_ptr);
-                }
-            }
-            /// <inheritdoc cref="VertexAttribL2dv"/>
-            public static unsafe void VertexAttribL2dv(uint index, double[] v)
-            {
-                fixed (double* v_ptr = v)
-                {
-                    VertexAttribL2dv(index, v_ptr);
-                }
-            }
-            /// <inheritdoc cref="VertexAttribL2dv"/>
-            public static unsafe void VertexAttribL2dv(uint index, in double v)
-            {
-                fixed (double* v_ptr = &v)
-                {
+                    double* v_ptr = (double*)tmp_vecPtr;
                     VertexAttribL2dv(index, v_ptr);
                 }
             }
             /// <inheritdoc cref="VertexAttribL3dv"/>
-            public static unsafe void VertexAttribL3dv(uint index, ReadOnlySpan<double> v)
+            public static unsafe void VertexAttribL3d(uint index, in Vector3d v)
             {
-                fixed (double* v_ptr = v)
+                fixed (Vector3d* tmp_vecPtr = &v)
                 {
-                    VertexAttribL3dv(index, v_ptr);
-                }
-            }
-            /// <inheritdoc cref="VertexAttribL3dv"/>
-            public static unsafe void VertexAttribL3dv(uint index, double[] v)
-            {
-                fixed (double* v_ptr = v)
-                {
-                    VertexAttribL3dv(index, v_ptr);
-                }
-            }
-            /// <inheritdoc cref="VertexAttribL3dv"/>
-            public static unsafe void VertexAttribL3dv(uint index, in double v)
-            {
-                fixed (double* v_ptr = &v)
-                {
+                    double* v_ptr = (double*)tmp_vecPtr;
                     VertexAttribL3dv(index, v_ptr);
                 }
             }
             /// <inheritdoc cref="VertexAttribL4dv"/>
-            public static unsafe void VertexAttribL4dv(uint index, ReadOnlySpan<double> v)
+            public static unsafe void VertexAttribL4d(uint index, in Vector4d v)
             {
-                fixed (double* v_ptr = v)
+                fixed (Vector4d* tmp_vecPtr = &v)
                 {
-                    VertexAttribL4dv(index, v_ptr);
-                }
-            }
-            /// <inheritdoc cref="VertexAttribL4dv"/>
-            public static unsafe void VertexAttribL4dv(uint index, double[] v)
-            {
-                fixed (double* v_ptr = v)
-                {
-                    VertexAttribL4dv(index, v_ptr);
-                }
-            }
-            /// <inheritdoc cref="VertexAttribL4dv"/>
-            public static unsafe void VertexAttribL4dv(uint index, in double v)
-            {
-                fixed (double* v_ptr = &v)
-                {
+                    double* v_ptr = (double*)tmp_vecPtr;
                     VertexAttribL4dv(index, v_ptr);
                 }
             }

--- a/src/OpenTK.Graphics/OpenGL/GL.Overloads.cs
+++ b/src/OpenTK.Graphics/OpenGL/GL.Overloads.cs
@@ -29380,26 +29380,11 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="SecondaryColor3fvEXT"/>
-            public static unsafe void SecondaryColor3fvEXT(ReadOnlySpan<float> v)
+            public static unsafe void SecondaryColor3fvEXT(in Color3<Rgb> v)
             {
-                fixed (float* v_ptr = v)
+                fixed (Color3<Rgb>* tmp_v = &v)
                 {
-                    SecondaryColor3fvEXT(v_ptr);
-                }
-            }
-            /// <inheritdoc cref="SecondaryColor3fvEXT"/>
-            public static unsafe void SecondaryColor3fvEXT(float[] v)
-            {
-                fixed (float* v_ptr = v)
-                {
-                    SecondaryColor3fvEXT(v_ptr);
-                }
-            }
-            /// <inheritdoc cref="SecondaryColor3fvEXT"/>
-            public static unsafe void SecondaryColor3fvEXT(in float v)
-            {
-                fixed (float* v_ptr = &v)
-                {
+                    float* v_ptr = (float*)tmp_v;
                     SecondaryColor3fvEXT(v_ptr);
                 }
             }
@@ -43340,34 +43325,39 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="Color3fVertex3fvSUN"/>
-            public static unsafe void Color3fVertex3fvSUN(ReadOnlySpan<float> c, ReadOnlySpan<float> v)
+            public static unsafe void Color3fVertex3fvSUN(in Color3<Rgb> c, ReadOnlySpan<float> v)
             {
-                fixed (float* c_ptr = c)
+                fixed (float* v_ptr = v)
                 {
-                    fixed (float* v_ptr = v)
+                    fixed (Color3<Rgb>* tmp_c = &c)
                     {
+                        float* c_ptr = (float*)tmp_c;
                         Color3fVertex3fvSUN(c_ptr, v_ptr);
                     }
                 }
             }
             /// <inheritdoc cref="Color3fVertex3fvSUN"/>
-            public static unsafe void Color3fVertex3fvSUN(float[] c, float[] v)
+            public static unsafe void Color3fVertex3fvSUN(in Color3<Rgb> c, float[] v)
             {
-                fixed (float* c_ptr = c)
+                fixed (float* v_ptr = v)
                 {
-                    fixed (float* v_ptr = v)
+                    fixed (Color3<Rgb>* tmp_c = &c)
                     {
+                        float* c_ptr = (float*)tmp_c;
                         Color3fVertex3fvSUN(c_ptr, v_ptr);
                     }
                 }
             }
             /// <inheritdoc cref="Color3fVertex3fvSUN"/>
-            public static unsafe void Color3fVertex3fvSUN(in float c, in float v)
+            public static unsafe void Color3fVertex3fvSUN(in Color3<Rgb> c, in float v)
             {
-                fixed (float* c_ptr = &c)
                 fixed (float* v_ptr = &v)
                 {
-                    Color3fVertex3fvSUN(c_ptr, v_ptr);
+                    fixed (Color3<Rgb>* tmp_c = &c)
+                    {
+                        float* c_ptr = (float*)tmp_c;
+                        Color3fVertex3fvSUN(c_ptr, v_ptr);
+                    }
                 }
             }
             /// <inheritdoc cref="Normal3fVertex3fvSUN"/>
@@ -43402,41 +43392,46 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="Color4fNormal3fVertex3fvSUN"/>
-            public static unsafe void Color4fNormal3fVertex3fvSUN(ReadOnlySpan<float> c, ReadOnlySpan<float> n, ReadOnlySpan<float> v)
+            public static unsafe void Color4fNormal3fVertex3fvSUN(in Color4<Rgba> c, ReadOnlySpan<float> n, ReadOnlySpan<float> v)
             {
-                fixed (float* c_ptr = c)
+                fixed (float* n_ptr = n)
                 {
-                    fixed (float* n_ptr = n)
+                    fixed (float* v_ptr = v)
                     {
-                        fixed (float* v_ptr = v)
+                        fixed (Color4<Rgba>* tmp_c = &c)
                         {
+                            float* c_ptr = (float*)tmp_c;
                             Color4fNormal3fVertex3fvSUN(c_ptr, n_ptr, v_ptr);
                         }
                     }
                 }
             }
             /// <inheritdoc cref="Color4fNormal3fVertex3fvSUN"/>
-            public static unsafe void Color4fNormal3fVertex3fvSUN(float[] c, float[] n, float[] v)
+            public static unsafe void Color4fNormal3fVertex3fvSUN(in Color4<Rgba> c, float[] n, float[] v)
             {
-                fixed (float* c_ptr = c)
+                fixed (float* n_ptr = n)
                 {
-                    fixed (float* n_ptr = n)
+                    fixed (float* v_ptr = v)
                     {
-                        fixed (float* v_ptr = v)
+                        fixed (Color4<Rgba>* tmp_c = &c)
                         {
+                            float* c_ptr = (float*)tmp_c;
                             Color4fNormal3fVertex3fvSUN(c_ptr, n_ptr, v_ptr);
                         }
                     }
                 }
             }
             /// <inheritdoc cref="Color4fNormal3fVertex3fvSUN"/>
-            public static unsafe void Color4fNormal3fVertex3fvSUN(in float c, in float n, in float v)
+            public static unsafe void Color4fNormal3fVertex3fvSUN(in Color4<Rgba> c, in float n, in float v)
             {
-                fixed (float* c_ptr = &c)
                 fixed (float* n_ptr = &n)
                 fixed (float* v_ptr = &v)
                 {
-                    Color4fNormal3fVertex3fvSUN(c_ptr, n_ptr, v_ptr);
+                    fixed (Color4<Rgba>* tmp_c = &c)
+                    {
+                        float* c_ptr = (float*)tmp_c;
+                        Color4fNormal3fVertex3fvSUN(c_ptr, n_ptr, v_ptr);
+                    }
                 }
             }
             /// <inheritdoc cref="TexCoord2fVertex3fvSUN"/>
@@ -43540,41 +43535,46 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="TexCoord2fColor3fVertex3fvSUN"/>
-            public static unsafe void TexCoord2fColor3fVertex3fvSUN(ReadOnlySpan<float> tc, ReadOnlySpan<float> c, ReadOnlySpan<float> v)
+            public static unsafe void TexCoord2fColor3fVertex3fvSUN(ReadOnlySpan<float> tc, in Color3<Rgb> c, ReadOnlySpan<float> v)
             {
                 fixed (float* tc_ptr = tc)
                 {
-                    fixed (float* c_ptr = c)
+                    fixed (float* v_ptr = v)
                     {
-                        fixed (float* v_ptr = v)
+                        fixed (Color3<Rgb>* tmp_c = &c)
                         {
+                            float* c_ptr = (float*)tmp_c;
                             TexCoord2fColor3fVertex3fvSUN(tc_ptr, c_ptr, v_ptr);
                         }
                     }
                 }
             }
             /// <inheritdoc cref="TexCoord2fColor3fVertex3fvSUN"/>
-            public static unsafe void TexCoord2fColor3fVertex3fvSUN(float[] tc, float[] c, float[] v)
+            public static unsafe void TexCoord2fColor3fVertex3fvSUN(float[] tc, in Color3<Rgb> c, float[] v)
             {
                 fixed (float* tc_ptr = tc)
                 {
-                    fixed (float* c_ptr = c)
+                    fixed (float* v_ptr = v)
                     {
-                        fixed (float* v_ptr = v)
+                        fixed (Color3<Rgb>* tmp_c = &c)
                         {
+                            float* c_ptr = (float*)tmp_c;
                             TexCoord2fColor3fVertex3fvSUN(tc_ptr, c_ptr, v_ptr);
                         }
                     }
                 }
             }
             /// <inheritdoc cref="TexCoord2fColor3fVertex3fvSUN"/>
-            public static unsafe void TexCoord2fColor3fVertex3fvSUN(in float tc, in float c, in float v)
+            public static unsafe void TexCoord2fColor3fVertex3fvSUN(in float tc, in Color3<Rgb> c, in float v)
             {
                 fixed (float* tc_ptr = &tc)
-                fixed (float* c_ptr = &c)
                 fixed (float* v_ptr = &v)
                 {
-                    TexCoord2fColor3fVertex3fvSUN(tc_ptr, c_ptr, v_ptr);
+                    fixed (Color3<Rgb>* tmp_c = &c)
+                    {
+                        float* c_ptr = (float*)tmp_c;
+                        TexCoord2fColor3fVertex3fvSUN(tc_ptr, c_ptr, v_ptr);
+                    }
                 }
             }
             /// <inheritdoc cref="TexCoord2fNormal3fVertex3fvSUN"/>
@@ -43616,16 +43616,17 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="TexCoord2fColor4fNormal3fVertex3fvSUN"/>
-            public static unsafe void TexCoord2fColor4fNormal3fVertex3fvSUN(ReadOnlySpan<float> tc, ReadOnlySpan<float> c, ReadOnlySpan<float> n, ReadOnlySpan<float> v)
+            public static unsafe void TexCoord2fColor4fNormal3fVertex3fvSUN(ReadOnlySpan<float> tc, in Color4<Rgba> c, ReadOnlySpan<float> n, ReadOnlySpan<float> v)
             {
                 fixed (float* tc_ptr = tc)
                 {
-                    fixed (float* c_ptr = c)
+                    fixed (float* n_ptr = n)
                     {
-                        fixed (float* n_ptr = n)
+                        fixed (float* v_ptr = v)
                         {
-                            fixed (float* v_ptr = v)
+                            fixed (Color4<Rgba>* tmp_c = &c)
                             {
+                                float* c_ptr = (float*)tmp_c;
                                 TexCoord2fColor4fNormal3fVertex3fvSUN(tc_ptr, c_ptr, n_ptr, v_ptr);
                             }
                         }
@@ -43633,16 +43634,17 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="TexCoord2fColor4fNormal3fVertex3fvSUN"/>
-            public static unsafe void TexCoord2fColor4fNormal3fVertex3fvSUN(float[] tc, float[] c, float[] n, float[] v)
+            public static unsafe void TexCoord2fColor4fNormal3fVertex3fvSUN(float[] tc, in Color4<Rgba> c, float[] n, float[] v)
             {
                 fixed (float* tc_ptr = tc)
                 {
-                    fixed (float* c_ptr = c)
+                    fixed (float* n_ptr = n)
                     {
-                        fixed (float* n_ptr = n)
+                        fixed (float* v_ptr = v)
                         {
-                            fixed (float* v_ptr = v)
+                            fixed (Color4<Rgba>* tmp_c = &c)
                             {
+                                float* c_ptr = (float*)tmp_c;
                                 TexCoord2fColor4fNormal3fVertex3fvSUN(tc_ptr, c_ptr, n_ptr, v_ptr);
                             }
                         }
@@ -43650,27 +43652,31 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="TexCoord2fColor4fNormal3fVertex3fvSUN"/>
-            public static unsafe void TexCoord2fColor4fNormal3fVertex3fvSUN(in float tc, in float c, in float n, in float v)
+            public static unsafe void TexCoord2fColor4fNormal3fVertex3fvSUN(in float tc, in Color4<Rgba> c, in float n, in float v)
             {
                 fixed (float* tc_ptr = &tc)
-                fixed (float* c_ptr = &c)
                 fixed (float* n_ptr = &n)
                 fixed (float* v_ptr = &v)
                 {
-                    TexCoord2fColor4fNormal3fVertex3fvSUN(tc_ptr, c_ptr, n_ptr, v_ptr);
+                    fixed (Color4<Rgba>* tmp_c = &c)
+                    {
+                        float* c_ptr = (float*)tmp_c;
+                        TexCoord2fColor4fNormal3fVertex3fvSUN(tc_ptr, c_ptr, n_ptr, v_ptr);
+                    }
                 }
             }
             /// <inheritdoc cref="TexCoord4fColor4fNormal3fVertex4fvSUN"/>
-            public static unsafe void TexCoord4fColor4fNormal3fVertex4fvSUN(ReadOnlySpan<float> tc, ReadOnlySpan<float> c, ReadOnlySpan<float> n, ReadOnlySpan<float> v)
+            public static unsafe void TexCoord4fColor4fNormal3fVertex4fvSUN(ReadOnlySpan<float> tc, in Color4<Rgba> c, ReadOnlySpan<float> n, ReadOnlySpan<float> v)
             {
                 fixed (float* tc_ptr = tc)
                 {
-                    fixed (float* c_ptr = c)
+                    fixed (float* n_ptr = n)
                     {
-                        fixed (float* n_ptr = n)
+                        fixed (float* v_ptr = v)
                         {
-                            fixed (float* v_ptr = v)
+                            fixed (Color4<Rgba>* tmp_c = &c)
                             {
+                                float* c_ptr = (float*)tmp_c;
                                 TexCoord4fColor4fNormal3fVertex4fvSUN(tc_ptr, c_ptr, n_ptr, v_ptr);
                             }
                         }
@@ -43678,16 +43684,17 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="TexCoord4fColor4fNormal3fVertex4fvSUN"/>
-            public static unsafe void TexCoord4fColor4fNormal3fVertex4fvSUN(float[] tc, float[] c, float[] n, float[] v)
+            public static unsafe void TexCoord4fColor4fNormal3fVertex4fvSUN(float[] tc, in Color4<Rgba> c, float[] n, float[] v)
             {
                 fixed (float* tc_ptr = tc)
                 {
-                    fixed (float* c_ptr = c)
+                    fixed (float* n_ptr = n)
                     {
-                        fixed (float* n_ptr = n)
+                        fixed (float* v_ptr = v)
                         {
-                            fixed (float* v_ptr = v)
+                            fixed (Color4<Rgba>* tmp_c = &c)
                             {
+                                float* c_ptr = (float*)tmp_c;
                                 TexCoord4fColor4fNormal3fVertex4fvSUN(tc_ptr, c_ptr, n_ptr, v_ptr);
                             }
                         }
@@ -43695,14 +43702,17 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="TexCoord4fColor4fNormal3fVertex4fvSUN"/>
-            public static unsafe void TexCoord4fColor4fNormal3fVertex4fvSUN(in float tc, in float c, in float n, in float v)
+            public static unsafe void TexCoord4fColor4fNormal3fVertex4fvSUN(in float tc, in Color4<Rgba> c, in float n, in float v)
             {
                 fixed (float* tc_ptr = &tc)
-                fixed (float* c_ptr = &c)
                 fixed (float* n_ptr = &n)
                 fixed (float* v_ptr = &v)
                 {
-                    TexCoord4fColor4fNormal3fVertex4fvSUN(tc_ptr, c_ptr, n_ptr, v_ptr);
+                    fixed (Color4<Rgba>* tmp_c = &c)
+                    {
+                        float* c_ptr = (float*)tmp_c;
+                        TexCoord4fColor4fNormal3fVertex4fvSUN(tc_ptr, c_ptr, n_ptr, v_ptr);
+                    }
                 }
             }
             /// <inheritdoc cref="ReplacementCodeuiVertex3fvSUN"/>
@@ -43775,41 +43785,46 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ReplacementCodeuiColor3fVertex3fvSUN"/>
-            public static unsafe void ReplacementCodeuiColor3fVertex3fvSUN(ReadOnlySpan<TriangleListSUN> rc, ReadOnlySpan<float> c, ReadOnlySpan<float> v)
+            public static unsafe void ReplacementCodeuiColor3fVertex3fvSUN(ReadOnlySpan<TriangleListSUN> rc, in Color3<Rgb> c, ReadOnlySpan<float> v)
             {
                 fixed (TriangleListSUN* rc_ptr = rc)
                 {
-                    fixed (float* c_ptr = c)
+                    fixed (float* v_ptr = v)
                     {
-                        fixed (float* v_ptr = v)
+                        fixed (Color3<Rgb>* tmp_c = &c)
                         {
+                            float* c_ptr = (float*)tmp_c;
                             ReplacementCodeuiColor3fVertex3fvSUN(rc_ptr, c_ptr, v_ptr);
                         }
                     }
                 }
             }
             /// <inheritdoc cref="ReplacementCodeuiColor3fVertex3fvSUN"/>
-            public static unsafe void ReplacementCodeuiColor3fVertex3fvSUN(TriangleListSUN[] rc, float[] c, float[] v)
+            public static unsafe void ReplacementCodeuiColor3fVertex3fvSUN(TriangleListSUN[] rc, in Color3<Rgb> c, float[] v)
             {
                 fixed (TriangleListSUN* rc_ptr = rc)
                 {
-                    fixed (float* c_ptr = c)
+                    fixed (float* v_ptr = v)
                     {
-                        fixed (float* v_ptr = v)
+                        fixed (Color3<Rgb>* tmp_c = &c)
                         {
+                            float* c_ptr = (float*)tmp_c;
                             ReplacementCodeuiColor3fVertex3fvSUN(rc_ptr, c_ptr, v_ptr);
                         }
                     }
                 }
             }
             /// <inheritdoc cref="ReplacementCodeuiColor3fVertex3fvSUN"/>
-            public static unsafe void ReplacementCodeuiColor3fVertex3fvSUN(in TriangleListSUN rc, in float c, in float v)
+            public static unsafe void ReplacementCodeuiColor3fVertex3fvSUN(in TriangleListSUN rc, in Color3<Rgb> c, in float v)
             {
                 fixed (TriangleListSUN* rc_ptr = &rc)
-                fixed (float* c_ptr = &c)
                 fixed (float* v_ptr = &v)
                 {
-                    ReplacementCodeuiColor3fVertex3fvSUN(rc_ptr, c_ptr, v_ptr);
+                    fixed (Color3<Rgb>* tmp_c = &c)
+                    {
+                        float* c_ptr = (float*)tmp_c;
+                        ReplacementCodeuiColor3fVertex3fvSUN(rc_ptr, c_ptr, v_ptr);
+                    }
                 }
             }
             /// <inheritdoc cref="ReplacementCodeuiNormal3fVertex3fvSUN"/>
@@ -43851,16 +43866,17 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ReplacementCodeuiColor4fNormal3fVertex3fvSUN"/>
-            public static unsafe void ReplacementCodeuiColor4fNormal3fVertex3fvSUN(ReadOnlySpan<TriangleListSUN> rc, ReadOnlySpan<float> c, ReadOnlySpan<float> n, ReadOnlySpan<float> v)
+            public static unsafe void ReplacementCodeuiColor4fNormal3fVertex3fvSUN(ReadOnlySpan<TriangleListSUN> rc, in Color4<Rgba> c, ReadOnlySpan<float> n, ReadOnlySpan<float> v)
             {
                 fixed (TriangleListSUN* rc_ptr = rc)
                 {
-                    fixed (float* c_ptr = c)
+                    fixed (float* n_ptr = n)
                     {
-                        fixed (float* n_ptr = n)
+                        fixed (float* v_ptr = v)
                         {
-                            fixed (float* v_ptr = v)
+                            fixed (Color4<Rgba>* tmp_c = &c)
                             {
+                                float* c_ptr = (float*)tmp_c;
                                 ReplacementCodeuiColor4fNormal3fVertex3fvSUN(rc_ptr, c_ptr, n_ptr, v_ptr);
                             }
                         }
@@ -43868,16 +43884,17 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ReplacementCodeuiColor4fNormal3fVertex3fvSUN"/>
-            public static unsafe void ReplacementCodeuiColor4fNormal3fVertex3fvSUN(TriangleListSUN[] rc, float[] c, float[] n, float[] v)
+            public static unsafe void ReplacementCodeuiColor4fNormal3fVertex3fvSUN(TriangleListSUN[] rc, in Color4<Rgba> c, float[] n, float[] v)
             {
                 fixed (TriangleListSUN* rc_ptr = rc)
                 {
-                    fixed (float* c_ptr = c)
+                    fixed (float* n_ptr = n)
                     {
-                        fixed (float* n_ptr = n)
+                        fixed (float* v_ptr = v)
                         {
-                            fixed (float* v_ptr = v)
+                            fixed (Color4<Rgba>* tmp_c = &c)
                             {
+                                float* c_ptr = (float*)tmp_c;
                                 ReplacementCodeuiColor4fNormal3fVertex3fvSUN(rc_ptr, c_ptr, n_ptr, v_ptr);
                             }
                         }
@@ -43885,14 +43902,17 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ReplacementCodeuiColor4fNormal3fVertex3fvSUN"/>
-            public static unsafe void ReplacementCodeuiColor4fNormal3fVertex3fvSUN(in TriangleListSUN rc, in float c, in float n, in float v)
+            public static unsafe void ReplacementCodeuiColor4fNormal3fVertex3fvSUN(in TriangleListSUN rc, in Color4<Rgba> c, in float n, in float v)
             {
                 fixed (TriangleListSUN* rc_ptr = &rc)
-                fixed (float* c_ptr = &c)
                 fixed (float* n_ptr = &n)
                 fixed (float* v_ptr = &v)
                 {
-                    ReplacementCodeuiColor4fNormal3fVertex3fvSUN(rc_ptr, c_ptr, n_ptr, v_ptr);
+                    fixed (Color4<Rgba>* tmp_c = &c)
+                    {
+                        float* c_ptr = (float*)tmp_c;
+                        ReplacementCodeuiColor4fNormal3fVertex3fvSUN(rc_ptr, c_ptr, n_ptr, v_ptr);
+                    }
                 }
             }
             /// <inheritdoc cref="ReplacementCodeuiTexCoord2fVertex3fvSUN"/>
@@ -43979,18 +43999,19 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ReplacementCodeuiTexCoord2fColor4fNormal3fVertex3fvSUN"/>
-            public static unsafe void ReplacementCodeuiTexCoord2fColor4fNormal3fVertex3fvSUN(ReadOnlySpan<TriangleListSUN> rc, ReadOnlySpan<float> tc, ReadOnlySpan<float> c, ReadOnlySpan<float> n, ReadOnlySpan<float> v)
+            public static unsafe void ReplacementCodeuiTexCoord2fColor4fNormal3fVertex3fvSUN(ReadOnlySpan<TriangleListSUN> rc, ReadOnlySpan<float> tc, in Color4<Rgba> c, ReadOnlySpan<float> n, ReadOnlySpan<float> v)
             {
                 fixed (TriangleListSUN* rc_ptr = rc)
                 {
                     fixed (float* tc_ptr = tc)
                     {
-                        fixed (float* c_ptr = c)
+                        fixed (float* n_ptr = n)
                         {
-                            fixed (float* n_ptr = n)
+                            fixed (float* v_ptr = v)
                             {
-                                fixed (float* v_ptr = v)
+                                fixed (Color4<Rgba>* tmp_c = &c)
                                 {
+                                    float* c_ptr = (float*)tmp_c;
                                     ReplacementCodeuiTexCoord2fColor4fNormal3fVertex3fvSUN(rc_ptr, tc_ptr, c_ptr, n_ptr, v_ptr);
                                 }
                             }
@@ -43999,18 +44020,19 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ReplacementCodeuiTexCoord2fColor4fNormal3fVertex3fvSUN"/>
-            public static unsafe void ReplacementCodeuiTexCoord2fColor4fNormal3fVertex3fvSUN(TriangleListSUN[] rc, float[] tc, float[] c, float[] n, float[] v)
+            public static unsafe void ReplacementCodeuiTexCoord2fColor4fNormal3fVertex3fvSUN(TriangleListSUN[] rc, float[] tc, in Color4<Rgba> c, float[] n, float[] v)
             {
                 fixed (TriangleListSUN* rc_ptr = rc)
                 {
                     fixed (float* tc_ptr = tc)
                     {
-                        fixed (float* c_ptr = c)
+                        fixed (float* n_ptr = n)
                         {
-                            fixed (float* n_ptr = n)
+                            fixed (float* v_ptr = v)
                             {
-                                fixed (float* v_ptr = v)
+                                fixed (Color4<Rgba>* tmp_c = &c)
                                 {
+                                    float* c_ptr = (float*)tmp_c;
                                     ReplacementCodeuiTexCoord2fColor4fNormal3fVertex3fvSUN(rc_ptr, tc_ptr, c_ptr, n_ptr, v_ptr);
                                 }
                             }
@@ -44019,15 +44041,18 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ReplacementCodeuiTexCoord2fColor4fNormal3fVertex3fvSUN"/>
-            public static unsafe void ReplacementCodeuiTexCoord2fColor4fNormal3fVertex3fvSUN(in TriangleListSUN rc, in float tc, in float c, in float n, in float v)
+            public static unsafe void ReplacementCodeuiTexCoord2fColor4fNormal3fVertex3fvSUN(in TriangleListSUN rc, in float tc, in Color4<Rgba> c, in float n, in float v)
             {
                 fixed (TriangleListSUN* rc_ptr = &rc)
                 fixed (float* tc_ptr = &tc)
-                fixed (float* c_ptr = &c)
                 fixed (float* n_ptr = &n)
                 fixed (float* v_ptr = &v)
                 {
-                    ReplacementCodeuiTexCoord2fColor4fNormal3fVertex3fvSUN(rc_ptr, tc_ptr, c_ptr, n_ptr, v_ptr);
+                    fixed (Color4<Rgba>* tmp_c = &c)
+                    {
+                        float* c_ptr = (float*)tmp_c;
+                        ReplacementCodeuiTexCoord2fColor4fNormal3fVertex3fvSUN(rc_ptr, tc_ptr, c_ptr, n_ptr, v_ptr);
+                    }
                 }
             }
         }

--- a/src/OpenTK.Graphics/OpenGL/GL.Overloads.cs
+++ b/src/OpenTK.Graphics/OpenGL/GL.Overloads.cs
@@ -2125,6 +2125,34 @@ namespace OpenTK.Graphics.OpenGL
                 Uniform2fv(location, count, value_ptr);
             }
         }
+        /// <inheritdoc cref="Uniform2fv"/>
+        public static unsafe void Uniform2f(int location, in System.Numerics.Vector2 value)
+        {
+            int count = 1;
+            fixed (System.Numerics.Vector2* tmp_vecPtr = &value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                Uniform2fv(location, count, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="Uniform2fv"/>
+        public static unsafe void Uniform2f(int location, int count, ReadOnlySpan<System.Numerics.Vector2> value)
+        {
+            fixed (System.Numerics.Vector2* tmp_vecPtr = value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                Uniform2fv(location, count, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="Uniform2fv"/>
+        public static unsafe void Uniform2f(int location, int count, System.Numerics.Vector2[] value)
+        {
+            fixed (System.Numerics.Vector2* tmp_vecPtr = value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                Uniform2fv(location, count, value_ptr);
+            }
+        }
         /// <inheritdoc cref="Uniform3fv"/>
         public static unsafe void Uniform3f(int location, in Vector3 value)
         {
@@ -2153,6 +2181,34 @@ namespace OpenTK.Graphics.OpenGL
                 Uniform3fv(location, count, value_ptr);
             }
         }
+        /// <inheritdoc cref="Uniform3fv"/>
+        public static unsafe void Uniform3f(int location, in System.Numerics.Vector3 value)
+        {
+            int count = 1;
+            fixed (System.Numerics.Vector3* tmp_vecPtr = &value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                Uniform3fv(location, count, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="Uniform3fv"/>
+        public static unsafe void Uniform3f(int location, int count, ReadOnlySpan<System.Numerics.Vector3> value)
+        {
+            fixed (System.Numerics.Vector3* tmp_vecPtr = value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                Uniform3fv(location, count, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="Uniform3fv"/>
+        public static unsafe void Uniform3f(int location, int count, System.Numerics.Vector3[] value)
+        {
+            fixed (System.Numerics.Vector3* tmp_vecPtr = value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                Uniform3fv(location, count, value_ptr);
+            }
+        }
         /// <inheritdoc cref="Uniform4fv"/>
         public static unsafe void Uniform4f(int location, in Vector4 value)
         {
@@ -2176,6 +2232,34 @@ namespace OpenTK.Graphics.OpenGL
         public static unsafe void Uniform4f(int location, int count, Vector4[] value)
         {
             fixed (Vector4* tmp_vecPtr = value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                Uniform4fv(location, count, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="Uniform4fv"/>
+        public static unsafe void Uniform4f(int location, in System.Numerics.Vector4 value)
+        {
+            int count = 1;
+            fixed (System.Numerics.Vector4* tmp_vecPtr = &value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                Uniform4fv(location, count, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="Uniform4fv"/>
+        public static unsafe void Uniform4f(int location, int count, ReadOnlySpan<System.Numerics.Vector4> value)
+        {
+            fixed (System.Numerics.Vector4* tmp_vecPtr = value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                Uniform4fv(location, count, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="Uniform4fv"/>
+        public static unsafe void Uniform4f(int location, int count, System.Numerics.Vector4[] value)
+        {
+            fixed (System.Numerics.Vector4* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
                 Uniform4fv(location, count, value_ptr);
@@ -2372,6 +2456,34 @@ namespace OpenTK.Graphics.OpenGL
         public static unsafe void UniformMatrix4f(int location, int count, bool transpose, Matrix4[] value)
         {
             fixed (Matrix4* tmp_vecPtr = value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                UniformMatrix4fv(location, count, transpose, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="UniformMatrix4fv"/>
+        public static unsafe void UniformMatrix4f(int location, bool transpose, in System.Numerics.Matrix4x4 value)
+        {
+            int count = 1;
+            fixed (System.Numerics.Matrix4x4* tmp_vecPtr = &value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                UniformMatrix4fv(location, count, transpose, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="UniformMatrix4fv"/>
+        public static unsafe void UniformMatrix4f(int location, int count, bool transpose, ReadOnlySpan<System.Numerics.Matrix4x4> value)
+        {
+            fixed (System.Numerics.Matrix4x4* tmp_vecPtr = value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                UniformMatrix4fv(location, count, transpose, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="UniformMatrix4fv"/>
+        public static unsafe void UniformMatrix4f(int location, int count, bool transpose, System.Numerics.Matrix4x4[] value)
+        {
+            fixed (System.Numerics.Matrix4x4* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
                 UniformMatrix4fv(location, count, transpose, value_ptr);
@@ -3011,6 +3123,34 @@ namespace OpenTK.Graphics.OpenGL
         public static unsafe void UniformMatrix3x2f(int location, int count, bool transpose, Matrix3x2[] value)
         {
             fixed (Matrix3x2* tmp_vecPtr = value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                UniformMatrix3x2fv(location, count, transpose, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="UniformMatrix3x2fv"/>
+        public static unsafe void UniformMatrix3x2f(int location, bool transpose, in System.Numerics.Matrix3x2 value)
+        {
+            int count = 1;
+            fixed (System.Numerics.Matrix3x2* tmp_vecPtr = &value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                UniformMatrix3x2fv(location, count, transpose, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="UniformMatrix3x2fv"/>
+        public static unsafe void UniformMatrix3x2f(int location, int count, bool transpose, ReadOnlySpan<System.Numerics.Matrix3x2> value)
+        {
+            fixed (System.Numerics.Matrix3x2* tmp_vecPtr = value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                UniformMatrix3x2fv(location, count, transpose, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="UniformMatrix3x2fv"/>
+        public static unsafe void UniformMatrix3x2f(int location, int count, bool transpose, System.Numerics.Matrix3x2[] value)
+        {
+            fixed (System.Numerics.Matrix3x2* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
                 UniformMatrix3x2fv(location, count, transpose, value_ptr);
@@ -6459,6 +6599,34 @@ namespace OpenTK.Graphics.OpenGL
                 ProgramUniform2fv(program, location, count, value_ptr);
             }
         }
+        /// <inheritdoc cref="ProgramUniform2fv"/>
+        public static unsafe void ProgramUniform2f(ProgramHandle program, int location, in System.Numerics.Vector2 value)
+        {
+            int count = 1;
+            fixed (System.Numerics.Vector2* tmp_vecPtr = &value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                ProgramUniform2fv(program, location, count, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="ProgramUniform2fv"/>
+        public static unsafe void ProgramUniform2f(ProgramHandle program, int location, int count, ReadOnlySpan<System.Numerics.Vector2> value)
+        {
+            fixed (System.Numerics.Vector2* tmp_vecPtr = value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                ProgramUniform2fv(program, location, count, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="ProgramUniform2fv"/>
+        public static unsafe void ProgramUniform2f(ProgramHandle program, int location, int count, System.Numerics.Vector2[] value)
+        {
+            fixed (System.Numerics.Vector2* tmp_vecPtr = value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                ProgramUniform2fv(program, location, count, value_ptr);
+            }
+        }
         /// <inheritdoc cref="ProgramUniform2dv"/>
         public static unsafe void ProgramUniform2d(ProgramHandle program, int location, in Vector2d value)
         {
@@ -6569,6 +6737,34 @@ namespace OpenTK.Graphics.OpenGL
                 ProgramUniform3fv(program, location, count, value_ptr);
             }
         }
+        /// <inheritdoc cref="ProgramUniform3fv"/>
+        public static unsafe void ProgramUniform3f(ProgramHandle program, int location, in System.Numerics.Vector3 value)
+        {
+            int count = 1;
+            fixed (System.Numerics.Vector3* tmp_vecPtr = &value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                ProgramUniform3fv(program, location, count, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="ProgramUniform3fv"/>
+        public static unsafe void ProgramUniform3f(ProgramHandle program, int location, int count, ReadOnlySpan<System.Numerics.Vector3> value)
+        {
+            fixed (System.Numerics.Vector3* tmp_vecPtr = value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                ProgramUniform3fv(program, location, count, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="ProgramUniform3fv"/>
+        public static unsafe void ProgramUniform3f(ProgramHandle program, int location, int count, System.Numerics.Vector3[] value)
+        {
+            fixed (System.Numerics.Vector3* tmp_vecPtr = value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                ProgramUniform3fv(program, location, count, value_ptr);
+            }
+        }
         /// <inheritdoc cref="ProgramUniform3dv"/>
         public static unsafe void ProgramUniform3d(ProgramHandle program, int location, in Vector3d value)
         {
@@ -6674,6 +6870,34 @@ namespace OpenTK.Graphics.OpenGL
         public static unsafe void ProgramUniform4f(ProgramHandle program, int location, int count, Vector4[] value)
         {
             fixed (Vector4* tmp_vecPtr = value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                ProgramUniform4fv(program, location, count, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="ProgramUniform4fv"/>
+        public static unsafe void ProgramUniform4f(ProgramHandle program, int location, in System.Numerics.Vector4 value)
+        {
+            int count = 1;
+            fixed (System.Numerics.Vector4* tmp_vecPtr = &value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                ProgramUniform4fv(program, location, count, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="ProgramUniform4fv"/>
+        public static unsafe void ProgramUniform4f(ProgramHandle program, int location, int count, ReadOnlySpan<System.Numerics.Vector4> value)
+        {
+            fixed (System.Numerics.Vector4* tmp_vecPtr = value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                ProgramUniform4fv(program, location, count, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="ProgramUniform4fv"/>
+        public static unsafe void ProgramUniform4f(ProgramHandle program, int location, int count, System.Numerics.Vector4[] value)
+        {
+            fixed (System.Numerics.Vector4* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
                 ProgramUniform4fv(program, location, count, value_ptr);
@@ -6817,6 +7041,34 @@ namespace OpenTK.Graphics.OpenGL
                 ProgramUniformMatrix4fv(program, location, count, transpose, value_ptr);
             }
         }
+        /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
+        public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, bool transpose, in System.Numerics.Matrix4x4 value)
+        {
+            int count = 1;
+            fixed (System.Numerics.Matrix4x4* tmp_vecPtr = &value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                ProgramUniformMatrix4fv(program, location, count, transpose, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
+        public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<System.Numerics.Matrix4x4> value)
+        {
+            fixed (System.Numerics.Matrix4x4* tmp_vecPtr = value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                ProgramUniformMatrix4fv(program, location, count, transpose, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
+        public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, int count, bool transpose, System.Numerics.Matrix4x4[] value)
+        {
+            fixed (System.Numerics.Matrix4x4* tmp_vecPtr = value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                ProgramUniformMatrix4fv(program, location, count, transpose, value_ptr);
+            }
+        }
         /// <inheritdoc cref="ProgramUniformMatrix2dv"/>
         public static unsafe void ProgramUniformMatrix2d(ProgramHandle program, int location, bool transpose, in Matrix2d value)
         {
@@ -6952,6 +7204,34 @@ namespace OpenTK.Graphics.OpenGL
         public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, int count, bool transpose, Matrix3x2[] value)
         {
             fixed (Matrix3x2* tmp_vecPtr = value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                ProgramUniformMatrix3x2fv(program, location, count, transpose, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
+        public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, bool transpose, in System.Numerics.Matrix3x2 value)
+        {
+            int count = 1;
+            fixed (System.Numerics.Matrix3x2* tmp_vecPtr = &value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                ProgramUniformMatrix3x2fv(program, location, count, transpose, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
+        public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<System.Numerics.Matrix3x2> value)
+        {
+            fixed (System.Numerics.Matrix3x2* tmp_vecPtr = value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                ProgramUniformMatrix3x2fv(program, location, count, transpose, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
+        public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, int count, bool transpose, System.Numerics.Matrix3x2[] value)
+        {
+            fixed (System.Numerics.Matrix3x2* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
                 ProgramUniformMatrix3x2fv(program, location, count, transpose, value_ptr);
@@ -17564,6 +17844,34 @@ namespace OpenTK.Graphics.OpenGL
                     ProgramUniform2fv(program, location, count, value_ptr);
                 }
             }
+            /// <inheritdoc cref="ProgramUniform2fv"/>
+            public static unsafe void ProgramUniform2f(ProgramHandle program, int location, in System.Numerics.Vector2 value)
+            {
+                int count = 1;
+                fixed (System.Numerics.Vector2* tmp_vecPtr = &value)
+                {
+                    float* value_ptr = (float*)tmp_vecPtr;
+                    ProgramUniform2fv(program, location, count, value_ptr);
+                }
+            }
+            /// <inheritdoc cref="ProgramUniform2fv"/>
+            public static unsafe void ProgramUniform2f(ProgramHandle program, int location, int count, ReadOnlySpan<System.Numerics.Vector2> value)
+            {
+                fixed (System.Numerics.Vector2* tmp_vecPtr = value)
+                {
+                    float* value_ptr = (float*)tmp_vecPtr;
+                    ProgramUniform2fv(program, location, count, value_ptr);
+                }
+            }
+            /// <inheritdoc cref="ProgramUniform2fv"/>
+            public static unsafe void ProgramUniform2f(ProgramHandle program, int location, int count, System.Numerics.Vector2[] value)
+            {
+                fixed (System.Numerics.Vector2* tmp_vecPtr = value)
+                {
+                    float* value_ptr = (float*)tmp_vecPtr;
+                    ProgramUniform2fv(program, location, count, value_ptr);
+                }
+            }
             /// <inheritdoc cref="ProgramUniform2dv"/>
             public static unsafe void ProgramUniform2d(ProgramHandle program, int location, in Vector2d value)
             {
@@ -17674,6 +17982,34 @@ namespace OpenTK.Graphics.OpenGL
                     ProgramUniform3fv(program, location, count, value_ptr);
                 }
             }
+            /// <inheritdoc cref="ProgramUniform3fv"/>
+            public static unsafe void ProgramUniform3f(ProgramHandle program, int location, in System.Numerics.Vector3 value)
+            {
+                int count = 1;
+                fixed (System.Numerics.Vector3* tmp_vecPtr = &value)
+                {
+                    float* value_ptr = (float*)tmp_vecPtr;
+                    ProgramUniform3fv(program, location, count, value_ptr);
+                }
+            }
+            /// <inheritdoc cref="ProgramUniform3fv"/>
+            public static unsafe void ProgramUniform3f(ProgramHandle program, int location, int count, ReadOnlySpan<System.Numerics.Vector3> value)
+            {
+                fixed (System.Numerics.Vector3* tmp_vecPtr = value)
+                {
+                    float* value_ptr = (float*)tmp_vecPtr;
+                    ProgramUniform3fv(program, location, count, value_ptr);
+                }
+            }
+            /// <inheritdoc cref="ProgramUniform3fv"/>
+            public static unsafe void ProgramUniform3f(ProgramHandle program, int location, int count, System.Numerics.Vector3[] value)
+            {
+                fixed (System.Numerics.Vector3* tmp_vecPtr = value)
+                {
+                    float* value_ptr = (float*)tmp_vecPtr;
+                    ProgramUniform3fv(program, location, count, value_ptr);
+                }
+            }
             /// <inheritdoc cref="ProgramUniform3dv"/>
             public static unsafe void ProgramUniform3d(ProgramHandle program, int location, in Vector3d value)
             {
@@ -17779,6 +18115,34 @@ namespace OpenTK.Graphics.OpenGL
             public static unsafe void ProgramUniform4f(ProgramHandle program, int location, int count, Vector4[] value)
             {
                 fixed (Vector4* tmp_vecPtr = value)
+                {
+                    float* value_ptr = (float*)tmp_vecPtr;
+                    ProgramUniform4fv(program, location, count, value_ptr);
+                }
+            }
+            /// <inheritdoc cref="ProgramUniform4fv"/>
+            public static unsafe void ProgramUniform4f(ProgramHandle program, int location, in System.Numerics.Vector4 value)
+            {
+                int count = 1;
+                fixed (System.Numerics.Vector4* tmp_vecPtr = &value)
+                {
+                    float* value_ptr = (float*)tmp_vecPtr;
+                    ProgramUniform4fv(program, location, count, value_ptr);
+                }
+            }
+            /// <inheritdoc cref="ProgramUniform4fv"/>
+            public static unsafe void ProgramUniform4f(ProgramHandle program, int location, int count, ReadOnlySpan<System.Numerics.Vector4> value)
+            {
+                fixed (System.Numerics.Vector4* tmp_vecPtr = value)
+                {
+                    float* value_ptr = (float*)tmp_vecPtr;
+                    ProgramUniform4fv(program, location, count, value_ptr);
+                }
+            }
+            /// <inheritdoc cref="ProgramUniform4fv"/>
+            public static unsafe void ProgramUniform4f(ProgramHandle program, int location, int count, System.Numerics.Vector4[] value)
+            {
+                fixed (System.Numerics.Vector4* tmp_vecPtr = value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
                     ProgramUniform4fv(program, location, count, value_ptr);
@@ -17922,6 +18286,34 @@ namespace OpenTK.Graphics.OpenGL
                     ProgramUniformMatrix4fv(program, location, count, transpose, value_ptr);
                 }
             }
+            /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
+            public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, bool transpose, in System.Numerics.Matrix4x4 value)
+            {
+                int count = 1;
+                fixed (System.Numerics.Matrix4x4* tmp_vecPtr = &value)
+                {
+                    float* value_ptr = (float*)tmp_vecPtr;
+                    ProgramUniformMatrix4fv(program, location, count, transpose, value_ptr);
+                }
+            }
+            /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
+            public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<System.Numerics.Matrix4x4> value)
+            {
+                fixed (System.Numerics.Matrix4x4* tmp_vecPtr = value)
+                {
+                    float* value_ptr = (float*)tmp_vecPtr;
+                    ProgramUniformMatrix4fv(program, location, count, transpose, value_ptr);
+                }
+            }
+            /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
+            public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, int count, bool transpose, System.Numerics.Matrix4x4[] value)
+            {
+                fixed (System.Numerics.Matrix4x4* tmp_vecPtr = value)
+                {
+                    float* value_ptr = (float*)tmp_vecPtr;
+                    ProgramUniformMatrix4fv(program, location, count, transpose, value_ptr);
+                }
+            }
             /// <inheritdoc cref="ProgramUniformMatrix2dv"/>
             public static unsafe void ProgramUniformMatrix2d(ProgramHandle program, int location, bool transpose, in Matrix2d value)
             {
@@ -18057,6 +18449,34 @@ namespace OpenTK.Graphics.OpenGL
             public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, int count, bool transpose, Matrix3x2[] value)
             {
                 fixed (Matrix3x2* tmp_vecPtr = value)
+                {
+                    float* value_ptr = (float*)tmp_vecPtr;
+                    ProgramUniformMatrix3x2fv(program, location, count, transpose, value_ptr);
+                }
+            }
+            /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
+            public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, bool transpose, in System.Numerics.Matrix3x2 value)
+            {
+                int count = 1;
+                fixed (System.Numerics.Matrix3x2* tmp_vecPtr = &value)
+                {
+                    float* value_ptr = (float*)tmp_vecPtr;
+                    ProgramUniformMatrix3x2fv(program, location, count, transpose, value_ptr);
+                }
+            }
+            /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
+            public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<System.Numerics.Matrix3x2> value)
+            {
+                fixed (System.Numerics.Matrix3x2* tmp_vecPtr = value)
+                {
+                    float* value_ptr = (float*)tmp_vecPtr;
+                    ProgramUniformMatrix3x2fv(program, location, count, transpose, value_ptr);
+                }
+            }
+            /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
+            public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, int count, bool transpose, System.Numerics.Matrix3x2[] value)
+            {
+                fixed (System.Numerics.Matrix3x2* tmp_vecPtr = value)
                 {
                     float* value_ptr = (float*)tmp_vecPtr;
                     ProgramUniformMatrix3x2fv(program, location, count, transpose, value_ptr);

--- a/src/OpenTK.Graphics/OpenGLES3/GL.Overloads.cs
+++ b/src/OpenTK.Graphics/OpenGLES3/GL.Overloads.cs
@@ -1713,6 +1713,34 @@ namespace OpenTK.Graphics.OpenGLES3
                 Uniform2fv(location, count, value_ptr);
             }
         }
+        /// <inheritdoc cref="Uniform2fv"/>
+        public static unsafe void Uniform2f(int location, in System.Numerics.Vector2 value)
+        {
+            int count = 1;
+            fixed (System.Numerics.Vector2* tmp_vecPtr = &value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                Uniform2fv(location, count, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="Uniform2fv"/>
+        public static unsafe void Uniform2f(int location, int count, ReadOnlySpan<System.Numerics.Vector2> value)
+        {
+            fixed (System.Numerics.Vector2* tmp_vecPtr = value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                Uniform2fv(location, count, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="Uniform2fv"/>
+        public static unsafe void Uniform2f(int location, int count, System.Numerics.Vector2[] value)
+        {
+            fixed (System.Numerics.Vector2* tmp_vecPtr = value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                Uniform2fv(location, count, value_ptr);
+            }
+        }
         /// <inheritdoc cref="Uniform2iv"/>
         public static unsafe void Uniform2i(int location, in Vector2i value)
         {
@@ -1769,6 +1797,34 @@ namespace OpenTK.Graphics.OpenGLES3
                 Uniform3fv(location, count, value_ptr);
             }
         }
+        /// <inheritdoc cref="Uniform3fv"/>
+        public static unsafe void Uniform3f(int location, in System.Numerics.Vector3 value)
+        {
+            int count = 1;
+            fixed (System.Numerics.Vector3* tmp_vecPtr = &value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                Uniform3fv(location, count, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="Uniform3fv"/>
+        public static unsafe void Uniform3f(int location, int count, ReadOnlySpan<System.Numerics.Vector3> value)
+        {
+            fixed (System.Numerics.Vector3* tmp_vecPtr = value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                Uniform3fv(location, count, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="Uniform3fv"/>
+        public static unsafe void Uniform3f(int location, int count, System.Numerics.Vector3[] value)
+        {
+            fixed (System.Numerics.Vector3* tmp_vecPtr = value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                Uniform3fv(location, count, value_ptr);
+            }
+        }
         /// <inheritdoc cref="Uniform3iv"/>
         public static unsafe void Uniform3i(int location, in Vector3i value)
         {
@@ -1820,6 +1876,34 @@ namespace OpenTK.Graphics.OpenGLES3
         public static unsafe void Uniform4f(int location, int count, Vector4[] value)
         {
             fixed (Vector4* tmp_vecPtr = value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                Uniform4fv(location, count, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="Uniform4fv"/>
+        public static unsafe void Uniform4f(int location, in System.Numerics.Vector4 value)
+        {
+            int count = 1;
+            fixed (System.Numerics.Vector4* tmp_vecPtr = &value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                Uniform4fv(location, count, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="Uniform4fv"/>
+        public static unsafe void Uniform4f(int location, int count, ReadOnlySpan<System.Numerics.Vector4> value)
+        {
+            fixed (System.Numerics.Vector4* tmp_vecPtr = value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                Uniform4fv(location, count, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="Uniform4fv"/>
+        public static unsafe void Uniform4f(int location, int count, System.Numerics.Vector4[] value)
+        {
+            fixed (System.Numerics.Vector4* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
                 Uniform4fv(location, count, value_ptr);
@@ -1932,6 +2016,34 @@ namespace OpenTK.Graphics.OpenGLES3
         public static unsafe void UniformMatrix4f(int location, int count, bool transpose, Matrix4[] value)
         {
             fixed (Matrix4* tmp_vecPtr = value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                UniformMatrix4fv(location, count, transpose, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="UniformMatrix4fv"/>
+        public static unsafe void UniformMatrix4f(int location, bool transpose, in System.Numerics.Matrix4x4 value)
+        {
+            int count = 1;
+            fixed (System.Numerics.Matrix4x4* tmp_vecPtr = &value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                UniformMatrix4fv(location, count, transpose, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="UniformMatrix4fv"/>
+        public static unsafe void UniformMatrix4f(int location, int count, bool transpose, ReadOnlySpan<System.Numerics.Matrix4x4> value)
+        {
+            fixed (System.Numerics.Matrix4x4* tmp_vecPtr = value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                UniformMatrix4fv(location, count, transpose, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="UniformMatrix4fv"/>
+        public static unsafe void UniformMatrix4f(int location, int count, bool transpose, System.Numerics.Matrix4x4[] value)
+        {
+            fixed (System.Numerics.Matrix4x4* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
                 UniformMatrix4fv(location, count, transpose, value_ptr);
@@ -2406,6 +2518,34 @@ namespace OpenTK.Graphics.OpenGLES3
         public static unsafe void UniformMatrix3x2f(int location, int count, bool transpose, Matrix3x2[] value)
         {
             fixed (Matrix3x2* tmp_vecPtr = value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                UniformMatrix3x2fv(location, count, transpose, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="UniformMatrix3x2fv"/>
+        public static unsafe void UniformMatrix3x2f(int location, bool transpose, in System.Numerics.Matrix3x2 value)
+        {
+            int count = 1;
+            fixed (System.Numerics.Matrix3x2* tmp_vecPtr = &value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                UniformMatrix3x2fv(location, count, transpose, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="UniformMatrix3x2fv"/>
+        public static unsafe void UniformMatrix3x2f(int location, int count, bool transpose, ReadOnlySpan<System.Numerics.Matrix3x2> value)
+        {
+            fixed (System.Numerics.Matrix3x2* tmp_vecPtr = value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                UniformMatrix3x2fv(location, count, transpose, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="UniformMatrix3x2fv"/>
+        public static unsafe void UniformMatrix3x2f(int location, int count, bool transpose, System.Numerics.Matrix3x2[] value)
+        {
+            fixed (System.Numerics.Matrix3x2* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
                 UniformMatrix3x2fv(location, count, transpose, value_ptr);
@@ -4420,6 +4560,34 @@ namespace OpenTK.Graphics.OpenGLES3
                 ProgramUniform2fv(program, location, count, value_ptr);
             }
         }
+        /// <inheritdoc cref="ProgramUniform2fv"/>
+        public static unsafe void ProgramUniform2f(ProgramHandle program, int location, in System.Numerics.Vector2 value)
+        {
+            int count = 1;
+            fixed (System.Numerics.Vector2* tmp_vecPtr = &value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                ProgramUniform2fv(program, location, count, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="ProgramUniform2fv"/>
+        public static unsafe void ProgramUniform2f(ProgramHandle program, int location, int count, ReadOnlySpan<System.Numerics.Vector2> value)
+        {
+            fixed (System.Numerics.Vector2* tmp_vecPtr = value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                ProgramUniform2fv(program, location, count, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="ProgramUniform2fv"/>
+        public static unsafe void ProgramUniform2f(ProgramHandle program, int location, int count, System.Numerics.Vector2[] value)
+        {
+            fixed (System.Numerics.Vector2* tmp_vecPtr = value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                ProgramUniform2fv(program, location, count, value_ptr);
+            }
+        }
         /// <inheritdoc cref="ProgramUniform3fv"/>
         public static unsafe void ProgramUniform3f(ProgramHandle program, int location, in Vector3 value)
         {
@@ -4448,6 +4616,34 @@ namespace OpenTK.Graphics.OpenGLES3
                 ProgramUniform3fv(program, location, count, value_ptr);
             }
         }
+        /// <inheritdoc cref="ProgramUniform3fv"/>
+        public static unsafe void ProgramUniform3f(ProgramHandle program, int location, in System.Numerics.Vector3 value)
+        {
+            int count = 1;
+            fixed (System.Numerics.Vector3* tmp_vecPtr = &value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                ProgramUniform3fv(program, location, count, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="ProgramUniform3fv"/>
+        public static unsafe void ProgramUniform3f(ProgramHandle program, int location, int count, ReadOnlySpan<System.Numerics.Vector3> value)
+        {
+            fixed (System.Numerics.Vector3* tmp_vecPtr = value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                ProgramUniform3fv(program, location, count, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="ProgramUniform3fv"/>
+        public static unsafe void ProgramUniform3f(ProgramHandle program, int location, int count, System.Numerics.Vector3[] value)
+        {
+            fixed (System.Numerics.Vector3* tmp_vecPtr = value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                ProgramUniform3fv(program, location, count, value_ptr);
+            }
+        }
         /// <inheritdoc cref="ProgramUniform4fv"/>
         public static unsafe void ProgramUniform4f(ProgramHandle program, int location, in Vector4 value)
         {
@@ -4471,6 +4667,34 @@ namespace OpenTK.Graphics.OpenGLES3
         public static unsafe void ProgramUniform4f(ProgramHandle program, int location, int count, Vector4[] value)
         {
             fixed (Vector4* tmp_vecPtr = value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                ProgramUniform4fv(program, location, count, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="ProgramUniform4fv"/>
+        public static unsafe void ProgramUniform4f(ProgramHandle program, int location, in System.Numerics.Vector4 value)
+        {
+            int count = 1;
+            fixed (System.Numerics.Vector4* tmp_vecPtr = &value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                ProgramUniform4fv(program, location, count, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="ProgramUniform4fv"/>
+        public static unsafe void ProgramUniform4f(ProgramHandle program, int location, int count, ReadOnlySpan<System.Numerics.Vector4> value)
+        {
+            fixed (System.Numerics.Vector4* tmp_vecPtr = value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                ProgramUniform4fv(program, location, count, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="ProgramUniform4fv"/>
+        public static unsafe void ProgramUniform4f(ProgramHandle program, int location, int count, System.Numerics.Vector4[] value)
+        {
+            fixed (System.Numerics.Vector4* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
                 ProgramUniform4fv(program, location, count, value_ptr);
@@ -4560,6 +4784,34 @@ namespace OpenTK.Graphics.OpenGLES3
                 ProgramUniformMatrix4fv(program, location, count, transpose, value_ptr);
             }
         }
+        /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
+        public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, bool transpose, in System.Numerics.Matrix4x4 value)
+        {
+            int count = 1;
+            fixed (System.Numerics.Matrix4x4* tmp_vecPtr = &value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                ProgramUniformMatrix4fv(program, location, count, transpose, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
+        public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<System.Numerics.Matrix4x4> value)
+        {
+            fixed (System.Numerics.Matrix4x4* tmp_vecPtr = value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                ProgramUniformMatrix4fv(program, location, count, transpose, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
+        public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, int count, bool transpose, System.Numerics.Matrix4x4[] value)
+        {
+            fixed (System.Numerics.Matrix4x4* tmp_vecPtr = value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                ProgramUniformMatrix4fv(program, location, count, transpose, value_ptr);
+            }
+        }
         /// <inheritdoc cref="ProgramUniformMatrix2x3fv"/>
         public static unsafe void ProgramUniformMatrix2x3f(ProgramHandle program, int location, bool transpose, in Matrix2x3 value)
         {
@@ -4611,6 +4863,34 @@ namespace OpenTK.Graphics.OpenGLES3
         public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, int count, bool transpose, Matrix3x2[] value)
         {
             fixed (Matrix3x2* tmp_vecPtr = value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                ProgramUniformMatrix3x2fv(program, location, count, transpose, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
+        public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, bool transpose, in System.Numerics.Matrix3x2 value)
+        {
+            int count = 1;
+            fixed (System.Numerics.Matrix3x2* tmp_vecPtr = &value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                ProgramUniformMatrix3x2fv(program, location, count, transpose, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
+        public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<System.Numerics.Matrix3x2> value)
+        {
+            fixed (System.Numerics.Matrix3x2* tmp_vecPtr = value)
+            {
+                float* value_ptr = (float*)tmp_vecPtr;
+                ProgramUniformMatrix3x2fv(program, location, count, transpose, value_ptr);
+            }
+        }
+        /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
+        public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, int count, bool transpose, System.Numerics.Matrix3x2[] value)
+        {
+            fixed (System.Numerics.Matrix3x2* tmp_vecPtr = value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
                 ProgramUniformMatrix3x2fv(program, location, count, transpose, value_ptr);

--- a/src/OpenTK.Graphics/OpenGLES3/GL.Overloads.cs
+++ b/src/OpenTK.Graphics/OpenGLES3/GL.Overloads.cs
@@ -1630,9 +1630,8 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="Uniform1fv"/>
-        public static unsafe void Uniform1f(int location, in float value)
+        public static unsafe void Uniform1f(int location, int count, in float value)
         {
-            int count = 1;
             fixed (float* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -1658,9 +1657,8 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="Uniform1iv"/>
-        public static unsafe void Uniform1i(int location, in int value)
+        public static unsafe void Uniform1i(int location, int count, in int value)
         {
-            int count = 1;
             fixed (int* tmp_vecPtr = &value)
             {
                 int* value_ptr = (int*)tmp_vecPtr;
@@ -1686,9 +1684,8 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="Uniform2fv"/>
-        public static unsafe void Uniform2f(int location, in Vector2 value)
+        public static unsafe void Uniform2f(int location, int count, in Vector2 value)
         {
-            int count = 1;
             fixed (Vector2* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -1714,9 +1711,8 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="Uniform2fv"/>
-        public static unsafe void Uniform2f(int location, in System.Numerics.Vector2 value)
+        public static unsafe void Uniform2f(int location, int count, in System.Numerics.Vector2 value)
         {
-            int count = 1;
             fixed (System.Numerics.Vector2* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -1742,9 +1738,8 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="Uniform2iv"/>
-        public static unsafe void Uniform2i(int location, in Vector2i value)
+        public static unsafe void Uniform2i(int location, int count, in Vector2i value)
         {
-            int count = 1;
             fixed (Vector2i* tmp_vecPtr = &value)
             {
                 int* value_ptr = (int*)tmp_vecPtr;
@@ -1770,9 +1765,8 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="Uniform3fv"/>
-        public static unsafe void Uniform3f(int location, in Vector3 value)
+        public static unsafe void Uniform3f(int location, int count, in Vector3 value)
         {
-            int count = 1;
             fixed (Vector3* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -1798,9 +1792,8 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="Uniform3fv"/>
-        public static unsafe void Uniform3f(int location, in System.Numerics.Vector3 value)
+        public static unsafe void Uniform3f(int location, int count, in System.Numerics.Vector3 value)
         {
-            int count = 1;
             fixed (System.Numerics.Vector3* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -1826,9 +1819,8 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="Uniform3iv"/>
-        public static unsafe void Uniform3i(int location, in Vector3i value)
+        public static unsafe void Uniform3i(int location, int count, in Vector3i value)
         {
-            int count = 1;
             fixed (Vector3i* tmp_vecPtr = &value)
             {
                 int* value_ptr = (int*)tmp_vecPtr;
@@ -1854,9 +1846,8 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="Uniform4fv"/>
-        public static unsafe void Uniform4f(int location, in Vector4 value)
+        public static unsafe void Uniform4f(int location, int count, in Vector4 value)
         {
-            int count = 1;
             fixed (Vector4* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -1882,9 +1873,8 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="Uniform4fv"/>
-        public static unsafe void Uniform4f(int location, in System.Numerics.Vector4 value)
+        public static unsafe void Uniform4f(int location, int count, in System.Numerics.Vector4 value)
         {
-            int count = 1;
             fixed (System.Numerics.Vector4* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -1910,9 +1900,8 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="Uniform4iv"/>
-        public static unsafe void Uniform4i(int location, in Vector4i value)
+        public static unsafe void Uniform4i(int location, int count, in Vector4i value)
         {
-            int count = 1;
             fixed (Vector4i* tmp_vecPtr = &value)
             {
                 int* value_ptr = (int*)tmp_vecPtr;
@@ -1938,9 +1927,8 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="UniformMatrix2fv"/>
-        public static unsafe void UniformMatrix2f(int location, bool transpose, in Matrix2 value)
+        public static unsafe void UniformMatrix2f(int location, int count, bool transpose, in Matrix2 value)
         {
-            int count = 1;
             fixed (Matrix2* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -1966,9 +1954,8 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="UniformMatrix3fv"/>
-        public static unsafe void UniformMatrix3f(int location, bool transpose, in Matrix3 value)
+        public static unsafe void UniformMatrix3f(int location, int count, bool transpose, in Matrix3 value)
         {
-            int count = 1;
             fixed (Matrix3* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -1994,9 +1981,8 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="UniformMatrix4fv"/>
-        public static unsafe void UniformMatrix4f(int location, bool transpose, in Matrix4 value)
+        public static unsafe void UniformMatrix4f(int location, int count, bool transpose, in Matrix4 value)
         {
-            int count = 1;
             fixed (Matrix4* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -2022,9 +2008,8 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="UniformMatrix4fv"/>
-        public static unsafe void UniformMatrix4f(int location, bool transpose, in System.Numerics.Matrix4x4 value)
+        public static unsafe void UniformMatrix4f(int location, int count, bool transpose, in System.Numerics.Matrix4x4 value)
         {
-            int count = 1;
             fixed (System.Numerics.Matrix4x4* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -2050,98 +2035,65 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="VertexAttrib1fv"/>
-        public static unsafe void VertexAttrib1fv(uint index, ReadOnlySpan<float> v)
+        public static unsafe void VertexAttrib1f(uint index, in float v)
         {
-            fixed (float* v_ptr = v)
+            fixed (float* tmp_vecPtr = &v)
             {
-                VertexAttrib1fv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttrib1fv"/>
-        public static unsafe void VertexAttrib1fv(uint index, float[] v)
-        {
-            fixed (float* v_ptr = v)
-            {
-                VertexAttrib1fv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttrib1fv"/>
-        public static unsafe void VertexAttrib1fv(uint index, in float v)
-        {
-            fixed (float* v_ptr = &v)
-            {
+                float* v_ptr = (float*)tmp_vecPtr;
                 VertexAttrib1fv(index, v_ptr);
             }
         }
         /// <inheritdoc cref="VertexAttrib2fv"/>
-        public static unsafe void VertexAttrib2fv(uint index, ReadOnlySpan<float> v)
+        public static unsafe void VertexAttrib2f(uint index, in Vector2 v)
         {
-            fixed (float* v_ptr = v)
+            fixed (Vector2* tmp_vecPtr = &v)
             {
+                float* v_ptr = (float*)tmp_vecPtr;
                 VertexAttrib2fv(index, v_ptr);
             }
         }
         /// <inheritdoc cref="VertexAttrib2fv"/>
-        public static unsafe void VertexAttrib2fv(uint index, float[] v)
+        public static unsafe void VertexAttrib2f(uint index, in System.Numerics.Vector2 v)
         {
-            fixed (float* v_ptr = v)
+            fixed (System.Numerics.Vector2* tmp_vecPtr = &v)
             {
-                VertexAttrib2fv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttrib2fv"/>
-        public static unsafe void VertexAttrib2fv(uint index, in float v)
-        {
-            fixed (float* v_ptr = &v)
-            {
+                float* v_ptr = (float*)tmp_vecPtr;
                 VertexAttrib2fv(index, v_ptr);
             }
         }
         /// <inheritdoc cref="VertexAttrib3fv"/>
-        public static unsafe void VertexAttrib3fv(uint index, ReadOnlySpan<float> v)
+        public static unsafe void VertexAttrib3f(uint index, in Vector3 v)
         {
-            fixed (float* v_ptr = v)
+            fixed (Vector3* tmp_vecPtr = &v)
             {
+                float* v_ptr = (float*)tmp_vecPtr;
                 VertexAttrib3fv(index, v_ptr);
             }
         }
         /// <inheritdoc cref="VertexAttrib3fv"/>
-        public static unsafe void VertexAttrib3fv(uint index, float[] v)
+        public static unsafe void VertexAttrib3f(uint index, in System.Numerics.Vector3 v)
         {
-            fixed (float* v_ptr = v)
+            fixed (System.Numerics.Vector3* tmp_vecPtr = &v)
             {
-                VertexAttrib3fv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttrib3fv"/>
-        public static unsafe void VertexAttrib3fv(uint index, in float v)
-        {
-            fixed (float* v_ptr = &v)
-            {
+                float* v_ptr = (float*)tmp_vecPtr;
                 VertexAttrib3fv(index, v_ptr);
             }
         }
         /// <inheritdoc cref="VertexAttrib4fv"/>
-        public static unsafe void VertexAttrib4fv(uint index, ReadOnlySpan<float> v)
+        public static unsafe void VertexAttrib4f(uint index, in Vector4 v)
         {
-            fixed (float* v_ptr = v)
+            fixed (Vector4* tmp_vecPtr = &v)
             {
+                float* v_ptr = (float*)tmp_vecPtr;
                 VertexAttrib4fv(index, v_ptr);
             }
         }
         /// <inheritdoc cref="VertexAttrib4fv"/>
-        public static unsafe void VertexAttrib4fv(uint index, float[] v)
+        public static unsafe void VertexAttrib4f(uint index, in System.Numerics.Vector4 v)
         {
-            fixed (float* v_ptr = v)
+            fixed (System.Numerics.Vector4* tmp_vecPtr = &v)
             {
-                VertexAttrib4fv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttrib4fv"/>
-        public static unsafe void VertexAttrib4fv(uint index, in float v)
-        {
-            fixed (float* v_ptr = &v)
-            {
+                float* v_ptr = (float*)tmp_vecPtr;
                 VertexAttrib4fv(index, v_ptr);
             }
         }
@@ -2468,9 +2420,8 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="UniformMatrix2x3fv"/>
-        public static unsafe void UniformMatrix2x3f(int location, bool transpose, in Matrix2x3 value)
+        public static unsafe void UniformMatrix2x3f(int location, int count, bool transpose, in Matrix2x3 value)
         {
-            int count = 1;
             fixed (Matrix2x3* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -2496,9 +2447,8 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="UniformMatrix3x2fv"/>
-        public static unsafe void UniformMatrix3x2f(int location, bool transpose, in Matrix3x2 value)
+        public static unsafe void UniformMatrix3x2f(int location, int count, bool transpose, in Matrix3x2 value)
         {
-            int count = 1;
             fixed (Matrix3x2* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -2524,9 +2474,8 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="UniformMatrix3x2fv"/>
-        public static unsafe void UniformMatrix3x2f(int location, bool transpose, in System.Numerics.Matrix3x2 value)
+        public static unsafe void UniformMatrix3x2f(int location, int count, bool transpose, in System.Numerics.Matrix3x2 value)
         {
-            int count = 1;
             fixed (System.Numerics.Matrix3x2* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -2552,9 +2501,8 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="UniformMatrix2x4fv"/>
-        public static unsafe void UniformMatrix2x4f(int location, bool transpose, in Matrix2x4 value)
+        public static unsafe void UniformMatrix2x4f(int location, int count, bool transpose, in Matrix2x4 value)
         {
-            int count = 1;
             fixed (Matrix2x4* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -2580,9 +2528,8 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="UniformMatrix4x2fv"/>
-        public static unsafe void UniformMatrix4x2f(int location, bool transpose, in Matrix4x2 value)
+        public static unsafe void UniformMatrix4x2f(int location, int count, bool transpose, in Matrix4x2 value)
         {
-            int count = 1;
             fixed (Matrix4x2* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -2608,9 +2555,8 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="UniformMatrix3x4fv"/>
-        public static unsafe void UniformMatrix3x4f(int location, bool transpose, in Matrix3x4 value)
+        public static unsafe void UniformMatrix3x4f(int location, int count, bool transpose, in Matrix3x4 value)
         {
-            int count = 1;
             fixed (Matrix3x4* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -2636,9 +2582,8 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="UniformMatrix4x3fv"/>
-        public static unsafe void UniformMatrix4x3f(int location, bool transpose, in Matrix4x3 value)
+        public static unsafe void UniformMatrix4x3f(int location, int count, bool transpose, in Matrix4x3 value)
         {
-            int count = 1;
             fixed (Matrix4x3* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -2937,26 +2882,11 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="VertexAttribI4iv"/>
-        public static unsafe void VertexAttribI4iv(uint index, ReadOnlySpan<int> v)
+        public static unsafe void VertexAttribI4i(uint index, in Vector4i v)
         {
-            fixed (int* v_ptr = v)
+            fixed (Vector4i* tmp_vecPtr = &v)
             {
-                VertexAttribI4iv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttribI4iv"/>
-        public static unsafe void VertexAttribI4iv(uint index, int[] v)
-        {
-            fixed (int* v_ptr = v)
-            {
-                VertexAttribI4iv(index, v_ptr);
-            }
-        }
-        /// <inheritdoc cref="VertexAttribI4iv"/>
-        public static unsafe void VertexAttribI4iv(uint index, in int v)
-        {
-            fixed (int* v_ptr = &v)
-            {
+                int* v_ptr = (int*)tmp_vecPtr;
                 VertexAttribI4iv(index, v_ptr);
             }
         }
@@ -4319,9 +4249,8 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniform2iv"/>
-        public static unsafe void ProgramUniform2i(ProgramHandle program, int location, in Vector2i value)
+        public static unsafe void ProgramUniform2i(ProgramHandle program, int location, int count, in Vector2i value)
         {
-            int count = 1;
             fixed (Vector2i* tmp_vecPtr = &value)
             {
                 int* value_ptr = (int*)tmp_vecPtr;
@@ -4347,9 +4276,8 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniform3iv"/>
-        public static unsafe void ProgramUniform3i(ProgramHandle program, int location, in Vector3i value)
+        public static unsafe void ProgramUniform3i(ProgramHandle program, int location, int count, in Vector3i value)
         {
-            int count = 1;
             fixed (Vector3i* tmp_vecPtr = &value)
             {
                 int* value_ptr = (int*)tmp_vecPtr;
@@ -4375,9 +4303,8 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniform4iv"/>
-        public static unsafe void ProgramUniform4i(ProgramHandle program, int location, in Vector4i value)
+        public static unsafe void ProgramUniform4i(ProgramHandle program, int location, int count, in Vector4i value)
         {
-            int count = 1;
             fixed (Vector4i* tmp_vecPtr = &value)
             {
                 int* value_ptr = (int*)tmp_vecPtr;
@@ -4533,9 +4460,8 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniform2fv"/>
-        public static unsafe void ProgramUniform2f(ProgramHandle program, int location, in Vector2 value)
+        public static unsafe void ProgramUniform2f(ProgramHandle program, int location, int count, in Vector2 value)
         {
-            int count = 1;
             fixed (Vector2* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -4561,9 +4487,8 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniform2fv"/>
-        public static unsafe void ProgramUniform2f(ProgramHandle program, int location, in System.Numerics.Vector2 value)
+        public static unsafe void ProgramUniform2f(ProgramHandle program, int location, int count, in System.Numerics.Vector2 value)
         {
-            int count = 1;
             fixed (System.Numerics.Vector2* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -4589,9 +4514,8 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniform3fv"/>
-        public static unsafe void ProgramUniform3f(ProgramHandle program, int location, in Vector3 value)
+        public static unsafe void ProgramUniform3f(ProgramHandle program, int location, int count, in Vector3 value)
         {
-            int count = 1;
             fixed (Vector3* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -4617,9 +4541,8 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniform3fv"/>
-        public static unsafe void ProgramUniform3f(ProgramHandle program, int location, in System.Numerics.Vector3 value)
+        public static unsafe void ProgramUniform3f(ProgramHandle program, int location, int count, in System.Numerics.Vector3 value)
         {
-            int count = 1;
             fixed (System.Numerics.Vector3* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -4645,9 +4568,8 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniform4fv"/>
-        public static unsafe void ProgramUniform4f(ProgramHandle program, int location, in Vector4 value)
+        public static unsafe void ProgramUniform4f(ProgramHandle program, int location, int count, in Vector4 value)
         {
-            int count = 1;
             fixed (Vector4* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -4673,9 +4595,8 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniform4fv"/>
-        public static unsafe void ProgramUniform4f(ProgramHandle program, int location, in System.Numerics.Vector4 value)
+        public static unsafe void ProgramUniform4f(ProgramHandle program, int location, int count, in System.Numerics.Vector4 value)
         {
-            int count = 1;
             fixed (System.Numerics.Vector4* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -4701,9 +4622,8 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2fv"/>
-        public static unsafe void ProgramUniformMatrix2f(ProgramHandle program, int location, bool transpose, in Matrix2 value)
+        public static unsafe void ProgramUniformMatrix2f(ProgramHandle program, int location, int count, bool transpose, in Matrix2 value)
         {
-            int count = 1;
             fixed (Matrix2* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -4729,9 +4649,8 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3fv"/>
-        public static unsafe void ProgramUniformMatrix3f(ProgramHandle program, int location, bool transpose, in Matrix3 value)
+        public static unsafe void ProgramUniformMatrix3f(ProgramHandle program, int location, int count, bool transpose, in Matrix3 value)
         {
-            int count = 1;
             fixed (Matrix3* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -4757,9 +4676,8 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
-        public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, bool transpose, in Matrix4 value)
+        public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, int count, bool transpose, in Matrix4 value)
         {
-            int count = 1;
             fixed (Matrix4* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -4785,9 +4703,8 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
-        public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, bool transpose, in System.Numerics.Matrix4x4 value)
+        public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, int count, bool transpose, in System.Numerics.Matrix4x4 value)
         {
-            int count = 1;
             fixed (System.Numerics.Matrix4x4* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -4813,9 +4730,8 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x3fv"/>
-        public static unsafe void ProgramUniformMatrix2x3f(ProgramHandle program, int location, bool transpose, in Matrix2x3 value)
+        public static unsafe void ProgramUniformMatrix2x3f(ProgramHandle program, int location, int count, bool transpose, in Matrix2x3 value)
         {
-            int count = 1;
             fixed (Matrix2x3* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -4841,9 +4757,8 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
-        public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, bool transpose, in Matrix3x2 value)
+        public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, int count, bool transpose, in Matrix3x2 value)
         {
-            int count = 1;
             fixed (Matrix3x2* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -4869,9 +4784,8 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
-        public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, bool transpose, in System.Numerics.Matrix3x2 value)
+        public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, int count, bool transpose, in System.Numerics.Matrix3x2 value)
         {
-            int count = 1;
             fixed (System.Numerics.Matrix3x2* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -4897,9 +4811,8 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x4fv"/>
-        public static unsafe void ProgramUniformMatrix2x4f(ProgramHandle program, int location, bool transpose, in Matrix2x4 value)
+        public static unsafe void ProgramUniformMatrix2x4f(ProgramHandle program, int location, int count, bool transpose, in Matrix2x4 value)
         {
-            int count = 1;
             fixed (Matrix2x4* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -4925,9 +4838,8 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x2fv"/>
-        public static unsafe void ProgramUniformMatrix4x2f(ProgramHandle program, int location, bool transpose, in Matrix4x2 value)
+        public static unsafe void ProgramUniformMatrix4x2f(ProgramHandle program, int location, int count, bool transpose, in Matrix4x2 value)
         {
-            int count = 1;
             fixed (Matrix4x2* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -4953,9 +4865,8 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x4fv"/>
-        public static unsafe void ProgramUniformMatrix3x4f(ProgramHandle program, int location, bool transpose, in Matrix3x4 value)
+        public static unsafe void ProgramUniformMatrix3x4f(ProgramHandle program, int location, int count, bool transpose, in Matrix3x4 value)
         {
-            int count = 1;
             fixed (Matrix3x4* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;
@@ -4981,9 +4892,8 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x3fv"/>
-        public static unsafe void ProgramUniformMatrix4x3f(ProgramHandle program, int location, bool transpose, in Matrix4x3 value)
+        public static unsafe void ProgramUniformMatrix4x3f(ProgramHandle program, int location, int count, bool transpose, in Matrix4x3 value)
         {
-            int count = 1;
             fixed (Matrix4x3* tmp_vecPtr = &value)
             {
                 float* value_ptr = (float*)tmp_vecPtr;

--- a/src/OpenTK.Graphics/OpenTK.Graphics.csproj
+++ b/src/OpenTK.Graphics/OpenTK.Graphics.csproj
@@ -1,10 +1,13 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>net5.0</TargetFramework>
         <Nullable>enable</Nullable>
         <RootNamespace>OpenTK.Graphics</RootNamespace>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
+    <ItemGroup>
+      <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
+    </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="../OpenTK.Core/OpenTK.Core.csproj" />
         <ProjectReference Include="../OpenTK.Mathematics/OpenTK.Mathematics.csproj" />


### PR DESCRIPTION
### Purpose of this PR

Adds overloads for `System.Numerics` types.
The generator code should ideally get some cleanup before being committed, the first commit is more of a proof of concept.

This PR also adds a initial implementation of `ColorTypeOverloader`.

### Testing status

Not tested.