### PR TITLE
Initial work on more accurate update loop.

### DIFF
--- a/OpenTK.sln
+++ b/OpenTK.sln
@@ -5,6 +5,7 @@ VisualStudioVersion = 17.3.32811.315
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "project", "project", "{5EEEC96B-BD2F-45B0-935D-19E9E6D7D969}"
 	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
 		.gitignore = .gitignore
 		CONTRIBUTING.md = CONTRIBUTING.md
 		README.md = README.md

--- a/src/OpenTK.Core/Utility/Utils.cs
+++ b/src/OpenTK.Core/Utility/Utils.cs
@@ -1,4 +1,8 @@
+using System;
+using System.Diagnostics;
+using System.Drawing;
 using System.Runtime.CompilerServices;
+using System.Threading;
 
 namespace OpenTK.Core
 {
@@ -10,6 +14,66 @@ namespace OpenTK.Core
             T temp = a;
             a = b;
             b = temp;
+        }
+
+        /// <summary>
+        /// Contains timing estimations used by <see cref="PreciseSleep(ref SleepTimings, double)"/> to achive highly precise sleeps.
+        /// </summary>
+        public struct SleepTimings
+        {
+            public double Estimate;
+            public double Mean;
+            public double M2;
+            public long Count;
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="SleepTimings"/> struct that starts out with the expected sleep time in milliseconds.
+            /// </summary>
+            /// <param name="expectedSleepTime">The expected resolution of <see cref="Thread.Sleep(int)"/> in ms.</param>
+            public SleepTimings(int expectedSleepTime)
+            {
+                Estimate = expectedSleepTime / 1000.0;
+                Mean = expectedSleepTime / 1000.0;
+                M2 = 0;
+                Count = 1;
+            }
+        }
+
+        /// <summary>
+        /// A method for precise sleeps using previous measurements for the time of <see cref="Thread.Sleep(int)"/> to more accurately sleep.
+        /// This function will use <see cref="Thread.Sleep(int)"/> in 1ms increments until the remaining sleep time is less than the estimated sleep time,
+        /// at which point a spin wait is done.
+        /// </summary>
+        /// <param name="timings">A struct containting the current sleep timings.</param>
+        /// <param name="seconds">The number of seconds to wait.</param>
+        public static void PreciseSleep(this ref SleepTimings timings, double seconds)
+        {
+            // See https://blog.bearcats.nl/accurate-sleep-function/
+            // FIXME: This method has a problem where if the timer resolution is about the same as the sleep times it will generally only spinwait.
+
+            while (seconds > timings.Estimate)
+            {
+                var start = Stopwatch.GetTimestamp();
+                Thread.Sleep(1);
+                var end = Stopwatch.GetTimestamp();
+
+                double observed = (end - start) / (double)Stopwatch.Frequency;
+                seconds -= observed;
+
+                timings.Count++;
+                double delta = observed - timings.Mean;
+                timings.Mean += delta / timings.Count;
+                timings.M2 += delta * (observed - timings.Mean);
+                double stddev = Math.Sqrt(timings.M2 / (timings.Count - 1));
+                timings.Estimate = timings.Mean + stddev;
+            }
+
+            // spin wait
+            var spinStart = Stopwatch.GetTimestamp();
+            var delay = (long)seconds * Stopwatch.Frequency;
+            while (Stopwatch.GetTimestamp() - spinStart < delay)
+            {
+            }
         }
     }
 }

--- a/src/OpenTK.Windowing.Desktop/GameWindowSettings.cs
+++ b/src/OpenTK.Windowing.Desktop/GameWindowSettings.cs
@@ -25,7 +25,7 @@ namespace OpenTK.Windowing.Desktop
         /// <summary>
         /// Gets or sets a value indicating whether the game window should use a separate thread for render events.
         /// </summary>
-        [Obsolete("There is not one size fits all multithreading solution, especially for OpenGL. This option will be removed in future versions, and you will have to implement what you need instead.")]
+        [Obsolete("There is not one size fits all multithreading solution, especially for OpenGL. This feature has been removed and will no longer work.", true)]
         public bool IsMultiThreaded { get; set; } = false;
 
         /// <summary>
@@ -38,6 +38,7 @@ namespace OpenTK.Windowing.Desktop
         ///  </para>
         ///  <para>Values lower than 1.0Hz are clamped to 0.0. Values higher than 500.0Hz are clamped to 200.0Hz.</para>
         /// </remarks>
+        [Obsolete("Use UpdateFrame instead. We no longer separate UpdateFrame and RenderFrame.", true)]
         public double RenderFrequency { get; set; } = 0.0;
 
         /// <summary>

--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -1059,9 +1059,6 @@ namespace OpenTK.Windowing.Desktop
         private GLFWCallbacks.DropCallback _dropCallback;
         private GLFWCallbacks.JoystickCallback _joystickCallback;
 
-        [Obsolete("Use the Monitors.OnMonitorConnected event instead.", true)]
-        private GLFWCallbacks.MonitorCallback _monitorCallback;
-
         private unsafe void RegisterWindowCallbacks()
         {
             // These must be assigned to fields even when they're methods

--- a/stylecop.ruleset
+++ b/stylecop.ruleset
@@ -65,7 +65,7 @@
     <Rule Id="SA1125" Action="Error" /> <!-- Use shorthand for nullable types -->
     <Rule Id="SA1127" Action="None" Intentional="true" /> <!-- Generic type constraints must be on their own line -->
     <Rule Id="SA1128" Action="Error" /> <!-- Put constructor initializers on their own line -->
-    <Rule Id="SA1129" Action="Error" /> <!-- Do not use default value type constructor -->
+    <Rule Id="SA1129" Action="None" Intentional="true" /> <!-- Do not use default value type constructor -->
     <Rule Id="SA1130" Action="Error" /> <!-- Use lambda syntax -->
     <Rule Id="SA1131" Action="Error" /> <!-- Use readable conditions -->
     <Rule Id="SA1132" Action="Error" /> <!-- Do not combine fields -->


### PR DESCRIPTION
### Purpose of this PR

This PR aims to improve the time timings of OpenTKs default `GameWindow.Run` method.
It does so by introducing a `PreciseSleep` function that estimates the time taken by `Thread.Sleep(1)` and uses that information to chose between sleeping and doing a spin wait/busy wait.

This PR also includes two windows specific calls to `SetThreadAffinityMask` and `timeBeginPeriod` that aim to improve the performance and timing of the run loop on windows. It's unclear if other operating systems will need special handling.

Fixes #1537 

### Testing status

Tested locally on a Windows 10 machine. This needs more verification.