### PR TITLE
[5.0] Disable typesafe handle generation by default.

### DIFF
--- a/OpenTK.sln
+++ b/OpenTK.sln
@@ -22,6 +22,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "props", "props", "{9A58BE7A-02D3-4B94-B648-BDF421CC77EF}"
 	ProjectSection(SolutionItems) = preProject
 		props\common.props = props\common.props
+		props\generator-options.props = props\generator-options.props
 		props\jetbrains.props = props\jetbrains.props
 		props\netfx-mono.props = props\netfx-mono.props
 		props\nuget-common.props = props\nuget-common.props

--- a/props/generator-options.props
+++ b/props/generator-options.props
@@ -1,0 +1,5 @@
+﻿<Project>
+  <PropertyGroup>
+    <!--<DefineConstants>TYPESAFE_HANDLES</DefineConstants>--> <!-- Correspons to Options.UseTypesafeGLHandles -->
+  </PropertyGroup>
+</Project>

--- a/src/Generator/Generator.csproj
+++ b/src/Generator/Generator.csproj
@@ -9,4 +9,9 @@
     <StartupObject>Generator.Program</StartupObject>
   </PropertyGroup>
 
+  <Import Project="../../props/generator-options.props" />
+
+  <ItemGroup>
+    <None Include="..\..\props\generator-options.props" Link="generator-options.props" />
+  </ItemGroup>
 </Project>

--- a/src/Generator/Options.cs
+++ b/src/Generator/Options.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Generator
+{
+    internal static class Options
+    {
+        /// <summary>
+        /// This option switches between generating bindings using "typesafe" gl handles in the generated functions vs not generating them.
+        /// </summary>
+        public static bool UseTypesafeGLHandles { get; set; } = false;
+    }
+}

--- a/src/Generator/Options.cs
+++ b/src/Generator/Options.cs
@@ -8,9 +8,15 @@ namespace Generator
 {
     internal static class Options
     {
+
         /// <summary>
         /// This option switches between generating bindings using "typesafe" gl handles in the generated functions vs not generating them.
         /// </summary>
-        public static bool UseTypesafeGLHandles { get; set; } = false;
+        public static readonly bool UseTypesafeGLHandles
+#if TYPESAFE_HANDLES
+            = true;
+#else
+            = false;
+#endif
     }
 }

--- a/src/Generator/Process/Overloaders.cs
+++ b/src/Generator/Process/Overloaders.cs
@@ -152,8 +152,6 @@ namespace Generator.Process
 
     public class ColorTypeOverloader : IOverloader
     {
-        private static readonly Regex VectorNameMatch = new Regex("Color([3-4])([fdhisb])v$", RegexOptions.Compiled);
-
         public bool TryGenerateOverloads(Overload overload, [NotNullWhen(true)] out List<Overload>? newOverloads)
         {
             NameTable nameTable = overload.NameTable.New();

--- a/src/OpenTK.Graphics/OpenGL/Compatibility/GL.Manual.cs
+++ b/src/OpenTK.Graphics/OpenGL/Compatibility/GL.Manual.cs
@@ -4,6 +4,11 @@ using OpenTK.Mathematics;
 
 namespace OpenTK.Graphics.OpenGL.Compatibility
 {
+#if !TYPESAFE_HANDLES
+    using ShaderHandle = System.Int32;
+    using ProgramHandle = System.Int32;
+#endif
+
     public static unsafe partial class GL
     {
         // FIXME: Remove this when it's fixed

--- a/src/OpenTK.Graphics/OpenGL/Compatibility/GL.Native.cs
+++ b/src/OpenTK.Graphics/OpenGL/Compatibility/GL.Native.cs
@@ -317,14 +317,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="list"> Specifies the display-list name. </param>
         /// <param name="mode"> Specifies the compilation mode, which can be GL_COMPILE or GL_COMPILE_AND_EXECUTE. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/glNewList.xml" /></remarks>
-        public static void NewList(DisplayListHandle list, ListMode mode) => GLPointers._NewList_fnptr((int)list, (uint)mode);
+        public static void NewList(int list, ListMode mode) => GLPointers._NewList_fnptr(list, (uint)mode);
         
         public static void EndList() => GLPointers._EndList_fnptr();
         
         /// <summary> <b>[requires: v1.0]</b> Execute a display list. </summary>
         /// <param name="list"> Specifies the integer name of the display list to be executed. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/glCallList.xml" /></remarks>
-        public static void CallList(DisplayListHandle list) => GLPointers._CallList_fnptr((int)list);
+        public static void CallList(int list) => GLPointers._CallList_fnptr(list);
         
         /// <summary> <b>[requires: v1.0]</b> Execute a list of display lists. </summary>
         /// <param name="n"> Specifies the number of display lists to be executed. </param>
@@ -337,17 +337,17 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="list"> Specifies the integer name of the first display list to delete. </param>
         /// <param name="range"> Specifies the number of display lists to delete. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/glDeleteLists.xml" /></remarks>
-        public static void DeleteLists(DisplayListHandle list, int range) => GLPointers._DeleteLists_fnptr((int)list, range);
+        public static void DeleteLists(int list, int range) => GLPointers._DeleteLists_fnptr(list, range);
         
         /// <summary> <b>[requires: v1.0]</b> Generate a contiguous set of empty display lists. </summary>
         /// <param name="range"> Specifies the number of contiguous empty display lists to be generated. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/glGenLists.xml" /></remarks>
-        public static DisplayListHandle GenLists(int range) => (DisplayListHandle) GLPointers._GenLists_fnptr(range);
+        public static int GenLists(int range) => GLPointers._GenLists_fnptr(range);
         
         /// <summary> <b>[requires: v1.0]</b> Set the display-list base for glCallLists. </summary>
         /// <param name="@base"> Specifies an integer offset that will be added to glCallLists offsets to generate display-list names. The initial value is 0. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/glListBase.xml" /></remarks>
-        public static void ListBase(DisplayListHandle @base) => GLPointers._ListBase_fnptr((int)@base);
+        public static void ListBase(int @base) => GLPointers._ListBase_fnptr(@base);
         
         /// <summary> <b>[requires: v1.0]</b> Delimit the vertices of a primitive or a group of like primitives. </summary>
         /// <param name="mode"> Specifies the primitive or primitives that will be created from vertices presented between glBegin and the subsequent glEnd. Ten symbolic constants are accepted: GL_POINTS, GL_LINES, GL_LINE_STRIP, GL_LINE_LOOP, GL_TRIANGLES, GL_TRIANGLE_STRIP, GL_TRIANGLE_FAN, GL_QUADS, GL_QUAD_STRIP, and GL_POLYGON. </param>
@@ -1513,7 +1513,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <summary> <b>[requires: v1.0]</b> Determine if a name corresponds to a display list. </summary>
         /// <param name="list"> Specifies a potential display list name. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/glIsList.xml" /></remarks>
-        public static bool IsList(DisplayListHandle list) => GLPointers._IsList_fnptr((int)list) != 0;
+        public static bool IsList(int list) => GLPointers._IsList_fnptr(list) != 0;
         
         /// <summary> <b>[requires: v1.0]</b> Multiply the current matrix by a perspective matrix. </summary>
         /// <param name="left"> Specify the coordinates for the left and right vertical clipping planes. </param>
@@ -1714,24 +1714,24 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="target"> Specifies the target to which the texture is bound. Must be one of GL_TEXTURE_1D, GL_TEXTURE_2D, GL_TEXTURE_3D, GL_TEXTURE_1D_ARRAY, GL_TEXTURE_2D_ARRAY, GL_TEXTURE_RECTANGLE, GL_TEXTURE_CUBE_MAP, GL_TEXTURE_CUBE_MAP_ARRAY, GL_TEXTURE_BUFFER, GL_TEXTURE_2D_MULTISAMPLE or GL_TEXTURE_2D_MULTISAMPLE_ARRAY. </param>
         /// <param name="texture"> Specifies the name of a texture. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindTexture.xhtml" /></remarks>
-        public static void BindTexture(TextureTarget target, TextureHandle texture) => GLPointers._BindTexture_fnptr((uint)target, (int)texture);
+        public static void BindTexture(TextureTarget target, int texture) => GLPointers._BindTexture_fnptr((uint)target, texture);
         
         /// <summary> <b>[requires: v1.1]</b> Delete named textures. </summary>
         /// <param name="n"> Specifies the number of textures to be deleted. </param>
         /// <param name="textures"> Specifies an array of textures to be deleted. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDeleteTextures.xhtml" /></remarks>
-        public static void DeleteTextures(int n, TextureHandle* textures) => GLPointers._DeleteTextures_fnptr(n, (int*)textures);
+        public static void DeleteTextures(int n, int* textures) => GLPointers._DeleteTextures_fnptr(n, textures);
         
         /// <summary> <b>[requires: v1.1]</b> Generate texture names. </summary>
         /// <param name="n"> Specifies the number of texture names to be generated. </param>
         /// <param name="textures"> Specifies an array in which the generated texture names are stored. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGenTextures.xhtml" /></remarks>
-        public static void GenTextures(int n, TextureHandle* textures) => GLPointers._GenTextures_fnptr(n, (int*)textures);
+        public static void GenTextures(int n, int* textures) => GLPointers._GenTextures_fnptr(n, textures);
         
         /// <summary> <b>[requires: v1.1]</b> Determine if a name corresponds to a texture. </summary>
         /// <param name="texture"> Specifies a value that may be the name of a texture. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsTexture.xhtml" /></remarks>
-        public static bool IsTexture(TextureHandle texture) => GLPointers._IsTexture_fnptr((int)texture) != 0;
+        public static bool IsTexture(int texture) => GLPointers._IsTexture_fnptr(texture) != 0;
         
         /// <summary> <b>[requires: v1.1]</b> Render a vertex using the specified vertex array element. </summary>
         /// <param name="i"> Specifies an index into the enabled vertex data arrays. </param>
@@ -1801,14 +1801,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="textures"> Specifies an array containing the names of the textures to be queried. </param>
         /// <param name="residences"> Specifies an array in which the texture residence status is returned. The residence status of a texture named by an element of textures is returned in the corresponding element of residences. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/glAreTexturesResident.xml" /></remarks>
-        public static bool AreTexturesResident(int n, TextureHandle* textures, bool* residences) => GLPointers._AreTexturesResident_fnptr(n, (int*)textures, (byte*)residences) != 0;
+        public static bool AreTexturesResident(int n, int* textures, bool* residences) => GLPointers._AreTexturesResident_fnptr(n, textures, (byte*)residences) != 0;
         
         /// <summary> <b>[requires: v1.1]</b> Set texture residence priority. </summary>
         /// <param name="n"> Specifies the number of textures to be prioritized. </param>
         /// <param name="textures"> Specifies an array containing the names of the textures to be prioritized. </param>
         /// <param name="priorities"> Specifies an array containing the texture priorities. A priority given in an element of priorities applies to the texture named by the corresponding element of textures. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/glPrioritizeTextures.xml" /></remarks>
-        public static void PrioritizeTextures(int n, TextureHandle* textures, float* priorities) => GLPointers._PrioritizeTextures_fnptr(n, (int*)textures, priorities);
+        public static void PrioritizeTextures(int n, int* textures, float* priorities) => GLPointers._PrioritizeTextures_fnptr(n, textures, priorities);
         
         /// <summary> <b>[requires: v1.1]</b> Set the current color index. </summary>
         /// <param name="c"> Specifies the new value for the current color index. </param>
@@ -2381,24 +2381,24 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="n"> Specifies the number of query object names to be generated. </param>
         /// <param name="ids"> Specifies an array in which the generated query object names are stored. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGenQueries.xhtml" /></remarks>
-        public static void GenQueries(int n, QueryHandle* ids) => GLPointers._GenQueries_fnptr(n, (int*)ids);
+        public static void GenQueries(int n, int* ids) => GLPointers._GenQueries_fnptr(n, ids);
         
         /// <summary> <b>[requires: v1.5]</b> Delete named query objects. </summary>
         /// <param name="n"> Specifies the number of query objects to be deleted. </param>
         /// <param name="ids"> Specifies an array of query objects to be deleted. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDeleteQueries.xhtml" /></remarks>
-        public static void DeleteQueries(int n, QueryHandle* ids) => GLPointers._DeleteQueries_fnptr(n, (int*)ids);
+        public static void DeleteQueries(int n, int* ids) => GLPointers._DeleteQueries_fnptr(n, ids);
         
         /// <summary> <b>[requires: v1.5]</b> Determine if a name corresponds to a query object. </summary>
         /// <param name="id"> Specifies a value that may be the name of a query object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsQuery.xhtml" /></remarks>
-        public static bool IsQuery(QueryHandle id) => GLPointers._IsQuery_fnptr((int)id) != 0;
+        public static bool IsQuery(int id) => GLPointers._IsQuery_fnptr(id) != 0;
         
         /// <summary> <b>[requires: v1.5]</b> Delimit the boundaries of a query object. </summary>
         /// <param name="target"> Specifies the target type of query object established between glBeginQuery and the subsequent glEndQuery. The symbolic constant must be one of GL_SAMPLES_PASSED, GL_ANY_SAMPLES_PASSED, GL_ANY_SAMPLES_PASSED_CONSERVATIVE, GL_PRIMITIVES_GENERATED, GL_TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN, or GL_TIME_ELAPSED. </param>
         /// <param name="id"> Specifies the name of a query object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBeginQuery.xhtml" /></remarks>
-        public static void BeginQuery(QueryTarget target, QueryHandle id) => GLPointers._BeginQuery_fnptr((uint)target, (int)id);
+        public static void BeginQuery(QueryTarget target, int id) => GLPointers._BeginQuery_fnptr((uint)target, id);
         
         /// <summary> <b>[requires: v1.5]</b> Delimit the boundaries of a query object. </summary>
         /// <param name="target"> Specifies the target type of query object established between glBeginQuery and the subsequent glEndQuery. The symbolic constant must be one of GL_SAMPLES_PASSED, GL_ANY_SAMPLES_PASSED, GL_ANY_SAMPLES_PASSED_CONSERVATIVE, GL_PRIMITIVES_GENERATED, GL_TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN, or GL_TIME_ELAPSED. </param>
@@ -2417,37 +2417,37 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="pname"> Specifies the symbolic name of a query object parameter. Accepted values are GL_QUERY_RESULT or GL_QUERY_RESULT_AVAILABLE. </param>
         /// <param name="parameters"> If a buffer is bound to the GL_QUERY_RESULT_BUFFER target, then params is treated as an offset to a location within that buffer's data store to receive the result of the query. If no buffer is bound to GL_QUERY_RESULT_BUFFER, then params is treated as an address in client memory of a variable to receive the resulting data. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetQueryObject.xhtml" /></remarks>
-        public static void GetQueryObjectiv(QueryHandle id, QueryObjectParameterName pname, int* parameters) => GLPointers._GetQueryObjectiv_fnptr((int)id, (uint)pname, parameters);
+        public static void GetQueryObjectiv(int id, QueryObjectParameterName pname, int* parameters) => GLPointers._GetQueryObjectiv_fnptr(id, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v1.5]</b> Return parameters of a query object. </summary>
         /// <param name="id"> Specifies the name of a query object. </param>
         /// <param name="pname"> Specifies the symbolic name of a query object parameter. Accepted values are GL_QUERY_RESULT or GL_QUERY_RESULT_AVAILABLE. </param>
         /// <param name="parameters"> If a buffer is bound to the GL_QUERY_RESULT_BUFFER target, then params is treated as an offset to a location within that buffer's data store to receive the result of the query. If no buffer is bound to GL_QUERY_RESULT_BUFFER, then params is treated as an address in client memory of a variable to receive the resulting data. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetQueryObject.xhtml" /></remarks>
-        public static void GetQueryObjectuiv(QueryHandle id, QueryObjectParameterName pname, uint* parameters) => GLPointers._GetQueryObjectuiv_fnptr((int)id, (uint)pname, parameters);
+        public static void GetQueryObjectuiv(int id, QueryObjectParameterName pname, uint* parameters) => GLPointers._GetQueryObjectuiv_fnptr(id, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v1.5]</b> Bind a named buffer object. </summary>
         /// <param name="target"> Specifies the target to which the buffer object is bound, which must be one of the buffer binding targets in the following table: </param>
         /// <param name="buffer"> Specifies the name of a buffer object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindBuffer.xhtml" /></remarks>
-        public static void BindBuffer(BufferTargetARB target, BufferHandle buffer) => GLPointers._BindBuffer_fnptr((uint)target, (int)buffer);
+        public static void BindBuffer(BufferTargetARB target, int buffer) => GLPointers._BindBuffer_fnptr((uint)target, buffer);
         
         /// <summary> <b>[requires: v1.5]</b> Delete named buffer objects. </summary>
         /// <param name="n"> Specifies the number of buffer objects to be deleted. </param>
         /// <param name="buffers"> Specifies an array of buffer objects to be deleted. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDeleteBuffers.xhtml" /></remarks>
-        public static void DeleteBuffers(int n, BufferHandle* buffers) => GLPointers._DeleteBuffers_fnptr(n, (int*)buffers);
+        public static void DeleteBuffers(int n, int* buffers) => GLPointers._DeleteBuffers_fnptr(n, buffers);
         
         /// <summary> <b>[requires: v1.5]</b> Generate buffer object names. </summary>
         /// <param name="n"> Specifies the number of buffer object names to be generated. </param>
         /// <param name="buffers"> Specifies an array in which the generated buffer object names are stored. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGenBuffers.xhtml" /></remarks>
-        public static void GenBuffers(int n, BufferHandle* buffers) => GLPointers._GenBuffers_fnptr(n, (int*)buffers);
+        public static void GenBuffers(int n, int* buffers) => GLPointers._GenBuffers_fnptr(n, buffers);
         
         /// <summary> <b>[requires: v1.5]</b> Determine if a name corresponds to a buffer object. </summary>
         /// <param name="buffer"> Specifies a value that may be the name of a buffer object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsBuffer.xhtml" /></remarks>
-        public static bool IsBuffer(BufferHandle buffer) => GLPointers._IsBuffer_fnptr((int)buffer) != 0;
+        public static bool IsBuffer(int buffer) => GLPointers._IsBuffer_fnptr(buffer) != 0;
         
         /// <summary> <b>[requires: v1.5]</b> Creates and initializes a buffer object's data    store. </summary>
         /// <param name="target"> Specifies the target to which the buffer object is bound for glBufferData, which must be one of the buffer binding targets in the following table: </param>
@@ -2536,44 +2536,44 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="program">Specifies the program object to which a shader object will be attached.</param>
         /// <param name="shader">Specifies the shader object that is to be attached.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glAttachShader.xhtml" /></remarks>
-        public static void AttachShader(ProgramHandle program, ShaderHandle shader) => GLPointers._AttachShader_fnptr((int)program, (int)shader);
+        public static void AttachShader(int program, int shader) => GLPointers._AttachShader_fnptr(program, shader);
         
         /// <summary> <b>[requires: v2.0]</b> Associates a generic vertex attribute index with a named attribute variable. </summary>
         /// <param name="program">Specifies the handle of the program object in which the association is to be made.</param>
         /// <param name="index">Specifies the index of the generic vertex attribute to be bound.</param>
         /// <param name="name">Specifies a null terminated string containing the name of the vertex shader attribute variable to which index is to be bound.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindAttribLocation.xhtml" /></remarks>
-        public static void BindAttribLocation(ProgramHandle program, uint index, byte* name) => GLPointers._BindAttribLocation_fnptr((int)program, index, name);
+        public static void BindAttribLocation(int program, uint index, byte* name) => GLPointers._BindAttribLocation_fnptr(program, index, name);
         
         /// <summary> <b>[requires: v2.0]</b> Compiles a shader object. </summary>
         /// <param name="shader">Specifies the shader object to be compiled.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCompileShader.xhtml" /></remarks>
-        public static void CompileShader(ShaderHandle shader) => GLPointers._CompileShader_fnptr((int)shader);
+        public static void CompileShader(int shader) => GLPointers._CompileShader_fnptr(shader);
         
         /// <summary> <b>[requires: v2.0]</b> Creates a program object. </summary>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCreateProgram.xhtml" /></remarks>
-        public static ProgramHandle CreateProgram() => (ProgramHandle) GLPointers._CreateProgram_fnptr();
+        public static int CreateProgram() => GLPointers._CreateProgram_fnptr();
         
         /// <summary> <b>[requires: v2.0]</b> Creates a shader object. </summary>
         /// <param name="shaderType">Specifies the type of shader to be created. Must be one of GL_COMPUTE_SHADER, GL_VERTEX_SHADER, GL_TESS_CONTROL_SHADER, GL_TESS_EVALUATION_SHADER, GL_GEOMETRY_SHADER, or GL_FRAGMENT_SHADER.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCreateShader.xhtml" /></remarks>
-        public static ShaderHandle CreateShader(ShaderType type) => (ShaderHandle) GLPointers._CreateShader_fnptr((uint)type);
+        public static int CreateShader(ShaderType type) => GLPointers._CreateShader_fnptr((uint)type);
         
         /// <summary> <b>[requires: v2.0]</b> Deletes a program object. </summary>
         /// <param name="program">Specifies the program object to be deleted.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDeleteProgram.xhtml" /></remarks>
-        public static void DeleteProgram(ProgramHandle program) => GLPointers._DeleteProgram_fnptr((int)program);
+        public static void DeleteProgram(int program) => GLPointers._DeleteProgram_fnptr(program);
         
         /// <summary> <b>[requires: v2.0]</b> Deletes a shader object. </summary>
         /// <param name="shader">Specifies the shader object to be deleted.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDeleteShader.xhtml" /></remarks>
-        public static void DeleteShader(ShaderHandle shader) => GLPointers._DeleteShader_fnptr((int)shader);
+        public static void DeleteShader(int shader) => GLPointers._DeleteShader_fnptr(shader);
         
         /// <summary> <b>[requires: v2.0]</b> Detaches a shader object from a program object to which it is attached. </summary>
         /// <param name="program">Specifies the program object from which to detach the shader object.</param>
         /// <param name="shader">Specifies the shader object to be detached.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDetachShader.xhtml" /></remarks>
-        public static void DetachShader(ProgramHandle program, ShaderHandle shader) => GLPointers._DetachShader_fnptr((int)program, (int)shader);
+        public static void DetachShader(int program, int shader) => GLPointers._DetachShader_fnptr(program, shader);
         
         /// <summary> <b>[requires: v2.0]</b> Enable or disable a generic vertex attribute    array. </summary>
         /// <param name="index">Specifies the index of the generic vertex attribute to be enabled or disabled.</param>
@@ -2594,7 +2594,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="type">Returns the data type of the attribute variable.</param>
         /// <param name="name">Returns a null terminated string containing the name of the attribute variable.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetActiveAttrib.xhtml" /></remarks>
-        public static void GetActiveAttrib(ProgramHandle program, uint index, int bufSize, int* length, int* size, AttributeType* type, byte* name) => GLPointers._GetActiveAttrib_fnptr((int)program, index, bufSize, length, size, (uint*)type, name);
+        public static void GetActiveAttrib(int program, uint index, int bufSize, int* length, int* size, AttributeType* type, byte* name) => GLPointers._GetActiveAttrib_fnptr(program, index, bufSize, length, size, (uint*)type, name);
         
         /// <summary> <b>[requires: v2.0]</b> Returns information about an active uniform variable for the specified program object. </summary>
         /// <param name="program">Specifies the program object to be queried.</param>
@@ -2605,7 +2605,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="type">Returns the data type of the uniform variable.</param>
         /// <param name="name">Returns a null terminated string containing the name of the uniform variable.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetActiveUniform.xhtml" /></remarks>
-        public static void GetActiveUniform(ProgramHandle program, uint index, int bufSize, int* length, int* size, UniformType* type, byte* name) => GLPointers._GetActiveUniform_fnptr((int)program, index, bufSize, length, size, (uint*)type, name);
+        public static void GetActiveUniform(int program, uint index, int bufSize, int* length, int* size, UniformType* type, byte* name) => GLPointers._GetActiveUniform_fnptr(program, index, bufSize, length, size, (uint*)type, name);
         
         /// <summary> <b>[requires: v2.0]</b> Returns the handles of the shader objects attached to a program object. </summary>
         /// <param name="program">Specifies the program object to be queried.</param>
@@ -2613,20 +2613,20 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="count">Returns the number of names actually returned in shaders.</param>
         /// <param name="shaders">Specifies an array that is used to return the names of attached shader objects.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetAttachedShaders.xhtml" /></remarks>
-        public static void GetAttachedShaders(ProgramHandle program, int maxCount, int* count, ShaderHandle* shaders) => GLPointers._GetAttachedShaders_fnptr((int)program, maxCount, count, (int*)shaders);
+        public static void GetAttachedShaders(int program, int maxCount, int* count, int* shaders) => GLPointers._GetAttachedShaders_fnptr(program, maxCount, count, shaders);
         
         /// <summary> <b>[requires: v2.0]</b> Returns the location of an attribute variable. </summary>
         /// <param name="program">Specifies the program object to be queried.</param>
         /// <param name="name">Points to a null terminated string containing the name of the attribute variable whose location is to be queried.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetAttribLocation.xhtml" /></remarks>
-        public static int GetAttribLocation(ProgramHandle program, byte* name) => GLPointers._GetAttribLocation_fnptr((int)program, name);
+        public static int GetAttribLocation(int program, byte* name) => GLPointers._GetAttribLocation_fnptr(program, name);
         
         /// <summary> <b>[requires: v2.0]</b> Returns a parameter from a program object. </summary>
         /// <param name="program">Specifies the program object to be queried.</param>
         /// <param name="pname">Specifies the object parameter. Accepted symbolic names are GL_DELETE_STATUS, GL_LINK_STATUS, GL_VALIDATE_STATUS, GL_INFO_LOG_LENGTH, GL_ATTACHED_SHADERS, GL_ACTIVE_ATOMIC_COUNTER_BUFFERS, GL_ACTIVE_ATTRIBUTES, GL_ACTIVE_ATTRIBUTE_MAX_LENGTH, GL_ACTIVE_UNIFORMS, GL_ACTIVE_UNIFORM_BLOCKS, GL_ACTIVE_UNIFORM_BLOCK_MAX_NAME_LENGTH, GL_ACTIVE_UNIFORM_MAX_LENGTH, GL_COMPUTE_WORK_GROUP_SIZE GL_PROGRAM_BINARY_LENGTH, GL_TRANSFORM_FEEDBACK_BUFFER_MODE, GL_TRANSFORM_FEEDBACK_VARYINGS, GL_TRANSFORM_FEEDBACK_VARYING_MAX_LENGTH, GL_GEOMETRY_VERTICES_OUT, GL_GEOMETRY_INPUT_TYPE, and GL_GEOMETRY_OUTPUT_TYPE.</param>
         /// <param name="parameters">Returns the requested object parameter.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetProgram.xhtml" /></remarks>
-        public static void GetProgramiv(ProgramHandle program, ProgramPropertyARB pname, int* parameters) => GLPointers._GetProgramiv_fnptr((int)program, (uint)pname, parameters);
+        public static void GetProgramiv(int program, ProgramPropertyARB pname, int* parameters) => GLPointers._GetProgramiv_fnptr(program, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v2.0]</b> Returns the information log for a program object. </summary>
         /// <param name="program">Specifies the program object whose information log is to be queried.</param>
@@ -2634,14 +2634,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="length">Returns the length of the string returned in infoLog (excluding the null terminator).</param>
         /// <param name="infoLog">Specifies an array of characters that is used to return the information log.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetProgramInfoLog.xhtml" /></remarks>
-        public static void GetProgramInfoLog(ProgramHandle program, int bufSize, int* length, byte* infoLog) => GLPointers._GetProgramInfoLog_fnptr((int)program, bufSize, length, infoLog);
+        public static void GetProgramInfoLog(int program, int bufSize, int* length, byte* infoLog) => GLPointers._GetProgramInfoLog_fnptr(program, bufSize, length, infoLog);
         
         /// <summary> <b>[requires: v2.0]</b> Returns a parameter from a shader object. </summary>
         /// <param name="shader">Specifies the shader object to be queried.</param>
         /// <param name="pname">Specifies the object parameter. Accepted symbolic names are GL_SHADER_TYPE, GL_DELETE_STATUS, GL_COMPILE_STATUS, GL_INFO_LOG_LENGTH, GL_SHADER_SOURCE_LENGTH.</param>
         /// <param name="parameters">Returns the requested object parameter.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetShader.xhtml" /></remarks>
-        public static void GetShaderiv(ShaderHandle shader, ShaderParameterName pname, int* parameters) => GLPointers._GetShaderiv_fnptr((int)shader, (uint)pname, parameters);
+        public static void GetShaderiv(int shader, ShaderParameterName pname, int* parameters) => GLPointers._GetShaderiv_fnptr(shader, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v2.0]</b> Returns the information log for a shader object. </summary>
         /// <param name="shader">Specifies the shader object whose information log is to be queried.</param>
@@ -2649,7 +2649,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="length">Returns the length of the string returned in infoLog (excluding the null terminator).</param>
         /// <param name="infoLog">Specifies an array of characters that is used to return the information log.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetShaderInfoLog.xhtml" /></remarks>
-        public static void GetShaderInfoLog(ShaderHandle shader, int bufSize, int* length, byte* infoLog) => GLPointers._GetShaderInfoLog_fnptr((int)shader, bufSize, length, infoLog);
+        public static void GetShaderInfoLog(int shader, int bufSize, int* length, byte* infoLog) => GLPointers._GetShaderInfoLog_fnptr(shader, bufSize, length, infoLog);
         
         /// <summary> <b>[requires: v2.0]</b> Returns the source code string from a shader object. </summary>
         /// <param name="shader">Specifies the shader object to be queried.</param>
@@ -2657,27 +2657,27 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="length">Returns the length of the string returned in source (excluding the null terminator).</param>
         /// <param name="source">Specifies an array of characters that is used to return the source code string.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetShaderSource.xhtml" /></remarks>
-        public static void GetShaderSource(ShaderHandle shader, int bufSize, int* length, byte* source) => GLPointers._GetShaderSource_fnptr((int)shader, bufSize, length, source);
+        public static void GetShaderSource(int shader, int bufSize, int* length, byte* source) => GLPointers._GetShaderSource_fnptr(shader, bufSize, length, source);
         
         /// <summary> <b>[requires: v2.0]</b> Returns the location of a uniform variable. </summary>
         /// <param name="program">Specifies the program object to be queried.</param>
         /// <param name="name">Points to a null terminated string containing the name of the uniform variable whose location is to be queried.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetUniformLocation.xhtml" /></remarks>
-        public static int GetUniformLocation(ProgramHandle program, byte* name) => GLPointers._GetUniformLocation_fnptr((int)program, name);
+        public static int GetUniformLocation(int program, byte* name) => GLPointers._GetUniformLocation_fnptr(program, name);
         
         /// <summary> <b>[requires: v2.0]</b> Returns the value of a uniform variable. </summary>
         /// <param name="program">Specifies the program object to be queried.</param>
         /// <param name="location">Specifies the location of the uniform variable to be queried.</param>
         /// <param name="parameters">Returns the value of the specified uniform variable.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetUniform.xhtml" /></remarks>
-        public static void GetUniformfv(ProgramHandle program, int location, float* parameters) => GLPointers._GetUniformfv_fnptr((int)program, location, parameters);
+        public static void GetUniformfv(int program, int location, float* parameters) => GLPointers._GetUniformfv_fnptr(program, location, parameters);
         
         /// <summary> <b>[requires: v2.0]</b> Returns the value of a uniform variable. </summary>
         /// <param name="program">Specifies the program object to be queried.</param>
         /// <param name="location">Specifies the location of the uniform variable to be queried.</param>
         /// <param name="parameters">Returns the value of the specified uniform variable.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetUniform.xhtml" /></remarks>
-        public static void GetUniformiv(ProgramHandle program, int location, int* parameters) => GLPointers._GetUniformiv_fnptr((int)program, location, parameters);
+        public static void GetUniformiv(int program, int location, int* parameters) => GLPointers._GetUniformiv_fnptr(program, location, parameters);
         
         /// <summary> <b>[requires: v2.0]</b> Return a generic vertex attribute parameter. </summary>
         /// <param name="index">Specifies the generic vertex attribute parameter to be queried.</param>
@@ -2710,17 +2710,17 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <summary> <b>[requires: v2.0]</b> Determines if a name corresponds to a program object. </summary>
         /// <param name="program">Specifies a potential program object.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsProgram.xhtml" /></remarks>
-        public static bool IsProgram(ProgramHandle program) => GLPointers._IsProgram_fnptr((int)program) != 0;
+        public static bool IsProgram(int program) => GLPointers._IsProgram_fnptr(program) != 0;
         
         /// <summary> <b>[requires: v2.0]</b> Determines if a name corresponds to a shader object. </summary>
         /// <param name="shader">Specifies a potential shader object.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsShader.xhtml" /></remarks>
-        public static bool IsShader(ShaderHandle shader) => GLPointers._IsShader_fnptr((int)shader) != 0;
+        public static bool IsShader(int shader) => GLPointers._IsShader_fnptr(shader) != 0;
         
         /// <summary> <b>[requires: v2.0]</b> Links a program object. </summary>
         /// <param name="program">Specifies the handle of the program object to be linked.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glLinkProgram.xhtml" /></remarks>
-        public static void LinkProgram(ProgramHandle program) => GLPointers._LinkProgram_fnptr((int)program);
+        public static void LinkProgram(int program) => GLPointers._LinkProgram_fnptr(program);
         
         /// <summary> <b>[requires: v2.0]</b> Replaces the source code in a shader object. </summary>
         /// <param name="shader">Specifies the handle of the shader object whose source code is to be replaced.</param>
@@ -2728,12 +2728,12 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="str">Specifies an array of pointers to strings containing the source code to be loaded into the shader.</param>
         /// <param name="length">Specifies an array of string lengths.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glShaderSource.xhtml" /></remarks>
-        public static void ShaderSource(ShaderHandle shader, int count, byte** str, int* length) => GLPointers._ShaderSource_fnptr((int)shader, count, str, length);
+        public static void ShaderSource(int shader, int count, byte** str, int* length) => GLPointers._ShaderSource_fnptr(shader, count, str, length);
         
         /// <summary> <b>[requires: v2.0]</b> Installs a program object as part of current rendering state. </summary>
         /// <param name="program">Specifies the handle of the program object whose executables are to be used as part of current rendering state.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glUseProgram.xhtml" /></remarks>
-        public static void UseProgram(ProgramHandle program) => GLPointers._UseProgram_fnptr((int)program);
+        public static void UseProgram(int program) => GLPointers._UseProgram_fnptr(program);
         
         /// <summary> <b>[requires: v2.0]</b> Specify the value of a uniform variable for the current program object. </summary>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
@@ -2878,7 +2878,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <summary> <b>[requires: v2.0]</b> Validates a program object. </summary>
         /// <param name="program">Specifies the handle of the program object to be validated.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glValidateProgram.xhtml" /></remarks>
-        public static void ValidateProgram(ProgramHandle program) => GLPointers._ValidateProgram_fnptr((int)program);
+        public static void ValidateProgram(int program) => GLPointers._ValidateProgram_fnptr(program);
         
         /// <summary> <b>[requires: v2.0]</b> Specifies the value of a generic vertex attribute. </summary>
         /// <param name="index">Specifies the index of the generic vertex attribute to be modified.</param>
@@ -3232,14 +3232,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="offset"> The starting offset in basic machine units into the buffer object buffer. </param>
         /// <param name="size"> The amount of data in machine units that can be read from the buffer object while used as an indexed target. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindBufferRange.xhtml" /></remarks>
-        public static void BindBufferRange(BufferTargetARB target, uint index, BufferHandle buffer, IntPtr offset, nint size) => GLPointers._BindBufferRange_fnptr((uint)target, index, (int)buffer, offset, size);
+        public static void BindBufferRange(BufferTargetARB target, uint index, int buffer, IntPtr offset, nint size) => GLPointers._BindBufferRange_fnptr((uint)target, index, buffer, offset, size);
         
         /// <summary> <b>[requires: v3.0 | v3.1 | GL_ARB_uniform_buffer_object]</b> Bind a buffer object to an indexed buffer target. </summary>
         /// <param name="target"> Specify the target of the bind operation. target must be one of GL_ATOMIC_COUNTER_BUFFER, GL_TRANSFORM_FEEDBACK_BUFFER, GL_UNIFORM_BUFFER or GL_SHADER_STORAGE_BUFFER. </param>
         /// <param name="index"> Specify the index of the binding point within the array specified by target. </param>
         /// <param name="buffer"> The name of a buffer object to bind to the specified binding point. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindBufferBase.xhtml" /></remarks>
-        public static void BindBufferBase(BufferTargetARB target, uint index, BufferHandle buffer) => GLPointers._BindBufferBase_fnptr((uint)target, index, (int)buffer);
+        public static void BindBufferBase(BufferTargetARB target, uint index, int buffer) => GLPointers._BindBufferBase_fnptr((uint)target, index, buffer);
         
         /// <summary> <b>[requires: v3.0]</b> Specify values to record in transform feedback buffers. </summary>
         /// <param name="program"> The name of the target program object. </param>
@@ -3247,7 +3247,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="varyings"> An array of count zero-terminated strings specifying the names of the varying variables to use for transform feedback. </param>
         /// <param name="bufferMode"> Identifies the mode used to capture the varying variables when transform feedback is active. bufferMode must be GL_INTERLEAVED_ATTRIBS or GL_SEPARATE_ATTRIBS. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTransformFeedbackVaryings.xhtml" /></remarks>
-        public static void TransformFeedbackVaryings(ProgramHandle program, int count, byte** varyings, TransformFeedbackBufferMode bufferMode) => GLPointers._TransformFeedbackVaryings_fnptr((int)program, count, varyings, (uint)bufferMode);
+        public static void TransformFeedbackVaryings(int program, int count, byte** varyings, TransformFeedbackBufferMode bufferMode) => GLPointers._TransformFeedbackVaryings_fnptr(program, count, varyings, (uint)bufferMode);
         
         /// <summary> <b>[requires: v3.0]</b> Retrieve information about varying variables selected for transform feedback. </summary>
         /// <param name="program"> The name of the target program object. </param>
@@ -3258,7 +3258,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="type"> The address of a variable that will receive the type of the varying. </param>
         /// <param name="name"> The address of a buffer into which will be written the name of the varying. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetTransformFeedbackVarying.xhtml" /></remarks>
-        public static void GetTransformFeedbackVarying(ProgramHandle program, uint index, int bufSize, int* length, int* size, AttributeType* type, byte* name) => GLPointers._GetTransformFeedbackVarying_fnptr((int)program, index, bufSize, length, size, (uint*)type, name);
+        public static void GetTransformFeedbackVarying(int program, uint index, int bufSize, int* length, int* size, AttributeType* type, byte* name) => GLPointers._GetTransformFeedbackVarying_fnptr(program, index, bufSize, length, size, (uint*)type, name);
         
         /// <summary> <b>[requires: v3.0]</b> Specify whether data read via glReadPixels should be clamped. </summary>
         /// <param name="target"> Target for color clamping. target must be GL_CLAMP_READ_COLOR. </param>
@@ -3436,20 +3436,20 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="location">Specifies the location of the uniform variable to be queried.</param>
         /// <param name="parameters">Returns the value of the specified uniform variable.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetUniform.xhtml" /></remarks>
-        public static void GetUniformuiv(ProgramHandle program, int location, uint* parameters) => GLPointers._GetUniformuiv_fnptr((int)program, location, parameters);
+        public static void GetUniformuiv(int program, int location, uint* parameters) => GLPointers._GetUniformuiv_fnptr(program, location, parameters);
         
         /// <summary> <b>[requires: v3.0]</b> Bind a user-defined varying out variable to a fragment shader color number. </summary>
         /// <param name="program"> The name of the program containing varying out variable whose binding to modify </param>
         /// <param name="colorNumber"> The color number to bind the user-defined varying out variable to </param>
         /// <param name="name"> The name of the user-defined varying out variable whose binding to modify </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindFragDataLocation.xhtml" /></remarks>
-        public static void BindFragDataLocation(ProgramHandle program, uint color, byte* name) => GLPointers._BindFragDataLocation_fnptr((int)program, color, name);
+        public static void BindFragDataLocation(int program, uint color, byte* name) => GLPointers._BindFragDataLocation_fnptr(program, color, name);
         
         /// <summary> <b>[requires: v3.0]</b> Query the bindings of color numbers to user-defined varying out variables. </summary>
         /// <param name="program"> The name of the program containing varying out variable whose binding to query </param>
         /// <param name="name"> The name of the user-defined varying out variable whose binding to query </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetFragDataLocation.xhtml" /></remarks>
-        public static int GetFragDataLocation(ProgramHandle program, byte* name) => GLPointers._GetFragDataLocation_fnptr((int)program, name);
+        public static int GetFragDataLocation(int program, byte* name) => GLPointers._GetFragDataLocation_fnptr(program, name);
         
         /// <summary> <b>[requires: v3.0]</b> Specify the value of a uniform variable for the current program object. </summary>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
@@ -3575,25 +3575,25 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Determine if a name corresponds to a renderbuffer object. </summary>
         /// <param name="renderbuffer"> Specifies a value that may be the name of a renderbuffer object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsRenderbuffer.xhtml" /></remarks>
-        public static bool IsRenderbuffer(RenderbufferHandle renderbuffer) => GLPointers._IsRenderbuffer_fnptr((int)renderbuffer) != 0;
+        public static bool IsRenderbuffer(int renderbuffer) => GLPointers._IsRenderbuffer_fnptr(renderbuffer) != 0;
         
         /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Bind a renderbuffer to a renderbuffer target. </summary>
         /// <param name="target"> Specifies the renderbuffer target of the binding operation. target must be GL_RENDERBUFFER. </param>
         /// <param name="renderbuffer"> Specifies the name of the renderbuffer object to bind. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindRenderbuffer.xhtml" /></remarks>
-        public static void BindRenderbuffer(RenderbufferTarget target, RenderbufferHandle renderbuffer) => GLPointers._BindRenderbuffer_fnptr((uint)target, (int)renderbuffer);
+        public static void BindRenderbuffer(RenderbufferTarget target, int renderbuffer) => GLPointers._BindRenderbuffer_fnptr((uint)target, renderbuffer);
         
         /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Delete renderbuffer objects. </summary>
         /// <param name="n"> Specifies the number of renderbuffer objects to be deleted. </param>
         /// <param name="renderbuffers"> A pointer to an array containing n renderbuffer objects to be deleted. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDeleteRenderbuffers.xhtml" /></remarks>
-        public static void DeleteRenderbuffers(int n, RenderbufferHandle* renderbuffers) => GLPointers._DeleteRenderbuffers_fnptr(n, (int*)renderbuffers);
+        public static void DeleteRenderbuffers(int n, int* renderbuffers) => GLPointers._DeleteRenderbuffers_fnptr(n, renderbuffers);
         
         /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Generate renderbuffer object names. </summary>
         /// <param name="n"> Specifies the number of renderbuffer object names to generate. </param>
         /// <param name="renderbuffers"> Specifies an array in which the generated renderbuffer object names are stored. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGenRenderbuffers.xhtml" /></remarks>
-        public static void GenRenderbuffers(int n, RenderbufferHandle* renderbuffers) => GLPointers._GenRenderbuffers_fnptr(n, (int*)renderbuffers);
+        public static void GenRenderbuffers(int n, int* renderbuffers) => GLPointers._GenRenderbuffers_fnptr(n, renderbuffers);
         
         /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Establish data storage, format and dimensions of a    renderbuffer object's image. </summary>
         /// <param name="target">Specifies a binding target of the allocation for glRenderbufferStorage function. Must be GL_RENDERBUFFER.</param>
@@ -3613,25 +3613,25 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Determine if a name corresponds to a framebuffer object. </summary>
         /// <param name="framebuffer"> Specifies a value that may be the name of a framebuffer object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsFramebuffer.xhtml" /></remarks>
-        public static bool IsFramebuffer(FramebufferHandle framebuffer) => GLPointers._IsFramebuffer_fnptr((int)framebuffer) != 0;
+        public static bool IsFramebuffer(int framebuffer) => GLPointers._IsFramebuffer_fnptr(framebuffer) != 0;
         
         /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Bind a framebuffer to a framebuffer target. </summary>
         /// <param name="target"> Specifies the framebuffer target of the binding operation. </param>
         /// <param name="framebuffer"> Specifies the name of the framebuffer object to bind. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindFramebuffer.xhtml" /></remarks>
-        public static void BindFramebuffer(FramebufferTarget target, FramebufferHandle framebuffer) => GLPointers._BindFramebuffer_fnptr((uint)target, (int)framebuffer);
+        public static void BindFramebuffer(FramebufferTarget target, int framebuffer) => GLPointers._BindFramebuffer_fnptr((uint)target, framebuffer);
         
         /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Delete framebuffer objects. </summary>
         /// <param name="n"> Specifies the number of framebuffer objects to be deleted. </param>
         /// <param name="framebuffers"> A pointer to an array containing n framebuffer objects to be deleted. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDeleteFramebuffers.xhtml" /></remarks>
-        public static void DeleteFramebuffers(int n, FramebufferHandle* framebuffers) => GLPointers._DeleteFramebuffers_fnptr(n, (int*)framebuffers);
+        public static void DeleteFramebuffers(int n, int* framebuffers) => GLPointers._DeleteFramebuffers_fnptr(n, framebuffers);
         
         /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Generate framebuffer object names. </summary>
         /// <param name="n"> Specifies the number of framebuffer object names to generate. </param>
         /// <param name="ids"> Specifies an array in which the generated framebuffer object names are stored. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGenFramebuffers.xhtml" /></remarks>
-        public static void GenFramebuffers(int n, FramebufferHandle* framebuffers) => GLPointers._GenFramebuffers_fnptr(n, (int*)framebuffers);
+        public static void GenFramebuffers(int n, int* framebuffers) => GLPointers._GenFramebuffers_fnptr(n, framebuffers);
         
         /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Check the completeness status of a framebuffer. </summary>
         /// <param name="target"> Specify the target to which the framebuffer is bound for glCheckFramebufferStatus, and the target against which framebuffer completeness of framebuffer is checked for glCheckNamedFramebufferStatus. </param>
@@ -3645,7 +3645,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="texture"> Specifies the name of an existing texture object to attach. </param>
         /// <param name="level"> Specifies the mipmap level of the texture object to attach. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glFramebufferTexture.xhtml" /></remarks>
-        public static void FramebufferTexture1D(FramebufferTarget target, FramebufferAttachment attachment, TextureTarget textarget, TextureHandle texture, int level) => GLPointers._FramebufferTexture1D_fnptr((uint)target, (uint)attachment, (uint)textarget, (int)texture, level);
+        public static void FramebufferTexture1D(FramebufferTarget target, FramebufferAttachment attachment, TextureTarget textarget, int texture, int level) => GLPointers._FramebufferTexture1D_fnptr((uint)target, (uint)attachment, (uint)textarget, texture, level);
         
         /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Attach a level of a texture object as a logical buffer of a framebuffer object. </summary>
         /// <param name="target"> Specifies the target to which the framebuffer is bound for all commands except glNamedFramebufferTexture. </param>
@@ -3654,7 +3654,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="texture"> Specifies the name of an existing texture object to attach. </param>
         /// <param name="level"> Specifies the mipmap level of the texture object to attach. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glFramebufferTexture.xhtml" /></remarks>
-        public static void FramebufferTexture2D(FramebufferTarget target, FramebufferAttachment attachment, TextureTarget textarget, TextureHandle texture, int level) => GLPointers._FramebufferTexture2D_fnptr((uint)target, (uint)attachment, (uint)textarget, (int)texture, level);
+        public static void FramebufferTexture2D(FramebufferTarget target, FramebufferAttachment attachment, TextureTarget textarget, int texture, int level) => GLPointers._FramebufferTexture2D_fnptr((uint)target, (uint)attachment, (uint)textarget, texture, level);
         
         /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Attach a level of a texture object as a logical buffer of a framebuffer object. </summary>
         /// <param name="target"> Specifies the target to which the framebuffer is bound for all commands except glNamedFramebufferTexture. </param>
@@ -3664,7 +3664,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="level"> Specifies the mipmap level of the texture object to attach. </param>
         /// <param name="layer">!!missing documentation!!</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glFramebufferTexture.xhtml" /></remarks>
-        public static void FramebufferTexture3D(FramebufferTarget target, FramebufferAttachment attachment, TextureTarget textarget, TextureHandle texture, int level, int zoffset) => GLPointers._FramebufferTexture3D_fnptr((uint)target, (uint)attachment, (uint)textarget, (int)texture, level, zoffset);
+        public static void FramebufferTexture3D(FramebufferTarget target, FramebufferAttachment attachment, TextureTarget textarget, int texture, int level, int zoffset) => GLPointers._FramebufferTexture3D_fnptr((uint)target, (uint)attachment, (uint)textarget, texture, level, zoffset);
         
         /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Attach a renderbuffer as a logical buffer of a framebuffer object. </summary>
         /// <param name="target"> Specifies the target to which the framebuffer is bound for glFramebufferRenderbuffer. </param>
@@ -3672,7 +3672,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="renderbuffertarget"> Specifies the renderbuffer target. Must be GL_RENDERBUFFER. </param>
         /// <param name="renderbuffer"> Specifies the name of an existing renderbuffer object of type renderbuffertarget to attach. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glFramebufferRenderbuffer.xhtml" /></remarks>
-        public static void FramebufferRenderbuffer(FramebufferTarget target, FramebufferAttachment attachment, RenderbufferTarget renderbuffertarget, RenderbufferHandle renderbuffer) => GLPointers._FramebufferRenderbuffer_fnptr((uint)target, (uint)attachment, (uint)renderbuffertarget, (int)renderbuffer);
+        public static void FramebufferRenderbuffer(FramebufferTarget target, FramebufferAttachment attachment, RenderbufferTarget renderbuffertarget, int renderbuffer) => GLPointers._FramebufferRenderbuffer_fnptr((uint)target, (uint)attachment, (uint)renderbuffertarget, renderbuffer);
         
         /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Retrieve information about attachments of a framebuffer object. </summary>
         /// <param name="target"> Specifies the target to which the framebuffer object is bound for glGetFramebufferAttachmentParameteriv. </param>
@@ -3717,7 +3717,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="level"> Specifies the mipmap level of the texture object to attach. </param>
         /// <param name="layer"> Specifies the layer of the texture object to attach. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glFramebufferTextureLayer.xhtml" /></remarks>
-        public static void FramebufferTextureLayer(FramebufferTarget target, FramebufferAttachment attachment, TextureHandle texture, int level, int layer) => GLPointers._FramebufferTextureLayer_fnptr((uint)target, (uint)attachment, (int)texture, level, layer);
+        public static void FramebufferTextureLayer(FramebufferTarget target, FramebufferAttachment attachment, int texture, int level, int layer) => GLPointers._FramebufferTextureLayer_fnptr((uint)target, (uint)attachment, texture, level, layer);
         
         /// <summary> <b>[requires: v3.0 | GL_ARB_map_buffer_range]</b> Map all or part of a buffer object's data store into the client's address space. </summary>
         /// <param name="target"> Specifies the target to which the buffer object is bound for glMapBufferRange, which must be one of the buffer binding targets in the following table: </param>
@@ -3737,24 +3737,24 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <summary> <b>[requires: v3.0 | GL_ARB_vertex_array_object]</b> Bind a vertex array object. </summary>
         /// <param name="array"> Specifies the name of the vertex array to bind. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindVertexArray.xhtml" /></remarks>
-        public static void BindVertexArray(VertexArrayHandle array) => GLPointers._BindVertexArray_fnptr((int)array);
+        public static void BindVertexArray(int array) => GLPointers._BindVertexArray_fnptr(array);
         
         /// <summary> <b>[requires: v3.0 | GL_ARB_vertex_array_object]</b> Delete vertex array objects. </summary>
         /// <param name="n"> Specifies the number of vertex array objects to be deleted. </param>
         /// <param name="arrays"> Specifies the address of an array containing the n names of the objects to be deleted. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDeleteVertexArrays.xhtml" /></remarks>
-        public static void DeleteVertexArrays(int n, VertexArrayHandle* arrays) => GLPointers._DeleteVertexArrays_fnptr(n, (int*)arrays);
+        public static void DeleteVertexArrays(int n, int* arrays) => GLPointers._DeleteVertexArrays_fnptr(n, arrays);
         
         /// <summary> <b>[requires: v3.0 | GL_ARB_vertex_array_object]</b> Generate vertex array object names. </summary>
         /// <param name="n"> Specifies the number of vertex array object names to generate. </param>
         /// <param name="arrays"> Specifies an array in which the generated vertex array object names are stored. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGenVertexArrays.xhtml" /></remarks>
-        public static void GenVertexArrays(int n, VertexArrayHandle* arrays) => GLPointers._GenVertexArrays_fnptr(n, (int*)arrays);
+        public static void GenVertexArrays(int n, int* arrays) => GLPointers._GenVertexArrays_fnptr(n, arrays);
         
         /// <summary> <b>[requires: v3.0 | GL_ARB_vertex_array_object]</b> Determine if a name corresponds to a vertex array object. </summary>
         /// <param name="array"> Specifies a value that may be the name of a vertex array object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsVertexArray.xhtml" /></remarks>
-        public static bool IsVertexArray(VertexArrayHandle array) => GLPointers._IsVertexArray_fnptr((int)array) != 0;
+        public static bool IsVertexArray(int array) => GLPointers._IsVertexArray_fnptr(array) != 0;
         
         /// <summary> <b>[requires: v3.1]</b> Draw multiple instances of a range of elements. </summary>
         /// <param name="mode"> Specifies what kind of primitives to render. Symbolic constants GL_POINTS, GL_LINE_STRIP, GL_LINE_LOOP, GL_LINES, GL_TRIANGLE_STRIP, GL_TRIANGLE_FAN, GL_TRIANGLES GL_LINES_ADJACENCY, GL_LINE_STRIP_ADJACENCY, GL_TRIANGLES_ADJACENCY, GL_TRIANGLE_STRIP_ADJACENCY and GL_PATCHES are accepted. </param>
@@ -3778,7 +3778,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="internalformat"> Specifies the internal format of the data in the store belonging to buffer. </param>
         /// <param name="buffer"> Specifies the name of the buffer object whose storage to attach to the active buffer texture. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexBuffer.xhtml" /></remarks>
-        public static void TexBuffer(TextureTarget target, SizedInternalFormat internalformat, BufferHandle buffer) => GLPointers._TexBuffer_fnptr((uint)target, (uint)internalformat, (int)buffer);
+        public static void TexBuffer(TextureTarget target, SizedInternalFormat internalformat, int buffer) => GLPointers._TexBuffer_fnptr((uint)target, (uint)internalformat, buffer);
         
         /// <summary> <b>[requires: v3.1]</b> Specify the primitive restart index. </summary>
         /// <param name="index"> Specifies the value to be interpreted as the primitive restart index. </param>
@@ -3800,7 +3800,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="uniformNames"> Specifies the address of an array of pointers to buffers containing the names of the queried uniforms. </param>
         /// <param name="uniformIndices"> Specifies the address of an array that will receive the indices of the uniforms. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetUniformIndices.xhtml" /></remarks>
-        public static void GetUniformIndices(ProgramHandle program, int uniformCount, byte** uniformNames, uint* uniformIndices) => GLPointers._GetUniformIndices_fnptr((int)program, uniformCount, uniformNames, uniformIndices);
+        public static void GetUniformIndices(int program, int uniformCount, byte** uniformNames, uint* uniformIndices) => GLPointers._GetUniformIndices_fnptr(program, uniformCount, uniformNames, uniformIndices);
         
         /// <summary> <b>[requires: v3.1 | GL_ARB_uniform_buffer_object]</b> Returns information about several active uniform variables for the specified program object. </summary>
         /// <param name="program">Specifies the program object to be queried.</param>
@@ -3809,7 +3809,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="pname">Specifies the property of each uniform in uniformIndices that should be written into the corresponding element of params.</param>
         /// <param name="parameters">Specifies the address of an array of uniformCount integers which are to receive the value of pname for each uniform in uniformIndices.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetActiveUniformsiv.xhtml" /></remarks>
-        public static void GetActiveUniformsiv(ProgramHandle program, int uniformCount, uint* uniformIndices, UniformPName pname, int* parameters) => GLPointers._GetActiveUniformsiv_fnptr((int)program, uniformCount, uniformIndices, (uint)pname, parameters);
+        public static void GetActiveUniformsiv(int program, int uniformCount, uint* uniformIndices, UniformPName pname, int* parameters) => GLPointers._GetActiveUniformsiv_fnptr(program, uniformCount, uniformIndices, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v3.1 | GL_ARB_uniform_buffer_object]</b> Query the name of an active uniform. </summary>
         /// <param name="program"> Specifies the program containing the active uniform index uniformIndex. </param>
@@ -3818,13 +3818,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="length"> Specifies the address of a variable that will receive the number of characters that were or would have been written to the buffer addressed by uniformName. </param>
         /// <param name="uniformName"> Specifies the address of a buffer into which the GL will place the name of the active uniform at uniformIndex within program. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetActiveUniformName.xhtml" /></remarks>
-        public static void GetActiveUniformName(ProgramHandle program, uint uniformIndex, int bufSize, int* length, byte* uniformName) => GLPointers._GetActiveUniformName_fnptr((int)program, uniformIndex, bufSize, length, uniformName);
+        public static void GetActiveUniformName(int program, uint uniformIndex, int bufSize, int* length, byte* uniformName) => GLPointers._GetActiveUniformName_fnptr(program, uniformIndex, bufSize, length, uniformName);
         
         /// <summary> <b>[requires: v3.1 | GL_ARB_uniform_buffer_object]</b> Retrieve the index of a named uniform block. </summary>
         /// <param name="program"> Specifies the name of a program containing the uniform block. </param>
         /// <param name="uniformBlockName"> Specifies the address an array of characters to containing the name of the uniform block whose index to retrieve. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetUniformBlockIndex.xhtml" /></remarks>
-        public static uint GetUniformBlockIndex(ProgramHandle program, byte* uniformBlockName) => GLPointers._GetUniformBlockIndex_fnptr((int)program, uniformBlockName);
+        public static uint GetUniformBlockIndex(int program, byte* uniformBlockName) => GLPointers._GetUniformBlockIndex_fnptr(program, uniformBlockName);
         
         /// <summary> <b>[requires: v3.1 | GL_ARB_uniform_buffer_object]</b> Query information about an active uniform block. </summary>
         /// <param name="program"> Specifies the name of a program containing the uniform block. </param>
@@ -3832,7 +3832,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="pname"> Specifies the name of the parameter to query. </param>
         /// <param name="parameters"> Specifies the address of a variable to receive the result of the query. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetActiveUniformBlock.xhtml" /></remarks>
-        public static void GetActiveUniformBlockiv(ProgramHandle program, uint uniformBlockIndex, UniformBlockPName pname, int* parameters) => GLPointers._GetActiveUniformBlockiv_fnptr((int)program, uniformBlockIndex, (uint)pname, parameters);
+        public static void GetActiveUniformBlockiv(int program, uint uniformBlockIndex, UniformBlockPName pname, int* parameters) => GLPointers._GetActiveUniformBlockiv_fnptr(program, uniformBlockIndex, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v3.1 | GL_ARB_uniform_buffer_object]</b> Retrieve the name of an active uniform block. </summary>
         /// <param name="program"> Specifies the name of a program containing the uniform block. </param>
@@ -3841,14 +3841,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="length"> Specifies the address of a variable to receive the number of characters that were written to uniformBlockName. </param>
         /// <param name="uniformBlockName"> Specifies the address an array of characters to receive the name of the uniform block at uniformBlockIndex. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetActiveUniformBlockName.xhtml" /></remarks>
-        public static void GetActiveUniformBlockName(ProgramHandle program, uint uniformBlockIndex, int bufSize, int* length, byte* uniformBlockName) => GLPointers._GetActiveUniformBlockName_fnptr((int)program, uniformBlockIndex, bufSize, length, uniformBlockName);
+        public static void GetActiveUniformBlockName(int program, uint uniformBlockIndex, int bufSize, int* length, byte* uniformBlockName) => GLPointers._GetActiveUniformBlockName_fnptr(program, uniformBlockIndex, bufSize, length, uniformBlockName);
         
         /// <summary> <b>[requires: v3.1 | GL_ARB_uniform_buffer_object]</b> Assign a binding point to an active uniform block. </summary>
         /// <param name="program"> The name of a program object containing the active uniform block whose binding to assign. </param>
         /// <param name="uniformBlockIndex"> The index of the active uniform block within program whose binding to assign. </param>
         /// <param name="uniformBlockBinding"> Specifies the binding point to which to bind the uniform block with index uniformBlockIndex within program. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glUniformBlockBinding.xhtml" /></remarks>
-        public static void UniformBlockBinding(ProgramHandle program, uint uniformBlockIndex, uint uniformBlockBinding) => GLPointers._UniformBlockBinding_fnptr((int)program, uniformBlockIndex, uniformBlockBinding);
+        public static void UniformBlockBinding(int program, uint uniformBlockIndex, uint uniformBlockBinding) => GLPointers._UniformBlockBinding_fnptr(program, uniformBlockIndex, uniformBlockBinding);
         
         /// <summary> <b>[requires: v3.2 | GL_ARB_draw_elements_base_vertex]</b> Render primitives from array data with a per-element offset. </summary>
         /// <param name="mode"> Specifies what kind of primitives to render. Symbolic constants GL_POINTS, GL_LINE_STRIP, GL_LINE_LOOP, GL_LINES, GL_TRIANGLE_STRIP, GL_TRIANGLE_FAN, GL_TRIANGLES, GL_LINES_ADJACENCY, GL_LINE_STRIP_ADJACENCY, GL_TRIANGLES_ADJACENCY, GL_TRIANGLE_STRIP_ADJACENCY and GL_PATCHES are accepted. </param>
@@ -3960,7 +3960,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="texture"> Specifies the name of an existing texture object to attach. </param>
         /// <param name="level"> Specifies the mipmap level of the texture object to attach. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glFramebufferTexture.xhtml" /></remarks>
-        public static void FramebufferTexture(FramebufferTarget target, FramebufferAttachment attachment, TextureHandle texture, int level) => GLPointers._FramebufferTexture_fnptr((uint)target, (uint)attachment, (int)texture, level);
+        public static void FramebufferTexture(FramebufferTarget target, FramebufferAttachment attachment, int texture, int level) => GLPointers._FramebufferTexture_fnptr((uint)target, (uint)attachment, texture, level);
         
         /// <summary> <b>[requires: v3.2 | GL_ARB_texture_multisample]</b> Establish the data storage, format, dimensions, and number of samples of a multisample texture's image. </summary>
         /// <param name="target"> Specifies the target of the operation. target must be GL_TEXTURE_2D_MULTISAMPLE or GL_PROXY_TEXTURE_2D_MULTISAMPLE. </param>
@@ -4002,126 +4002,126 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="index"> The index of the color input to bind the user-defined varying out variable to </param>
         /// <param name="name"> The name of the user-defined varying out variable whose binding to modify </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindFragDataLocationIndexed.xhtml" /></remarks>
-        public static void BindFragDataLocationIndexed(ProgramHandle program, uint colorNumber, uint index, byte* name) => GLPointers._BindFragDataLocationIndexed_fnptr((int)program, colorNumber, index, name);
+        public static void BindFragDataLocationIndexed(int program, uint colorNumber, uint index, byte* name) => GLPointers._BindFragDataLocationIndexed_fnptr(program, colorNumber, index, name);
         
         /// <summary> <b>[requires: v3.3 | GL_ARB_blend_func_extended]</b> Query the bindings of color indices to user-defined varying out variables. </summary>
         /// <param name="program"> The name of the program containing varying out variable whose binding to query </param>
         /// <param name="name"> The name of the user-defined varying out variable whose index to query </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetFragDataIndex.xhtml" /></remarks>
-        public static int GetFragDataIndex(ProgramHandle program, byte* name) => GLPointers._GetFragDataIndex_fnptr((int)program, name);
+        public static int GetFragDataIndex(int program, byte* name) => GLPointers._GetFragDataIndex_fnptr(program, name);
         
         /// <summary> <b>[requires: v3.3 | GL_ARB_sampler_objects]</b> Generate sampler object names. </summary>
         /// <param name="n"> Specifies the number of sampler object names to generate. </param>
         /// <param name="samplers"> Specifies an array in which the generated sampler object names are stored. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGenSamplers.xhtml" /></remarks>
-        public static void GenSamplers(int count, SamplerHandle* samplers) => GLPointers._GenSamplers_fnptr(count, (int*)samplers);
+        public static void GenSamplers(int count, int* samplers) => GLPointers._GenSamplers_fnptr(count, samplers);
         
         /// <summary> <b>[requires: v3.3 | GL_ARB_sampler_objects]</b> Delete named sampler objects. </summary>
         /// <param name="n"> Specifies the number of sampler objects to be deleted. </param>
         /// <param name="samplers"> Specifies an array of sampler objects to be deleted. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDeleteSamplers.xhtml" /></remarks>
-        public static void DeleteSamplers(int count, SamplerHandle* samplers) => GLPointers._DeleteSamplers_fnptr(count, (int*)samplers);
+        public static void DeleteSamplers(int count, int* samplers) => GLPointers._DeleteSamplers_fnptr(count, samplers);
         
         /// <summary> <b>[requires: v3.3 | GL_ARB_sampler_objects]</b> Determine if a name corresponds to a sampler object. </summary>
         /// <param name="id"> Specifies a value that may be the name of a sampler object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsSampler.xhtml" /></remarks>
-        public static bool IsSampler(SamplerHandle sampler) => GLPointers._IsSampler_fnptr((int)sampler) != 0;
+        public static bool IsSampler(int sampler) => GLPointers._IsSampler_fnptr(sampler) != 0;
         
         /// <summary> <b>[requires: v3.3 | GL_ARB_sampler_objects]</b> Bind a named sampler to a texturing target. </summary>
         /// <param name="unit"> Specifies the index of the texture unit to which the sampler is bound. </param>
         /// <param name="sampler"> Specifies the name of a sampler. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindSampler.xhtml" /></remarks>
-        public static void BindSampler(uint unit, SamplerHandle sampler) => GLPointers._BindSampler_fnptr(unit, (int)sampler);
+        public static void BindSampler(uint unit, int sampler) => GLPointers._BindSampler_fnptr(unit, sampler);
         
         /// <summary> <b>[requires: v3.3 | GL_ARB_sampler_objects]</b> Set sampler parameters. </summary>
         /// <param name="sampler"> Specifies the sampler object whose parameter to modify. </param>
         /// <param name="pname"> Specifies the symbolic name of a sampler parameter. pname can be one of the following: GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, GL_TEXTURE_WRAP_R, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_BORDER_COLOR, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_LOD_BIAS GL_TEXTURE_COMPARE_MODE, or GL_TEXTURE_COMPARE_FUNC. </param>
         /// <param name="param"> For the scalar commands, specifies the value of pname. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glSamplerParameter.xhtml" /></remarks>
-        public static void SamplerParameteri(SamplerHandle sampler, SamplerParameterI pname, int param) => GLPointers._SamplerParameteri_fnptr((int)sampler, (uint)pname, param);
+        public static void SamplerParameteri(int sampler, SamplerParameterI pname, int param) => GLPointers._SamplerParameteri_fnptr(sampler, (uint)pname, param);
         
         /// <summary> <b>[requires: v3.3 | GL_ARB_sampler_objects]</b> Set sampler parameters. </summary>
         /// <param name="sampler"> Specifies the sampler object whose parameter to modify. </param>
         /// <param name="pname"> Specifies the symbolic name of a sampler parameter. pname can be one of the following: GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, GL_TEXTURE_WRAP_R, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_BORDER_COLOR, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_LOD_BIAS GL_TEXTURE_COMPARE_MODE, or GL_TEXTURE_COMPARE_FUNC. </param>
         /// <param name="parameters"> For the vector commands (glSamplerParameter*v), specifies a pointer to an array where the value or values of pname are stored. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glSamplerParameter.xhtml" /></remarks>
-        public static void SamplerParameteriv(SamplerHandle sampler, SamplerParameterI pname, int* param) => GLPointers._SamplerParameteriv_fnptr((int)sampler, (uint)pname, param);
+        public static void SamplerParameteriv(int sampler, SamplerParameterI pname, int* param) => GLPointers._SamplerParameteriv_fnptr(sampler, (uint)pname, param);
         
         /// <summary> <b>[requires: v3.3 | GL_ARB_sampler_objects]</b> Set sampler parameters. </summary>
         /// <param name="sampler"> Specifies the sampler object whose parameter to modify. </param>
         /// <param name="pname"> Specifies the symbolic name of a sampler parameter. pname can be one of the following: GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, GL_TEXTURE_WRAP_R, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_BORDER_COLOR, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_LOD_BIAS GL_TEXTURE_COMPARE_MODE, or GL_TEXTURE_COMPARE_FUNC. </param>
         /// <param name="param"> For the scalar commands, specifies the value of pname. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glSamplerParameter.xhtml" /></remarks>
-        public static void SamplerParameterf(SamplerHandle sampler, SamplerParameterF pname, float param) => GLPointers._SamplerParameterf_fnptr((int)sampler, (uint)pname, param);
+        public static void SamplerParameterf(int sampler, SamplerParameterF pname, float param) => GLPointers._SamplerParameterf_fnptr(sampler, (uint)pname, param);
         
         /// <summary> <b>[requires: v3.3 | GL_ARB_sampler_objects]</b> Set sampler parameters. </summary>
         /// <param name="sampler"> Specifies the sampler object whose parameter to modify. </param>
         /// <param name="pname"> Specifies the symbolic name of a sampler parameter. pname can be one of the following: GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, GL_TEXTURE_WRAP_R, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_BORDER_COLOR, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_LOD_BIAS GL_TEXTURE_COMPARE_MODE, or GL_TEXTURE_COMPARE_FUNC. </param>
         /// <param name="parameters"> For the vector commands (glSamplerParameter*v), specifies a pointer to an array where the value or values of pname are stored. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glSamplerParameter.xhtml" /></remarks>
-        public static void SamplerParameterfv(SamplerHandle sampler, SamplerParameterF pname, float* param) => GLPointers._SamplerParameterfv_fnptr((int)sampler, (uint)pname, param);
+        public static void SamplerParameterfv(int sampler, SamplerParameterF pname, float* param) => GLPointers._SamplerParameterfv_fnptr(sampler, (uint)pname, param);
         
         /// <summary> <b>[requires: v3.3 | GL_ARB_sampler_objects]</b> Set sampler parameters. </summary>
         /// <param name="sampler"> Specifies the sampler object whose parameter to modify. </param>
         /// <param name="pname"> Specifies the symbolic name of a sampler parameter. pname can be one of the following: GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, GL_TEXTURE_WRAP_R, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_BORDER_COLOR, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_LOD_BIAS GL_TEXTURE_COMPARE_MODE, or GL_TEXTURE_COMPARE_FUNC. </param>
         /// <param name="parameters"> For the vector commands (glSamplerParameter*v), specifies a pointer to an array where the value or values of pname are stored. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glSamplerParameter.xhtml" /></remarks>
-        public static void SamplerParameterIiv(SamplerHandle sampler, SamplerParameterI pname, int* param) => GLPointers._SamplerParameterIiv_fnptr((int)sampler, (uint)pname, param);
+        public static void SamplerParameterIiv(int sampler, SamplerParameterI pname, int* param) => GLPointers._SamplerParameterIiv_fnptr(sampler, (uint)pname, param);
         
         /// <summary> <b>[requires: v3.3 | GL_ARB_sampler_objects]</b> Set sampler parameters. </summary>
         /// <param name="sampler"> Specifies the sampler object whose parameter to modify. </param>
         /// <param name="pname"> Specifies the symbolic name of a sampler parameter. pname can be one of the following: GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, GL_TEXTURE_WRAP_R, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_BORDER_COLOR, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_LOD_BIAS GL_TEXTURE_COMPARE_MODE, or GL_TEXTURE_COMPARE_FUNC. </param>
         /// <param name="parameters"> For the vector commands (glSamplerParameter*v), specifies a pointer to an array where the value or values of pname are stored. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glSamplerParameter.xhtml" /></remarks>
-        public static void SamplerParameterIuiv(SamplerHandle sampler, SamplerParameterI pname, uint* param) => GLPointers._SamplerParameterIuiv_fnptr((int)sampler, (uint)pname, param);
+        public static void SamplerParameterIuiv(int sampler, SamplerParameterI pname, uint* param) => GLPointers._SamplerParameterIuiv_fnptr(sampler, (uint)pname, param);
         
         /// <summary> <b>[requires: v3.3 | GL_ARB_sampler_objects]</b> Return sampler parameter values. </summary>
         /// <param name="sampler"> Specifies name of the sampler object from which to retrieve parameters. </param>
         /// <param name="pname"> Specifies the symbolic name of a sampler parameter. GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_LOD_BIAS, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, GL_TEXTURE_WRAP_R, GL_TEXTURE_BORDER_COLOR, GL_TEXTURE_COMPARE_MODE, and GL_TEXTURE_COMPARE_FUNC are accepted. </param>
         /// <param name="parameters"> Returns the sampler parameters. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetSamplerParameter.xhtml" /></remarks>
-        public static void GetSamplerParameteriv(SamplerHandle sampler, SamplerParameterI pname, int* parameters) => GLPointers._GetSamplerParameteriv_fnptr((int)sampler, (uint)pname, parameters);
+        public static void GetSamplerParameteriv(int sampler, SamplerParameterI pname, int* parameters) => GLPointers._GetSamplerParameteriv_fnptr(sampler, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v3.3 | GL_ARB_sampler_objects]</b> Return sampler parameter values. </summary>
         /// <param name="sampler"> Specifies name of the sampler object from which to retrieve parameters. </param>
         /// <param name="pname"> Specifies the symbolic name of a sampler parameter. GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_LOD_BIAS, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, GL_TEXTURE_WRAP_R, GL_TEXTURE_BORDER_COLOR, GL_TEXTURE_COMPARE_MODE, and GL_TEXTURE_COMPARE_FUNC are accepted. </param>
         /// <param name="parameters"> Returns the sampler parameters. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetSamplerParameter.xhtml" /></remarks>
-        public static void GetSamplerParameterIiv(SamplerHandle sampler, SamplerParameterI pname, int* parameters) => GLPointers._GetSamplerParameterIiv_fnptr((int)sampler, (uint)pname, parameters);
+        public static void GetSamplerParameterIiv(int sampler, SamplerParameterI pname, int* parameters) => GLPointers._GetSamplerParameterIiv_fnptr(sampler, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v3.3 | GL_ARB_sampler_objects]</b> Return sampler parameter values. </summary>
         /// <param name="sampler"> Specifies name of the sampler object from which to retrieve parameters. </param>
         /// <param name="pname"> Specifies the symbolic name of a sampler parameter. GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_LOD_BIAS, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, GL_TEXTURE_WRAP_R, GL_TEXTURE_BORDER_COLOR, GL_TEXTURE_COMPARE_MODE, and GL_TEXTURE_COMPARE_FUNC are accepted. </param>
         /// <param name="parameters"> Returns the sampler parameters. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetSamplerParameter.xhtml" /></remarks>
-        public static void GetSamplerParameterfv(SamplerHandle sampler, SamplerParameterF pname, float* parameters) => GLPointers._GetSamplerParameterfv_fnptr((int)sampler, (uint)pname, parameters);
+        public static void GetSamplerParameterfv(int sampler, SamplerParameterF pname, float* parameters) => GLPointers._GetSamplerParameterfv_fnptr(sampler, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v3.3 | GL_ARB_sampler_objects]</b> Return sampler parameter values. </summary>
         /// <param name="sampler"> Specifies name of the sampler object from which to retrieve parameters. </param>
         /// <param name="pname"> Specifies the symbolic name of a sampler parameter. GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_LOD_BIAS, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, GL_TEXTURE_WRAP_R, GL_TEXTURE_BORDER_COLOR, GL_TEXTURE_COMPARE_MODE, and GL_TEXTURE_COMPARE_FUNC are accepted. </param>
         /// <param name="parameters"> Returns the sampler parameters. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetSamplerParameter.xhtml" /></remarks>
-        public static void GetSamplerParameterIuiv(SamplerHandle sampler, SamplerParameterI pname, uint* parameters) => GLPointers._GetSamplerParameterIuiv_fnptr((int)sampler, (uint)pname, parameters);
+        public static void GetSamplerParameterIuiv(int sampler, SamplerParameterI pname, uint* parameters) => GLPointers._GetSamplerParameterIuiv_fnptr(sampler, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v3.3 | GL_ARB_timer_query]</b> Record the GL time into a query object after all previous commands have reached the GL server but have not yet necessarily executed.. </summary>
         /// <param name="id"> Specify the name of a query object into which to record the GL time. </param>
         /// <param name="target"> Specify the counter to query. target must be GL_TIMESTAMP. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glQueryCounter.xhtml" /></remarks>
-        public static void QueryCounter(QueryHandle id, QueryCounterTarget target) => GLPointers._QueryCounter_fnptr((int)id, (uint)target);
+        public static void QueryCounter(int id, QueryCounterTarget target) => GLPointers._QueryCounter_fnptr(id, (uint)target);
         
         /// <summary> <b>[requires: v3.3 | GL_ARB_timer_query]</b> Return parameters of a query object. </summary>
         /// <param name="id"> Specifies the name of a query object. </param>
         /// <param name="pname"> Specifies the symbolic name of a query object parameter. Accepted values are GL_QUERY_RESULT or GL_QUERY_RESULT_AVAILABLE. </param>
         /// <param name="parameters"> If a buffer is bound to the GL_QUERY_RESULT_BUFFER target, then params is treated as an offset to a location within that buffer's data store to receive the result of the query. If no buffer is bound to GL_QUERY_RESULT_BUFFER, then params is treated as an address in client memory of a variable to receive the resulting data. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetQueryObject.xhtml" /></remarks>
-        public static void GetQueryObjecti64v(QueryHandle id, QueryObjectParameterName pname, long* parameters) => GLPointers._GetQueryObjecti64v_fnptr((int)id, (uint)pname, parameters);
+        public static void GetQueryObjecti64v(int id, QueryObjectParameterName pname, long* parameters) => GLPointers._GetQueryObjecti64v_fnptr(id, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v3.3 | GL_ARB_timer_query]</b> Return parameters of a query object. </summary>
         /// <param name="id"> Specifies the name of a query object. </param>
         /// <param name="pname"> Specifies the symbolic name of a query object parameter. Accepted values are GL_QUERY_RESULT or GL_QUERY_RESULT_AVAILABLE. </param>
         /// <param name="parameters"> If a buffer is bound to the GL_QUERY_RESULT_BUFFER target, then params is treated as an offset to a location within that buffer's data store to receive the result of the query. If no buffer is bound to GL_QUERY_RESULT_BUFFER, then params is treated as an address in client memory of a variable to receive the resulting data. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetQueryObject.xhtml" /></remarks>
-        public static void GetQueryObjectui64v(QueryHandle id, QueryObjectParameterName pname, ulong* parameters) => GLPointers._GetQueryObjectui64v_fnptr((int)id, (uint)pname, parameters);
+        public static void GetQueryObjectui64v(int id, QueryObjectParameterName pname, ulong* parameters) => GLPointers._GetQueryObjectui64v_fnptr(id, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v3.3]</b> Modify the rate at which generic vertex attributes advance during instanced rendering. </summary>
         /// <param name="index"> Specify the index of the generic vertex attribute. </param>
@@ -4417,21 +4417,21 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="location">Specifies the location of the uniform variable to be queried.</param>
         /// <param name="parameters">Returns the value of the specified uniform variable.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetUniform.xhtml" /></remarks>
-        public static void GetUniformdv(ProgramHandle program, int location, double* parameters) => GLPointers._GetUniformdv_fnptr((int)program, location, parameters);
+        public static void GetUniformdv(int program, int location, double* parameters) => GLPointers._GetUniformdv_fnptr(program, location, parameters);
         
         /// <summary> <b>[requires: v4.0 | GL_ARB_shader_subroutine]</b> Retrieve the location of a subroutine uniform of a given shader stage within a program. </summary>
         /// <param name="program"> Specifies the name of the program containing shader stage. </param>
         /// <param name="shadertype"> Specifies the shader stage from which to query for subroutine uniform index. shadertype must be one of GL_VERTEX_SHADER, GL_TESS_CONTROL_SHADER, GL_TESS_EVALUATION_SHADER, GL_GEOMETRY_SHADER or GL_FRAGMENT_SHADER. </param>
         /// <param name="name"> Specifies the name of the subroutine uniform whose index to query. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetSubroutineUniformLocation.xhtml" /></remarks>
-        public static int GetSubroutineUniformLocation(ProgramHandle program, ShaderType shadertype, byte* name) => GLPointers._GetSubroutineUniformLocation_fnptr((int)program, (uint)shadertype, name);
+        public static int GetSubroutineUniformLocation(int program, ShaderType shadertype, byte* name) => GLPointers._GetSubroutineUniformLocation_fnptr(program, (uint)shadertype, name);
         
         /// <summary> <b>[requires: v4.0 | GL_ARB_shader_subroutine]</b> Retrieve the index of a subroutine uniform of a given shader stage within a program. </summary>
         /// <param name="program"> Specifies the name of the program containing shader stage. </param>
         /// <param name="shadertype"> Specifies the shader stage from which to query for subroutine uniform index. shadertype must be one of GL_VERTEX_SHADER, GL_TESS_CONTROL_SHADER, GL_TESS_EVALUATION_SHADER, GL_GEOMETRY_SHADER or GL_FRAGMENT_SHADER. </param>
         /// <param name="name"> Specifies the name of the subroutine uniform whose index to query. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetSubroutineIndex.xhtml" /></remarks>
-        public static uint GetSubroutineIndex(ProgramHandle program, ShaderType shadertype, byte* name) => GLPointers._GetSubroutineIndex_fnptr((int)program, (uint)shadertype, name);
+        public static uint GetSubroutineIndex(int program, ShaderType shadertype, byte* name) => GLPointers._GetSubroutineIndex_fnptr(program, (uint)shadertype, name);
         
         /// <summary> <b>[requires: v4.0 | GL_ARB_shader_subroutine]</b> Query a property of an active shader subroutine uniform. </summary>
         /// <param name="program"> Specifies the name of the program containing the subroutine. </param>
@@ -4440,7 +4440,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="pname"> Specifies the parameter of the shader subroutine uniform to query. pname must be GL_NUM_COMPATIBLE_SUBROUTINES, GL_COMPATIBLE_SUBROUTINES, GL_UNIFORM_SIZE or GL_UNIFORM_NAME_LENGTH. </param>
         /// <param name="values"> Specifies the address of a into which the queried value or values will be placed. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetActiveSubroutineUniform.xhtml" /></remarks>
-        public static void GetActiveSubroutineUniformiv(ProgramHandle program, ShaderType shadertype, uint index, SubroutineParameterName pname, int* values) => GLPointers._GetActiveSubroutineUniformiv_fnptr((int)program, (uint)shadertype, index, (uint)pname, values);
+        public static void GetActiveSubroutineUniformiv(int program, ShaderType shadertype, uint index, SubroutineParameterName pname, int* values) => GLPointers._GetActiveSubroutineUniformiv_fnptr(program, (uint)shadertype, index, (uint)pname, values);
         
         /// <summary> <b>[requires: v4.0 | GL_ARB_shader_subroutine]</b> Query the name of an active shader subroutine uniform. </summary>
         /// <param name="program"> Specifies the name of the program containing the subroutine. </param>
@@ -4450,7 +4450,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="length"> Specifies the address of a variable into which is written the number of characters copied into name. </param>
         /// <param name="name"> Specifies the address of a buffer that will receive the name of the specified shader subroutine uniform. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetActiveSubroutineUniformName.xhtml" /></remarks>
-        public static void GetActiveSubroutineUniformName(ProgramHandle program, ShaderType shadertype, uint index, int bufSize, int* length, byte* name) => GLPointers._GetActiveSubroutineUniformName_fnptr((int)program, (uint)shadertype, index, bufSize, length, name);
+        public static void GetActiveSubroutineUniformName(int program, ShaderType shadertype, uint index, int bufSize, int* length, byte* name) => GLPointers._GetActiveSubroutineUniformName_fnptr(program, (uint)shadertype, index, bufSize, length, name);
         
         /// <summary> <b>[requires: v4.0 | GL_ARB_shader_subroutine]</b> Query the name of an active shader subroutine. </summary>
         /// <param name="program"> Specifies the name of the program containing the subroutine. </param>
@@ -4460,7 +4460,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="length"> Specifies the address of a variable which is to receive the length of the shader subroutine uniform name. </param>
         /// <param name="name"> Specifies the address of an array into which the name of the shader subroutine uniform will be written. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetActiveSubroutineName.xhtml" /></remarks>
-        public static void GetActiveSubroutineName(ProgramHandle program, ShaderType shadertype, uint index, int bufSize, int* length, byte* name) => GLPointers._GetActiveSubroutineName_fnptr((int)program, (uint)shadertype, index, bufSize, length, name);
+        public static void GetActiveSubroutineName(int program, ShaderType shadertype, uint index, int bufSize, int* length, byte* name) => GLPointers._GetActiveSubroutineName_fnptr(program, (uint)shadertype, index, bufSize, length, name);
         
         /// <summary> <b>[requires: v4.0 | GL_ARB_shader_subroutine]</b> Load active subroutine uniforms. </summary>
         /// <param name="shadertype"> Specifies the shader stage from which to query for subroutine uniform index. shadertype must be one of GL_VERTEX_SHADER, GL_TESS_CONTROL_SHADER, GL_TESS_EVALUATION_SHADER, GL_GEOMETRY_SHADER or GL_FRAGMENT_SHADER. </param>
@@ -4482,7 +4482,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="pname"> Specifies the parameter of the shader to query. pname must be GL_ACTIVE_SUBROUTINE_UNIFORMS, GL_ACTIVE_SUBROUTINE_UNIFORM_LOCATIONS, GL_ACTIVE_SUBROUTINES, GL_ACTIVE_SUBROUTINE_UNIFORM_MAX_LENGTH, or GL_ACTIVE_SUBROUTINE_MAX_LENGTH. </param>
         /// <param name="values"> Specifies the address of a variable into which the queried value or values will be placed. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetProgramStage.xhtml" /></remarks>
-        public static void GetProgramStageiv(ProgramHandle program, ShaderType shadertype, ProgramStagePName pname, int* values) => GLPointers._GetProgramStageiv_fnptr((int)program, (uint)shadertype, (uint)pname, values);
+        public static void GetProgramStageiv(int program, ShaderType shadertype, ProgramStagePName pname, int* values) => GLPointers._GetProgramStageiv_fnptr(program, (uint)shadertype, (uint)pname, values);
         
         /// <summary> <b>[requires: v4.0 | GL_ARB_tessellation_shader]</b> Specifies the parameters for patch primitives. </summary>
         /// <param name="pname"> Specifies the name of the parameter to set. The symbolc constants GL_PATCH_VERTICES, GL_PATCH_DEFAULT_OUTER_LEVEL, and GL_PATCH_DEFAULT_INNER_LEVEL are accepted. </param>
@@ -4500,24 +4500,24 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="target"> Specifies the target to which to bind the transform feedback object id. target must be GL_TRANSFORM_FEEDBACK. </param>
         /// <param name="id"> Specifies the name of a transform feedback object reserved by glGenTransformFeedbacks. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindTransformFeedback.xhtml" /></remarks>
-        public static void BindTransformFeedback(BindTransformFeedbackTarget target, TransformFeedbackHandle id) => GLPointers._BindTransformFeedback_fnptr((uint)target, (int)id);
+        public static void BindTransformFeedback(BindTransformFeedbackTarget target, int id) => GLPointers._BindTransformFeedback_fnptr((uint)target, id);
         
         /// <summary> <b>[requires: v4.0 | GL_ARB_transform_feedback2]</b> Delete transform feedback objects. </summary>
         /// <param name="n"> Specifies the number of transform feedback objects to delete. </param>
         /// <param name="ids"> Specifies an array of names of transform feedback objects to delete. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDeleteTransformFeedbacks.xhtml" /></remarks>
-        public static void DeleteTransformFeedbacks(int n, TransformFeedbackHandle* ids) => GLPointers._DeleteTransformFeedbacks_fnptr(n, (int*)ids);
+        public static void DeleteTransformFeedbacks(int n, int* ids) => GLPointers._DeleteTransformFeedbacks_fnptr(n, ids);
         
         /// <summary> <b>[requires: v4.0 | GL_ARB_transform_feedback2]</b> Reserve transform feedback object names. </summary>
         /// <param name="n"> Specifies the number of transform feedback object names to reserve. </param>
         /// <param name="ids"> Specifies an array of into which the reserved names will be written. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGenTransformFeedbacks.xhtml" /></remarks>
-        public static void GenTransformFeedbacks(int n, TransformFeedbackHandle* ids) => GLPointers._GenTransformFeedbacks_fnptr(n, (int*)ids);
+        public static void GenTransformFeedbacks(int n, int* ids) => GLPointers._GenTransformFeedbacks_fnptr(n, ids);
         
         /// <summary> <b>[requires: v4.0 | GL_ARB_transform_feedback2]</b> Determine if a name corresponds to a transform feedback object. </summary>
         /// <param name="id"> Specifies a value that may be the name of a transform feedback object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsTransformFeedback.xhtml" /></remarks>
-        public static bool IsTransformFeedback(TransformFeedbackHandle id) => GLPointers._IsTransformFeedback_fnptr((int)id) != 0;
+        public static bool IsTransformFeedback(int id) => GLPointers._IsTransformFeedback_fnptr(id) != 0;
         
         /// <summary> <b>[requires: v4.0 | GL_ARB_transform_feedback2]</b> Pause transform feedback operations. </summary>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glPauseTransformFeedback.xhtml" /></remarks>
@@ -4531,21 +4531,21 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="mode"> Specifies what kind of primitives to render. Symbolic constants GL_POINTS, GL_LINE_STRIP, GL_LINE_LOOP, GL_LINES, GL_LINE_STRIP_ADJACENCY, GL_LINES_ADJACENCY, GL_TRIANGLE_STRIP, GL_TRIANGLE_FAN, GL_TRIANGLES, GL_TRIANGLE_STRIP_ADJACENCY, GL_TRIANGLES_ADJACENCY, and GL_PATCHES are accepted. </param>
         /// <param name="id"> Specifies the name of a transform feedback object from which to retrieve a primitive count. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDrawTransformFeedback.xhtml" /></remarks>
-        public static void DrawTransformFeedback(PrimitiveType mode, TransformFeedbackHandle id) => GLPointers._DrawTransformFeedback_fnptr((uint)mode, (int)id);
+        public static void DrawTransformFeedback(PrimitiveType mode, int id) => GLPointers._DrawTransformFeedback_fnptr((uint)mode, id);
         
         /// <summary> <b>[requires: v4.0 | GL_ARB_transform_feedback3]</b> Render primitives using a count derived from a specifed stream of a transform feedback object. </summary>
         /// <param name="mode"> Specifies what kind of primitives to render. Symbolic constants GL_POINTS, GL_LINE_STRIP, GL_LINE_LOOP, GL_LINES, GL_LINE_STRIP_ADJACENCY, GL_LINES_ADJACENCY, GL_TRIANGLE_STRIP, GL_TRIANGLE_FAN, GL_TRIANGLES, GL_TRIANGLE_STRIP_ADJACENCY, GL_TRIANGLES_ADJACENCY, and GL_PATCHES are accepted. </param>
         /// <param name="id"> Specifies the name of a transform feedback object from which to retrieve a primitive count. </param>
         /// <param name="stream"> Specifies the index of the transform feedback stream from which to retrieve a primitive count. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDrawTransformFeedbackStream.xhtml" /></remarks>
-        public static void DrawTransformFeedbackStream(PrimitiveType mode, TransformFeedbackHandle id, uint stream) => GLPointers._DrawTransformFeedbackStream_fnptr((uint)mode, (int)id, stream);
+        public static void DrawTransformFeedbackStream(PrimitiveType mode, int id, uint stream) => GLPointers._DrawTransformFeedbackStream_fnptr((uint)mode, id, stream);
         
         /// <summary> <b>[requires: v4.0 | GL_ARB_transform_feedback3]</b> Delimit the boundaries of a query object on an indexed target. </summary>
         /// <param name="target"> Specifies the target type of query object established between glBeginQueryIndexed and the subsequent glEndQueryIndexed. The symbolic constant must be one of GL_SAMPLES_PASSED, GL_ANY_SAMPLES_PASSED, GL_PRIMITIVES_GENERATED, GL_TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN, or GL_TIME_ELAPSED. </param>
         /// <param name="index"> Specifies the index of the query target upon which to begin the query. </param>
         /// <param name="id"> Specifies the name of a query object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBeginQueryIndexed.xhtml" /></remarks>
-        public static void BeginQueryIndexed(QueryTarget target, uint index, QueryHandle id) => GLPointers._BeginQueryIndexed_fnptr((uint)target, index, (int)id);
+        public static void BeginQueryIndexed(QueryTarget target, uint index, int id) => GLPointers._BeginQueryIndexed_fnptr((uint)target, index, id);
         
         /// <summary> <b>[requires: v4.0 | GL_ARB_transform_feedback3]</b> Delimit the boundaries of a query object on an indexed target. </summary>
         /// <param name="target"> Specifies the target type of query object established between glBeginQueryIndexed and the subsequent glEndQueryIndexed. The symbolic constant must be one of GL_SAMPLES_PASSED, GL_ANY_SAMPLES_PASSED, GL_PRIMITIVES_GENERATED, GL_TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN, or GL_TIME_ELAPSED. </param>
@@ -4572,7 +4572,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="binary"> Specifies the address of an array of bytes containing pre-compiled binary shader code. </param>
         /// <param name="length"> Specifies the length of the array whose address is given in binary. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glShaderBinary.xhtml" /></remarks>
-        public static void ShaderBinary(int count, ShaderHandle* shaders, ShaderBinaryFormat binaryFormat, void* binary, int length) => GLPointers._ShaderBinary_fnptr(count, (int*)shaders, (uint)binaryFormat, binary, length);
+        public static void ShaderBinary(int count, int* shaders, ShaderBinaryFormat binaryFormat, void* binary, int length) => GLPointers._ShaderBinary_fnptr(count, shaders, (uint)binaryFormat, binary, length);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_ES2_compatibility]</b> Retrieve the range and precision for numeric formats supported by the shader compiler. </summary>
         /// <param name="shaderType"> Specifies the type of shader whose precision to query. shaderType must be GL_VERTEX_SHADER or GL_FRAGMENT_SHADER. </param>
@@ -4600,7 +4600,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="binaryFormat"> Specifies the address of a variable to receive a token indicating the format of the binary data returned by the GL. </param>
         /// <param name="binary"> Specifies the address an array into which the GL will return program's binary representation. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetProgramBinary.xhtml" /></remarks>
-        public static void GetProgramBinary(ProgramHandle program, int bufSize, int* length, All* binaryFormat, void* binary) => GLPointers._GetProgramBinary_fnptr((int)program, bufSize, length, (uint*)binaryFormat, binary);
+        public static void GetProgramBinary(int program, int bufSize, int* length, All* binaryFormat, void* binary) => GLPointers._GetProgramBinary_fnptr(program, bufSize, length, (uint*)binaryFormat, binary);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_get_program_binary]</b> Load a program object with a program binary. </summary>
         /// <param name="program"> Specifies the name of a program object into which to load a program binary. </param>
@@ -4608,70 +4608,70 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="binary"> Specifies the address an array containing the binary to be loaded into program. </param>
         /// <param name="length"> Specifies the number of bytes contained in binary. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramBinary.xhtml" /></remarks>
-        public static void ProgramBinary(ProgramHandle program, All binaryFormat, void* binary, int length) => GLPointers._ProgramBinary_fnptr((int)program, (uint)binaryFormat, binary, length);
+        public static void ProgramBinary(int program, All binaryFormat, void* binary, int length) => GLPointers._ProgramBinary_fnptr(program, (uint)binaryFormat, binary, length);
         
         /// <summary> <b>[requires: v4.1 | v4.1 | GL_ARB_get_program_binary | GL_ARB_separate_shader_objects]</b> Specify a parameter for a program object. </summary>
         /// <param name="program"> Specifies the name of a program object whose parameter to modify. </param>
         /// <param name="pname"> Specifies the name of the parameter to modify. </param>
         /// <param name="value"> Specifies the new value of the parameter specified by pname for program. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramParameter.xhtml" /></remarks>
-        public static void ProgramParameteri(ProgramHandle program, ProgramParameterPName pname, int value) => GLPointers._ProgramParameteri_fnptr((int)program, (uint)pname, value);
+        public static void ProgramParameteri(int program, ProgramParameterPName pname, int value) => GLPointers._ProgramParameteri_fnptr(program, (uint)pname, value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Bind stages of a program object to a program pipeline. </summary>
         /// <param name="pipeline"> Specifies the program pipeline object to which to bind stages from program. </param>
         /// <param name="stages"> Specifies a set of program stages to bind to the program pipeline object. </param>
         /// <param name="program"> Specifies the program object containing the shader executables to use in pipeline. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glUseProgramStages.xhtml" /></remarks>
-        public static void UseProgramStages(ProgramPipelineHandle pipeline, UseProgramStageMask stages, ProgramHandle program) => GLPointers._UseProgramStages_fnptr((int)pipeline, (uint)stages, (int)program);
+        public static void UseProgramStages(int pipeline, UseProgramStageMask stages, int program) => GLPointers._UseProgramStages_fnptr(pipeline, (uint)stages, program);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Set the active program object for a program pipeline object. </summary>
         /// <param name="pipeline"> Specifies the program pipeline object to set the active program object for. </param>
         /// <param name="program"> Specifies the program object to set as the active program pipeline object pipeline. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glActiveShaderProgram.xhtml" /></remarks>
-        public static void ActiveShaderProgram(ProgramPipelineHandle pipeline, ProgramHandle program) => GLPointers._ActiveShaderProgram_fnptr((int)pipeline, (int)program);
+        public static void ActiveShaderProgram(int pipeline, int program) => GLPointers._ActiveShaderProgram_fnptr(pipeline, program);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Create a stand-alone program from an array of null-terminated source code strings. </summary>
         /// <param name="type"> Specifies the type of shader to create. </param>
         /// <param name="count"> Specifies the number of source code strings in the array strings. </param>
         /// <param name="strings"> Specifies the address of an array of pointers to source code strings from which to create the program object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCreateShaderProgram.xhtml" /></remarks>
-        public static ProgramHandle CreateShaderProgramv(ShaderType type, int count, byte** strings) => (ProgramHandle) GLPointers._CreateShaderProgramv_fnptr((uint)type, count, strings);
+        public static int CreateShaderProgramv(ShaderType type, int count, byte** strings) => GLPointers._CreateShaderProgramv_fnptr((uint)type, count, strings);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Bind a program pipeline to the current context. </summary>
         /// <param name="pipeline"> Specifies the name of the pipeline object to bind to the context. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindProgramPipeline.xhtml" /></remarks>
-        public static void BindProgramPipeline(ProgramPipelineHandle pipeline) => GLPointers._BindProgramPipeline_fnptr((int)pipeline);
+        public static void BindProgramPipeline(int pipeline) => GLPointers._BindProgramPipeline_fnptr(pipeline);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Delete program pipeline objects. </summary>
         /// <param name="n"> Specifies the number of program pipeline objects to delete. </param>
         /// <param name="pipelines"> Specifies an array of names of program pipeline objects to delete. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDeleteProgramPipelines.xhtml" /></remarks>
-        public static void DeleteProgramPipelines(int n, ProgramPipelineHandle* pipelines) => GLPointers._DeleteProgramPipelines_fnptr(n, (int*)pipelines);
+        public static void DeleteProgramPipelines(int n, int* pipelines) => GLPointers._DeleteProgramPipelines_fnptr(n, pipelines);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Reserve program pipeline object names. </summary>
         /// <param name="n"> Specifies the number of program pipeline object names to reserve. </param>
         /// <param name="pipelines"> Specifies an array of into which the reserved names will be written. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGenProgramPipelines.xhtml" /></remarks>
-        public static void GenProgramPipelines(int n, ProgramPipelineHandle* pipelines) => GLPointers._GenProgramPipelines_fnptr(n, (int*)pipelines);
+        public static void GenProgramPipelines(int n, int* pipelines) => GLPointers._GenProgramPipelines_fnptr(n, pipelines);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Determine if a name corresponds to a program pipeline object. </summary>
         /// <param name="pipeline"> Specifies a value that may be the name of a program pipeline object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsProgramPipeline.xhtml" /></remarks>
-        public static bool IsProgramPipeline(ProgramPipelineHandle pipeline) => GLPointers._IsProgramPipeline_fnptr((int)pipeline) != 0;
+        public static bool IsProgramPipeline(int pipeline) => GLPointers._IsProgramPipeline_fnptr(pipeline) != 0;
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Retrieve properties of a program pipeline object. </summary>
         /// <param name="pipeline"> Specifies the name of a program pipeline object whose parameter retrieve. </param>
         /// <param name="pname"> Specifies the name of the parameter to retrieve. </param>
         /// <param name="parameters"> Specifies the address of a variable into which will be written the value or values of pname for pipeline. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetProgramPipeline.xhtml" /></remarks>
-        public static void GetProgramPipelineiv(ProgramPipelineHandle pipeline, PipelineParameterName pname, int* parameters) => GLPointers._GetProgramPipelineiv_fnptr((int)pipeline, (uint)pname, parameters);
+        public static void GetProgramPipelineiv(int pipeline, PipelineParameterName pname, int* parameters) => GLPointers._GetProgramPipelineiv_fnptr(pipeline, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
         /// <param name="v0"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform1i(ProgramHandle program, int location, int v0) => GLPointers._ProgramUniform1i_fnptr((int)program, location, v0);
+        public static void ProgramUniform1i(int program, int location, int v0) => GLPointers._ProgramUniform1i_fnptr(program, location, v0);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -4679,14 +4679,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform1iv(ProgramHandle program, int location, int count, int* value) => GLPointers._ProgramUniform1iv_fnptr((int)program, location, count, value);
+        public static void ProgramUniform1iv(int program, int location, int count, int* value) => GLPointers._ProgramUniform1iv_fnptr(program, location, count, value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
         /// <param name="v0"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform1f(ProgramHandle program, int location, float v0) => GLPointers._ProgramUniform1f_fnptr((int)program, location, v0);
+        public static void ProgramUniform1f(int program, int location, float v0) => GLPointers._ProgramUniform1f_fnptr(program, location, v0);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -4694,22 +4694,22 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform1fv(ProgramHandle program, int location, int count, float* value) => GLPointers._ProgramUniform1fv_fnptr((int)program, location, count, value);
+        public static void ProgramUniform1fv(int program, int location, int count, float* value) => GLPointers._ProgramUniform1fv_fnptr(program, location, count, value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void ProgramUniform1d(ProgramHandle program, int location, double v0) => GLPointers._ProgramUniform1d_fnptr((int)program, location, v0);
+        public static void ProgramUniform1d(int program, int location, double v0) => GLPointers._ProgramUniform1d_fnptr(program, location, v0);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void ProgramUniform1dv(ProgramHandle program, int location, int count, double* value) => GLPointers._ProgramUniform1dv_fnptr((int)program, location, count, value);
+        public static void ProgramUniform1dv(int program, int location, int count, double* value) => GLPointers._ProgramUniform1dv_fnptr(program, location, count, value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
         /// <param name="v0"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform1ui(ProgramHandle program, int location, uint v0) => GLPointers._ProgramUniform1ui_fnptr((int)program, location, v0);
+        public static void ProgramUniform1ui(int program, int location, uint v0) => GLPointers._ProgramUniform1ui_fnptr(program, location, v0);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -4717,7 +4717,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform1uiv(ProgramHandle program, int location, int count, uint* value) => GLPointers._ProgramUniform1uiv_fnptr((int)program, location, count, value);
+        public static void ProgramUniform1uiv(int program, int location, int count, uint* value) => GLPointers._ProgramUniform1uiv_fnptr(program, location, count, value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -4725,7 +4725,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="v0"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
         /// <param name="v1"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform2i(ProgramHandle program, int location, int v0, int v1) => GLPointers._ProgramUniform2i_fnptr((int)program, location, v0, v1);
+        public static void ProgramUniform2i(int program, int location, int v0, int v1) => GLPointers._ProgramUniform2i_fnptr(program, location, v0, v1);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -4733,7 +4733,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform2iv(ProgramHandle program, int location, int count, int* value) => GLPointers._ProgramUniform2iv_fnptr((int)program, location, count, value);
+        public static void ProgramUniform2iv(int program, int location, int count, int* value) => GLPointers._ProgramUniform2iv_fnptr(program, location, count, value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -4741,7 +4741,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="v0"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
         /// <param name="v1"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform2f(ProgramHandle program, int location, float v0, float v1) => GLPointers._ProgramUniform2f_fnptr((int)program, location, v0, v1);
+        public static void ProgramUniform2f(int program, int location, float v0, float v1) => GLPointers._ProgramUniform2f_fnptr(program, location, v0, v1);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -4749,15 +4749,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform2fv(ProgramHandle program, int location, int count, float* value) => GLPointers._ProgramUniform2fv_fnptr((int)program, location, count, value);
+        public static void ProgramUniform2fv(int program, int location, int count, float* value) => GLPointers._ProgramUniform2fv_fnptr(program, location, count, value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void ProgramUniform2d(ProgramHandle program, int location, double v0, double v1) => GLPointers._ProgramUniform2d_fnptr((int)program, location, v0, v1);
+        public static void ProgramUniform2d(int program, int location, double v0, double v1) => GLPointers._ProgramUniform2d_fnptr(program, location, v0, v1);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void ProgramUniform2dv(ProgramHandle program, int location, int count, double* value) => GLPointers._ProgramUniform2dv_fnptr((int)program, location, count, value);
+        public static void ProgramUniform2dv(int program, int location, int count, double* value) => GLPointers._ProgramUniform2dv_fnptr(program, location, count, value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -4765,7 +4765,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="v0"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
         /// <param name="v1"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform2ui(ProgramHandle program, int location, uint v0, uint v1) => GLPointers._ProgramUniform2ui_fnptr((int)program, location, v0, v1);
+        public static void ProgramUniform2ui(int program, int location, uint v0, uint v1) => GLPointers._ProgramUniform2ui_fnptr(program, location, v0, v1);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -4773,7 +4773,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform2uiv(ProgramHandle program, int location, int count, uint* value) => GLPointers._ProgramUniform2uiv_fnptr((int)program, location, count, value);
+        public static void ProgramUniform2uiv(int program, int location, int count, uint* value) => GLPointers._ProgramUniform2uiv_fnptr(program, location, count, value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -4782,7 +4782,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="v1"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
         /// <param name="v2"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform3i(ProgramHandle program, int location, int v0, int v1, int v2) => GLPointers._ProgramUniform3i_fnptr((int)program, location, v0, v1, v2);
+        public static void ProgramUniform3i(int program, int location, int v0, int v1, int v2) => GLPointers._ProgramUniform3i_fnptr(program, location, v0, v1, v2);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -4790,7 +4790,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform3iv(ProgramHandle program, int location, int count, int* value) => GLPointers._ProgramUniform3iv_fnptr((int)program, location, count, value);
+        public static void ProgramUniform3iv(int program, int location, int count, int* value) => GLPointers._ProgramUniform3iv_fnptr(program, location, count, value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -4799,7 +4799,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="v1"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
         /// <param name="v2"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform3f(ProgramHandle program, int location, float v0, float v1, float v2) => GLPointers._ProgramUniform3f_fnptr((int)program, location, v0, v1, v2);
+        public static void ProgramUniform3f(int program, int location, float v0, float v1, float v2) => GLPointers._ProgramUniform3f_fnptr(program, location, v0, v1, v2);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -4807,15 +4807,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform3fv(ProgramHandle program, int location, int count, float* value) => GLPointers._ProgramUniform3fv_fnptr((int)program, location, count, value);
+        public static void ProgramUniform3fv(int program, int location, int count, float* value) => GLPointers._ProgramUniform3fv_fnptr(program, location, count, value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void ProgramUniform3d(ProgramHandle program, int location, double v0, double v1, double v2) => GLPointers._ProgramUniform3d_fnptr((int)program, location, v0, v1, v2);
+        public static void ProgramUniform3d(int program, int location, double v0, double v1, double v2) => GLPointers._ProgramUniform3d_fnptr(program, location, v0, v1, v2);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void ProgramUniform3dv(ProgramHandle program, int location, int count, double* value) => GLPointers._ProgramUniform3dv_fnptr((int)program, location, count, value);
+        public static void ProgramUniform3dv(int program, int location, int count, double* value) => GLPointers._ProgramUniform3dv_fnptr(program, location, count, value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -4824,7 +4824,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="v1"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
         /// <param name="v2"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform3ui(ProgramHandle program, int location, uint v0, uint v1, uint v2) => GLPointers._ProgramUniform3ui_fnptr((int)program, location, v0, v1, v2);
+        public static void ProgramUniform3ui(int program, int location, uint v0, uint v1, uint v2) => GLPointers._ProgramUniform3ui_fnptr(program, location, v0, v1, v2);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -4832,25 +4832,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform3uiv(ProgramHandle program, int location, int count, uint* value) => GLPointers._ProgramUniform3uiv_fnptr((int)program, location, count, value);
-        
-        /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
-        /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
-        /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
-        /// <param name="v0"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
-        /// <param name="v1"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
-        /// <param name="v2"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
-        /// <param name="v3"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
-        /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform4i(ProgramHandle program, int location, int v0, int v1, int v2, int v3) => GLPointers._ProgramUniform4i_fnptr((int)program, location, v0, v1, v2, v3);
-        
-        /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
-        /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
-        /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
-        /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
-        /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
-        /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform4iv(ProgramHandle program, int location, int count, int* value) => GLPointers._ProgramUniform4iv_fnptr((int)program, location, count, value);
+        public static void ProgramUniform3uiv(int program, int location, int count, uint* value) => GLPointers._ProgramUniform3uiv_fnptr(program, location, count, value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -4860,7 +4842,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="v2"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
         /// <param name="v3"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform4f(ProgramHandle program, int location, float v0, float v1, float v2, float v3) => GLPointers._ProgramUniform4f_fnptr((int)program, location, v0, v1, v2, v3);
+        public static void ProgramUniform4i(int program, int location, int v0, int v1, int v2, int v3) => GLPointers._ProgramUniform4i_fnptr(program, location, v0, v1, v2, v3);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -4868,15 +4850,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform4fv(ProgramHandle program, int location, int count, float* value) => GLPointers._ProgramUniform4fv_fnptr((int)program, location, count, value);
-        
-        /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
-        /// <remarks><see href="" /></remarks>
-        public static void ProgramUniform4d(ProgramHandle program, int location, double v0, double v1, double v2, double v3) => GLPointers._ProgramUniform4d_fnptr((int)program, location, v0, v1, v2, v3);
-        
-        /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
-        /// <remarks><see href="" /></remarks>
-        public static void ProgramUniform4dv(ProgramHandle program, int location, int count, double* value) => GLPointers._ProgramUniform4dv_fnptr((int)program, location, count, value);
+        public static void ProgramUniform4iv(int program, int location, int count, int* value) => GLPointers._ProgramUniform4iv_fnptr(program, location, count, value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -4886,7 +4860,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="v2"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
         /// <param name="v3"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform4ui(ProgramHandle program, int location, uint v0, uint v1, uint v2, uint v3) => GLPointers._ProgramUniform4ui_fnptr((int)program, location, v0, v1, v2, v3);
+        public static void ProgramUniform4f(int program, int location, float v0, float v1, float v2, float v3) => GLPointers._ProgramUniform4f_fnptr(program, location, v0, v1, v2, v3);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -4894,7 +4868,33 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform4uiv(ProgramHandle program, int location, int count, uint* value) => GLPointers._ProgramUniform4uiv_fnptr((int)program, location, count, value);
+        public static void ProgramUniform4fv(int program, int location, int count, float* value) => GLPointers._ProgramUniform4fv_fnptr(program, location, count, value);
+        
+        /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
+        /// <remarks><see href="" /></remarks>
+        public static void ProgramUniform4d(int program, int location, double v0, double v1, double v2, double v3) => GLPointers._ProgramUniform4d_fnptr(program, location, v0, v1, v2, v3);
+        
+        /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
+        /// <remarks><see href="" /></remarks>
+        public static void ProgramUniform4dv(int program, int location, int count, double* value) => GLPointers._ProgramUniform4dv_fnptr(program, location, count, value);
+        
+        /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
+        /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
+        /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
+        /// <param name="v0"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
+        /// <param name="v1"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
+        /// <param name="v2"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
+        /// <param name="v3"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
+        /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
+        public static void ProgramUniform4ui(int program, int location, uint v0, uint v1, uint v2, uint v3) => GLPointers._ProgramUniform4ui_fnptr(program, location, v0, v1, v2, v3);
+        
+        /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
+        /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
+        /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
+        /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
+        /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
+        /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
+        public static void ProgramUniform4uiv(int program, int location, int count, uint* value) => GLPointers._ProgramUniform4uiv_fnptr(program, location, count, value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -4903,7 +4903,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniformMatrix2fv(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix2fv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+        public static void ProgramUniformMatrix2fv(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix2fv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -4912,7 +4912,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniformMatrix3fv(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix3fv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+        public static void ProgramUniformMatrix3fv(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix3fv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -4921,19 +4921,19 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniformMatrix4fv(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix4fv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+        public static void ProgramUniformMatrix4fv(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix4fv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void ProgramUniformMatrix2dv(ProgramHandle program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix2dv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+        public static void ProgramUniformMatrix2dv(int program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix2dv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void ProgramUniformMatrix3dv(ProgramHandle program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix3dv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+        public static void ProgramUniformMatrix3dv(int program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix3dv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void ProgramUniformMatrix4dv(ProgramHandle program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix4dv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+        public static void ProgramUniformMatrix4dv(int program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix4dv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -4942,7 +4942,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniformMatrix2x3fv(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix2x3fv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+        public static void ProgramUniformMatrix2x3fv(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix2x3fv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -4951,7 +4951,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniformMatrix3x2fv(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix3x2fv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+        public static void ProgramUniformMatrix3x2fv(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix3x2fv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -4960,7 +4960,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniformMatrix2x4fv(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix2x4fv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+        public static void ProgramUniformMatrix2x4fv(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix2x4fv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -4969,7 +4969,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniformMatrix4x2fv(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix4x2fv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+        public static void ProgramUniformMatrix4x2fv(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix4x2fv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -4978,7 +4978,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniformMatrix3x4fv(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix3x4fv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+        public static void ProgramUniformMatrix3x4fv(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix3x4fv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -4987,36 +4987,36 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniformMatrix4x3fv(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix4x3fv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+        public static void ProgramUniformMatrix4x3fv(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix4x3fv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void ProgramUniformMatrix2x3dv(ProgramHandle program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix2x3dv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+        public static void ProgramUniformMatrix2x3dv(int program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix2x3dv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void ProgramUniformMatrix3x2dv(ProgramHandle program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix3x2dv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+        public static void ProgramUniformMatrix3x2dv(int program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix3x2dv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void ProgramUniformMatrix2x4dv(ProgramHandle program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix2x4dv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+        public static void ProgramUniformMatrix2x4dv(int program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix2x4dv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void ProgramUniformMatrix4x2dv(ProgramHandle program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix4x2dv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+        public static void ProgramUniformMatrix4x2dv(int program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix4x2dv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void ProgramUniformMatrix3x4dv(ProgramHandle program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix3x4dv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+        public static void ProgramUniformMatrix3x4dv(int program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix3x4dv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void ProgramUniformMatrix4x3dv(ProgramHandle program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix4x3dv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+        public static void ProgramUniformMatrix4x3dv(int program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix4x3dv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Validate a program pipeline object against current GL state. </summary>
         /// <param name="pipeline"> Specifies the name of a program pipeline object to validate. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glValidateProgramPipeline.xhtml" /></remarks>
-        public static void ValidateProgramPipeline(ProgramPipelineHandle pipeline) => GLPointers._ValidateProgramPipeline_fnptr((int)pipeline);
+        public static void ValidateProgramPipeline(int pipeline) => GLPointers._ValidateProgramPipeline_fnptr(pipeline);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Retrieve the info log string from a program pipeline object. </summary>
         /// <param name="pipeline"> Specifies the name of a program pipeline object from which to retrieve the info log. </param>
@@ -5024,7 +5024,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="length"> Specifies the address of a variable into which will be written the number of characters written into infoLog. </param>
         /// <param name="infoLog"> Specifies the address of an array of characters into which will be written the info log for pipeline. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetProgramPipelineInfoLog.xhtml" /></remarks>
-        public static void GetProgramPipelineInfoLog(ProgramPipelineHandle pipeline, int bufSize, int* length, byte* infoLog) => GLPointers._GetProgramPipelineInfoLog_fnptr((int)pipeline, bufSize, length, infoLog);
+        public static void GetProgramPipelineInfoLog(int pipeline, int bufSize, int* length, byte* infoLog) => GLPointers._GetProgramPipelineInfoLog_fnptr(pipeline, bufSize, length, infoLog);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_vertex_attrib_64bit]</b> Specifies the value of a generic vertex attribute. </summary>
         /// <param name="index">Specifies the index of the generic vertex attribute to be modified.</param>
@@ -5213,7 +5213,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="pname"> Specifies which parameter of the atomic counter buffer to retrieve. </param>
         /// <param name="parameters"> Specifies the address of a variable into which to write the retrieved information. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetActiveAtomicCounterBufferiv.xhtml" /></remarks>
-        public static void GetActiveAtomicCounterBufferiv(ProgramHandle program, uint bufferIndex, AtomicCounterBufferPName pname, int* parameters) => GLPointers._GetActiveAtomicCounterBufferiv_fnptr((int)program, bufferIndex, (uint)pname, parameters);
+        public static void GetActiveAtomicCounterBufferiv(int program, uint bufferIndex, AtomicCounterBufferPName pname, int* parameters) => GLPointers._GetActiveAtomicCounterBufferiv_fnptr(program, bufferIndex, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v4.2 | GL_ARB_shader_image_load_store]</b> Bind a level of a texture to an image unit. </summary>
         /// <param name="unit"> Specifies the index of the image unit to which to bind the texture </param>
@@ -5224,7 +5224,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="access"> Specifies a token indicating the type of access that will be performed on the image. </param>
         /// <param name="format"> Specifies the format that the elements of the image will be treated as for the purposes of formatted stores. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindImageTexture.xhtml" /></remarks>
-        public static void BindImageTexture(uint unit, TextureHandle texture, int level, bool layered, int layer, BufferAccessARB access, InternalFormat format) => GLPointers._BindImageTexture_fnptr(unit, (int)texture, level, (byte)(layered ? 1 : 0), layer, (uint)access, (uint)format);
+        public static void BindImageTexture(uint unit, int texture, int level, bool layered, int layer, BufferAccessARB access, InternalFormat format) => GLPointers._BindImageTexture_fnptr(unit, texture, level, (byte)(layered ? 1 : 0), layer, (uint)access, (uint)format);
         
         /// <summary> <b>[requires: v4.2 | GL_ARB_shader_image_load_store]</b> Defines a barrier ordering memory transactions. </summary>
         /// <param name="barriers"> Specifies the barriers to insert. </param>
@@ -5263,7 +5263,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="id"> Specifies the name of a transform feedback object from which to retrieve a primitive count. </param>
         /// <param name="instancecount"> Specifies the number of instances of the geometry to render. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDrawTransformFeedbackInstanced.xhtml" /></remarks>
-        public static void DrawTransformFeedbackInstanced(PrimitiveType mode, TransformFeedbackHandle id, int instancecount) => GLPointers._DrawTransformFeedbackInstanced_fnptr((uint)mode, (int)id, instancecount);
+        public static void DrawTransformFeedbackInstanced(PrimitiveType mode, int id, int instancecount) => GLPointers._DrawTransformFeedbackInstanced_fnptr((uint)mode, id, instancecount);
         
         /// <summary> <b>[requires: v4.2 | GL_ARB_transform_feedback_instanced]</b> Render multiple instances of primitives using a count derived from a specifed stream of a transform feedback object. </summary>
         /// <param name="mode"> Specifies what kind of primitives to render. Symbolic constants GL_POINTS, GL_LINE_STRIP, GL_LINE_LOOP, GL_LINES, GL_LINE_STRIP_ADJACENCY, GL_LINES_ADJACENCY, GL_TRIANGLE_STRIP, GL_TRIANGLE_FAN, GL_TRIANGLES, GL_TRIANGLE_STRIP_ADJACENCY, GL_TRIANGLES_ADJACENCY, and GL_PATCHES are accepted. </param>
@@ -5271,7 +5271,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="stream"> Specifies the index of the transform feedback stream from which to retrieve a primitive count. </param>
         /// <param name="instancecount"> Specifies the number of instances of the geometry to render. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDrawTransformFeedbackStreamInstanced.xhtml" /></remarks>
-        public static void DrawTransformFeedbackStreamInstanced(PrimitiveType mode, TransformFeedbackHandle id, uint stream, int instancecount) => GLPointers._DrawTransformFeedbackStreamInstanced_fnptr((uint)mode, (int)id, stream, instancecount);
+        public static void DrawTransformFeedbackStreamInstanced(PrimitiveType mode, int id, uint stream, int instancecount) => GLPointers._DrawTransformFeedbackStreamInstanced_fnptr((uint)mode, id, stream, instancecount);
         
         /// <summary> <b>[requires: v4.3 | GL_ARB_clear_buffer_object]</b> Fill a buffer object's data store with a fixed value. </summary>
         /// <param name="target"> Specifies the target to which the buffer object is bound for glClearBufferData, which must be one of the buffer binding targets in the following table: </param>
@@ -5357,25 +5357,25 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="height"> The height of the region to be invalidated. </param>
         /// <param name="depth"> The depth of the region to be invalidated. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glInvalidateTexSubImage.xhtml" /></remarks>
-        public static void InvalidateTexSubImage(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth) => GLPointers._InvalidateTexSubImage_fnptr((int)texture, level, xoffset, yoffset, zoffset, width, height, depth);
+        public static void InvalidateTexSubImage(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth) => GLPointers._InvalidateTexSubImage_fnptr(texture, level, xoffset, yoffset, zoffset, width, height, depth);
         
         /// <summary> <b>[requires: v4.3 | GL_ARB_invalidate_subdata]</b> Invalidate the entirety a texture image. </summary>
         /// <param name="texture"> The name of a texture object to invalidate. </param>
         /// <param name="level"> The level of detail of the texture object to invalidate. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glInvalidateTexImage.xhtml" /></remarks>
-        public static void InvalidateTexImage(TextureHandle texture, int level) => GLPointers._InvalidateTexImage_fnptr((int)texture, level);
+        public static void InvalidateTexImage(int texture, int level) => GLPointers._InvalidateTexImage_fnptr(texture, level);
         
         /// <summary> <b>[requires: v4.3 | GL_ARB_invalidate_subdata]</b> Invalidate a region of a buffer object's data store. </summary>
         /// <param name="buffer"> The name of a buffer object, a subrange of whose data store to invalidate. </param>
         /// <param name="offset"> The offset within the buffer's data store of the start of the range to be invalidated. </param>
         /// <param name="length"> The length of the range within the buffer's data store to be invalidated. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glInvalidateBufferSubData.xhtml" /></remarks>
-        public static void InvalidateBufferSubData(BufferHandle buffer, IntPtr offset, nint length) => GLPointers._InvalidateBufferSubData_fnptr((int)buffer, offset, length);
+        public static void InvalidateBufferSubData(int buffer, IntPtr offset, nint length) => GLPointers._InvalidateBufferSubData_fnptr(buffer, offset, length);
         
         /// <summary> <b>[requires: v4.3 | GL_ARB_invalidate_subdata]</b> Invalidate the content of a buffer object's data store. </summary>
         /// <param name="buffer"> The name of a buffer object whose data store to invalidate. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glInvalidateBufferData.xhtml" /></remarks>
-        public static void InvalidateBufferData(BufferHandle buffer) => GLPointers._InvalidateBufferData_fnptr((int)buffer);
+        public static void InvalidateBufferData(int buffer) => GLPointers._InvalidateBufferData_fnptr(buffer);
         
         /// <summary> <b>[requires: v4.3 | GL_ARB_invalidate_subdata]</b> Invalidate the content of some or all of a framebuffer's attachments. </summary>
         /// <param name="target"> Specifies the target to which the framebuffer object is attached for glInvalidateFramebuffer. </param>
@@ -5418,14 +5418,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="pname"> The name of the parameter within programInterface to query. </param>
         /// <param name="parameters"> The address of a variable to retrieve the value of pname for the program interface. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetProgramInterface.xhtml" /></remarks>
-        public static void GetProgramInterfaceiv(ProgramHandle program, ProgramInterface programInterface, ProgramInterfacePName pname, int* parameters) => GLPointers._GetProgramInterfaceiv_fnptr((int)program, (uint)programInterface, (uint)pname, parameters);
+        public static void GetProgramInterfaceiv(int program, ProgramInterface programInterface, ProgramInterfacePName pname, int* parameters) => GLPointers._GetProgramInterfaceiv_fnptr(program, (uint)programInterface, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v4.3 | GL_ARB_program_interface_query]</b> Query the index of a named resource within a program. </summary>
         /// <param name="program"> The name of a program object whose resources to query. </param>
         /// <param name="programInterface"> A token identifying the interface within program containing the resource named name. </param>
         /// <param name="name"> The name of the resource to query the index of. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetProgramResourceIndex.xhtml" /></remarks>
-        public static uint GetProgramResourceIndex(ProgramHandle program, ProgramInterface programInterface, byte* name) => GLPointers._GetProgramResourceIndex_fnptr((int)program, (uint)programInterface, name);
+        public static uint GetProgramResourceIndex(int program, ProgramInterface programInterface, byte* name) => GLPointers._GetProgramResourceIndex_fnptr(program, (uint)programInterface, name);
         
         /// <summary> <b>[requires: v4.3 | GL_ARB_program_interface_query]</b> Query the name of an indexed resource within a program. </summary>
         /// <param name="program"> The name of a program object whose resources to query. </param>
@@ -5435,7 +5435,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="length"> The address of a variable which will receive the length of the resource name. </param>
         /// <param name="name"> The address of a character array into which will be written the name of the resource. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetProgramResourceName.xhtml" /></remarks>
-        public static void GetProgramResourceName(ProgramHandle program, ProgramInterface programInterface, uint index, int bufSize, int* length, byte* name) => GLPointers._GetProgramResourceName_fnptr((int)program, (uint)programInterface, index, bufSize, length, name);
+        public static void GetProgramResourceName(int program, ProgramInterface programInterface, uint index, int bufSize, int* length, byte* name) => GLPointers._GetProgramResourceName_fnptr(program, (uint)programInterface, index, bufSize, length, name);
         
         /// <summary> <b>[requires: v4.3 | GL_ARB_program_interface_query]</b> Retrieve values for multiple properties of a single active resource within a program object. </summary>
         /// <param name="program"> The name of a program object whose resources to query. </param>
@@ -5447,28 +5447,28 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="length">!!missing documentation!!</param>
         /// <param name="parameters">!!missing documentation!!</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetProgramResource.xhtml" /></remarks>
-        public static void GetProgramResourceiv(ProgramHandle program, ProgramInterface programInterface, uint index, int propCount, ProgramResourceProperty* props, int count, int* length, int* parameters) => GLPointers._GetProgramResourceiv_fnptr((int)program, (uint)programInterface, index, propCount, (uint*)props, count, length, parameters);
+        public static void GetProgramResourceiv(int program, ProgramInterface programInterface, uint index, int propCount, ProgramResourceProperty* props, int count, int* length, int* parameters) => GLPointers._GetProgramResourceiv_fnptr(program, (uint)programInterface, index, propCount, (uint*)props, count, length, parameters);
         
         /// <summary> <b>[requires: v4.3 | GL_ARB_program_interface_query]</b> Query the location of a named resource within a program. </summary>
         /// <param name="program"> The name of a program object whose resources to query. </param>
         /// <param name="programInterface"> A token identifying the interface within program containing the resource named name. </param>
         /// <param name="name"> The name of the resource to query the location of. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetProgramResourceLocation.xhtml" /></remarks>
-        public static int GetProgramResourceLocation(ProgramHandle program, ProgramInterface programInterface, byte* name) => GLPointers._GetProgramResourceLocation_fnptr((int)program, (uint)programInterface, name);
+        public static int GetProgramResourceLocation(int program, ProgramInterface programInterface, byte* name) => GLPointers._GetProgramResourceLocation_fnptr(program, (uint)programInterface, name);
         
         /// <summary> <b>[requires: v4.3 | GL_ARB_program_interface_query]</b> Query the fragment color index of a named variable within a program. </summary>
         /// <param name="program"> The name of a program object whose resources to query. </param>
         /// <param name="programInterface"> A token identifying the interface within program containing the resource named name. </param>
         /// <param name="name"> The name of the resource to query the location of. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetProgramResourceLocationIndex.xhtml" /></remarks>
-        public static int GetProgramResourceLocationIndex(ProgramHandle program, ProgramInterface programInterface, byte* name) => GLPointers._GetProgramResourceLocationIndex_fnptr((int)program, (uint)programInterface, name);
+        public static int GetProgramResourceLocationIndex(int program, ProgramInterface programInterface, byte* name) => GLPointers._GetProgramResourceLocationIndex_fnptr(program, (uint)programInterface, name);
         
         /// <summary> <b>[requires: v4.3 | GL_ARB_shader_storage_buffer_object]</b> Change an active shader storage block binding. </summary>
         /// <param name="program"> The name of the program containing the block whose binding to change. </param>
         /// <param name="storageBlockIndex"> The index storage block within the program. </param>
         /// <param name="storageBlockBinding"> The index storage block binding to associate with the specified storage block. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glShaderStorageBlockBinding.xhtml" /></remarks>
-        public static void ShaderStorageBlockBinding(ProgramHandle program, uint storageBlockIndex, uint storageBlockBinding) => GLPointers._ShaderStorageBlockBinding_fnptr((int)program, storageBlockIndex, storageBlockBinding);
+        public static void ShaderStorageBlockBinding(int program, uint storageBlockIndex, uint storageBlockBinding) => GLPointers._ShaderStorageBlockBinding_fnptr(program, storageBlockIndex, storageBlockBinding);
         
         /// <summary> <b>[requires: v4.3 | GL_ARB_texture_buffer_range]</b> Attach a range of a buffer object's data store to a buffer texture object. </summary>
         /// <param name="target"> Specifies the target to which the texture object is bound for glTexBufferRange. Must be GL_TEXTURE_BUFFER. </param>
@@ -5477,7 +5477,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="offset"> Specifies the offset of the start of the range of the buffer's data store to attach. </param>
         /// <param name="size"> Specifies the size of the range of the buffer's data store to attach. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexBufferRange.xhtml" /></remarks>
-        public static void TexBufferRange(TextureTarget target, SizedInternalFormat internalformat, BufferHandle buffer, IntPtr offset, nint size) => GLPointers._TexBufferRange_fnptr((uint)target, (uint)internalformat, (int)buffer, offset, size);
+        public static void TexBufferRange(TextureTarget target, SizedInternalFormat internalformat, int buffer, IntPtr offset, nint size) => GLPointers._TexBufferRange_fnptr((uint)target, (uint)internalformat, buffer, offset, size);
         
         /// <summary> <b>[requires: v4.3 | GL_ARB_texture_storage_multisample]</b> Specify storage for a two-dimensional multisample texture. </summary>
         /// <param name="target"> Specifies the target to which the texture object is bound for glTexStorage2DMultisample. Must be one of GL_TEXTURE_2D_MULTISAMPLE or GL_PROXY_TEXTURE_2D_MULTISAMPLE. </param>
@@ -5510,7 +5510,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="minlayer"> Specifies the index of the first layer to include in the view. </param>
         /// <param name="numlayers"> Specifies the number of layers to include in the view. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTextureView.xhtml" /></remarks>
-        public static void TextureView(TextureHandle texture, TextureTarget target, TextureHandle origtexture, SizedInternalFormat internalformat, uint minlevel, uint numlevels, uint minlayer, uint numlayers) => GLPointers._TextureView_fnptr((int)texture, (uint)target, (int)origtexture, (uint)internalformat, minlevel, numlevels, minlayer, numlayers);
+        public static void TextureView(int texture, TextureTarget target, int origtexture, SizedInternalFormat internalformat, uint minlevel, uint numlevels, uint minlayer, uint numlayers) => GLPointers._TextureView_fnptr(texture, (uint)target, origtexture, (uint)internalformat, minlevel, numlevels, minlayer, numlayers);
         
         /// <summary> <b>[requires: v4.3 | GL_ARB_vertex_attrib_binding]</b> Bind a buffer to a vertex buffer bind point. </summary>
         /// <param name="bindingindex">The index of the vertex buffer binding point to which to bind the buffer.</param>
@@ -5518,7 +5518,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="offset">The offset of the first element of the buffer.</param>
         /// <param name="stride">The distance between elements within the buffer.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindVertexBuffer.xhtml" /></remarks>
-        public static void BindVertexBuffer(uint bindingindex, BufferHandle buffer, IntPtr offset, int stride) => GLPointers._BindVertexBuffer_fnptr(bindingindex, (int)buffer, offset, stride);
+        public static void BindVertexBuffer(uint bindingindex, int buffer, IntPtr offset, int stride) => GLPointers._BindVertexBuffer_fnptr(bindingindex, buffer, offset, stride);
         
         /// <summary> <b>[requires: v4.3 | GL_ARB_vertex_attrib_binding]</b> Specify the organization of vertex arrays. </summary>
         /// <param name="attribindex">The generic vertex attribute array being described.</param>
@@ -5654,7 +5654,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="type"> The type of the data whose address in memory is given by data. </param>
         /// <param name="data"> The address in memory of the data to be used to clear the specified region. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glClearTexImage.xhtml" /></remarks>
-        public static void ClearTexImage(TextureHandle texture, int level, PixelFormat format, PixelType type, void* data) => GLPointers._ClearTexImage_fnptr((int)texture, level, (uint)format, (uint)type, data);
+        public static void ClearTexImage(int texture, int level, PixelFormat format, PixelType type, void* data) => GLPointers._ClearTexImage_fnptr(texture, level, (uint)format, (uint)type, data);
         
         /// <summary> <b>[requires: v4.4 | GL_ARB_clear_texture]</b> Fills all or part of a texture image with a constant value. </summary>
         /// <param name="texture"> The name of an existing texture object containing the image to be cleared. </param>
@@ -5669,7 +5669,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="type"> The type of the data whose address in memory is given by data. </param>
         /// <param name="data"> The address in memory of the data to be used to clear the specified region. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glClearTexSubImage.xhtml" /></remarks>
-        public static void ClearTexSubImage(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, void* data) => GLPointers._ClearTexSubImage_fnptr((int)texture, level, xoffset, yoffset, zoffset, width, height, depth, (uint)format, (uint)type, data);
+        public static void ClearTexSubImage(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, void* data) => GLPointers._ClearTexSubImage_fnptr(texture, level, xoffset, yoffset, zoffset, width, height, depth, (uint)format, (uint)type, data);
         
         /// <summary> <b>[requires: v4.4 | GL_ARB_multi_bind]</b> Bind one or more buffer objects to a sequence of indexed buffer targets. </summary>
         /// <param name="target"> Specify the target of the bind operation. target must be one of GL_ATOMIC_COUNTER_BUFFER, GL_TRANSFORM_FEEDBACK_BUFFER, GL_UNIFORM_BUFFER or GL_SHADER_STORAGE_BUFFER. </param>
@@ -5677,7 +5677,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="count"> Specify the number of contiguous binding points to which to bind buffers. </param>
         /// <param name="buffers"> A pointer to an array of names of buffer objects to bind to the targets on the specified binding point, or NULL. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindBuffersBase.xhtml" /></remarks>
-        public static void BindBuffersBase(BufferTargetARB target, uint first, int count, BufferHandle* buffers) => GLPointers._BindBuffersBase_fnptr((uint)target, first, count, (int*)buffers);
+        public static void BindBuffersBase(BufferTargetARB target, uint first, int count, int* buffers) => GLPointers._BindBuffersBase_fnptr((uint)target, first, count, buffers);
         
         /// <summary> <b>[requires: v4.4 | GL_ARB_multi_bind]</b> Bind ranges of one or more buffer objects to a sequence of indexed buffer targets. </summary>
         /// <param name="target"> Specify the target of the bind operation. target must be one of GL_ATOMIC_COUNTER_BUFFER, GL_TRANSFORM_FEEDBACK_BUFFER, GL_UNIFORM_BUFFER or GL_SHADER_STORAGE_BUFFER. </param>
@@ -5687,28 +5687,28 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="offsets"> A pointer to an array of offsets into the corresponding buffer in buffers to bind, or NULL if buffers is NULL. </param>
         /// <param name="sizes"> A pointer to an array of sizes of the corresponding buffer in buffers to bind, or NULL if buffers is NULL. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindBuffersRange.xhtml" /></remarks>
-        public static void BindBuffersRange(BufferTargetARB target, uint first, int count, BufferHandle* buffers, IntPtr* offsets, nint* sizes) => GLPointers._BindBuffersRange_fnptr((uint)target, first, count, (int*)buffers, offsets, sizes);
+        public static void BindBuffersRange(BufferTargetARB target, uint first, int count, int* buffers, IntPtr* offsets, nint* sizes) => GLPointers._BindBuffersRange_fnptr((uint)target, first, count, buffers, offsets, sizes);
         
         /// <summary> <b>[requires: v4.4 | GL_ARB_multi_bind]</b> Bind one or more named textures to a sequence of consecutive texture units. </summary>
         /// <param name="first"> Specifies the first texture unit to which a texture is to be bound. </param>
         /// <param name="count"> Specifies the number of textures to bind. </param>
         /// <param name="textures"> Specifies the address of an array of names of existing texture objects. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindTextures.xhtml" /></remarks>
-        public static void BindTextures(uint first, int count, TextureHandle* textures) => GLPointers._BindTextures_fnptr(first, count, (int*)textures);
+        public static void BindTextures(uint first, int count, int* textures) => GLPointers._BindTextures_fnptr(first, count, textures);
         
         /// <summary> <b>[requires: v4.4 | GL_ARB_multi_bind]</b> Bind one or more named sampler objects to a sequence of consecutive sampler units. </summary>
         /// <param name="first"> Specifies the first sampler unit to which a sampler object is to be bound. </param>
         /// <param name="count"> Specifies the number of samplers to bind. </param>
         /// <param name="samplers"> Specifies the address of an array of names of existing sampler objects. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindSamplers.xhtml" /></remarks>
-        public static void BindSamplers(uint first, int count, SamplerHandle* samplers) => GLPointers._BindSamplers_fnptr(first, count, (int*)samplers);
+        public static void BindSamplers(uint first, int count, int* samplers) => GLPointers._BindSamplers_fnptr(first, count, samplers);
         
         /// <summary> <b>[requires: v4.4 | GL_ARB_multi_bind]</b> Bind one or more named texture images to a sequence of consecutive image units. </summary>
         /// <param name="first"> Specifies the first image unit to which a texture is to be bound. </param>
         /// <param name="count"> Specifies the number of textures to bind. </param>
         /// <param name="textures"> Specifies the address of an array of names of existing texture objects. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindImageTextures.xhtml" /></remarks>
-        public static void BindImageTextures(uint first, int count, TextureHandle* textures) => GLPointers._BindImageTextures_fnptr(first, count, (int*)textures);
+        public static void BindImageTextures(uint first, int count, int* textures) => GLPointers._BindImageTextures_fnptr(first, count, textures);
         
         /// <summary> <b>[requires: v4.4 | GL_ARB_multi_bind]</b> Attach multiple buffer objects to a vertex array object. </summary>
         /// <param name="first"> Specifies the first vertex buffer binding point to which a buffer object is to be bound. </param>
@@ -5717,7 +5717,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="offsets"> Specifies the address of an array of offsets to associate with the binding points. </param>
         /// <param name="strides">!!missing documentation!!</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindVertexBuffers.xhtml" /></remarks>
-        public static void BindVertexBuffers(uint first, int count, BufferHandle* buffers, IntPtr* offsets, int* strides) => GLPointers._BindVertexBuffers_fnptr(first, count, (int*)buffers, offsets, strides);
+        public static void BindVertexBuffers(uint first, int count, int* buffers, IntPtr* offsets, int* strides) => GLPointers._BindVertexBuffers_fnptr(first, count, buffers, offsets, strides);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_clip_control]</b> Control clip coordinate to window coordinate behavior. </summary>
         /// <param name="origin"> Specifies the clip control origin. Must be one of GL_LOWER_LEFT or GL_UPPER_LEFT. </param>
@@ -5729,14 +5729,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="n"> Number of transform feedback objects to create. </param>
         /// <param name="ids"> Specifies an array in which names of the new transform feedback objects are stored. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCreateTransformFeedbacks.xhtml" /></remarks>
-        public static void CreateTransformFeedbacks(int n, TransformFeedbackHandle* ids) => GLPointers._CreateTransformFeedbacks_fnptr(n, (int*)ids);
+        public static void CreateTransformFeedbacks(int n, int* ids) => GLPointers._CreateTransformFeedbacks_fnptr(n, ids);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Bind a buffer object to a transform feedback buffer object. </summary>
         /// <param name="xfb"> Name of the transform feedback buffer object. </param>
         /// <param name="index"> Index of the binding point within xfb. </param>
         /// <param name="buffer"> Name of the buffer object to bind to the specified binding point. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTransformFeedbackBufferBase.xhtml" /></remarks>
-        public static void TransformFeedbackBufferBase(TransformFeedbackHandle xfb, uint index, BufferHandle buffer) => GLPointers._TransformFeedbackBufferBase_fnptr((int)xfb, index, (int)buffer);
+        public static void TransformFeedbackBufferBase(int xfb, uint index, int buffer) => GLPointers._TransformFeedbackBufferBase_fnptr(xfb, index, buffer);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Bind a range within a buffer object to a transform feedback buffer object. </summary>
         /// <param name="xfb"> Name of the transform feedback buffer object. </param>
@@ -5745,22 +5745,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="offset"> The starting offset in basic machine units into the buffer object. </param>
         /// <param name="size"> The amount of data in basic machine units that can be read from or written to the buffer object while used as an indexed target. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTransformFeedbackBufferRange.xhtml" /></remarks>
-        public static void TransformFeedbackBufferRange(TransformFeedbackHandle xfb, uint index, BufferHandle buffer, IntPtr offset, nint size) => GLPointers._TransformFeedbackBufferRange_fnptr((int)xfb, index, (int)buffer, offset, size);
+        public static void TransformFeedbackBufferRange(int xfb, uint index, int buffer, IntPtr offset, nint size) => GLPointers._TransformFeedbackBufferRange_fnptr(xfb, index, buffer, offset, size);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Query the state of a transform feedback object.. </summary>
         /// <param name="xfb">The name of an existing transform feedback object, or zero for the default transform feedback object.</param>
         /// <param name="pname">Property to use for the query. Must be one of the values: GL_TRANSFORM_FEEDBACK_BUFFER_BINDING, GL_TRANSFORM_FEEDBACK_BUFFER_START, GL_TRANSFORM_FEEDBACK_BUFFER_SIZE, GL_TRANSFORM_FEEDBACK_PAUSED, GL_TRANSFORM_FEEDBACK_ACTIVE.</param>
         /// <param name="param">The address of a buffer into which will be written the requested state information.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetTransformFeedback.xhtml" /></remarks>
-        public static void GetTransformFeedbackiv(TransformFeedbackHandle xfb, TransformFeedbackPName pname, int* param) => GLPointers._GetTransformFeedbackiv_fnptr((int)xfb, (uint)pname, param);
-        
-        /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Query the state of a transform feedback object.. </summary>
-        /// <param name="xfb">The name of an existing transform feedback object, or zero for the default transform feedback object.</param>
-        /// <param name="pname">Property to use for the query. Must be one of the values: GL_TRANSFORM_FEEDBACK_BUFFER_BINDING, GL_TRANSFORM_FEEDBACK_BUFFER_START, GL_TRANSFORM_FEEDBACK_BUFFER_SIZE, GL_TRANSFORM_FEEDBACK_PAUSED, GL_TRANSFORM_FEEDBACK_ACTIVE.</param>
-        /// <param name="index">Index of the transform feedback stream (for indexed state).</param>
-        /// <param name="param">The address of a buffer into which will be written the requested state information.</param>
-        /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetTransformFeedback.xhtml" /></remarks>
-        public static void GetTransformFeedbacki_v(TransformFeedbackHandle xfb, TransformFeedbackPName pname, uint index, int* param) => GLPointers._GetTransformFeedbacki_v_fnptr((int)xfb, (uint)pname, index, param);
+        public static void GetTransformFeedbackiv(int xfb, TransformFeedbackPName pname, int* param) => GLPointers._GetTransformFeedbackiv_fnptr(xfb, (uint)pname, param);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Query the state of a transform feedback object.. </summary>
         /// <param name="xfb">The name of an existing transform feedback object, or zero for the default transform feedback object.</param>
@@ -5768,13 +5760,21 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="index">Index of the transform feedback stream (for indexed state).</param>
         /// <param name="param">The address of a buffer into which will be written the requested state information.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetTransformFeedback.xhtml" /></remarks>
-        public static void GetTransformFeedbacki64_v(TransformFeedbackHandle xfb, TransformFeedbackPName pname, uint index, long* param) => GLPointers._GetTransformFeedbacki64_v_fnptr((int)xfb, (uint)pname, index, param);
+        public static void GetTransformFeedbacki_v(int xfb, TransformFeedbackPName pname, uint index, int* param) => GLPointers._GetTransformFeedbacki_v_fnptr(xfb, (uint)pname, index, param);
+        
+        /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Query the state of a transform feedback object.. </summary>
+        /// <param name="xfb">The name of an existing transform feedback object, or zero for the default transform feedback object.</param>
+        /// <param name="pname">Property to use for the query. Must be one of the values: GL_TRANSFORM_FEEDBACK_BUFFER_BINDING, GL_TRANSFORM_FEEDBACK_BUFFER_START, GL_TRANSFORM_FEEDBACK_BUFFER_SIZE, GL_TRANSFORM_FEEDBACK_PAUSED, GL_TRANSFORM_FEEDBACK_ACTIVE.</param>
+        /// <param name="index">Index of the transform feedback stream (for indexed state).</param>
+        /// <param name="param">The address of a buffer into which will be written the requested state information.</param>
+        /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetTransformFeedback.xhtml" /></remarks>
+        public static void GetTransformFeedbacki64_v(int xfb, TransformFeedbackPName pname, uint index, long* param) => GLPointers._GetTransformFeedbacki64_v_fnptr(xfb, (uint)pname, index, param);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Create buffer objects. </summary>
         /// <param name="n"> Specifies the number of buffer objects to create. </param>
         /// <param name="buffers"> Specifies an array in which names of the new buffer objects are stored. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCreateBuffers.xhtml" /></remarks>
-        public static void CreateBuffers(int n, BufferHandle* buffers) => GLPointers._CreateBuffers_fnptr(n, (int*)buffers);
+        public static void CreateBuffers(int n, int* buffers) => GLPointers._CreateBuffers_fnptr(n, buffers);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Creates and initializes a buffer object's immutable data    store. </summary>
         /// <param name="buffer">Specifies the name of the buffer object for glNamedBufferStorage function.</param>
@@ -5782,7 +5782,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="data">Specifies a pointer to data that will be copied into the data store for initialization, or NULL if no data is to be copied.</param>
         /// <param name="flags">Specifies the intended usage of the buffer's data store. Must be a bitwise combination of the following flags. GL_DYNAMIC_STORAGE_BIT, GL_MAP_READ_BIT GL_MAP_WRITE_BIT, GL_MAP_PERSISTENT_BIT, GL_MAP_COHERENT_BIT, and GL_CLIENT_STORAGE_BIT.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBufferStorage.xhtml" /></remarks>
-        public static void NamedBufferStorage(BufferHandle buffer, nint size, void* data, BufferStorageMask flags) => GLPointers._NamedBufferStorage_fnptr((int)buffer, size, data, (uint)flags);
+        public static void NamedBufferStorage(int buffer, nint size, void* data, BufferStorageMask flags) => GLPointers._NamedBufferStorage_fnptr(buffer, size, data, (uint)flags);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Creates and initializes a buffer object's data    store. </summary>
         /// <param name="buffer">Specifies the name of the buffer object for glNamedBufferData function.</param>
@@ -5790,7 +5790,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="data">Specifies a pointer to data that will be copied into the data store for initialization, or NULL if no data is to be copied.</param>
         /// <param name="usage">Specifies the expected usage pattern of the data store. The symbolic constant must be GL_STREAM_DRAW, GL_STREAM_READ, GL_STREAM_COPY, GL_STATIC_DRAW, GL_STATIC_READ, GL_STATIC_COPY, GL_DYNAMIC_DRAW, GL_DYNAMIC_READ, or GL_DYNAMIC_COPY.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBufferData.xhtml" /></remarks>
-        public static void NamedBufferData(BufferHandle buffer, nint size, void* data, VertexBufferObjectUsage usage) => GLPointers._NamedBufferData_fnptr((int)buffer, size, data, (uint)usage);
+        public static void NamedBufferData(int buffer, nint size, void* data, VertexBufferObjectUsage usage) => GLPointers._NamedBufferData_fnptr(buffer, size, data, (uint)usage);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Updates a subset of a buffer object's data store. </summary>
         /// <param name="buffer"> Specifies the name of the buffer object for glNamedBufferSubData. </param>
@@ -5798,7 +5798,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="size"> Specifies the size in bytes of the data store region being replaced. </param>
         /// <param name="data"> Specifies a pointer to the new data that will be copied into the data store. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBufferSubData.xhtml" /></remarks>
-        public static void NamedBufferSubData(BufferHandle buffer, IntPtr offset, nint size, void* data) => GLPointers._NamedBufferSubData_fnptr((int)buffer, offset, size, data);
+        public static void NamedBufferSubData(int buffer, IntPtr offset, nint size, void* data) => GLPointers._NamedBufferSubData_fnptr(buffer, offset, size, data);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Copy all or part of the data store of a buffer object to the data store of another buffer object. </summary>
         /// <param name="readBuffer"> Specifies the name of the source buffer object for glCopyNamedBufferSubData. </param>
@@ -5807,7 +5807,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="writeOffset"> Specifies the offset, in basic machine units, within the data store of the destination buffer object at which data will be written. </param>
         /// <param name="size"> Specifies the size, in basic machine units, of the data to be copied from the source buffer object to the destination buffer object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCopyBufferSubData.xhtml" /></remarks>
-        public static void CopyNamedBufferSubData(BufferHandle readBuffer, BufferHandle writeBuffer, IntPtr readOffset, IntPtr writeOffset, nint size) => GLPointers._CopyNamedBufferSubData_fnptr((int)readBuffer, (int)writeBuffer, readOffset, writeOffset, size);
+        public static void CopyNamedBufferSubData(int readBuffer, int writeBuffer, IntPtr readOffset, IntPtr writeOffset, nint size) => GLPointers._CopyNamedBufferSubData_fnptr(readBuffer, writeBuffer, readOffset, writeOffset, size);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Fill a buffer object's data store with a fixed value. </summary>
         /// <param name="buffer"> Specifies the name of the buffer object for glClearNamedBufferData. </param>
@@ -5816,7 +5816,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="type"> The type of the data in memory addressed by data. </param>
         /// <param name="data"> The address of a memory location storing the data to be replicated into the buffer's data store. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glClearBufferData.xhtml" /></remarks>
-        public static void ClearNamedBufferData(BufferHandle buffer, SizedInternalFormat internalformat, PixelFormat format, PixelType type, void* data) => GLPointers._ClearNamedBufferData_fnptr((int)buffer, (uint)internalformat, (uint)format, (uint)type, data);
+        public static void ClearNamedBufferData(int buffer, SizedInternalFormat internalformat, PixelFormat format, PixelType type, void* data) => GLPointers._ClearNamedBufferData_fnptr(buffer, (uint)internalformat, (uint)format, (uint)type, data);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Fill all or part of buffer object's data store with a fixed value. </summary>
         /// <param name="buffer"> Specifies the name of the buffer object for glClearNamedBufferSubData. </param>
@@ -5827,13 +5827,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="type"> The type of the data in memory addressed by data. </param>
         /// <param name="data"> The address of a memory location storing the data to be replicated into the buffer's data store. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glClearBufferSubData.xhtml" /></remarks>
-        public static void ClearNamedBufferSubData(BufferHandle buffer, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, void* data) => GLPointers._ClearNamedBufferSubData_fnptr((int)buffer, (uint)internalformat, offset, size, (uint)format, (uint)type, data);
+        public static void ClearNamedBufferSubData(int buffer, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, void* data) => GLPointers._ClearNamedBufferSubData_fnptr(buffer, (uint)internalformat, offset, size, (uint)format, (uint)type, data);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Map all of a buffer object's data store into the client's address space. </summary>
         /// <param name="buffer"> Specifies the name of the buffer object for glMapNamedBuffer. </param>
         /// <param name="access"> Specifies the access policy for glMapBuffer and glMapNamedBuffer, indicating whether it will be possible to read from, write to, or both read from and write to the buffer object's mapped data store. The symbolic constant must be GL_READ_ONLY, GL_WRITE_ONLY, or GL_READ_WRITE. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glMapBuffer.xhtml" /></remarks>
-        public static void* MapNamedBuffer(BufferHandle buffer, BufferAccessARB access) => GLPointers._MapNamedBuffer_fnptr((int)buffer, (uint)access);
+        public static void* MapNamedBuffer(int buffer, BufferAccessARB access) => GLPointers._MapNamedBuffer_fnptr(buffer, (uint)access);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Map all or part of a buffer object's data store into the client's address space. </summary>
         /// <param name="buffer"> Specifies the name of the buffer object for glMapNamedBufferRange. </param>
@@ -5841,40 +5841,40 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="length"> Specifies the length of the range to be mapped. </param>
         /// <param name="access"> Specifies a combination of access flags indicating the desired access to the mapped range. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glMapBufferRange.xhtml" /></remarks>
-        public static void* MapNamedBufferRange(BufferHandle buffer, IntPtr offset, nint length, MapBufferAccessMask access) => GLPointers._MapNamedBufferRange_fnptr((int)buffer, offset, length, (uint)access);
+        public static void* MapNamedBufferRange(int buffer, IntPtr offset, nint length, MapBufferAccessMask access) => GLPointers._MapNamedBufferRange_fnptr(buffer, offset, length, (uint)access);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Release the mapping of a buffer object's data store into the client's address space. </summary>
         /// <param name="buffer"> Specifies the name of the buffer object for glUnmapNamedBuffer. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glUnmapBuffer.xhtml" /></remarks>
-        public static bool UnmapNamedBuffer(BufferHandle buffer) => GLPointers._UnmapNamedBuffer_fnptr((int)buffer) != 0;
+        public static bool UnmapNamedBuffer(int buffer) => GLPointers._UnmapNamedBuffer_fnptr(buffer) != 0;
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Indicate modifications to a range of a mapped buffer. </summary>
         /// <param name="buffer"> Specifies the name of the buffer object for glFlushMappedNamedBufferRange. </param>
         /// <param name="offset"> Specifies the start of the buffer subrange, in basic machine units. </param>
         /// <param name="length"> Specifies the length of the buffer subrange, in basic machine units. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glFlushMappedBufferRange.xhtml" /></remarks>
-        public static void FlushMappedNamedBufferRange(BufferHandle buffer, IntPtr offset, nint length) => GLPointers._FlushMappedNamedBufferRange_fnptr((int)buffer, offset, length);
+        public static void FlushMappedNamedBufferRange(int buffer, IntPtr offset, nint length) => GLPointers._FlushMappedNamedBufferRange_fnptr(buffer, offset, length);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Return parameters of a buffer object. </summary>
         /// <param name="buffer"> Specifies the name of the buffer object for glGetNamedBufferParameteriv and glGetNamedBufferParameteri64v. </param>
         /// <param name="pname">!!missing documentation!!</param>
         /// <param name="parameters">!!missing documentation!!</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetBufferParameter.xhtml" /></remarks>
-        public static void GetNamedBufferParameteriv(BufferHandle buffer, BufferPNameARB pname, int* parameters) => GLPointers._GetNamedBufferParameteriv_fnptr((int)buffer, (uint)pname, parameters);
+        public static void GetNamedBufferParameteriv(int buffer, BufferPNameARB pname, int* parameters) => GLPointers._GetNamedBufferParameteriv_fnptr(buffer, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Return parameters of a buffer object. </summary>
         /// <param name="buffer"> Specifies the name of the buffer object for glGetNamedBufferParameteriv and glGetNamedBufferParameteri64v. </param>
         /// <param name="pname">!!missing documentation!!</param>
         /// <param name="parameters">!!missing documentation!!</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetBufferParameter.xhtml" /></remarks>
-        public static void GetNamedBufferParameteri64v(BufferHandle buffer, BufferPNameARB pname, long* parameters) => GLPointers._GetNamedBufferParameteri64v_fnptr((int)buffer, (uint)pname, parameters);
+        public static void GetNamedBufferParameteri64v(int buffer, BufferPNameARB pname, long* parameters) => GLPointers._GetNamedBufferParameteri64v_fnptr(buffer, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Return the pointer to a mapped buffer object's data store. </summary>
         /// <param name="buffer"> Specifies the name of the buffer object for glGetNamedBufferPointerv. </param>
         /// <param name="pname"> Specifies the name of the pointer to be returned. Must be GL_BUFFER_MAP_POINTER. </param>
         /// <param name="parameters"> Returns the pointer value specified by pname. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetBufferPointerv.xhtml" /></remarks>
-        public static void GetNamedBufferPointerv(BufferHandle buffer, BufferPointerNameARB pname, void** parameters) => GLPointers._GetNamedBufferPointerv_fnptr((int)buffer, (uint)pname, parameters);
+        public static void GetNamedBufferPointerv(int buffer, BufferPointerNameARB pname, void** parameters) => GLPointers._GetNamedBufferPointerv_fnptr(buffer, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Returns a subset of a buffer object's data store. </summary>
         /// <param name="buffer"> Specifies the name of the buffer object for glGetNamedBufferSubData. </param>
@@ -5882,13 +5882,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="size"> Specifies the size in bytes of the data store region being returned. </param>
         /// <param name="data"> Specifies a pointer to the location where buffer object data is returned. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetBufferSubData.xhtml" /></remarks>
-        public static void GetNamedBufferSubData(BufferHandle buffer, IntPtr offset, nint size, void* data) => GLPointers._GetNamedBufferSubData_fnptr((int)buffer, offset, size, data);
+        public static void GetNamedBufferSubData(int buffer, IntPtr offset, nint size, void* data) => GLPointers._GetNamedBufferSubData_fnptr(buffer, offset, size, data);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Create framebuffer objects. </summary>
         /// <param name="n"> Number of framebuffer objects to create. </param>
         /// <param name="framebuffers"> Specifies an array in which names of the new framebuffer objects are stored. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCreateFramebuffers.xhtml" /></remarks>
-        public static void CreateFramebuffers(int n, FramebufferHandle* framebuffers) => GLPointers._CreateFramebuffers_fnptr(n, (int*)framebuffers);
+        public static void CreateFramebuffers(int n, int* framebuffers) => GLPointers._CreateFramebuffers_fnptr(n, framebuffers);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Attach a renderbuffer as a logical buffer of a framebuffer object. </summary>
         /// <param name="framebuffer"> Specifies the name of the framebuffer object for glNamedFramebufferRenderbuffer. </param>
@@ -5896,14 +5896,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="renderbuffertarget"> Specifies the renderbuffer target. Must be GL_RENDERBUFFER. </param>
         /// <param name="renderbuffer"> Specifies the name of an existing renderbuffer object of type renderbuffertarget to attach. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glFramebufferRenderbuffer.xhtml" /></remarks>
-        public static void NamedFramebufferRenderbuffer(FramebufferHandle framebuffer, FramebufferAttachment attachment, RenderbufferTarget renderbuffertarget, RenderbufferHandle renderbuffer) => GLPointers._NamedFramebufferRenderbuffer_fnptr((int)framebuffer, (uint)attachment, (uint)renderbuffertarget, (int)renderbuffer);
+        public static void NamedFramebufferRenderbuffer(int framebuffer, FramebufferAttachment attachment, RenderbufferTarget renderbuffertarget, int renderbuffer) => GLPointers._NamedFramebufferRenderbuffer_fnptr(framebuffer, (uint)attachment, (uint)renderbuffertarget, renderbuffer);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Set a named parameter of a framebuffer object. </summary>
         /// <param name="framebuffer"> Specifies the name of the framebuffer object for glNamedFramebufferParameteri. </param>
         /// <param name="pname"> Specifies the framebuffer parameter to be modified. </param>
         /// <param name="param"> The new value for the parameter named pname. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glFramebufferParameteri.xhtml" /></remarks>
-        public static void NamedFramebufferParameteri(FramebufferHandle framebuffer, FramebufferParameterName pname, int param) => GLPointers._NamedFramebufferParameteri_fnptr((int)framebuffer, (uint)pname, param);
+        public static void NamedFramebufferParameteri(int framebuffer, FramebufferParameterName pname, int param) => GLPointers._NamedFramebufferParameteri_fnptr(framebuffer, (uint)pname, param);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Attach a level of a texture object as a logical buffer of a framebuffer object. </summary>
         /// <param name="framebuffer"> Specifies the name of the framebuffer object for glNamedFramebufferTexture. </param>
@@ -5911,7 +5911,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="texture"> Specifies the name of an existing texture object to attach. </param>
         /// <param name="level"> Specifies the mipmap level of the texture object to attach. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glFramebufferTexture.xhtml" /></remarks>
-        public static void NamedFramebufferTexture(FramebufferHandle framebuffer, FramebufferAttachment attachment, TextureHandle texture, int level) => GLPointers._NamedFramebufferTexture_fnptr((int)framebuffer, (uint)attachment, (int)texture, level);
+        public static void NamedFramebufferTexture(int framebuffer, FramebufferAttachment attachment, int texture, int level) => GLPointers._NamedFramebufferTexture_fnptr(framebuffer, (uint)attachment, texture, level);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Attach a single layer of a texture object as a logical buffer of a framebuffer object. </summary>
         /// <param name="framebuffer"> Specifies the name of the framebuffer object for glNamedFramebufferTextureLayer. </param>
@@ -5920,33 +5920,33 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="level"> Specifies the mipmap level of the texture object to attach. </param>
         /// <param name="layer"> Specifies the layer of the texture object to attach. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glFramebufferTextureLayer.xhtml" /></remarks>
-        public static void NamedFramebufferTextureLayer(FramebufferHandle framebuffer, FramebufferAttachment attachment, TextureHandle texture, int level, int layer) => GLPointers._NamedFramebufferTextureLayer_fnptr((int)framebuffer, (uint)attachment, (int)texture, level, layer);
+        public static void NamedFramebufferTextureLayer(int framebuffer, FramebufferAttachment attachment, int texture, int level, int layer) => GLPointers._NamedFramebufferTextureLayer_fnptr(framebuffer, (uint)attachment, texture, level, layer);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specify which color buffers are to be drawn into. </summary>
         /// <param name="framebuffer">Specifies the name of the framebuffer object for glNamedFramebufferDrawBuffer function. Must be zero or the name of a framebuffer object.</param>
         /// <param name="buf">For default framebuffer, the argument specifies up to four color buffers to be drawn into. Symbolic constants GL_NONE, GL_FRONT_LEFT, GL_FRONT_RIGHT, GL_BACK_LEFT, GL_BACK_RIGHT, GL_FRONT, GL_BACK, GL_LEFT, GL_RIGHT, and GL_FRONT_AND_BACK are accepted. The initial value is GL_FRONT for single-buffered contexts, and GL_BACK for double-buffered contexts. For framebuffer objects, GL_COLOR_ATTACHMENT$m$ and GL_NONE enums are accepted, where $m$ is a value between 0 and GL_MAX_COLOR_ATTACHMENTS.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDrawBuffer.xhtml" /></remarks>
-        public static void NamedFramebufferDrawBuffer(FramebufferHandle framebuffer, ColorBuffer buf) => GLPointers._NamedFramebufferDrawBuffer_fnptr((int)framebuffer, (uint)buf);
+        public static void NamedFramebufferDrawBuffer(int framebuffer, ColorBuffer buf) => GLPointers._NamedFramebufferDrawBuffer_fnptr(framebuffer, (uint)buf);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specifies a list of color buffers to be drawn    into. </summary>
         /// <param name="framebuffer">Specifies the name of the framebuffer object for glNamedFramebufferDrawBuffers.</param>
         /// <param name="n">Specifies the number of buffers in bufs.</param>
         /// <param name="bufs">Points to an array of symbolic constants specifying the buffers into which fragment colors or data values will be written.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDrawBuffers.xhtml" /></remarks>
-        public static void NamedFramebufferDrawBuffers(FramebufferHandle framebuffer, int n, ColorBuffer* bufs) => GLPointers._NamedFramebufferDrawBuffers_fnptr((int)framebuffer, n, (uint*)bufs);
+        public static void NamedFramebufferDrawBuffers(int framebuffer, int n, ColorBuffer* bufs) => GLPointers._NamedFramebufferDrawBuffers_fnptr(framebuffer, n, (uint*)bufs);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Select a color buffer source for pixels. </summary>
         /// <param name="framebuffer">Specifies the name of the framebuffer object for glNamedFramebufferReadBuffer function.</param>
         /// <param name="mode">Specifies a color buffer. Accepted values are GL_FRONT_LEFT, GL_FRONT_RIGHT, GL_BACK_LEFT, GL_BACK_RIGHT, GL_FRONT, GL_BACK, GL_LEFT, GL_RIGHT, and the constants GL_COLOR_ATTACHMENTi.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glReadBuffer.xhtml" /></remarks>
-        public static void NamedFramebufferReadBuffer(FramebufferHandle framebuffer, ColorBuffer src) => GLPointers._NamedFramebufferReadBuffer_fnptr((int)framebuffer, (uint)src);
+        public static void NamedFramebufferReadBuffer(int framebuffer, ColorBuffer src) => GLPointers._NamedFramebufferReadBuffer_fnptr(framebuffer, (uint)src);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Invalidate the content of some or all of a framebuffer's attachments. </summary>
         /// <param name="framebuffer"> Specifies the name of the framebuffer object for glInvalidateNamedFramebufferData. </param>
         /// <param name="numAttachments"> Specifies the number of entries in the attachments array. </param>
         /// <param name="attachments"> Specifies a pointer to an array identifying the attachments to be invalidated. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glInvalidateFramebuffer.xhtml" /></remarks>
-        public static void InvalidateNamedFramebufferData(FramebufferHandle framebuffer, int numAttachments, FramebufferAttachment* attachments) => GLPointers._InvalidateNamedFramebufferData_fnptr((int)framebuffer, numAttachments, (uint*)attachments);
+        public static void InvalidateNamedFramebufferData(int framebuffer, int numAttachments, FramebufferAttachment* attachments) => GLPointers._InvalidateNamedFramebufferData_fnptr(framebuffer, numAttachments, (uint*)attachments);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Invalidate the content of a region of some or all of a framebuffer's attachments. </summary>
         /// <param name="framebuffer"> Specifies the name of the framebuffer object for glInvalidateNamedFramebufferSubData. </param>
@@ -5957,7 +5957,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="width"> Specifies the width of the region to be invalidated. </param>
         /// <param name="height"> Specifies the height of the region to be invalidated. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glInvalidateSubFramebuffer.xhtml" /></remarks>
-        public static void InvalidateNamedFramebufferSubData(FramebufferHandle framebuffer, int numAttachments, FramebufferAttachment* attachments, int x, int y, int width, int height) => GLPointers._InvalidateNamedFramebufferSubData_fnptr((int)framebuffer, numAttachments, (uint*)attachments, x, y, width, height);
+        public static void InvalidateNamedFramebufferSubData(int framebuffer, int numAttachments, FramebufferAttachment* attachments, int x, int y, int width, int height) => GLPointers._InvalidateNamedFramebufferSubData_fnptr(framebuffer, numAttachments, (uint*)attachments, x, y, width, height);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Clear individual buffers of a framebuffer. </summary>
         /// <param name="framebuffer"> Specifies the name of the framebuffer object for glClearNamedFramebuffer*. </param>
@@ -5965,7 +5965,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="drawbuffer"> Specify a particular draw buffer to clear. </param>
         /// <param name="value"> A pointer to the value or values to clear the buffer to. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glClearBuffer.xhtml" /></remarks>
-        public static void ClearNamedFramebufferiv(FramebufferHandle framebuffer, Buffer buffer, int drawbuffer, int* value) => GLPointers._ClearNamedFramebufferiv_fnptr((int)framebuffer, (uint)buffer, drawbuffer, value);
+        public static void ClearNamedFramebufferiv(int framebuffer, Buffer buffer, int drawbuffer, int* value) => GLPointers._ClearNamedFramebufferiv_fnptr(framebuffer, (uint)buffer, drawbuffer, value);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Clear individual buffers of a framebuffer. </summary>
         /// <param name="framebuffer"> Specifies the name of the framebuffer object for glClearNamedFramebuffer*. </param>
@@ -5973,7 +5973,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="drawbuffer"> Specify a particular draw buffer to clear. </param>
         /// <param name="value"> A pointer to the value or values to clear the buffer to. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glClearBuffer.xhtml" /></remarks>
-        public static void ClearNamedFramebufferuiv(FramebufferHandle framebuffer, Buffer buffer, int drawbuffer, uint* value) => GLPointers._ClearNamedFramebufferuiv_fnptr((int)framebuffer, (uint)buffer, drawbuffer, value);
+        public static void ClearNamedFramebufferuiv(int framebuffer, Buffer buffer, int drawbuffer, uint* value) => GLPointers._ClearNamedFramebufferuiv_fnptr(framebuffer, (uint)buffer, drawbuffer, value);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Clear individual buffers of a framebuffer. </summary>
         /// <param name="framebuffer"> Specifies the name of the framebuffer object for glClearNamedFramebuffer*. </param>
@@ -5981,7 +5981,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="drawbuffer"> Specify a particular draw buffer to clear. </param>
         /// <param name="value"> A pointer to the value or values to clear the buffer to. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glClearBuffer.xhtml" /></remarks>
-        public static void ClearNamedFramebufferfv(FramebufferHandle framebuffer, Buffer buffer, int drawbuffer, float* value) => GLPointers._ClearNamedFramebufferfv_fnptr((int)framebuffer, (uint)buffer, drawbuffer, value);
+        public static void ClearNamedFramebufferfv(int framebuffer, Buffer buffer, int drawbuffer, float* value) => GLPointers._ClearNamedFramebufferfv_fnptr(framebuffer, (uint)buffer, drawbuffer, value);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Clear individual buffers of a framebuffer. </summary>
         /// <param name="framebuffer"> Specifies the name of the framebuffer object for glClearNamedFramebuffer*. </param>
@@ -5990,7 +5990,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="depth"> The value to clear the depth buffer to. </param>
         /// <param name="stencil"> The value to clear the stencil buffer to. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glClearBuffer.xhtml" /></remarks>
-        public static void ClearNamedFramebufferfi(FramebufferHandle framebuffer, Buffer buffer, int drawbuffer, float depth, int stencil) => GLPointers._ClearNamedFramebufferfi_fnptr((int)framebuffer, (uint)buffer, drawbuffer, depth, stencil);
+        public static void ClearNamedFramebufferfi(int framebuffer, Buffer buffer, int drawbuffer, float depth, int stencil) => GLPointers._ClearNamedFramebufferfi_fnptr(framebuffer, (uint)buffer, drawbuffer, depth, stencil);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Copy a block of pixels from one framebuffer object to another. </summary>
         /// <param name="readFramebuffer"> Specifies the name of the source framebuffer object for glBlitNamedFramebuffer. </param>
@@ -6006,20 +6006,20 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="mask"> The bitwise OR of the flags indicating which buffers are to be copied. The allowed flags are GL_COLOR_BUFFER_BIT, GL_DEPTH_BUFFER_BIT and GL_STENCIL_BUFFER_BIT. </param>
         /// <param name="filter"> Specifies the interpolation to be applied if the image is stretched. Must be GL_NEAREST or GL_LINEAR. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBlitFramebuffer.xhtml" /></remarks>
-        public static void BlitNamedFramebuffer(FramebufferHandle readFramebuffer, FramebufferHandle drawFramebuffer, int srcX0, int srcY0, int srcX1, int srcY1, int dstX0, int dstY0, int dstX1, int dstY1, ClearBufferMask mask, BlitFramebufferFilter filter) => GLPointers._BlitNamedFramebuffer_fnptr((int)readFramebuffer, (int)drawFramebuffer, srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, (uint)mask, (uint)filter);
+        public static void BlitNamedFramebuffer(int readFramebuffer, int drawFramebuffer, int srcX0, int srcY0, int srcX1, int srcY1, int dstX0, int dstY0, int dstX1, int dstY1, ClearBufferMask mask, BlitFramebufferFilter filter) => GLPointers._BlitNamedFramebuffer_fnptr(readFramebuffer, drawFramebuffer, srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, (uint)mask, (uint)filter);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Check the completeness status of a framebuffer. </summary>
         /// <param name="framebuffer"> Specifies the name of the framebuffer object for glCheckNamedFramebufferStatus </param>
         /// <param name="target"> Specify the target to which the framebuffer is bound for glCheckFramebufferStatus, and the target against which framebuffer completeness of framebuffer is checked for glCheckNamedFramebufferStatus. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCheckFramebufferStatus.xhtml" /></remarks>
-        public static FramebufferStatus CheckNamedFramebufferStatus(FramebufferHandle framebuffer, FramebufferTarget target) => (FramebufferStatus) GLPointers._CheckNamedFramebufferStatus_fnptr((int)framebuffer, (uint)target);
+        public static FramebufferStatus CheckNamedFramebufferStatus(int framebuffer, FramebufferTarget target) => (FramebufferStatus) GLPointers._CheckNamedFramebufferStatus_fnptr(framebuffer, (uint)target);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Query a named parameter of a framebuffer object. </summary>
         /// <param name="framebuffer"> Specifies the name of the framebuffer object for glGetNamedFramebufferParameteriv. </param>
         /// <param name="pname"> Specifies the parameter of the framebuffer object to query. </param>
         /// <param name="param">!!missing documentation!!</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetFramebufferParameter.xhtml" /></remarks>
-        public static void GetNamedFramebufferParameteriv(FramebufferHandle framebuffer, GetFramebufferParameter pname, int* param) => GLPointers._GetNamedFramebufferParameteriv_fnptr((int)framebuffer, (uint)pname, param);
+        public static void GetNamedFramebufferParameteriv(int framebuffer, GetFramebufferParameter pname, int* param) => GLPointers._GetNamedFramebufferParameteriv_fnptr(framebuffer, (uint)pname, param);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Retrieve information about attachments of a framebuffer object. </summary>
         /// <param name="framebuffer"> Specifies the name of the framebuffer object for glGetNamedFramebufferAttachmentParameteriv. </param>
@@ -6027,13 +6027,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="pname"> Specifies the parameter of attachment to query. </param>
         /// <param name="parameters"> Returns the value of parameter pname for attachment. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetFramebufferAttachmentParameter.xhtml" /></remarks>
-        public static void GetNamedFramebufferAttachmentParameteriv(FramebufferHandle framebuffer, FramebufferAttachment attachment, FramebufferAttachmentParameterName pname, int* parameters) => GLPointers._GetNamedFramebufferAttachmentParameteriv_fnptr((int)framebuffer, (uint)attachment, (uint)pname, parameters);
+        public static void GetNamedFramebufferAttachmentParameteriv(int framebuffer, FramebufferAttachment attachment, FramebufferAttachmentParameterName pname, int* parameters) => GLPointers._GetNamedFramebufferAttachmentParameteriv_fnptr(framebuffer, (uint)attachment, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Create renderbuffer objects. </summary>
         /// <param name="n"> Number of renderbuffer objects to create. </param>
         /// <param name="renderbuffers"> Specifies an array in which names of the new renderbuffer objects are stored. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCreateRenderbuffers.xhtml" /></remarks>
-        public static void CreateRenderbuffers(int n, RenderbufferHandle* renderbuffers) => GLPointers._CreateRenderbuffers_fnptr(n, (int*)renderbuffers);
+        public static void CreateRenderbuffers(int n, int* renderbuffers) => GLPointers._CreateRenderbuffers_fnptr(n, renderbuffers);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Establish data storage, format and dimensions of a    renderbuffer object's image. </summary>
         /// <param name="renderbuffer">Specifies the name of the renderbuffer object for glNamedRenderbufferStorage function.</param>
@@ -6041,7 +6041,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="width">Specifies the width of the renderbuffer, in pixels.</param>
         /// <param name="height">Specifies the height of the renderbuffer, in pixels.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glRenderbufferStorage.xhtml" /></remarks>
-        public static void NamedRenderbufferStorage(RenderbufferHandle renderbuffer, InternalFormat internalformat, int width, int height) => GLPointers._NamedRenderbufferStorage_fnptr((int)renderbuffer, (uint)internalformat, width, height);
+        public static void NamedRenderbufferStorage(int renderbuffer, InternalFormat internalformat, int width, int height) => GLPointers._NamedRenderbufferStorage_fnptr(renderbuffer, (uint)internalformat, width, height);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Establish data storage, format, dimensions and sample count of    a renderbuffer object's image. </summary>
         /// <param name="renderbuffer">Specifies the name of the renderbuffer object for glNamedRenderbufferStorageMultisample function.</param>
@@ -6050,28 +6050,28 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="width">Specifies the width of the renderbuffer, in pixels.</param>
         /// <param name="height">Specifies the height of the renderbuffer, in pixels.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glRenderbufferStorageMultisample.xhtml" /></remarks>
-        public static void NamedRenderbufferStorageMultisample(RenderbufferHandle renderbuffer, int samples, InternalFormat internalformat, int width, int height) => GLPointers._NamedRenderbufferStorageMultisample_fnptr((int)renderbuffer, samples, (uint)internalformat, width, height);
+        public static void NamedRenderbufferStorageMultisample(int renderbuffer, int samples, InternalFormat internalformat, int width, int height) => GLPointers._NamedRenderbufferStorageMultisample_fnptr(renderbuffer, samples, (uint)internalformat, width, height);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Query a named parameter of a renderbuffer object. </summary>
         /// <param name="renderbuffer"> Specifies the name of the renderbuffer object for glGetNamedRenderbufferParameteriv. </param>
         /// <param name="pname"> Specifies the parameter of the renderbuffer object to query. </param>
         /// <param name="parameters"> Returns the value of parameter pname for the renderbuffer object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetRenderbufferParameter.xhtml" /></remarks>
-        public static void GetNamedRenderbufferParameteriv(RenderbufferHandle renderbuffer, RenderbufferParameterName pname, int* parameters) => GLPointers._GetNamedRenderbufferParameteriv_fnptr((int)renderbuffer, (uint)pname, parameters);
+        public static void GetNamedRenderbufferParameteriv(int renderbuffer, RenderbufferParameterName pname, int* parameters) => GLPointers._GetNamedRenderbufferParameteriv_fnptr(renderbuffer, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Create texture objects. </summary>
         /// <param name="target"> Specifies the effective texture target of each created texture. </param>
         /// <param name="n"> Number of texture objects to create. </param>
         /// <param name="textures"> Specifies an array in which names of the new texture objects are stored. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCreateTextures.xhtml" /></remarks>
-        public static void CreateTextures(TextureTarget target, int n, TextureHandle* textures) => GLPointers._CreateTextures_fnptr((uint)target, n, (int*)textures);
+        public static void CreateTextures(TextureTarget target, int n, int* textures) => GLPointers._CreateTextures_fnptr((uint)target, n, textures);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Attach a buffer object's data store to a buffer texture object. </summary>
         /// <param name="texture"> Specifies the texture object name for glTextureBuffer. </param>
         /// <param name="internalformat"> Specifies the internal format of the data in the store belonging to buffer. </param>
         /// <param name="buffer"> Specifies the name of the buffer object whose storage to attach to the active buffer texture. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexBuffer.xhtml" /></remarks>
-        public static void TextureBuffer(TextureHandle texture, SizedInternalFormat internalformat, BufferHandle buffer) => GLPointers._TextureBuffer_fnptr((int)texture, (uint)internalformat, (int)buffer);
+        public static void TextureBuffer(int texture, SizedInternalFormat internalformat, int buffer) => GLPointers._TextureBuffer_fnptr(texture, (uint)internalformat, buffer);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Attach a range of a buffer object's data store to a buffer texture object. </summary>
         /// <param name="texture"> Specifies the texture object name for glTextureBufferRange. </param>
@@ -6080,7 +6080,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="offset"> Specifies the offset of the start of the range of the buffer's data store to attach. </param>
         /// <param name="size"> Specifies the size of the range of the buffer's data store to attach. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexBufferRange.xhtml" /></remarks>
-        public static void TextureBufferRange(TextureHandle texture, SizedInternalFormat internalformat, BufferHandle buffer, IntPtr offset, nint size) => GLPointers._TextureBufferRange_fnptr((int)texture, (uint)internalformat, (int)buffer, offset, size);
+        public static void TextureBufferRange(int texture, SizedInternalFormat internalformat, int buffer, IntPtr offset, nint size) => GLPointers._TextureBufferRange_fnptr(texture, (uint)internalformat, buffer, offset, size);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Simultaneously specify storage for all levels of a one-dimensional texture. </summary>
         /// <param name="texture"> Specifies the texture object name for glTextureStorage1D. The effective target of texture must be one of the valid non-proxy target values above. </param>
@@ -6088,7 +6088,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="internalformat"> Specifies the sized internal format to be used to store texture image data. </param>
         /// <param name="width"> Specifies the width of the texture, in texels. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexStorage1D.xhtml" /></remarks>
-        public static void TextureStorage1D(TextureHandle texture, int levels, SizedInternalFormat internalformat, int width) => GLPointers._TextureStorage1D_fnptr((int)texture, levels, (uint)internalformat, width);
+        public static void TextureStorage1D(int texture, int levels, SizedInternalFormat internalformat, int width) => GLPointers._TextureStorage1D_fnptr(texture, levels, (uint)internalformat, width);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Simultaneously specify storage for all levels of a two-dimensional or one-dimensional array texture. </summary>
         /// <param name="texture"> Specifies the texture object name for glTextureStorage2D. The effective target of texture must be one of the valid non-proxy target values above. </param>
@@ -6097,7 +6097,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="width"> Specifies the width of the texture, in texels. </param>
         /// <param name="height"> Specifies the height of the texture, in texels. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexStorage2D.xhtml" /></remarks>
-        public static void TextureStorage2D(TextureHandle texture, int levels, SizedInternalFormat internalformat, int width, int height) => GLPointers._TextureStorage2D_fnptr((int)texture, levels, (uint)internalformat, width, height);
+        public static void TextureStorage2D(int texture, int levels, SizedInternalFormat internalformat, int width, int height) => GLPointers._TextureStorage2D_fnptr(texture, levels, (uint)internalformat, width, height);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Simultaneously specify storage for all levels of a three-dimensional, two-dimensional array or cube-map array texture. </summary>
         /// <param name="texture"> Specifies the texture object name for glTextureStorage3D. The effective target of texture must be one of the valid non-proxy target values above. </param>
@@ -6107,7 +6107,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="height"> Specifies the height of the texture, in texels. </param>
         /// <param name="depth"> Specifies the depth of the texture, in texels. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexStorage3D.xhtml" /></remarks>
-        public static void TextureStorage3D(TextureHandle texture, int levels, SizedInternalFormat internalformat, int width, int height, int depth) => GLPointers._TextureStorage3D_fnptr((int)texture, levels, (uint)internalformat, width, height, depth);
+        public static void TextureStorage3D(int texture, int levels, SizedInternalFormat internalformat, int width, int height, int depth) => GLPointers._TextureStorage3D_fnptr(texture, levels, (uint)internalformat, width, height, depth);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specify storage for a two-dimensional multisample texture. </summary>
         /// <param name="texture"> Specifies the texture object name for glTextureStorage2DMultisample. The effective target of texture must be one of the valid non-proxy target values above. </param>
@@ -6117,7 +6117,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="height"> Specifies the height of the texture, in texels. </param>
         /// <param name="fixedsamplelocations"> Specifies whether the image will use identical sample locations and the same number of samples for all texels in the image, and the sample locations will not depend on the internal format or size of the image. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexStorage2DMultisample.xhtml" /></remarks>
-        public static void TextureStorage2DMultisample(TextureHandle texture, int samples, SizedInternalFormat internalformat, int width, int height, bool fixedsamplelocations) => GLPointers._TextureStorage2DMultisample_fnptr((int)texture, samples, (uint)internalformat, width, height, (byte)(fixedsamplelocations ? 1 : 0));
+        public static void TextureStorage2DMultisample(int texture, int samples, SizedInternalFormat internalformat, int width, int height, bool fixedsamplelocations) => GLPointers._TextureStorage2DMultisample_fnptr(texture, samples, (uint)internalformat, width, height, (byte)(fixedsamplelocations ? 1 : 0));
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specify storage for a two-dimensional multisample array texture. </summary>
         /// <param name="texture"> Specifies the texture object name for glTextureStorage3DMultisample. The effective target of texture must be one of the valid non-proxy target values above. </param>
@@ -6128,7 +6128,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="depth"> Specifies the depth of the texture, in layers. </param>
         /// <param name="fixedsamplelocations"> Specifies whether the image will use identical sample locations and the same number of samples for all texels in the image, and the sample locations will not depend on the internal format or size of the image. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexStorage3DMultisample.xhtml" /></remarks>
-        public static void TextureStorage3DMultisample(TextureHandle texture, int samples, SizedInternalFormat internalformat, int width, int height, int depth, bool fixedsamplelocations) => GLPointers._TextureStorage3DMultisample_fnptr((int)texture, samples, (uint)internalformat, width, height, depth, (byte)(fixedsamplelocations ? 1 : 0));
+        public static void TextureStorage3DMultisample(int texture, int samples, SizedInternalFormat internalformat, int width, int height, int depth, bool fixedsamplelocations) => GLPointers._TextureStorage3DMultisample_fnptr(texture, samples, (uint)internalformat, width, height, depth, (byte)(fixedsamplelocations ? 1 : 0));
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specify a one-dimensional texture subimage. </summary>
         /// <param name="texture"> Specifies the texture object name for glTextureSubImage1D. The effective target of texture must be one of the valid target values above. </param>
@@ -6139,7 +6139,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="type"> Specifies the data type of the pixel data. The following symbolic values are accepted: GL_UNSIGNED_BYTE, GL_BYTE, GL_UNSIGNED_SHORT, GL_SHORT, GL_UNSIGNED_INT, GL_INT, GL_FLOAT, GL_UNSIGNED_BYTE_3_3_2, GL_UNSIGNED_BYTE_2_3_3_REV, GL_UNSIGNED_SHORT_5_6_5, GL_UNSIGNED_SHORT_5_6_5_REV, GL_UNSIGNED_SHORT_4_4_4_4, GL_UNSIGNED_SHORT_4_4_4_4_REV, GL_UNSIGNED_SHORT_5_5_5_1, GL_UNSIGNED_SHORT_1_5_5_5_REV, GL_UNSIGNED_INT_8_8_8_8, GL_UNSIGNED_INT_8_8_8_8_REV, GL_UNSIGNED_INT_10_10_10_2, and GL_UNSIGNED_INT_2_10_10_10_REV. </param>
         /// <param name="pixels"> Specifies a pointer to the image data in memory. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexSubImage1D.xhtml" /></remarks>
-        public static void TextureSubImage1D(TextureHandle texture, int level, int xoffset, int width, PixelFormat format, PixelType type, void* pixels) => GLPointers._TextureSubImage1D_fnptr((int)texture, level, xoffset, width, (uint)format, (uint)type, pixels);
+        public static void TextureSubImage1D(int texture, int level, int xoffset, int width, PixelFormat format, PixelType type, void* pixels) => GLPointers._TextureSubImage1D_fnptr(texture, level, xoffset, width, (uint)format, (uint)type, pixels);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specify a two-dimensional texture subimage. </summary>
         /// <param name="texture"> Specifies the texture object name for glTextureSubImage2D. The effective target of texture must be one of the valid target values above. </param>
@@ -6152,7 +6152,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="type"> Specifies the data type of the pixel data. The following symbolic values are accepted: GL_UNSIGNED_BYTE, GL_BYTE, GL_UNSIGNED_SHORT, GL_SHORT, GL_UNSIGNED_INT, GL_INT, GL_FLOAT, GL_UNSIGNED_BYTE_3_3_2, GL_UNSIGNED_BYTE_2_3_3_REV, GL_UNSIGNED_SHORT_5_6_5, GL_UNSIGNED_SHORT_5_6_5_REV, GL_UNSIGNED_SHORT_4_4_4_4, GL_UNSIGNED_SHORT_4_4_4_4_REV, GL_UNSIGNED_SHORT_5_5_5_1, GL_UNSIGNED_SHORT_1_5_5_5_REV, GL_UNSIGNED_INT_8_8_8_8, GL_UNSIGNED_INT_8_8_8_8_REV, GL_UNSIGNED_INT_10_10_10_2, and GL_UNSIGNED_INT_2_10_10_10_REV. </param>
         /// <param name="pixels"> Specifies a pointer to the image data in memory. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexSubImage2D.xhtml" /></remarks>
-        public static void TextureSubImage2D(TextureHandle texture, int level, int xoffset, int yoffset, int width, int height, PixelFormat format, PixelType type, void* pixels) => GLPointers._TextureSubImage2D_fnptr((int)texture, level, xoffset, yoffset, width, height, (uint)format, (uint)type, pixels);
+        public static void TextureSubImage2D(int texture, int level, int xoffset, int yoffset, int width, int height, PixelFormat format, PixelType type, void* pixels) => GLPointers._TextureSubImage2D_fnptr(texture, level, xoffset, yoffset, width, height, (uint)format, (uint)type, pixels);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specify a three-dimensional texture subimage. </summary>
         /// <param name="texture"> Specifies the texture object name for glTextureSubImage3D. The effective target of texture must be one of the valid target values above. </param>
@@ -6167,7 +6167,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="type"> Specifies the data type of the pixel data. The following symbolic values are accepted: GL_UNSIGNED_BYTE, GL_BYTE, GL_UNSIGNED_SHORT, GL_SHORT, GL_UNSIGNED_INT, GL_INT, GL_FLOAT, GL_UNSIGNED_BYTE_3_3_2, GL_UNSIGNED_BYTE_2_3_3_REV, GL_UNSIGNED_SHORT_5_6_5, GL_UNSIGNED_SHORT_5_6_5_REV, GL_UNSIGNED_SHORT_4_4_4_4, GL_UNSIGNED_SHORT_4_4_4_4_REV, GL_UNSIGNED_SHORT_5_5_5_1, GL_UNSIGNED_SHORT_1_5_5_5_REV, GL_UNSIGNED_INT_8_8_8_8, GL_UNSIGNED_INT_8_8_8_8_REV, GL_UNSIGNED_INT_10_10_10_2, and GL_UNSIGNED_INT_2_10_10_10_REV. </param>
         /// <param name="pixels"> Specifies a pointer to the image data in memory. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexSubImage3D.xhtml" /></remarks>
-        public static void TextureSubImage3D(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, void* pixels) => GLPointers._TextureSubImage3D_fnptr((int)texture, level, xoffset, yoffset, zoffset, width, height, depth, (uint)format, (uint)type, pixels);
+        public static void TextureSubImage3D(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, void* pixels) => GLPointers._TextureSubImage3D_fnptr(texture, level, xoffset, yoffset, zoffset, width, height, depth, (uint)format, (uint)type, pixels);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specify a one-dimensional texture subimage in a compressed    format. </summary>
         /// <param name="texture">Specifies the texture object name for glCompressedTextureSubImage1D function.</param>
@@ -6178,7 +6178,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="imageSize">Specifies the number of unsigned bytes of image data starting at the address specified by data.</param>
         /// <param name="data">Specifies a pointer to the compressed image data in memory.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCompressedTexSubImage1D.xhtml" /></remarks>
-        public static void CompressedTextureSubImage1D(TextureHandle texture, int level, int xoffset, int width, InternalFormat format, int imageSize, void* data) => GLPointers._CompressedTextureSubImage1D_fnptr((int)texture, level, xoffset, width, (uint)format, imageSize, data);
+        public static void CompressedTextureSubImage1D(int texture, int level, int xoffset, int width, InternalFormat format, int imageSize, void* data) => GLPointers._CompressedTextureSubImage1D_fnptr(texture, level, xoffset, width, (uint)format, imageSize, data);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specify a two-dimensional texture subimage in a compressed format. </summary>
         /// <param name="texture">Specifies the texture object name for glCompressedTextureSubImage2D function.</param>
@@ -6191,7 +6191,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="imageSize">Specifies the number of unsigned bytes of image data starting at the address specified by data.</param>
         /// <param name="data">Specifies a pointer to the compressed image data in memory.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCompressedTexSubImage2D.xhtml" /></remarks>
-        public static void CompressedTextureSubImage2D(TextureHandle texture, int level, int xoffset, int yoffset, int width, int height, InternalFormat format, int imageSize, void* data) => GLPointers._CompressedTextureSubImage2D_fnptr((int)texture, level, xoffset, yoffset, width, height, (uint)format, imageSize, data);
+        public static void CompressedTextureSubImage2D(int texture, int level, int xoffset, int yoffset, int width, int height, InternalFormat format, int imageSize, void* data) => GLPointers._CompressedTextureSubImage2D_fnptr(texture, level, xoffset, yoffset, width, height, (uint)format, imageSize, data);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specify a three-dimensional texture subimage in a compressed format. </summary>
         /// <param name="texture">Specifies the texture object name for glCompressedTextureSubImage3D function.</param>
@@ -6206,7 +6206,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="imageSize">Specifies the number of unsigned bytes of image data starting at the address specified by data.</param>
         /// <param name="data">Specifies a pointer to the compressed image data in memory.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCompressedTexSubImage3D.xhtml" /></remarks>
-        public static void CompressedTextureSubImage3D(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, InternalFormat format, int imageSize, void* data) => GLPointers._CompressedTextureSubImage3D_fnptr((int)texture, level, xoffset, yoffset, zoffset, width, height, depth, (uint)format, imageSize, data);
+        public static void CompressedTextureSubImage3D(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, InternalFormat format, int imageSize, void* data) => GLPointers._CompressedTextureSubImage3D_fnptr(texture, level, xoffset, yoffset, zoffset, width, height, depth, (uint)format, imageSize, data);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Copy a one-dimensional texture subimage. </summary>
         /// <param name="texture">Specifies the texture object name for glCopyTextureSubImage1D function.</param>
@@ -6216,7 +6216,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="y">Specify the window coordinates of the left corner of the row of pixels to be copied.</param>
         /// <param name="width">Specifies the width of the texture subimage.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCopyTexSubImage1D.xhtml" /></remarks>
-        public static void CopyTextureSubImage1D(TextureHandle texture, int level, int xoffset, int x, int y, int width) => GLPointers._CopyTextureSubImage1D_fnptr((int)texture, level, xoffset, x, y, width);
+        public static void CopyTextureSubImage1D(int texture, int level, int xoffset, int x, int y, int width) => GLPointers._CopyTextureSubImage1D_fnptr(texture, level, xoffset, x, y, width);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Copy a two-dimensional texture subimage. </summary>
         /// <param name="texture">Specifies the texture object name for glCopyTextureSubImage2D function.</param>
@@ -6228,7 +6228,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="width">Specifies the width of the texture subimage.</param>
         /// <param name="height">Specifies the height of the texture subimage.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCopyTexSubImage2D.xhtml" /></remarks>
-        public static void CopyTextureSubImage2D(TextureHandle texture, int level, int xoffset, int yoffset, int x, int y, int width, int height) => GLPointers._CopyTextureSubImage2D_fnptr((int)texture, level, xoffset, yoffset, x, y, width, height);
+        public static void CopyTextureSubImage2D(int texture, int level, int xoffset, int yoffset, int x, int y, int width, int height) => GLPointers._CopyTextureSubImage2D_fnptr(texture, level, xoffset, yoffset, x, y, width, height);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Copy a three-dimensional texture subimage. </summary>
         /// <param name="texture">Specifies the texture object name for glCopyTextureSubImage3D function.</param>
@@ -6241,60 +6241,60 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="width">Specifies the width of the texture subimage.</param>
         /// <param name="height">Specifies the height of the texture subimage.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCopyTexSubImage3D.xhtml" /></remarks>
-        public static void CopyTextureSubImage3D(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int x, int y, int width, int height) => GLPointers._CopyTextureSubImage3D_fnptr((int)texture, level, xoffset, yoffset, zoffset, x, y, width, height);
+        public static void CopyTextureSubImage3D(int texture, int level, int xoffset, int yoffset, int zoffset, int x, int y, int width, int height) => GLPointers._CopyTextureSubImage3D_fnptr(texture, level, xoffset, yoffset, zoffset, x, y, width, height);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Set texture parameters. </summary>
         /// <param name="texture">Specifies the texture object name for glTextureParameter functions.</param>
         /// <param name="pname">Specifies the symbolic name of a single-valued texture parameter. pname can be one of the following: GL_DEPTH_STENCIL_TEXTURE_MODE, GL_TEXTURE_BASE_LEVEL, GL_TEXTURE_COMPARE_FUNC, GL_TEXTURE_COMPARE_MODE, GL_TEXTURE_LOD_BIAS, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_MAX_LEVEL, GL_TEXTURE_SWIZZLE_R, GL_TEXTURE_SWIZZLE_G, GL_TEXTURE_SWIZZLE_B, GL_TEXTURE_SWIZZLE_A, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, or GL_TEXTURE_WRAP_R.</param>
         /// <param name="param">For the scalar commands, specifies the value of pname.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexParameter.xhtml" /></remarks>
-        public static void TextureParameterf(TextureHandle texture, TextureParameterName pname, float param) => GLPointers._TextureParameterf_fnptr((int)texture, (uint)pname, param);
+        public static void TextureParameterf(int texture, TextureParameterName pname, float param) => GLPointers._TextureParameterf_fnptr(texture, (uint)pname, param);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Set texture parameters. </summary>
         /// <param name="texture">Specifies the texture object name for glTextureParameter functions.</param>
         /// <param name="pname">Specifies the symbolic name of a single-valued texture parameter. pname can be one of the following: GL_DEPTH_STENCIL_TEXTURE_MODE, GL_TEXTURE_BASE_LEVEL, GL_TEXTURE_COMPARE_FUNC, GL_TEXTURE_COMPARE_MODE, GL_TEXTURE_LOD_BIAS, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_MAX_LEVEL, GL_TEXTURE_SWIZZLE_R, GL_TEXTURE_SWIZZLE_G, GL_TEXTURE_SWIZZLE_B, GL_TEXTURE_SWIZZLE_A, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, or GL_TEXTURE_WRAP_R.</param>
         /// <param name="parameters">For the vector commands, specifies a pointer to an array where the value or values of pname are stored.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexParameter.xhtml" /></remarks>
-        public static void TextureParameterfv(TextureHandle texture, TextureParameterName pname, float* param) => GLPointers._TextureParameterfv_fnptr((int)texture, (uint)pname, param);
+        public static void TextureParameterfv(int texture, TextureParameterName pname, float* param) => GLPointers._TextureParameterfv_fnptr(texture, (uint)pname, param);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Set texture parameters. </summary>
         /// <param name="texture">Specifies the texture object name for glTextureParameter functions.</param>
         /// <param name="pname">Specifies the symbolic name of a single-valued texture parameter. pname can be one of the following: GL_DEPTH_STENCIL_TEXTURE_MODE, GL_TEXTURE_BASE_LEVEL, GL_TEXTURE_COMPARE_FUNC, GL_TEXTURE_COMPARE_MODE, GL_TEXTURE_LOD_BIAS, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_MAX_LEVEL, GL_TEXTURE_SWIZZLE_R, GL_TEXTURE_SWIZZLE_G, GL_TEXTURE_SWIZZLE_B, GL_TEXTURE_SWIZZLE_A, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, or GL_TEXTURE_WRAP_R.</param>
         /// <param name="param">For the scalar commands, specifies the value of pname.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexParameter.xhtml" /></remarks>
-        public static void TextureParameteri(TextureHandle texture, TextureParameterName pname, int param) => GLPointers._TextureParameteri_fnptr((int)texture, (uint)pname, param);
+        public static void TextureParameteri(int texture, TextureParameterName pname, int param) => GLPointers._TextureParameteri_fnptr(texture, (uint)pname, param);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Set texture parameters. </summary>
         /// <param name="texture">Specifies the texture object name for glTextureParameter functions.</param>
         /// <param name="pname">Specifies the symbolic name of a single-valued texture parameter. pname can be one of the following: GL_DEPTH_STENCIL_TEXTURE_MODE, GL_TEXTURE_BASE_LEVEL, GL_TEXTURE_COMPARE_FUNC, GL_TEXTURE_COMPARE_MODE, GL_TEXTURE_LOD_BIAS, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_MAX_LEVEL, GL_TEXTURE_SWIZZLE_R, GL_TEXTURE_SWIZZLE_G, GL_TEXTURE_SWIZZLE_B, GL_TEXTURE_SWIZZLE_A, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, or GL_TEXTURE_WRAP_R.</param>
         /// <param name="parameters">For the vector commands, specifies a pointer to an array where the value or values of pname are stored.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexParameter.xhtml" /></remarks>
-        public static void TextureParameterIiv(TextureHandle texture, TextureParameterName pname, int* parameters) => GLPointers._TextureParameterIiv_fnptr((int)texture, (uint)pname, parameters);
+        public static void TextureParameterIiv(int texture, TextureParameterName pname, int* parameters) => GLPointers._TextureParameterIiv_fnptr(texture, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Set texture parameters. </summary>
         /// <param name="texture">Specifies the texture object name for glTextureParameter functions.</param>
         /// <param name="pname">Specifies the symbolic name of a single-valued texture parameter. pname can be one of the following: GL_DEPTH_STENCIL_TEXTURE_MODE, GL_TEXTURE_BASE_LEVEL, GL_TEXTURE_COMPARE_FUNC, GL_TEXTURE_COMPARE_MODE, GL_TEXTURE_LOD_BIAS, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_MAX_LEVEL, GL_TEXTURE_SWIZZLE_R, GL_TEXTURE_SWIZZLE_G, GL_TEXTURE_SWIZZLE_B, GL_TEXTURE_SWIZZLE_A, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, or GL_TEXTURE_WRAP_R.</param>
         /// <param name="parameters">For the vector commands, specifies a pointer to an array where the value or values of pname are stored.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexParameter.xhtml" /></remarks>
-        public static void TextureParameterIuiv(TextureHandle texture, TextureParameterName pname, uint* parameters) => GLPointers._TextureParameterIuiv_fnptr((int)texture, (uint)pname, parameters);
+        public static void TextureParameterIuiv(int texture, TextureParameterName pname, uint* parameters) => GLPointers._TextureParameterIuiv_fnptr(texture, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Set texture parameters. </summary>
         /// <param name="texture">Specifies the texture object name for glTextureParameter functions.</param>
         /// <param name="pname">Specifies the symbolic name of a single-valued texture parameter. pname can be one of the following: GL_DEPTH_STENCIL_TEXTURE_MODE, GL_TEXTURE_BASE_LEVEL, GL_TEXTURE_COMPARE_FUNC, GL_TEXTURE_COMPARE_MODE, GL_TEXTURE_LOD_BIAS, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_MAX_LEVEL, GL_TEXTURE_SWIZZLE_R, GL_TEXTURE_SWIZZLE_G, GL_TEXTURE_SWIZZLE_B, GL_TEXTURE_SWIZZLE_A, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, or GL_TEXTURE_WRAP_R.</param>
         /// <param name="parameters">For the vector commands, specifies a pointer to an array where the value or values of pname are stored.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexParameter.xhtml" /></remarks>
-        public static void TextureParameteriv(TextureHandle texture, TextureParameterName pname, int* param) => GLPointers._TextureParameteriv_fnptr((int)texture, (uint)pname, param);
+        public static void TextureParameteriv(int texture, TextureParameterName pname, int* param) => GLPointers._TextureParameteriv_fnptr(texture, (uint)pname, param);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Generate mipmaps for a specified texture object. </summary>
         /// <param name="texture"> Specifies the texture object name for glGenerateTextureMipmap. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGenerateMipmap.xhtml" /></remarks>
-        public static void GenerateTextureMipmap(TextureHandle texture) => GLPointers._GenerateTextureMipmap_fnptr((int)texture);
+        public static void GenerateTextureMipmap(int texture) => GLPointers._GenerateTextureMipmap_fnptr(texture);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Bind an existing texture object to the specified texture unit . </summary>
         /// <param name="unit">Specifies the texture unit, to which the texture object should be bound to. </param>
         /// <param name="texture">Specifies the name of a texture. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindTextureUnit.xhtml" /></remarks>
-        public static void BindTextureUnit(uint unit, TextureHandle texture) => GLPointers._BindTextureUnit_fnptr(unit, (int)texture);
+        public static void BindTextureUnit(uint unit, int texture) => GLPointers._BindTextureUnit_fnptr(unit, texture);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Return a texture image. </summary>
         /// <param name="texture"> Specifies the texture object name. </param>
@@ -6304,7 +6304,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="bufSize">Specifies the size of the buffer pixels for glGetnTexImage and glGetTextureImage functions.</param>
         /// <param name="pixels">Returns the texture image. Should be a pointer to an array of the type specified by type.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetTexImage.xhtml" /></remarks>
-        public static void GetTextureImage(TextureHandle texture, int level, PixelFormat format, PixelType type, int bufSize, void* pixels) => GLPointers._GetTextureImage_fnptr((int)texture, level, (uint)format, (uint)type, bufSize, pixels);
+        public static void GetTextureImage(int texture, int level, PixelFormat format, PixelType type, int bufSize, void* pixels) => GLPointers._GetTextureImage_fnptr(texture, level, (uint)format, (uint)type, bufSize, pixels);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Return a compressed texture image. </summary>
         /// <param name="texture">Specifies the texture object name for glGetCompressedTextureImage function.</param>
@@ -6312,7 +6312,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="bufSize">Specifies the size of the buffer pixels for glGetCompressedTextureImage and glGetnCompressedTexImage functions.</param>
         /// <param name="pixels">Returns the compressed texture image.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetCompressedTexImage.xhtml" /></remarks>
-        public static void GetCompressedTextureImage(TextureHandle texture, int level, int bufSize, void* pixels) => GLPointers._GetCompressedTextureImage_fnptr((int)texture, level, bufSize, pixels);
+        public static void GetCompressedTextureImage(int texture, int level, int bufSize, void* pixels) => GLPointers._GetCompressedTextureImage_fnptr(texture, level, bufSize, pixels);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Return texture parameter values for a specific level of    detail. </summary>
         /// <param name="texture">Specifies the texture object name for glGetTextureLevelParameterfv and glGetTextureLevelParameteriv functions.</param>
@@ -6320,7 +6320,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="pname">Specifies the symbolic name of a texture parameter. GL_TEXTURE_WIDTH, GL_TEXTURE_HEIGHT, GL_TEXTURE_DEPTH, GL_TEXTURE_INTERNAL_FORMAT, GL_TEXTURE_RED_SIZE, GL_TEXTURE_GREEN_SIZE, GL_TEXTURE_BLUE_SIZE, GL_TEXTURE_ALPHA_SIZE, GL_TEXTURE_DEPTH_SIZE, GL_TEXTURE_COMPRESSED, GL_TEXTURE_COMPRESSED_IMAGE_SIZE, and GL_TEXTURE_BUFFER_OFFSET are accepted.</param>
         /// <param name="parameters">Returns the requested data.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetTexLevelParameter.xhtml" /></remarks>
-        public static void GetTextureLevelParameterfv(TextureHandle texture, int level, GetTextureParameter pname, float* parameters) => GLPointers._GetTextureLevelParameterfv_fnptr((int)texture, level, (uint)pname, parameters);
+        public static void GetTextureLevelParameterfv(int texture, int level, GetTextureParameter pname, float* parameters) => GLPointers._GetTextureLevelParameterfv_fnptr(texture, level, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Return texture parameter values for a specific level of    detail. </summary>
         /// <param name="texture">Specifies the texture object name for glGetTextureLevelParameterfv and glGetTextureLevelParameteriv functions.</param>
@@ -6328,59 +6328,59 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="pname">Specifies the symbolic name of a texture parameter. GL_TEXTURE_WIDTH, GL_TEXTURE_HEIGHT, GL_TEXTURE_DEPTH, GL_TEXTURE_INTERNAL_FORMAT, GL_TEXTURE_RED_SIZE, GL_TEXTURE_GREEN_SIZE, GL_TEXTURE_BLUE_SIZE, GL_TEXTURE_ALPHA_SIZE, GL_TEXTURE_DEPTH_SIZE, GL_TEXTURE_COMPRESSED, GL_TEXTURE_COMPRESSED_IMAGE_SIZE, and GL_TEXTURE_BUFFER_OFFSET are accepted.</param>
         /// <param name="parameters">Returns the requested data.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetTexLevelParameter.xhtml" /></remarks>
-        public static void GetTextureLevelParameteriv(TextureHandle texture, int level, GetTextureParameter pname, int* parameters) => GLPointers._GetTextureLevelParameteriv_fnptr((int)texture, level, (uint)pname, parameters);
+        public static void GetTextureLevelParameteriv(int texture, int level, GetTextureParameter pname, int* parameters) => GLPointers._GetTextureLevelParameteriv_fnptr(texture, level, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Return texture parameter values. </summary>
         /// <param name="texture">Specifies the texture object name for glGetTextureParameterfv, glGetTextureParameteriv, glGetTextureParameterIiv, and glGetTextureParameterIuiv functions.</param>
         /// <param name="pname">Specifies the symbolic name of a texture parameter. GL_DEPTH_STENCIL_TEXTURE_MODE, GL_IMAGE_FORMAT_COMPATIBILITY_TYPE, GL_TEXTURE_BASE_LEVEL, GL_TEXTURE_BORDER_COLOR, GL_TEXTURE_COMPARE_MODE, GL_TEXTURE_COMPARE_FUNC, GL_TEXTURE_IMMUTABLE_FORMAT, GL_TEXTURE_IMMUTABLE_LEVELS, GL_TEXTURE_LOD_BIAS, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MAX_LEVEL, GL_TEXTURE_MAX_LOD, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_SWIZZLE_R, GL_TEXTURE_SWIZZLE_G, GL_TEXTURE_SWIZZLE_B, GL_TEXTURE_SWIZZLE_A, GL_TEXTURE_SWIZZLE_RGBA, GL_TEXTURE_TARGET, GL_TEXTURE_VIEW_MIN_LAYER, GL_TEXTURE_VIEW_MIN_LEVEL, GL_TEXTURE_VIEW_NUM_LAYERS, GL_TEXTURE_VIEW_NUM_LEVELS, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, and GL_TEXTURE_WRAP_R are accepted.</param>
         /// <param name="parameters">Returns the texture parameters.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetTexParameter.xhtml" /></remarks>
-        public static void GetTextureParameterfv(TextureHandle texture, GetTextureParameter pname, float* parameters) => GLPointers._GetTextureParameterfv_fnptr((int)texture, (uint)pname, parameters);
+        public static void GetTextureParameterfv(int texture, GetTextureParameter pname, float* parameters) => GLPointers._GetTextureParameterfv_fnptr(texture, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Return texture parameter values. </summary>
         /// <param name="texture">Specifies the texture object name for glGetTextureParameterfv, glGetTextureParameteriv, glGetTextureParameterIiv, and glGetTextureParameterIuiv functions.</param>
         /// <param name="pname">Specifies the symbolic name of a texture parameter. GL_DEPTH_STENCIL_TEXTURE_MODE, GL_IMAGE_FORMAT_COMPATIBILITY_TYPE, GL_TEXTURE_BASE_LEVEL, GL_TEXTURE_BORDER_COLOR, GL_TEXTURE_COMPARE_MODE, GL_TEXTURE_COMPARE_FUNC, GL_TEXTURE_IMMUTABLE_FORMAT, GL_TEXTURE_IMMUTABLE_LEVELS, GL_TEXTURE_LOD_BIAS, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MAX_LEVEL, GL_TEXTURE_MAX_LOD, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_SWIZZLE_R, GL_TEXTURE_SWIZZLE_G, GL_TEXTURE_SWIZZLE_B, GL_TEXTURE_SWIZZLE_A, GL_TEXTURE_SWIZZLE_RGBA, GL_TEXTURE_TARGET, GL_TEXTURE_VIEW_MIN_LAYER, GL_TEXTURE_VIEW_MIN_LEVEL, GL_TEXTURE_VIEW_NUM_LAYERS, GL_TEXTURE_VIEW_NUM_LEVELS, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, and GL_TEXTURE_WRAP_R are accepted.</param>
         /// <param name="parameters">Returns the texture parameters.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetTexParameter.xhtml" /></remarks>
-        public static void GetTextureParameterIiv(TextureHandle texture, GetTextureParameter pname, int* parameters) => GLPointers._GetTextureParameterIiv_fnptr((int)texture, (uint)pname, parameters);
+        public static void GetTextureParameterIiv(int texture, GetTextureParameter pname, int* parameters) => GLPointers._GetTextureParameterIiv_fnptr(texture, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Return texture parameter values. </summary>
         /// <param name="texture">Specifies the texture object name for glGetTextureParameterfv, glGetTextureParameteriv, glGetTextureParameterIiv, and glGetTextureParameterIuiv functions.</param>
         /// <param name="pname">Specifies the symbolic name of a texture parameter. GL_DEPTH_STENCIL_TEXTURE_MODE, GL_IMAGE_FORMAT_COMPATIBILITY_TYPE, GL_TEXTURE_BASE_LEVEL, GL_TEXTURE_BORDER_COLOR, GL_TEXTURE_COMPARE_MODE, GL_TEXTURE_COMPARE_FUNC, GL_TEXTURE_IMMUTABLE_FORMAT, GL_TEXTURE_IMMUTABLE_LEVELS, GL_TEXTURE_LOD_BIAS, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MAX_LEVEL, GL_TEXTURE_MAX_LOD, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_SWIZZLE_R, GL_TEXTURE_SWIZZLE_G, GL_TEXTURE_SWIZZLE_B, GL_TEXTURE_SWIZZLE_A, GL_TEXTURE_SWIZZLE_RGBA, GL_TEXTURE_TARGET, GL_TEXTURE_VIEW_MIN_LAYER, GL_TEXTURE_VIEW_MIN_LEVEL, GL_TEXTURE_VIEW_NUM_LAYERS, GL_TEXTURE_VIEW_NUM_LEVELS, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, and GL_TEXTURE_WRAP_R are accepted.</param>
         /// <param name="parameters">Returns the texture parameters.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetTexParameter.xhtml" /></remarks>
-        public static void GetTextureParameterIuiv(TextureHandle texture, GetTextureParameter pname, uint* parameters) => GLPointers._GetTextureParameterIuiv_fnptr((int)texture, (uint)pname, parameters);
+        public static void GetTextureParameterIuiv(int texture, GetTextureParameter pname, uint* parameters) => GLPointers._GetTextureParameterIuiv_fnptr(texture, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Return texture parameter values. </summary>
         /// <param name="texture">Specifies the texture object name for glGetTextureParameterfv, glGetTextureParameteriv, glGetTextureParameterIiv, and glGetTextureParameterIuiv functions.</param>
         /// <param name="pname">Specifies the symbolic name of a texture parameter. GL_DEPTH_STENCIL_TEXTURE_MODE, GL_IMAGE_FORMAT_COMPATIBILITY_TYPE, GL_TEXTURE_BASE_LEVEL, GL_TEXTURE_BORDER_COLOR, GL_TEXTURE_COMPARE_MODE, GL_TEXTURE_COMPARE_FUNC, GL_TEXTURE_IMMUTABLE_FORMAT, GL_TEXTURE_IMMUTABLE_LEVELS, GL_TEXTURE_LOD_BIAS, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MAX_LEVEL, GL_TEXTURE_MAX_LOD, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_SWIZZLE_R, GL_TEXTURE_SWIZZLE_G, GL_TEXTURE_SWIZZLE_B, GL_TEXTURE_SWIZZLE_A, GL_TEXTURE_SWIZZLE_RGBA, GL_TEXTURE_TARGET, GL_TEXTURE_VIEW_MIN_LAYER, GL_TEXTURE_VIEW_MIN_LEVEL, GL_TEXTURE_VIEW_NUM_LAYERS, GL_TEXTURE_VIEW_NUM_LEVELS, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, and GL_TEXTURE_WRAP_R are accepted.</param>
         /// <param name="parameters">Returns the texture parameters.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetTexParameter.xhtml" /></remarks>
-        public static void GetTextureParameteriv(TextureHandle texture, GetTextureParameter pname, int* parameters) => GLPointers._GetTextureParameteriv_fnptr((int)texture, (uint)pname, parameters);
+        public static void GetTextureParameteriv(int texture, GetTextureParameter pname, int* parameters) => GLPointers._GetTextureParameteriv_fnptr(texture, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Create vertex array objects. </summary>
         /// <param name="n"> Number of vertex array objects to create. </param>
         /// <param name="arrays"> Specifies an array in which names of the new vertex array objects are stored. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCreateVertexArrays.xhtml" /></remarks>
-        public static void CreateVertexArrays(int n, VertexArrayHandle* arrays) => GLPointers._CreateVertexArrays_fnptr(n, (int*)arrays);
+        public static void CreateVertexArrays(int n, int* arrays) => GLPointers._CreateVertexArrays_fnptr(n, arrays);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Enable or disable a generic vertex attribute    array. </summary>
         /// <param name="vaobj">Specifies the name of the vertex array object for glDisableVertexArrayAttrib and glEnableVertexArrayAttrib functions.</param>
         /// <param name="index">Specifies the index of the generic vertex attribute to be enabled or disabled.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glEnableVertexAttribArray.xhtml" /></remarks>
-        public static void DisableVertexArrayAttrib(VertexArrayHandle vaobj, uint index) => GLPointers._DisableVertexArrayAttrib_fnptr((int)vaobj, index);
+        public static void DisableVertexArrayAttrib(int vaobj, uint index) => GLPointers._DisableVertexArrayAttrib_fnptr(vaobj, index);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Enable or disable a generic vertex attribute    array. </summary>
         /// <param name="vaobj">Specifies the name of the vertex array object for glDisableVertexArrayAttrib and glEnableVertexArrayAttrib functions.</param>
         /// <param name="index">Specifies the index of the generic vertex attribute to be enabled or disabled.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glEnableVertexAttribArray.xhtml" /></remarks>
-        public static void EnableVertexArrayAttrib(VertexArrayHandle vaobj, uint index) => GLPointers._EnableVertexArrayAttrib_fnptr((int)vaobj, index);
+        public static void EnableVertexArrayAttrib(int vaobj, uint index) => GLPointers._EnableVertexArrayAttrib_fnptr(vaobj, index);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Configures element array buffer binding of a vertex array object. </summary>
         /// <param name="vaobj"> Specifies the name of the vertex array object. </param>
         /// <param name="buffer"> Specifies the name of the buffer object to use for the element array buffer binding. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glVertexArrayElementBuffer.xhtml" /></remarks>
-        public static void VertexArrayElementBuffer(VertexArrayHandle vaobj, BufferHandle buffer) => GLPointers._VertexArrayElementBuffer_fnptr((int)vaobj, (int)buffer);
+        public static void VertexArrayElementBuffer(int vaobj, int buffer) => GLPointers._VertexArrayElementBuffer_fnptr(vaobj, buffer);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Bind a buffer to a vertex buffer bind point. </summary>
         /// <param name="vaobj">Specifies the name of the vertex array object to be used by glVertexArrayVertexBuffer function.</param>
@@ -6389,7 +6389,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="offset">The offset of the first element of the buffer.</param>
         /// <param name="stride">The distance between elements within the buffer.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindVertexBuffer.xhtml" /></remarks>
-        public static void VertexArrayVertexBuffer(VertexArrayHandle vaobj, uint bindingindex, BufferHandle buffer, IntPtr offset, int stride) => GLPointers._VertexArrayVertexBuffer_fnptr((int)vaobj, bindingindex, (int)buffer, offset, stride);
+        public static void VertexArrayVertexBuffer(int vaobj, uint bindingindex, int buffer, IntPtr offset, int stride) => GLPointers._VertexArrayVertexBuffer_fnptr(vaobj, bindingindex, buffer, offset, stride);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Attach multiple buffer objects to a vertex array object. </summary>
         /// <param name="vaobj"> Specifies the name of the vertex array object for glVertexArrayVertexBuffers. </param>
@@ -6399,14 +6399,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="offsets"> Specifies the address of an array of offsets to associate with the binding points. </param>
         /// <param name="strides">!!missing documentation!!</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindVertexBuffers.xhtml" /></remarks>
-        public static void VertexArrayVertexBuffers(VertexArrayHandle vaobj, uint first, int count, BufferHandle* buffers, IntPtr* offsets, int* strides) => GLPointers._VertexArrayVertexBuffers_fnptr((int)vaobj, first, count, (int*)buffers, offsets, strides);
+        public static void VertexArrayVertexBuffers(int vaobj, uint first, int count, int* buffers, IntPtr* offsets, int* strides) => GLPointers._VertexArrayVertexBuffers_fnptr(vaobj, first, count, buffers, offsets, strides);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Associate a vertex attribute and a vertex buffer binding for a vertex array object. </summary>
         /// <param name="vaobj"> Specifies the name of the vertex array object for glVertexArrayAttribBinding. </param>
         /// <param name="attribindex"> The index of the attribute to associate with a vertex buffer binding. </param>
         /// <param name="bindingindex"> The index of the vertex buffer binding with which to associate the generic vertex attribute. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glVertexAttribBinding.xhtml" /></remarks>
-        public static void VertexArrayAttribBinding(VertexArrayHandle vaobj, uint attribindex, uint bindingindex) => GLPointers._VertexArrayAttribBinding_fnptr((int)vaobj, attribindex, bindingindex);
+        public static void VertexArrayAttribBinding(int vaobj, uint attribindex, uint bindingindex) => GLPointers._VertexArrayAttribBinding_fnptr(vaobj, attribindex, bindingindex);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specify the organization of vertex arrays. </summary>
         /// <param name="vaobj">Specifies the name of the vertex array object for glVertexArrayAttrib{I, L}Format functions.</param>
@@ -6416,7 +6416,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="normalized"> Specifies whether fixed-point data values should be normalized (GL_TRUE) or converted directly as fixed-point values (GL_FALSE) when they are accessed. This parameter is ignored if type is GL_FIXED. </param>
         /// <param name="relativeoffset">The distance between elements within the buffer.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glVertexAttribFormat.xhtml" /></remarks>
-        public static void VertexArrayAttribFormat(VertexArrayHandle vaobj, uint attribindex, int size, VertexAttribType type, bool normalized, uint relativeoffset) => GLPointers._VertexArrayAttribFormat_fnptr((int)vaobj, attribindex, size, (uint)type, (byte)(normalized ? 1 : 0), relativeoffset);
+        public static void VertexArrayAttribFormat(int vaobj, uint attribindex, int size, VertexAttribType type, bool normalized, uint relativeoffset) => GLPointers._VertexArrayAttribFormat_fnptr(vaobj, attribindex, size, (uint)type, (byte)(normalized ? 1 : 0), relativeoffset);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specify the organization of vertex arrays. </summary>
         /// <param name="vaobj">Specifies the name of the vertex array object for glVertexArrayAttrib{I, L}Format functions.</param>
@@ -6425,7 +6425,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="type">The type of the data stored in the array.</param>
         /// <param name="relativeoffset">The distance between elements within the buffer.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glVertexAttribFormat.xhtml" /></remarks>
-        public static void VertexArrayAttribIFormat(VertexArrayHandle vaobj, uint attribindex, int size, VertexAttribIType type, uint relativeoffset) => GLPointers._VertexArrayAttribIFormat_fnptr((int)vaobj, attribindex, size, (uint)type, relativeoffset);
+        public static void VertexArrayAttribIFormat(int vaobj, uint attribindex, int size, VertexAttribIType type, uint relativeoffset) => GLPointers._VertexArrayAttribIFormat_fnptr(vaobj, attribindex, size, (uint)type, relativeoffset);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specify the organization of vertex arrays. </summary>
         /// <param name="vaobj">Specifies the name of the vertex array object for glVertexArrayAttrib{I, L}Format functions.</param>
@@ -6434,21 +6434,21 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="type">The type of the data stored in the array.</param>
         /// <param name="relativeoffset">The distance between elements within the buffer.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glVertexAttribFormat.xhtml" /></remarks>
-        public static void VertexArrayAttribLFormat(VertexArrayHandle vaobj, uint attribindex, int size, VertexAttribLType type, uint relativeoffset) => GLPointers._VertexArrayAttribLFormat_fnptr((int)vaobj, attribindex, size, (uint)type, relativeoffset);
+        public static void VertexArrayAttribLFormat(int vaobj, uint attribindex, int size, VertexAttribLType type, uint relativeoffset) => GLPointers._VertexArrayAttribLFormat_fnptr(vaobj, attribindex, size, (uint)type, relativeoffset);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Modify the rate at which generic vertex attributes    advance. </summary>
         /// <param name="vaobj">Specifies the name of the vertex array object for glVertexArrayBindingDivisor function.</param>
         /// <param name="bindingindex">The index of the binding whose divisor to modify.</param>
         /// <param name="divisor">The new value for the instance step rate to apply.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glVertexBindingDivisor.xhtml" /></remarks>
-        public static void VertexArrayBindingDivisor(VertexArrayHandle vaobj, uint bindingindex, uint divisor) => GLPointers._VertexArrayBindingDivisor_fnptr((int)vaobj, bindingindex, divisor);
+        public static void VertexArrayBindingDivisor(int vaobj, uint bindingindex, uint divisor) => GLPointers._VertexArrayBindingDivisor_fnptr(vaobj, bindingindex, divisor);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Retrieve parameters of a vertex array object. </summary>
         /// <param name="vaobj">specifies the name of the vertex array object to use for the query.</param>
         /// <param name="pname">Name of the property to use for the query. Must be GL_ELEMENT_ARRAY_BUFFER_BINDING.</param>
         /// <param name="param">Returns the requested value.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetVertexArrayiv.xhtml" /></remarks>
-        public static void GetVertexArrayiv(VertexArrayHandle vaobj, VertexArrayPName pname, int* param) => GLPointers._GetVertexArrayiv_fnptr((int)vaobj, (uint)pname, param);
+        public static void GetVertexArrayiv(int vaobj, VertexArrayPName pname, int* param) => GLPointers._GetVertexArrayiv_fnptr(vaobj, (uint)pname, param);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Retrieve parameters of an attribute of a vertex array    object. </summary>
         /// <param name="vaobj">Specifies the name of a vertex array object.</param>
@@ -6456,7 +6456,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="pname">Specifies the property to be used for the query. For glGetVertexArrayIndexediv, it must be one of the following values: GL_VERTEX_ATTRIB_ARRAY_ENABLED, GL_VERTEX_ATTRIB_ARRAY_SIZE, GL_VERTEX_ATTRIB_ARRAY_STRIDE, GL_VERTEX_ATTRIB_ARRAY_TYPE, GL_VERTEX_ATTRIB_ARRAY_NORMALIZED, GL_VERTEX_ATTRIB_ARRAY_INTEGER, GL_VERTEX_ATTRIB_ARRAY_LONG, GL_VERTEX_ATTRIB_ARRAY_DIVISOR, or GL_VERTEX_ATTRIB_RELATIVE_OFFSET. For glGetVertexArrayIndexed64v, it must be equal to GL_VERTEX_BINDING_OFFSET.</param>
         /// <param name="param">Returns the requested value.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetVertexArrayIndexed.xhtml" /></remarks>
-        public static void GetVertexArrayIndexediv(VertexArrayHandle vaobj, uint index, VertexArrayPName pname, int* param) => GLPointers._GetVertexArrayIndexediv_fnptr((int)vaobj, index, (uint)pname, param);
+        public static void GetVertexArrayIndexediv(int vaobj, uint index, VertexArrayPName pname, int* param) => GLPointers._GetVertexArrayIndexediv_fnptr(vaobj, index, (uint)pname, param);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Retrieve parameters of an attribute of a vertex array    object. </summary>
         /// <param name="vaobj">Specifies the name of a vertex array object.</param>
@@ -6464,26 +6464,26 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="pname">Specifies the property to be used for the query. For glGetVertexArrayIndexediv, it must be one of the following values: GL_VERTEX_ATTRIB_ARRAY_ENABLED, GL_VERTEX_ATTRIB_ARRAY_SIZE, GL_VERTEX_ATTRIB_ARRAY_STRIDE, GL_VERTEX_ATTRIB_ARRAY_TYPE, GL_VERTEX_ATTRIB_ARRAY_NORMALIZED, GL_VERTEX_ATTRIB_ARRAY_INTEGER, GL_VERTEX_ATTRIB_ARRAY_LONG, GL_VERTEX_ATTRIB_ARRAY_DIVISOR, or GL_VERTEX_ATTRIB_RELATIVE_OFFSET. For glGetVertexArrayIndexed64v, it must be equal to GL_VERTEX_BINDING_OFFSET.</param>
         /// <param name="param">Returns the requested value.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetVertexArrayIndexed.xhtml" /></remarks>
-        public static void GetVertexArrayIndexed64iv(VertexArrayHandle vaobj, uint index, VertexArrayPName pname, long* param) => GLPointers._GetVertexArrayIndexed64iv_fnptr((int)vaobj, index, (uint)pname, param);
+        public static void GetVertexArrayIndexed64iv(int vaobj, uint index, VertexArrayPName pname, long* param) => GLPointers._GetVertexArrayIndexed64iv_fnptr(vaobj, index, (uint)pname, param);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Create sampler objects. </summary>
         /// <param name="n"> Number of sampler objects to create. </param>
         /// <param name="samplers"> Specifies an array in which names of the new sampler objects are stored. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCreateSamplers.xhtml" /></remarks>
-        public static void CreateSamplers(int n, SamplerHandle* samplers) => GLPointers._CreateSamplers_fnptr(n, (int*)samplers);
+        public static void CreateSamplers(int n, int* samplers) => GLPointers._CreateSamplers_fnptr(n, samplers);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Create program pipeline objects. </summary>
         /// <param name="n"> Number of program pipeline objects to create. </param>
         /// <param name="pipelines"> Specifies an array in which names of the new program pipeline objects are stored. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCreateProgramPipelines.xhtml" /></remarks>
-        public static void CreateProgramPipelines(int n, ProgramPipelineHandle* pipelines) => GLPointers._CreateProgramPipelines_fnptr(n, (int*)pipelines);
+        public static void CreateProgramPipelines(int n, int* pipelines) => GLPointers._CreateProgramPipelines_fnptr(n, pipelines);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Create query objects. </summary>
         /// <param name="target"> Specifies the target of each created query object. </param>
         /// <param name="n"> Number of query objects to create. </param>
         /// <param name="ids"> Specifies an array in which names of the new query objects are stored. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCreateQueries.xhtml" /></remarks>
-        public static void CreateQueries(QueryTarget target, int n, QueryHandle* ids) => GLPointers._CreateQueries_fnptr((uint)target, n, (int*)ids);
+        public static void CreateQueries(QueryTarget target, int n, int* ids) => GLPointers._CreateQueries_fnptr((uint)target, n, ids);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Return parameters of a query object. </summary>
         /// <param name="id"> Specifies the name of a query object. </param>
@@ -6491,7 +6491,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="pname"> Specifies the symbolic name of a query object parameter. Accepted values are GL_QUERY_RESULT or GL_QUERY_RESULT_AVAILABLE. </param>
         /// <param name="offset"> Specifies the byte offset into buffer's data store where the queried result will be written. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetQueryObject.xhtml" /></remarks>
-        public static void GetQueryBufferObjecti64v(QueryHandle id, BufferHandle buffer, QueryObjectParameterName pname, IntPtr offset) => GLPointers._GetQueryBufferObjecti64v_fnptr((int)id, (int)buffer, (uint)pname, offset);
+        public static void GetQueryBufferObjecti64v(int id, int buffer, QueryObjectParameterName pname, IntPtr offset) => GLPointers._GetQueryBufferObjecti64v_fnptr(id, buffer, (uint)pname, offset);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Return parameters of a query object. </summary>
         /// <param name="id"> Specifies the name of a query object. </param>
@@ -6499,7 +6499,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="pname"> Specifies the symbolic name of a query object parameter. Accepted values are GL_QUERY_RESULT or GL_QUERY_RESULT_AVAILABLE. </param>
         /// <param name="offset"> Specifies the byte offset into buffer's data store where the queried result will be written. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetQueryObject.xhtml" /></remarks>
-        public static void GetQueryBufferObjectiv(QueryHandle id, BufferHandle buffer, QueryObjectParameterName pname, IntPtr offset) => GLPointers._GetQueryBufferObjectiv_fnptr((int)id, (int)buffer, (uint)pname, offset);
+        public static void GetQueryBufferObjectiv(int id, int buffer, QueryObjectParameterName pname, IntPtr offset) => GLPointers._GetQueryBufferObjectiv_fnptr(id, buffer, (uint)pname, offset);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Return parameters of a query object. </summary>
         /// <param name="id"> Specifies the name of a query object. </param>
@@ -6507,7 +6507,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="pname"> Specifies the symbolic name of a query object parameter. Accepted values are GL_QUERY_RESULT or GL_QUERY_RESULT_AVAILABLE. </param>
         /// <param name="offset"> Specifies the byte offset into buffer's data store where the queried result will be written. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetQueryObject.xhtml" /></remarks>
-        public static void GetQueryBufferObjectui64v(QueryHandle id, BufferHandle buffer, QueryObjectParameterName pname, IntPtr offset) => GLPointers._GetQueryBufferObjectui64v_fnptr((int)id, (int)buffer, (uint)pname, offset);
+        public static void GetQueryBufferObjectui64v(int id, int buffer, QueryObjectParameterName pname, IntPtr offset) => GLPointers._GetQueryBufferObjectui64v_fnptr(id, buffer, (uint)pname, offset);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Return parameters of a query object. </summary>
         /// <param name="id"> Specifies the name of a query object. </param>
@@ -6515,7 +6515,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="pname"> Specifies the symbolic name of a query object parameter. Accepted values are GL_QUERY_RESULT or GL_QUERY_RESULT_AVAILABLE. </param>
         /// <param name="offset"> Specifies the byte offset into buffer's data store where the queried result will be written. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetQueryObject.xhtml" /></remarks>
-        public static void GetQueryBufferObjectuiv(QueryHandle id, BufferHandle buffer, QueryObjectParameterName pname, IntPtr offset) => GLPointers._GetQueryBufferObjectuiv_fnptr((int)id, (int)buffer, (uint)pname, offset);
+        public static void GetQueryBufferObjectuiv(int id, int buffer, QueryObjectParameterName pname, IntPtr offset) => GLPointers._GetQueryBufferObjectuiv_fnptr(id, buffer, (uint)pname, offset);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_ES3_1_compatibility]</b> Defines a barrier ordering memory transactions. </summary>
         /// <param name="barriers"> Specifies the barriers to insert. </param>
@@ -6536,7 +6536,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="bufSize">Specifies the size of the buffer to receive the retrieved pixel data.</param>
         /// <param name="pixels">Returns the texture subimage. Should be a pointer to an array of the type specified by type.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetTextureSubImage.xhtml" /></remarks>
-        public static void GetTextureSubImage(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, int bufSize, void* pixels) => GLPointers._GetTextureSubImage_fnptr((int)texture, level, xoffset, yoffset, zoffset, width, height, depth, (uint)format, (uint)type, bufSize, pixels);
+        public static void GetTextureSubImage(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, int bufSize, void* pixels) => GLPointers._GetTextureSubImage_fnptr(texture, level, xoffset, yoffset, zoffset, width, height, depth, (uint)format, (uint)type, bufSize, pixels);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_get_texture_sub_image]</b> Retrieve a sub-region of a compressed texture image from a    compressed texture object. </summary>
         /// <param name="texture">Specifies the name of the source texture object. Must be GL_TEXTURE_1D, GL_TEXTURE_1D_ARRAY, GL_TEXTURE_2D, GL_TEXTURE_2D_ARRAY, GL_TEXTURE_3D, GL_TEXTURE_CUBE_MAP, GL_TEXTURE_CUBE_MAP_ARRAY or GL_TEXTURE_RECTANGLE. In specific, buffer and multisample textures are not permitted.</param>
@@ -6550,7 +6550,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="bufSize">Specifies the size of the buffer to receive the retrieved pixel data.</param>
         /// <param name="pixels">Returns the texture subimage. Should be a pointer to an array of the type specified by type.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetCompressedTextureSubImage.xhtml" /></remarks>
-        public static void GetCompressedTextureSubImage(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, int bufSize, void* pixels) => GLPointers._GetCompressedTextureSubImage_fnptr((int)texture, level, xoffset, yoffset, zoffset, width, height, depth, bufSize, pixels);
+        public static void GetCompressedTextureSubImage(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, int bufSize, void* pixels) => GLPointers._GetCompressedTextureSubImage_fnptr(texture, level, xoffset, yoffset, zoffset, width, height, depth, bufSize, pixels);
         
         /// <summary> <b>[requires: v4.5 | GL_KHR_robustness]</b> Check if the rendering context has not been lost due to software or hardware issues. </summary>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetGraphicsResetStatus.xhtml" /></remarks>
@@ -6580,7 +6580,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="bufSize">Specifies the size of the buffer params.</param>
         /// <param name="parameters">Returns the value of the specified uniform variable.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetUniform.xhtml" /></remarks>
-        public static void GetnUniformdv(ProgramHandle program, int location, int bufSize, double* parameters) => GLPointers._GetnUniformdv_fnptr((int)program, location, bufSize, parameters);
+        public static void GetnUniformdv(int program, int location, int bufSize, double* parameters) => GLPointers._GetnUniformdv_fnptr(program, location, bufSize, parameters);
         
         /// <summary> <b>[requires: v4.5 | GL_KHR_robustness]</b> Returns the value of a uniform variable. </summary>
         /// <param name="program">Specifies the program object to be queried.</param>
@@ -6588,7 +6588,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="bufSize">Specifies the size of the buffer params.</param>
         /// <param name="parameters">Returns the value of the specified uniform variable.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetUniform.xhtml" /></remarks>
-        public static void GetnUniformfv(ProgramHandle program, int location, int bufSize, float* parameters) => GLPointers._GetnUniformfv_fnptr((int)program, location, bufSize, parameters);
+        public static void GetnUniformfv(int program, int location, int bufSize, float* parameters) => GLPointers._GetnUniformfv_fnptr(program, location, bufSize, parameters);
         
         /// <summary> <b>[requires: v4.5 | GL_KHR_robustness]</b> Returns the value of a uniform variable. </summary>
         /// <param name="program">Specifies the program object to be queried.</param>
@@ -6596,7 +6596,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="bufSize">Specifies the size of the buffer params.</param>
         /// <param name="parameters">Returns the value of the specified uniform variable.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetUniform.xhtml" /></remarks>
-        public static void GetnUniformiv(ProgramHandle program, int location, int bufSize, int* parameters) => GLPointers._GetnUniformiv_fnptr((int)program, location, bufSize, parameters);
+        public static void GetnUniformiv(int program, int location, int bufSize, int* parameters) => GLPointers._GetnUniformiv_fnptr(program, location, bufSize, parameters);
         
         /// <summary> <b>[requires: v4.5 | GL_KHR_robustness]</b> Returns the value of a uniform variable. </summary>
         /// <param name="program">Specifies the program object to be queried.</param>
@@ -6604,7 +6604,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="bufSize">Specifies the size of the buffer params.</param>
         /// <param name="parameters">Returns the value of the specified uniform variable.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetUniform.xhtml" /></remarks>
-        public static void GetnUniformuiv(ProgramHandle program, int location, int bufSize, uint* parameters) => GLPointers._GetnUniformuiv_fnptr((int)program, location, bufSize, parameters);
+        public static void GetnUniformuiv(int program, int location, int bufSize, uint* parameters) => GLPointers._GetnUniformuiv_fnptr(program, location, bufSize, parameters);
         
         /// <summary> <b>[requires: v4.5 | GL_KHR_robustness]</b> Read a block of pixels from the frame buffer. </summary>
         /// <param name="x">Specify the window coordinates of the first pixel that is read from the frame buffer. This location is the lower left corner of a rectangular block of pixels.</param>
@@ -6646,7 +6646,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTextureBarrier.xhtml" /></remarks>
         public static void TextureBarrier() => GLPointers._TextureBarrier_fnptr();
         
-        public static void SpecializeShader(ShaderHandle shader, byte* pEntryPoint, uint numSpecializationConstants, uint* pConstantIndex, uint* pConstantValue) => GLPointers._SpecializeShader_fnptr((int)shader, pEntryPoint, numSpecializationConstants, pConstantIndex, pConstantValue);
+        public static void SpecializeShader(int shader, byte* pEntryPoint, uint numSpecializationConstants, uint* pConstantIndex, uint* pConstantValue) => GLPointers._SpecializeShader_fnptr(shader, pEntryPoint, numSpecializationConstants, pConstantIndex, pConstantValue);
         
         public static void MultiDrawArraysIndirectCount(PrimitiveType mode, void* indirect, IntPtr drawcount, int maxdrawcount, int stride) => GLPointers._MultiDrawArraysIndirectCount_fnptr((uint)mode, indirect, drawcount, maxdrawcount, stride);
         
@@ -6703,7 +6703,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_AMD_framebuffer_multisample_advanced]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedRenderbufferStorageMultisampleAdvancedAMD(RenderbufferHandle renderbuffer, int samples, int storageSamples, InternalFormat internalformat, int width, int height) => GLPointers._NamedRenderbufferStorageMultisampleAdvancedAMD_fnptr((int)renderbuffer, samples, storageSamples, (uint)internalformat, width, height);
+            public static void NamedRenderbufferStorageMultisampleAdvancedAMD(int renderbuffer, int samples, int storageSamples, InternalFormat internalformat, int width, int height) => GLPointers._NamedRenderbufferStorageMultisampleAdvancedAMD_fnptr(renderbuffer, samples, storageSamples, (uint)internalformat, width, height);
             
             /// <summary> <b>[requires: GL_AMD_framebuffer_sample_positions]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -6711,7 +6711,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_AMD_framebuffer_sample_positions]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedFramebufferSamplePositionsfvAMD(FramebufferHandle framebuffer, uint numsamples, uint pixelindex, float* values) => GLPointers._NamedFramebufferSamplePositionsfvAMD_fnptr((int)framebuffer, numsamples, pixelindex, values);
+            public static void NamedFramebufferSamplePositionsfvAMD(int framebuffer, uint numsamples, uint pixelindex, float* values) => GLPointers._NamedFramebufferSamplePositionsfvAMD_fnptr(framebuffer, numsamples, pixelindex, values);
             
             /// <summary> <b>[requires: GL_AMD_framebuffer_sample_positions]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -6719,7 +6719,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_AMD_framebuffer_sample_positions]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetNamedFramebufferParameterfvAMD(FramebufferHandle framebuffer, All pname, uint numsamples, uint pixelindex, int size, float* values) => GLPointers._GetNamedFramebufferParameterfvAMD_fnptr((int)framebuffer, (uint)pname, numsamples, pixelindex, size, values);
+            public static void GetNamedFramebufferParameterfvAMD(int framebuffer, All pname, uint numsamples, uint pixelindex, int size, float* values) => GLPointers._GetNamedFramebufferParameterfvAMD_fnptr(framebuffer, (uint)pname, numsamples, pixelindex, size, values);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -6787,75 +6787,75 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetUniformi64vNV(ProgramHandle program, int location, long* parameters) => GLPointers._GetUniformi64vNV_fnptr((int)program, location, parameters);
+            public static void GetUniformi64vNV(int program, int location, long* parameters) => GLPointers._GetUniformi64vNV_fnptr(program, location, parameters);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_shader_buffer_load]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetUniformui64vNV(ProgramHandle program, int location, ulong* parameters) => GLPointers._GetUniformui64vNV_fnptr((int)program, location, parameters);
+            public static void GetUniformui64vNV(int program, int location, ulong* parameters) => GLPointers._GetUniformui64vNV_fnptr(program, location, parameters);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform1i64NV(ProgramHandle program, int location, long x) => GLPointers._ProgramUniform1i64NV_fnptr((int)program, location, x);
+            public static void ProgramUniform1i64NV(int program, int location, long x) => GLPointers._ProgramUniform1i64NV_fnptr(program, location, x);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform2i64NV(ProgramHandle program, int location, long x, long y) => GLPointers._ProgramUniform2i64NV_fnptr((int)program, location, x, y);
+            public static void ProgramUniform2i64NV(int program, int location, long x, long y) => GLPointers._ProgramUniform2i64NV_fnptr(program, location, x, y);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform3i64NV(ProgramHandle program, int location, long x, long y, long z) => GLPointers._ProgramUniform3i64NV_fnptr((int)program, location, x, y, z);
+            public static void ProgramUniform3i64NV(int program, int location, long x, long y, long z) => GLPointers._ProgramUniform3i64NV_fnptr(program, location, x, y, z);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform4i64NV(ProgramHandle program, int location, long x, long y, long z, long w) => GLPointers._ProgramUniform4i64NV_fnptr((int)program, location, x, y, z, w);
+            public static void ProgramUniform4i64NV(int program, int location, long x, long y, long z, long w) => GLPointers._ProgramUniform4i64NV_fnptr(program, location, x, y, z, w);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform1i64vNV(ProgramHandle program, int location, int count, long* value) => GLPointers._ProgramUniform1i64vNV_fnptr((int)program, location, count, value);
+            public static void ProgramUniform1i64vNV(int program, int location, int count, long* value) => GLPointers._ProgramUniform1i64vNV_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform2i64vNV(ProgramHandle program, int location, int count, long* value) => GLPointers._ProgramUniform2i64vNV_fnptr((int)program, location, count, value);
+            public static void ProgramUniform2i64vNV(int program, int location, int count, long* value) => GLPointers._ProgramUniform2i64vNV_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform3i64vNV(ProgramHandle program, int location, int count, long* value) => GLPointers._ProgramUniform3i64vNV_fnptr((int)program, location, count, value);
+            public static void ProgramUniform3i64vNV(int program, int location, int count, long* value) => GLPointers._ProgramUniform3i64vNV_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform4i64vNV(ProgramHandle program, int location, int count, long* value) => GLPointers._ProgramUniform4i64vNV_fnptr((int)program, location, count, value);
+            public static void ProgramUniform4i64vNV(int program, int location, int count, long* value) => GLPointers._ProgramUniform4i64vNV_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform1ui64NV(ProgramHandle program, int location, ulong x) => GLPointers._ProgramUniform1ui64NV_fnptr((int)program, location, x);
+            public static void ProgramUniform1ui64NV(int program, int location, ulong x) => GLPointers._ProgramUniform1ui64NV_fnptr(program, location, x);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform2ui64NV(ProgramHandle program, int location, ulong x, ulong y) => GLPointers._ProgramUniform2ui64NV_fnptr((int)program, location, x, y);
+            public static void ProgramUniform2ui64NV(int program, int location, ulong x, ulong y) => GLPointers._ProgramUniform2ui64NV_fnptr(program, location, x, y);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform3ui64NV(ProgramHandle program, int location, ulong x, ulong y, ulong z) => GLPointers._ProgramUniform3ui64NV_fnptr((int)program, location, x, y, z);
+            public static void ProgramUniform3ui64NV(int program, int location, ulong x, ulong y, ulong z) => GLPointers._ProgramUniform3ui64NV_fnptr(program, location, x, y, z);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform4ui64NV(ProgramHandle program, int location, ulong x, ulong y, ulong z, ulong w) => GLPointers._ProgramUniform4ui64NV_fnptr((int)program, location, x, y, z, w);
+            public static void ProgramUniform4ui64NV(int program, int location, ulong x, ulong y, ulong z, ulong w) => GLPointers._ProgramUniform4ui64NV_fnptr(program, location, x, y, z, w);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform1ui64vNV(ProgramHandle program, int location, int count, ulong* value) => GLPointers._ProgramUniform1ui64vNV_fnptr((int)program, location, count, value);
+            public static void ProgramUniform1ui64vNV(int program, int location, int count, ulong* value) => GLPointers._ProgramUniform1ui64vNV_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform2ui64vNV(ProgramHandle program, int location, int count, ulong* value) => GLPointers._ProgramUniform2ui64vNV_fnptr((int)program, location, count, value);
+            public static void ProgramUniform2ui64vNV(int program, int location, int count, ulong* value) => GLPointers._ProgramUniform2ui64vNV_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform3ui64vNV(ProgramHandle program, int location, int count, ulong* value) => GLPointers._ProgramUniform3ui64vNV_fnptr((int)program, location, count, value);
+            public static void ProgramUniform3ui64vNV(int program, int location, int count, ulong* value) => GLPointers._ProgramUniform3ui64vNV_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform4ui64vNV(ProgramHandle program, int location, int count, ulong* value) => GLPointers._ProgramUniform4ui64vNV_fnptr((int)program, location, count, value);
+            public static void ProgramUniform4ui64vNV(int program, int location, int count, ulong* value) => GLPointers._ProgramUniform4ui64vNV_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_AMD_interleaved_elements]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -6883,7 +6883,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_AMD_occlusion_query_event]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void QueryObjectParameteruiAMD(QueryTarget target, QueryHandle id, All pname, OcclusionQueryEventMaskAMD param) => GLPointers._QueryObjectParameteruiAMD_fnptr((uint)target, (int)id, (uint)pname, (uint)param);
+            public static void QueryObjectParameteruiAMD(QueryTarget target, int id, All pname, OcclusionQueryEventMaskAMD param) => GLPointers._QueryObjectParameteruiAMD_fnptr((uint)target, id, (uint)pname, (uint)param);
             
             /// <summary> <b>[requires: GL_AMD_performance_monitor]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -6939,7 +6939,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_AMD_sparse_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureStorageSparseAMD(TextureHandle texture, All target, SizedInternalFormat internalFormat, int width, int height, int depth, int layers, TextureStorageMaskAMD flags) => GLPointers._TextureStorageSparseAMD_fnptr((int)texture, (uint)target, (uint)internalFormat, width, height, depth, layers, (uint)flags);
+            public static void TextureStorageSparseAMD(int texture, All target, SizedInternalFormat internalFormat, int width, int height, int depth, int layers, TextureStorageMaskAMD flags) => GLPointers._TextureStorageSparseAMD_fnptr(texture, (uint)target, (uint)internalFormat, width, height, depth, layers, (uint)flags);
             
             /// <summary> <b>[requires: GL_AMD_stencil_operation_extended]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -7038,19 +7038,19 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_APPLE_vertex_array_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void BindVertexArrayAPPLE(VertexArrayHandle array) => GLPointers._BindVertexArrayAPPLE_fnptr((int)array);
+            public static void BindVertexArrayAPPLE(int array) => GLPointers._BindVertexArrayAPPLE_fnptr(array);
             
             /// <summary> <b>[requires: GL_APPLE_vertex_array_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void DeleteVertexArraysAPPLE(int n, VertexArrayHandle* arrays) => GLPointers._DeleteVertexArraysAPPLE_fnptr(n, (int*)arrays);
+            public static void DeleteVertexArraysAPPLE(int n, int* arrays) => GLPointers._DeleteVertexArraysAPPLE_fnptr(n, arrays);
             
             /// <summary> <b>[requires: GL_APPLE_vertex_array_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GenVertexArraysAPPLE(int n, VertexArrayHandle* arrays) => GLPointers._GenVertexArraysAPPLE_fnptr(n, (int*)arrays);
+            public static void GenVertexArraysAPPLE(int n, int* arrays) => GLPointers._GenVertexArraysAPPLE_fnptr(n, arrays);
             
             /// <summary> <b>[requires: GL_APPLE_vertex_array_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static bool IsVertexArrayAPPLE(VertexArrayHandle array) => GLPointers._IsVertexArrayAPPLE_fnptr((int)array) != 0;
+            public static bool IsVertexArrayAPPLE(int array) => GLPointers._IsVertexArrayAPPLE_fnptr(array) != 0;
             
             /// <summary> <b>[requires: GL_APPLE_vertex_array_range]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -7106,7 +7106,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="binary"> Specifies the address of an array of bytes containing pre-compiled binary shader code. </param>
             /// <param name="length"> Specifies the length of the array whose address is given in binary. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glShaderBinary.xhtml" /></remarks>
-            public static void ShaderBinary(int count, ShaderHandle* shaders, ShaderBinaryFormat binaryFormat, void* binary, int length) => GLPointers._ShaderBinary_fnptr(count, (int*)shaders, (uint)binaryFormat, binary, length);
+            public static void ShaderBinary(int count, int* shaders, ShaderBinaryFormat binaryFormat, void* binary, int length) => GLPointers._ShaderBinary_fnptr(count, shaders, (uint)binaryFormat, binary, length);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_ES2_compatibility]</b> Retrieve the range and precision for numeric formats supported by the shader compiler. </summary>
             /// <param name="shaderType"> Specifies the type of shader whose precision to query. shaderType must be GL_VERTEX_SHADER or GL_FRAGMENT_SHADER. </param>
@@ -7168,11 +7168,11 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_ARB_bindless_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static ulong GetTextureHandleARB(TextureHandle texture) => GLPointers._GetTextureHandleARB_fnptr((int)texture);
+            public static ulong GetTextureHandleARB(int texture) => GLPointers._GetTextureHandleARB_fnptr(texture);
             
             /// <summary> <b>[requires: GL_ARB_bindless_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static ulong GetTextureSamplerHandleARB(TextureHandle texture, SamplerHandle sampler) => GLPointers._GetTextureSamplerHandleARB_fnptr((int)texture, (int)sampler);
+            public static ulong GetTextureSamplerHandleARB(int texture, int sampler) => GLPointers._GetTextureSamplerHandleARB_fnptr(texture, sampler);
             
             /// <summary> <b>[requires: GL_ARB_bindless_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -7184,7 +7184,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_ARB_bindless_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static ulong GetImageHandleARB(TextureHandle texture, int level, bool layered, int layer, PixelFormat format) => GLPointers._GetImageHandleARB_fnptr((int)texture, level, (byte)(layered ? 1 : 0), layer, (uint)format);
+            public static ulong GetImageHandleARB(int texture, int level, bool layered, int layer, PixelFormat format) => GLPointers._GetImageHandleARB_fnptr(texture, level, (byte)(layered ? 1 : 0), layer, (uint)format);
             
             /// <summary> <b>[requires: GL_ARB_bindless_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -7204,11 +7204,11 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_ARB_bindless_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformHandleui64ARB(ProgramHandle program, int location, ulong value) => GLPointers._ProgramUniformHandleui64ARB_fnptr((int)program, location, value);
+            public static void ProgramUniformHandleui64ARB(int program, int location, ulong value) => GLPointers._ProgramUniformHandleui64ARB_fnptr(program, location, value);
             
             /// <summary> <b>[requires: GL_ARB_bindless_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformHandleui64vARB(ProgramHandle program, int location, int count, ulong* values) => GLPointers._ProgramUniformHandleui64vARB_fnptr((int)program, location, count, values);
+            public static void ProgramUniformHandleui64vARB(int program, int location, int count, ulong* values) => GLPointers._ProgramUniformHandleui64vARB_fnptr(program, location, count, values);
             
             /// <summary> <b>[requires: GL_ARB_bindless_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -7236,13 +7236,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="index"> The index of the color input to bind the user-defined varying out variable to </param>
             /// <param name="name"> The name of the user-defined varying out variable whose binding to modify </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindFragDataLocationIndexed.xhtml" /></remarks>
-            public static void BindFragDataLocationIndexed(ProgramHandle program, uint colorNumber, uint index, byte* name) => GLPointers._BindFragDataLocationIndexed_fnptr((int)program, colorNumber, index, name);
+            public static void BindFragDataLocationIndexed(int program, uint colorNumber, uint index, byte* name) => GLPointers._BindFragDataLocationIndexed_fnptr(program, colorNumber, index, name);
             
             /// <summary> <b>[requires: v3.3 | GL_ARB_blend_func_extended]</b> Query the bindings of color indices to user-defined varying out variables. </summary>
             /// <param name="program"> The name of the program containing varying out variable whose binding to query </param>
             /// <param name="name"> The name of the user-defined varying out variable whose index to query </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetFragDataIndex.xhtml" /></remarks>
-            public static int GetFragDataIndex(ProgramHandle program, byte* name) => GLPointers._GetFragDataIndex_fnptr((int)program, name);
+            public static int GetFragDataIndex(int program, byte* name) => GLPointers._GetFragDataIndex_fnptr(program, name);
             
             /// <summary> <b>[requires: v4.4 | GL_ARB_buffer_storage]</b> Creates and initializes a buffer object's immutable data    store. </summary>
             /// <param name="target"> Specifies the target to which the buffer object is bound for glBufferStorage, which must be one of the buffer binding targets in the following table: </param>
@@ -7283,7 +7283,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="type"> The type of the data whose address in memory is given by data. </param>
             /// <param name="data"> The address in memory of the data to be used to clear the specified region. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glClearTexImage.xhtml" /></remarks>
-            public static void ClearTexImage(TextureHandle texture, int level, PixelFormat format, PixelType type, void* data) => GLPointers._ClearTexImage_fnptr((int)texture, level, (uint)format, (uint)type, data);
+            public static void ClearTexImage(int texture, int level, PixelFormat format, PixelType type, void* data) => GLPointers._ClearTexImage_fnptr(texture, level, (uint)format, (uint)type, data);
             
             /// <summary> <b>[requires: v4.4 | GL_ARB_clear_texture]</b> Fills all or part of a texture image with a constant value. </summary>
             /// <param name="texture"> The name of an existing texture object containing the image to be cleared. </param>
@@ -7298,7 +7298,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="type"> The type of the data whose address in memory is given by data. </param>
             /// <param name="data"> The address in memory of the data to be used to clear the specified region. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glClearTexSubImage.xhtml" /></remarks>
-            public static void ClearTexSubImage(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, void* data) => GLPointers._ClearTexSubImage_fnptr((int)texture, level, xoffset, yoffset, zoffset, width, height, depth, (uint)format, (uint)type, data);
+            public static void ClearTexSubImage(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, void* data) => GLPointers._ClearTexSubImage_fnptr(texture, level, xoffset, yoffset, zoffset, width, height, depth, (uint)format, (uint)type, data);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_clip_control]</b> Control clip coordinate to window coordinate behavior. </summary>
             /// <param name="origin"> Specifies the clip control origin. Must be one of GL_LOWER_LEFT or GL_UPPER_LEFT. </param>
@@ -7374,14 +7374,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="n"> Number of transform feedback objects to create. </param>
             /// <param name="ids"> Specifies an array in which names of the new transform feedback objects are stored. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCreateTransformFeedbacks.xhtml" /></remarks>
-            public static void CreateTransformFeedbacks(int n, TransformFeedbackHandle* ids) => GLPointers._CreateTransformFeedbacks_fnptr(n, (int*)ids);
+            public static void CreateTransformFeedbacks(int n, int* ids) => GLPointers._CreateTransformFeedbacks_fnptr(n, ids);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Bind a buffer object to a transform feedback buffer object. </summary>
             /// <param name="xfb"> Name of the transform feedback buffer object. </param>
             /// <param name="index"> Index of the binding point within xfb. </param>
             /// <param name="buffer"> Name of the buffer object to bind to the specified binding point. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTransformFeedbackBufferBase.xhtml" /></remarks>
-            public static void TransformFeedbackBufferBase(TransformFeedbackHandle xfb, uint index, BufferHandle buffer) => GLPointers._TransformFeedbackBufferBase_fnptr((int)xfb, index, (int)buffer);
+            public static void TransformFeedbackBufferBase(int xfb, uint index, int buffer) => GLPointers._TransformFeedbackBufferBase_fnptr(xfb, index, buffer);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Bind a range within a buffer object to a transform feedback buffer object. </summary>
             /// <param name="xfb"> Name of the transform feedback buffer object. </param>
@@ -7390,22 +7390,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="offset"> The starting offset in basic machine units into the buffer object. </param>
             /// <param name="size"> The amount of data in basic machine units that can be read from or written to the buffer object while used as an indexed target. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTransformFeedbackBufferRange.xhtml" /></remarks>
-            public static void TransformFeedbackBufferRange(TransformFeedbackHandle xfb, uint index, BufferHandle buffer, IntPtr offset, nint size) => GLPointers._TransformFeedbackBufferRange_fnptr((int)xfb, index, (int)buffer, offset, size);
+            public static void TransformFeedbackBufferRange(int xfb, uint index, int buffer, IntPtr offset, nint size) => GLPointers._TransformFeedbackBufferRange_fnptr(xfb, index, buffer, offset, size);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Query the state of a transform feedback object.. </summary>
             /// <param name="xfb">The name of an existing transform feedback object, or zero for the default transform feedback object.</param>
             /// <param name="pname">Property to use for the query. Must be one of the values: GL_TRANSFORM_FEEDBACK_BUFFER_BINDING, GL_TRANSFORM_FEEDBACK_BUFFER_START, GL_TRANSFORM_FEEDBACK_BUFFER_SIZE, GL_TRANSFORM_FEEDBACK_PAUSED, GL_TRANSFORM_FEEDBACK_ACTIVE.</param>
             /// <param name="param">The address of a buffer into which will be written the requested state information.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetTransformFeedback.xhtml" /></remarks>
-            public static void GetTransformFeedbackiv(TransformFeedbackHandle xfb, TransformFeedbackPName pname, int* param) => GLPointers._GetTransformFeedbackiv_fnptr((int)xfb, (uint)pname, param);
-            
-            /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Query the state of a transform feedback object.. </summary>
-            /// <param name="xfb">The name of an existing transform feedback object, or zero for the default transform feedback object.</param>
-            /// <param name="pname">Property to use for the query. Must be one of the values: GL_TRANSFORM_FEEDBACK_BUFFER_BINDING, GL_TRANSFORM_FEEDBACK_BUFFER_START, GL_TRANSFORM_FEEDBACK_BUFFER_SIZE, GL_TRANSFORM_FEEDBACK_PAUSED, GL_TRANSFORM_FEEDBACK_ACTIVE.</param>
-            /// <param name="index">Index of the transform feedback stream (for indexed state).</param>
-            /// <param name="param">The address of a buffer into which will be written the requested state information.</param>
-            /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetTransformFeedback.xhtml" /></remarks>
-            public static void GetTransformFeedbacki_v(TransformFeedbackHandle xfb, TransformFeedbackPName pname, uint index, int* param) => GLPointers._GetTransformFeedbacki_v_fnptr((int)xfb, (uint)pname, index, param);
+            public static void GetTransformFeedbackiv(int xfb, TransformFeedbackPName pname, int* param) => GLPointers._GetTransformFeedbackiv_fnptr(xfb, (uint)pname, param);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Query the state of a transform feedback object.. </summary>
             /// <param name="xfb">The name of an existing transform feedback object, or zero for the default transform feedback object.</param>
@@ -7413,13 +7405,21 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="index">Index of the transform feedback stream (for indexed state).</param>
             /// <param name="param">The address of a buffer into which will be written the requested state information.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetTransformFeedback.xhtml" /></remarks>
-            public static void GetTransformFeedbacki64_v(TransformFeedbackHandle xfb, TransformFeedbackPName pname, uint index, long* param) => GLPointers._GetTransformFeedbacki64_v_fnptr((int)xfb, (uint)pname, index, param);
+            public static void GetTransformFeedbacki_v(int xfb, TransformFeedbackPName pname, uint index, int* param) => GLPointers._GetTransformFeedbacki_v_fnptr(xfb, (uint)pname, index, param);
+            
+            /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Query the state of a transform feedback object.. </summary>
+            /// <param name="xfb">The name of an existing transform feedback object, or zero for the default transform feedback object.</param>
+            /// <param name="pname">Property to use for the query. Must be one of the values: GL_TRANSFORM_FEEDBACK_BUFFER_BINDING, GL_TRANSFORM_FEEDBACK_BUFFER_START, GL_TRANSFORM_FEEDBACK_BUFFER_SIZE, GL_TRANSFORM_FEEDBACK_PAUSED, GL_TRANSFORM_FEEDBACK_ACTIVE.</param>
+            /// <param name="index">Index of the transform feedback stream (for indexed state).</param>
+            /// <param name="param">The address of a buffer into which will be written the requested state information.</param>
+            /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetTransformFeedback.xhtml" /></remarks>
+            public static void GetTransformFeedbacki64_v(int xfb, TransformFeedbackPName pname, uint index, long* param) => GLPointers._GetTransformFeedbacki64_v_fnptr(xfb, (uint)pname, index, param);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Create buffer objects. </summary>
             /// <param name="n"> Specifies the number of buffer objects to create. </param>
             /// <param name="buffers"> Specifies an array in which names of the new buffer objects are stored. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCreateBuffers.xhtml" /></remarks>
-            public static void CreateBuffers(int n, BufferHandle* buffers) => GLPointers._CreateBuffers_fnptr(n, (int*)buffers);
+            public static void CreateBuffers(int n, int* buffers) => GLPointers._CreateBuffers_fnptr(n, buffers);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Creates and initializes a buffer object's immutable data    store. </summary>
             /// <param name="buffer">Specifies the name of the buffer object for glNamedBufferStorage function.</param>
@@ -7427,7 +7427,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="data">Specifies a pointer to data that will be copied into the data store for initialization, or NULL if no data is to be copied.</param>
             /// <param name="flags">Specifies the intended usage of the buffer's data store. Must be a bitwise combination of the following flags. GL_DYNAMIC_STORAGE_BIT, GL_MAP_READ_BIT GL_MAP_WRITE_BIT, GL_MAP_PERSISTENT_BIT, GL_MAP_COHERENT_BIT, and GL_CLIENT_STORAGE_BIT.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBufferStorage.xhtml" /></remarks>
-            public static void NamedBufferStorage(BufferHandle buffer, nint size, void* data, BufferStorageMask flags) => GLPointers._NamedBufferStorage_fnptr((int)buffer, size, data, (uint)flags);
+            public static void NamedBufferStorage(int buffer, nint size, void* data, BufferStorageMask flags) => GLPointers._NamedBufferStorage_fnptr(buffer, size, data, (uint)flags);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Creates and initializes a buffer object's data    store. </summary>
             /// <param name="buffer">Specifies the name of the buffer object for glNamedBufferData function.</param>
@@ -7435,7 +7435,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="data">Specifies a pointer to data that will be copied into the data store for initialization, or NULL if no data is to be copied.</param>
             /// <param name="usage">Specifies the expected usage pattern of the data store. The symbolic constant must be GL_STREAM_DRAW, GL_STREAM_READ, GL_STREAM_COPY, GL_STATIC_DRAW, GL_STATIC_READ, GL_STATIC_COPY, GL_DYNAMIC_DRAW, GL_DYNAMIC_READ, or GL_DYNAMIC_COPY.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBufferData.xhtml" /></remarks>
-            public static void NamedBufferData(BufferHandle buffer, nint size, void* data, VertexBufferObjectUsage usage) => GLPointers._NamedBufferData_fnptr((int)buffer, size, data, (uint)usage);
+            public static void NamedBufferData(int buffer, nint size, void* data, VertexBufferObjectUsage usage) => GLPointers._NamedBufferData_fnptr(buffer, size, data, (uint)usage);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Updates a subset of a buffer object's data store. </summary>
             /// <param name="buffer"> Specifies the name of the buffer object for glNamedBufferSubData. </param>
@@ -7443,7 +7443,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="size"> Specifies the size in bytes of the data store region being replaced. </param>
             /// <param name="data"> Specifies a pointer to the new data that will be copied into the data store. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBufferSubData.xhtml" /></remarks>
-            public static void NamedBufferSubData(BufferHandle buffer, IntPtr offset, nint size, void* data) => GLPointers._NamedBufferSubData_fnptr((int)buffer, offset, size, data);
+            public static void NamedBufferSubData(int buffer, IntPtr offset, nint size, void* data) => GLPointers._NamedBufferSubData_fnptr(buffer, offset, size, data);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Copy all or part of the data store of a buffer object to the data store of another buffer object. </summary>
             /// <param name="readBuffer"> Specifies the name of the source buffer object for glCopyNamedBufferSubData. </param>
@@ -7452,7 +7452,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="writeOffset"> Specifies the offset, in basic machine units, within the data store of the destination buffer object at which data will be written. </param>
             /// <param name="size"> Specifies the size, in basic machine units, of the data to be copied from the source buffer object to the destination buffer object. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCopyBufferSubData.xhtml" /></remarks>
-            public static void CopyNamedBufferSubData(BufferHandle readBuffer, BufferHandle writeBuffer, IntPtr readOffset, IntPtr writeOffset, nint size) => GLPointers._CopyNamedBufferSubData_fnptr((int)readBuffer, (int)writeBuffer, readOffset, writeOffset, size);
+            public static void CopyNamedBufferSubData(int readBuffer, int writeBuffer, IntPtr readOffset, IntPtr writeOffset, nint size) => GLPointers._CopyNamedBufferSubData_fnptr(readBuffer, writeBuffer, readOffset, writeOffset, size);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Fill a buffer object's data store with a fixed value. </summary>
             /// <param name="buffer"> Specifies the name of the buffer object for glClearNamedBufferData. </param>
@@ -7461,7 +7461,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="type"> The type of the data in memory addressed by data. </param>
             /// <param name="data"> The address of a memory location storing the data to be replicated into the buffer's data store. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glClearBufferData.xhtml" /></remarks>
-            public static void ClearNamedBufferData(BufferHandle buffer, SizedInternalFormat internalformat, PixelFormat format, PixelType type, void* data) => GLPointers._ClearNamedBufferData_fnptr((int)buffer, (uint)internalformat, (uint)format, (uint)type, data);
+            public static void ClearNamedBufferData(int buffer, SizedInternalFormat internalformat, PixelFormat format, PixelType type, void* data) => GLPointers._ClearNamedBufferData_fnptr(buffer, (uint)internalformat, (uint)format, (uint)type, data);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Fill all or part of buffer object's data store with a fixed value. </summary>
             /// <param name="buffer"> Specifies the name of the buffer object for glClearNamedBufferSubData. </param>
@@ -7472,13 +7472,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="type"> The type of the data in memory addressed by data. </param>
             /// <param name="data"> The address of a memory location storing the data to be replicated into the buffer's data store. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glClearBufferSubData.xhtml" /></remarks>
-            public static void ClearNamedBufferSubData(BufferHandle buffer, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, void* data) => GLPointers._ClearNamedBufferSubData_fnptr((int)buffer, (uint)internalformat, offset, size, (uint)format, (uint)type, data);
+            public static void ClearNamedBufferSubData(int buffer, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, void* data) => GLPointers._ClearNamedBufferSubData_fnptr(buffer, (uint)internalformat, offset, size, (uint)format, (uint)type, data);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Map all of a buffer object's data store into the client's address space. </summary>
             /// <param name="buffer"> Specifies the name of the buffer object for glMapNamedBuffer. </param>
             /// <param name="access"> Specifies the access policy for glMapBuffer and glMapNamedBuffer, indicating whether it will be possible to read from, write to, or both read from and write to the buffer object's mapped data store. The symbolic constant must be GL_READ_ONLY, GL_WRITE_ONLY, or GL_READ_WRITE. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glMapBuffer.xhtml" /></remarks>
-            public static void* MapNamedBuffer(BufferHandle buffer, BufferAccessARB access) => GLPointers._MapNamedBuffer_fnptr((int)buffer, (uint)access);
+            public static void* MapNamedBuffer(int buffer, BufferAccessARB access) => GLPointers._MapNamedBuffer_fnptr(buffer, (uint)access);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Map all or part of a buffer object's data store into the client's address space. </summary>
             /// <param name="buffer"> Specifies the name of the buffer object for glMapNamedBufferRange. </param>
@@ -7486,40 +7486,40 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="length"> Specifies the length of the range to be mapped. </param>
             /// <param name="access"> Specifies a combination of access flags indicating the desired access to the mapped range. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glMapBufferRange.xhtml" /></remarks>
-            public static void* MapNamedBufferRange(BufferHandle buffer, IntPtr offset, nint length, MapBufferAccessMask access) => GLPointers._MapNamedBufferRange_fnptr((int)buffer, offset, length, (uint)access);
+            public static void* MapNamedBufferRange(int buffer, IntPtr offset, nint length, MapBufferAccessMask access) => GLPointers._MapNamedBufferRange_fnptr(buffer, offset, length, (uint)access);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Release the mapping of a buffer object's data store into the client's address space. </summary>
             /// <param name="buffer"> Specifies the name of the buffer object for glUnmapNamedBuffer. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glUnmapBuffer.xhtml" /></remarks>
-            public static bool UnmapNamedBuffer(BufferHandle buffer) => GLPointers._UnmapNamedBuffer_fnptr((int)buffer) != 0;
+            public static bool UnmapNamedBuffer(int buffer) => GLPointers._UnmapNamedBuffer_fnptr(buffer) != 0;
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Indicate modifications to a range of a mapped buffer. </summary>
             /// <param name="buffer"> Specifies the name of the buffer object for glFlushMappedNamedBufferRange. </param>
             /// <param name="offset"> Specifies the start of the buffer subrange, in basic machine units. </param>
             /// <param name="length"> Specifies the length of the buffer subrange, in basic machine units. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glFlushMappedBufferRange.xhtml" /></remarks>
-            public static void FlushMappedNamedBufferRange(BufferHandle buffer, IntPtr offset, nint length) => GLPointers._FlushMappedNamedBufferRange_fnptr((int)buffer, offset, length);
+            public static void FlushMappedNamedBufferRange(int buffer, IntPtr offset, nint length) => GLPointers._FlushMappedNamedBufferRange_fnptr(buffer, offset, length);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Return parameters of a buffer object. </summary>
             /// <param name="buffer"> Specifies the name of the buffer object for glGetNamedBufferParameteriv and glGetNamedBufferParameteri64v. </param>
             /// <param name="pname">!!missing documentation!!</param>
             /// <param name="parameters">!!missing documentation!!</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetBufferParameter.xhtml" /></remarks>
-            public static void GetNamedBufferParameteriv(BufferHandle buffer, BufferPNameARB pname, int* parameters) => GLPointers._GetNamedBufferParameteriv_fnptr((int)buffer, (uint)pname, parameters);
+            public static void GetNamedBufferParameteriv(int buffer, BufferPNameARB pname, int* parameters) => GLPointers._GetNamedBufferParameteriv_fnptr(buffer, (uint)pname, parameters);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Return parameters of a buffer object. </summary>
             /// <param name="buffer"> Specifies the name of the buffer object for glGetNamedBufferParameteriv and glGetNamedBufferParameteri64v. </param>
             /// <param name="pname">!!missing documentation!!</param>
             /// <param name="parameters">!!missing documentation!!</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetBufferParameter.xhtml" /></remarks>
-            public static void GetNamedBufferParameteri64v(BufferHandle buffer, BufferPNameARB pname, long* parameters) => GLPointers._GetNamedBufferParameteri64v_fnptr((int)buffer, (uint)pname, parameters);
+            public static void GetNamedBufferParameteri64v(int buffer, BufferPNameARB pname, long* parameters) => GLPointers._GetNamedBufferParameteri64v_fnptr(buffer, (uint)pname, parameters);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Return the pointer to a mapped buffer object's data store. </summary>
             /// <param name="buffer"> Specifies the name of the buffer object for glGetNamedBufferPointerv. </param>
             /// <param name="pname"> Specifies the name of the pointer to be returned. Must be GL_BUFFER_MAP_POINTER. </param>
             /// <param name="parameters"> Returns the pointer value specified by pname. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetBufferPointerv.xhtml" /></remarks>
-            public static void GetNamedBufferPointerv(BufferHandle buffer, BufferPointerNameARB pname, void** parameters) => GLPointers._GetNamedBufferPointerv_fnptr((int)buffer, (uint)pname, parameters);
+            public static void GetNamedBufferPointerv(int buffer, BufferPointerNameARB pname, void** parameters) => GLPointers._GetNamedBufferPointerv_fnptr(buffer, (uint)pname, parameters);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Returns a subset of a buffer object's data store. </summary>
             /// <param name="buffer"> Specifies the name of the buffer object for glGetNamedBufferSubData. </param>
@@ -7527,13 +7527,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="size"> Specifies the size in bytes of the data store region being returned. </param>
             /// <param name="data"> Specifies a pointer to the location where buffer object data is returned. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetBufferSubData.xhtml" /></remarks>
-            public static void GetNamedBufferSubData(BufferHandle buffer, IntPtr offset, nint size, void* data) => GLPointers._GetNamedBufferSubData_fnptr((int)buffer, offset, size, data);
+            public static void GetNamedBufferSubData(int buffer, IntPtr offset, nint size, void* data) => GLPointers._GetNamedBufferSubData_fnptr(buffer, offset, size, data);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Create framebuffer objects. </summary>
             /// <param name="n"> Number of framebuffer objects to create. </param>
             /// <param name="framebuffers"> Specifies an array in which names of the new framebuffer objects are stored. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCreateFramebuffers.xhtml" /></remarks>
-            public static void CreateFramebuffers(int n, FramebufferHandle* framebuffers) => GLPointers._CreateFramebuffers_fnptr(n, (int*)framebuffers);
+            public static void CreateFramebuffers(int n, int* framebuffers) => GLPointers._CreateFramebuffers_fnptr(n, framebuffers);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Attach a renderbuffer as a logical buffer of a framebuffer object. </summary>
             /// <param name="framebuffer"> Specifies the name of the framebuffer object for glNamedFramebufferRenderbuffer. </param>
@@ -7541,14 +7541,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="renderbuffertarget"> Specifies the renderbuffer target. Must be GL_RENDERBUFFER. </param>
             /// <param name="renderbuffer"> Specifies the name of an existing renderbuffer object of type renderbuffertarget to attach. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glFramebufferRenderbuffer.xhtml" /></remarks>
-            public static void NamedFramebufferRenderbuffer(FramebufferHandle framebuffer, FramebufferAttachment attachment, RenderbufferTarget renderbuffertarget, RenderbufferHandle renderbuffer) => GLPointers._NamedFramebufferRenderbuffer_fnptr((int)framebuffer, (uint)attachment, (uint)renderbuffertarget, (int)renderbuffer);
+            public static void NamedFramebufferRenderbuffer(int framebuffer, FramebufferAttachment attachment, RenderbufferTarget renderbuffertarget, int renderbuffer) => GLPointers._NamedFramebufferRenderbuffer_fnptr(framebuffer, (uint)attachment, (uint)renderbuffertarget, renderbuffer);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Set a named parameter of a framebuffer object. </summary>
             /// <param name="framebuffer"> Specifies the name of the framebuffer object for glNamedFramebufferParameteri. </param>
             /// <param name="pname"> Specifies the framebuffer parameter to be modified. </param>
             /// <param name="param"> The new value for the parameter named pname. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glFramebufferParameteri.xhtml" /></remarks>
-            public static void NamedFramebufferParameteri(FramebufferHandle framebuffer, FramebufferParameterName pname, int param) => GLPointers._NamedFramebufferParameteri_fnptr((int)framebuffer, (uint)pname, param);
+            public static void NamedFramebufferParameteri(int framebuffer, FramebufferParameterName pname, int param) => GLPointers._NamedFramebufferParameteri_fnptr(framebuffer, (uint)pname, param);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Attach a level of a texture object as a logical buffer of a framebuffer object. </summary>
             /// <param name="framebuffer"> Specifies the name of the framebuffer object for glNamedFramebufferTexture. </param>
@@ -7556,7 +7556,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="texture"> Specifies the name of an existing texture object to attach. </param>
             /// <param name="level"> Specifies the mipmap level of the texture object to attach. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glFramebufferTexture.xhtml" /></remarks>
-            public static void NamedFramebufferTexture(FramebufferHandle framebuffer, FramebufferAttachment attachment, TextureHandle texture, int level) => GLPointers._NamedFramebufferTexture_fnptr((int)framebuffer, (uint)attachment, (int)texture, level);
+            public static void NamedFramebufferTexture(int framebuffer, FramebufferAttachment attachment, int texture, int level) => GLPointers._NamedFramebufferTexture_fnptr(framebuffer, (uint)attachment, texture, level);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Attach a single layer of a texture object as a logical buffer of a framebuffer object. </summary>
             /// <param name="framebuffer"> Specifies the name of the framebuffer object for glNamedFramebufferTextureLayer. </param>
@@ -7565,33 +7565,33 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="level"> Specifies the mipmap level of the texture object to attach. </param>
             /// <param name="layer"> Specifies the layer of the texture object to attach. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glFramebufferTextureLayer.xhtml" /></remarks>
-            public static void NamedFramebufferTextureLayer(FramebufferHandle framebuffer, FramebufferAttachment attachment, TextureHandle texture, int level, int layer) => GLPointers._NamedFramebufferTextureLayer_fnptr((int)framebuffer, (uint)attachment, (int)texture, level, layer);
+            public static void NamedFramebufferTextureLayer(int framebuffer, FramebufferAttachment attachment, int texture, int level, int layer) => GLPointers._NamedFramebufferTextureLayer_fnptr(framebuffer, (uint)attachment, texture, level, layer);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specify which color buffers are to be drawn into. </summary>
             /// <param name="framebuffer">Specifies the name of the framebuffer object for glNamedFramebufferDrawBuffer function. Must be zero or the name of a framebuffer object.</param>
             /// <param name="buf">For default framebuffer, the argument specifies up to four color buffers to be drawn into. Symbolic constants GL_NONE, GL_FRONT_LEFT, GL_FRONT_RIGHT, GL_BACK_LEFT, GL_BACK_RIGHT, GL_FRONT, GL_BACK, GL_LEFT, GL_RIGHT, and GL_FRONT_AND_BACK are accepted. The initial value is GL_FRONT for single-buffered contexts, and GL_BACK for double-buffered contexts. For framebuffer objects, GL_COLOR_ATTACHMENT$m$ and GL_NONE enums are accepted, where $m$ is a value between 0 and GL_MAX_COLOR_ATTACHMENTS.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDrawBuffer.xhtml" /></remarks>
-            public static void NamedFramebufferDrawBuffer(FramebufferHandle framebuffer, ColorBuffer buf) => GLPointers._NamedFramebufferDrawBuffer_fnptr((int)framebuffer, (uint)buf);
+            public static void NamedFramebufferDrawBuffer(int framebuffer, ColorBuffer buf) => GLPointers._NamedFramebufferDrawBuffer_fnptr(framebuffer, (uint)buf);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specifies a list of color buffers to be drawn    into. </summary>
             /// <param name="framebuffer">Specifies the name of the framebuffer object for glNamedFramebufferDrawBuffers.</param>
             /// <param name="n">Specifies the number of buffers in bufs.</param>
             /// <param name="bufs">Points to an array of symbolic constants specifying the buffers into which fragment colors or data values will be written.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDrawBuffers.xhtml" /></remarks>
-            public static void NamedFramebufferDrawBuffers(FramebufferHandle framebuffer, int n, ColorBuffer* bufs) => GLPointers._NamedFramebufferDrawBuffers_fnptr((int)framebuffer, n, (uint*)bufs);
+            public static void NamedFramebufferDrawBuffers(int framebuffer, int n, ColorBuffer* bufs) => GLPointers._NamedFramebufferDrawBuffers_fnptr(framebuffer, n, (uint*)bufs);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Select a color buffer source for pixels. </summary>
             /// <param name="framebuffer">Specifies the name of the framebuffer object for glNamedFramebufferReadBuffer function.</param>
             /// <param name="mode">Specifies a color buffer. Accepted values are GL_FRONT_LEFT, GL_FRONT_RIGHT, GL_BACK_LEFT, GL_BACK_RIGHT, GL_FRONT, GL_BACK, GL_LEFT, GL_RIGHT, and the constants GL_COLOR_ATTACHMENTi.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glReadBuffer.xhtml" /></remarks>
-            public static void NamedFramebufferReadBuffer(FramebufferHandle framebuffer, ColorBuffer src) => GLPointers._NamedFramebufferReadBuffer_fnptr((int)framebuffer, (uint)src);
+            public static void NamedFramebufferReadBuffer(int framebuffer, ColorBuffer src) => GLPointers._NamedFramebufferReadBuffer_fnptr(framebuffer, (uint)src);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Invalidate the content of some or all of a framebuffer's attachments. </summary>
             /// <param name="framebuffer"> Specifies the name of the framebuffer object for glInvalidateNamedFramebufferData. </param>
             /// <param name="numAttachments"> Specifies the number of entries in the attachments array. </param>
             /// <param name="attachments"> Specifies a pointer to an array identifying the attachments to be invalidated. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glInvalidateFramebuffer.xhtml" /></remarks>
-            public static void InvalidateNamedFramebufferData(FramebufferHandle framebuffer, int numAttachments, FramebufferAttachment* attachments) => GLPointers._InvalidateNamedFramebufferData_fnptr((int)framebuffer, numAttachments, (uint*)attachments);
+            public static void InvalidateNamedFramebufferData(int framebuffer, int numAttachments, FramebufferAttachment* attachments) => GLPointers._InvalidateNamedFramebufferData_fnptr(framebuffer, numAttachments, (uint*)attachments);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Invalidate the content of a region of some or all of a framebuffer's attachments. </summary>
             /// <param name="framebuffer"> Specifies the name of the framebuffer object for glInvalidateNamedFramebufferSubData. </param>
@@ -7602,7 +7602,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="width"> Specifies the width of the region to be invalidated. </param>
             /// <param name="height"> Specifies the height of the region to be invalidated. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glInvalidateSubFramebuffer.xhtml" /></remarks>
-            public static void InvalidateNamedFramebufferSubData(FramebufferHandle framebuffer, int numAttachments, FramebufferAttachment* attachments, int x, int y, int width, int height) => GLPointers._InvalidateNamedFramebufferSubData_fnptr((int)framebuffer, numAttachments, (uint*)attachments, x, y, width, height);
+            public static void InvalidateNamedFramebufferSubData(int framebuffer, int numAttachments, FramebufferAttachment* attachments, int x, int y, int width, int height) => GLPointers._InvalidateNamedFramebufferSubData_fnptr(framebuffer, numAttachments, (uint*)attachments, x, y, width, height);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Clear individual buffers of a framebuffer. </summary>
             /// <param name="framebuffer"> Specifies the name of the framebuffer object for glClearNamedFramebuffer*. </param>
@@ -7610,7 +7610,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="drawbuffer"> Specify a particular draw buffer to clear. </param>
             /// <param name="value"> A pointer to the value or values to clear the buffer to. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glClearBuffer.xhtml" /></remarks>
-            public static void ClearNamedFramebufferiv(FramebufferHandle framebuffer, Buffer buffer, int drawbuffer, int* value) => GLPointers._ClearNamedFramebufferiv_fnptr((int)framebuffer, (uint)buffer, drawbuffer, value);
+            public static void ClearNamedFramebufferiv(int framebuffer, Buffer buffer, int drawbuffer, int* value) => GLPointers._ClearNamedFramebufferiv_fnptr(framebuffer, (uint)buffer, drawbuffer, value);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Clear individual buffers of a framebuffer. </summary>
             /// <param name="framebuffer"> Specifies the name of the framebuffer object for glClearNamedFramebuffer*. </param>
@@ -7618,7 +7618,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="drawbuffer"> Specify a particular draw buffer to clear. </param>
             /// <param name="value"> A pointer to the value or values to clear the buffer to. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glClearBuffer.xhtml" /></remarks>
-            public static void ClearNamedFramebufferuiv(FramebufferHandle framebuffer, Buffer buffer, int drawbuffer, uint* value) => GLPointers._ClearNamedFramebufferuiv_fnptr((int)framebuffer, (uint)buffer, drawbuffer, value);
+            public static void ClearNamedFramebufferuiv(int framebuffer, Buffer buffer, int drawbuffer, uint* value) => GLPointers._ClearNamedFramebufferuiv_fnptr(framebuffer, (uint)buffer, drawbuffer, value);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Clear individual buffers of a framebuffer. </summary>
             /// <param name="framebuffer"> Specifies the name of the framebuffer object for glClearNamedFramebuffer*. </param>
@@ -7626,7 +7626,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="drawbuffer"> Specify a particular draw buffer to clear. </param>
             /// <param name="value"> A pointer to the value or values to clear the buffer to. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glClearBuffer.xhtml" /></remarks>
-            public static void ClearNamedFramebufferfv(FramebufferHandle framebuffer, Buffer buffer, int drawbuffer, float* value) => GLPointers._ClearNamedFramebufferfv_fnptr((int)framebuffer, (uint)buffer, drawbuffer, value);
+            public static void ClearNamedFramebufferfv(int framebuffer, Buffer buffer, int drawbuffer, float* value) => GLPointers._ClearNamedFramebufferfv_fnptr(framebuffer, (uint)buffer, drawbuffer, value);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Clear individual buffers of a framebuffer. </summary>
             /// <param name="framebuffer"> Specifies the name of the framebuffer object for glClearNamedFramebuffer*. </param>
@@ -7635,7 +7635,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="depth"> The value to clear the depth buffer to. </param>
             /// <param name="stencil"> The value to clear the stencil buffer to. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glClearBuffer.xhtml" /></remarks>
-            public static void ClearNamedFramebufferfi(FramebufferHandle framebuffer, Buffer buffer, int drawbuffer, float depth, int stencil) => GLPointers._ClearNamedFramebufferfi_fnptr((int)framebuffer, (uint)buffer, drawbuffer, depth, stencil);
+            public static void ClearNamedFramebufferfi(int framebuffer, Buffer buffer, int drawbuffer, float depth, int stencil) => GLPointers._ClearNamedFramebufferfi_fnptr(framebuffer, (uint)buffer, drawbuffer, depth, stencil);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Copy a block of pixels from one framebuffer object to another. </summary>
             /// <param name="readFramebuffer"> Specifies the name of the source framebuffer object for glBlitNamedFramebuffer. </param>
@@ -7651,20 +7651,20 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="mask"> The bitwise OR of the flags indicating which buffers are to be copied. The allowed flags are GL_COLOR_BUFFER_BIT, GL_DEPTH_BUFFER_BIT and GL_STENCIL_BUFFER_BIT. </param>
             /// <param name="filter"> Specifies the interpolation to be applied if the image is stretched. Must be GL_NEAREST or GL_LINEAR. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBlitFramebuffer.xhtml" /></remarks>
-            public static void BlitNamedFramebuffer(FramebufferHandle readFramebuffer, FramebufferHandle drawFramebuffer, int srcX0, int srcY0, int srcX1, int srcY1, int dstX0, int dstY0, int dstX1, int dstY1, ClearBufferMask mask, BlitFramebufferFilter filter) => GLPointers._BlitNamedFramebuffer_fnptr((int)readFramebuffer, (int)drawFramebuffer, srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, (uint)mask, (uint)filter);
+            public static void BlitNamedFramebuffer(int readFramebuffer, int drawFramebuffer, int srcX0, int srcY0, int srcX1, int srcY1, int dstX0, int dstY0, int dstX1, int dstY1, ClearBufferMask mask, BlitFramebufferFilter filter) => GLPointers._BlitNamedFramebuffer_fnptr(readFramebuffer, drawFramebuffer, srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, (uint)mask, (uint)filter);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Check the completeness status of a framebuffer. </summary>
             /// <param name="framebuffer"> Specifies the name of the framebuffer object for glCheckNamedFramebufferStatus </param>
             /// <param name="target"> Specify the target to which the framebuffer is bound for glCheckFramebufferStatus, and the target against which framebuffer completeness of framebuffer is checked for glCheckNamedFramebufferStatus. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCheckFramebufferStatus.xhtml" /></remarks>
-            public static FramebufferStatus CheckNamedFramebufferStatus(FramebufferHandle framebuffer, FramebufferTarget target) => (FramebufferStatus) GLPointers._CheckNamedFramebufferStatus_fnptr((int)framebuffer, (uint)target);
+            public static FramebufferStatus CheckNamedFramebufferStatus(int framebuffer, FramebufferTarget target) => (FramebufferStatus) GLPointers._CheckNamedFramebufferStatus_fnptr(framebuffer, (uint)target);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Query a named parameter of a framebuffer object. </summary>
             /// <param name="framebuffer"> Specifies the name of the framebuffer object for glGetNamedFramebufferParameteriv. </param>
             /// <param name="pname"> Specifies the parameter of the framebuffer object to query. </param>
             /// <param name="param">!!missing documentation!!</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetFramebufferParameter.xhtml" /></remarks>
-            public static void GetNamedFramebufferParameteriv(FramebufferHandle framebuffer, GetFramebufferParameter pname, int* param) => GLPointers._GetNamedFramebufferParameteriv_fnptr((int)framebuffer, (uint)pname, param);
+            public static void GetNamedFramebufferParameteriv(int framebuffer, GetFramebufferParameter pname, int* param) => GLPointers._GetNamedFramebufferParameteriv_fnptr(framebuffer, (uint)pname, param);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Retrieve information about attachments of a framebuffer object. </summary>
             /// <param name="framebuffer"> Specifies the name of the framebuffer object for glGetNamedFramebufferAttachmentParameteriv. </param>
@@ -7672,13 +7672,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="pname"> Specifies the parameter of attachment to query. </param>
             /// <param name="parameters"> Returns the value of parameter pname for attachment. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetFramebufferAttachmentParameter.xhtml" /></remarks>
-            public static void GetNamedFramebufferAttachmentParameteriv(FramebufferHandle framebuffer, FramebufferAttachment attachment, FramebufferAttachmentParameterName pname, int* parameters) => GLPointers._GetNamedFramebufferAttachmentParameteriv_fnptr((int)framebuffer, (uint)attachment, (uint)pname, parameters);
+            public static void GetNamedFramebufferAttachmentParameteriv(int framebuffer, FramebufferAttachment attachment, FramebufferAttachmentParameterName pname, int* parameters) => GLPointers._GetNamedFramebufferAttachmentParameteriv_fnptr(framebuffer, (uint)attachment, (uint)pname, parameters);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Create renderbuffer objects. </summary>
             /// <param name="n"> Number of renderbuffer objects to create. </param>
             /// <param name="renderbuffers"> Specifies an array in which names of the new renderbuffer objects are stored. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCreateRenderbuffers.xhtml" /></remarks>
-            public static void CreateRenderbuffers(int n, RenderbufferHandle* renderbuffers) => GLPointers._CreateRenderbuffers_fnptr(n, (int*)renderbuffers);
+            public static void CreateRenderbuffers(int n, int* renderbuffers) => GLPointers._CreateRenderbuffers_fnptr(n, renderbuffers);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Establish data storage, format and dimensions of a    renderbuffer object's image. </summary>
             /// <param name="renderbuffer">Specifies the name of the renderbuffer object for glNamedRenderbufferStorage function.</param>
@@ -7686,7 +7686,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="width">Specifies the width of the renderbuffer, in pixels.</param>
             /// <param name="height">Specifies the height of the renderbuffer, in pixels.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glRenderbufferStorage.xhtml" /></remarks>
-            public static void NamedRenderbufferStorage(RenderbufferHandle renderbuffer, InternalFormat internalformat, int width, int height) => GLPointers._NamedRenderbufferStorage_fnptr((int)renderbuffer, (uint)internalformat, width, height);
+            public static void NamedRenderbufferStorage(int renderbuffer, InternalFormat internalformat, int width, int height) => GLPointers._NamedRenderbufferStorage_fnptr(renderbuffer, (uint)internalformat, width, height);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Establish data storage, format, dimensions and sample count of    a renderbuffer object's image. </summary>
             /// <param name="renderbuffer">Specifies the name of the renderbuffer object for glNamedRenderbufferStorageMultisample function.</param>
@@ -7695,28 +7695,28 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="width">Specifies the width of the renderbuffer, in pixels.</param>
             /// <param name="height">Specifies the height of the renderbuffer, in pixels.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glRenderbufferStorageMultisample.xhtml" /></remarks>
-            public static void NamedRenderbufferStorageMultisample(RenderbufferHandle renderbuffer, int samples, InternalFormat internalformat, int width, int height) => GLPointers._NamedRenderbufferStorageMultisample_fnptr((int)renderbuffer, samples, (uint)internalformat, width, height);
+            public static void NamedRenderbufferStorageMultisample(int renderbuffer, int samples, InternalFormat internalformat, int width, int height) => GLPointers._NamedRenderbufferStorageMultisample_fnptr(renderbuffer, samples, (uint)internalformat, width, height);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Query a named parameter of a renderbuffer object. </summary>
             /// <param name="renderbuffer"> Specifies the name of the renderbuffer object for glGetNamedRenderbufferParameteriv. </param>
             /// <param name="pname"> Specifies the parameter of the renderbuffer object to query. </param>
             /// <param name="parameters"> Returns the value of parameter pname for the renderbuffer object. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetRenderbufferParameter.xhtml" /></remarks>
-            public static void GetNamedRenderbufferParameteriv(RenderbufferHandle renderbuffer, RenderbufferParameterName pname, int* parameters) => GLPointers._GetNamedRenderbufferParameteriv_fnptr((int)renderbuffer, (uint)pname, parameters);
+            public static void GetNamedRenderbufferParameteriv(int renderbuffer, RenderbufferParameterName pname, int* parameters) => GLPointers._GetNamedRenderbufferParameteriv_fnptr(renderbuffer, (uint)pname, parameters);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Create texture objects. </summary>
             /// <param name="target"> Specifies the effective texture target of each created texture. </param>
             /// <param name="n"> Number of texture objects to create. </param>
             /// <param name="textures"> Specifies an array in which names of the new texture objects are stored. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCreateTextures.xhtml" /></remarks>
-            public static void CreateTextures(TextureTarget target, int n, TextureHandle* textures) => GLPointers._CreateTextures_fnptr((uint)target, n, (int*)textures);
+            public static void CreateTextures(TextureTarget target, int n, int* textures) => GLPointers._CreateTextures_fnptr((uint)target, n, textures);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Attach a buffer object's data store to a buffer texture object. </summary>
             /// <param name="texture"> Specifies the texture object name for glTextureBuffer. </param>
             /// <param name="internalformat"> Specifies the internal format of the data in the store belonging to buffer. </param>
             /// <param name="buffer"> Specifies the name of the buffer object whose storage to attach to the active buffer texture. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexBuffer.xhtml" /></remarks>
-            public static void TextureBuffer(TextureHandle texture, SizedInternalFormat internalformat, BufferHandle buffer) => GLPointers._TextureBuffer_fnptr((int)texture, (uint)internalformat, (int)buffer);
+            public static void TextureBuffer(int texture, SizedInternalFormat internalformat, int buffer) => GLPointers._TextureBuffer_fnptr(texture, (uint)internalformat, buffer);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Attach a range of a buffer object's data store to a buffer texture object. </summary>
             /// <param name="texture"> Specifies the texture object name for glTextureBufferRange. </param>
@@ -7725,7 +7725,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="offset"> Specifies the offset of the start of the range of the buffer's data store to attach. </param>
             /// <param name="size"> Specifies the size of the range of the buffer's data store to attach. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexBufferRange.xhtml" /></remarks>
-            public static void TextureBufferRange(TextureHandle texture, SizedInternalFormat internalformat, BufferHandle buffer, IntPtr offset, nint size) => GLPointers._TextureBufferRange_fnptr((int)texture, (uint)internalformat, (int)buffer, offset, size);
+            public static void TextureBufferRange(int texture, SizedInternalFormat internalformat, int buffer, IntPtr offset, nint size) => GLPointers._TextureBufferRange_fnptr(texture, (uint)internalformat, buffer, offset, size);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Simultaneously specify storage for all levels of a one-dimensional texture. </summary>
             /// <param name="texture"> Specifies the texture object name for glTextureStorage1D. The effective target of texture must be one of the valid non-proxy target values above. </param>
@@ -7733,7 +7733,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="internalformat"> Specifies the sized internal format to be used to store texture image data. </param>
             /// <param name="width"> Specifies the width of the texture, in texels. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexStorage1D.xhtml" /></remarks>
-            public static void TextureStorage1D(TextureHandle texture, int levels, SizedInternalFormat internalformat, int width) => GLPointers._TextureStorage1D_fnptr((int)texture, levels, (uint)internalformat, width);
+            public static void TextureStorage1D(int texture, int levels, SizedInternalFormat internalformat, int width) => GLPointers._TextureStorage1D_fnptr(texture, levels, (uint)internalformat, width);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Simultaneously specify storage for all levels of a two-dimensional or one-dimensional array texture. </summary>
             /// <param name="texture"> Specifies the texture object name for glTextureStorage2D. The effective target of texture must be one of the valid non-proxy target values above. </param>
@@ -7742,7 +7742,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="width"> Specifies the width of the texture, in texels. </param>
             /// <param name="height"> Specifies the height of the texture, in texels. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexStorage2D.xhtml" /></remarks>
-            public static void TextureStorage2D(TextureHandle texture, int levels, SizedInternalFormat internalformat, int width, int height) => GLPointers._TextureStorage2D_fnptr((int)texture, levels, (uint)internalformat, width, height);
+            public static void TextureStorage2D(int texture, int levels, SizedInternalFormat internalformat, int width, int height) => GLPointers._TextureStorage2D_fnptr(texture, levels, (uint)internalformat, width, height);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Simultaneously specify storage for all levels of a three-dimensional, two-dimensional array or cube-map array texture. </summary>
             /// <param name="texture"> Specifies the texture object name for glTextureStorage3D. The effective target of texture must be one of the valid non-proxy target values above. </param>
@@ -7752,7 +7752,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="height"> Specifies the height of the texture, in texels. </param>
             /// <param name="depth"> Specifies the depth of the texture, in texels. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexStorage3D.xhtml" /></remarks>
-            public static void TextureStorage3D(TextureHandle texture, int levels, SizedInternalFormat internalformat, int width, int height, int depth) => GLPointers._TextureStorage3D_fnptr((int)texture, levels, (uint)internalformat, width, height, depth);
+            public static void TextureStorage3D(int texture, int levels, SizedInternalFormat internalformat, int width, int height, int depth) => GLPointers._TextureStorage3D_fnptr(texture, levels, (uint)internalformat, width, height, depth);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specify storage for a two-dimensional multisample texture. </summary>
             /// <param name="texture"> Specifies the texture object name for glTextureStorage2DMultisample. The effective target of texture must be one of the valid non-proxy target values above. </param>
@@ -7762,7 +7762,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="height"> Specifies the height of the texture, in texels. </param>
             /// <param name="fixedsamplelocations"> Specifies whether the image will use identical sample locations and the same number of samples for all texels in the image, and the sample locations will not depend on the internal format or size of the image. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexStorage2DMultisample.xhtml" /></remarks>
-            public static void TextureStorage2DMultisample(TextureHandle texture, int samples, SizedInternalFormat internalformat, int width, int height, bool fixedsamplelocations) => GLPointers._TextureStorage2DMultisample_fnptr((int)texture, samples, (uint)internalformat, width, height, (byte)(fixedsamplelocations ? 1 : 0));
+            public static void TextureStorage2DMultisample(int texture, int samples, SizedInternalFormat internalformat, int width, int height, bool fixedsamplelocations) => GLPointers._TextureStorage2DMultisample_fnptr(texture, samples, (uint)internalformat, width, height, (byte)(fixedsamplelocations ? 1 : 0));
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specify storage for a two-dimensional multisample array texture. </summary>
             /// <param name="texture"> Specifies the texture object name for glTextureStorage3DMultisample. The effective target of texture must be one of the valid non-proxy target values above. </param>
@@ -7773,7 +7773,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="depth"> Specifies the depth of the texture, in layers. </param>
             /// <param name="fixedsamplelocations"> Specifies whether the image will use identical sample locations and the same number of samples for all texels in the image, and the sample locations will not depend on the internal format or size of the image. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexStorage3DMultisample.xhtml" /></remarks>
-            public static void TextureStorage3DMultisample(TextureHandle texture, int samples, SizedInternalFormat internalformat, int width, int height, int depth, bool fixedsamplelocations) => GLPointers._TextureStorage3DMultisample_fnptr((int)texture, samples, (uint)internalformat, width, height, depth, (byte)(fixedsamplelocations ? 1 : 0));
+            public static void TextureStorage3DMultisample(int texture, int samples, SizedInternalFormat internalformat, int width, int height, int depth, bool fixedsamplelocations) => GLPointers._TextureStorage3DMultisample_fnptr(texture, samples, (uint)internalformat, width, height, depth, (byte)(fixedsamplelocations ? 1 : 0));
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specify a one-dimensional texture subimage. </summary>
             /// <param name="texture"> Specifies the texture object name for glTextureSubImage1D. The effective target of texture must be one of the valid target values above. </param>
@@ -7784,7 +7784,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="type"> Specifies the data type of the pixel data. The following symbolic values are accepted: GL_UNSIGNED_BYTE, GL_BYTE, GL_UNSIGNED_SHORT, GL_SHORT, GL_UNSIGNED_INT, GL_INT, GL_FLOAT, GL_UNSIGNED_BYTE_3_3_2, GL_UNSIGNED_BYTE_2_3_3_REV, GL_UNSIGNED_SHORT_5_6_5, GL_UNSIGNED_SHORT_5_6_5_REV, GL_UNSIGNED_SHORT_4_4_4_4, GL_UNSIGNED_SHORT_4_4_4_4_REV, GL_UNSIGNED_SHORT_5_5_5_1, GL_UNSIGNED_SHORT_1_5_5_5_REV, GL_UNSIGNED_INT_8_8_8_8, GL_UNSIGNED_INT_8_8_8_8_REV, GL_UNSIGNED_INT_10_10_10_2, and GL_UNSIGNED_INT_2_10_10_10_REV. </param>
             /// <param name="pixels"> Specifies a pointer to the image data in memory. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexSubImage1D.xhtml" /></remarks>
-            public static void TextureSubImage1D(TextureHandle texture, int level, int xoffset, int width, PixelFormat format, PixelType type, void* pixels) => GLPointers._TextureSubImage1D_fnptr((int)texture, level, xoffset, width, (uint)format, (uint)type, pixels);
+            public static void TextureSubImage1D(int texture, int level, int xoffset, int width, PixelFormat format, PixelType type, void* pixels) => GLPointers._TextureSubImage1D_fnptr(texture, level, xoffset, width, (uint)format, (uint)type, pixels);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specify a two-dimensional texture subimage. </summary>
             /// <param name="texture"> Specifies the texture object name for glTextureSubImage2D. The effective target of texture must be one of the valid target values above. </param>
@@ -7797,7 +7797,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="type"> Specifies the data type of the pixel data. The following symbolic values are accepted: GL_UNSIGNED_BYTE, GL_BYTE, GL_UNSIGNED_SHORT, GL_SHORT, GL_UNSIGNED_INT, GL_INT, GL_FLOAT, GL_UNSIGNED_BYTE_3_3_2, GL_UNSIGNED_BYTE_2_3_3_REV, GL_UNSIGNED_SHORT_5_6_5, GL_UNSIGNED_SHORT_5_6_5_REV, GL_UNSIGNED_SHORT_4_4_4_4, GL_UNSIGNED_SHORT_4_4_4_4_REV, GL_UNSIGNED_SHORT_5_5_5_1, GL_UNSIGNED_SHORT_1_5_5_5_REV, GL_UNSIGNED_INT_8_8_8_8, GL_UNSIGNED_INT_8_8_8_8_REV, GL_UNSIGNED_INT_10_10_10_2, and GL_UNSIGNED_INT_2_10_10_10_REV. </param>
             /// <param name="pixels"> Specifies a pointer to the image data in memory. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexSubImage2D.xhtml" /></remarks>
-            public static void TextureSubImage2D(TextureHandle texture, int level, int xoffset, int yoffset, int width, int height, PixelFormat format, PixelType type, void* pixels) => GLPointers._TextureSubImage2D_fnptr((int)texture, level, xoffset, yoffset, width, height, (uint)format, (uint)type, pixels);
+            public static void TextureSubImage2D(int texture, int level, int xoffset, int yoffset, int width, int height, PixelFormat format, PixelType type, void* pixels) => GLPointers._TextureSubImage2D_fnptr(texture, level, xoffset, yoffset, width, height, (uint)format, (uint)type, pixels);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specify a three-dimensional texture subimage. </summary>
             /// <param name="texture"> Specifies the texture object name for glTextureSubImage3D. The effective target of texture must be one of the valid target values above. </param>
@@ -7812,7 +7812,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="type"> Specifies the data type of the pixel data. The following symbolic values are accepted: GL_UNSIGNED_BYTE, GL_BYTE, GL_UNSIGNED_SHORT, GL_SHORT, GL_UNSIGNED_INT, GL_INT, GL_FLOAT, GL_UNSIGNED_BYTE_3_3_2, GL_UNSIGNED_BYTE_2_3_3_REV, GL_UNSIGNED_SHORT_5_6_5, GL_UNSIGNED_SHORT_5_6_5_REV, GL_UNSIGNED_SHORT_4_4_4_4, GL_UNSIGNED_SHORT_4_4_4_4_REV, GL_UNSIGNED_SHORT_5_5_5_1, GL_UNSIGNED_SHORT_1_5_5_5_REV, GL_UNSIGNED_INT_8_8_8_8, GL_UNSIGNED_INT_8_8_8_8_REV, GL_UNSIGNED_INT_10_10_10_2, and GL_UNSIGNED_INT_2_10_10_10_REV. </param>
             /// <param name="pixels"> Specifies a pointer to the image data in memory. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexSubImage3D.xhtml" /></remarks>
-            public static void TextureSubImage3D(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, void* pixels) => GLPointers._TextureSubImage3D_fnptr((int)texture, level, xoffset, yoffset, zoffset, width, height, depth, (uint)format, (uint)type, pixels);
+            public static void TextureSubImage3D(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, void* pixels) => GLPointers._TextureSubImage3D_fnptr(texture, level, xoffset, yoffset, zoffset, width, height, depth, (uint)format, (uint)type, pixels);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specify a one-dimensional texture subimage in a compressed    format. </summary>
             /// <param name="texture">Specifies the texture object name for glCompressedTextureSubImage1D function.</param>
@@ -7823,7 +7823,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="imageSize">Specifies the number of unsigned bytes of image data starting at the address specified by data.</param>
             /// <param name="data">Specifies a pointer to the compressed image data in memory.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCompressedTexSubImage1D.xhtml" /></remarks>
-            public static void CompressedTextureSubImage1D(TextureHandle texture, int level, int xoffset, int width, InternalFormat format, int imageSize, void* data) => GLPointers._CompressedTextureSubImage1D_fnptr((int)texture, level, xoffset, width, (uint)format, imageSize, data);
+            public static void CompressedTextureSubImage1D(int texture, int level, int xoffset, int width, InternalFormat format, int imageSize, void* data) => GLPointers._CompressedTextureSubImage1D_fnptr(texture, level, xoffset, width, (uint)format, imageSize, data);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specify a two-dimensional texture subimage in a compressed format. </summary>
             /// <param name="texture">Specifies the texture object name for glCompressedTextureSubImage2D function.</param>
@@ -7836,7 +7836,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="imageSize">Specifies the number of unsigned bytes of image data starting at the address specified by data.</param>
             /// <param name="data">Specifies a pointer to the compressed image data in memory.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCompressedTexSubImage2D.xhtml" /></remarks>
-            public static void CompressedTextureSubImage2D(TextureHandle texture, int level, int xoffset, int yoffset, int width, int height, InternalFormat format, int imageSize, void* data) => GLPointers._CompressedTextureSubImage2D_fnptr((int)texture, level, xoffset, yoffset, width, height, (uint)format, imageSize, data);
+            public static void CompressedTextureSubImage2D(int texture, int level, int xoffset, int yoffset, int width, int height, InternalFormat format, int imageSize, void* data) => GLPointers._CompressedTextureSubImage2D_fnptr(texture, level, xoffset, yoffset, width, height, (uint)format, imageSize, data);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specify a three-dimensional texture subimage in a compressed format. </summary>
             /// <param name="texture">Specifies the texture object name for glCompressedTextureSubImage3D function.</param>
@@ -7851,7 +7851,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="imageSize">Specifies the number of unsigned bytes of image data starting at the address specified by data.</param>
             /// <param name="data">Specifies a pointer to the compressed image data in memory.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCompressedTexSubImage3D.xhtml" /></remarks>
-            public static void CompressedTextureSubImage3D(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, InternalFormat format, int imageSize, void* data) => GLPointers._CompressedTextureSubImage3D_fnptr((int)texture, level, xoffset, yoffset, zoffset, width, height, depth, (uint)format, imageSize, data);
+            public static void CompressedTextureSubImage3D(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, InternalFormat format, int imageSize, void* data) => GLPointers._CompressedTextureSubImage3D_fnptr(texture, level, xoffset, yoffset, zoffset, width, height, depth, (uint)format, imageSize, data);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Copy a one-dimensional texture subimage. </summary>
             /// <param name="texture">Specifies the texture object name for glCopyTextureSubImage1D function.</param>
@@ -7861,7 +7861,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="y">Specify the window coordinates of the left corner of the row of pixels to be copied.</param>
             /// <param name="width">Specifies the width of the texture subimage.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCopyTexSubImage1D.xhtml" /></remarks>
-            public static void CopyTextureSubImage1D(TextureHandle texture, int level, int xoffset, int x, int y, int width) => GLPointers._CopyTextureSubImage1D_fnptr((int)texture, level, xoffset, x, y, width);
+            public static void CopyTextureSubImage1D(int texture, int level, int xoffset, int x, int y, int width) => GLPointers._CopyTextureSubImage1D_fnptr(texture, level, xoffset, x, y, width);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Copy a two-dimensional texture subimage. </summary>
             /// <param name="texture">Specifies the texture object name for glCopyTextureSubImage2D function.</param>
@@ -7873,7 +7873,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="width">Specifies the width of the texture subimage.</param>
             /// <param name="height">Specifies the height of the texture subimage.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCopyTexSubImage2D.xhtml" /></remarks>
-            public static void CopyTextureSubImage2D(TextureHandle texture, int level, int xoffset, int yoffset, int x, int y, int width, int height) => GLPointers._CopyTextureSubImage2D_fnptr((int)texture, level, xoffset, yoffset, x, y, width, height);
+            public static void CopyTextureSubImage2D(int texture, int level, int xoffset, int yoffset, int x, int y, int width, int height) => GLPointers._CopyTextureSubImage2D_fnptr(texture, level, xoffset, yoffset, x, y, width, height);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Copy a three-dimensional texture subimage. </summary>
             /// <param name="texture">Specifies the texture object name for glCopyTextureSubImage3D function.</param>
@@ -7886,60 +7886,60 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="width">Specifies the width of the texture subimage.</param>
             /// <param name="height">Specifies the height of the texture subimage.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCopyTexSubImage3D.xhtml" /></remarks>
-            public static void CopyTextureSubImage3D(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int x, int y, int width, int height) => GLPointers._CopyTextureSubImage3D_fnptr((int)texture, level, xoffset, yoffset, zoffset, x, y, width, height);
+            public static void CopyTextureSubImage3D(int texture, int level, int xoffset, int yoffset, int zoffset, int x, int y, int width, int height) => GLPointers._CopyTextureSubImage3D_fnptr(texture, level, xoffset, yoffset, zoffset, x, y, width, height);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Set texture parameters. </summary>
             /// <param name="texture">Specifies the texture object name for glTextureParameter functions.</param>
             /// <param name="pname">Specifies the symbolic name of a single-valued texture parameter. pname can be one of the following: GL_DEPTH_STENCIL_TEXTURE_MODE, GL_TEXTURE_BASE_LEVEL, GL_TEXTURE_COMPARE_FUNC, GL_TEXTURE_COMPARE_MODE, GL_TEXTURE_LOD_BIAS, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_MAX_LEVEL, GL_TEXTURE_SWIZZLE_R, GL_TEXTURE_SWIZZLE_G, GL_TEXTURE_SWIZZLE_B, GL_TEXTURE_SWIZZLE_A, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, or GL_TEXTURE_WRAP_R.</param>
             /// <param name="param">For the scalar commands, specifies the value of pname.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexParameter.xhtml" /></remarks>
-            public static void TextureParameterf(TextureHandle texture, TextureParameterName pname, float param) => GLPointers._TextureParameterf_fnptr((int)texture, (uint)pname, param);
+            public static void TextureParameterf(int texture, TextureParameterName pname, float param) => GLPointers._TextureParameterf_fnptr(texture, (uint)pname, param);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Set texture parameters. </summary>
             /// <param name="texture">Specifies the texture object name for glTextureParameter functions.</param>
             /// <param name="pname">Specifies the symbolic name of a single-valued texture parameter. pname can be one of the following: GL_DEPTH_STENCIL_TEXTURE_MODE, GL_TEXTURE_BASE_LEVEL, GL_TEXTURE_COMPARE_FUNC, GL_TEXTURE_COMPARE_MODE, GL_TEXTURE_LOD_BIAS, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_MAX_LEVEL, GL_TEXTURE_SWIZZLE_R, GL_TEXTURE_SWIZZLE_G, GL_TEXTURE_SWIZZLE_B, GL_TEXTURE_SWIZZLE_A, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, or GL_TEXTURE_WRAP_R.</param>
             /// <param name="parameters">For the vector commands, specifies a pointer to an array where the value or values of pname are stored.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexParameter.xhtml" /></remarks>
-            public static void TextureParameterfv(TextureHandle texture, TextureParameterName pname, float* param) => GLPointers._TextureParameterfv_fnptr((int)texture, (uint)pname, param);
+            public static void TextureParameterfv(int texture, TextureParameterName pname, float* param) => GLPointers._TextureParameterfv_fnptr(texture, (uint)pname, param);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Set texture parameters. </summary>
             /// <param name="texture">Specifies the texture object name for glTextureParameter functions.</param>
             /// <param name="pname">Specifies the symbolic name of a single-valued texture parameter. pname can be one of the following: GL_DEPTH_STENCIL_TEXTURE_MODE, GL_TEXTURE_BASE_LEVEL, GL_TEXTURE_COMPARE_FUNC, GL_TEXTURE_COMPARE_MODE, GL_TEXTURE_LOD_BIAS, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_MAX_LEVEL, GL_TEXTURE_SWIZZLE_R, GL_TEXTURE_SWIZZLE_G, GL_TEXTURE_SWIZZLE_B, GL_TEXTURE_SWIZZLE_A, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, or GL_TEXTURE_WRAP_R.</param>
             /// <param name="param">For the scalar commands, specifies the value of pname.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexParameter.xhtml" /></remarks>
-            public static void TextureParameteri(TextureHandle texture, TextureParameterName pname, int param) => GLPointers._TextureParameteri_fnptr((int)texture, (uint)pname, param);
+            public static void TextureParameteri(int texture, TextureParameterName pname, int param) => GLPointers._TextureParameteri_fnptr(texture, (uint)pname, param);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Set texture parameters. </summary>
             /// <param name="texture">Specifies the texture object name for glTextureParameter functions.</param>
             /// <param name="pname">Specifies the symbolic name of a single-valued texture parameter. pname can be one of the following: GL_DEPTH_STENCIL_TEXTURE_MODE, GL_TEXTURE_BASE_LEVEL, GL_TEXTURE_COMPARE_FUNC, GL_TEXTURE_COMPARE_MODE, GL_TEXTURE_LOD_BIAS, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_MAX_LEVEL, GL_TEXTURE_SWIZZLE_R, GL_TEXTURE_SWIZZLE_G, GL_TEXTURE_SWIZZLE_B, GL_TEXTURE_SWIZZLE_A, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, or GL_TEXTURE_WRAP_R.</param>
             /// <param name="parameters">For the vector commands, specifies a pointer to an array where the value or values of pname are stored.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexParameter.xhtml" /></remarks>
-            public static void TextureParameterIiv(TextureHandle texture, TextureParameterName pname, int* parameters) => GLPointers._TextureParameterIiv_fnptr((int)texture, (uint)pname, parameters);
+            public static void TextureParameterIiv(int texture, TextureParameterName pname, int* parameters) => GLPointers._TextureParameterIiv_fnptr(texture, (uint)pname, parameters);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Set texture parameters. </summary>
             /// <param name="texture">Specifies the texture object name for glTextureParameter functions.</param>
             /// <param name="pname">Specifies the symbolic name of a single-valued texture parameter. pname can be one of the following: GL_DEPTH_STENCIL_TEXTURE_MODE, GL_TEXTURE_BASE_LEVEL, GL_TEXTURE_COMPARE_FUNC, GL_TEXTURE_COMPARE_MODE, GL_TEXTURE_LOD_BIAS, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_MAX_LEVEL, GL_TEXTURE_SWIZZLE_R, GL_TEXTURE_SWIZZLE_G, GL_TEXTURE_SWIZZLE_B, GL_TEXTURE_SWIZZLE_A, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, or GL_TEXTURE_WRAP_R.</param>
             /// <param name="parameters">For the vector commands, specifies a pointer to an array where the value or values of pname are stored.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexParameter.xhtml" /></remarks>
-            public static void TextureParameterIuiv(TextureHandle texture, TextureParameterName pname, uint* parameters) => GLPointers._TextureParameterIuiv_fnptr((int)texture, (uint)pname, parameters);
+            public static void TextureParameterIuiv(int texture, TextureParameterName pname, uint* parameters) => GLPointers._TextureParameterIuiv_fnptr(texture, (uint)pname, parameters);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Set texture parameters. </summary>
             /// <param name="texture">Specifies the texture object name for glTextureParameter functions.</param>
             /// <param name="pname">Specifies the symbolic name of a single-valued texture parameter. pname can be one of the following: GL_DEPTH_STENCIL_TEXTURE_MODE, GL_TEXTURE_BASE_LEVEL, GL_TEXTURE_COMPARE_FUNC, GL_TEXTURE_COMPARE_MODE, GL_TEXTURE_LOD_BIAS, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_MAX_LEVEL, GL_TEXTURE_SWIZZLE_R, GL_TEXTURE_SWIZZLE_G, GL_TEXTURE_SWIZZLE_B, GL_TEXTURE_SWIZZLE_A, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, or GL_TEXTURE_WRAP_R.</param>
             /// <param name="parameters">For the vector commands, specifies a pointer to an array where the value or values of pname are stored.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexParameter.xhtml" /></remarks>
-            public static void TextureParameteriv(TextureHandle texture, TextureParameterName pname, int* param) => GLPointers._TextureParameteriv_fnptr((int)texture, (uint)pname, param);
+            public static void TextureParameteriv(int texture, TextureParameterName pname, int* param) => GLPointers._TextureParameteriv_fnptr(texture, (uint)pname, param);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Generate mipmaps for a specified texture object. </summary>
             /// <param name="texture"> Specifies the texture object name for glGenerateTextureMipmap. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGenerateMipmap.xhtml" /></remarks>
-            public static void GenerateTextureMipmap(TextureHandle texture) => GLPointers._GenerateTextureMipmap_fnptr((int)texture);
+            public static void GenerateTextureMipmap(int texture) => GLPointers._GenerateTextureMipmap_fnptr(texture);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Bind an existing texture object to the specified texture unit . </summary>
             /// <param name="unit">Specifies the texture unit, to which the texture object should be bound to. </param>
             /// <param name="texture">Specifies the name of a texture. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindTextureUnit.xhtml" /></remarks>
-            public static void BindTextureUnit(uint unit, TextureHandle texture) => GLPointers._BindTextureUnit_fnptr(unit, (int)texture);
+            public static void BindTextureUnit(uint unit, int texture) => GLPointers._BindTextureUnit_fnptr(unit, texture);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Return a texture image. </summary>
             /// <param name="texture"> Specifies the texture object name. </param>
@@ -7949,7 +7949,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="bufSize">Specifies the size of the buffer pixels for glGetnTexImage and glGetTextureImage functions.</param>
             /// <param name="pixels">Returns the texture image. Should be a pointer to an array of the type specified by type.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetTexImage.xhtml" /></remarks>
-            public static void GetTextureImage(TextureHandle texture, int level, PixelFormat format, PixelType type, int bufSize, void* pixels) => GLPointers._GetTextureImage_fnptr((int)texture, level, (uint)format, (uint)type, bufSize, pixels);
+            public static void GetTextureImage(int texture, int level, PixelFormat format, PixelType type, int bufSize, void* pixels) => GLPointers._GetTextureImage_fnptr(texture, level, (uint)format, (uint)type, bufSize, pixels);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Return a compressed texture image. </summary>
             /// <param name="texture">Specifies the texture object name for glGetCompressedTextureImage function.</param>
@@ -7957,7 +7957,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="bufSize">Specifies the size of the buffer pixels for glGetCompressedTextureImage and glGetnCompressedTexImage functions.</param>
             /// <param name="pixels">Returns the compressed texture image.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetCompressedTexImage.xhtml" /></remarks>
-            public static void GetCompressedTextureImage(TextureHandle texture, int level, int bufSize, void* pixels) => GLPointers._GetCompressedTextureImage_fnptr((int)texture, level, bufSize, pixels);
+            public static void GetCompressedTextureImage(int texture, int level, int bufSize, void* pixels) => GLPointers._GetCompressedTextureImage_fnptr(texture, level, bufSize, pixels);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Return texture parameter values for a specific level of    detail. </summary>
             /// <param name="texture">Specifies the texture object name for glGetTextureLevelParameterfv and glGetTextureLevelParameteriv functions.</param>
@@ -7965,7 +7965,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="pname">Specifies the symbolic name of a texture parameter. GL_TEXTURE_WIDTH, GL_TEXTURE_HEIGHT, GL_TEXTURE_DEPTH, GL_TEXTURE_INTERNAL_FORMAT, GL_TEXTURE_RED_SIZE, GL_TEXTURE_GREEN_SIZE, GL_TEXTURE_BLUE_SIZE, GL_TEXTURE_ALPHA_SIZE, GL_TEXTURE_DEPTH_SIZE, GL_TEXTURE_COMPRESSED, GL_TEXTURE_COMPRESSED_IMAGE_SIZE, and GL_TEXTURE_BUFFER_OFFSET are accepted.</param>
             /// <param name="parameters">Returns the requested data.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetTexLevelParameter.xhtml" /></remarks>
-            public static void GetTextureLevelParameterfv(TextureHandle texture, int level, GetTextureParameter pname, float* parameters) => GLPointers._GetTextureLevelParameterfv_fnptr((int)texture, level, (uint)pname, parameters);
+            public static void GetTextureLevelParameterfv(int texture, int level, GetTextureParameter pname, float* parameters) => GLPointers._GetTextureLevelParameterfv_fnptr(texture, level, (uint)pname, parameters);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Return texture parameter values for a specific level of    detail. </summary>
             /// <param name="texture">Specifies the texture object name for glGetTextureLevelParameterfv and glGetTextureLevelParameteriv functions.</param>
@@ -7973,59 +7973,59 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="pname">Specifies the symbolic name of a texture parameter. GL_TEXTURE_WIDTH, GL_TEXTURE_HEIGHT, GL_TEXTURE_DEPTH, GL_TEXTURE_INTERNAL_FORMAT, GL_TEXTURE_RED_SIZE, GL_TEXTURE_GREEN_SIZE, GL_TEXTURE_BLUE_SIZE, GL_TEXTURE_ALPHA_SIZE, GL_TEXTURE_DEPTH_SIZE, GL_TEXTURE_COMPRESSED, GL_TEXTURE_COMPRESSED_IMAGE_SIZE, and GL_TEXTURE_BUFFER_OFFSET are accepted.</param>
             /// <param name="parameters">Returns the requested data.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetTexLevelParameter.xhtml" /></remarks>
-            public static void GetTextureLevelParameteriv(TextureHandle texture, int level, GetTextureParameter pname, int* parameters) => GLPointers._GetTextureLevelParameteriv_fnptr((int)texture, level, (uint)pname, parameters);
+            public static void GetTextureLevelParameteriv(int texture, int level, GetTextureParameter pname, int* parameters) => GLPointers._GetTextureLevelParameteriv_fnptr(texture, level, (uint)pname, parameters);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Return texture parameter values. </summary>
             /// <param name="texture">Specifies the texture object name for glGetTextureParameterfv, glGetTextureParameteriv, glGetTextureParameterIiv, and glGetTextureParameterIuiv functions.</param>
             /// <param name="pname">Specifies the symbolic name of a texture parameter. GL_DEPTH_STENCIL_TEXTURE_MODE, GL_IMAGE_FORMAT_COMPATIBILITY_TYPE, GL_TEXTURE_BASE_LEVEL, GL_TEXTURE_BORDER_COLOR, GL_TEXTURE_COMPARE_MODE, GL_TEXTURE_COMPARE_FUNC, GL_TEXTURE_IMMUTABLE_FORMAT, GL_TEXTURE_IMMUTABLE_LEVELS, GL_TEXTURE_LOD_BIAS, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MAX_LEVEL, GL_TEXTURE_MAX_LOD, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_SWIZZLE_R, GL_TEXTURE_SWIZZLE_G, GL_TEXTURE_SWIZZLE_B, GL_TEXTURE_SWIZZLE_A, GL_TEXTURE_SWIZZLE_RGBA, GL_TEXTURE_TARGET, GL_TEXTURE_VIEW_MIN_LAYER, GL_TEXTURE_VIEW_MIN_LEVEL, GL_TEXTURE_VIEW_NUM_LAYERS, GL_TEXTURE_VIEW_NUM_LEVELS, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, and GL_TEXTURE_WRAP_R are accepted.</param>
             /// <param name="parameters">Returns the texture parameters.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetTexParameter.xhtml" /></remarks>
-            public static void GetTextureParameterfv(TextureHandle texture, GetTextureParameter pname, float* parameters) => GLPointers._GetTextureParameterfv_fnptr((int)texture, (uint)pname, parameters);
+            public static void GetTextureParameterfv(int texture, GetTextureParameter pname, float* parameters) => GLPointers._GetTextureParameterfv_fnptr(texture, (uint)pname, parameters);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Return texture parameter values. </summary>
             /// <param name="texture">Specifies the texture object name for glGetTextureParameterfv, glGetTextureParameteriv, glGetTextureParameterIiv, and glGetTextureParameterIuiv functions.</param>
             /// <param name="pname">Specifies the symbolic name of a texture parameter. GL_DEPTH_STENCIL_TEXTURE_MODE, GL_IMAGE_FORMAT_COMPATIBILITY_TYPE, GL_TEXTURE_BASE_LEVEL, GL_TEXTURE_BORDER_COLOR, GL_TEXTURE_COMPARE_MODE, GL_TEXTURE_COMPARE_FUNC, GL_TEXTURE_IMMUTABLE_FORMAT, GL_TEXTURE_IMMUTABLE_LEVELS, GL_TEXTURE_LOD_BIAS, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MAX_LEVEL, GL_TEXTURE_MAX_LOD, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_SWIZZLE_R, GL_TEXTURE_SWIZZLE_G, GL_TEXTURE_SWIZZLE_B, GL_TEXTURE_SWIZZLE_A, GL_TEXTURE_SWIZZLE_RGBA, GL_TEXTURE_TARGET, GL_TEXTURE_VIEW_MIN_LAYER, GL_TEXTURE_VIEW_MIN_LEVEL, GL_TEXTURE_VIEW_NUM_LAYERS, GL_TEXTURE_VIEW_NUM_LEVELS, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, and GL_TEXTURE_WRAP_R are accepted.</param>
             /// <param name="parameters">Returns the texture parameters.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetTexParameter.xhtml" /></remarks>
-            public static void GetTextureParameterIiv(TextureHandle texture, GetTextureParameter pname, int* parameters) => GLPointers._GetTextureParameterIiv_fnptr((int)texture, (uint)pname, parameters);
+            public static void GetTextureParameterIiv(int texture, GetTextureParameter pname, int* parameters) => GLPointers._GetTextureParameterIiv_fnptr(texture, (uint)pname, parameters);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Return texture parameter values. </summary>
             /// <param name="texture">Specifies the texture object name for glGetTextureParameterfv, glGetTextureParameteriv, glGetTextureParameterIiv, and glGetTextureParameterIuiv functions.</param>
             /// <param name="pname">Specifies the symbolic name of a texture parameter. GL_DEPTH_STENCIL_TEXTURE_MODE, GL_IMAGE_FORMAT_COMPATIBILITY_TYPE, GL_TEXTURE_BASE_LEVEL, GL_TEXTURE_BORDER_COLOR, GL_TEXTURE_COMPARE_MODE, GL_TEXTURE_COMPARE_FUNC, GL_TEXTURE_IMMUTABLE_FORMAT, GL_TEXTURE_IMMUTABLE_LEVELS, GL_TEXTURE_LOD_BIAS, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MAX_LEVEL, GL_TEXTURE_MAX_LOD, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_SWIZZLE_R, GL_TEXTURE_SWIZZLE_G, GL_TEXTURE_SWIZZLE_B, GL_TEXTURE_SWIZZLE_A, GL_TEXTURE_SWIZZLE_RGBA, GL_TEXTURE_TARGET, GL_TEXTURE_VIEW_MIN_LAYER, GL_TEXTURE_VIEW_MIN_LEVEL, GL_TEXTURE_VIEW_NUM_LAYERS, GL_TEXTURE_VIEW_NUM_LEVELS, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, and GL_TEXTURE_WRAP_R are accepted.</param>
             /// <param name="parameters">Returns the texture parameters.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetTexParameter.xhtml" /></remarks>
-            public static void GetTextureParameterIuiv(TextureHandle texture, GetTextureParameter pname, uint* parameters) => GLPointers._GetTextureParameterIuiv_fnptr((int)texture, (uint)pname, parameters);
+            public static void GetTextureParameterIuiv(int texture, GetTextureParameter pname, uint* parameters) => GLPointers._GetTextureParameterIuiv_fnptr(texture, (uint)pname, parameters);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Return texture parameter values. </summary>
             /// <param name="texture">Specifies the texture object name for glGetTextureParameterfv, glGetTextureParameteriv, glGetTextureParameterIiv, and glGetTextureParameterIuiv functions.</param>
             /// <param name="pname">Specifies the symbolic name of a texture parameter. GL_DEPTH_STENCIL_TEXTURE_MODE, GL_IMAGE_FORMAT_COMPATIBILITY_TYPE, GL_TEXTURE_BASE_LEVEL, GL_TEXTURE_BORDER_COLOR, GL_TEXTURE_COMPARE_MODE, GL_TEXTURE_COMPARE_FUNC, GL_TEXTURE_IMMUTABLE_FORMAT, GL_TEXTURE_IMMUTABLE_LEVELS, GL_TEXTURE_LOD_BIAS, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MAX_LEVEL, GL_TEXTURE_MAX_LOD, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_SWIZZLE_R, GL_TEXTURE_SWIZZLE_G, GL_TEXTURE_SWIZZLE_B, GL_TEXTURE_SWIZZLE_A, GL_TEXTURE_SWIZZLE_RGBA, GL_TEXTURE_TARGET, GL_TEXTURE_VIEW_MIN_LAYER, GL_TEXTURE_VIEW_MIN_LEVEL, GL_TEXTURE_VIEW_NUM_LAYERS, GL_TEXTURE_VIEW_NUM_LEVELS, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, and GL_TEXTURE_WRAP_R are accepted.</param>
             /// <param name="parameters">Returns the texture parameters.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetTexParameter.xhtml" /></remarks>
-            public static void GetTextureParameteriv(TextureHandle texture, GetTextureParameter pname, int* parameters) => GLPointers._GetTextureParameteriv_fnptr((int)texture, (uint)pname, parameters);
+            public static void GetTextureParameteriv(int texture, GetTextureParameter pname, int* parameters) => GLPointers._GetTextureParameteriv_fnptr(texture, (uint)pname, parameters);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Create vertex array objects. </summary>
             /// <param name="n"> Number of vertex array objects to create. </param>
             /// <param name="arrays"> Specifies an array in which names of the new vertex array objects are stored. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCreateVertexArrays.xhtml" /></remarks>
-            public static void CreateVertexArrays(int n, VertexArrayHandle* arrays) => GLPointers._CreateVertexArrays_fnptr(n, (int*)arrays);
+            public static void CreateVertexArrays(int n, int* arrays) => GLPointers._CreateVertexArrays_fnptr(n, arrays);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Enable or disable a generic vertex attribute    array. </summary>
             /// <param name="vaobj">Specifies the name of the vertex array object for glDisableVertexArrayAttrib and glEnableVertexArrayAttrib functions.</param>
             /// <param name="index">Specifies the index of the generic vertex attribute to be enabled or disabled.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glEnableVertexAttribArray.xhtml" /></remarks>
-            public static void DisableVertexArrayAttrib(VertexArrayHandle vaobj, uint index) => GLPointers._DisableVertexArrayAttrib_fnptr((int)vaobj, index);
+            public static void DisableVertexArrayAttrib(int vaobj, uint index) => GLPointers._DisableVertexArrayAttrib_fnptr(vaobj, index);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Enable or disable a generic vertex attribute    array. </summary>
             /// <param name="vaobj">Specifies the name of the vertex array object for glDisableVertexArrayAttrib and glEnableVertexArrayAttrib functions.</param>
             /// <param name="index">Specifies the index of the generic vertex attribute to be enabled or disabled.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glEnableVertexAttribArray.xhtml" /></remarks>
-            public static void EnableVertexArrayAttrib(VertexArrayHandle vaobj, uint index) => GLPointers._EnableVertexArrayAttrib_fnptr((int)vaobj, index);
+            public static void EnableVertexArrayAttrib(int vaobj, uint index) => GLPointers._EnableVertexArrayAttrib_fnptr(vaobj, index);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Configures element array buffer binding of a vertex array object. </summary>
             /// <param name="vaobj"> Specifies the name of the vertex array object. </param>
             /// <param name="buffer"> Specifies the name of the buffer object to use for the element array buffer binding. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glVertexArrayElementBuffer.xhtml" /></remarks>
-            public static void VertexArrayElementBuffer(VertexArrayHandle vaobj, BufferHandle buffer) => GLPointers._VertexArrayElementBuffer_fnptr((int)vaobj, (int)buffer);
+            public static void VertexArrayElementBuffer(int vaobj, int buffer) => GLPointers._VertexArrayElementBuffer_fnptr(vaobj, buffer);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Bind a buffer to a vertex buffer bind point. </summary>
             /// <param name="vaobj">Specifies the name of the vertex array object to be used by glVertexArrayVertexBuffer function.</param>
@@ -8034,7 +8034,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="offset">The offset of the first element of the buffer.</param>
             /// <param name="stride">The distance between elements within the buffer.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindVertexBuffer.xhtml" /></remarks>
-            public static void VertexArrayVertexBuffer(VertexArrayHandle vaobj, uint bindingindex, BufferHandle buffer, IntPtr offset, int stride) => GLPointers._VertexArrayVertexBuffer_fnptr((int)vaobj, bindingindex, (int)buffer, offset, stride);
+            public static void VertexArrayVertexBuffer(int vaobj, uint bindingindex, int buffer, IntPtr offset, int stride) => GLPointers._VertexArrayVertexBuffer_fnptr(vaobj, bindingindex, buffer, offset, stride);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Attach multiple buffer objects to a vertex array object. </summary>
             /// <param name="vaobj"> Specifies the name of the vertex array object for glVertexArrayVertexBuffers. </param>
@@ -8044,14 +8044,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="offsets"> Specifies the address of an array of offsets to associate with the binding points. </param>
             /// <param name="strides">!!missing documentation!!</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindVertexBuffers.xhtml" /></remarks>
-            public static void VertexArrayVertexBuffers(VertexArrayHandle vaobj, uint first, int count, BufferHandle* buffers, IntPtr* offsets, int* strides) => GLPointers._VertexArrayVertexBuffers_fnptr((int)vaobj, first, count, (int*)buffers, offsets, strides);
+            public static void VertexArrayVertexBuffers(int vaobj, uint first, int count, int* buffers, IntPtr* offsets, int* strides) => GLPointers._VertexArrayVertexBuffers_fnptr(vaobj, first, count, buffers, offsets, strides);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Associate a vertex attribute and a vertex buffer binding for a vertex array object. </summary>
             /// <param name="vaobj"> Specifies the name of the vertex array object for glVertexArrayAttribBinding. </param>
             /// <param name="attribindex"> The index of the attribute to associate with a vertex buffer binding. </param>
             /// <param name="bindingindex"> The index of the vertex buffer binding with which to associate the generic vertex attribute. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glVertexAttribBinding.xhtml" /></remarks>
-            public static void VertexArrayAttribBinding(VertexArrayHandle vaobj, uint attribindex, uint bindingindex) => GLPointers._VertexArrayAttribBinding_fnptr((int)vaobj, attribindex, bindingindex);
+            public static void VertexArrayAttribBinding(int vaobj, uint attribindex, uint bindingindex) => GLPointers._VertexArrayAttribBinding_fnptr(vaobj, attribindex, bindingindex);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specify the organization of vertex arrays. </summary>
             /// <param name="vaobj">Specifies the name of the vertex array object for glVertexArrayAttrib{I, L}Format functions.</param>
@@ -8061,7 +8061,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="normalized"> Specifies whether fixed-point data values should be normalized (GL_TRUE) or converted directly as fixed-point values (GL_FALSE) when they are accessed. This parameter is ignored if type is GL_FIXED. </param>
             /// <param name="relativeoffset">The distance between elements within the buffer.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glVertexAttribFormat.xhtml" /></remarks>
-            public static void VertexArrayAttribFormat(VertexArrayHandle vaobj, uint attribindex, int size, VertexAttribType type, bool normalized, uint relativeoffset) => GLPointers._VertexArrayAttribFormat_fnptr((int)vaobj, attribindex, size, (uint)type, (byte)(normalized ? 1 : 0), relativeoffset);
+            public static void VertexArrayAttribFormat(int vaobj, uint attribindex, int size, VertexAttribType type, bool normalized, uint relativeoffset) => GLPointers._VertexArrayAttribFormat_fnptr(vaobj, attribindex, size, (uint)type, (byte)(normalized ? 1 : 0), relativeoffset);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specify the organization of vertex arrays. </summary>
             /// <param name="vaobj">Specifies the name of the vertex array object for glVertexArrayAttrib{I, L}Format functions.</param>
@@ -8070,7 +8070,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="type">The type of the data stored in the array.</param>
             /// <param name="relativeoffset">The distance between elements within the buffer.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glVertexAttribFormat.xhtml" /></remarks>
-            public static void VertexArrayAttribIFormat(VertexArrayHandle vaobj, uint attribindex, int size, VertexAttribIType type, uint relativeoffset) => GLPointers._VertexArrayAttribIFormat_fnptr((int)vaobj, attribindex, size, (uint)type, relativeoffset);
+            public static void VertexArrayAttribIFormat(int vaobj, uint attribindex, int size, VertexAttribIType type, uint relativeoffset) => GLPointers._VertexArrayAttribIFormat_fnptr(vaobj, attribindex, size, (uint)type, relativeoffset);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specify the organization of vertex arrays. </summary>
             /// <param name="vaobj">Specifies the name of the vertex array object for glVertexArrayAttrib{I, L}Format functions.</param>
@@ -8079,21 +8079,21 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="type">The type of the data stored in the array.</param>
             /// <param name="relativeoffset">The distance between elements within the buffer.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glVertexAttribFormat.xhtml" /></remarks>
-            public static void VertexArrayAttribLFormat(VertexArrayHandle vaobj, uint attribindex, int size, VertexAttribLType type, uint relativeoffset) => GLPointers._VertexArrayAttribLFormat_fnptr((int)vaobj, attribindex, size, (uint)type, relativeoffset);
+            public static void VertexArrayAttribLFormat(int vaobj, uint attribindex, int size, VertexAttribLType type, uint relativeoffset) => GLPointers._VertexArrayAttribLFormat_fnptr(vaobj, attribindex, size, (uint)type, relativeoffset);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Modify the rate at which generic vertex attributes    advance. </summary>
             /// <param name="vaobj">Specifies the name of the vertex array object for glVertexArrayBindingDivisor function.</param>
             /// <param name="bindingindex">The index of the binding whose divisor to modify.</param>
             /// <param name="divisor">The new value for the instance step rate to apply.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glVertexBindingDivisor.xhtml" /></remarks>
-            public static void VertexArrayBindingDivisor(VertexArrayHandle vaobj, uint bindingindex, uint divisor) => GLPointers._VertexArrayBindingDivisor_fnptr((int)vaobj, bindingindex, divisor);
+            public static void VertexArrayBindingDivisor(int vaobj, uint bindingindex, uint divisor) => GLPointers._VertexArrayBindingDivisor_fnptr(vaobj, bindingindex, divisor);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Retrieve parameters of a vertex array object. </summary>
             /// <param name="vaobj">specifies the name of the vertex array object to use for the query.</param>
             /// <param name="pname">Name of the property to use for the query. Must be GL_ELEMENT_ARRAY_BUFFER_BINDING.</param>
             /// <param name="param">Returns the requested value.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetVertexArrayiv.xhtml" /></remarks>
-            public static void GetVertexArrayiv(VertexArrayHandle vaobj, VertexArrayPName pname, int* param) => GLPointers._GetVertexArrayiv_fnptr((int)vaobj, (uint)pname, param);
+            public static void GetVertexArrayiv(int vaobj, VertexArrayPName pname, int* param) => GLPointers._GetVertexArrayiv_fnptr(vaobj, (uint)pname, param);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Retrieve parameters of an attribute of a vertex array    object. </summary>
             /// <param name="vaobj">Specifies the name of a vertex array object.</param>
@@ -8101,7 +8101,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="pname">Specifies the property to be used for the query. For glGetVertexArrayIndexediv, it must be one of the following values: GL_VERTEX_ATTRIB_ARRAY_ENABLED, GL_VERTEX_ATTRIB_ARRAY_SIZE, GL_VERTEX_ATTRIB_ARRAY_STRIDE, GL_VERTEX_ATTRIB_ARRAY_TYPE, GL_VERTEX_ATTRIB_ARRAY_NORMALIZED, GL_VERTEX_ATTRIB_ARRAY_INTEGER, GL_VERTEX_ATTRIB_ARRAY_LONG, GL_VERTEX_ATTRIB_ARRAY_DIVISOR, or GL_VERTEX_ATTRIB_RELATIVE_OFFSET. For glGetVertexArrayIndexed64v, it must be equal to GL_VERTEX_BINDING_OFFSET.</param>
             /// <param name="param">Returns the requested value.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetVertexArrayIndexed.xhtml" /></remarks>
-            public static void GetVertexArrayIndexediv(VertexArrayHandle vaobj, uint index, VertexArrayPName pname, int* param) => GLPointers._GetVertexArrayIndexediv_fnptr((int)vaobj, index, (uint)pname, param);
+            public static void GetVertexArrayIndexediv(int vaobj, uint index, VertexArrayPName pname, int* param) => GLPointers._GetVertexArrayIndexediv_fnptr(vaobj, index, (uint)pname, param);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Retrieve parameters of an attribute of a vertex array    object. </summary>
             /// <param name="vaobj">Specifies the name of a vertex array object.</param>
@@ -8109,26 +8109,26 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="pname">Specifies the property to be used for the query. For glGetVertexArrayIndexediv, it must be one of the following values: GL_VERTEX_ATTRIB_ARRAY_ENABLED, GL_VERTEX_ATTRIB_ARRAY_SIZE, GL_VERTEX_ATTRIB_ARRAY_STRIDE, GL_VERTEX_ATTRIB_ARRAY_TYPE, GL_VERTEX_ATTRIB_ARRAY_NORMALIZED, GL_VERTEX_ATTRIB_ARRAY_INTEGER, GL_VERTEX_ATTRIB_ARRAY_LONG, GL_VERTEX_ATTRIB_ARRAY_DIVISOR, or GL_VERTEX_ATTRIB_RELATIVE_OFFSET. For glGetVertexArrayIndexed64v, it must be equal to GL_VERTEX_BINDING_OFFSET.</param>
             /// <param name="param">Returns the requested value.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetVertexArrayIndexed.xhtml" /></remarks>
-            public static void GetVertexArrayIndexed64iv(VertexArrayHandle vaobj, uint index, VertexArrayPName pname, long* param) => GLPointers._GetVertexArrayIndexed64iv_fnptr((int)vaobj, index, (uint)pname, param);
+            public static void GetVertexArrayIndexed64iv(int vaobj, uint index, VertexArrayPName pname, long* param) => GLPointers._GetVertexArrayIndexed64iv_fnptr(vaobj, index, (uint)pname, param);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Create sampler objects. </summary>
             /// <param name="n"> Number of sampler objects to create. </param>
             /// <param name="samplers"> Specifies an array in which names of the new sampler objects are stored. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCreateSamplers.xhtml" /></remarks>
-            public static void CreateSamplers(int n, SamplerHandle* samplers) => GLPointers._CreateSamplers_fnptr(n, (int*)samplers);
+            public static void CreateSamplers(int n, int* samplers) => GLPointers._CreateSamplers_fnptr(n, samplers);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Create program pipeline objects. </summary>
             /// <param name="n"> Number of program pipeline objects to create. </param>
             /// <param name="pipelines"> Specifies an array in which names of the new program pipeline objects are stored. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCreateProgramPipelines.xhtml" /></remarks>
-            public static void CreateProgramPipelines(int n, ProgramPipelineHandle* pipelines) => GLPointers._CreateProgramPipelines_fnptr(n, (int*)pipelines);
+            public static void CreateProgramPipelines(int n, int* pipelines) => GLPointers._CreateProgramPipelines_fnptr(n, pipelines);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Create query objects. </summary>
             /// <param name="target"> Specifies the target of each created query object. </param>
             /// <param name="n"> Number of query objects to create. </param>
             /// <param name="ids"> Specifies an array in which names of the new query objects are stored. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCreateQueries.xhtml" /></remarks>
-            public static void CreateQueries(QueryTarget target, int n, QueryHandle* ids) => GLPointers._CreateQueries_fnptr((uint)target, n, (int*)ids);
+            public static void CreateQueries(QueryTarget target, int n, int* ids) => GLPointers._CreateQueries_fnptr((uint)target, n, ids);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Return parameters of a query object. </summary>
             /// <param name="id"> Specifies the name of a query object. </param>
@@ -8136,7 +8136,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="pname"> Specifies the symbolic name of a query object parameter. Accepted values are GL_QUERY_RESULT or GL_QUERY_RESULT_AVAILABLE. </param>
             /// <param name="offset"> Specifies the byte offset into buffer's data store where the queried result will be written. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetQueryObject.xhtml" /></remarks>
-            public static void GetQueryBufferObjecti64v(QueryHandle id, BufferHandle buffer, QueryObjectParameterName pname, IntPtr offset) => GLPointers._GetQueryBufferObjecti64v_fnptr((int)id, (int)buffer, (uint)pname, offset);
+            public static void GetQueryBufferObjecti64v(int id, int buffer, QueryObjectParameterName pname, IntPtr offset) => GLPointers._GetQueryBufferObjecti64v_fnptr(id, buffer, (uint)pname, offset);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Return parameters of a query object. </summary>
             /// <param name="id"> Specifies the name of a query object. </param>
@@ -8144,7 +8144,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="pname"> Specifies the symbolic name of a query object parameter. Accepted values are GL_QUERY_RESULT or GL_QUERY_RESULT_AVAILABLE. </param>
             /// <param name="offset"> Specifies the byte offset into buffer's data store where the queried result will be written. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetQueryObject.xhtml" /></remarks>
-            public static void GetQueryBufferObjectiv(QueryHandle id, BufferHandle buffer, QueryObjectParameterName pname, IntPtr offset) => GLPointers._GetQueryBufferObjectiv_fnptr((int)id, (int)buffer, (uint)pname, offset);
+            public static void GetQueryBufferObjectiv(int id, int buffer, QueryObjectParameterName pname, IntPtr offset) => GLPointers._GetQueryBufferObjectiv_fnptr(id, buffer, (uint)pname, offset);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Return parameters of a query object. </summary>
             /// <param name="id"> Specifies the name of a query object. </param>
@@ -8152,7 +8152,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="pname"> Specifies the symbolic name of a query object parameter. Accepted values are GL_QUERY_RESULT or GL_QUERY_RESULT_AVAILABLE. </param>
             /// <param name="offset"> Specifies the byte offset into buffer's data store where the queried result will be written. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetQueryObject.xhtml" /></remarks>
-            public static void GetQueryBufferObjectui64v(QueryHandle id, BufferHandle buffer, QueryObjectParameterName pname, IntPtr offset) => GLPointers._GetQueryBufferObjectui64v_fnptr((int)id, (int)buffer, (uint)pname, offset);
+            public static void GetQueryBufferObjectui64v(int id, int buffer, QueryObjectParameterName pname, IntPtr offset) => GLPointers._GetQueryBufferObjectui64v_fnptr(id, buffer, (uint)pname, offset);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Return parameters of a query object. </summary>
             /// <param name="id"> Specifies the name of a query object. </param>
@@ -8160,7 +8160,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="pname"> Specifies the symbolic name of a query object parameter. Accepted values are GL_QUERY_RESULT or GL_QUERY_RESULT_AVAILABLE. </param>
             /// <param name="offset"> Specifies the byte offset into buffer's data store where the queried result will be written. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetQueryObject.xhtml" /></remarks>
-            public static void GetQueryBufferObjectuiv(QueryHandle id, BufferHandle buffer, QueryObjectParameterName pname, IntPtr offset) => GLPointers._GetQueryBufferObjectuiv_fnptr((int)id, (int)buffer, (uint)pname, offset);
+            public static void GetQueryBufferObjectuiv(int id, int buffer, QueryObjectParameterName pname, IntPtr offset) => GLPointers._GetQueryBufferObjectuiv_fnptr(id, buffer, (uint)pname, offset);
             
             /// <summary> <b>[requires: GL_ARB_draw_buffers]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -8249,15 +8249,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_ARB_fragment_program | GL_ARB_vertex_program]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void BindProgramARB(ProgramTarget target, ProgramHandle program) => GLPointers._BindProgramARB_fnptr((uint)target, (int)program);
+            public static void BindProgramARB(ProgramTarget target, int program) => GLPointers._BindProgramARB_fnptr((uint)target, program);
             
             /// <summary> <b>[requires: GL_ARB_fragment_program | GL_ARB_vertex_program]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void DeleteProgramsARB(int n, ProgramHandle* programs) => GLPointers._DeleteProgramsARB_fnptr(n, (int*)programs);
+            public static void DeleteProgramsARB(int n, int* programs) => GLPointers._DeleteProgramsARB_fnptr(n, programs);
             
             /// <summary> <b>[requires: GL_ARB_fragment_program | GL_ARB_vertex_program]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GenProgramsARB(int n, ProgramHandle* programs) => GLPointers._GenProgramsARB_fnptr(n, (int*)programs);
+            public static void GenProgramsARB(int n, int* programs) => GLPointers._GenProgramsARB_fnptr(n, programs);
             
             /// <summary> <b>[requires: GL_ARB_fragment_program | GL_ARB_vertex_program]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -8317,7 +8317,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_ARB_fragment_program | GL_ARB_vertex_program]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static bool IsProgramARB(ProgramHandle program) => GLPointers._IsProgramARB_fnptr((int)program) != 0;
+            public static bool IsProgramARB(int program) => GLPointers._IsProgramARB_fnptr(program) != 0;
             
             /// <summary> <b>[requires: v4.3 | GL_ARB_framebuffer_no_attachments]</b> Set a named parameter of a framebuffer object. </summary>
             /// <param name="target"> Specifies the target to which the framebuffer is bound for glFramebufferParameteri. </param>
@@ -8336,25 +8336,25 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Determine if a name corresponds to a renderbuffer object. </summary>
             /// <param name="renderbuffer"> Specifies a value that may be the name of a renderbuffer object. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsRenderbuffer.xhtml" /></remarks>
-            public static bool IsRenderbuffer(RenderbufferHandle renderbuffer) => GLPointers._IsRenderbuffer_fnptr((int)renderbuffer) != 0;
+            public static bool IsRenderbuffer(int renderbuffer) => GLPointers._IsRenderbuffer_fnptr(renderbuffer) != 0;
             
             /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Bind a renderbuffer to a renderbuffer target. </summary>
             /// <param name="target"> Specifies the renderbuffer target of the binding operation. target must be GL_RENDERBUFFER. </param>
             /// <param name="renderbuffer"> Specifies the name of the renderbuffer object to bind. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindRenderbuffer.xhtml" /></remarks>
-            public static void BindRenderbuffer(RenderbufferTarget target, RenderbufferHandle renderbuffer) => GLPointers._BindRenderbuffer_fnptr((uint)target, (int)renderbuffer);
+            public static void BindRenderbuffer(RenderbufferTarget target, int renderbuffer) => GLPointers._BindRenderbuffer_fnptr((uint)target, renderbuffer);
             
             /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Delete renderbuffer objects. </summary>
             /// <param name="n"> Specifies the number of renderbuffer objects to be deleted. </param>
             /// <param name="renderbuffers"> A pointer to an array containing n renderbuffer objects to be deleted. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDeleteRenderbuffers.xhtml" /></remarks>
-            public static void DeleteRenderbuffers(int n, RenderbufferHandle* renderbuffers) => GLPointers._DeleteRenderbuffers_fnptr(n, (int*)renderbuffers);
+            public static void DeleteRenderbuffers(int n, int* renderbuffers) => GLPointers._DeleteRenderbuffers_fnptr(n, renderbuffers);
             
             /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Generate renderbuffer object names. </summary>
             /// <param name="n"> Specifies the number of renderbuffer object names to generate. </param>
             /// <param name="renderbuffers"> Specifies an array in which the generated renderbuffer object names are stored. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGenRenderbuffers.xhtml" /></remarks>
-            public static void GenRenderbuffers(int n, RenderbufferHandle* renderbuffers) => GLPointers._GenRenderbuffers_fnptr(n, (int*)renderbuffers);
+            public static void GenRenderbuffers(int n, int* renderbuffers) => GLPointers._GenRenderbuffers_fnptr(n, renderbuffers);
             
             /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Establish data storage, format and dimensions of a    renderbuffer object's image. </summary>
             /// <param name="target">Specifies a binding target of the allocation for glRenderbufferStorage function. Must be GL_RENDERBUFFER.</param>
@@ -8374,25 +8374,25 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Determine if a name corresponds to a framebuffer object. </summary>
             /// <param name="framebuffer"> Specifies a value that may be the name of a framebuffer object. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsFramebuffer.xhtml" /></remarks>
-            public static bool IsFramebuffer(FramebufferHandle framebuffer) => GLPointers._IsFramebuffer_fnptr((int)framebuffer) != 0;
+            public static bool IsFramebuffer(int framebuffer) => GLPointers._IsFramebuffer_fnptr(framebuffer) != 0;
             
             /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Bind a framebuffer to a framebuffer target. </summary>
             /// <param name="target"> Specifies the framebuffer target of the binding operation. </param>
             /// <param name="framebuffer"> Specifies the name of the framebuffer object to bind. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindFramebuffer.xhtml" /></remarks>
-            public static void BindFramebuffer(FramebufferTarget target, FramebufferHandle framebuffer) => GLPointers._BindFramebuffer_fnptr((uint)target, (int)framebuffer);
+            public static void BindFramebuffer(FramebufferTarget target, int framebuffer) => GLPointers._BindFramebuffer_fnptr((uint)target, framebuffer);
             
             /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Delete framebuffer objects. </summary>
             /// <param name="n"> Specifies the number of framebuffer objects to be deleted. </param>
             /// <param name="framebuffers"> A pointer to an array containing n framebuffer objects to be deleted. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDeleteFramebuffers.xhtml" /></remarks>
-            public static void DeleteFramebuffers(int n, FramebufferHandle* framebuffers) => GLPointers._DeleteFramebuffers_fnptr(n, (int*)framebuffers);
+            public static void DeleteFramebuffers(int n, int* framebuffers) => GLPointers._DeleteFramebuffers_fnptr(n, framebuffers);
             
             /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Generate framebuffer object names. </summary>
             /// <param name="n"> Specifies the number of framebuffer object names to generate. </param>
             /// <param name="ids"> Specifies an array in which the generated framebuffer object names are stored. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGenFramebuffers.xhtml" /></remarks>
-            public static void GenFramebuffers(int n, FramebufferHandle* framebuffers) => GLPointers._GenFramebuffers_fnptr(n, (int*)framebuffers);
+            public static void GenFramebuffers(int n, int* framebuffers) => GLPointers._GenFramebuffers_fnptr(n, framebuffers);
             
             /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Check the completeness status of a framebuffer. </summary>
             /// <param name="target"> Specify the target to which the framebuffer is bound for glCheckFramebufferStatus, and the target against which framebuffer completeness of framebuffer is checked for glCheckNamedFramebufferStatus. </param>
@@ -8406,7 +8406,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="texture"> Specifies the name of an existing texture object to attach. </param>
             /// <param name="level"> Specifies the mipmap level of the texture object to attach. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glFramebufferTexture.xhtml" /></remarks>
-            public static void FramebufferTexture1D(FramebufferTarget target, FramebufferAttachment attachment, TextureTarget textarget, TextureHandle texture, int level) => GLPointers._FramebufferTexture1D_fnptr((uint)target, (uint)attachment, (uint)textarget, (int)texture, level);
+            public static void FramebufferTexture1D(FramebufferTarget target, FramebufferAttachment attachment, TextureTarget textarget, int texture, int level) => GLPointers._FramebufferTexture1D_fnptr((uint)target, (uint)attachment, (uint)textarget, texture, level);
             
             /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Attach a level of a texture object as a logical buffer of a framebuffer object. </summary>
             /// <param name="target"> Specifies the target to which the framebuffer is bound for all commands except glNamedFramebufferTexture. </param>
@@ -8415,7 +8415,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="texture"> Specifies the name of an existing texture object to attach. </param>
             /// <param name="level"> Specifies the mipmap level of the texture object to attach. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glFramebufferTexture.xhtml" /></remarks>
-            public static void FramebufferTexture2D(FramebufferTarget target, FramebufferAttachment attachment, TextureTarget textarget, TextureHandle texture, int level) => GLPointers._FramebufferTexture2D_fnptr((uint)target, (uint)attachment, (uint)textarget, (int)texture, level);
+            public static void FramebufferTexture2D(FramebufferTarget target, FramebufferAttachment attachment, TextureTarget textarget, int texture, int level) => GLPointers._FramebufferTexture2D_fnptr((uint)target, (uint)attachment, (uint)textarget, texture, level);
             
             /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Attach a level of a texture object as a logical buffer of a framebuffer object. </summary>
             /// <param name="target"> Specifies the target to which the framebuffer is bound for all commands except glNamedFramebufferTexture. </param>
@@ -8425,7 +8425,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="level"> Specifies the mipmap level of the texture object to attach. </param>
             /// <param name="layer">!!missing documentation!!</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glFramebufferTexture.xhtml" /></remarks>
-            public static void FramebufferTexture3D(FramebufferTarget target, FramebufferAttachment attachment, TextureTarget textarget, TextureHandle texture, int level, int zoffset) => GLPointers._FramebufferTexture3D_fnptr((uint)target, (uint)attachment, (uint)textarget, (int)texture, level, zoffset);
+            public static void FramebufferTexture3D(FramebufferTarget target, FramebufferAttachment attachment, TextureTarget textarget, int texture, int level, int zoffset) => GLPointers._FramebufferTexture3D_fnptr((uint)target, (uint)attachment, (uint)textarget, texture, level, zoffset);
             
             /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Attach a renderbuffer as a logical buffer of a framebuffer object. </summary>
             /// <param name="target"> Specifies the target to which the framebuffer is bound for glFramebufferRenderbuffer. </param>
@@ -8433,7 +8433,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="renderbuffertarget"> Specifies the renderbuffer target. Must be GL_RENDERBUFFER. </param>
             /// <param name="renderbuffer"> Specifies the name of an existing renderbuffer object of type renderbuffertarget to attach. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glFramebufferRenderbuffer.xhtml" /></remarks>
-            public static void FramebufferRenderbuffer(FramebufferTarget target, FramebufferAttachment attachment, RenderbufferTarget renderbuffertarget, RenderbufferHandle renderbuffer) => GLPointers._FramebufferRenderbuffer_fnptr((uint)target, (uint)attachment, (uint)renderbuffertarget, (int)renderbuffer);
+            public static void FramebufferRenderbuffer(FramebufferTarget target, FramebufferAttachment attachment, RenderbufferTarget renderbuffertarget, int renderbuffer) => GLPointers._FramebufferRenderbuffer_fnptr((uint)target, (uint)attachment, (uint)renderbuffertarget, renderbuffer);
             
             /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Retrieve information about attachments of a framebuffer object. </summary>
             /// <param name="target"> Specifies the target to which the framebuffer object is bound for glGetFramebufferAttachmentParameteriv. </param>
@@ -8478,23 +8478,23 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="level"> Specifies the mipmap level of the texture object to attach. </param>
             /// <param name="layer"> Specifies the layer of the texture object to attach. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glFramebufferTextureLayer.xhtml" /></remarks>
-            public static void FramebufferTextureLayer(FramebufferTarget target, FramebufferAttachment attachment, TextureHandle texture, int level, int layer) => GLPointers._FramebufferTextureLayer_fnptr((uint)target, (uint)attachment, (int)texture, level, layer);
+            public static void FramebufferTextureLayer(FramebufferTarget target, FramebufferAttachment attachment, int texture, int level, int layer) => GLPointers._FramebufferTextureLayer_fnptr((uint)target, (uint)attachment, texture, level, layer);
             
             /// <summary> <b>[requires: GL_ARB_geometry_shader4]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramParameteriARB(ProgramHandle program, ProgramParameterPName pname, int value) => GLPointers._ProgramParameteriARB_fnptr((int)program, (uint)pname, value);
+            public static void ProgramParameteriARB(int program, ProgramParameterPName pname, int value) => GLPointers._ProgramParameteriARB_fnptr(program, (uint)pname, value);
             
             /// <summary> <b>[requires: GL_ARB_geometry_shader4]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void FramebufferTextureARB(FramebufferTarget target, FramebufferAttachment attachment, TextureHandle texture, int level) => GLPointers._FramebufferTextureARB_fnptr((uint)target, (uint)attachment, (int)texture, level);
+            public static void FramebufferTextureARB(FramebufferTarget target, FramebufferAttachment attachment, int texture, int level) => GLPointers._FramebufferTextureARB_fnptr((uint)target, (uint)attachment, texture, level);
             
             /// <summary> <b>[requires: GL_ARB_geometry_shader4]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void FramebufferTextureLayerARB(FramebufferTarget target, FramebufferAttachment attachment, TextureHandle texture, int level, int layer) => GLPointers._FramebufferTextureLayerARB_fnptr((uint)target, (uint)attachment, (int)texture, level, layer);
+            public static void FramebufferTextureLayerARB(FramebufferTarget target, FramebufferAttachment attachment, int texture, int level, int layer) => GLPointers._FramebufferTextureLayerARB_fnptr((uint)target, (uint)attachment, texture, level, layer);
             
             /// <summary> <b>[requires: GL_ARB_geometry_shader4]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void FramebufferTextureFaceARB(FramebufferTarget target, FramebufferAttachment attachment, TextureHandle texture, int level, TextureTarget face) => GLPointers._FramebufferTextureFaceARB_fnptr((uint)target, (uint)attachment, (int)texture, level, (uint)face);
+            public static void FramebufferTextureFaceARB(FramebufferTarget target, FramebufferAttachment attachment, int texture, int level, TextureTarget face) => GLPointers._FramebufferTextureFaceARB_fnptr((uint)target, (uint)attachment, texture, level, (uint)face);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_get_program_binary]</b> Return a binary representation of a program object's compiled and linked executable source. </summary>
             /// <param name="program"> Specifies the name of a program object whose binary representation to retrieve. </param>
@@ -8503,7 +8503,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="binaryFormat"> Specifies the address of a variable to receive a token indicating the format of the binary data returned by the GL. </param>
             /// <param name="binary"> Specifies the address an array into which the GL will return program's binary representation. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetProgramBinary.xhtml" /></remarks>
-            public static void GetProgramBinary(ProgramHandle program, int bufSize, int* length, All* binaryFormat, void* binary) => GLPointers._GetProgramBinary_fnptr((int)program, bufSize, length, (uint*)binaryFormat, binary);
+            public static void GetProgramBinary(int program, int bufSize, int* length, All* binaryFormat, void* binary) => GLPointers._GetProgramBinary_fnptr(program, bufSize, length, (uint*)binaryFormat, binary);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_get_program_binary]</b> Load a program object with a program binary. </summary>
             /// <param name="program"> Specifies the name of a program object into which to load a program binary. </param>
@@ -8511,14 +8511,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="binary"> Specifies the address an array containing the binary to be loaded into program. </param>
             /// <param name="length"> Specifies the number of bytes contained in binary. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramBinary.xhtml" /></remarks>
-            public static void ProgramBinary(ProgramHandle program, All binaryFormat, void* binary, int length) => GLPointers._ProgramBinary_fnptr((int)program, (uint)binaryFormat, binary, length);
+            public static void ProgramBinary(int program, All binaryFormat, void* binary, int length) => GLPointers._ProgramBinary_fnptr(program, (uint)binaryFormat, binary, length);
             
             /// <summary> <b>[requires: v4.1 | v4.1 | GL_ARB_get_program_binary | GL_ARB_separate_shader_objects]</b> Specify a parameter for a program object. </summary>
             /// <param name="program"> Specifies the name of a program object whose parameter to modify. </param>
             /// <param name="pname"> Specifies the name of the parameter to modify. </param>
             /// <param name="value"> Specifies the new value of the parameter specified by pname for program. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramParameter.xhtml" /></remarks>
-            public static void ProgramParameteri(ProgramHandle program, ProgramParameterPName pname, int value) => GLPointers._ProgramParameteri_fnptr((int)program, (uint)pname, value);
+            public static void ProgramParameteri(int program, ProgramParameterPName pname, int value) => GLPointers._ProgramParameteri_fnptr(program, (uint)pname, value);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_get_texture_sub_image]</b> Retrieve a sub-region of a texture image from a texture    object. </summary>
             /// <param name="texture">Specifies the name of the source texture object. Must be GL_TEXTURE_1D, GL_TEXTURE_1D_ARRAY, GL_TEXTURE_2D, GL_TEXTURE_2D_ARRAY, GL_TEXTURE_3D, GL_TEXTURE_CUBE_MAP, GL_TEXTURE_CUBE_MAP_ARRAY or GL_TEXTURE_RECTANGLE. In specific, buffer and multisample textures are not permitted.</param>
@@ -8534,7 +8534,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="bufSize">Specifies the size of the buffer to receive the retrieved pixel data.</param>
             /// <param name="pixels">Returns the texture subimage. Should be a pointer to an array of the type specified by type.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetTextureSubImage.xhtml" /></remarks>
-            public static void GetTextureSubImage(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, int bufSize, void* pixels) => GLPointers._GetTextureSubImage_fnptr((int)texture, level, xoffset, yoffset, zoffset, width, height, depth, (uint)format, (uint)type, bufSize, pixels);
+            public static void GetTextureSubImage(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, int bufSize, void* pixels) => GLPointers._GetTextureSubImage_fnptr(texture, level, xoffset, yoffset, zoffset, width, height, depth, (uint)format, (uint)type, bufSize, pixels);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_get_texture_sub_image]</b> Retrieve a sub-region of a compressed texture image from a    compressed texture object. </summary>
             /// <param name="texture">Specifies the name of the source texture object. Must be GL_TEXTURE_1D, GL_TEXTURE_1D_ARRAY, GL_TEXTURE_2D, GL_TEXTURE_2D_ARRAY, GL_TEXTURE_3D, GL_TEXTURE_CUBE_MAP, GL_TEXTURE_CUBE_MAP_ARRAY or GL_TEXTURE_RECTANGLE. In specific, buffer and multisample textures are not permitted.</param>
@@ -8548,11 +8548,11 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="bufSize">Specifies the size of the buffer to receive the retrieved pixel data.</param>
             /// <param name="pixels">Returns the texture subimage. Should be a pointer to an array of the type specified by type.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetCompressedTextureSubImage.xhtml" /></remarks>
-            public static void GetCompressedTextureSubImage(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, int bufSize, void* pixels) => GLPointers._GetCompressedTextureSubImage_fnptr((int)texture, level, xoffset, yoffset, zoffset, width, height, depth, bufSize, pixels);
+            public static void GetCompressedTextureSubImage(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, int bufSize, void* pixels) => GLPointers._GetCompressedTextureSubImage_fnptr(texture, level, xoffset, yoffset, zoffset, width, height, depth, bufSize, pixels);
             
             /// <summary> <b>[requires: GL_ARB_gl_spirv]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void SpecializeShaderARB(ShaderHandle shader, byte* pEntryPoint, uint numSpecializationConstants, uint* pConstantIndex, uint* pConstantValue) => GLPointers._SpecializeShaderARB_fnptr((int)shader, pEntryPoint, numSpecializationConstants, pConstantIndex, pConstantValue);
+            public static void SpecializeShaderARB(int shader, byte* pEntryPoint, uint numSpecializationConstants, uint* pConstantIndex, uint* pConstantValue) => GLPointers._SpecializeShaderARB_fnptr(shader, pEntryPoint, numSpecializationConstants, pConstantIndex, pConstantValue);
             
             /// <summary> <b>[requires: v4.0 | GL_ARB_gpu_shader_fp64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -8627,7 +8627,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="location">Specifies the location of the uniform variable to be queried.</param>
             /// <param name="parameters">Returns the value of the specified uniform variable.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetUniform.xhtml" /></remarks>
-            public static void GetUniformdv(ProgramHandle program, int location, double* parameters) => GLPointers._GetUniformdv_fnptr((int)program, location, parameters);
+            public static void GetUniformdv(int program, int location, double* parameters) => GLPointers._GetUniformdv_fnptr(program, location, parameters);
             
             /// <summary> <b>[requires: GL_ARB_gpu_shader_int64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -8695,83 +8695,83 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_ARB_gpu_shader_int64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetUniformi64vARB(ProgramHandle program, int location, long* parameters) => GLPointers._GetUniformi64vARB_fnptr((int)program, location, parameters);
+            public static void GetUniformi64vARB(int program, int location, long* parameters) => GLPointers._GetUniformi64vARB_fnptr(program, location, parameters);
             
             /// <summary> <b>[requires: GL_ARB_gpu_shader_int64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetUniformui64vARB(ProgramHandle program, int location, ulong* parameters) => GLPointers._GetUniformui64vARB_fnptr((int)program, location, parameters);
+            public static void GetUniformui64vARB(int program, int location, ulong* parameters) => GLPointers._GetUniformui64vARB_fnptr(program, location, parameters);
             
             /// <summary> <b>[requires: GL_ARB_gpu_shader_int64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetnUniformi64vARB(ProgramHandle program, int location, int bufSize, long* parameters) => GLPointers._GetnUniformi64vARB_fnptr((int)program, location, bufSize, parameters);
+            public static void GetnUniformi64vARB(int program, int location, int bufSize, long* parameters) => GLPointers._GetnUniformi64vARB_fnptr(program, location, bufSize, parameters);
             
             /// <summary> <b>[requires: GL_ARB_gpu_shader_int64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetnUniformui64vARB(ProgramHandle program, int location, int bufSize, ulong* parameters) => GLPointers._GetnUniformui64vARB_fnptr((int)program, location, bufSize, parameters);
+            public static void GetnUniformui64vARB(int program, int location, int bufSize, ulong* parameters) => GLPointers._GetnUniformui64vARB_fnptr(program, location, bufSize, parameters);
             
             /// <summary> <b>[requires: GL_ARB_gpu_shader_int64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform1i64ARB(ProgramHandle program, int location, long x) => GLPointers._ProgramUniform1i64ARB_fnptr((int)program, location, x);
+            public static void ProgramUniform1i64ARB(int program, int location, long x) => GLPointers._ProgramUniform1i64ARB_fnptr(program, location, x);
             
             /// <summary> <b>[requires: GL_ARB_gpu_shader_int64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform2i64ARB(ProgramHandle program, int location, long x, long y) => GLPointers._ProgramUniform2i64ARB_fnptr((int)program, location, x, y);
+            public static void ProgramUniform2i64ARB(int program, int location, long x, long y) => GLPointers._ProgramUniform2i64ARB_fnptr(program, location, x, y);
             
             /// <summary> <b>[requires: GL_ARB_gpu_shader_int64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform3i64ARB(ProgramHandle program, int location, long x, long y, long z) => GLPointers._ProgramUniform3i64ARB_fnptr((int)program, location, x, y, z);
+            public static void ProgramUniform3i64ARB(int program, int location, long x, long y, long z) => GLPointers._ProgramUniform3i64ARB_fnptr(program, location, x, y, z);
             
             /// <summary> <b>[requires: GL_ARB_gpu_shader_int64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform4i64ARB(ProgramHandle program, int location, long x, long y, long z, long w) => GLPointers._ProgramUniform4i64ARB_fnptr((int)program, location, x, y, z, w);
+            public static void ProgramUniform4i64ARB(int program, int location, long x, long y, long z, long w) => GLPointers._ProgramUniform4i64ARB_fnptr(program, location, x, y, z, w);
             
             /// <summary> <b>[requires: GL_ARB_gpu_shader_int64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform1i64vARB(ProgramHandle program, int location, int count, long* value) => GLPointers._ProgramUniform1i64vARB_fnptr((int)program, location, count, value);
+            public static void ProgramUniform1i64vARB(int program, int location, int count, long* value) => GLPointers._ProgramUniform1i64vARB_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_ARB_gpu_shader_int64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform2i64vARB(ProgramHandle program, int location, int count, long* value) => GLPointers._ProgramUniform2i64vARB_fnptr((int)program, location, count, value);
+            public static void ProgramUniform2i64vARB(int program, int location, int count, long* value) => GLPointers._ProgramUniform2i64vARB_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_ARB_gpu_shader_int64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform3i64vARB(ProgramHandle program, int location, int count, long* value) => GLPointers._ProgramUniform3i64vARB_fnptr((int)program, location, count, value);
+            public static void ProgramUniform3i64vARB(int program, int location, int count, long* value) => GLPointers._ProgramUniform3i64vARB_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_ARB_gpu_shader_int64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform4i64vARB(ProgramHandle program, int location, int count, long* value) => GLPointers._ProgramUniform4i64vARB_fnptr((int)program, location, count, value);
+            public static void ProgramUniform4i64vARB(int program, int location, int count, long* value) => GLPointers._ProgramUniform4i64vARB_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_ARB_gpu_shader_int64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform1ui64ARB(ProgramHandle program, int location, ulong x) => GLPointers._ProgramUniform1ui64ARB_fnptr((int)program, location, x);
+            public static void ProgramUniform1ui64ARB(int program, int location, ulong x) => GLPointers._ProgramUniform1ui64ARB_fnptr(program, location, x);
             
             /// <summary> <b>[requires: GL_ARB_gpu_shader_int64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform2ui64ARB(ProgramHandle program, int location, ulong x, ulong y) => GLPointers._ProgramUniform2ui64ARB_fnptr((int)program, location, x, y);
+            public static void ProgramUniform2ui64ARB(int program, int location, ulong x, ulong y) => GLPointers._ProgramUniform2ui64ARB_fnptr(program, location, x, y);
             
             /// <summary> <b>[requires: GL_ARB_gpu_shader_int64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform3ui64ARB(ProgramHandle program, int location, ulong x, ulong y, ulong z) => GLPointers._ProgramUniform3ui64ARB_fnptr((int)program, location, x, y, z);
+            public static void ProgramUniform3ui64ARB(int program, int location, ulong x, ulong y, ulong z) => GLPointers._ProgramUniform3ui64ARB_fnptr(program, location, x, y, z);
             
             /// <summary> <b>[requires: GL_ARB_gpu_shader_int64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform4ui64ARB(ProgramHandle program, int location, ulong x, ulong y, ulong z, ulong w) => GLPointers._ProgramUniform4ui64ARB_fnptr((int)program, location, x, y, z, w);
+            public static void ProgramUniform4ui64ARB(int program, int location, ulong x, ulong y, ulong z, ulong w) => GLPointers._ProgramUniform4ui64ARB_fnptr(program, location, x, y, z, w);
             
             /// <summary> <b>[requires: GL_ARB_gpu_shader_int64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform1ui64vARB(ProgramHandle program, int location, int count, ulong* value) => GLPointers._ProgramUniform1ui64vARB_fnptr((int)program, location, count, value);
+            public static void ProgramUniform1ui64vARB(int program, int location, int count, ulong* value) => GLPointers._ProgramUniform1ui64vARB_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_ARB_gpu_shader_int64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform2ui64vARB(ProgramHandle program, int location, int count, ulong* value) => GLPointers._ProgramUniform2ui64vARB_fnptr((int)program, location, count, value);
+            public static void ProgramUniform2ui64vARB(int program, int location, int count, ulong* value) => GLPointers._ProgramUniform2ui64vARB_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_ARB_gpu_shader_int64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform3ui64vARB(ProgramHandle program, int location, int count, ulong* value) => GLPointers._ProgramUniform3ui64vARB_fnptr((int)program, location, count, value);
+            public static void ProgramUniform3ui64vARB(int program, int location, int count, ulong* value) => GLPointers._ProgramUniform3ui64vARB_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_ARB_gpu_shader_int64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform4ui64vARB(ProgramHandle program, int location, int count, ulong* value) => GLPointers._ProgramUniform4ui64vARB_fnptr((int)program, location, count, value);
+            public static void ProgramUniform4ui64vARB(int program, int location, int count, ulong* value) => GLPointers._ProgramUniform4ui64vARB_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: v1.4 | GL_ARB_imaging]</b> Set the blend color. </summary>
             /// <param name="red"> specify the components of GL_BLEND_COLOR </param>
@@ -9077,25 +9077,25 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="height"> The height of the region to be invalidated. </param>
             /// <param name="depth"> The depth of the region to be invalidated. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glInvalidateTexSubImage.xhtml" /></remarks>
-            public static void InvalidateTexSubImage(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth) => GLPointers._InvalidateTexSubImage_fnptr((int)texture, level, xoffset, yoffset, zoffset, width, height, depth);
+            public static void InvalidateTexSubImage(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth) => GLPointers._InvalidateTexSubImage_fnptr(texture, level, xoffset, yoffset, zoffset, width, height, depth);
             
             /// <summary> <b>[requires: v4.3 | GL_ARB_invalidate_subdata]</b> Invalidate the entirety a texture image. </summary>
             /// <param name="texture"> The name of a texture object to invalidate. </param>
             /// <param name="level"> The level of detail of the texture object to invalidate. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glInvalidateTexImage.xhtml" /></remarks>
-            public static void InvalidateTexImage(TextureHandle texture, int level) => GLPointers._InvalidateTexImage_fnptr((int)texture, level);
+            public static void InvalidateTexImage(int texture, int level) => GLPointers._InvalidateTexImage_fnptr(texture, level);
             
             /// <summary> <b>[requires: v4.3 | GL_ARB_invalidate_subdata]</b> Invalidate a region of a buffer object's data store. </summary>
             /// <param name="buffer"> The name of a buffer object, a subrange of whose data store to invalidate. </param>
             /// <param name="offset"> The offset within the buffer's data store of the start of the range to be invalidated. </param>
             /// <param name="length"> The length of the range within the buffer's data store to be invalidated. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glInvalidateBufferSubData.xhtml" /></remarks>
-            public static void InvalidateBufferSubData(BufferHandle buffer, IntPtr offset, nint length) => GLPointers._InvalidateBufferSubData_fnptr((int)buffer, offset, length);
+            public static void InvalidateBufferSubData(int buffer, IntPtr offset, nint length) => GLPointers._InvalidateBufferSubData_fnptr(buffer, offset, length);
             
             /// <summary> <b>[requires: v4.3 | GL_ARB_invalidate_subdata]</b> Invalidate the content of a buffer object's data store. </summary>
             /// <param name="buffer"> The name of a buffer object whose data store to invalidate. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glInvalidateBufferData.xhtml" /></remarks>
-            public static void InvalidateBufferData(BufferHandle buffer) => GLPointers._InvalidateBufferData_fnptr((int)buffer);
+            public static void InvalidateBufferData(int buffer) => GLPointers._InvalidateBufferData_fnptr(buffer);
             
             /// <summary> <b>[requires: v4.3 | GL_ARB_invalidate_subdata]</b> Invalidate the content of some or all of a framebuffer's attachments. </summary>
             /// <param name="target"> Specifies the target to which the framebuffer object is attached for glInvalidateFramebuffer. </param>
@@ -9156,7 +9156,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="count"> Specify the number of contiguous binding points to which to bind buffers. </param>
             /// <param name="buffers"> A pointer to an array of names of buffer objects to bind to the targets on the specified binding point, or NULL. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindBuffersBase.xhtml" /></remarks>
-            public static void BindBuffersBase(BufferTargetARB target, uint first, int count, BufferHandle* buffers) => GLPointers._BindBuffersBase_fnptr((uint)target, first, count, (int*)buffers);
+            public static void BindBuffersBase(BufferTargetARB target, uint first, int count, int* buffers) => GLPointers._BindBuffersBase_fnptr((uint)target, first, count, buffers);
             
             /// <summary> <b>[requires: v4.4 | GL_ARB_multi_bind]</b> Bind ranges of one or more buffer objects to a sequence of indexed buffer targets. </summary>
             /// <param name="target"> Specify the target of the bind operation. target must be one of GL_ATOMIC_COUNTER_BUFFER, GL_TRANSFORM_FEEDBACK_BUFFER, GL_UNIFORM_BUFFER or GL_SHADER_STORAGE_BUFFER. </param>
@@ -9166,28 +9166,28 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="offsets"> A pointer to an array of offsets into the corresponding buffer in buffers to bind, or NULL if buffers is NULL. </param>
             /// <param name="sizes"> A pointer to an array of sizes of the corresponding buffer in buffers to bind, or NULL if buffers is NULL. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindBuffersRange.xhtml" /></remarks>
-            public static void BindBuffersRange(BufferTargetARB target, uint first, int count, BufferHandle* buffers, IntPtr* offsets, nint* sizes) => GLPointers._BindBuffersRange_fnptr((uint)target, first, count, (int*)buffers, offsets, sizes);
+            public static void BindBuffersRange(BufferTargetARB target, uint first, int count, int* buffers, IntPtr* offsets, nint* sizes) => GLPointers._BindBuffersRange_fnptr((uint)target, first, count, buffers, offsets, sizes);
             
             /// <summary> <b>[requires: v4.4 | GL_ARB_multi_bind]</b> Bind one or more named textures to a sequence of consecutive texture units. </summary>
             /// <param name="first"> Specifies the first texture unit to which a texture is to be bound. </param>
             /// <param name="count"> Specifies the number of textures to bind. </param>
             /// <param name="textures"> Specifies the address of an array of names of existing texture objects. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindTextures.xhtml" /></remarks>
-            public static void BindTextures(uint first, int count, TextureHandle* textures) => GLPointers._BindTextures_fnptr(first, count, (int*)textures);
+            public static void BindTextures(uint first, int count, int* textures) => GLPointers._BindTextures_fnptr(first, count, textures);
             
             /// <summary> <b>[requires: v4.4 | GL_ARB_multi_bind]</b> Bind one or more named sampler objects to a sequence of consecutive sampler units. </summary>
             /// <param name="first"> Specifies the first sampler unit to which a sampler object is to be bound. </param>
             /// <param name="count"> Specifies the number of samplers to bind. </param>
             /// <param name="samplers"> Specifies the address of an array of names of existing sampler objects. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindSamplers.xhtml" /></remarks>
-            public static void BindSamplers(uint first, int count, SamplerHandle* samplers) => GLPointers._BindSamplers_fnptr(first, count, (int*)samplers);
+            public static void BindSamplers(uint first, int count, int* samplers) => GLPointers._BindSamplers_fnptr(first, count, samplers);
             
             /// <summary> <b>[requires: v4.4 | GL_ARB_multi_bind]</b> Bind one or more named texture images to a sequence of consecutive image units. </summary>
             /// <param name="first"> Specifies the first image unit to which a texture is to be bound. </param>
             /// <param name="count"> Specifies the number of textures to bind. </param>
             /// <param name="textures"> Specifies the address of an array of names of existing texture objects. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindImageTextures.xhtml" /></remarks>
-            public static void BindImageTextures(uint first, int count, TextureHandle* textures) => GLPointers._BindImageTextures_fnptr(first, count, (int*)textures);
+            public static void BindImageTextures(uint first, int count, int* textures) => GLPointers._BindImageTextures_fnptr(first, count, textures);
             
             /// <summary> <b>[requires: v4.4 | GL_ARB_multi_bind]</b> Attach multiple buffer objects to a vertex array object. </summary>
             /// <param name="first"> Specifies the first vertex buffer binding point to which a buffer object is to be bound. </param>
@@ -9196,7 +9196,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="offsets"> Specifies the address of an array of offsets to associate with the binding points. </param>
             /// <param name="strides">!!missing documentation!!</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindVertexBuffers.xhtml" /></remarks>
-            public static void BindVertexBuffers(uint first, int count, BufferHandle* buffers, IntPtr* offsets, int* strides) => GLPointers._BindVertexBuffers_fnptr(first, count, (int*)buffers, offsets, strides);
+            public static void BindVertexBuffers(uint first, int count, int* buffers, IntPtr* offsets, int* strides) => GLPointers._BindVertexBuffers_fnptr(first, count, buffers, offsets, strides);
             
             /// <summary> <b>[requires: v4.3 | GL_ARB_multi_draw_indirect]</b> Render multiple sets of primitives from array data, taking parameters from memory. </summary>
             /// <param name="mode"> Specifies what kind of primitives to render. Symbolic constants GL_POINTS, GL_LINE_STRIP, GL_LINE_LOOP, GL_LINES, GL_LINE_STRIP_ADJACENCY, GL_LINES_ADJACENCY, GL_TRIANGLE_STRIP, GL_TRIANGLE_FAN, GL_TRIANGLES, GL_TRIANGLE_STRIP_ADJACENCY, GL_TRIANGLES_ADJACENCY, and GL_PATCHES are accepted. </param>
@@ -9357,19 +9357,19 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_ARB_occlusion_query]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GenQueriesARB(int n, QueryHandle* ids) => GLPointers._GenQueriesARB_fnptr(n, (int*)ids);
+            public static void GenQueriesARB(int n, int* ids) => GLPointers._GenQueriesARB_fnptr(n, ids);
             
             /// <summary> <b>[requires: GL_ARB_occlusion_query]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void DeleteQueriesARB(int n, QueryHandle* ids) => GLPointers._DeleteQueriesARB_fnptr(n, (int*)ids);
+            public static void DeleteQueriesARB(int n, int* ids) => GLPointers._DeleteQueriesARB_fnptr(n, ids);
             
             /// <summary> <b>[requires: GL_ARB_occlusion_query]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static bool IsQueryARB(QueryHandle id) => GLPointers._IsQueryARB_fnptr((int)id) != 0;
+            public static bool IsQueryARB(int id) => GLPointers._IsQueryARB_fnptr(id) != 0;
             
             /// <summary> <b>[requires: GL_ARB_occlusion_query]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void BeginQueryARB(QueryTarget target, QueryHandle id) => GLPointers._BeginQueryARB_fnptr((uint)target, (int)id);
+            public static void BeginQueryARB(QueryTarget target, int id) => GLPointers._BeginQueryARB_fnptr((uint)target, id);
             
             /// <summary> <b>[requires: GL_ARB_occlusion_query]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -9381,11 +9381,11 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_ARB_occlusion_query]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetQueryObjectivARB(QueryHandle id, QueryObjectParameterName pname, int* parameters) => GLPointers._GetQueryObjectivARB_fnptr((int)id, (uint)pname, parameters);
+            public static void GetQueryObjectivARB(int id, QueryObjectParameterName pname, int* parameters) => GLPointers._GetQueryObjectivARB_fnptr(id, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_ARB_occlusion_query]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetQueryObjectuivARB(QueryHandle id, QueryObjectParameterName pname, uint* parameters) => GLPointers._GetQueryObjectuivARB_fnptr((int)id, (uint)pname, parameters);
+            public static void GetQueryObjectuivARB(int id, QueryObjectParameterName pname, uint* parameters) => GLPointers._GetQueryObjectuivARB_fnptr(id, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_ARB_parallel_shader_compile]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -9409,14 +9409,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="pname"> The name of the parameter within programInterface to query. </param>
             /// <param name="parameters"> The address of a variable to retrieve the value of pname for the program interface. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetProgramInterface.xhtml" /></remarks>
-            public static void GetProgramInterfaceiv(ProgramHandle program, ProgramInterface programInterface, ProgramInterfacePName pname, int* parameters) => GLPointers._GetProgramInterfaceiv_fnptr((int)program, (uint)programInterface, (uint)pname, parameters);
+            public static void GetProgramInterfaceiv(int program, ProgramInterface programInterface, ProgramInterfacePName pname, int* parameters) => GLPointers._GetProgramInterfaceiv_fnptr(program, (uint)programInterface, (uint)pname, parameters);
             
             /// <summary> <b>[requires: v4.3 | GL_ARB_program_interface_query]</b> Query the index of a named resource within a program. </summary>
             /// <param name="program"> The name of a program object whose resources to query. </param>
             /// <param name="programInterface"> A token identifying the interface within program containing the resource named name. </param>
             /// <param name="name"> The name of the resource to query the index of. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetProgramResourceIndex.xhtml" /></remarks>
-            public static uint GetProgramResourceIndex(ProgramHandle program, ProgramInterface programInterface, byte* name) => GLPointers._GetProgramResourceIndex_fnptr((int)program, (uint)programInterface, name);
+            public static uint GetProgramResourceIndex(int program, ProgramInterface programInterface, byte* name) => GLPointers._GetProgramResourceIndex_fnptr(program, (uint)programInterface, name);
             
             /// <summary> <b>[requires: v4.3 | GL_ARB_program_interface_query]</b> Query the name of an indexed resource within a program. </summary>
             /// <param name="program"> The name of a program object whose resources to query. </param>
@@ -9426,7 +9426,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="length"> The address of a variable which will receive the length of the resource name. </param>
             /// <param name="name"> The address of a character array into which will be written the name of the resource. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetProgramResourceName.xhtml" /></remarks>
-            public static void GetProgramResourceName(ProgramHandle program, ProgramInterface programInterface, uint index, int bufSize, int* length, byte* name) => GLPointers._GetProgramResourceName_fnptr((int)program, (uint)programInterface, index, bufSize, length, name);
+            public static void GetProgramResourceName(int program, ProgramInterface programInterface, uint index, int bufSize, int* length, byte* name) => GLPointers._GetProgramResourceName_fnptr(program, (uint)programInterface, index, bufSize, length, name);
             
             /// <summary> <b>[requires: v4.3 | GL_ARB_program_interface_query]</b> Retrieve values for multiple properties of a single active resource within a program object. </summary>
             /// <param name="program"> The name of a program object whose resources to query. </param>
@@ -9438,21 +9438,21 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="length">!!missing documentation!!</param>
             /// <param name="parameters">!!missing documentation!!</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetProgramResource.xhtml" /></remarks>
-            public static void GetProgramResourceiv(ProgramHandle program, ProgramInterface programInterface, uint index, int propCount, ProgramResourceProperty* props, int count, int* length, int* parameters) => GLPointers._GetProgramResourceiv_fnptr((int)program, (uint)programInterface, index, propCount, (uint*)props, count, length, parameters);
+            public static void GetProgramResourceiv(int program, ProgramInterface programInterface, uint index, int propCount, ProgramResourceProperty* props, int count, int* length, int* parameters) => GLPointers._GetProgramResourceiv_fnptr(program, (uint)programInterface, index, propCount, (uint*)props, count, length, parameters);
             
             /// <summary> <b>[requires: v4.3 | GL_ARB_program_interface_query]</b> Query the location of a named resource within a program. </summary>
             /// <param name="program"> The name of a program object whose resources to query. </param>
             /// <param name="programInterface"> A token identifying the interface within program containing the resource named name. </param>
             /// <param name="name"> The name of the resource to query the location of. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetProgramResourceLocation.xhtml" /></remarks>
-            public static int GetProgramResourceLocation(ProgramHandle program, ProgramInterface programInterface, byte* name) => GLPointers._GetProgramResourceLocation_fnptr((int)program, (uint)programInterface, name);
+            public static int GetProgramResourceLocation(int program, ProgramInterface programInterface, byte* name) => GLPointers._GetProgramResourceLocation_fnptr(program, (uint)programInterface, name);
             
             /// <summary> <b>[requires: v4.3 | GL_ARB_program_interface_query]</b> Query the fragment color index of a named variable within a program. </summary>
             /// <param name="program"> The name of a program object whose resources to query. </param>
             /// <param name="programInterface"> A token identifying the interface within program containing the resource named name. </param>
             /// <param name="name"> The name of the resource to query the location of. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetProgramResourceLocationIndex.xhtml" /></remarks>
-            public static int GetProgramResourceLocationIndex(ProgramHandle program, ProgramInterface programInterface, byte* name) => GLPointers._GetProgramResourceLocationIndex_fnptr((int)program, (uint)programInterface, name);
+            public static int GetProgramResourceLocationIndex(int program, ProgramInterface programInterface, byte* name) => GLPointers._GetProgramResourceLocationIndex_fnptr(program, (uint)programInterface, name);
             
             /// <summary> <b>[requires: v3.2 | GL_ARB_provoking_vertex]</b> Specifiy the vertex to be used as the source of data for flat shaded varyings. </summary>
             /// <param name="provokeMode"> Specifies the vertex to be used as the source of data for flat shaded varyings. </param>
@@ -9477,19 +9477,19 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_ARB_robustness]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetnUniformfvARB(ProgramHandle program, int location, int bufSize, float* parameters) => GLPointers._GetnUniformfvARB_fnptr((int)program, location, bufSize, parameters);
+            public static void GetnUniformfvARB(int program, int location, int bufSize, float* parameters) => GLPointers._GetnUniformfvARB_fnptr(program, location, bufSize, parameters);
             
             /// <summary> <b>[requires: GL_ARB_robustness]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetnUniformivARB(ProgramHandle program, int location, int bufSize, int* parameters) => GLPointers._GetnUniformivARB_fnptr((int)program, location, bufSize, parameters);
+            public static void GetnUniformivARB(int program, int location, int bufSize, int* parameters) => GLPointers._GetnUniformivARB_fnptr(program, location, bufSize, parameters);
             
             /// <summary> <b>[requires: GL_ARB_robustness]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetnUniformuivARB(ProgramHandle program, int location, int bufSize, uint* parameters) => GLPointers._GetnUniformuivARB_fnptr((int)program, location, bufSize, parameters);
+            public static void GetnUniformuivARB(int program, int location, int bufSize, uint* parameters) => GLPointers._GetnUniformuivARB_fnptr(program, location, bufSize, parameters);
             
             /// <summary> <b>[requires: GL_ARB_robustness]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetnUniformdvARB(ProgramHandle program, int location, int bufSize, double* parameters) => GLPointers._GetnUniformdvARB_fnptr((int)program, location, bufSize, parameters);
+            public static void GetnUniformdvARB(int program, int location, int bufSize, double* parameters) => GLPointers._GetnUniformdvARB_fnptr(program, location, bufSize, parameters);
             
             /// <summary> <b>[requires: GL_ARB_robustness]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -9545,7 +9545,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_ARB_sample_locations]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedFramebufferSampleLocationsfvARB(FramebufferHandle framebuffer, uint start, int count, float* v) => GLPointers._NamedFramebufferSampleLocationsfvARB_fnptr((int)framebuffer, start, count, v);
+            public static void NamedFramebufferSampleLocationsfvARB(int framebuffer, uint start, int count, float* v) => GLPointers._NamedFramebufferSampleLocationsfvARB_fnptr(framebuffer, start, count, v);
             
             /// <summary> <b>[requires: GL_ARB_sample_locations]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -9559,150 +9559,150 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="n"> Specifies the number of sampler object names to generate. </param>
             /// <param name="samplers"> Specifies an array in which the generated sampler object names are stored. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGenSamplers.xhtml" /></remarks>
-            public static void GenSamplers(int count, SamplerHandle* samplers) => GLPointers._GenSamplers_fnptr(count, (int*)samplers);
+            public static void GenSamplers(int count, int* samplers) => GLPointers._GenSamplers_fnptr(count, samplers);
             
             /// <summary> <b>[requires: v3.3 | GL_ARB_sampler_objects]</b> Delete named sampler objects. </summary>
             /// <param name="n"> Specifies the number of sampler objects to be deleted. </param>
             /// <param name="samplers"> Specifies an array of sampler objects to be deleted. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDeleteSamplers.xhtml" /></remarks>
-            public static void DeleteSamplers(int count, SamplerHandle* samplers) => GLPointers._DeleteSamplers_fnptr(count, (int*)samplers);
+            public static void DeleteSamplers(int count, int* samplers) => GLPointers._DeleteSamplers_fnptr(count, samplers);
             
             /// <summary> <b>[requires: v3.3 | GL_ARB_sampler_objects]</b> Determine if a name corresponds to a sampler object. </summary>
             /// <param name="id"> Specifies a value that may be the name of a sampler object. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsSampler.xhtml" /></remarks>
-            public static bool IsSampler(SamplerHandle sampler) => GLPointers._IsSampler_fnptr((int)sampler) != 0;
+            public static bool IsSampler(int sampler) => GLPointers._IsSampler_fnptr(sampler) != 0;
             
             /// <summary> <b>[requires: v3.3 | GL_ARB_sampler_objects]</b> Bind a named sampler to a texturing target. </summary>
             /// <param name="unit"> Specifies the index of the texture unit to which the sampler is bound. </param>
             /// <param name="sampler"> Specifies the name of a sampler. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindSampler.xhtml" /></remarks>
-            public static void BindSampler(uint unit, SamplerHandle sampler) => GLPointers._BindSampler_fnptr(unit, (int)sampler);
+            public static void BindSampler(uint unit, int sampler) => GLPointers._BindSampler_fnptr(unit, sampler);
             
             /// <summary> <b>[requires: v3.3 | GL_ARB_sampler_objects]</b> Set sampler parameters. </summary>
             /// <param name="sampler"> Specifies the sampler object whose parameter to modify. </param>
             /// <param name="pname"> Specifies the symbolic name of a sampler parameter. pname can be one of the following: GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, GL_TEXTURE_WRAP_R, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_BORDER_COLOR, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_LOD_BIAS GL_TEXTURE_COMPARE_MODE, or GL_TEXTURE_COMPARE_FUNC. </param>
             /// <param name="param"> For the scalar commands, specifies the value of pname. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glSamplerParameter.xhtml" /></remarks>
-            public static void SamplerParameteri(SamplerHandle sampler, SamplerParameterI pname, int param) => GLPointers._SamplerParameteri_fnptr((int)sampler, (uint)pname, param);
+            public static void SamplerParameteri(int sampler, SamplerParameterI pname, int param) => GLPointers._SamplerParameteri_fnptr(sampler, (uint)pname, param);
             
             /// <summary> <b>[requires: v3.3 | GL_ARB_sampler_objects]</b> Set sampler parameters. </summary>
             /// <param name="sampler"> Specifies the sampler object whose parameter to modify. </param>
             /// <param name="pname"> Specifies the symbolic name of a sampler parameter. pname can be one of the following: GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, GL_TEXTURE_WRAP_R, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_BORDER_COLOR, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_LOD_BIAS GL_TEXTURE_COMPARE_MODE, or GL_TEXTURE_COMPARE_FUNC. </param>
             /// <param name="parameters"> For the vector commands (glSamplerParameter*v), specifies a pointer to an array where the value or values of pname are stored. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glSamplerParameter.xhtml" /></remarks>
-            public static void SamplerParameteriv(SamplerHandle sampler, SamplerParameterI pname, int* param) => GLPointers._SamplerParameteriv_fnptr((int)sampler, (uint)pname, param);
+            public static void SamplerParameteriv(int sampler, SamplerParameterI pname, int* param) => GLPointers._SamplerParameteriv_fnptr(sampler, (uint)pname, param);
             
             /// <summary> <b>[requires: v3.3 | GL_ARB_sampler_objects]</b> Set sampler parameters. </summary>
             /// <param name="sampler"> Specifies the sampler object whose parameter to modify. </param>
             /// <param name="pname"> Specifies the symbolic name of a sampler parameter. pname can be one of the following: GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, GL_TEXTURE_WRAP_R, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_BORDER_COLOR, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_LOD_BIAS GL_TEXTURE_COMPARE_MODE, or GL_TEXTURE_COMPARE_FUNC. </param>
             /// <param name="param"> For the scalar commands, specifies the value of pname. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glSamplerParameter.xhtml" /></remarks>
-            public static void SamplerParameterf(SamplerHandle sampler, SamplerParameterF pname, float param) => GLPointers._SamplerParameterf_fnptr((int)sampler, (uint)pname, param);
+            public static void SamplerParameterf(int sampler, SamplerParameterF pname, float param) => GLPointers._SamplerParameterf_fnptr(sampler, (uint)pname, param);
             
             /// <summary> <b>[requires: v3.3 | GL_ARB_sampler_objects]</b> Set sampler parameters. </summary>
             /// <param name="sampler"> Specifies the sampler object whose parameter to modify. </param>
             /// <param name="pname"> Specifies the symbolic name of a sampler parameter. pname can be one of the following: GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, GL_TEXTURE_WRAP_R, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_BORDER_COLOR, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_LOD_BIAS GL_TEXTURE_COMPARE_MODE, or GL_TEXTURE_COMPARE_FUNC. </param>
             /// <param name="parameters"> For the vector commands (glSamplerParameter*v), specifies a pointer to an array where the value or values of pname are stored. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glSamplerParameter.xhtml" /></remarks>
-            public static void SamplerParameterfv(SamplerHandle sampler, SamplerParameterF pname, float* param) => GLPointers._SamplerParameterfv_fnptr((int)sampler, (uint)pname, param);
+            public static void SamplerParameterfv(int sampler, SamplerParameterF pname, float* param) => GLPointers._SamplerParameterfv_fnptr(sampler, (uint)pname, param);
             
             /// <summary> <b>[requires: v3.3 | GL_ARB_sampler_objects]</b> Set sampler parameters. </summary>
             /// <param name="sampler"> Specifies the sampler object whose parameter to modify. </param>
             /// <param name="pname"> Specifies the symbolic name of a sampler parameter. pname can be one of the following: GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, GL_TEXTURE_WRAP_R, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_BORDER_COLOR, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_LOD_BIAS GL_TEXTURE_COMPARE_MODE, or GL_TEXTURE_COMPARE_FUNC. </param>
             /// <param name="parameters"> For the vector commands (glSamplerParameter*v), specifies a pointer to an array where the value or values of pname are stored. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glSamplerParameter.xhtml" /></remarks>
-            public static void SamplerParameterIiv(SamplerHandle sampler, SamplerParameterI pname, int* param) => GLPointers._SamplerParameterIiv_fnptr((int)sampler, (uint)pname, param);
+            public static void SamplerParameterIiv(int sampler, SamplerParameterI pname, int* param) => GLPointers._SamplerParameterIiv_fnptr(sampler, (uint)pname, param);
             
             /// <summary> <b>[requires: v3.3 | GL_ARB_sampler_objects]</b> Set sampler parameters. </summary>
             /// <param name="sampler"> Specifies the sampler object whose parameter to modify. </param>
             /// <param name="pname"> Specifies the symbolic name of a sampler parameter. pname can be one of the following: GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, GL_TEXTURE_WRAP_R, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_BORDER_COLOR, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_LOD_BIAS GL_TEXTURE_COMPARE_MODE, or GL_TEXTURE_COMPARE_FUNC. </param>
             /// <param name="parameters"> For the vector commands (glSamplerParameter*v), specifies a pointer to an array where the value or values of pname are stored. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glSamplerParameter.xhtml" /></remarks>
-            public static void SamplerParameterIuiv(SamplerHandle sampler, SamplerParameterI pname, uint* param) => GLPointers._SamplerParameterIuiv_fnptr((int)sampler, (uint)pname, param);
+            public static void SamplerParameterIuiv(int sampler, SamplerParameterI pname, uint* param) => GLPointers._SamplerParameterIuiv_fnptr(sampler, (uint)pname, param);
             
             /// <summary> <b>[requires: v3.3 | GL_ARB_sampler_objects]</b> Return sampler parameter values. </summary>
             /// <param name="sampler"> Specifies name of the sampler object from which to retrieve parameters. </param>
             /// <param name="pname"> Specifies the symbolic name of a sampler parameter. GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_LOD_BIAS, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, GL_TEXTURE_WRAP_R, GL_TEXTURE_BORDER_COLOR, GL_TEXTURE_COMPARE_MODE, and GL_TEXTURE_COMPARE_FUNC are accepted. </param>
             /// <param name="parameters"> Returns the sampler parameters. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetSamplerParameter.xhtml" /></remarks>
-            public static void GetSamplerParameteriv(SamplerHandle sampler, SamplerParameterI pname, int* parameters) => GLPointers._GetSamplerParameteriv_fnptr((int)sampler, (uint)pname, parameters);
+            public static void GetSamplerParameteriv(int sampler, SamplerParameterI pname, int* parameters) => GLPointers._GetSamplerParameteriv_fnptr(sampler, (uint)pname, parameters);
             
             /// <summary> <b>[requires: v3.3 | GL_ARB_sampler_objects]</b> Return sampler parameter values. </summary>
             /// <param name="sampler"> Specifies name of the sampler object from which to retrieve parameters. </param>
             /// <param name="pname"> Specifies the symbolic name of a sampler parameter. GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_LOD_BIAS, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, GL_TEXTURE_WRAP_R, GL_TEXTURE_BORDER_COLOR, GL_TEXTURE_COMPARE_MODE, and GL_TEXTURE_COMPARE_FUNC are accepted. </param>
             /// <param name="parameters"> Returns the sampler parameters. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetSamplerParameter.xhtml" /></remarks>
-            public static void GetSamplerParameterIiv(SamplerHandle sampler, SamplerParameterI pname, int* parameters) => GLPointers._GetSamplerParameterIiv_fnptr((int)sampler, (uint)pname, parameters);
+            public static void GetSamplerParameterIiv(int sampler, SamplerParameterI pname, int* parameters) => GLPointers._GetSamplerParameterIiv_fnptr(sampler, (uint)pname, parameters);
             
             /// <summary> <b>[requires: v3.3 | GL_ARB_sampler_objects]</b> Return sampler parameter values. </summary>
             /// <param name="sampler"> Specifies name of the sampler object from which to retrieve parameters. </param>
             /// <param name="pname"> Specifies the symbolic name of a sampler parameter. GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_LOD_BIAS, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, GL_TEXTURE_WRAP_R, GL_TEXTURE_BORDER_COLOR, GL_TEXTURE_COMPARE_MODE, and GL_TEXTURE_COMPARE_FUNC are accepted. </param>
             /// <param name="parameters"> Returns the sampler parameters. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetSamplerParameter.xhtml" /></remarks>
-            public static void GetSamplerParameterfv(SamplerHandle sampler, SamplerParameterF pname, float* parameters) => GLPointers._GetSamplerParameterfv_fnptr((int)sampler, (uint)pname, parameters);
+            public static void GetSamplerParameterfv(int sampler, SamplerParameterF pname, float* parameters) => GLPointers._GetSamplerParameterfv_fnptr(sampler, (uint)pname, parameters);
             
             /// <summary> <b>[requires: v3.3 | GL_ARB_sampler_objects]</b> Return sampler parameter values. </summary>
             /// <param name="sampler"> Specifies name of the sampler object from which to retrieve parameters. </param>
             /// <param name="pname"> Specifies the symbolic name of a sampler parameter. GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_LOD_BIAS, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, GL_TEXTURE_WRAP_R, GL_TEXTURE_BORDER_COLOR, GL_TEXTURE_COMPARE_MODE, and GL_TEXTURE_COMPARE_FUNC are accepted. </param>
             /// <param name="parameters"> Returns the sampler parameters. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetSamplerParameter.xhtml" /></remarks>
-            public static void GetSamplerParameterIuiv(SamplerHandle sampler, SamplerParameterI pname, uint* parameters) => GLPointers._GetSamplerParameterIuiv_fnptr((int)sampler, (uint)pname, parameters);
+            public static void GetSamplerParameterIuiv(int sampler, SamplerParameterI pname, uint* parameters) => GLPointers._GetSamplerParameterIuiv_fnptr(sampler, (uint)pname, parameters);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Bind stages of a program object to a program pipeline. </summary>
             /// <param name="pipeline"> Specifies the program pipeline object to which to bind stages from program. </param>
             /// <param name="stages"> Specifies a set of program stages to bind to the program pipeline object. </param>
             /// <param name="program"> Specifies the program object containing the shader executables to use in pipeline. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glUseProgramStages.xhtml" /></remarks>
-            public static void UseProgramStages(ProgramPipelineHandle pipeline, UseProgramStageMask stages, ProgramHandle program) => GLPointers._UseProgramStages_fnptr((int)pipeline, (uint)stages, (int)program);
+            public static void UseProgramStages(int pipeline, UseProgramStageMask stages, int program) => GLPointers._UseProgramStages_fnptr(pipeline, (uint)stages, program);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Set the active program object for a program pipeline object. </summary>
             /// <param name="pipeline"> Specifies the program pipeline object to set the active program object for. </param>
             /// <param name="program"> Specifies the program object to set as the active program pipeline object pipeline. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glActiveShaderProgram.xhtml" /></remarks>
-            public static void ActiveShaderProgram(ProgramPipelineHandle pipeline, ProgramHandle program) => GLPointers._ActiveShaderProgram_fnptr((int)pipeline, (int)program);
+            public static void ActiveShaderProgram(int pipeline, int program) => GLPointers._ActiveShaderProgram_fnptr(pipeline, program);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Create a stand-alone program from an array of null-terminated source code strings. </summary>
             /// <param name="type"> Specifies the type of shader to create. </param>
             /// <param name="count"> Specifies the number of source code strings in the array strings. </param>
             /// <param name="strings"> Specifies the address of an array of pointers to source code strings from which to create the program object. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCreateShaderProgram.xhtml" /></remarks>
-            public static ProgramHandle CreateShaderProgramv(ShaderType type, int count, byte** strings) => (ProgramHandle) GLPointers._CreateShaderProgramv_fnptr((uint)type, count, strings);
+            public static int CreateShaderProgramv(ShaderType type, int count, byte** strings) => GLPointers._CreateShaderProgramv_fnptr((uint)type, count, strings);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Bind a program pipeline to the current context. </summary>
             /// <param name="pipeline"> Specifies the name of the pipeline object to bind to the context. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindProgramPipeline.xhtml" /></remarks>
-            public static void BindProgramPipeline(ProgramPipelineHandle pipeline) => GLPointers._BindProgramPipeline_fnptr((int)pipeline);
+            public static void BindProgramPipeline(int pipeline) => GLPointers._BindProgramPipeline_fnptr(pipeline);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Delete program pipeline objects. </summary>
             /// <param name="n"> Specifies the number of program pipeline objects to delete. </param>
             /// <param name="pipelines"> Specifies an array of names of program pipeline objects to delete. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDeleteProgramPipelines.xhtml" /></remarks>
-            public static void DeleteProgramPipelines(int n, ProgramPipelineHandle* pipelines) => GLPointers._DeleteProgramPipelines_fnptr(n, (int*)pipelines);
+            public static void DeleteProgramPipelines(int n, int* pipelines) => GLPointers._DeleteProgramPipelines_fnptr(n, pipelines);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Reserve program pipeline object names. </summary>
             /// <param name="n"> Specifies the number of program pipeline object names to reserve. </param>
             /// <param name="pipelines"> Specifies an array of into which the reserved names will be written. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGenProgramPipelines.xhtml" /></remarks>
-            public static void GenProgramPipelines(int n, ProgramPipelineHandle* pipelines) => GLPointers._GenProgramPipelines_fnptr(n, (int*)pipelines);
+            public static void GenProgramPipelines(int n, int* pipelines) => GLPointers._GenProgramPipelines_fnptr(n, pipelines);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Determine if a name corresponds to a program pipeline object. </summary>
             /// <param name="pipeline"> Specifies a value that may be the name of a program pipeline object. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsProgramPipeline.xhtml" /></remarks>
-            public static bool IsProgramPipeline(ProgramPipelineHandle pipeline) => GLPointers._IsProgramPipeline_fnptr((int)pipeline) != 0;
+            public static bool IsProgramPipeline(int pipeline) => GLPointers._IsProgramPipeline_fnptr(pipeline) != 0;
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Retrieve properties of a program pipeline object. </summary>
             /// <param name="pipeline"> Specifies the name of a program pipeline object whose parameter retrieve. </param>
             /// <param name="pname"> Specifies the name of the parameter to retrieve. </param>
             /// <param name="parameters"> Specifies the address of a variable into which will be written the value or values of pname for pipeline. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetProgramPipeline.xhtml" /></remarks>
-            public static void GetProgramPipelineiv(ProgramPipelineHandle pipeline, PipelineParameterName pname, int* parameters) => GLPointers._GetProgramPipelineiv_fnptr((int)pipeline, (uint)pname, parameters);
+            public static void GetProgramPipelineiv(int pipeline, PipelineParameterName pname, int* parameters) => GLPointers._GetProgramPipelineiv_fnptr(pipeline, (uint)pname, parameters);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
             /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
             /// <param name="v0"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniform1i(ProgramHandle program, int location, int v0) => GLPointers._ProgramUniform1i_fnptr((int)program, location, v0);
+            public static void ProgramUniform1i(int program, int location, int v0) => GLPointers._ProgramUniform1i_fnptr(program, location, v0);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -9710,14 +9710,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
             /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniform1iv(ProgramHandle program, int location, int count, int* value) => GLPointers._ProgramUniform1iv_fnptr((int)program, location, count, value);
+            public static void ProgramUniform1iv(int program, int location, int count, int* value) => GLPointers._ProgramUniform1iv_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
             /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
             /// <param name="v0"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniform1f(ProgramHandle program, int location, float v0) => GLPointers._ProgramUniform1f_fnptr((int)program, location, v0);
+            public static void ProgramUniform1f(int program, int location, float v0) => GLPointers._ProgramUniform1f_fnptr(program, location, v0);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -9725,22 +9725,22 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
             /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniform1fv(ProgramHandle program, int location, int count, float* value) => GLPointers._ProgramUniform1fv_fnptr((int)program, location, count, value);
+            public static void ProgramUniform1fv(int program, int location, int count, float* value) => GLPointers._ProgramUniform1fv_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform1d(ProgramHandle program, int location, double v0) => GLPointers._ProgramUniform1d_fnptr((int)program, location, v0);
+            public static void ProgramUniform1d(int program, int location, double v0) => GLPointers._ProgramUniform1d_fnptr(program, location, v0);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform1dv(ProgramHandle program, int location, int count, double* value) => GLPointers._ProgramUniform1dv_fnptr((int)program, location, count, value);
+            public static void ProgramUniform1dv(int program, int location, int count, double* value) => GLPointers._ProgramUniform1dv_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
             /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
             /// <param name="v0"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniform1ui(ProgramHandle program, int location, uint v0) => GLPointers._ProgramUniform1ui_fnptr((int)program, location, v0);
+            public static void ProgramUniform1ui(int program, int location, uint v0) => GLPointers._ProgramUniform1ui_fnptr(program, location, v0);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -9748,7 +9748,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
             /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniform1uiv(ProgramHandle program, int location, int count, uint* value) => GLPointers._ProgramUniform1uiv_fnptr((int)program, location, count, value);
+            public static void ProgramUniform1uiv(int program, int location, int count, uint* value) => GLPointers._ProgramUniform1uiv_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -9756,7 +9756,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="v0"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
             /// <param name="v1"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniform2i(ProgramHandle program, int location, int v0, int v1) => GLPointers._ProgramUniform2i_fnptr((int)program, location, v0, v1);
+            public static void ProgramUniform2i(int program, int location, int v0, int v1) => GLPointers._ProgramUniform2i_fnptr(program, location, v0, v1);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -9764,7 +9764,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
             /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniform2iv(ProgramHandle program, int location, int count, int* value) => GLPointers._ProgramUniform2iv_fnptr((int)program, location, count, value);
+            public static void ProgramUniform2iv(int program, int location, int count, int* value) => GLPointers._ProgramUniform2iv_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -9772,7 +9772,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="v0"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
             /// <param name="v1"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniform2f(ProgramHandle program, int location, float v0, float v1) => GLPointers._ProgramUniform2f_fnptr((int)program, location, v0, v1);
+            public static void ProgramUniform2f(int program, int location, float v0, float v1) => GLPointers._ProgramUniform2f_fnptr(program, location, v0, v1);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -9780,15 +9780,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
             /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniform2fv(ProgramHandle program, int location, int count, float* value) => GLPointers._ProgramUniform2fv_fnptr((int)program, location, count, value);
+            public static void ProgramUniform2fv(int program, int location, int count, float* value) => GLPointers._ProgramUniform2fv_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform2d(ProgramHandle program, int location, double v0, double v1) => GLPointers._ProgramUniform2d_fnptr((int)program, location, v0, v1);
+            public static void ProgramUniform2d(int program, int location, double v0, double v1) => GLPointers._ProgramUniform2d_fnptr(program, location, v0, v1);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform2dv(ProgramHandle program, int location, int count, double* value) => GLPointers._ProgramUniform2dv_fnptr((int)program, location, count, value);
+            public static void ProgramUniform2dv(int program, int location, int count, double* value) => GLPointers._ProgramUniform2dv_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -9796,7 +9796,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="v0"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
             /// <param name="v1"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniform2ui(ProgramHandle program, int location, uint v0, uint v1) => GLPointers._ProgramUniform2ui_fnptr((int)program, location, v0, v1);
+            public static void ProgramUniform2ui(int program, int location, uint v0, uint v1) => GLPointers._ProgramUniform2ui_fnptr(program, location, v0, v1);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -9804,7 +9804,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
             /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniform2uiv(ProgramHandle program, int location, int count, uint* value) => GLPointers._ProgramUniform2uiv_fnptr((int)program, location, count, value);
+            public static void ProgramUniform2uiv(int program, int location, int count, uint* value) => GLPointers._ProgramUniform2uiv_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -9813,7 +9813,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="v1"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
             /// <param name="v2"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniform3i(ProgramHandle program, int location, int v0, int v1, int v2) => GLPointers._ProgramUniform3i_fnptr((int)program, location, v0, v1, v2);
+            public static void ProgramUniform3i(int program, int location, int v0, int v1, int v2) => GLPointers._ProgramUniform3i_fnptr(program, location, v0, v1, v2);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -9821,7 +9821,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
             /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniform3iv(ProgramHandle program, int location, int count, int* value) => GLPointers._ProgramUniform3iv_fnptr((int)program, location, count, value);
+            public static void ProgramUniform3iv(int program, int location, int count, int* value) => GLPointers._ProgramUniform3iv_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -9830,7 +9830,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="v1"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
             /// <param name="v2"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniform3f(ProgramHandle program, int location, float v0, float v1, float v2) => GLPointers._ProgramUniform3f_fnptr((int)program, location, v0, v1, v2);
+            public static void ProgramUniform3f(int program, int location, float v0, float v1, float v2) => GLPointers._ProgramUniform3f_fnptr(program, location, v0, v1, v2);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -9838,15 +9838,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
             /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniform3fv(ProgramHandle program, int location, int count, float* value) => GLPointers._ProgramUniform3fv_fnptr((int)program, location, count, value);
+            public static void ProgramUniform3fv(int program, int location, int count, float* value) => GLPointers._ProgramUniform3fv_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform3d(ProgramHandle program, int location, double v0, double v1, double v2) => GLPointers._ProgramUniform3d_fnptr((int)program, location, v0, v1, v2);
+            public static void ProgramUniform3d(int program, int location, double v0, double v1, double v2) => GLPointers._ProgramUniform3d_fnptr(program, location, v0, v1, v2);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform3dv(ProgramHandle program, int location, int count, double* value) => GLPointers._ProgramUniform3dv_fnptr((int)program, location, count, value);
+            public static void ProgramUniform3dv(int program, int location, int count, double* value) => GLPointers._ProgramUniform3dv_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -9855,7 +9855,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="v1"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
             /// <param name="v2"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniform3ui(ProgramHandle program, int location, uint v0, uint v1, uint v2) => GLPointers._ProgramUniform3ui_fnptr((int)program, location, v0, v1, v2);
+            public static void ProgramUniform3ui(int program, int location, uint v0, uint v1, uint v2) => GLPointers._ProgramUniform3ui_fnptr(program, location, v0, v1, v2);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -9863,25 +9863,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
             /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniform3uiv(ProgramHandle program, int location, int count, uint* value) => GLPointers._ProgramUniform3uiv_fnptr((int)program, location, count, value);
-            
-            /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
-            /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
-            /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
-            /// <param name="v0"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
-            /// <param name="v1"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
-            /// <param name="v2"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
-            /// <param name="v3"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
-            /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniform4i(ProgramHandle program, int location, int v0, int v1, int v2, int v3) => GLPointers._ProgramUniform4i_fnptr((int)program, location, v0, v1, v2, v3);
-            
-            /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
-            /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
-            /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
-            /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
-            /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
-            /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniform4iv(ProgramHandle program, int location, int count, int* value) => GLPointers._ProgramUniform4iv_fnptr((int)program, location, count, value);
+            public static void ProgramUniform3uiv(int program, int location, int count, uint* value) => GLPointers._ProgramUniform3uiv_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -9891,7 +9873,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="v2"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
             /// <param name="v3"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniform4f(ProgramHandle program, int location, float v0, float v1, float v2, float v3) => GLPointers._ProgramUniform4f_fnptr((int)program, location, v0, v1, v2, v3);
+            public static void ProgramUniform4i(int program, int location, int v0, int v1, int v2, int v3) => GLPointers._ProgramUniform4i_fnptr(program, location, v0, v1, v2, v3);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -9899,15 +9881,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
             /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniform4fv(ProgramHandle program, int location, int count, float* value) => GLPointers._ProgramUniform4fv_fnptr((int)program, location, count, value);
-            
-            /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
-            /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform4d(ProgramHandle program, int location, double v0, double v1, double v2, double v3) => GLPointers._ProgramUniform4d_fnptr((int)program, location, v0, v1, v2, v3);
-            
-            /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
-            /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform4dv(ProgramHandle program, int location, int count, double* value) => GLPointers._ProgramUniform4dv_fnptr((int)program, location, count, value);
+            public static void ProgramUniform4iv(int program, int location, int count, int* value) => GLPointers._ProgramUniform4iv_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -9917,7 +9891,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="v2"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
             /// <param name="v3"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniform4ui(ProgramHandle program, int location, uint v0, uint v1, uint v2, uint v3) => GLPointers._ProgramUniform4ui_fnptr((int)program, location, v0, v1, v2, v3);
+            public static void ProgramUniform4f(int program, int location, float v0, float v1, float v2, float v3) => GLPointers._ProgramUniform4f_fnptr(program, location, v0, v1, v2, v3);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -9925,7 +9899,33 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
             /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniform4uiv(ProgramHandle program, int location, int count, uint* value) => GLPointers._ProgramUniform4uiv_fnptr((int)program, location, count, value);
+            public static void ProgramUniform4fv(int program, int location, int count, float* value) => GLPointers._ProgramUniform4fv_fnptr(program, location, count, value);
+            
+            /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
+            /// <remarks><see href="" /></remarks>
+            public static void ProgramUniform4d(int program, int location, double v0, double v1, double v2, double v3) => GLPointers._ProgramUniform4d_fnptr(program, location, v0, v1, v2, v3);
+            
+            /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
+            /// <remarks><see href="" /></remarks>
+            public static void ProgramUniform4dv(int program, int location, int count, double* value) => GLPointers._ProgramUniform4dv_fnptr(program, location, count, value);
+            
+            /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
+            /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
+            /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
+            /// <param name="v0"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
+            /// <param name="v1"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
+            /// <param name="v2"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
+            /// <param name="v3"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
+            /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
+            public static void ProgramUniform4ui(int program, int location, uint v0, uint v1, uint v2, uint v3) => GLPointers._ProgramUniform4ui_fnptr(program, location, v0, v1, v2, v3);
+            
+            /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
+            /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
+            /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
+            /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
+            /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
+            /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
+            public static void ProgramUniform4uiv(int program, int location, int count, uint* value) => GLPointers._ProgramUniform4uiv_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -9934,7 +9934,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
             /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniformMatrix2fv(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix2fv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix2fv(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix2fv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -9943,7 +9943,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
             /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniformMatrix3fv(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix3fv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix3fv(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix3fv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -9952,19 +9952,19 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
             /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniformMatrix4fv(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix4fv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix4fv(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix4fv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix2dv(ProgramHandle program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix2dv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix2dv(int program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix2dv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix3dv(ProgramHandle program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix3dv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix3dv(int program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix3dv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix4dv(ProgramHandle program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix4dv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix4dv(int program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix4dv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -9973,7 +9973,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
             /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniformMatrix2x3fv(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix2x3fv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix2x3fv(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix2x3fv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -9982,7 +9982,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
             /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniformMatrix3x2fv(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix3x2fv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix3x2fv(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix3x2fv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -9991,7 +9991,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
             /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniformMatrix2x4fv(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix2x4fv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix2x4fv(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix2x4fv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -10000,7 +10000,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
             /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniformMatrix4x2fv(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix4x2fv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix4x2fv(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix4x2fv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -10009,7 +10009,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
             /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniformMatrix3x4fv(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix3x4fv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix3x4fv(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix3x4fv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -10018,36 +10018,36 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
             /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniformMatrix4x3fv(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix4x3fv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix4x3fv(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix4x3fv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix2x3dv(ProgramHandle program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix2x3dv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix2x3dv(int program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix2x3dv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix3x2dv(ProgramHandle program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix3x2dv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix3x2dv(int program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix3x2dv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix2x4dv(ProgramHandle program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix2x4dv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix2x4dv(int program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix2x4dv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix4x2dv(ProgramHandle program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix4x2dv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix4x2dv(int program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix4x2dv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix3x4dv(ProgramHandle program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix3x4dv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix3x4dv(int program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix3x4dv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix4x3dv(ProgramHandle program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix4x3dv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix4x3dv(int program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix4x3dv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Validate a program pipeline object against current GL state. </summary>
             /// <param name="pipeline"> Specifies the name of a program pipeline object to validate. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glValidateProgramPipeline.xhtml" /></remarks>
-            public static void ValidateProgramPipeline(ProgramPipelineHandle pipeline) => GLPointers._ValidateProgramPipeline_fnptr((int)pipeline);
+            public static void ValidateProgramPipeline(int pipeline) => GLPointers._ValidateProgramPipeline_fnptr(pipeline);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Retrieve the info log string from a program pipeline object. </summary>
             /// <param name="pipeline"> Specifies the name of a program pipeline object from which to retrieve the info log. </param>
@@ -10055,7 +10055,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="length"> Specifies the address of a variable into which will be written the number of characters written into infoLog. </param>
             /// <param name="infoLog"> Specifies the address of an array of characters into which will be written the info log for pipeline. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetProgramPipelineInfoLog.xhtml" /></remarks>
-            public static void GetProgramPipelineInfoLog(ProgramPipelineHandle pipeline, int bufSize, int* length, byte* infoLog) => GLPointers._GetProgramPipelineInfoLog_fnptr((int)pipeline, bufSize, length, infoLog);
+            public static void GetProgramPipelineInfoLog(int pipeline, int bufSize, int* length, byte* infoLog) => GLPointers._GetProgramPipelineInfoLog_fnptr(pipeline, bufSize, length, infoLog);
             
             /// <summary> <b>[requires: v4.2 | GL_ARB_shader_atomic_counters]</b> Retrieve information about the set of active atomic counter buffers for a program. </summary>
             /// <param name="program"> The name of a program object from which to retrieve information. </param>
@@ -10063,7 +10063,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="pname"> Specifies which parameter of the atomic counter buffer to retrieve. </param>
             /// <param name="parameters"> Specifies the address of a variable into which to write the retrieved information. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetActiveAtomicCounterBufferiv.xhtml" /></remarks>
-            public static void GetActiveAtomicCounterBufferiv(ProgramHandle program, uint bufferIndex, AtomicCounterBufferPName pname, int* parameters) => GLPointers._GetActiveAtomicCounterBufferiv_fnptr((int)program, bufferIndex, (uint)pname, parameters);
+            public static void GetActiveAtomicCounterBufferiv(int program, uint bufferIndex, AtomicCounterBufferPName pname, int* parameters) => GLPointers._GetActiveAtomicCounterBufferiv_fnptr(program, bufferIndex, (uint)pname, parameters);
             
             /// <summary> <b>[requires: v4.2 | GL_ARB_shader_image_load_store]</b> Bind a level of a texture to an image unit. </summary>
             /// <param name="unit"> Specifies the index of the image unit to which to bind the texture </param>
@@ -10074,7 +10074,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="access"> Specifies a token indicating the type of access that will be performed on the image. </param>
             /// <param name="format"> Specifies the format that the elements of the image will be treated as for the purposes of formatted stores. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindImageTexture.xhtml" /></remarks>
-            public static void BindImageTexture(uint unit, TextureHandle texture, int level, bool layered, int layer, BufferAccessARB access, InternalFormat format) => GLPointers._BindImageTexture_fnptr(unit, (int)texture, level, (byte)(layered ? 1 : 0), layer, (uint)access, (uint)format);
+            public static void BindImageTexture(uint unit, int texture, int level, bool layered, int layer, BufferAccessARB access, InternalFormat format) => GLPointers._BindImageTexture_fnptr(unit, texture, level, (byte)(layered ? 1 : 0), layer, (uint)access, (uint)format);
             
             /// <summary> <b>[requires: v4.2 | GL_ARB_shader_image_load_store]</b> Defines a barrier ordering memory transactions. </summary>
             /// <param name="barriers"> Specifies the barriers to insert. </param>
@@ -10242,21 +10242,21 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="storageBlockIndex"> The index storage block within the program. </param>
             /// <param name="storageBlockBinding"> The index storage block binding to associate with the specified storage block. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glShaderStorageBlockBinding.xhtml" /></remarks>
-            public static void ShaderStorageBlockBinding(ProgramHandle program, uint storageBlockIndex, uint storageBlockBinding) => GLPointers._ShaderStorageBlockBinding_fnptr((int)program, storageBlockIndex, storageBlockBinding);
+            public static void ShaderStorageBlockBinding(int program, uint storageBlockIndex, uint storageBlockBinding) => GLPointers._ShaderStorageBlockBinding_fnptr(program, storageBlockIndex, storageBlockBinding);
             
             /// <summary> <b>[requires: v4.0 | GL_ARB_shader_subroutine]</b> Retrieve the location of a subroutine uniform of a given shader stage within a program. </summary>
             /// <param name="program"> Specifies the name of the program containing shader stage. </param>
             /// <param name="shadertype"> Specifies the shader stage from which to query for subroutine uniform index. shadertype must be one of GL_VERTEX_SHADER, GL_TESS_CONTROL_SHADER, GL_TESS_EVALUATION_SHADER, GL_GEOMETRY_SHADER or GL_FRAGMENT_SHADER. </param>
             /// <param name="name"> Specifies the name of the subroutine uniform whose index to query. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetSubroutineUniformLocation.xhtml" /></remarks>
-            public static int GetSubroutineUniformLocation(ProgramHandle program, ShaderType shadertype, byte* name) => GLPointers._GetSubroutineUniformLocation_fnptr((int)program, (uint)shadertype, name);
+            public static int GetSubroutineUniformLocation(int program, ShaderType shadertype, byte* name) => GLPointers._GetSubroutineUniformLocation_fnptr(program, (uint)shadertype, name);
             
             /// <summary> <b>[requires: v4.0 | GL_ARB_shader_subroutine]</b> Retrieve the index of a subroutine uniform of a given shader stage within a program. </summary>
             /// <param name="program"> Specifies the name of the program containing shader stage. </param>
             /// <param name="shadertype"> Specifies the shader stage from which to query for subroutine uniform index. shadertype must be one of GL_VERTEX_SHADER, GL_TESS_CONTROL_SHADER, GL_TESS_EVALUATION_SHADER, GL_GEOMETRY_SHADER or GL_FRAGMENT_SHADER. </param>
             /// <param name="name"> Specifies the name of the subroutine uniform whose index to query. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetSubroutineIndex.xhtml" /></remarks>
-            public static uint GetSubroutineIndex(ProgramHandle program, ShaderType shadertype, byte* name) => GLPointers._GetSubroutineIndex_fnptr((int)program, (uint)shadertype, name);
+            public static uint GetSubroutineIndex(int program, ShaderType shadertype, byte* name) => GLPointers._GetSubroutineIndex_fnptr(program, (uint)shadertype, name);
             
             /// <summary> <b>[requires: v4.0 | GL_ARB_shader_subroutine]</b> Query a property of an active shader subroutine uniform. </summary>
             /// <param name="program"> Specifies the name of the program containing the subroutine. </param>
@@ -10265,7 +10265,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="pname"> Specifies the parameter of the shader subroutine uniform to query. pname must be GL_NUM_COMPATIBLE_SUBROUTINES, GL_COMPATIBLE_SUBROUTINES, GL_UNIFORM_SIZE or GL_UNIFORM_NAME_LENGTH. </param>
             /// <param name="values"> Specifies the address of a into which the queried value or values will be placed. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetActiveSubroutineUniform.xhtml" /></remarks>
-            public static void GetActiveSubroutineUniformiv(ProgramHandle program, ShaderType shadertype, uint index, SubroutineParameterName pname, int* values) => GLPointers._GetActiveSubroutineUniformiv_fnptr((int)program, (uint)shadertype, index, (uint)pname, values);
+            public static void GetActiveSubroutineUniformiv(int program, ShaderType shadertype, uint index, SubroutineParameterName pname, int* values) => GLPointers._GetActiveSubroutineUniformiv_fnptr(program, (uint)shadertype, index, (uint)pname, values);
             
             /// <summary> <b>[requires: v4.0 | GL_ARB_shader_subroutine]</b> Query the name of an active shader subroutine uniform. </summary>
             /// <param name="program"> Specifies the name of the program containing the subroutine. </param>
@@ -10275,7 +10275,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="length"> Specifies the address of a variable into which is written the number of characters copied into name. </param>
             /// <param name="name"> Specifies the address of a buffer that will receive the name of the specified shader subroutine uniform. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetActiveSubroutineUniformName.xhtml" /></remarks>
-            public static void GetActiveSubroutineUniformName(ProgramHandle program, ShaderType shadertype, uint index, int bufSize, int* length, byte* name) => GLPointers._GetActiveSubroutineUniformName_fnptr((int)program, (uint)shadertype, index, bufSize, length, name);
+            public static void GetActiveSubroutineUniformName(int program, ShaderType shadertype, uint index, int bufSize, int* length, byte* name) => GLPointers._GetActiveSubroutineUniformName_fnptr(program, (uint)shadertype, index, bufSize, length, name);
             
             /// <summary> <b>[requires: v4.0 | GL_ARB_shader_subroutine]</b> Query the name of an active shader subroutine. </summary>
             /// <param name="program"> Specifies the name of the program containing the subroutine. </param>
@@ -10285,7 +10285,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="length"> Specifies the address of a variable which is to receive the length of the shader subroutine uniform name. </param>
             /// <param name="name"> Specifies the address of an array into which the name of the shader subroutine uniform will be written. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetActiveSubroutineName.xhtml" /></remarks>
-            public static void GetActiveSubroutineName(ProgramHandle program, ShaderType shadertype, uint index, int bufSize, int* length, byte* name) => GLPointers._GetActiveSubroutineName_fnptr((int)program, (uint)shadertype, index, bufSize, length, name);
+            public static void GetActiveSubroutineName(int program, ShaderType shadertype, uint index, int bufSize, int* length, byte* name) => GLPointers._GetActiveSubroutineName_fnptr(program, (uint)shadertype, index, bufSize, length, name);
             
             /// <summary> <b>[requires: v4.0 | GL_ARB_shader_subroutine]</b> Load active subroutine uniforms. </summary>
             /// <param name="shadertype"> Specifies the shader stage from which to query for subroutine uniform index. shadertype must be one of GL_VERTEX_SHADER, GL_TESS_CONTROL_SHADER, GL_TESS_EVALUATION_SHADER, GL_GEOMETRY_SHADER or GL_FRAGMENT_SHADER. </param>
@@ -10307,7 +10307,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="pname"> Specifies the parameter of the shader to query. pname must be GL_ACTIVE_SUBROUTINE_UNIFORMS, GL_ACTIVE_SUBROUTINE_UNIFORM_LOCATIONS, GL_ACTIVE_SUBROUTINES, GL_ACTIVE_SUBROUTINE_UNIFORM_MAX_LENGTH, or GL_ACTIVE_SUBROUTINE_MAX_LENGTH. </param>
             /// <param name="values"> Specifies the address of a variable into which the queried value or values will be placed. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetProgramStage.xhtml" /></remarks>
-            public static void GetProgramStageiv(ProgramHandle program, ShaderType shadertype, ProgramStagePName pname, int* values) => GLPointers._GetProgramStageiv_fnptr((int)program, (uint)shadertype, (uint)pname, values);
+            public static void GetProgramStageiv(int program, ShaderType shadertype, ProgramStagePName pname, int* values) => GLPointers._GetProgramStageiv_fnptr(program, (uint)shadertype, (uint)pname, values);
             
             /// <summary> <b>[requires: GL_ARB_shading_language_include]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -10319,7 +10319,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_ARB_shading_language_include]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void CompileShaderIncludeARB(ShaderHandle shader, int count, byte** path, int* length) => GLPointers._CompileShaderIncludeARB_fnptr((int)shader, count, path, length);
+            public static void CompileShaderIncludeARB(int shader, int count, byte** path, int* length) => GLPointers._CompileShaderIncludeARB_fnptr(shader, count, path, length);
             
             /// <summary> <b>[requires: GL_ARB_shading_language_include]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -10339,11 +10339,11 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_ARB_sparse_buffer]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedBufferPageCommitmentEXT(BufferHandle buffer, IntPtr offset, nint size, bool commit) => GLPointers._NamedBufferPageCommitmentEXT_fnptr((int)buffer, offset, size, (byte)(commit ? 1 : 0));
+            public static void NamedBufferPageCommitmentEXT(int buffer, IntPtr offset, nint size, bool commit) => GLPointers._NamedBufferPageCommitmentEXT_fnptr(buffer, offset, size, (byte)(commit ? 1 : 0));
             
             /// <summary> <b>[requires: GL_ARB_sparse_buffer]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedBufferPageCommitmentARB(BufferHandle buffer, IntPtr offset, nint size, bool commit) => GLPointers._NamedBufferPageCommitmentARB_fnptr((int)buffer, offset, size, (byte)(commit ? 1 : 0));
+            public static void NamedBufferPageCommitmentARB(int buffer, IntPtr offset, nint size, bool commit) => GLPointers._NamedBufferPageCommitmentARB_fnptr(buffer, offset, size, (byte)(commit ? 1 : 0));
             
             /// <summary> <b>[requires: GL_ARB_sparse_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -10412,7 +10412,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_ARB_texture_buffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TexBufferARB(TextureTarget target, SizedInternalFormat internalformat, BufferHandle buffer) => GLPointers._TexBufferARB_fnptr((uint)target, (uint)internalformat, (int)buffer);
+            public static void TexBufferARB(TextureTarget target, SizedInternalFormat internalformat, int buffer) => GLPointers._TexBufferARB_fnptr((uint)target, (uint)internalformat, buffer);
             
             /// <summary> <b>[requires: v4.3 | GL_ARB_texture_buffer_range]</b> Attach a range of a buffer object's data store to a buffer texture object. </summary>
             /// <param name="target"> Specifies the target to which the texture object is bound for glTexBufferRange. Must be GL_TEXTURE_BUFFER. </param>
@@ -10421,7 +10421,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="offset"> Specifies the offset of the start of the range of the buffer's data store to attach. </param>
             /// <param name="size"> Specifies the size of the range of the buffer's data store to attach. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexBufferRange.xhtml" /></remarks>
-            public static void TexBufferRange(TextureTarget target, SizedInternalFormat internalformat, BufferHandle buffer, IntPtr offset, nint size) => GLPointers._TexBufferRange_fnptr((uint)target, (uint)internalformat, (int)buffer, offset, size);
+            public static void TexBufferRange(TextureTarget target, SizedInternalFormat internalformat, int buffer, IntPtr offset, nint size) => GLPointers._TexBufferRange_fnptr((uint)target, (uint)internalformat, buffer, offset, size);
             
             /// <summary> <b>[requires: GL_ARB_texture_compression]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -10543,50 +10543,50 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="minlayer"> Specifies the index of the first layer to include in the view. </param>
             /// <param name="numlayers"> Specifies the number of layers to include in the view. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTextureView.xhtml" /></remarks>
-            public static void TextureView(TextureHandle texture, TextureTarget target, TextureHandle origtexture, SizedInternalFormat internalformat, uint minlevel, uint numlevels, uint minlayer, uint numlayers) => GLPointers._TextureView_fnptr((int)texture, (uint)target, (int)origtexture, (uint)internalformat, minlevel, numlevels, minlayer, numlayers);
+            public static void TextureView(int texture, TextureTarget target, int origtexture, SizedInternalFormat internalformat, uint minlevel, uint numlevels, uint minlayer, uint numlayers) => GLPointers._TextureView_fnptr(texture, (uint)target, origtexture, (uint)internalformat, minlevel, numlevels, minlayer, numlayers);
             
             /// <summary> <b>[requires: v3.3 | GL_ARB_timer_query]</b> Record the GL time into a query object after all previous commands have reached the GL server but have not yet necessarily executed.. </summary>
             /// <param name="id"> Specify the name of a query object into which to record the GL time. </param>
             /// <param name="target"> Specify the counter to query. target must be GL_TIMESTAMP. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glQueryCounter.xhtml" /></remarks>
-            public static void QueryCounter(QueryHandle id, QueryCounterTarget target) => GLPointers._QueryCounter_fnptr((int)id, (uint)target);
+            public static void QueryCounter(int id, QueryCounterTarget target) => GLPointers._QueryCounter_fnptr(id, (uint)target);
             
             /// <summary> <b>[requires: v3.3 | GL_ARB_timer_query]</b> Return parameters of a query object. </summary>
             /// <param name="id"> Specifies the name of a query object. </param>
             /// <param name="pname"> Specifies the symbolic name of a query object parameter. Accepted values are GL_QUERY_RESULT or GL_QUERY_RESULT_AVAILABLE. </param>
             /// <param name="parameters"> If a buffer is bound to the GL_QUERY_RESULT_BUFFER target, then params is treated as an offset to a location within that buffer's data store to receive the result of the query. If no buffer is bound to GL_QUERY_RESULT_BUFFER, then params is treated as an address in client memory of a variable to receive the resulting data. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetQueryObject.xhtml" /></remarks>
-            public static void GetQueryObjecti64v(QueryHandle id, QueryObjectParameterName pname, long* parameters) => GLPointers._GetQueryObjecti64v_fnptr((int)id, (uint)pname, parameters);
+            public static void GetQueryObjecti64v(int id, QueryObjectParameterName pname, long* parameters) => GLPointers._GetQueryObjecti64v_fnptr(id, (uint)pname, parameters);
             
             /// <summary> <b>[requires: v3.3 | GL_ARB_timer_query]</b> Return parameters of a query object. </summary>
             /// <param name="id"> Specifies the name of a query object. </param>
             /// <param name="pname"> Specifies the symbolic name of a query object parameter. Accepted values are GL_QUERY_RESULT or GL_QUERY_RESULT_AVAILABLE. </param>
             /// <param name="parameters"> If a buffer is bound to the GL_QUERY_RESULT_BUFFER target, then params is treated as an offset to a location within that buffer's data store to receive the result of the query. If no buffer is bound to GL_QUERY_RESULT_BUFFER, then params is treated as an address in client memory of a variable to receive the resulting data. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetQueryObject.xhtml" /></remarks>
-            public static void GetQueryObjectui64v(QueryHandle id, QueryObjectParameterName pname, ulong* parameters) => GLPointers._GetQueryObjectui64v_fnptr((int)id, (uint)pname, parameters);
+            public static void GetQueryObjectui64v(int id, QueryObjectParameterName pname, ulong* parameters) => GLPointers._GetQueryObjectui64v_fnptr(id, (uint)pname, parameters);
             
             /// <summary> <b>[requires: v4.0 | GL_ARB_transform_feedback2]</b> Bind a transform feedback object. </summary>
             /// <param name="target"> Specifies the target to which to bind the transform feedback object id. target must be GL_TRANSFORM_FEEDBACK. </param>
             /// <param name="id"> Specifies the name of a transform feedback object reserved by glGenTransformFeedbacks. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindTransformFeedback.xhtml" /></remarks>
-            public static void BindTransformFeedback(BindTransformFeedbackTarget target, TransformFeedbackHandle id) => GLPointers._BindTransformFeedback_fnptr((uint)target, (int)id);
+            public static void BindTransformFeedback(BindTransformFeedbackTarget target, int id) => GLPointers._BindTransformFeedback_fnptr((uint)target, id);
             
             /// <summary> <b>[requires: v4.0 | GL_ARB_transform_feedback2]</b> Delete transform feedback objects. </summary>
             /// <param name="n"> Specifies the number of transform feedback objects to delete. </param>
             /// <param name="ids"> Specifies an array of names of transform feedback objects to delete. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDeleteTransformFeedbacks.xhtml" /></remarks>
-            public static void DeleteTransformFeedbacks(int n, TransformFeedbackHandle* ids) => GLPointers._DeleteTransformFeedbacks_fnptr(n, (int*)ids);
+            public static void DeleteTransformFeedbacks(int n, int* ids) => GLPointers._DeleteTransformFeedbacks_fnptr(n, ids);
             
             /// <summary> <b>[requires: v4.0 | GL_ARB_transform_feedback2]</b> Reserve transform feedback object names. </summary>
             /// <param name="n"> Specifies the number of transform feedback object names to reserve. </param>
             /// <param name="ids"> Specifies an array of into which the reserved names will be written. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGenTransformFeedbacks.xhtml" /></remarks>
-            public static void GenTransformFeedbacks(int n, TransformFeedbackHandle* ids) => GLPointers._GenTransformFeedbacks_fnptr(n, (int*)ids);
+            public static void GenTransformFeedbacks(int n, int* ids) => GLPointers._GenTransformFeedbacks_fnptr(n, ids);
             
             /// <summary> <b>[requires: v4.0 | GL_ARB_transform_feedback2]</b> Determine if a name corresponds to a transform feedback object. </summary>
             /// <param name="id"> Specifies a value that may be the name of a transform feedback object. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsTransformFeedback.xhtml" /></remarks>
-            public static bool IsTransformFeedback(TransformFeedbackHandle id) => GLPointers._IsTransformFeedback_fnptr((int)id) != 0;
+            public static bool IsTransformFeedback(int id) => GLPointers._IsTransformFeedback_fnptr(id) != 0;
             
             /// <summary> <b>[requires: v4.0 | GL_ARB_transform_feedback2]</b> Pause transform feedback operations. </summary>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glPauseTransformFeedback.xhtml" /></remarks>
@@ -10600,21 +10600,21 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="mode"> Specifies what kind of primitives to render. Symbolic constants GL_POINTS, GL_LINE_STRIP, GL_LINE_LOOP, GL_LINES, GL_LINE_STRIP_ADJACENCY, GL_LINES_ADJACENCY, GL_TRIANGLE_STRIP, GL_TRIANGLE_FAN, GL_TRIANGLES, GL_TRIANGLE_STRIP_ADJACENCY, GL_TRIANGLES_ADJACENCY, and GL_PATCHES are accepted. </param>
             /// <param name="id"> Specifies the name of a transform feedback object from which to retrieve a primitive count. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDrawTransformFeedback.xhtml" /></remarks>
-            public static void DrawTransformFeedback(PrimitiveType mode, TransformFeedbackHandle id) => GLPointers._DrawTransformFeedback_fnptr((uint)mode, (int)id);
+            public static void DrawTransformFeedback(PrimitiveType mode, int id) => GLPointers._DrawTransformFeedback_fnptr((uint)mode, id);
             
             /// <summary> <b>[requires: v4.0 | GL_ARB_transform_feedback3]</b> Render primitives using a count derived from a specifed stream of a transform feedback object. </summary>
             /// <param name="mode"> Specifies what kind of primitives to render. Symbolic constants GL_POINTS, GL_LINE_STRIP, GL_LINE_LOOP, GL_LINES, GL_LINE_STRIP_ADJACENCY, GL_LINES_ADJACENCY, GL_TRIANGLE_STRIP, GL_TRIANGLE_FAN, GL_TRIANGLES, GL_TRIANGLE_STRIP_ADJACENCY, GL_TRIANGLES_ADJACENCY, and GL_PATCHES are accepted. </param>
             /// <param name="id"> Specifies the name of a transform feedback object from which to retrieve a primitive count. </param>
             /// <param name="stream"> Specifies the index of the transform feedback stream from which to retrieve a primitive count. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDrawTransformFeedbackStream.xhtml" /></remarks>
-            public static void DrawTransformFeedbackStream(PrimitiveType mode, TransformFeedbackHandle id, uint stream) => GLPointers._DrawTransformFeedbackStream_fnptr((uint)mode, (int)id, stream);
+            public static void DrawTransformFeedbackStream(PrimitiveType mode, int id, uint stream) => GLPointers._DrawTransformFeedbackStream_fnptr((uint)mode, id, stream);
             
             /// <summary> <b>[requires: v4.0 | GL_ARB_transform_feedback3]</b> Delimit the boundaries of a query object on an indexed target. </summary>
             /// <param name="target"> Specifies the target type of query object established between glBeginQueryIndexed and the subsequent glEndQueryIndexed. The symbolic constant must be one of GL_SAMPLES_PASSED, GL_ANY_SAMPLES_PASSED, GL_PRIMITIVES_GENERATED, GL_TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN, or GL_TIME_ELAPSED. </param>
             /// <param name="index"> Specifies the index of the query target upon which to begin the query. </param>
             /// <param name="id"> Specifies the name of a query object. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBeginQueryIndexed.xhtml" /></remarks>
-            public static void BeginQueryIndexed(QueryTarget target, uint index, QueryHandle id) => GLPointers._BeginQueryIndexed_fnptr((uint)target, index, (int)id);
+            public static void BeginQueryIndexed(QueryTarget target, uint index, int id) => GLPointers._BeginQueryIndexed_fnptr((uint)target, index, id);
             
             /// <summary> <b>[requires: v4.0 | GL_ARB_transform_feedback3]</b> Delimit the boundaries of a query object on an indexed target. </summary>
             /// <param name="target"> Specifies the target type of query object established between glBeginQueryIndexed and the subsequent glEndQueryIndexed. The symbolic constant must be one of GL_SAMPLES_PASSED, GL_ANY_SAMPLES_PASSED, GL_PRIMITIVES_GENERATED, GL_TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN, or GL_TIME_ELAPSED. </param>
@@ -10635,7 +10635,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="id"> Specifies the name of a transform feedback object from which to retrieve a primitive count. </param>
             /// <param name="instancecount"> Specifies the number of instances of the geometry to render. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDrawTransformFeedbackInstanced.xhtml" /></remarks>
-            public static void DrawTransformFeedbackInstanced(PrimitiveType mode, TransformFeedbackHandle id, int instancecount) => GLPointers._DrawTransformFeedbackInstanced_fnptr((uint)mode, (int)id, instancecount);
+            public static void DrawTransformFeedbackInstanced(PrimitiveType mode, int id, int instancecount) => GLPointers._DrawTransformFeedbackInstanced_fnptr((uint)mode, id, instancecount);
             
             /// <summary> <b>[requires: v4.2 | GL_ARB_transform_feedback_instanced]</b> Render multiple instances of primitives using a count derived from a specifed stream of a transform feedback object. </summary>
             /// <param name="mode"> Specifies what kind of primitives to render. Symbolic constants GL_POINTS, GL_LINE_STRIP, GL_LINE_LOOP, GL_LINES, GL_LINE_STRIP_ADJACENCY, GL_LINES_ADJACENCY, GL_TRIANGLE_STRIP, GL_TRIANGLE_FAN, GL_TRIANGLES, GL_TRIANGLE_STRIP_ADJACENCY, GL_TRIANGLES_ADJACENCY, and GL_PATCHES are accepted. </param>
@@ -10643,7 +10643,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="stream"> Specifies the index of the transform feedback stream from which to retrieve a primitive count. </param>
             /// <param name="instancecount"> Specifies the number of instances of the geometry to render. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDrawTransformFeedbackStreamInstanced.xhtml" /></remarks>
-            public static void DrawTransformFeedbackStreamInstanced(PrimitiveType mode, TransformFeedbackHandle id, uint stream, int instancecount) => GLPointers._DrawTransformFeedbackStreamInstanced_fnptr((uint)mode, (int)id, stream, instancecount);
+            public static void DrawTransformFeedbackStreamInstanced(PrimitiveType mode, int id, uint stream, int instancecount) => GLPointers._DrawTransformFeedbackStreamInstanced_fnptr((uint)mode, id, stream, instancecount);
             
             /// <summary> <b>[requires: GL_ARB_transpose_matrix]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -10667,7 +10667,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="uniformNames"> Specifies the address of an array of pointers to buffers containing the names of the queried uniforms. </param>
             /// <param name="uniformIndices"> Specifies the address of an array that will receive the indices of the uniforms. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetUniformIndices.xhtml" /></remarks>
-            public static void GetUniformIndices(ProgramHandle program, int uniformCount, byte** uniformNames, uint* uniformIndices) => GLPointers._GetUniformIndices_fnptr((int)program, uniformCount, uniformNames, uniformIndices);
+            public static void GetUniformIndices(int program, int uniformCount, byte** uniformNames, uint* uniformIndices) => GLPointers._GetUniformIndices_fnptr(program, uniformCount, uniformNames, uniformIndices);
             
             /// <summary> <b>[requires: v3.1 | GL_ARB_uniform_buffer_object]</b> Returns information about several active uniform variables for the specified program object. </summary>
             /// <param name="program">Specifies the program object to be queried.</param>
@@ -10676,7 +10676,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="pname">Specifies the property of each uniform in uniformIndices that should be written into the corresponding element of params.</param>
             /// <param name="parameters">Specifies the address of an array of uniformCount integers which are to receive the value of pname for each uniform in uniformIndices.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetActiveUniformsiv.xhtml" /></remarks>
-            public static void GetActiveUniformsiv(ProgramHandle program, int uniformCount, uint* uniformIndices, UniformPName pname, int* parameters) => GLPointers._GetActiveUniformsiv_fnptr((int)program, uniformCount, uniformIndices, (uint)pname, parameters);
+            public static void GetActiveUniformsiv(int program, int uniformCount, uint* uniformIndices, UniformPName pname, int* parameters) => GLPointers._GetActiveUniformsiv_fnptr(program, uniformCount, uniformIndices, (uint)pname, parameters);
             
             /// <summary> <b>[requires: v3.1 | GL_ARB_uniform_buffer_object]</b> Query the name of an active uniform. </summary>
             /// <param name="program"> Specifies the program containing the active uniform index uniformIndex. </param>
@@ -10685,13 +10685,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="length"> Specifies the address of a variable that will receive the number of characters that were or would have been written to the buffer addressed by uniformName. </param>
             /// <param name="uniformName"> Specifies the address of a buffer into which the GL will place the name of the active uniform at uniformIndex within program. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetActiveUniformName.xhtml" /></remarks>
-            public static void GetActiveUniformName(ProgramHandle program, uint uniformIndex, int bufSize, int* length, byte* uniformName) => GLPointers._GetActiveUniformName_fnptr((int)program, uniformIndex, bufSize, length, uniformName);
+            public static void GetActiveUniformName(int program, uint uniformIndex, int bufSize, int* length, byte* uniformName) => GLPointers._GetActiveUniformName_fnptr(program, uniformIndex, bufSize, length, uniformName);
             
             /// <summary> <b>[requires: v3.1 | GL_ARB_uniform_buffer_object]</b> Retrieve the index of a named uniform block. </summary>
             /// <param name="program"> Specifies the name of a program containing the uniform block. </param>
             /// <param name="uniformBlockName"> Specifies the address an array of characters to containing the name of the uniform block whose index to retrieve. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetUniformBlockIndex.xhtml" /></remarks>
-            public static uint GetUniformBlockIndex(ProgramHandle program, byte* uniformBlockName) => GLPointers._GetUniformBlockIndex_fnptr((int)program, uniformBlockName);
+            public static uint GetUniformBlockIndex(int program, byte* uniformBlockName) => GLPointers._GetUniformBlockIndex_fnptr(program, uniformBlockName);
             
             /// <summary> <b>[requires: v3.1 | GL_ARB_uniform_buffer_object]</b> Query information about an active uniform block. </summary>
             /// <param name="program"> Specifies the name of a program containing the uniform block. </param>
@@ -10699,7 +10699,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="pname"> Specifies the name of the parameter to query. </param>
             /// <param name="parameters"> Specifies the address of a variable to receive the result of the query. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetActiveUniformBlock.xhtml" /></remarks>
-            public static void GetActiveUniformBlockiv(ProgramHandle program, uint uniformBlockIndex, UniformBlockPName pname, int* parameters) => GLPointers._GetActiveUniformBlockiv_fnptr((int)program, uniformBlockIndex, (uint)pname, parameters);
+            public static void GetActiveUniformBlockiv(int program, uint uniformBlockIndex, UniformBlockPName pname, int* parameters) => GLPointers._GetActiveUniformBlockiv_fnptr(program, uniformBlockIndex, (uint)pname, parameters);
             
             /// <summary> <b>[requires: v3.1 | GL_ARB_uniform_buffer_object]</b> Retrieve the name of an active uniform block. </summary>
             /// <param name="program"> Specifies the name of a program containing the uniform block. </param>
@@ -10708,14 +10708,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="length"> Specifies the address of a variable to receive the number of characters that were written to uniformBlockName. </param>
             /// <param name="uniformBlockName"> Specifies the address an array of characters to receive the name of the uniform block at uniformBlockIndex. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetActiveUniformBlockName.xhtml" /></remarks>
-            public static void GetActiveUniformBlockName(ProgramHandle program, uint uniformBlockIndex, int bufSize, int* length, byte* uniformBlockName) => GLPointers._GetActiveUniformBlockName_fnptr((int)program, uniformBlockIndex, bufSize, length, uniformBlockName);
+            public static void GetActiveUniformBlockName(int program, uint uniformBlockIndex, int bufSize, int* length, byte* uniformBlockName) => GLPointers._GetActiveUniformBlockName_fnptr(program, uniformBlockIndex, bufSize, length, uniformBlockName);
             
             /// <summary> <b>[requires: v3.1 | GL_ARB_uniform_buffer_object]</b> Assign a binding point to an active uniform block. </summary>
             /// <param name="program"> The name of a program object containing the active uniform block whose binding to assign. </param>
             /// <param name="uniformBlockIndex"> The index of the active uniform block within program whose binding to assign. </param>
             /// <param name="uniformBlockBinding"> Specifies the binding point to which to bind the uniform block with index uniformBlockIndex within program. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glUniformBlockBinding.xhtml" /></remarks>
-            public static void UniformBlockBinding(ProgramHandle program, uint uniformBlockIndex, uint uniformBlockBinding) => GLPointers._UniformBlockBinding_fnptr((int)program, uniformBlockIndex, uniformBlockBinding);
+            public static void UniformBlockBinding(int program, uint uniformBlockIndex, uint uniformBlockBinding) => GLPointers._UniformBlockBinding_fnptr(program, uniformBlockIndex, uniformBlockBinding);
             
             /// <summary> <b>[requires: v3.0 | v3.1 | GL_ARB_uniform_buffer_object]</b> Bind a range within a buffer object to an indexed buffer target. </summary>
             /// <param name="target"> Specify the target of the bind operation. target must be one of GL_ATOMIC_COUNTER_BUFFER, GL_TRANSFORM_FEEDBACK_BUFFER, GL_UNIFORM_BUFFER, or GL_SHADER_STORAGE_BUFFER. </param>
@@ -10724,14 +10724,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="offset"> The starting offset in basic machine units into the buffer object buffer. </param>
             /// <param name="size"> The amount of data in machine units that can be read from the buffer object while used as an indexed target. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindBufferRange.xhtml" /></remarks>
-            public static void BindBufferRange(BufferTargetARB target, uint index, BufferHandle buffer, IntPtr offset, nint size) => GLPointers._BindBufferRange_fnptr((uint)target, index, (int)buffer, offset, size);
+            public static void BindBufferRange(BufferTargetARB target, uint index, int buffer, IntPtr offset, nint size) => GLPointers._BindBufferRange_fnptr((uint)target, index, buffer, offset, size);
             
             /// <summary> <b>[requires: v3.0 | v3.1 | GL_ARB_uniform_buffer_object]</b> Bind a buffer object to an indexed buffer target. </summary>
             /// <param name="target"> Specify the target of the bind operation. target must be one of GL_ATOMIC_COUNTER_BUFFER, GL_TRANSFORM_FEEDBACK_BUFFER, GL_UNIFORM_BUFFER or GL_SHADER_STORAGE_BUFFER. </param>
             /// <param name="index"> Specify the index of the binding point within the array specified by target. </param>
             /// <param name="buffer"> The name of a buffer object to bind to the specified binding point. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindBufferBase.xhtml" /></remarks>
-            public static void BindBufferBase(BufferTargetARB target, uint index, BufferHandle buffer) => GLPointers._BindBufferBase_fnptr((uint)target, index, (int)buffer);
+            public static void BindBufferBase(BufferTargetARB target, uint index, int buffer) => GLPointers._BindBufferBase_fnptr((uint)target, index, buffer);
             
             /// <summary> <b>[requires: v3.0 | v3.1 | GL_ARB_uniform_buffer_object]</b> Return the value or values of a selected parameter. </summary>
             /// <param name="target"> Specifies the parameter value to be returned for indexed versions of glGet. The symbolic constants in the list below are accepted. </param>
@@ -10743,24 +10743,24 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <summary> <b>[requires: v3.0 | GL_ARB_vertex_array_object]</b> Bind a vertex array object. </summary>
             /// <param name="array"> Specifies the name of the vertex array to bind. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindVertexArray.xhtml" /></remarks>
-            public static void BindVertexArray(VertexArrayHandle array) => GLPointers._BindVertexArray_fnptr((int)array);
+            public static void BindVertexArray(int array) => GLPointers._BindVertexArray_fnptr(array);
             
             /// <summary> <b>[requires: v3.0 | GL_ARB_vertex_array_object]</b> Delete vertex array objects. </summary>
             /// <param name="n"> Specifies the number of vertex array objects to be deleted. </param>
             /// <param name="arrays"> Specifies the address of an array containing the n names of the objects to be deleted. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDeleteVertexArrays.xhtml" /></remarks>
-            public static void DeleteVertexArrays(int n, VertexArrayHandle* arrays) => GLPointers._DeleteVertexArrays_fnptr(n, (int*)arrays);
+            public static void DeleteVertexArrays(int n, int* arrays) => GLPointers._DeleteVertexArrays_fnptr(n, arrays);
             
             /// <summary> <b>[requires: v3.0 | GL_ARB_vertex_array_object]</b> Generate vertex array object names. </summary>
             /// <param name="n"> Specifies the number of vertex array object names to generate. </param>
             /// <param name="arrays"> Specifies an array in which the generated vertex array object names are stored. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGenVertexArrays.xhtml" /></remarks>
-            public static void GenVertexArrays(int n, VertexArrayHandle* arrays) => GLPointers._GenVertexArrays_fnptr(n, (int*)arrays);
+            public static void GenVertexArrays(int n, int* arrays) => GLPointers._GenVertexArrays_fnptr(n, arrays);
             
             /// <summary> <b>[requires: v3.0 | GL_ARB_vertex_array_object]</b> Determine if a name corresponds to a vertex array object. </summary>
             /// <param name="array"> Specifies a value that may be the name of a vertex array object. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsVertexArray.xhtml" /></remarks>
-            public static bool IsVertexArray(VertexArrayHandle array) => GLPointers._IsVertexArray_fnptr((int)array) != 0;
+            public static bool IsVertexArray(int array) => GLPointers._IsVertexArray_fnptr(array) != 0;
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_vertex_attrib_64bit]</b> Specifies the value of a generic vertex attribute. </summary>
             /// <param name="index">Specifies the index of the generic vertex attribute to be modified.</param>
@@ -10838,7 +10838,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="offset">The offset of the first element of the buffer.</param>
             /// <param name="stride">The distance between elements within the buffer.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindVertexBuffer.xhtml" /></remarks>
-            public static void BindVertexBuffer(uint bindingindex, BufferHandle buffer, IntPtr offset, int stride) => GLPointers._BindVertexBuffer_fnptr(bindingindex, (int)buffer, offset, stride);
+            public static void BindVertexBuffer(uint bindingindex, int buffer, IntPtr offset, int stride) => GLPointers._BindVertexBuffer_fnptr(bindingindex, buffer, offset, stride);
             
             /// <summary> <b>[requires: v4.3 | GL_ARB_vertex_attrib_binding]</b> Specify the organization of vertex arrays. </summary>
             /// <param name="attribindex">The generic vertex attribute array being described.</param>
@@ -10919,19 +10919,19 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_ARB_vertex_buffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void BindBufferARB(BufferTargetARB target, BufferHandle buffer) => GLPointers._BindBufferARB_fnptr((uint)target, (int)buffer);
+            public static void BindBufferARB(BufferTargetARB target, int buffer) => GLPointers._BindBufferARB_fnptr((uint)target, buffer);
             
             /// <summary> <b>[requires: GL_ARB_vertex_buffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void DeleteBuffersARB(int n, BufferHandle* buffers) => GLPointers._DeleteBuffersARB_fnptr(n, (int*)buffers);
+            public static void DeleteBuffersARB(int n, int* buffers) => GLPointers._DeleteBuffersARB_fnptr(n, buffers);
             
             /// <summary> <b>[requires: GL_ARB_vertex_buffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GenBuffersARB(int n, BufferHandle* buffers) => GLPointers._GenBuffersARB_fnptr(n, (int*)buffers);
+            public static void GenBuffersARB(int n, int* buffers) => GLPointers._GenBuffersARB_fnptr(n, buffers);
             
             /// <summary> <b>[requires: GL_ARB_vertex_buffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static bool IsBufferARB(BufferHandle buffer) => GLPointers._IsBufferARB_fnptr((int)buffer) != 0;
+            public static bool IsBufferARB(int buffer) => GLPointers._IsBufferARB_fnptr(buffer) != 0;
             
             /// <summary> <b>[requires: GL_ARB_vertex_buffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -11550,11 +11550,11 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_ATI_map_object_buffer]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void* MapObjectBufferATI(BufferHandle buffer) => GLPointers._MapObjectBufferATI_fnptr((int)buffer);
+            public static void* MapObjectBufferATI(int buffer) => GLPointers._MapObjectBufferATI_fnptr(buffer);
             
             /// <summary> <b>[requires: GL_ATI_map_object_buffer]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void UnmapObjectBufferATI(BufferHandle buffer) => GLPointers._UnmapObjectBufferATI_fnptr((int)buffer);
+            public static void UnmapObjectBufferATI(int buffer) => GLPointers._UnmapObjectBufferATI_fnptr(buffer);
             
             /// <summary> <b>[requires: GL_ATI_pn_triangles]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -11578,27 +11578,27 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_ATI_vertex_array_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static bool IsObjectBufferATI(BufferHandle buffer) => GLPointers._IsObjectBufferATI_fnptr((int)buffer) != 0;
+            public static bool IsObjectBufferATI(int buffer) => GLPointers._IsObjectBufferATI_fnptr(buffer) != 0;
             
             /// <summary> <b>[requires: GL_ATI_vertex_array_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void UpdateObjectBufferATI(BufferHandle buffer, uint offset, int size, void* pointer, PreserveModeATI preserve) => GLPointers._UpdateObjectBufferATI_fnptr((int)buffer, offset, size, pointer, (uint)preserve);
+            public static void UpdateObjectBufferATI(int buffer, uint offset, int size, void* pointer, PreserveModeATI preserve) => GLPointers._UpdateObjectBufferATI_fnptr(buffer, offset, size, pointer, (uint)preserve);
             
             /// <summary> <b>[requires: GL_ATI_vertex_array_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetObjectBufferfvATI(BufferHandle buffer, ArrayObjectPNameATI pname, float* parameters) => GLPointers._GetObjectBufferfvATI_fnptr((int)buffer, (uint)pname, parameters);
+            public static void GetObjectBufferfvATI(int buffer, ArrayObjectPNameATI pname, float* parameters) => GLPointers._GetObjectBufferfvATI_fnptr(buffer, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_ATI_vertex_array_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetObjectBufferivATI(BufferHandle buffer, ArrayObjectPNameATI pname, int* parameters) => GLPointers._GetObjectBufferivATI_fnptr((int)buffer, (uint)pname, parameters);
+            public static void GetObjectBufferivATI(int buffer, ArrayObjectPNameATI pname, int* parameters) => GLPointers._GetObjectBufferivATI_fnptr(buffer, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_ATI_vertex_array_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void FreeObjectBufferATI(BufferHandle buffer) => GLPointers._FreeObjectBufferATI_fnptr((int)buffer);
+            public static void FreeObjectBufferATI(int buffer) => GLPointers._FreeObjectBufferATI_fnptr(buffer);
             
             /// <summary> <b>[requires: GL_ATI_vertex_array_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ArrayObjectATI(EnableCap array, int size, ScalarType type, int stride, BufferHandle buffer, uint offset) => GLPointers._ArrayObjectATI_fnptr((uint)array, size, (uint)type, stride, (int)buffer, offset);
+            public static void ArrayObjectATI(EnableCap array, int size, ScalarType type, int stride, int buffer, uint offset) => GLPointers._ArrayObjectATI_fnptr((uint)array, size, (uint)type, stride, buffer, offset);
             
             /// <summary> <b>[requires: GL_ATI_vertex_array_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -11610,7 +11610,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_ATI_vertex_array_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void VariantArrayObjectATI(uint id, ScalarType type, int stride, BufferHandle buffer, uint offset) => GLPointers._VariantArrayObjectATI_fnptr(id, (uint)type, stride, (int)buffer, offset);
+            public static void VariantArrayObjectATI(uint id, ScalarType type, int stride, int buffer, uint offset) => GLPointers._VariantArrayObjectATI_fnptr(id, (uint)type, stride, buffer, offset);
             
             /// <summary> <b>[requires: GL_ATI_vertex_array_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -11622,7 +11622,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_ATI_vertex_attrib_array_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void VertexAttribArrayObjectATI(uint index, int size, VertexAttribPointerType type, bool normalized, int stride, BufferHandle buffer, uint offset) => GLPointers._VertexAttribArrayObjectATI_fnptr(index, size, (uint)type, (byte)(normalized ? 1 : 0), stride, (int)buffer, offset);
+            public static void VertexAttribArrayObjectATI(uint index, int size, VertexAttribPointerType type, bool normalized, int stride, int buffer, uint offset) => GLPointers._VertexAttribArrayObjectATI_fnptr(index, size, (uint)type, (byte)(normalized ? 1 : 0), stride, buffer, offset);
             
             /// <summary> <b>[requires: GL_ATI_vertex_attrib_array_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -11821,19 +11821,19 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_EXT_EGL_image_storage]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void EGLImageTargetTextureStorageEXT(TextureHandle texture, void* image, int* attrib_list) => GLPointers._EGLImageTargetTextureStorageEXT_fnptr((int)texture, image, attrib_list);
+            public static void EGLImageTargetTextureStorageEXT(int texture, void* image, int* attrib_list) => GLPointers._EGLImageTargetTextureStorageEXT_fnptr(texture, image, attrib_list);
             
             /// <summary> <b>[requires: GL_EXT_bindable_uniform]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void UniformBufferEXT(ProgramHandle program, int location, BufferHandle buffer) => GLPointers._UniformBufferEXT_fnptr((int)program, location, (int)buffer);
+            public static void UniformBufferEXT(int program, int location, int buffer) => GLPointers._UniformBufferEXT_fnptr(program, location, buffer);
             
             /// <summary> <b>[requires: GL_EXT_bindable_uniform]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static int GetUniformBufferSizeEXT(ProgramHandle program, int location) => GLPointers._GetUniformBufferSizeEXT_fnptr((int)program, location);
+            public static int GetUniformBufferSizeEXT(int program, int location) => GLPointers._GetUniformBufferSizeEXT_fnptr(program, location);
             
             /// <summary> <b>[requires: GL_EXT_bindable_uniform]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static IntPtr GetUniformOffsetEXT(ProgramHandle program, int location) => GLPointers._GetUniformOffsetEXT_fnptr((int)program, location);
+            public static IntPtr GetUniformOffsetEXT(int program, int location) => GLPointers._GetUniformOffsetEXT_fnptr(program, location);
             
             /// <summary> <b>[requires: GL_EXT_blend_color]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -12129,87 +12129,87 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureParameterfEXT(TextureHandle texture, TextureTarget target, TextureParameterName pname, float param) => GLPointers._TextureParameterfEXT_fnptr((int)texture, (uint)target, (uint)pname, param);
+            public static void TextureParameterfEXT(int texture, TextureTarget target, TextureParameterName pname, float param) => GLPointers._TextureParameterfEXT_fnptr(texture, (uint)target, (uint)pname, param);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureParameterfvEXT(TextureHandle texture, TextureTarget target, TextureParameterName pname, float* parameters) => GLPointers._TextureParameterfvEXT_fnptr((int)texture, (uint)target, (uint)pname, parameters);
+            public static void TextureParameterfvEXT(int texture, TextureTarget target, TextureParameterName pname, float* parameters) => GLPointers._TextureParameterfvEXT_fnptr(texture, (uint)target, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureParameteriEXT(TextureHandle texture, TextureTarget target, TextureParameterName pname, int param) => GLPointers._TextureParameteriEXT_fnptr((int)texture, (uint)target, (uint)pname, param);
+            public static void TextureParameteriEXT(int texture, TextureTarget target, TextureParameterName pname, int param) => GLPointers._TextureParameteriEXT_fnptr(texture, (uint)target, (uint)pname, param);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureParameterivEXT(TextureHandle texture, TextureTarget target, TextureParameterName pname, int* parameters) => GLPointers._TextureParameterivEXT_fnptr((int)texture, (uint)target, (uint)pname, parameters);
+            public static void TextureParameterivEXT(int texture, TextureTarget target, TextureParameterName pname, int* parameters) => GLPointers._TextureParameterivEXT_fnptr(texture, (uint)target, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureImage1DEXT(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int width, int border, PixelFormat format, PixelType type, void* pixels) => GLPointers._TextureImage1DEXT_fnptr((int)texture, (uint)target, level, (int)internalformat, width, border, (uint)format, (uint)type, pixels);
+            public static void TextureImage1DEXT(int texture, TextureTarget target, int level, InternalFormat internalformat, int width, int border, PixelFormat format, PixelType type, void* pixels) => GLPointers._TextureImage1DEXT_fnptr(texture, (uint)target, level, (int)internalformat, width, border, (uint)format, (uint)type, pixels);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureImage2DEXT(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int border, PixelFormat format, PixelType type, void* pixels) => GLPointers._TextureImage2DEXT_fnptr((int)texture, (uint)target, level, (int)internalformat, width, height, border, (uint)format, (uint)type, pixels);
+            public static void TextureImage2DEXT(int texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int border, PixelFormat format, PixelType type, void* pixels) => GLPointers._TextureImage2DEXT_fnptr(texture, (uint)target, level, (int)internalformat, width, height, border, (uint)format, (uint)type, pixels);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureSubImage1DEXT(TextureHandle texture, TextureTarget target, int level, int xoffset, int width, PixelFormat format, PixelType type, void* pixels) => GLPointers._TextureSubImage1DEXT_fnptr((int)texture, (uint)target, level, xoffset, width, (uint)format, (uint)type, pixels);
+            public static void TextureSubImage1DEXT(int texture, TextureTarget target, int level, int xoffset, int width, PixelFormat format, PixelType type, void* pixels) => GLPointers._TextureSubImage1DEXT_fnptr(texture, (uint)target, level, xoffset, width, (uint)format, (uint)type, pixels);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureSubImage2DEXT(TextureHandle texture, TextureTarget target, int level, int xoffset, int yoffset, int width, int height, PixelFormat format, PixelType type, void* pixels) => GLPointers._TextureSubImage2DEXT_fnptr((int)texture, (uint)target, level, xoffset, yoffset, width, height, (uint)format, (uint)type, pixels);
+            public static void TextureSubImage2DEXT(int texture, TextureTarget target, int level, int xoffset, int yoffset, int width, int height, PixelFormat format, PixelType type, void* pixels) => GLPointers._TextureSubImage2DEXT_fnptr(texture, (uint)target, level, xoffset, yoffset, width, height, (uint)format, (uint)type, pixels);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void CopyTextureImage1DEXT(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int x, int y, int width, int border) => GLPointers._CopyTextureImage1DEXT_fnptr((int)texture, (uint)target, level, (uint)internalformat, x, y, width, border);
+            public static void CopyTextureImage1DEXT(int texture, TextureTarget target, int level, InternalFormat internalformat, int x, int y, int width, int border) => GLPointers._CopyTextureImage1DEXT_fnptr(texture, (uint)target, level, (uint)internalformat, x, y, width, border);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void CopyTextureImage2DEXT(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int x, int y, int width, int height, int border) => GLPointers._CopyTextureImage2DEXT_fnptr((int)texture, (uint)target, level, (uint)internalformat, x, y, width, height, border);
+            public static void CopyTextureImage2DEXT(int texture, TextureTarget target, int level, InternalFormat internalformat, int x, int y, int width, int height, int border) => GLPointers._CopyTextureImage2DEXT_fnptr(texture, (uint)target, level, (uint)internalformat, x, y, width, height, border);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void CopyTextureSubImage1DEXT(TextureHandle texture, TextureTarget target, int level, int xoffset, int x, int y, int width) => GLPointers._CopyTextureSubImage1DEXT_fnptr((int)texture, (uint)target, level, xoffset, x, y, width);
+            public static void CopyTextureSubImage1DEXT(int texture, TextureTarget target, int level, int xoffset, int x, int y, int width) => GLPointers._CopyTextureSubImage1DEXT_fnptr(texture, (uint)target, level, xoffset, x, y, width);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void CopyTextureSubImage2DEXT(TextureHandle texture, TextureTarget target, int level, int xoffset, int yoffset, int x, int y, int width, int height) => GLPointers._CopyTextureSubImage2DEXT_fnptr((int)texture, (uint)target, level, xoffset, yoffset, x, y, width, height);
+            public static void CopyTextureSubImage2DEXT(int texture, TextureTarget target, int level, int xoffset, int yoffset, int x, int y, int width, int height) => GLPointers._CopyTextureSubImage2DEXT_fnptr(texture, (uint)target, level, xoffset, yoffset, x, y, width, height);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetTextureImageEXT(TextureHandle texture, TextureTarget target, int level, PixelFormat format, PixelType type, void* pixels) => GLPointers._GetTextureImageEXT_fnptr((int)texture, (uint)target, level, (uint)format, (uint)type, pixels);
+            public static void GetTextureImageEXT(int texture, TextureTarget target, int level, PixelFormat format, PixelType type, void* pixels) => GLPointers._GetTextureImageEXT_fnptr(texture, (uint)target, level, (uint)format, (uint)type, pixels);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetTextureParameterfvEXT(TextureHandle texture, TextureTarget target, GetTextureParameter pname, float* parameters) => GLPointers._GetTextureParameterfvEXT_fnptr((int)texture, (uint)target, (uint)pname, parameters);
+            public static void GetTextureParameterfvEXT(int texture, TextureTarget target, GetTextureParameter pname, float* parameters) => GLPointers._GetTextureParameterfvEXT_fnptr(texture, (uint)target, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetTextureParameterivEXT(TextureHandle texture, TextureTarget target, GetTextureParameter pname, int* parameters) => GLPointers._GetTextureParameterivEXT_fnptr((int)texture, (uint)target, (uint)pname, parameters);
+            public static void GetTextureParameterivEXT(int texture, TextureTarget target, GetTextureParameter pname, int* parameters) => GLPointers._GetTextureParameterivEXT_fnptr(texture, (uint)target, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetTextureLevelParameterfvEXT(TextureHandle texture, TextureTarget target, int level, GetTextureParameter pname, float* parameters) => GLPointers._GetTextureLevelParameterfvEXT_fnptr((int)texture, (uint)target, level, (uint)pname, parameters);
+            public static void GetTextureLevelParameterfvEXT(int texture, TextureTarget target, int level, GetTextureParameter pname, float* parameters) => GLPointers._GetTextureLevelParameterfvEXT_fnptr(texture, (uint)target, level, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetTextureLevelParameterivEXT(TextureHandle texture, TextureTarget target, int level, GetTextureParameter pname, int* parameters) => GLPointers._GetTextureLevelParameterivEXT_fnptr((int)texture, (uint)target, level, (uint)pname, parameters);
+            public static void GetTextureLevelParameterivEXT(int texture, TextureTarget target, int level, GetTextureParameter pname, int* parameters) => GLPointers._GetTextureLevelParameterivEXT_fnptr(texture, (uint)target, level, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureImage3DEXT(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int depth, int border, PixelFormat format, PixelType type, void* pixels) => GLPointers._TextureImage3DEXT_fnptr((int)texture, (uint)target, level, (int)internalformat, width, height, depth, border, (uint)format, (uint)type, pixels);
+            public static void TextureImage3DEXT(int texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int depth, int border, PixelFormat format, PixelType type, void* pixels) => GLPointers._TextureImage3DEXT_fnptr(texture, (uint)target, level, (int)internalformat, width, height, depth, border, (uint)format, (uint)type, pixels);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureSubImage3DEXT(TextureHandle texture, TextureTarget target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, void* pixels) => GLPointers._TextureSubImage3DEXT_fnptr((int)texture, (uint)target, level, xoffset, yoffset, zoffset, width, height, depth, (uint)format, (uint)type, pixels);
+            public static void TextureSubImage3DEXT(int texture, TextureTarget target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, void* pixels) => GLPointers._TextureSubImage3DEXT_fnptr(texture, (uint)target, level, xoffset, yoffset, zoffset, width, height, depth, (uint)format, (uint)type, pixels);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void CopyTextureSubImage3DEXT(TextureHandle texture, TextureTarget target, int level, int xoffset, int yoffset, int zoffset, int x, int y, int width, int height) => GLPointers._CopyTextureSubImage3DEXT_fnptr((int)texture, (uint)target, level, xoffset, yoffset, zoffset, x, y, width, height);
+            public static void CopyTextureSubImage3DEXT(int texture, TextureTarget target, int level, int xoffset, int yoffset, int zoffset, int x, int y, int width, int height) => GLPointers._CopyTextureSubImage3DEXT_fnptr(texture, (uint)target, level, xoffset, yoffset, zoffset, x, y, width, height);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void BindMultiTextureEXT(TextureUnit texunit, TextureTarget target, TextureHandle texture) => GLPointers._BindMultiTextureEXT_fnptr((uint)texunit, (uint)target, (int)texture);
+            public static void BindMultiTextureEXT(TextureUnit texunit, TextureTarget target, int texture) => GLPointers._BindMultiTextureEXT_fnptr((uint)texunit, (uint)target, texture);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -12397,31 +12397,31 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void CompressedTextureImage3DEXT(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int depth, int border, int imageSize, void* bits) => GLPointers._CompressedTextureImage3DEXT_fnptr((int)texture, (uint)target, level, (uint)internalformat, width, height, depth, border, imageSize, bits);
+            public static void CompressedTextureImage3DEXT(int texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int depth, int border, int imageSize, void* bits) => GLPointers._CompressedTextureImage3DEXT_fnptr(texture, (uint)target, level, (uint)internalformat, width, height, depth, border, imageSize, bits);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void CompressedTextureImage2DEXT(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int border, int imageSize, void* bits) => GLPointers._CompressedTextureImage2DEXT_fnptr((int)texture, (uint)target, level, (uint)internalformat, width, height, border, imageSize, bits);
+            public static void CompressedTextureImage2DEXT(int texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int border, int imageSize, void* bits) => GLPointers._CompressedTextureImage2DEXT_fnptr(texture, (uint)target, level, (uint)internalformat, width, height, border, imageSize, bits);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void CompressedTextureImage1DEXT(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int width, int border, int imageSize, void* bits) => GLPointers._CompressedTextureImage1DEXT_fnptr((int)texture, (uint)target, level, (uint)internalformat, width, border, imageSize, bits);
+            public static void CompressedTextureImage1DEXT(int texture, TextureTarget target, int level, InternalFormat internalformat, int width, int border, int imageSize, void* bits) => GLPointers._CompressedTextureImage1DEXT_fnptr(texture, (uint)target, level, (uint)internalformat, width, border, imageSize, bits);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void CompressedTextureSubImage3DEXT(TextureHandle texture, TextureTarget target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, InternalFormat format, int imageSize, void* bits) => GLPointers._CompressedTextureSubImage3DEXT_fnptr((int)texture, (uint)target, level, xoffset, yoffset, zoffset, width, height, depth, (uint)format, imageSize, bits);
+            public static void CompressedTextureSubImage3DEXT(int texture, TextureTarget target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, InternalFormat format, int imageSize, void* bits) => GLPointers._CompressedTextureSubImage3DEXT_fnptr(texture, (uint)target, level, xoffset, yoffset, zoffset, width, height, depth, (uint)format, imageSize, bits);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void CompressedTextureSubImage2DEXT(TextureHandle texture, TextureTarget target, int level, int xoffset, int yoffset, int width, int height, InternalFormat format, int imageSize, void* bits) => GLPointers._CompressedTextureSubImage2DEXT_fnptr((int)texture, (uint)target, level, xoffset, yoffset, width, height, (uint)format, imageSize, bits);
+            public static void CompressedTextureSubImage2DEXT(int texture, TextureTarget target, int level, int xoffset, int yoffset, int width, int height, InternalFormat format, int imageSize, void* bits) => GLPointers._CompressedTextureSubImage2DEXT_fnptr(texture, (uint)target, level, xoffset, yoffset, width, height, (uint)format, imageSize, bits);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void CompressedTextureSubImage1DEXT(TextureHandle texture, TextureTarget target, int level, int xoffset, int width, InternalFormat format, int imageSize, void* bits) => GLPointers._CompressedTextureSubImage1DEXT_fnptr((int)texture, (uint)target, level, xoffset, width, (uint)format, imageSize, bits);
+            public static void CompressedTextureSubImage1DEXT(int texture, TextureTarget target, int level, int xoffset, int width, InternalFormat format, int imageSize, void* bits) => GLPointers._CompressedTextureSubImage1DEXT_fnptr(texture, (uint)target, level, xoffset, width, (uint)format, imageSize, bits);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetCompressedTextureImageEXT(TextureHandle texture, TextureTarget target, int lod, void* img) => GLPointers._GetCompressedTextureImageEXT_fnptr((int)texture, (uint)target, lod, img);
+            public static void GetCompressedTextureImageEXT(int texture, TextureTarget target, int lod, void* img) => GLPointers._GetCompressedTextureImageEXT_fnptr(texture, (uint)target, lod, img);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -12469,155 +12469,155 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedBufferDataEXT(BufferHandle buffer, nint size, void* data, VertexBufferObjectUsage usage) => GLPointers._NamedBufferDataEXT_fnptr((int)buffer, size, data, (uint)usage);
+            public static void NamedBufferDataEXT(int buffer, nint size, void* data, VertexBufferObjectUsage usage) => GLPointers._NamedBufferDataEXT_fnptr(buffer, size, data, (uint)usage);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedBufferSubDataEXT(BufferHandle buffer, IntPtr offset, nint size, void* data) => GLPointers._NamedBufferSubDataEXT_fnptr((int)buffer, offset, size, data);
+            public static void NamedBufferSubDataEXT(int buffer, IntPtr offset, nint size, void* data) => GLPointers._NamedBufferSubDataEXT_fnptr(buffer, offset, size, data);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void* MapNamedBufferEXT(BufferHandle buffer, BufferAccessARB access) => GLPointers._MapNamedBufferEXT_fnptr((int)buffer, (uint)access);
+            public static void* MapNamedBufferEXT(int buffer, BufferAccessARB access) => GLPointers._MapNamedBufferEXT_fnptr(buffer, (uint)access);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static bool UnmapNamedBufferEXT(BufferHandle buffer) => GLPointers._UnmapNamedBufferEXT_fnptr((int)buffer) != 0;
+            public static bool UnmapNamedBufferEXT(int buffer) => GLPointers._UnmapNamedBufferEXT_fnptr(buffer) != 0;
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetNamedBufferParameterivEXT(BufferHandle buffer, BufferPNameARB pname, int* parameters) => GLPointers._GetNamedBufferParameterivEXT_fnptr((int)buffer, (uint)pname, parameters);
+            public static void GetNamedBufferParameterivEXT(int buffer, BufferPNameARB pname, int* parameters) => GLPointers._GetNamedBufferParameterivEXT_fnptr(buffer, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetNamedBufferPointervEXT(BufferHandle buffer, BufferPointerNameARB pname, void** parameters) => GLPointers._GetNamedBufferPointervEXT_fnptr((int)buffer, (uint)pname, parameters);
+            public static void GetNamedBufferPointervEXT(int buffer, BufferPointerNameARB pname, void** parameters) => GLPointers._GetNamedBufferPointervEXT_fnptr(buffer, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetNamedBufferSubDataEXT(BufferHandle buffer, IntPtr offset, nint size, void* data) => GLPointers._GetNamedBufferSubDataEXT_fnptr((int)buffer, offset, size, data);
+            public static void GetNamedBufferSubDataEXT(int buffer, IntPtr offset, nint size, void* data) => GLPointers._GetNamedBufferSubDataEXT_fnptr(buffer, offset, size, data);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform1fEXT(ProgramHandle program, int location, float v0) => GLPointers._ProgramUniform1fEXT_fnptr((int)program, location, v0);
+            public static void ProgramUniform1fEXT(int program, int location, float v0) => GLPointers._ProgramUniform1fEXT_fnptr(program, location, v0);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform2fEXT(ProgramHandle program, int location, float v0, float v1) => GLPointers._ProgramUniform2fEXT_fnptr((int)program, location, v0, v1);
+            public static void ProgramUniform2fEXT(int program, int location, float v0, float v1) => GLPointers._ProgramUniform2fEXT_fnptr(program, location, v0, v1);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform3fEXT(ProgramHandle program, int location, float v0, float v1, float v2) => GLPointers._ProgramUniform3fEXT_fnptr((int)program, location, v0, v1, v2);
+            public static void ProgramUniform3fEXT(int program, int location, float v0, float v1, float v2) => GLPointers._ProgramUniform3fEXT_fnptr(program, location, v0, v1, v2);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform4fEXT(ProgramHandle program, int location, float v0, float v1, float v2, float v3) => GLPointers._ProgramUniform4fEXT_fnptr((int)program, location, v0, v1, v2, v3);
+            public static void ProgramUniform4fEXT(int program, int location, float v0, float v1, float v2, float v3) => GLPointers._ProgramUniform4fEXT_fnptr(program, location, v0, v1, v2, v3);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform1iEXT(ProgramHandle program, int location, int v0) => GLPointers._ProgramUniform1iEXT_fnptr((int)program, location, v0);
+            public static void ProgramUniform1iEXT(int program, int location, int v0) => GLPointers._ProgramUniform1iEXT_fnptr(program, location, v0);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform2iEXT(ProgramHandle program, int location, int v0, int v1) => GLPointers._ProgramUniform2iEXT_fnptr((int)program, location, v0, v1);
+            public static void ProgramUniform2iEXT(int program, int location, int v0, int v1) => GLPointers._ProgramUniform2iEXT_fnptr(program, location, v0, v1);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform3iEXT(ProgramHandle program, int location, int v0, int v1, int v2) => GLPointers._ProgramUniform3iEXT_fnptr((int)program, location, v0, v1, v2);
+            public static void ProgramUniform3iEXT(int program, int location, int v0, int v1, int v2) => GLPointers._ProgramUniform3iEXT_fnptr(program, location, v0, v1, v2);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform4iEXT(ProgramHandle program, int location, int v0, int v1, int v2, int v3) => GLPointers._ProgramUniform4iEXT_fnptr((int)program, location, v0, v1, v2, v3);
+            public static void ProgramUniform4iEXT(int program, int location, int v0, int v1, int v2, int v3) => GLPointers._ProgramUniform4iEXT_fnptr(program, location, v0, v1, v2, v3);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform1fvEXT(ProgramHandle program, int location, int count, float* value) => GLPointers._ProgramUniform1fvEXT_fnptr((int)program, location, count, value);
+            public static void ProgramUniform1fvEXT(int program, int location, int count, float* value) => GLPointers._ProgramUniform1fvEXT_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform2fvEXT(ProgramHandle program, int location, int count, float* value) => GLPointers._ProgramUniform2fvEXT_fnptr((int)program, location, count, value);
+            public static void ProgramUniform2fvEXT(int program, int location, int count, float* value) => GLPointers._ProgramUniform2fvEXT_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform3fvEXT(ProgramHandle program, int location, int count, float* value) => GLPointers._ProgramUniform3fvEXT_fnptr((int)program, location, count, value);
+            public static void ProgramUniform3fvEXT(int program, int location, int count, float* value) => GLPointers._ProgramUniform3fvEXT_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform4fvEXT(ProgramHandle program, int location, int count, float* value) => GLPointers._ProgramUniform4fvEXT_fnptr((int)program, location, count, value);
+            public static void ProgramUniform4fvEXT(int program, int location, int count, float* value) => GLPointers._ProgramUniform4fvEXT_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform1ivEXT(ProgramHandle program, int location, int count, int* value) => GLPointers._ProgramUniform1ivEXT_fnptr((int)program, location, count, value);
+            public static void ProgramUniform1ivEXT(int program, int location, int count, int* value) => GLPointers._ProgramUniform1ivEXT_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform2ivEXT(ProgramHandle program, int location, int count, int* value) => GLPointers._ProgramUniform2ivEXT_fnptr((int)program, location, count, value);
+            public static void ProgramUniform2ivEXT(int program, int location, int count, int* value) => GLPointers._ProgramUniform2ivEXT_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform3ivEXT(ProgramHandle program, int location, int count, int* value) => GLPointers._ProgramUniform3ivEXT_fnptr((int)program, location, count, value);
+            public static void ProgramUniform3ivEXT(int program, int location, int count, int* value) => GLPointers._ProgramUniform3ivEXT_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform4ivEXT(ProgramHandle program, int location, int count, int* value) => GLPointers._ProgramUniform4ivEXT_fnptr((int)program, location, count, value);
+            public static void ProgramUniform4ivEXT(int program, int location, int count, int* value) => GLPointers._ProgramUniform4ivEXT_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix2fvEXT(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix2fvEXT_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix2fvEXT(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix2fvEXT_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix3fvEXT(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix3fvEXT_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix3fvEXT(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix3fvEXT_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix4fvEXT(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix4fvEXT_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix4fvEXT(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix4fvEXT_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix2x3fvEXT(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix2x3fvEXT_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix2x3fvEXT(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix2x3fvEXT_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix3x2fvEXT(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix3x2fvEXT_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix3x2fvEXT(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix3x2fvEXT_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix2x4fvEXT(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix2x4fvEXT_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix2x4fvEXT(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix2x4fvEXT_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix4x2fvEXT(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix4x2fvEXT_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix4x2fvEXT(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix4x2fvEXT_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix3x4fvEXT(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix3x4fvEXT_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix3x4fvEXT(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix3x4fvEXT_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix4x3fvEXT(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix4x3fvEXT_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix4x3fvEXT(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix4x3fvEXT_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureBufferEXT(TextureHandle texture, TextureTarget target, SizedInternalFormat internalformat, BufferHandle buffer) => GLPointers._TextureBufferEXT_fnptr((int)texture, (uint)target, (uint)internalformat, (int)buffer);
+            public static void TextureBufferEXT(int texture, TextureTarget target, SizedInternalFormat internalformat, int buffer) => GLPointers._TextureBufferEXT_fnptr(texture, (uint)target, (uint)internalformat, buffer);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void MultiTexBufferEXT(TextureUnit texunit, TextureTarget target, InternalFormat internalformat, BufferHandle buffer) => GLPointers._MultiTexBufferEXT_fnptr((uint)texunit, (uint)target, (uint)internalformat, (int)buffer);
+            public static void MultiTexBufferEXT(TextureUnit texunit, TextureTarget target, InternalFormat internalformat, int buffer) => GLPointers._MultiTexBufferEXT_fnptr((uint)texunit, (uint)target, (uint)internalformat, buffer);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureParameterIivEXT(TextureHandle texture, TextureTarget target, TextureParameterName pname, int* parameters) => GLPointers._TextureParameterIivEXT_fnptr((int)texture, (uint)target, (uint)pname, parameters);
+            public static void TextureParameterIivEXT(int texture, TextureTarget target, TextureParameterName pname, int* parameters) => GLPointers._TextureParameterIivEXT_fnptr(texture, (uint)target, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureParameterIuivEXT(TextureHandle texture, TextureTarget target, TextureParameterName pname, uint* parameters) => GLPointers._TextureParameterIuivEXT_fnptr((int)texture, (uint)target, (uint)pname, parameters);
+            public static void TextureParameterIuivEXT(int texture, TextureTarget target, TextureParameterName pname, uint* parameters) => GLPointers._TextureParameterIuivEXT_fnptr(texture, (uint)target, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetTextureParameterIivEXT(TextureHandle texture, TextureTarget target, GetTextureParameter pname, int* parameters) => GLPointers._GetTextureParameterIivEXT_fnptr((int)texture, (uint)target, (uint)pname, parameters);
+            public static void GetTextureParameterIivEXT(int texture, TextureTarget target, GetTextureParameter pname, int* parameters) => GLPointers._GetTextureParameterIivEXT_fnptr(texture, (uint)target, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetTextureParameterIuivEXT(TextureHandle texture, TextureTarget target, GetTextureParameter pname, uint* parameters) => GLPointers._GetTextureParameterIuivEXT_fnptr((int)texture, (uint)target, (uint)pname, parameters);
+            public static void GetTextureParameterIuivEXT(int texture, TextureTarget target, GetTextureParameter pname, uint* parameters) => GLPointers._GetTextureParameterIuivEXT_fnptr(texture, (uint)target, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -12637,71 +12637,71 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform1uiEXT(ProgramHandle program, int location, uint v0) => GLPointers._ProgramUniform1uiEXT_fnptr((int)program, location, v0);
+            public static void ProgramUniform1uiEXT(int program, int location, uint v0) => GLPointers._ProgramUniform1uiEXT_fnptr(program, location, v0);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform2uiEXT(ProgramHandle program, int location, uint v0, uint v1) => GLPointers._ProgramUniform2uiEXT_fnptr((int)program, location, v0, v1);
+            public static void ProgramUniform2uiEXT(int program, int location, uint v0, uint v1) => GLPointers._ProgramUniform2uiEXT_fnptr(program, location, v0, v1);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform3uiEXT(ProgramHandle program, int location, uint v0, uint v1, uint v2) => GLPointers._ProgramUniform3uiEXT_fnptr((int)program, location, v0, v1, v2);
+            public static void ProgramUniform3uiEXT(int program, int location, uint v0, uint v1, uint v2) => GLPointers._ProgramUniform3uiEXT_fnptr(program, location, v0, v1, v2);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform4uiEXT(ProgramHandle program, int location, uint v0, uint v1, uint v2, uint v3) => GLPointers._ProgramUniform4uiEXT_fnptr((int)program, location, v0, v1, v2, v3);
+            public static void ProgramUniform4uiEXT(int program, int location, uint v0, uint v1, uint v2, uint v3) => GLPointers._ProgramUniform4uiEXT_fnptr(program, location, v0, v1, v2, v3);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform1uivEXT(ProgramHandle program, int location, int count, uint* value) => GLPointers._ProgramUniform1uivEXT_fnptr((int)program, location, count, value);
+            public static void ProgramUniform1uivEXT(int program, int location, int count, uint* value) => GLPointers._ProgramUniform1uivEXT_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform2uivEXT(ProgramHandle program, int location, int count, uint* value) => GLPointers._ProgramUniform2uivEXT_fnptr((int)program, location, count, value);
+            public static void ProgramUniform2uivEXT(int program, int location, int count, uint* value) => GLPointers._ProgramUniform2uivEXT_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform3uivEXT(ProgramHandle program, int location, int count, uint* value) => GLPointers._ProgramUniform3uivEXT_fnptr((int)program, location, count, value);
+            public static void ProgramUniform3uivEXT(int program, int location, int count, uint* value) => GLPointers._ProgramUniform3uivEXT_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform4uivEXT(ProgramHandle program, int location, int count, uint* value) => GLPointers._ProgramUniform4uivEXT_fnptr((int)program, location, count, value);
+            public static void ProgramUniform4uivEXT(int program, int location, int count, uint* value) => GLPointers._ProgramUniform4uivEXT_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedProgramLocalParameters4fvEXT(ProgramHandle program, ProgramTarget target, uint index, int count, float* parameters) => GLPointers._NamedProgramLocalParameters4fvEXT_fnptr((int)program, (uint)target, index, count, parameters);
+            public static void NamedProgramLocalParameters4fvEXT(int program, ProgramTarget target, uint index, int count, float* parameters) => GLPointers._NamedProgramLocalParameters4fvEXT_fnptr(program, (uint)target, index, count, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedProgramLocalParameterI4iEXT(ProgramHandle program, ProgramTarget target, uint index, int x, int y, int z, int w) => GLPointers._NamedProgramLocalParameterI4iEXT_fnptr((int)program, (uint)target, index, x, y, z, w);
+            public static void NamedProgramLocalParameterI4iEXT(int program, ProgramTarget target, uint index, int x, int y, int z, int w) => GLPointers._NamedProgramLocalParameterI4iEXT_fnptr(program, (uint)target, index, x, y, z, w);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedProgramLocalParameterI4ivEXT(ProgramHandle program, ProgramTarget target, uint index, int* parameters) => GLPointers._NamedProgramLocalParameterI4ivEXT_fnptr((int)program, (uint)target, index, parameters);
+            public static void NamedProgramLocalParameterI4ivEXT(int program, ProgramTarget target, uint index, int* parameters) => GLPointers._NamedProgramLocalParameterI4ivEXT_fnptr(program, (uint)target, index, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedProgramLocalParametersI4ivEXT(ProgramHandle program, ProgramTarget target, uint index, int count, int* parameters) => GLPointers._NamedProgramLocalParametersI4ivEXT_fnptr((int)program, (uint)target, index, count, parameters);
+            public static void NamedProgramLocalParametersI4ivEXT(int program, ProgramTarget target, uint index, int count, int* parameters) => GLPointers._NamedProgramLocalParametersI4ivEXT_fnptr(program, (uint)target, index, count, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedProgramLocalParameterI4uiEXT(ProgramHandle program, ProgramTarget target, uint index, uint x, uint y, uint z, uint w) => GLPointers._NamedProgramLocalParameterI4uiEXT_fnptr((int)program, (uint)target, index, x, y, z, w);
+            public static void NamedProgramLocalParameterI4uiEXT(int program, ProgramTarget target, uint index, uint x, uint y, uint z, uint w) => GLPointers._NamedProgramLocalParameterI4uiEXT_fnptr(program, (uint)target, index, x, y, z, w);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedProgramLocalParameterI4uivEXT(ProgramHandle program, ProgramTarget target, uint index, uint* parameters) => GLPointers._NamedProgramLocalParameterI4uivEXT_fnptr((int)program, (uint)target, index, parameters);
+            public static void NamedProgramLocalParameterI4uivEXT(int program, ProgramTarget target, uint index, uint* parameters) => GLPointers._NamedProgramLocalParameterI4uivEXT_fnptr(program, (uint)target, index, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedProgramLocalParametersI4uivEXT(ProgramHandle program, ProgramTarget target, uint index, int count, uint* parameters) => GLPointers._NamedProgramLocalParametersI4uivEXT_fnptr((int)program, (uint)target, index, count, parameters);
+            public static void NamedProgramLocalParametersI4uivEXT(int program, ProgramTarget target, uint index, int count, uint* parameters) => GLPointers._NamedProgramLocalParametersI4uivEXT_fnptr(program, (uint)target, index, count, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetNamedProgramLocalParameterIivEXT(ProgramHandle program, ProgramTarget target, uint index, int* parameters) => GLPointers._GetNamedProgramLocalParameterIivEXT_fnptr((int)program, (uint)target, index, parameters);
+            public static void GetNamedProgramLocalParameterIivEXT(int program, ProgramTarget target, uint index, int* parameters) => GLPointers._GetNamedProgramLocalParameterIivEXT_fnptr(program, (uint)target, index, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetNamedProgramLocalParameterIuivEXT(ProgramHandle program, ProgramTarget target, uint index, uint* parameters) => GLPointers._GetNamedProgramLocalParameterIuivEXT_fnptr((int)program, (uint)target, index, parameters);
+            public static void GetNamedProgramLocalParameterIuivEXT(int program, ProgramTarget target, uint index, uint* parameters) => GLPointers._GetNamedProgramLocalParameterIuivEXT_fnptr(program, (uint)target, index, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -12725,83 +12725,83 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedProgramStringEXT(ProgramHandle program, ProgramTarget target, ProgramFormat format, int len, void* str) => GLPointers._NamedProgramStringEXT_fnptr((int)program, (uint)target, (uint)format, len, str);
+            public static void NamedProgramStringEXT(int program, ProgramTarget target, ProgramFormat format, int len, void* str) => GLPointers._NamedProgramStringEXT_fnptr(program, (uint)target, (uint)format, len, str);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedProgramLocalParameter4dEXT(ProgramHandle program, ProgramTarget target, uint index, double x, double y, double z, double w) => GLPointers._NamedProgramLocalParameter4dEXT_fnptr((int)program, (uint)target, index, x, y, z, w);
+            public static void NamedProgramLocalParameter4dEXT(int program, ProgramTarget target, uint index, double x, double y, double z, double w) => GLPointers._NamedProgramLocalParameter4dEXT_fnptr(program, (uint)target, index, x, y, z, w);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedProgramLocalParameter4dvEXT(ProgramHandle program, ProgramTarget target, uint index, double* parameters) => GLPointers._NamedProgramLocalParameter4dvEXT_fnptr((int)program, (uint)target, index, parameters);
+            public static void NamedProgramLocalParameter4dvEXT(int program, ProgramTarget target, uint index, double* parameters) => GLPointers._NamedProgramLocalParameter4dvEXT_fnptr(program, (uint)target, index, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedProgramLocalParameter4fEXT(ProgramHandle program, ProgramTarget target, uint index, float x, float y, float z, float w) => GLPointers._NamedProgramLocalParameter4fEXT_fnptr((int)program, (uint)target, index, x, y, z, w);
+            public static void NamedProgramLocalParameter4fEXT(int program, ProgramTarget target, uint index, float x, float y, float z, float w) => GLPointers._NamedProgramLocalParameter4fEXT_fnptr(program, (uint)target, index, x, y, z, w);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedProgramLocalParameter4fvEXT(ProgramHandle program, ProgramTarget target, uint index, float* parameters) => GLPointers._NamedProgramLocalParameter4fvEXT_fnptr((int)program, (uint)target, index, parameters);
+            public static void NamedProgramLocalParameter4fvEXT(int program, ProgramTarget target, uint index, float* parameters) => GLPointers._NamedProgramLocalParameter4fvEXT_fnptr(program, (uint)target, index, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetNamedProgramLocalParameterdvEXT(ProgramHandle program, ProgramTarget target, uint index, double* parameters) => GLPointers._GetNamedProgramLocalParameterdvEXT_fnptr((int)program, (uint)target, index, parameters);
+            public static void GetNamedProgramLocalParameterdvEXT(int program, ProgramTarget target, uint index, double* parameters) => GLPointers._GetNamedProgramLocalParameterdvEXT_fnptr(program, (uint)target, index, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetNamedProgramLocalParameterfvEXT(ProgramHandle program, ProgramTarget target, uint index, float* parameters) => GLPointers._GetNamedProgramLocalParameterfvEXT_fnptr((int)program, (uint)target, index, parameters);
+            public static void GetNamedProgramLocalParameterfvEXT(int program, ProgramTarget target, uint index, float* parameters) => GLPointers._GetNamedProgramLocalParameterfvEXT_fnptr(program, (uint)target, index, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetNamedProgramivEXT(ProgramHandle program, ProgramTarget target, ProgramPropertyARB pname, int* parameters) => GLPointers._GetNamedProgramivEXT_fnptr((int)program, (uint)target, (uint)pname, parameters);
+            public static void GetNamedProgramivEXT(int program, ProgramTarget target, ProgramPropertyARB pname, int* parameters) => GLPointers._GetNamedProgramivEXT_fnptr(program, (uint)target, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetNamedProgramStringEXT(ProgramHandle program, ProgramTarget target, ProgramStringProperty pname, void* str) => GLPointers._GetNamedProgramStringEXT_fnptr((int)program, (uint)target, (uint)pname, str);
+            public static void GetNamedProgramStringEXT(int program, ProgramTarget target, ProgramStringProperty pname, void* str) => GLPointers._GetNamedProgramStringEXT_fnptr(program, (uint)target, (uint)pname, str);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedRenderbufferStorageEXT(RenderbufferHandle renderbuffer, InternalFormat internalformat, int width, int height) => GLPointers._NamedRenderbufferStorageEXT_fnptr((int)renderbuffer, (uint)internalformat, width, height);
+            public static void NamedRenderbufferStorageEXT(int renderbuffer, InternalFormat internalformat, int width, int height) => GLPointers._NamedRenderbufferStorageEXT_fnptr(renderbuffer, (uint)internalformat, width, height);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetNamedRenderbufferParameterivEXT(RenderbufferHandle renderbuffer, RenderbufferParameterName pname, int* parameters) => GLPointers._GetNamedRenderbufferParameterivEXT_fnptr((int)renderbuffer, (uint)pname, parameters);
+            public static void GetNamedRenderbufferParameterivEXT(int renderbuffer, RenderbufferParameterName pname, int* parameters) => GLPointers._GetNamedRenderbufferParameterivEXT_fnptr(renderbuffer, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedRenderbufferStorageMultisampleEXT(RenderbufferHandle renderbuffer, int samples, InternalFormat internalformat, int width, int height) => GLPointers._NamedRenderbufferStorageMultisampleEXT_fnptr((int)renderbuffer, samples, (uint)internalformat, width, height);
+            public static void NamedRenderbufferStorageMultisampleEXT(int renderbuffer, int samples, InternalFormat internalformat, int width, int height) => GLPointers._NamedRenderbufferStorageMultisampleEXT_fnptr(renderbuffer, samples, (uint)internalformat, width, height);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedRenderbufferStorageMultisampleCoverageEXT(RenderbufferHandle renderbuffer, int coverageSamples, int colorSamples, InternalFormat internalformat, int width, int height) => GLPointers._NamedRenderbufferStorageMultisampleCoverageEXT_fnptr((int)renderbuffer, coverageSamples, colorSamples, (uint)internalformat, width, height);
+            public static void NamedRenderbufferStorageMultisampleCoverageEXT(int renderbuffer, int coverageSamples, int colorSamples, InternalFormat internalformat, int width, int height) => GLPointers._NamedRenderbufferStorageMultisampleCoverageEXT_fnptr(renderbuffer, coverageSamples, colorSamples, (uint)internalformat, width, height);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static FramebufferStatus CheckNamedFramebufferStatusEXT(FramebufferHandle framebuffer, FramebufferTarget target) => (FramebufferStatus) GLPointers._CheckNamedFramebufferStatusEXT_fnptr((int)framebuffer, (uint)target);
+            public static FramebufferStatus CheckNamedFramebufferStatusEXT(int framebuffer, FramebufferTarget target) => (FramebufferStatus) GLPointers._CheckNamedFramebufferStatusEXT_fnptr(framebuffer, (uint)target);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedFramebufferTexture1DEXT(FramebufferHandle framebuffer, FramebufferAttachment attachment, TextureTarget textarget, TextureHandle texture, int level) => GLPointers._NamedFramebufferTexture1DEXT_fnptr((int)framebuffer, (uint)attachment, (uint)textarget, (int)texture, level);
+            public static void NamedFramebufferTexture1DEXT(int framebuffer, FramebufferAttachment attachment, TextureTarget textarget, int texture, int level) => GLPointers._NamedFramebufferTexture1DEXT_fnptr(framebuffer, (uint)attachment, (uint)textarget, texture, level);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedFramebufferTexture2DEXT(FramebufferHandle framebuffer, FramebufferAttachment attachment, TextureTarget textarget, TextureHandle texture, int level) => GLPointers._NamedFramebufferTexture2DEXT_fnptr((int)framebuffer, (uint)attachment, (uint)textarget, (int)texture, level);
+            public static void NamedFramebufferTexture2DEXT(int framebuffer, FramebufferAttachment attachment, TextureTarget textarget, int texture, int level) => GLPointers._NamedFramebufferTexture2DEXT_fnptr(framebuffer, (uint)attachment, (uint)textarget, texture, level);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedFramebufferTexture3DEXT(FramebufferHandle framebuffer, FramebufferAttachment attachment, TextureTarget textarget, TextureHandle texture, int level, int zoffset) => GLPointers._NamedFramebufferTexture3DEXT_fnptr((int)framebuffer, (uint)attachment, (uint)textarget, (int)texture, level, zoffset);
+            public static void NamedFramebufferTexture3DEXT(int framebuffer, FramebufferAttachment attachment, TextureTarget textarget, int texture, int level, int zoffset) => GLPointers._NamedFramebufferTexture3DEXT_fnptr(framebuffer, (uint)attachment, (uint)textarget, texture, level, zoffset);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedFramebufferRenderbufferEXT(FramebufferHandle framebuffer, FramebufferAttachment attachment, RenderbufferTarget renderbuffertarget, RenderbufferHandle renderbuffer) => GLPointers._NamedFramebufferRenderbufferEXT_fnptr((int)framebuffer, (uint)attachment, (uint)renderbuffertarget, (int)renderbuffer);
+            public static void NamedFramebufferRenderbufferEXT(int framebuffer, FramebufferAttachment attachment, RenderbufferTarget renderbuffertarget, int renderbuffer) => GLPointers._NamedFramebufferRenderbufferEXT_fnptr(framebuffer, (uint)attachment, (uint)renderbuffertarget, renderbuffer);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetNamedFramebufferAttachmentParameterivEXT(FramebufferHandle framebuffer, FramebufferAttachment attachment, FramebufferAttachmentParameterName pname, int* parameters) => GLPointers._GetNamedFramebufferAttachmentParameterivEXT_fnptr((int)framebuffer, (uint)attachment, (uint)pname, parameters);
+            public static void GetNamedFramebufferAttachmentParameterivEXT(int framebuffer, FramebufferAttachment attachment, FramebufferAttachmentParameterName pname, int* parameters) => GLPointers._GetNamedFramebufferAttachmentParameterivEXT_fnptr(framebuffer, (uint)attachment, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GenerateTextureMipmapEXT(TextureHandle texture, TextureTarget target) => GLPointers._GenerateTextureMipmapEXT_fnptr((int)texture, (uint)target);
+            public static void GenerateTextureMipmapEXT(int texture, TextureTarget target) => GLPointers._GenerateTextureMipmapEXT_fnptr(texture, (uint)target);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -12809,275 +12809,275 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void FramebufferDrawBufferEXT(FramebufferHandle framebuffer, DrawBufferMode mode) => GLPointers._FramebufferDrawBufferEXT_fnptr((int)framebuffer, (uint)mode);
+            public static void FramebufferDrawBufferEXT(int framebuffer, DrawBufferMode mode) => GLPointers._FramebufferDrawBufferEXT_fnptr(framebuffer, (uint)mode);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void FramebufferDrawBuffersEXT(FramebufferHandle framebuffer, int n, DrawBufferMode* bufs) => GLPointers._FramebufferDrawBuffersEXT_fnptr((int)framebuffer, n, (uint*)bufs);
+            public static void FramebufferDrawBuffersEXT(int framebuffer, int n, DrawBufferMode* bufs) => GLPointers._FramebufferDrawBuffersEXT_fnptr(framebuffer, n, (uint*)bufs);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void FramebufferReadBufferEXT(FramebufferHandle framebuffer, ReadBufferMode mode) => GLPointers._FramebufferReadBufferEXT_fnptr((int)framebuffer, (uint)mode);
+            public static void FramebufferReadBufferEXT(int framebuffer, ReadBufferMode mode) => GLPointers._FramebufferReadBufferEXT_fnptr(framebuffer, (uint)mode);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetFramebufferParameterivEXT(FramebufferHandle framebuffer, GetFramebufferParameter pname, int* parameters) => GLPointers._GetFramebufferParameterivEXT_fnptr((int)framebuffer, (uint)pname, parameters);
+            public static void GetFramebufferParameterivEXT(int framebuffer, GetFramebufferParameter pname, int* parameters) => GLPointers._GetFramebufferParameterivEXT_fnptr(framebuffer, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedCopyBufferSubDataEXT(BufferHandle readBuffer, BufferHandle writeBuffer, IntPtr readOffset, IntPtr writeOffset, nint size) => GLPointers._NamedCopyBufferSubDataEXT_fnptr((int)readBuffer, (int)writeBuffer, readOffset, writeOffset, size);
+            public static void NamedCopyBufferSubDataEXT(int readBuffer, int writeBuffer, IntPtr readOffset, IntPtr writeOffset, nint size) => GLPointers._NamedCopyBufferSubDataEXT_fnptr(readBuffer, writeBuffer, readOffset, writeOffset, size);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedFramebufferTextureEXT(FramebufferHandle framebuffer, FramebufferAttachment attachment, TextureHandle texture, int level) => GLPointers._NamedFramebufferTextureEXT_fnptr((int)framebuffer, (uint)attachment, (int)texture, level);
+            public static void NamedFramebufferTextureEXT(int framebuffer, FramebufferAttachment attachment, int texture, int level) => GLPointers._NamedFramebufferTextureEXT_fnptr(framebuffer, (uint)attachment, texture, level);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedFramebufferTextureLayerEXT(FramebufferHandle framebuffer, FramebufferAttachment attachment, TextureHandle texture, int level, int layer) => GLPointers._NamedFramebufferTextureLayerEXT_fnptr((int)framebuffer, (uint)attachment, (int)texture, level, layer);
+            public static void NamedFramebufferTextureLayerEXT(int framebuffer, FramebufferAttachment attachment, int texture, int level, int layer) => GLPointers._NamedFramebufferTextureLayerEXT_fnptr(framebuffer, (uint)attachment, texture, level, layer);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedFramebufferTextureFaceEXT(FramebufferHandle framebuffer, FramebufferAttachment attachment, TextureHandle texture, int level, TextureTarget face) => GLPointers._NamedFramebufferTextureFaceEXT_fnptr((int)framebuffer, (uint)attachment, (int)texture, level, (uint)face);
+            public static void NamedFramebufferTextureFaceEXT(int framebuffer, FramebufferAttachment attachment, int texture, int level, TextureTarget face) => GLPointers._NamedFramebufferTextureFaceEXT_fnptr(framebuffer, (uint)attachment, texture, level, (uint)face);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureRenderbufferEXT(TextureHandle texture, TextureTarget target, RenderbufferHandle renderbuffer) => GLPointers._TextureRenderbufferEXT_fnptr((int)texture, (uint)target, (int)renderbuffer);
+            public static void TextureRenderbufferEXT(int texture, TextureTarget target, int renderbuffer) => GLPointers._TextureRenderbufferEXT_fnptr(texture, (uint)target, renderbuffer);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void MultiTexRenderbufferEXT(TextureUnit texunit, TextureTarget target, RenderbufferHandle renderbuffer) => GLPointers._MultiTexRenderbufferEXT_fnptr((uint)texunit, (uint)target, (int)renderbuffer);
+            public static void MultiTexRenderbufferEXT(TextureUnit texunit, TextureTarget target, int renderbuffer) => GLPointers._MultiTexRenderbufferEXT_fnptr((uint)texunit, (uint)target, renderbuffer);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void VertexArrayVertexOffsetEXT(VertexArrayHandle vaobj, BufferHandle buffer, int size, VertexPointerType type, int stride, IntPtr offset) => GLPointers._VertexArrayVertexOffsetEXT_fnptr((int)vaobj, (int)buffer, size, (uint)type, stride, offset);
+            public static void VertexArrayVertexOffsetEXT(int vaobj, int buffer, int size, VertexPointerType type, int stride, IntPtr offset) => GLPointers._VertexArrayVertexOffsetEXT_fnptr(vaobj, buffer, size, (uint)type, stride, offset);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void VertexArrayColorOffsetEXT(VertexArrayHandle vaobj, BufferHandle buffer, int size, ColorPointerType type, int stride, IntPtr offset) => GLPointers._VertexArrayColorOffsetEXT_fnptr((int)vaobj, (int)buffer, size, (uint)type, stride, offset);
+            public static void VertexArrayColorOffsetEXT(int vaobj, int buffer, int size, ColorPointerType type, int stride, IntPtr offset) => GLPointers._VertexArrayColorOffsetEXT_fnptr(vaobj, buffer, size, (uint)type, stride, offset);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void VertexArrayEdgeFlagOffsetEXT(VertexArrayHandle vaobj, BufferHandle buffer, int stride, IntPtr offset) => GLPointers._VertexArrayEdgeFlagOffsetEXT_fnptr((int)vaobj, (int)buffer, stride, offset);
+            public static void VertexArrayEdgeFlagOffsetEXT(int vaobj, int buffer, int stride, IntPtr offset) => GLPointers._VertexArrayEdgeFlagOffsetEXT_fnptr(vaobj, buffer, stride, offset);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void VertexArrayIndexOffsetEXT(VertexArrayHandle vaobj, BufferHandle buffer, IndexPointerType type, int stride, IntPtr offset) => GLPointers._VertexArrayIndexOffsetEXT_fnptr((int)vaobj, (int)buffer, (uint)type, stride, offset);
+            public static void VertexArrayIndexOffsetEXT(int vaobj, int buffer, IndexPointerType type, int stride, IntPtr offset) => GLPointers._VertexArrayIndexOffsetEXT_fnptr(vaobj, buffer, (uint)type, stride, offset);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void VertexArrayNormalOffsetEXT(VertexArrayHandle vaobj, BufferHandle buffer, NormalPointerType type, int stride, IntPtr offset) => GLPointers._VertexArrayNormalOffsetEXT_fnptr((int)vaobj, (int)buffer, (uint)type, stride, offset);
+            public static void VertexArrayNormalOffsetEXT(int vaobj, int buffer, NormalPointerType type, int stride, IntPtr offset) => GLPointers._VertexArrayNormalOffsetEXT_fnptr(vaobj, buffer, (uint)type, stride, offset);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void VertexArrayTexCoordOffsetEXT(VertexArrayHandle vaobj, BufferHandle buffer, int size, TexCoordPointerType type, int stride, IntPtr offset) => GLPointers._VertexArrayTexCoordOffsetEXT_fnptr((int)vaobj, (int)buffer, size, (uint)type, stride, offset);
+            public static void VertexArrayTexCoordOffsetEXT(int vaobj, int buffer, int size, TexCoordPointerType type, int stride, IntPtr offset) => GLPointers._VertexArrayTexCoordOffsetEXT_fnptr(vaobj, buffer, size, (uint)type, stride, offset);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void VertexArrayMultiTexCoordOffsetEXT(VertexArrayHandle vaobj, BufferHandle buffer, All texunit, int size, TexCoordPointerType type, int stride, IntPtr offset) => GLPointers._VertexArrayMultiTexCoordOffsetEXT_fnptr((int)vaobj, (int)buffer, (uint)texunit, size, (uint)type, stride, offset);
+            public static void VertexArrayMultiTexCoordOffsetEXT(int vaobj, int buffer, All texunit, int size, TexCoordPointerType type, int stride, IntPtr offset) => GLPointers._VertexArrayMultiTexCoordOffsetEXT_fnptr(vaobj, buffer, (uint)texunit, size, (uint)type, stride, offset);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void VertexArrayFogCoordOffsetEXT(VertexArrayHandle vaobj, BufferHandle buffer, FogCoordinatePointerType type, int stride, IntPtr offset) => GLPointers._VertexArrayFogCoordOffsetEXT_fnptr((int)vaobj, (int)buffer, (uint)type, stride, offset);
+            public static void VertexArrayFogCoordOffsetEXT(int vaobj, int buffer, FogCoordinatePointerType type, int stride, IntPtr offset) => GLPointers._VertexArrayFogCoordOffsetEXT_fnptr(vaobj, buffer, (uint)type, stride, offset);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void VertexArraySecondaryColorOffsetEXT(VertexArrayHandle vaobj, BufferHandle buffer, int size, ColorPointerType type, int stride, IntPtr offset) => GLPointers._VertexArraySecondaryColorOffsetEXT_fnptr((int)vaobj, (int)buffer, size, (uint)type, stride, offset);
+            public static void VertexArraySecondaryColorOffsetEXT(int vaobj, int buffer, int size, ColorPointerType type, int stride, IntPtr offset) => GLPointers._VertexArraySecondaryColorOffsetEXT_fnptr(vaobj, buffer, size, (uint)type, stride, offset);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void VertexArrayVertexAttribOffsetEXT(VertexArrayHandle vaobj, BufferHandle buffer, uint index, int size, VertexAttribPointerType type, bool normalized, int stride, IntPtr offset) => GLPointers._VertexArrayVertexAttribOffsetEXT_fnptr((int)vaobj, (int)buffer, index, size, (uint)type, (byte)(normalized ? 1 : 0), stride, offset);
+            public static void VertexArrayVertexAttribOffsetEXT(int vaobj, int buffer, uint index, int size, VertexAttribPointerType type, bool normalized, int stride, IntPtr offset) => GLPointers._VertexArrayVertexAttribOffsetEXT_fnptr(vaobj, buffer, index, size, (uint)type, (byte)(normalized ? 1 : 0), stride, offset);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void VertexArrayVertexAttribIOffsetEXT(VertexArrayHandle vaobj, BufferHandle buffer, uint index, int size, VertexAttribType type, int stride, IntPtr offset) => GLPointers._VertexArrayVertexAttribIOffsetEXT_fnptr((int)vaobj, (int)buffer, index, size, (uint)type, stride, offset);
+            public static void VertexArrayVertexAttribIOffsetEXT(int vaobj, int buffer, uint index, int size, VertexAttribType type, int stride, IntPtr offset) => GLPointers._VertexArrayVertexAttribIOffsetEXT_fnptr(vaobj, buffer, index, size, (uint)type, stride, offset);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void EnableVertexArrayEXT(VertexArrayHandle vaobj, EnableCap array) => GLPointers._EnableVertexArrayEXT_fnptr((int)vaobj, (uint)array);
+            public static void EnableVertexArrayEXT(int vaobj, EnableCap array) => GLPointers._EnableVertexArrayEXT_fnptr(vaobj, (uint)array);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void DisableVertexArrayEXT(VertexArrayHandle vaobj, EnableCap array) => GLPointers._DisableVertexArrayEXT_fnptr((int)vaobj, (uint)array);
+            public static void DisableVertexArrayEXT(int vaobj, EnableCap array) => GLPointers._DisableVertexArrayEXT_fnptr(vaobj, (uint)array);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void EnableVertexArrayAttribEXT(VertexArrayHandle vaobj, uint index) => GLPointers._EnableVertexArrayAttribEXT_fnptr((int)vaobj, index);
+            public static void EnableVertexArrayAttribEXT(int vaobj, uint index) => GLPointers._EnableVertexArrayAttribEXT_fnptr(vaobj, index);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void DisableVertexArrayAttribEXT(VertexArrayHandle vaobj, uint index) => GLPointers._DisableVertexArrayAttribEXT_fnptr((int)vaobj, index);
+            public static void DisableVertexArrayAttribEXT(int vaobj, uint index) => GLPointers._DisableVertexArrayAttribEXT_fnptr(vaobj, index);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetVertexArrayIntegervEXT(VertexArrayHandle vaobj, VertexArrayPName pname, int* param) => GLPointers._GetVertexArrayIntegervEXT_fnptr((int)vaobj, (uint)pname, param);
+            public static void GetVertexArrayIntegervEXT(int vaobj, VertexArrayPName pname, int* param) => GLPointers._GetVertexArrayIntegervEXT_fnptr(vaobj, (uint)pname, param);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetVertexArrayPointervEXT(VertexArrayHandle vaobj, VertexArrayPName pname, void** param) => GLPointers._GetVertexArrayPointervEXT_fnptr((int)vaobj, (uint)pname, param);
+            public static void GetVertexArrayPointervEXT(int vaobj, VertexArrayPName pname, void** param) => GLPointers._GetVertexArrayPointervEXT_fnptr(vaobj, (uint)pname, param);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetVertexArrayIntegeri_vEXT(VertexArrayHandle vaobj, uint index, VertexArrayPName pname, int* param) => GLPointers._GetVertexArrayIntegeri_vEXT_fnptr((int)vaobj, index, (uint)pname, param);
+            public static void GetVertexArrayIntegeri_vEXT(int vaobj, uint index, VertexArrayPName pname, int* param) => GLPointers._GetVertexArrayIntegeri_vEXT_fnptr(vaobj, index, (uint)pname, param);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetVertexArrayPointeri_vEXT(VertexArrayHandle vaobj, uint index, VertexArrayPName pname, void** param) => GLPointers._GetVertexArrayPointeri_vEXT_fnptr((int)vaobj, index, (uint)pname, param);
+            public static void GetVertexArrayPointeri_vEXT(int vaobj, uint index, VertexArrayPName pname, void** param) => GLPointers._GetVertexArrayPointeri_vEXT_fnptr(vaobj, index, (uint)pname, param);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void* MapNamedBufferRangeEXT(BufferHandle buffer, IntPtr offset, nint length, MapBufferAccessMask access) => GLPointers._MapNamedBufferRangeEXT_fnptr((int)buffer, offset, length, (uint)access);
+            public static void* MapNamedBufferRangeEXT(int buffer, IntPtr offset, nint length, MapBufferAccessMask access) => GLPointers._MapNamedBufferRangeEXT_fnptr(buffer, offset, length, (uint)access);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void FlushMappedNamedBufferRangeEXT(BufferHandle buffer, IntPtr offset, nint length) => GLPointers._FlushMappedNamedBufferRangeEXT_fnptr((int)buffer, offset, length);
+            public static void FlushMappedNamedBufferRangeEXT(int buffer, IntPtr offset, nint length) => GLPointers._FlushMappedNamedBufferRangeEXT_fnptr(buffer, offset, length);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedBufferStorageEXT(BufferHandle buffer, nint size, void* data, BufferStorageMask flags) => GLPointers._NamedBufferStorageEXT_fnptr((int)buffer, size, data, (uint)flags);
+            public static void NamedBufferStorageEXT(int buffer, nint size, void* data, BufferStorageMask flags) => GLPointers._NamedBufferStorageEXT_fnptr(buffer, size, data, (uint)flags);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ClearNamedBufferDataEXT(BufferHandle buffer, SizedInternalFormat internalformat, PixelFormat format, PixelType type, void* data) => GLPointers._ClearNamedBufferDataEXT_fnptr((int)buffer, (uint)internalformat, (uint)format, (uint)type, data);
+            public static void ClearNamedBufferDataEXT(int buffer, SizedInternalFormat internalformat, PixelFormat format, PixelType type, void* data) => GLPointers._ClearNamedBufferDataEXT_fnptr(buffer, (uint)internalformat, (uint)format, (uint)type, data);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ClearNamedBufferSubDataEXT(BufferHandle buffer, SizedInternalFormat internalformat, nint offset, nint size, PixelFormat format, PixelType type, void* data) => GLPointers._ClearNamedBufferSubDataEXT_fnptr((int)buffer, (uint)internalformat, offset, size, (uint)format, (uint)type, data);
+            public static void ClearNamedBufferSubDataEXT(int buffer, SizedInternalFormat internalformat, nint offset, nint size, PixelFormat format, PixelType type, void* data) => GLPointers._ClearNamedBufferSubDataEXT_fnptr(buffer, (uint)internalformat, offset, size, (uint)format, (uint)type, data);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedFramebufferParameteriEXT(FramebufferHandle framebuffer, FramebufferParameterName pname, int param) => GLPointers._NamedFramebufferParameteriEXT_fnptr((int)framebuffer, (uint)pname, param);
+            public static void NamedFramebufferParameteriEXT(int framebuffer, FramebufferParameterName pname, int param) => GLPointers._NamedFramebufferParameteriEXT_fnptr(framebuffer, (uint)pname, param);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetNamedFramebufferParameterivEXT(FramebufferHandle framebuffer, GetFramebufferParameter pname, int* parameters) => GLPointers._GetNamedFramebufferParameterivEXT_fnptr((int)framebuffer, (uint)pname, parameters);
+            public static void GetNamedFramebufferParameterivEXT(int framebuffer, GetFramebufferParameter pname, int* parameters) => GLPointers._GetNamedFramebufferParameterivEXT_fnptr(framebuffer, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform1dEXT(ProgramHandle program, int location, double x) => GLPointers._ProgramUniform1dEXT_fnptr((int)program, location, x);
+            public static void ProgramUniform1dEXT(int program, int location, double x) => GLPointers._ProgramUniform1dEXT_fnptr(program, location, x);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform2dEXT(ProgramHandle program, int location, double x, double y) => GLPointers._ProgramUniform2dEXT_fnptr((int)program, location, x, y);
+            public static void ProgramUniform2dEXT(int program, int location, double x, double y) => GLPointers._ProgramUniform2dEXT_fnptr(program, location, x, y);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform3dEXT(ProgramHandle program, int location, double x, double y, double z) => GLPointers._ProgramUniform3dEXT_fnptr((int)program, location, x, y, z);
+            public static void ProgramUniform3dEXT(int program, int location, double x, double y, double z) => GLPointers._ProgramUniform3dEXT_fnptr(program, location, x, y, z);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform4dEXT(ProgramHandle program, int location, double x, double y, double z, double w) => GLPointers._ProgramUniform4dEXT_fnptr((int)program, location, x, y, z, w);
+            public static void ProgramUniform4dEXT(int program, int location, double x, double y, double z, double w) => GLPointers._ProgramUniform4dEXT_fnptr(program, location, x, y, z, w);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform1dvEXT(ProgramHandle program, int location, int count, double* value) => GLPointers._ProgramUniform1dvEXT_fnptr((int)program, location, count, value);
+            public static void ProgramUniform1dvEXT(int program, int location, int count, double* value) => GLPointers._ProgramUniform1dvEXT_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform2dvEXT(ProgramHandle program, int location, int count, double* value) => GLPointers._ProgramUniform2dvEXT_fnptr((int)program, location, count, value);
+            public static void ProgramUniform2dvEXT(int program, int location, int count, double* value) => GLPointers._ProgramUniform2dvEXT_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform3dvEXT(ProgramHandle program, int location, int count, double* value) => GLPointers._ProgramUniform3dvEXT_fnptr((int)program, location, count, value);
+            public static void ProgramUniform3dvEXT(int program, int location, int count, double* value) => GLPointers._ProgramUniform3dvEXT_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform4dvEXT(ProgramHandle program, int location, int count, double* value) => GLPointers._ProgramUniform4dvEXT_fnptr((int)program, location, count, value);
+            public static void ProgramUniform4dvEXT(int program, int location, int count, double* value) => GLPointers._ProgramUniform4dvEXT_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix2dvEXT(ProgramHandle program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix2dvEXT_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix2dvEXT(int program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix2dvEXT_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix3dvEXT(ProgramHandle program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix3dvEXT_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix3dvEXT(int program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix3dvEXT_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix4dvEXT(ProgramHandle program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix4dvEXT_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix4dvEXT(int program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix4dvEXT_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix2x3dvEXT(ProgramHandle program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix2x3dvEXT_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix2x3dvEXT(int program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix2x3dvEXT_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix2x4dvEXT(ProgramHandle program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix2x4dvEXT_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix2x4dvEXT(int program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix2x4dvEXT_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix3x2dvEXT(ProgramHandle program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix3x2dvEXT_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix3x2dvEXT(int program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix3x2dvEXT_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix3x4dvEXT(ProgramHandle program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix3x4dvEXT_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix3x4dvEXT(int program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix3x4dvEXT_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix4x2dvEXT(ProgramHandle program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix4x2dvEXT_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix4x2dvEXT(int program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix4x2dvEXT_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix4x3dvEXT(ProgramHandle program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix4x3dvEXT_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix4x3dvEXT(int program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix4x3dvEXT_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureBufferRangeEXT(TextureHandle texture, TextureTarget target, SizedInternalFormat internalformat, BufferHandle buffer, IntPtr offset, nint size) => GLPointers._TextureBufferRangeEXT_fnptr((int)texture, (uint)target, (uint)internalformat, (int)buffer, offset, size);
-            
-            /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_texture_storage]</b>  </summary>
-            /// <remarks><see href="" /></remarks>
-            public static void TextureStorage1DEXT(TextureHandle texture, All target, int levels, SizedInternalFormat internalformat, int width) => GLPointers._TextureStorage1DEXT_fnptr((int)texture, (uint)target, levels, (uint)internalformat, width);
+            public static void TextureBufferRangeEXT(int texture, TextureTarget target, SizedInternalFormat internalformat, int buffer, IntPtr offset, nint size) => GLPointers._TextureBufferRangeEXT_fnptr(texture, (uint)target, (uint)internalformat, buffer, offset, size);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_texture_storage]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureStorage2DEXT(TextureHandle texture, All target, int levels, SizedInternalFormat internalformat, int width, int height) => GLPointers._TextureStorage2DEXT_fnptr((int)texture, (uint)target, levels, (uint)internalformat, width, height);
+            public static void TextureStorage1DEXT(int texture, All target, int levels, SizedInternalFormat internalformat, int width) => GLPointers._TextureStorage1DEXT_fnptr(texture, (uint)target, levels, (uint)internalformat, width);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_texture_storage]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureStorage3DEXT(TextureHandle texture, All target, int levels, SizedInternalFormat internalformat, int width, int height, int depth) => GLPointers._TextureStorage3DEXT_fnptr((int)texture, (uint)target, levels, (uint)internalformat, width, height, depth);
+            public static void TextureStorage2DEXT(int texture, All target, int levels, SizedInternalFormat internalformat, int width, int height) => GLPointers._TextureStorage2DEXT_fnptr(texture, (uint)target, levels, (uint)internalformat, width, height);
+            
+            /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_texture_storage]</b>  </summary>
+            /// <remarks><see href="" /></remarks>
+            public static void TextureStorage3DEXT(int texture, All target, int levels, SizedInternalFormat internalformat, int width, int height, int depth) => GLPointers._TextureStorage3DEXT_fnptr(texture, (uint)target, levels, (uint)internalformat, width, height, depth);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureStorage2DMultisampleEXT(TextureHandle texture, TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, bool fixedsamplelocations) => GLPointers._TextureStorage2DMultisampleEXT_fnptr((int)texture, (uint)target, samples, (uint)internalformat, width, height, (byte)(fixedsamplelocations ? 1 : 0));
+            public static void TextureStorage2DMultisampleEXT(int texture, TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, bool fixedsamplelocations) => GLPointers._TextureStorage2DMultisampleEXT_fnptr(texture, (uint)target, samples, (uint)internalformat, width, height, (byte)(fixedsamplelocations ? 1 : 0));
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureStorage3DMultisampleEXT(TextureHandle texture, All target, int samples, SizedInternalFormat internalformat, int width, int height, int depth, bool fixedsamplelocations) => GLPointers._TextureStorage3DMultisampleEXT_fnptr((int)texture, (uint)target, samples, (uint)internalformat, width, height, depth, (byte)(fixedsamplelocations ? 1 : 0));
+            public static void TextureStorage3DMultisampleEXT(int texture, All target, int samples, SizedInternalFormat internalformat, int width, int height, int depth, bool fixedsamplelocations) => GLPointers._TextureStorage3DMultisampleEXT_fnptr(texture, (uint)target, samples, (uint)internalformat, width, height, depth, (byte)(fixedsamplelocations ? 1 : 0));
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void VertexArrayBindVertexBufferEXT(VertexArrayHandle vaobj, uint bindingindex, BufferHandle buffer, IntPtr offset, int stride) => GLPointers._VertexArrayBindVertexBufferEXT_fnptr((int)vaobj, bindingindex, (int)buffer, offset, stride);
+            public static void VertexArrayBindVertexBufferEXT(int vaobj, uint bindingindex, int buffer, IntPtr offset, int stride) => GLPointers._VertexArrayBindVertexBufferEXT_fnptr(vaobj, bindingindex, buffer, offset, stride);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void VertexArrayVertexAttribFormatEXT(VertexArrayHandle vaobj, uint attribindex, int size, VertexAttribType type, bool normalized, uint relativeoffset) => GLPointers._VertexArrayVertexAttribFormatEXT_fnptr((int)vaobj, attribindex, size, (uint)type, (byte)(normalized ? 1 : 0), relativeoffset);
+            public static void VertexArrayVertexAttribFormatEXT(int vaobj, uint attribindex, int size, VertexAttribType type, bool normalized, uint relativeoffset) => GLPointers._VertexArrayVertexAttribFormatEXT_fnptr(vaobj, attribindex, size, (uint)type, (byte)(normalized ? 1 : 0), relativeoffset);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void VertexArrayVertexAttribIFormatEXT(VertexArrayHandle vaobj, uint attribindex, int size, VertexAttribIType type, uint relativeoffset) => GLPointers._VertexArrayVertexAttribIFormatEXT_fnptr((int)vaobj, attribindex, size, (uint)type, relativeoffset);
+            public static void VertexArrayVertexAttribIFormatEXT(int vaobj, uint attribindex, int size, VertexAttribIType type, uint relativeoffset) => GLPointers._VertexArrayVertexAttribIFormatEXT_fnptr(vaobj, attribindex, size, (uint)type, relativeoffset);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void VertexArrayVertexAttribLFormatEXT(VertexArrayHandle vaobj, uint attribindex, int size, VertexAttribLType type, uint relativeoffset) => GLPointers._VertexArrayVertexAttribLFormatEXT_fnptr((int)vaobj, attribindex, size, (uint)type, relativeoffset);
+            public static void VertexArrayVertexAttribLFormatEXT(int vaobj, uint attribindex, int size, VertexAttribLType type, uint relativeoffset) => GLPointers._VertexArrayVertexAttribLFormatEXT_fnptr(vaobj, attribindex, size, (uint)type, relativeoffset);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void VertexArrayVertexAttribBindingEXT(VertexArrayHandle vaobj, uint attribindex, uint bindingindex) => GLPointers._VertexArrayVertexAttribBindingEXT_fnptr((int)vaobj, attribindex, bindingindex);
+            public static void VertexArrayVertexAttribBindingEXT(int vaobj, uint attribindex, uint bindingindex) => GLPointers._VertexArrayVertexAttribBindingEXT_fnptr(vaobj, attribindex, bindingindex);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void VertexArrayVertexBindingDivisorEXT(VertexArrayHandle vaobj, uint bindingindex, uint divisor) => GLPointers._VertexArrayVertexBindingDivisorEXT_fnptr((int)vaobj, bindingindex, divisor);
+            public static void VertexArrayVertexBindingDivisorEXT(int vaobj, uint bindingindex, uint divisor) => GLPointers._VertexArrayVertexBindingDivisorEXT_fnptr(vaobj, bindingindex, divisor);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void VertexArrayVertexAttribLOffsetEXT(VertexArrayHandle vaobj, BufferHandle buffer, uint index, int size, VertexAttribLType type, int stride, IntPtr offset) => GLPointers._VertexArrayVertexAttribLOffsetEXT_fnptr((int)vaobj, (int)buffer, index, size, (uint)type, stride, offset);
+            public static void VertexArrayVertexAttribLOffsetEXT(int vaobj, int buffer, uint index, int size, VertexAttribLType type, int stride, IntPtr offset) => GLPointers._VertexArrayVertexAttribLOffsetEXT_fnptr(vaobj, buffer, index, size, (uint)type, stride, offset);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TexturePageCommitmentEXT(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, bool commit) => GLPointers._TexturePageCommitmentEXT_fnptr((int)texture, level, xoffset, yoffset, zoffset, width, height, depth, (byte)(commit ? 1 : 0));
+            public static void TexturePageCommitmentEXT(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, bool commit) => GLPointers._TexturePageCommitmentEXT_fnptr(texture, level, xoffset, yoffset, zoffset, width, height, depth, (byte)(commit ? 1 : 0));
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void VertexArrayVertexAttribDivisorEXT(VertexArrayHandle vaobj, uint index, uint divisor) => GLPointers._VertexArrayVertexAttribDivisorEXT_fnptr((int)vaobj, index, divisor);
+            public static void VertexArrayVertexAttribDivisorEXT(int vaobj, uint index, uint divisor) => GLPointers._VertexArrayVertexAttribDivisorEXT_fnptr(vaobj, index, divisor);
             
             /// <summary> <b>[requires: GL_EXT_draw_buffers2]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -13101,7 +13101,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_EXT_external_buffer]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedBufferStorageExternalEXT(BufferHandle buffer, IntPtr offset, nint size, void* clientBuffer, BufferStorageMask flags) => GLPointers._NamedBufferStorageExternalEXT_fnptr((int)buffer, offset, size, clientBuffer, (uint)flags);
+            public static void NamedBufferStorageExternalEXT(int buffer, IntPtr offset, nint size, void* clientBuffer, BufferStorageMask flags) => GLPointers._NamedBufferStorageExternalEXT_fnptr(buffer, offset, size, clientBuffer, (uint)flags);
             
             /// <summary> <b>[requires: GL_EXT_fog_coord]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -13133,19 +13133,19 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_EXT_framebuffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static bool IsRenderbufferEXT(RenderbufferHandle renderbuffer) => GLPointers._IsRenderbufferEXT_fnptr((int)renderbuffer) != 0;
+            public static bool IsRenderbufferEXT(int renderbuffer) => GLPointers._IsRenderbufferEXT_fnptr(renderbuffer) != 0;
             
             /// <summary> <b>[requires: GL_EXT_framebuffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void BindRenderbufferEXT(RenderbufferTarget target, RenderbufferHandle renderbuffer) => GLPointers._BindRenderbufferEXT_fnptr((uint)target, (int)renderbuffer);
+            public static void BindRenderbufferEXT(RenderbufferTarget target, int renderbuffer) => GLPointers._BindRenderbufferEXT_fnptr((uint)target, renderbuffer);
             
             /// <summary> <b>[requires: GL_EXT_framebuffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void DeleteRenderbuffersEXT(int n, RenderbufferHandle* renderbuffers) => GLPointers._DeleteRenderbuffersEXT_fnptr(n, (int*)renderbuffers);
+            public static void DeleteRenderbuffersEXT(int n, int* renderbuffers) => GLPointers._DeleteRenderbuffersEXT_fnptr(n, renderbuffers);
             
             /// <summary> <b>[requires: GL_EXT_framebuffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GenRenderbuffersEXT(int n, RenderbufferHandle* renderbuffers) => GLPointers._GenRenderbuffersEXT_fnptr(n, (int*)renderbuffers);
+            public static void GenRenderbuffersEXT(int n, int* renderbuffers) => GLPointers._GenRenderbuffersEXT_fnptr(n, renderbuffers);
             
             /// <summary> <b>[requires: GL_EXT_framebuffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -13157,19 +13157,19 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_EXT_framebuffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static bool IsFramebufferEXT(FramebufferHandle framebuffer) => GLPointers._IsFramebufferEXT_fnptr((int)framebuffer) != 0;
+            public static bool IsFramebufferEXT(int framebuffer) => GLPointers._IsFramebufferEXT_fnptr(framebuffer) != 0;
             
             /// <summary> <b>[requires: GL_EXT_framebuffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void BindFramebufferEXT(FramebufferTarget target, FramebufferHandle framebuffer) => GLPointers._BindFramebufferEXT_fnptr((uint)target, (int)framebuffer);
+            public static void BindFramebufferEXT(FramebufferTarget target, int framebuffer) => GLPointers._BindFramebufferEXT_fnptr((uint)target, framebuffer);
             
             /// <summary> <b>[requires: GL_EXT_framebuffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void DeleteFramebuffersEXT(int n, FramebufferHandle* framebuffers) => GLPointers._DeleteFramebuffersEXT_fnptr(n, (int*)framebuffers);
+            public static void DeleteFramebuffersEXT(int n, int* framebuffers) => GLPointers._DeleteFramebuffersEXT_fnptr(n, framebuffers);
             
             /// <summary> <b>[requires: GL_EXT_framebuffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GenFramebuffersEXT(int n, FramebufferHandle* framebuffers) => GLPointers._GenFramebuffersEXT_fnptr(n, (int*)framebuffers);
+            public static void GenFramebuffersEXT(int n, int* framebuffers) => GLPointers._GenFramebuffersEXT_fnptr(n, framebuffers);
             
             /// <summary> <b>[requires: GL_EXT_framebuffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -13177,19 +13177,19 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_EXT_framebuffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void FramebufferTexture1DEXT(FramebufferTarget target, FramebufferAttachment attachment, TextureTarget textarget, TextureHandle texture, int level) => GLPointers._FramebufferTexture1DEXT_fnptr((uint)target, (uint)attachment, (uint)textarget, (int)texture, level);
+            public static void FramebufferTexture1DEXT(FramebufferTarget target, FramebufferAttachment attachment, TextureTarget textarget, int texture, int level) => GLPointers._FramebufferTexture1DEXT_fnptr((uint)target, (uint)attachment, (uint)textarget, texture, level);
             
             /// <summary> <b>[requires: GL_EXT_framebuffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void FramebufferTexture2DEXT(FramebufferTarget target, FramebufferAttachment attachment, TextureTarget textarget, TextureHandle texture, int level) => GLPointers._FramebufferTexture2DEXT_fnptr((uint)target, (uint)attachment, (uint)textarget, (int)texture, level);
+            public static void FramebufferTexture2DEXT(FramebufferTarget target, FramebufferAttachment attachment, TextureTarget textarget, int texture, int level) => GLPointers._FramebufferTexture2DEXT_fnptr((uint)target, (uint)attachment, (uint)textarget, texture, level);
             
             /// <summary> <b>[requires: GL_EXT_framebuffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void FramebufferTexture3DEXT(FramebufferTarget target, FramebufferAttachment attachment, TextureTarget textarget, TextureHandle texture, int level, int zoffset) => GLPointers._FramebufferTexture3DEXT_fnptr((uint)target, (uint)attachment, (uint)textarget, (int)texture, level, zoffset);
+            public static void FramebufferTexture3DEXT(FramebufferTarget target, FramebufferAttachment attachment, TextureTarget textarget, int texture, int level, int zoffset) => GLPointers._FramebufferTexture3DEXT_fnptr((uint)target, (uint)attachment, (uint)textarget, texture, level, zoffset);
             
             /// <summary> <b>[requires: GL_EXT_framebuffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void FramebufferRenderbufferEXT(FramebufferTarget target, FramebufferAttachment attachment, RenderbufferTarget renderbuffertarget, RenderbufferHandle renderbuffer) => GLPointers._FramebufferRenderbufferEXT_fnptr((uint)target, (uint)attachment, (uint)renderbuffertarget, (int)renderbuffer);
+            public static void FramebufferRenderbufferEXT(FramebufferTarget target, FramebufferAttachment attachment, RenderbufferTarget renderbuffertarget, int renderbuffer) => GLPointers._FramebufferRenderbufferEXT_fnptr((uint)target, (uint)attachment, (uint)renderbuffertarget, renderbuffer);
             
             /// <summary> <b>[requires: GL_EXT_framebuffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -13201,7 +13201,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_EXT_geometry_shader4 | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramParameteriEXT(ProgramHandle program, ProgramParameterPName pname, int value) => GLPointers._ProgramParameteriEXT_fnptr((int)program, (uint)pname, value);
+            public static void ProgramParameteriEXT(int program, ProgramParameterPName pname, int value) => GLPointers._ProgramParameteriEXT_fnptr(program, (uint)pname, value);
             
             /// <summary> <b>[requires: GL_EXT_gpu_program_parameters]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -13213,15 +13213,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_EXT_gpu_shader4]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetUniformuivEXT(ProgramHandle program, int location, uint* parameters) => GLPointers._GetUniformuivEXT_fnptr((int)program, location, parameters);
+            public static void GetUniformuivEXT(int program, int location, uint* parameters) => GLPointers._GetUniformuivEXT_fnptr(program, location, parameters);
             
             /// <summary> <b>[requires: GL_EXT_gpu_shader4]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void BindFragDataLocationEXT(ProgramHandle program, uint color, byte* name) => GLPointers._BindFragDataLocationEXT_fnptr((int)program, color, name);
+            public static void BindFragDataLocationEXT(int program, uint color, byte* name) => GLPointers._BindFragDataLocationEXT_fnptr(program, color, name);
             
             /// <summary> <b>[requires: GL_EXT_gpu_shader4]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static int GetFragDataLocationEXT(ProgramHandle program, byte* name) => GLPointers._GetFragDataLocationEXT_fnptr((int)program, name);
+            public static int GetFragDataLocationEXT(int program, byte* name) => GLPointers._GetFragDataLocationEXT_fnptr(program, name);
             
             /// <summary> <b>[requires: GL_EXT_gpu_shader4]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -13457,23 +13457,23 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_EXT_memory_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureStorageMem2DEXT(TextureHandle texture, int levels, SizedInternalFormat internalFormat, int width, int height, uint memory, ulong offset) => GLPointers._TextureStorageMem2DEXT_fnptr((int)texture, levels, (uint)internalFormat, width, height, memory, offset);
+            public static void TextureStorageMem2DEXT(int texture, int levels, SizedInternalFormat internalFormat, int width, int height, uint memory, ulong offset) => GLPointers._TextureStorageMem2DEXT_fnptr(texture, levels, (uint)internalFormat, width, height, memory, offset);
             
             /// <summary> <b>[requires: GL_EXT_memory_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureStorageMem2DMultisampleEXT(TextureHandle texture, int samples, SizedInternalFormat internalFormat, int width, int height, bool fixedSampleLocations, uint memory, ulong offset) => GLPointers._TextureStorageMem2DMultisampleEXT_fnptr((int)texture, samples, (uint)internalFormat, width, height, (byte)(fixedSampleLocations ? 1 : 0), memory, offset);
+            public static void TextureStorageMem2DMultisampleEXT(int texture, int samples, SizedInternalFormat internalFormat, int width, int height, bool fixedSampleLocations, uint memory, ulong offset) => GLPointers._TextureStorageMem2DMultisampleEXT_fnptr(texture, samples, (uint)internalFormat, width, height, (byte)(fixedSampleLocations ? 1 : 0), memory, offset);
             
             /// <summary> <b>[requires: GL_EXT_memory_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureStorageMem3DEXT(TextureHandle texture, int levels, SizedInternalFormat internalFormat, int width, int height, int depth, uint memory, ulong offset) => GLPointers._TextureStorageMem3DEXT_fnptr((int)texture, levels, (uint)internalFormat, width, height, depth, memory, offset);
+            public static void TextureStorageMem3DEXT(int texture, int levels, SizedInternalFormat internalFormat, int width, int height, int depth, uint memory, ulong offset) => GLPointers._TextureStorageMem3DEXT_fnptr(texture, levels, (uint)internalFormat, width, height, depth, memory, offset);
             
             /// <summary> <b>[requires: GL_EXT_memory_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureStorageMem3DMultisampleEXT(TextureHandle texture, int samples, SizedInternalFormat internalFormat, int width, int height, int depth, bool fixedSampleLocations, uint memory, ulong offset) => GLPointers._TextureStorageMem3DMultisampleEXT_fnptr((int)texture, samples, (uint)internalFormat, width, height, depth, (byte)(fixedSampleLocations ? 1 : 0), memory, offset);
+            public static void TextureStorageMem3DMultisampleEXT(int texture, int samples, SizedInternalFormat internalFormat, int width, int height, int depth, bool fixedSampleLocations, uint memory, ulong offset) => GLPointers._TextureStorageMem3DMultisampleEXT_fnptr(texture, samples, (uint)internalFormat, width, height, depth, (byte)(fixedSampleLocations ? 1 : 0), memory, offset);
             
             /// <summary> <b>[requires: GL_EXT_memory_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedBufferStorageMemEXT(BufferHandle buffer, nint size, uint memory, ulong offset) => GLPointers._NamedBufferStorageMemEXT_fnptr((int)buffer, size, memory, offset);
+            public static void NamedBufferStorageMemEXT(int buffer, nint size, uint memory, ulong offset) => GLPointers._NamedBufferStorageMemEXT_fnptr(buffer, size, memory, offset);
             
             /// <summary> <b>[requires: GL_EXT_memory_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -13481,7 +13481,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_EXT_memory_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureStorageMem1DEXT(TextureHandle texture, int levels, SizedInternalFormat internalFormat, int width, uint memory, ulong offset) => GLPointers._TextureStorageMem1DEXT_fnptr((int)texture, levels, (uint)internalFormat, width, memory, offset);
+            public static void TextureStorageMem1DEXT(int texture, int levels, SizedInternalFormat internalFormat, int width, uint memory, ulong offset) => GLPointers._TextureStorageMem1DEXT_fnptr(texture, levels, (uint)internalFormat, width, memory, offset);
             
             /// <summary> <b>[requires: GL_EXT_memory_object_fd]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -13597,11 +13597,11 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_EXT_semaphore]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void WaitSemaphoreEXT(uint semaphore, uint numBufferBarriers, BufferHandle* buffers, uint numTextureBarriers, TextureHandle* textures, TextureLayout* srcLayouts) => GLPointers._WaitSemaphoreEXT_fnptr(semaphore, numBufferBarriers, (int*)buffers, numTextureBarriers, (int*)textures, (uint*)srcLayouts);
+            public static void WaitSemaphoreEXT(uint semaphore, uint numBufferBarriers, int* buffers, uint numTextureBarriers, int* textures, TextureLayout* srcLayouts) => GLPointers._WaitSemaphoreEXT_fnptr(semaphore, numBufferBarriers, buffers, numTextureBarriers, textures, (uint*)srcLayouts);
             
             /// <summary> <b>[requires: GL_EXT_semaphore]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void SignalSemaphoreEXT(uint semaphore, uint numBufferBarriers, BufferHandle* buffers, uint numTextureBarriers, TextureHandle* textures, TextureLayout* dstLayouts) => GLPointers._SignalSemaphoreEXT_fnptr(semaphore, numBufferBarriers, (int*)buffers, numTextureBarriers, (int*)textures, (uint*)dstLayouts);
+            public static void SignalSemaphoreEXT(uint semaphore, uint numBufferBarriers, int* buffers, uint numTextureBarriers, int* textures, TextureLayout* dstLayouts) => GLPointers._SignalSemaphoreEXT_fnptr(semaphore, numBufferBarriers, buffers, numTextureBarriers, textures, (uint*)dstLayouts);
             
             /// <summary> <b>[requires: GL_EXT_semaphore_fd]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -13685,55 +13685,55 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void UseShaderProgramEXT(All type, ProgramHandle program) => GLPointers._UseShaderProgramEXT_fnptr((uint)type, (int)program);
+            public static void UseShaderProgramEXT(All type, int program) => GLPointers._UseShaderProgramEXT_fnptr((uint)type, program);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ActiveProgramEXT(ProgramHandle program) => GLPointers._ActiveProgramEXT_fnptr((int)program);
+            public static void ActiveProgramEXT(int program) => GLPointers._ActiveProgramEXT_fnptr(program);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static ProgramHandle CreateShaderProgramEXT(ShaderType type, byte* str) => (ProgramHandle) GLPointers._CreateShaderProgramEXT_fnptr((uint)type, str);
+            public static int CreateShaderProgramEXT(ShaderType type, byte* str) => GLPointers._CreateShaderProgramEXT_fnptr((uint)type, str);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ActiveShaderProgramEXT(ProgramPipelineHandle pipeline, ProgramHandle program) => GLPointers._ActiveShaderProgramEXT_fnptr((int)pipeline, (int)program);
+            public static void ActiveShaderProgramEXT(int pipeline, int program) => GLPointers._ActiveShaderProgramEXT_fnptr(pipeline, program);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void BindProgramPipelineEXT(ProgramPipelineHandle pipeline) => GLPointers._BindProgramPipelineEXT_fnptr((int)pipeline);
+            public static void BindProgramPipelineEXT(int pipeline) => GLPointers._BindProgramPipelineEXT_fnptr(pipeline);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static ProgramHandle CreateShaderProgramvEXT(ShaderType type, int count, byte** strings) => (ProgramHandle) GLPointers._CreateShaderProgramvEXT_fnptr((uint)type, count, strings);
+            public static int CreateShaderProgramvEXT(ShaderType type, int count, byte** strings) => GLPointers._CreateShaderProgramvEXT_fnptr((uint)type, count, strings);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void DeleteProgramPipelinesEXT(int n, ProgramPipelineHandle* pipelines) => GLPointers._DeleteProgramPipelinesEXT_fnptr(n, (int*)pipelines);
+            public static void DeleteProgramPipelinesEXT(int n, int* pipelines) => GLPointers._DeleteProgramPipelinesEXT_fnptr(n, pipelines);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GenProgramPipelinesEXT(int n, ProgramPipelineHandle* pipelines) => GLPointers._GenProgramPipelinesEXT_fnptr(n, (int*)pipelines);
+            public static void GenProgramPipelinesEXT(int n, int* pipelines) => GLPointers._GenProgramPipelinesEXT_fnptr(n, pipelines);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetProgramPipelineInfoLogEXT(ProgramPipelineHandle pipeline, int bufSize, int* length, byte* infoLog) => GLPointers._GetProgramPipelineInfoLogEXT_fnptr((int)pipeline, bufSize, length, infoLog);
+            public static void GetProgramPipelineInfoLogEXT(int pipeline, int bufSize, int* length, byte* infoLog) => GLPointers._GetProgramPipelineInfoLogEXT_fnptr(pipeline, bufSize, length, infoLog);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetProgramPipelineivEXT(ProgramPipelineHandle pipeline, PipelineParameterName pname, int* parameters) => GLPointers._GetProgramPipelineivEXT_fnptr((int)pipeline, (uint)pname, parameters);
+            public static void GetProgramPipelineivEXT(int pipeline, PipelineParameterName pname, int* parameters) => GLPointers._GetProgramPipelineivEXT_fnptr(pipeline, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static bool IsProgramPipelineEXT(ProgramPipelineHandle pipeline) => GLPointers._IsProgramPipelineEXT_fnptr((int)pipeline) != 0;
+            public static bool IsProgramPipelineEXT(int pipeline) => GLPointers._IsProgramPipelineEXT_fnptr(pipeline) != 0;
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void UseProgramStagesEXT(ProgramPipelineHandle pipeline, UseProgramStageMask stages, ProgramHandle program) => GLPointers._UseProgramStagesEXT_fnptr((int)pipeline, (uint)stages, (int)program);
+            public static void UseProgramStagesEXT(int pipeline, UseProgramStageMask stages, int program) => GLPointers._UseProgramStagesEXT_fnptr(pipeline, (uint)stages, program);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ValidateProgramPipelineEXT(ProgramPipelineHandle pipeline) => GLPointers._ValidateProgramPipelineEXT_fnptr((int)pipeline);
+            public static void ValidateProgramPipelineEXT(int pipeline) => GLPointers._ValidateProgramPipelineEXT_fnptr(pipeline);
             
             /// <summary> <b>[requires: GL_EXT_shader_framebuffer_fetch_non_coherent]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -13741,7 +13741,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_EXT_shader_image_load_store]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void BindImageTextureEXT(uint index, TextureHandle texture, int level, bool layered, int layer, BufferAccessARB access, int format) => GLPointers._BindImageTextureEXT_fnptr(index, (int)texture, level, (byte)(layered ? 1 : 0), layer, (uint)access, format);
+            public static void BindImageTextureEXT(uint index, int texture, int level, bool layered, int layer, BufferAccessARB access, int format) => GLPointers._BindImageTextureEXT_fnptr(index, texture, level, (byte)(layered ? 1 : 0), layer, (uint)access, format);
             
             /// <summary> <b>[requires: GL_EXT_shader_image_load_store]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -13773,11 +13773,11 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_EXT_texture_array | GL_NV_geometry_program4]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void FramebufferTextureLayerEXT(FramebufferTarget target, FramebufferAttachment attachment, TextureHandle texture, int level, int layer) => GLPointers._FramebufferTextureLayerEXT_fnptr((uint)target, (uint)attachment, (int)texture, level, layer);
+            public static void FramebufferTextureLayerEXT(FramebufferTarget target, FramebufferAttachment attachment, int texture, int level, int layer) => GLPointers._FramebufferTextureLayerEXT_fnptr((uint)target, (uint)attachment, texture, level, layer);
             
             /// <summary> <b>[requires: GL_EXT_texture_buffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TexBufferEXT(TextureTarget target, SizedInternalFormat internalformat, BufferHandle buffer) => GLPointers._TexBufferEXT_fnptr((uint)target, (uint)internalformat, (int)buffer);
+            public static void TexBufferEXT(TextureTarget target, SizedInternalFormat internalformat, int buffer) => GLPointers._TexBufferEXT_fnptr((uint)target, (uint)internalformat, buffer);
             
             /// <summary> <b>[requires: GL_EXT_texture_integer]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -13805,27 +13805,27 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_EXT_texture_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static bool AreTexturesResidentEXT(int n, TextureHandle* textures, bool* residences) => GLPointers._AreTexturesResidentEXT_fnptr(n, (int*)textures, (byte*)residences) != 0;
+            public static bool AreTexturesResidentEXT(int n, int* textures, bool* residences) => GLPointers._AreTexturesResidentEXT_fnptr(n, textures, (byte*)residences) != 0;
             
             /// <summary> <b>[requires: GL_EXT_texture_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void BindTextureEXT(TextureTarget target, TextureHandle texture) => GLPointers._BindTextureEXT_fnptr((uint)target, (int)texture);
+            public static void BindTextureEXT(TextureTarget target, int texture) => GLPointers._BindTextureEXT_fnptr((uint)target, texture);
             
             /// <summary> <b>[requires: GL_EXT_texture_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void DeleteTexturesEXT(int n, TextureHandle* textures) => GLPointers._DeleteTexturesEXT_fnptr(n, (int*)textures);
+            public static void DeleteTexturesEXT(int n, int* textures) => GLPointers._DeleteTexturesEXT_fnptr(n, textures);
             
             /// <summary> <b>[requires: GL_EXT_texture_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GenTexturesEXT(int n, TextureHandle* textures) => GLPointers._GenTexturesEXT_fnptr(n, (int*)textures);
+            public static void GenTexturesEXT(int n, int* textures) => GLPointers._GenTexturesEXT_fnptr(n, textures);
             
             /// <summary> <b>[requires: GL_EXT_texture_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static bool IsTextureEXT(TextureHandle texture) => GLPointers._IsTextureEXT_fnptr((int)texture) != 0;
+            public static bool IsTextureEXT(int texture) => GLPointers._IsTextureEXT_fnptr(texture) != 0;
             
             /// <summary> <b>[requires: GL_EXT_texture_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void PrioritizeTexturesEXT(int n, TextureHandle* textures, float* priorities) => GLPointers._PrioritizeTexturesEXT_fnptr(n, (int*)textures, priorities);
+            public static void PrioritizeTexturesEXT(int n, int* textures, float* priorities) => GLPointers._PrioritizeTexturesEXT_fnptr(n, textures, priorities);
             
             /// <summary> <b>[requires: GL_EXT_texture_perturb_normal]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -13845,11 +13845,11 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_EXT_timer_query]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetQueryObjecti64vEXT(QueryHandle id, QueryObjectParameterName pname, long* parameters) => GLPointers._GetQueryObjecti64vEXT_fnptr((int)id, (uint)pname, parameters);
+            public static void GetQueryObjecti64vEXT(int id, QueryObjectParameterName pname, long* parameters) => GLPointers._GetQueryObjecti64vEXT_fnptr(id, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_EXT_timer_query]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetQueryObjectui64vEXT(QueryHandle id, QueryObjectParameterName pname, ulong* parameters) => GLPointers._GetQueryObjectui64vEXT_fnptr((int)id, (uint)pname, parameters);
+            public static void GetQueryObjectui64vEXT(int id, QueryObjectParameterName pname, ulong* parameters) => GLPointers._GetQueryObjectui64vEXT_fnptr(id, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_EXT_transform_feedback]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -13861,23 +13861,23 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_EXT_transform_feedback]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void BindBufferRangeEXT(BufferTargetARB target, uint index, BufferHandle buffer, IntPtr offset, nint size) => GLPointers._BindBufferRangeEXT_fnptr((uint)target, index, (int)buffer, offset, size);
+            public static void BindBufferRangeEXT(BufferTargetARB target, uint index, int buffer, IntPtr offset, nint size) => GLPointers._BindBufferRangeEXT_fnptr((uint)target, index, buffer, offset, size);
             
             /// <summary> <b>[requires: GL_EXT_transform_feedback]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void BindBufferOffsetEXT(BufferTargetARB target, uint index, BufferHandle buffer, IntPtr offset) => GLPointers._BindBufferOffsetEXT_fnptr((uint)target, index, (int)buffer, offset);
+            public static void BindBufferOffsetEXT(BufferTargetARB target, uint index, int buffer, IntPtr offset) => GLPointers._BindBufferOffsetEXT_fnptr((uint)target, index, buffer, offset);
             
             /// <summary> <b>[requires: GL_EXT_transform_feedback]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void BindBufferBaseEXT(BufferTargetARB target, uint index, BufferHandle buffer) => GLPointers._BindBufferBaseEXT_fnptr((uint)target, index, (int)buffer);
+            public static void BindBufferBaseEXT(BufferTargetARB target, uint index, int buffer) => GLPointers._BindBufferBaseEXT_fnptr((uint)target, index, buffer);
             
             /// <summary> <b>[requires: GL_EXT_transform_feedback]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TransformFeedbackVaryingsEXT(ProgramHandle program, int count, byte** varyings, TransformFeedbackBufferMode bufferMode) => GLPointers._TransformFeedbackVaryingsEXT_fnptr((int)program, count, varyings, (uint)bufferMode);
+            public static void TransformFeedbackVaryingsEXT(int program, int count, byte** varyings, TransformFeedbackBufferMode bufferMode) => GLPointers._TransformFeedbackVaryingsEXT_fnptr(program, count, varyings, (uint)bufferMode);
             
             /// <summary> <b>[requires: GL_EXT_transform_feedback]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetTransformFeedbackVaryingEXT(ProgramHandle program, uint index, int bufSize, int* length, int* size, AttributeType* type, byte* name) => GLPointers._GetTransformFeedbackVaryingEXT_fnptr((int)program, index, bufSize, length, size, (uint*)type, name);
+            public static void GetTransformFeedbackVaryingEXT(int program, uint index, int bufSize, int* length, int* size, AttributeType* type, byte* name) => GLPointers._GetTransformFeedbackVaryingEXT_fnptr(program, index, bufSize, length, size, (uint*)type, name);
             
             /// <summary> <b>[requires: GL_EXT_vertex_array]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -14188,11 +14188,11 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_NV_bindless_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static ulong GetTextureHandleNV(TextureHandle texture) => GLPointers._GetTextureHandleNV_fnptr((int)texture);
+            public static ulong GetTextureHandleNV(int texture) => GLPointers._GetTextureHandleNV_fnptr(texture);
             
             /// <summary> <b>[requires: GL_NV_bindless_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static ulong GetTextureSamplerHandleNV(TextureHandle texture, SamplerHandle sampler) => GLPointers._GetTextureSamplerHandleNV_fnptr((int)texture, (int)sampler);
+            public static ulong GetTextureSamplerHandleNV(int texture, int sampler) => GLPointers._GetTextureSamplerHandleNV_fnptr(texture, sampler);
             
             /// <summary> <b>[requires: GL_NV_bindless_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -14204,7 +14204,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_NV_bindless_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static ulong GetImageHandleNV(TextureHandle texture, int level, bool layered, int layer, PixelFormat format) => GLPointers._GetImageHandleNV_fnptr((int)texture, level, (byte)(layered ? 1 : 0), layer, (uint)format);
+            public static ulong GetImageHandleNV(int texture, int level, bool layered, int layer, PixelFormat format) => GLPointers._GetImageHandleNV_fnptr(texture, level, (byte)(layered ? 1 : 0), layer, (uint)format);
             
             /// <summary> <b>[requires: GL_NV_bindless_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -14224,11 +14224,11 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_NV_bindless_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformHandleui64NV(ProgramHandle program, int location, ulong value) => GLPointers._ProgramUniformHandleui64NV_fnptr((int)program, location, value);
+            public static void ProgramUniformHandleui64NV(int program, int location, ulong value) => GLPointers._ProgramUniformHandleui64NV_fnptr(program, location, value);
             
             /// <summary> <b>[requires: GL_NV_bindless_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformHandleui64vNV(ProgramHandle program, int location, int count, ulong* values) => GLPointers._ProgramUniformHandleui64vNV_fnptr((int)program, location, count, values);
+            public static void ProgramUniformHandleui64vNV(int program, int location, int count, ulong* values) => GLPointers._ProgramUniformHandleui64vNV_fnptr(program, location, count, values);
             
             /// <summary> <b>[requires: GL_NV_bindless_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -14284,7 +14284,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_NV_command_list]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void DrawCommandsStatesNV(BufferHandle buffer, IntPtr* indirects, int* sizes, uint* states, uint* fbos, uint count) => GLPointers._DrawCommandsStatesNV_fnptr((int)buffer, indirects, sizes, states, fbos, count);
+            public static void DrawCommandsStatesNV(int buffer, IntPtr* indirects, int* sizes, uint* states, uint* fbos, uint count) => GLPointers._DrawCommandsStatesNV_fnptr(buffer, indirects, sizes, states, fbos, count);
             
             /// <summary> <b>[requires: GL_NV_command_list]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -14356,11 +14356,11 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_NV_draw_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void DrawTextureNV(TextureHandle texture, SamplerHandle sampler, float x0, float y0, float x1, float y1, float z, float s0, float t0, float s1, float t1) => GLPointers._DrawTextureNV_fnptr((int)texture, (int)sampler, x0, y0, x1, y1, z, s0, t0, s1, t1);
+            public static void DrawTextureNV(int texture, int sampler, float x0, float y0, float x1, float y1, float z, float s0, float t0, float s1, float t1) => GLPointers._DrawTextureNV_fnptr(texture, sampler, x0, y0, x1, y1, z, s0, t0, s1, t1);
             
             /// <summary> <b>[requires: GL_NV_draw_vulkan_image]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void DrawVkImageNV(ulong vkImage, SamplerHandle sampler, float x0, float y0, float x1, float y1, float z, float s0, float t0, float s1, float t1) => GLPointers._DrawVkImageNV_fnptr(vkImage, (int)sampler, x0, y0, x1, y1, z, s0, t0, s1, t1);
+            public static void DrawVkImageNV(ulong vkImage, int sampler, float x0, float y0, float x1, float y1, float z, float s0, float t0, float s1, float t1) => GLPointers._DrawVkImageNV_fnptr(vkImage, sampler, x0, y0, x1, y1, z, s0, t0, s1, t1);
             
             /// <summary> <b>[requires: GL_NV_draw_vulkan_image]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -14424,7 +14424,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_NV_explicit_multisample]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TexRenderbufferNV(TextureTarget target, RenderbufferHandle renderbuffer) => GLPointers._TexRenderbufferNV_fnptr((uint)target, (int)renderbuffer);
+            public static void TexRenderbufferNV(TextureTarget target, int renderbuffer) => GLPointers._TexRenderbufferNV_fnptr((uint)target, renderbuffer);
             
             /// <summary> <b>[requires: GL_NV_fence]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -14460,27 +14460,27 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_NV_fragment_program]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramNamedParameter4fNV(ProgramHandle id, int len, byte* name, float x, float y, float z, float w) => GLPointers._ProgramNamedParameter4fNV_fnptr((int)id, len, name, x, y, z, w);
+            public static void ProgramNamedParameter4fNV(int id, int len, byte* name, float x, float y, float z, float w) => GLPointers._ProgramNamedParameter4fNV_fnptr(id, len, name, x, y, z, w);
             
             /// <summary> <b>[requires: GL_NV_fragment_program]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramNamedParameter4fvNV(ProgramHandle id, int len, byte* name, float* v) => GLPointers._ProgramNamedParameter4fvNV_fnptr((int)id, len, name, v);
+            public static void ProgramNamedParameter4fvNV(int id, int len, byte* name, float* v) => GLPointers._ProgramNamedParameter4fvNV_fnptr(id, len, name, v);
             
             /// <summary> <b>[requires: GL_NV_fragment_program]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramNamedParameter4dNV(ProgramHandle id, int len, byte* name, double x, double y, double z, double w) => GLPointers._ProgramNamedParameter4dNV_fnptr((int)id, len, name, x, y, z, w);
+            public static void ProgramNamedParameter4dNV(int id, int len, byte* name, double x, double y, double z, double w) => GLPointers._ProgramNamedParameter4dNV_fnptr(id, len, name, x, y, z, w);
             
             /// <summary> <b>[requires: GL_NV_fragment_program]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramNamedParameter4dvNV(ProgramHandle id, int len, byte* name, double* v) => GLPointers._ProgramNamedParameter4dvNV_fnptr((int)id, len, name, v);
+            public static void ProgramNamedParameter4dvNV(int id, int len, byte* name, double* v) => GLPointers._ProgramNamedParameter4dvNV_fnptr(id, len, name, v);
             
             /// <summary> <b>[requires: GL_NV_fragment_program]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetProgramNamedParameterfvNV(ProgramHandle id, int len, byte* name, float* parameters) => GLPointers._GetProgramNamedParameterfvNV_fnptr((int)id, len, name, parameters);
+            public static void GetProgramNamedParameterfvNV(int id, int len, byte* name, float* parameters) => GLPointers._GetProgramNamedParameterfvNV_fnptr(id, len, name, parameters);
             
             /// <summary> <b>[requires: GL_NV_fragment_program]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetProgramNamedParameterdvNV(ProgramHandle id, int len, byte* name, double* parameters) => GLPointers._GetProgramNamedParameterdvNV_fnptr((int)id, len, name, parameters);
+            public static void GetProgramNamedParameterdvNV(int id, int len, byte* name, double* parameters) => GLPointers._GetProgramNamedParameterdvNV_fnptr(id, len, name, parameters);
             
             /// <summary> <b>[requires: GL_EXT_raster_multisample | GL_NV_framebuffer_mixed_samples]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -14508,15 +14508,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_NV_geometry_program4]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void FramebufferTextureEXT(FramebufferTarget target, FramebufferAttachment attachment, TextureHandle texture, int level) => GLPointers._FramebufferTextureEXT_fnptr((uint)target, (uint)attachment, (int)texture, level);
+            public static void FramebufferTextureEXT(FramebufferTarget target, FramebufferAttachment attachment, int texture, int level) => GLPointers._FramebufferTextureEXT_fnptr((uint)target, (uint)attachment, texture, level);
             
             /// <summary> <b>[requires: GL_EXT_texture_array | GL_NV_geometry_program4]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void FramebufferTextureLayerEXT(FramebufferTarget target, FramebufferAttachment attachment, TextureHandle texture, int level, int layer) => GLPointers._FramebufferTextureLayerEXT_fnptr((uint)target, (uint)attachment, (int)texture, level, layer);
+            public static void FramebufferTextureLayerEXT(FramebufferTarget target, FramebufferAttachment attachment, int texture, int level, int layer) => GLPointers._FramebufferTextureLayerEXT_fnptr((uint)target, (uint)attachment, texture, level, layer);
             
             /// <summary> <b>[requires: GL_NV_geometry_program4]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void FramebufferTextureFaceEXT(FramebufferTarget target, FramebufferAttachment attachment, TextureHandle texture, int level, TextureTarget face) => GLPointers._FramebufferTextureFaceEXT_fnptr((uint)target, (uint)attachment, (int)texture, level, (uint)face);
+            public static void FramebufferTextureFaceEXT(FramebufferTarget target, FramebufferAttachment attachment, int texture, int level, TextureTarget face) => GLPointers._FramebufferTextureFaceEXT_fnptr((uint)target, (uint)attachment, texture, level, (uint)face);
             
             /// <summary> <b>[requires: GL_NV_gpu_program4]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -14656,71 +14656,71 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetUniformi64vNV(ProgramHandle program, int location, long* parameters) => GLPointers._GetUniformi64vNV_fnptr((int)program, location, parameters);
+            public static void GetUniformi64vNV(int program, int location, long* parameters) => GLPointers._GetUniformi64vNV_fnptr(program, location, parameters);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform1i64NV(ProgramHandle program, int location, long x) => GLPointers._ProgramUniform1i64NV_fnptr((int)program, location, x);
+            public static void ProgramUniform1i64NV(int program, int location, long x) => GLPointers._ProgramUniform1i64NV_fnptr(program, location, x);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform2i64NV(ProgramHandle program, int location, long x, long y) => GLPointers._ProgramUniform2i64NV_fnptr((int)program, location, x, y);
+            public static void ProgramUniform2i64NV(int program, int location, long x, long y) => GLPointers._ProgramUniform2i64NV_fnptr(program, location, x, y);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform3i64NV(ProgramHandle program, int location, long x, long y, long z) => GLPointers._ProgramUniform3i64NV_fnptr((int)program, location, x, y, z);
+            public static void ProgramUniform3i64NV(int program, int location, long x, long y, long z) => GLPointers._ProgramUniform3i64NV_fnptr(program, location, x, y, z);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform4i64NV(ProgramHandle program, int location, long x, long y, long z, long w) => GLPointers._ProgramUniform4i64NV_fnptr((int)program, location, x, y, z, w);
+            public static void ProgramUniform4i64NV(int program, int location, long x, long y, long z, long w) => GLPointers._ProgramUniform4i64NV_fnptr(program, location, x, y, z, w);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform1i64vNV(ProgramHandle program, int location, int count, long* value) => GLPointers._ProgramUniform1i64vNV_fnptr((int)program, location, count, value);
+            public static void ProgramUniform1i64vNV(int program, int location, int count, long* value) => GLPointers._ProgramUniform1i64vNV_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform2i64vNV(ProgramHandle program, int location, int count, long* value) => GLPointers._ProgramUniform2i64vNV_fnptr((int)program, location, count, value);
+            public static void ProgramUniform2i64vNV(int program, int location, int count, long* value) => GLPointers._ProgramUniform2i64vNV_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform3i64vNV(ProgramHandle program, int location, int count, long* value) => GLPointers._ProgramUniform3i64vNV_fnptr((int)program, location, count, value);
+            public static void ProgramUniform3i64vNV(int program, int location, int count, long* value) => GLPointers._ProgramUniform3i64vNV_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform4i64vNV(ProgramHandle program, int location, int count, long* value) => GLPointers._ProgramUniform4i64vNV_fnptr((int)program, location, count, value);
+            public static void ProgramUniform4i64vNV(int program, int location, int count, long* value) => GLPointers._ProgramUniform4i64vNV_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform1ui64NV(ProgramHandle program, int location, ulong x) => GLPointers._ProgramUniform1ui64NV_fnptr((int)program, location, x);
+            public static void ProgramUniform1ui64NV(int program, int location, ulong x) => GLPointers._ProgramUniform1ui64NV_fnptr(program, location, x);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform2ui64NV(ProgramHandle program, int location, ulong x, ulong y) => GLPointers._ProgramUniform2ui64NV_fnptr((int)program, location, x, y);
+            public static void ProgramUniform2ui64NV(int program, int location, ulong x, ulong y) => GLPointers._ProgramUniform2ui64NV_fnptr(program, location, x, y);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform3ui64NV(ProgramHandle program, int location, ulong x, ulong y, ulong z) => GLPointers._ProgramUniform3ui64NV_fnptr((int)program, location, x, y, z);
+            public static void ProgramUniform3ui64NV(int program, int location, ulong x, ulong y, ulong z) => GLPointers._ProgramUniform3ui64NV_fnptr(program, location, x, y, z);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform4ui64NV(ProgramHandle program, int location, ulong x, ulong y, ulong z, ulong w) => GLPointers._ProgramUniform4ui64NV_fnptr((int)program, location, x, y, z, w);
+            public static void ProgramUniform4ui64NV(int program, int location, ulong x, ulong y, ulong z, ulong w) => GLPointers._ProgramUniform4ui64NV_fnptr(program, location, x, y, z, w);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform1ui64vNV(ProgramHandle program, int location, int count, ulong* value) => GLPointers._ProgramUniform1ui64vNV_fnptr((int)program, location, count, value);
+            public static void ProgramUniform1ui64vNV(int program, int location, int count, ulong* value) => GLPointers._ProgramUniform1ui64vNV_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform2ui64vNV(ProgramHandle program, int location, int count, ulong* value) => GLPointers._ProgramUniform2ui64vNV_fnptr((int)program, location, count, value);
+            public static void ProgramUniform2ui64vNV(int program, int location, int count, ulong* value) => GLPointers._ProgramUniform2ui64vNV_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform3ui64vNV(ProgramHandle program, int location, int count, ulong* value) => GLPointers._ProgramUniform3ui64vNV_fnptr((int)program, location, count, value);
+            public static void ProgramUniform3ui64vNV(int program, int location, int count, ulong* value) => GLPointers._ProgramUniform3ui64vNV_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform4ui64vNV(ProgramHandle program, int location, int count, ulong* value) => GLPointers._ProgramUniform4ui64vNV_fnptr((int)program, location, count, value);
+            public static void ProgramUniform4ui64vNV(int program, int location, int count, ulong* value) => GLPointers._ProgramUniform4ui64vNV_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_NV_half_float]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -14916,11 +14916,11 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_NV_gpu_multicast]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void MulticastBufferSubDataNV(All gpuMask, BufferHandle buffer, IntPtr offset, nint size, void* data) => GLPointers._MulticastBufferSubDataNV_fnptr((uint)gpuMask, (int)buffer, offset, size, data);
+            public static void MulticastBufferSubDataNV(All gpuMask, int buffer, IntPtr offset, nint size, void* data) => GLPointers._MulticastBufferSubDataNV_fnptr((uint)gpuMask, buffer, offset, size, data);
             
             /// <summary> <b>[requires: GL_NV_gpu_multicast]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void MulticastCopyBufferSubDataNV(uint readGpu, All writeGpuMask, BufferHandle readBuffer, BufferHandle writeBuffer, IntPtr readOffset, IntPtr writeOffset, nint size) => GLPointers._MulticastCopyBufferSubDataNV_fnptr(readGpu, (uint)writeGpuMask, (int)readBuffer, (int)writeBuffer, readOffset, writeOffset, size);
+            public static void MulticastCopyBufferSubDataNV(uint readGpu, All writeGpuMask, int readBuffer, int writeBuffer, IntPtr readOffset, IntPtr writeOffset, nint size) => GLPointers._MulticastCopyBufferSubDataNV_fnptr(readGpu, (uint)writeGpuMask, readBuffer, writeBuffer, readOffset, writeOffset, size);
             
             /// <summary> <b>[requires: GL_NV_gpu_multicast]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -14932,7 +14932,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_NV_gpu_multicast]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void MulticastFramebufferSampleLocationsfvNV(uint gpu, FramebufferHandle framebuffer, uint start, int count, float* v) => GLPointers._MulticastFramebufferSampleLocationsfvNV_fnptr(gpu, (int)framebuffer, start, count, v);
+            public static void MulticastFramebufferSampleLocationsfvNV(uint gpu, int framebuffer, uint start, int count, float* v) => GLPointers._MulticastFramebufferSampleLocationsfvNV_fnptr(gpu, framebuffer, start, count, v);
             
             /// <summary> <b>[requires: GL_NV_gpu_multicast]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -14976,11 +14976,11 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_NV_memory_attachment]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureAttachMemoryNV(TextureHandle texture, uint memory, ulong offset) => GLPointers._TextureAttachMemoryNV_fnptr((int)texture, memory, offset);
+            public static void TextureAttachMemoryNV(int texture, uint memory, ulong offset) => GLPointers._TextureAttachMemoryNV_fnptr(texture, memory, offset);
             
             /// <summary> <b>[requires: GL_NV_memory_attachment]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedBufferAttachMemoryNV(BufferHandle buffer, uint memory, ulong offset) => GLPointers._NamedBufferAttachMemoryNV_fnptr((int)buffer, memory, offset);
+            public static void NamedBufferAttachMemoryNV(int buffer, uint memory, ulong offset) => GLPointers._NamedBufferAttachMemoryNV_fnptr(buffer, memory, offset);
             
             /// <summary> <b>[requires: GL_NV_memory_object_sparse]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -14992,11 +14992,11 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_NV_memory_object_sparse]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedBufferPageCommitmentMemNV(BufferHandle buffer, IntPtr offset, nint size, uint memory, ulong memOffset, bool commit) => GLPointers._NamedBufferPageCommitmentMemNV_fnptr((int)buffer, offset, size, memory, memOffset, (byte)(commit ? 1 : 0));
+            public static void NamedBufferPageCommitmentMemNV(int buffer, IntPtr offset, nint size, uint memory, ulong memOffset, bool commit) => GLPointers._NamedBufferPageCommitmentMemNV_fnptr(buffer, offset, size, memory, memOffset, (byte)(commit ? 1 : 0));
             
             /// <summary> <b>[requires: GL_NV_memory_object_sparse]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TexturePageCommitmentMemNV(TextureHandle texture, int layer, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, uint memory, ulong offset, bool commit) => GLPointers._TexturePageCommitmentMemNV_fnptr((int)texture, layer, level, xoffset, yoffset, zoffset, width, height, depth, memory, offset, (byte)(commit ? 1 : 0));
+            public static void TexturePageCommitmentMemNV(int texture, int layer, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, uint memory, ulong offset, bool commit) => GLPointers._TexturePageCommitmentMemNV_fnptr(texture, layer, level, xoffset, yoffset, zoffset, width, height, depth, memory, offset, (byte)(commit ? 1 : 0));
             
             /// <summary> <b>[requires: GL_NV_mesh_shader]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -15276,11 +15276,11 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_NV_path_rendering]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramPathFragmentInputGenNV(ProgramHandle program, int location, All genMode, int components, float* coeffs) => GLPointers._ProgramPathFragmentInputGenNV_fnptr((int)program, location, (uint)genMode, components, coeffs);
+            public static void ProgramPathFragmentInputGenNV(int program, int location, All genMode, int components, float* coeffs) => GLPointers._ProgramPathFragmentInputGenNV_fnptr(program, location, (uint)genMode, components, coeffs);
             
             /// <summary> <b>[requires: GL_NV_path_rendering]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetProgramResourcefvNV(ProgramHandle program, ProgramInterface programInterface, uint index, int propCount, All* props, int count, int* length, float* parameters) => GLPointers._GetProgramResourcefvNV_fnptr((int)program, (uint)programInterface, index, propCount, (uint*)props, count, length, parameters);
+            public static void GetProgramResourcefvNV(int program, ProgramInterface programInterface, uint index, int propCount, All* props, int count, int* length, float* parameters) => GLPointers._GetProgramResourcefvNV_fnptr(program, (uint)programInterface, index, propCount, (uint*)props, count, length, parameters);
             
             /// <summary> <b>[requires: GL_NV_path_rendering]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -15516,7 +15516,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_NV_sample_locations]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedFramebufferSampleLocationsfvNV(FramebufferHandle framebuffer, uint start, int count, float* v) => GLPointers._NamedFramebufferSampleLocationsfvNV_fnptr((int)framebuffer, start, count, v);
+            public static void NamedFramebufferSampleLocationsfvNV(int framebuffer, uint start, int count, float* v) => GLPointers._NamedFramebufferSampleLocationsfvNV_fnptr(framebuffer, start, count, v);
             
             /// <summary> <b>[requires: GL_NV_sample_locations]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -15544,15 +15544,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_NV_shader_buffer_load]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void MakeNamedBufferResidentNV(BufferHandle buffer, All access) => GLPointers._MakeNamedBufferResidentNV_fnptr((int)buffer, (uint)access);
+            public static void MakeNamedBufferResidentNV(int buffer, All access) => GLPointers._MakeNamedBufferResidentNV_fnptr(buffer, (uint)access);
             
             /// <summary> <b>[requires: GL_NV_shader_buffer_load]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void MakeNamedBufferNonResidentNV(BufferHandle buffer) => GLPointers._MakeNamedBufferNonResidentNV_fnptr((int)buffer);
+            public static void MakeNamedBufferNonResidentNV(int buffer) => GLPointers._MakeNamedBufferNonResidentNV_fnptr(buffer);
             
             /// <summary> <b>[requires: GL_NV_shader_buffer_load]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static bool IsNamedBufferResidentNV(BufferHandle buffer) => GLPointers._IsNamedBufferResidentNV_fnptr((int)buffer) != 0;
+            public static bool IsNamedBufferResidentNV(int buffer) => GLPointers._IsNamedBufferResidentNV_fnptr(buffer) != 0;
             
             /// <summary> <b>[requires: GL_NV_shader_buffer_load]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -15560,7 +15560,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_NV_shader_buffer_load]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetNamedBufferParameterui64vNV(BufferHandle buffer, BufferPNameARB pname, ulong* parameters) => GLPointers._GetNamedBufferParameterui64vNV_fnptr((int)buffer, (uint)pname, parameters);
+            public static void GetNamedBufferParameterui64vNV(int buffer, BufferPNameARB pname, ulong* parameters) => GLPointers._GetNamedBufferParameterui64vNV_fnptr(buffer, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_NV_shader_buffer_load]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -15576,19 +15576,19 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_shader_buffer_load]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetUniformui64vNV(ProgramHandle program, int location, ulong* parameters) => GLPointers._GetUniformui64vNV_fnptr((int)program, location, parameters);
+            public static void GetUniformui64vNV(int program, int location, ulong* parameters) => GLPointers._GetUniformui64vNV_fnptr(program, location, parameters);
             
             /// <summary> <b>[requires: GL_NV_shader_buffer_load]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformui64NV(ProgramHandle program, int location, ulong value) => GLPointers._ProgramUniformui64NV_fnptr((int)program, location, value);
+            public static void ProgramUniformui64NV(int program, int location, ulong value) => GLPointers._ProgramUniformui64NV_fnptr(program, location, value);
             
             /// <summary> <b>[requires: GL_NV_shader_buffer_load]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformui64vNV(ProgramHandle program, int location, int count, ulong* value) => GLPointers._ProgramUniformui64vNV_fnptr((int)program, location, count, value);
+            public static void ProgramUniformui64vNV(int program, int location, int count, ulong* value) => GLPointers._ProgramUniformui64vNV_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_NV_shading_rate_image]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void BindShadingRateImageNV(TextureHandle texture) => GLPointers._BindShadingRateImageNV_fnptr((int)texture);
+            public static void BindShadingRateImageNV(int texture) => GLPointers._BindShadingRateImageNV_fnptr(texture);
             
             /// <summary> <b>[requires: GL_NV_shading_rate_image]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -15628,19 +15628,19 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_NV_texture_multisample]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureImage2DMultisampleNV(TextureHandle texture, TextureTarget target, int samples, InternalFormat internalFormat, int width, int height, bool fixedSampleLocations) => GLPointers._TextureImage2DMultisampleNV_fnptr((int)texture, (uint)target, samples, (int)internalFormat, width, height, (byte)(fixedSampleLocations ? 1 : 0));
+            public static void TextureImage2DMultisampleNV(int texture, TextureTarget target, int samples, InternalFormat internalFormat, int width, int height, bool fixedSampleLocations) => GLPointers._TextureImage2DMultisampleNV_fnptr(texture, (uint)target, samples, (int)internalFormat, width, height, (byte)(fixedSampleLocations ? 1 : 0));
             
             /// <summary> <b>[requires: GL_NV_texture_multisample]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureImage3DMultisampleNV(TextureHandle texture, TextureTarget target, int samples, InternalFormat internalFormat, int width, int height, int depth, bool fixedSampleLocations) => GLPointers._TextureImage3DMultisampleNV_fnptr((int)texture, (uint)target, samples, (int)internalFormat, width, height, depth, (byte)(fixedSampleLocations ? 1 : 0));
+            public static void TextureImage3DMultisampleNV(int texture, TextureTarget target, int samples, InternalFormat internalFormat, int width, int height, int depth, bool fixedSampleLocations) => GLPointers._TextureImage3DMultisampleNV_fnptr(texture, (uint)target, samples, (int)internalFormat, width, height, depth, (byte)(fixedSampleLocations ? 1 : 0));
             
             /// <summary> <b>[requires: GL_NV_texture_multisample]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureImage2DMultisampleCoverageNV(TextureHandle texture, TextureTarget target, int coverageSamples, int colorSamples, InternalFormat internalFormat, int width, int height, bool fixedSampleLocations) => GLPointers._TextureImage2DMultisampleCoverageNV_fnptr((int)texture, (uint)target, coverageSamples, colorSamples, (int)internalFormat, width, height, (byte)(fixedSampleLocations ? 1 : 0));
+            public static void TextureImage2DMultisampleCoverageNV(int texture, TextureTarget target, int coverageSamples, int colorSamples, InternalFormat internalFormat, int width, int height, bool fixedSampleLocations) => GLPointers._TextureImage2DMultisampleCoverageNV_fnptr(texture, (uint)target, coverageSamples, colorSamples, (int)internalFormat, width, height, (byte)(fixedSampleLocations ? 1 : 0));
             
             /// <summary> <b>[requires: GL_NV_texture_multisample]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureImage3DMultisampleCoverageNV(TextureHandle texture, TextureTarget target, int coverageSamples, int colorSamples, InternalFormat internalFormat, int width, int height, int depth, bool fixedSampleLocations) => GLPointers._TextureImage3DMultisampleCoverageNV_fnptr((int)texture, (uint)target, coverageSamples, colorSamples, (int)internalFormat, width, height, depth, (byte)(fixedSampleLocations ? 1 : 0));
+            public static void TextureImage3DMultisampleCoverageNV(int texture, TextureTarget target, int coverageSamples, int colorSamples, InternalFormat internalFormat, int width, int height, int depth, bool fixedSampleLocations) => GLPointers._TextureImage3DMultisampleCoverageNV_fnptr(texture, (uint)target, coverageSamples, colorSamples, (int)internalFormat, width, height, depth, (byte)(fixedSampleLocations ? 1 : 0));
             
             /// <summary> <b>[requires: GL_NV_transform_feedback]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -15656,35 +15656,35 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_NV_transform_feedback]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void BindBufferRangeNV(BufferTargetARB target, uint index, BufferHandle buffer, IntPtr offset, nint size) => GLPointers._BindBufferRangeNV_fnptr((uint)target, index, (int)buffer, offset, size);
+            public static void BindBufferRangeNV(BufferTargetARB target, uint index, int buffer, IntPtr offset, nint size) => GLPointers._BindBufferRangeNV_fnptr((uint)target, index, buffer, offset, size);
             
             /// <summary> <b>[requires: GL_NV_transform_feedback]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void BindBufferOffsetNV(BufferTargetARB target, uint index, BufferHandle buffer, IntPtr offset) => GLPointers._BindBufferOffsetNV_fnptr((uint)target, index, (int)buffer, offset);
+            public static void BindBufferOffsetNV(BufferTargetARB target, uint index, int buffer, IntPtr offset) => GLPointers._BindBufferOffsetNV_fnptr((uint)target, index, buffer, offset);
             
             /// <summary> <b>[requires: GL_NV_transform_feedback]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void BindBufferBaseNV(BufferTargetARB target, uint index, BufferHandle buffer) => GLPointers._BindBufferBaseNV_fnptr((uint)target, index, (int)buffer);
+            public static void BindBufferBaseNV(BufferTargetARB target, uint index, int buffer) => GLPointers._BindBufferBaseNV_fnptr((uint)target, index, buffer);
             
             /// <summary> <b>[requires: GL_NV_transform_feedback]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TransformFeedbackVaryingsNV(ProgramHandle program, int count, TransformFeedbackTokenNV* locations, TransformFeedbackBufferMode bufferMode) => GLPointers._TransformFeedbackVaryingsNV_fnptr((int)program, count, (int*)locations, (uint)bufferMode);
+            public static void TransformFeedbackVaryingsNV(int program, int count, TransformFeedbackTokenNV* locations, TransformFeedbackBufferMode bufferMode) => GLPointers._TransformFeedbackVaryingsNV_fnptr(program, count, (int*)locations, (uint)bufferMode);
             
             /// <summary> <b>[requires: GL_NV_transform_feedback]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ActiveVaryingNV(ProgramHandle program, byte* name) => GLPointers._ActiveVaryingNV_fnptr((int)program, name);
+            public static void ActiveVaryingNV(int program, byte* name) => GLPointers._ActiveVaryingNV_fnptr(program, name);
             
             /// <summary> <b>[requires: GL_NV_transform_feedback]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static int GetVaryingLocationNV(ProgramHandle program, byte* name) => GLPointers._GetVaryingLocationNV_fnptr((int)program, name);
+            public static int GetVaryingLocationNV(int program, byte* name) => GLPointers._GetVaryingLocationNV_fnptr(program, name);
             
             /// <summary> <b>[requires: GL_NV_transform_feedback]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetActiveVaryingNV(ProgramHandle program, uint index, int bufSize, int* length, int* size, All* type, byte* name) => GLPointers._GetActiveVaryingNV_fnptr((int)program, index, bufSize, length, size, (uint*)type, name);
+            public static void GetActiveVaryingNV(int program, uint index, int bufSize, int* length, int* size, All* type, byte* name) => GLPointers._GetActiveVaryingNV_fnptr(program, index, bufSize, length, size, (uint*)type, name);
             
             /// <summary> <b>[requires: GL_NV_transform_feedback]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetTransformFeedbackVaryingNV(ProgramHandle program, uint index, int* location) => GLPointers._GetTransformFeedbackVaryingNV_fnptr((int)program, index, location);
+            public static void GetTransformFeedbackVaryingNV(int program, uint index, int* location) => GLPointers._GetTransformFeedbackVaryingNV_fnptr(program, index, location);
             
             /// <summary> <b>[requires: GL_NV_transform_feedback]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -15692,19 +15692,19 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_NV_transform_feedback2]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void BindTransformFeedbackNV(BufferTargetARB target, TransformFeedbackHandle id) => GLPointers._BindTransformFeedbackNV_fnptr((uint)target, (int)id);
+            public static void BindTransformFeedbackNV(BufferTargetARB target, int id) => GLPointers._BindTransformFeedbackNV_fnptr((uint)target, id);
             
             /// <summary> <b>[requires: GL_NV_transform_feedback2]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void DeleteTransformFeedbacksNV(int n, TransformFeedbackHandle* ids) => GLPointers._DeleteTransformFeedbacksNV_fnptr(n, (int*)ids);
+            public static void DeleteTransformFeedbacksNV(int n, int* ids) => GLPointers._DeleteTransformFeedbacksNV_fnptr(n, ids);
             
             /// <summary> <b>[requires: GL_NV_transform_feedback2]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GenTransformFeedbacksNV(int n, TransformFeedbackHandle* ids) => GLPointers._GenTransformFeedbacksNV_fnptr(n, (int*)ids);
+            public static void GenTransformFeedbacksNV(int n, int* ids) => GLPointers._GenTransformFeedbacksNV_fnptr(n, ids);
             
             /// <summary> <b>[requires: GL_NV_transform_feedback2]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static bool IsTransformFeedbackNV(TransformFeedbackHandle id) => GLPointers._IsTransformFeedbackNV_fnptr((int)id) != 0;
+            public static bool IsTransformFeedbackNV(int id) => GLPointers._IsTransformFeedbackNV_fnptr(id) != 0;
             
             /// <summary> <b>[requires: GL_NV_transform_feedback2]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -15716,7 +15716,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_NV_transform_feedback2]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void DrawTransformFeedbackNV(PrimitiveType mode, TransformFeedbackHandle id) => GLPointers._DrawTransformFeedbackNV_fnptr((uint)mode, (int)id);
+            public static void DrawTransformFeedbackNV(PrimitiveType mode, int id) => GLPointers._DrawTransformFeedbackNV_fnptr((uint)mode, id);
             
             /// <summary> <b>[requires: GL_NV_vdpau_interop]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -15896,15 +15896,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_NV_vertex_program]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static bool AreProgramsResidentNV(int n, ProgramHandle* programs, bool* residences) => GLPointers._AreProgramsResidentNV_fnptr(n, (int*)programs, (byte*)residences) != 0;
+            public static bool AreProgramsResidentNV(int n, int* programs, bool* residences) => GLPointers._AreProgramsResidentNV_fnptr(n, programs, (byte*)residences) != 0;
             
             /// <summary> <b>[requires: GL_NV_vertex_program]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void BindProgramNV(VertexAttribEnumNV target, ProgramHandle id) => GLPointers._BindProgramNV_fnptr((uint)target, (int)id);
+            public static void BindProgramNV(VertexAttribEnumNV target, int id) => GLPointers._BindProgramNV_fnptr((uint)target, id);
             
             /// <summary> <b>[requires: GL_NV_vertex_program]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void DeleteProgramsNV(int n, ProgramHandle* programs) => GLPointers._DeleteProgramsNV_fnptr(n, (int*)programs);
+            public static void DeleteProgramsNV(int n, int* programs) => GLPointers._DeleteProgramsNV_fnptr(n, programs);
             
             /// <summary> <b>[requires: GL_NV_vertex_program]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -15912,7 +15912,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_NV_vertex_program]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GenProgramsNV(int n, ProgramHandle* programs) => GLPointers._GenProgramsNV_fnptr(n, (int*)programs);
+            public static void GenProgramsNV(int n, int* programs) => GLPointers._GenProgramsNV_fnptr(n, programs);
             
             /// <summary> <b>[requires: GL_NV_vertex_program]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -15924,11 +15924,11 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_NV_vertex_program]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetProgramivNV(ProgramHandle id, VertexAttribEnumNV pname, int* parameters) => GLPointers._GetProgramivNV_fnptr((int)id, (uint)pname, parameters);
+            public static void GetProgramivNV(int id, VertexAttribEnumNV pname, int* parameters) => GLPointers._GetProgramivNV_fnptr(id, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_NV_vertex_program]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetProgramStringNV(ProgramHandle id, VertexAttribEnumNV pname, byte* program) => GLPointers._GetProgramStringNV_fnptr((int)id, (uint)pname, program);
+            public static void GetProgramStringNV(int id, VertexAttribEnumNV pname, byte* program) => GLPointers._GetProgramStringNV_fnptr(id, (uint)pname, program);
             
             /// <summary> <b>[requires: GL_NV_vertex_program]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -15952,7 +15952,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_NV_vertex_program]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static bool IsProgramNV(ProgramHandle id) => GLPointers._IsProgramNV_fnptr((int)id) != 0;
+            public static bool IsProgramNV(int id) => GLPointers._IsProgramNV_fnptr(id) != 0;
             
             /// <summary> <b>[requires: GL_NV_vertex_program]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -15984,7 +15984,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_NV_vertex_program]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void RequestResidentProgramsNV(int n, ProgramHandle* programs) => GLPointers._RequestResidentProgramsNV_fnptr(n, (int*)programs);
+            public static void RequestResidentProgramsNV(int n, int* programs) => GLPointers._RequestResidentProgramsNV_fnptr(n, programs);
             
             /// <summary> <b>[requires: GL_NV_vertex_program]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -16252,7 +16252,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_NV_video_capture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void BindVideoCaptureStreamTextureNV(uint video_capture_slot, uint stream, All frame_region, All target, TextureHandle texture) => GLPointers._BindVideoCaptureStreamTextureNV_fnptr(video_capture_slot, stream, (uint)frame_region, (uint)target, (int)texture);
+            public static void BindVideoCaptureStreamTextureNV(uint video_capture_slot, uint stream, All frame_region, All target, int texture) => GLPointers._BindVideoCaptureStreamTextureNV_fnptr(video_capture_slot, stream, (uint)frame_region, (uint)target, texture);
             
             /// <summary> <b>[requires: GL_NV_video_capture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -16395,15 +16395,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_INTEL_map_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void SyncTextureINTEL(TextureHandle texture) => GLPointers._SyncTextureINTEL_fnptr((int)texture);
+            public static void SyncTextureINTEL(int texture) => GLPointers._SyncTextureINTEL_fnptr(texture);
             
             /// <summary> <b>[requires: GL_INTEL_map_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void UnmapTexture2DINTEL(TextureHandle texture, int level) => GLPointers._UnmapTexture2DINTEL_fnptr((int)texture, level);
+            public static void UnmapTexture2DINTEL(int texture, int level) => GLPointers._UnmapTexture2DINTEL_fnptr(texture, level);
             
             /// <summary> <b>[requires: GL_INTEL_map_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void* MapTexture2DINTEL(TextureHandle texture, int level, All access, int* stride, All* layout) => GLPointers._MapTexture2DINTEL_fnptr((int)texture, level, (uint)access, stride, (uint*)layout);
+            public static void* MapTexture2DINTEL(int texture, int level, All access, int* stride, All* layout) => GLPointers._MapTexture2DINTEL_fnptr(texture, level, (uint)access, stride, (uint*)layout);
             
             /// <summary> <b>[requires: GL_INTEL_parallel_arrays]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -16622,7 +16622,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="bufSize">Specifies the size of the buffer params.</param>
             /// <param name="parameters">Returns the value of the specified uniform variable.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetUniform.xhtml" /></remarks>
-            public static void GetnUniformfv(ProgramHandle program, int location, int bufSize, float* parameters) => GLPointers._GetnUniformfv_fnptr((int)program, location, bufSize, parameters);
+            public static void GetnUniformfv(int program, int location, int bufSize, float* parameters) => GLPointers._GetnUniformfv_fnptr(program, location, bufSize, parameters);
             
             /// <summary> <b>[requires: v4.5 | GL_KHR_robustness]</b> Returns the value of a uniform variable. </summary>
             /// <param name="program">Specifies the program object to be queried.</param>
@@ -16630,7 +16630,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="bufSize">Specifies the size of the buffer params.</param>
             /// <param name="parameters">Returns the value of the specified uniform variable.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetUniform.xhtml" /></remarks>
-            public static void GetnUniformiv(ProgramHandle program, int location, int bufSize, int* parameters) => GLPointers._GetnUniformiv_fnptr((int)program, location, bufSize, parameters);
+            public static void GetnUniformiv(int program, int location, int bufSize, int* parameters) => GLPointers._GetnUniformiv_fnptr(program, location, bufSize, parameters);
             
             /// <summary> <b>[requires: v4.5 | GL_KHR_robustness]</b> Returns the value of a uniform variable. </summary>
             /// <param name="program">Specifies the program object to be queried.</param>
@@ -16638,7 +16638,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="bufSize">Specifies the size of the buffer params.</param>
             /// <param name="parameters">Returns the value of the specified uniform variable.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetUniform.xhtml" /></remarks>
-            public static void GetnUniformuiv(ProgramHandle program, int location, int bufSize, uint* parameters) => GLPointers._GetnUniformuiv_fnptr((int)program, location, bufSize, parameters);
+            public static void GetnUniformuiv(int program, int location, int bufSize, uint* parameters) => GLPointers._GetnUniformuiv_fnptr(program, location, bufSize, parameters);
             
             /// <summary> <b>[requires: GL_KHR_robustness]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -16650,15 +16650,15 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_KHR_robustness]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetnUniformfvKHR(ProgramHandle program, int location, int bufSize, float* parameters) => GLPointers._GetnUniformfvKHR_fnptr((int)program, location, bufSize, parameters);
+            public static void GetnUniformfvKHR(int program, int location, int bufSize, float* parameters) => GLPointers._GetnUniformfvKHR_fnptr(program, location, bufSize, parameters);
             
             /// <summary> <b>[requires: GL_KHR_robustness]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetnUniformivKHR(ProgramHandle program, int location, int bufSize, int* parameters) => GLPointers._GetnUniformivKHR_fnptr((int)program, location, bufSize, parameters);
+            public static void GetnUniformivKHR(int program, int location, int bufSize, int* parameters) => GLPointers._GetnUniformivKHR_fnptr(program, location, bufSize, parameters);
             
             /// <summary> <b>[requires: GL_KHR_robustness]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetnUniformuivKHR(ProgramHandle program, int location, int bufSize, uint* parameters) => GLPointers._GetnUniformuivKHR_fnptr((int)program, location, bufSize, parameters);
+            public static void GetnUniformuivKHR(int program, int location, int bufSize, uint* parameters) => GLPointers._GetnUniformuivKHR_fnptr(program, location, bufSize, parameters);
             
             /// <summary> <b>[requires: GL_KHR_parallel_shader_compile]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -16788,7 +16788,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_NVX_linked_gpu_multicast]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void LGPUNamedBufferSubDataNVX(All gpuMask, BufferHandle buffer, IntPtr offset, nint size, void* data) => GLPointers._LGPUNamedBufferSubDataNVX_fnptr((uint)gpuMask, (int)buffer, offset, size, data);
+            public static void LGPUNamedBufferSubDataNVX(All gpuMask, int buffer, IntPtr offset, nint size, void* data) => GLPointers._LGPUNamedBufferSubDataNVX_fnptr((uint)gpuMask, buffer, offset, size, data);
             
             /// <summary> <b>[requires: GL_NVX_linked_gpu_multicast]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -16816,7 +16816,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_NVX_gpu_multicast2]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static uint AsyncCopyBufferSubDataNVX(int waitSemaphoreCount, uint* waitSemaphoreArray, ulong* fenceValueArray, uint readGpu, All writeGpuMask, BufferHandle readBuffer, BufferHandle writeBuffer, IntPtr readOffset, IntPtr writeOffset, nint size, int signalSemaphoreCount, uint* signalSemaphoreArray, ulong* signalValueArray) => GLPointers._AsyncCopyBufferSubDataNVX_fnptr(waitSemaphoreCount, waitSemaphoreArray, fenceValueArray, readGpu, (uint)writeGpuMask, (int)readBuffer, (int)writeBuffer, readOffset, writeOffset, size, signalSemaphoreCount, signalSemaphoreArray, signalValueArray);
+            public static uint AsyncCopyBufferSubDataNVX(int waitSemaphoreCount, uint* waitSemaphoreArray, ulong* fenceValueArray, uint readGpu, All writeGpuMask, int readBuffer, int writeBuffer, IntPtr readOffset, IntPtr writeOffset, nint size, int signalSemaphoreCount, uint* signalSemaphoreArray, ulong* signalValueArray) => GLPointers._AsyncCopyBufferSubDataNVX_fnptr(waitSemaphoreCount, waitSemaphoreArray, fenceValueArray, readGpu, (uint)writeGpuMask, readBuffer, writeBuffer, readOffset, writeOffset, size, signalSemaphoreCount, signalSemaphoreArray, signalValueArray);
             
             /// <summary> <b>[requires: GL_NVX_gpu_multicast2]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -17259,7 +17259,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_OES_fixed_point]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void PrioritizeTexturesxOES(int n, TextureHandle* textures, int* priorities) => GLPointers._PrioritizeTexturesxOES_fnptr(n, (int*)textures, priorities);
+            public static void PrioritizeTexturesxOES(int n, int* textures, int* priorities) => GLPointers._PrioritizeTexturesxOES_fnptr(n, textures, priorities);
             
             /// <summary> <b>[requires: GL_OES_fixed_point]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -17390,7 +17390,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         {
             /// <summary> <b>[requires: GL_OVR_multiview]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void FramebufferTextureMultiviewOVR(FramebufferTarget target, FramebufferAttachment attachment, TextureHandle texture, int level, int baseViewIndex, int numViews) => GLPointers._FramebufferTextureMultiviewOVR_fnptr((uint)target, (uint)attachment, (int)texture, level, baseViewIndex, numViews);
+            public static void FramebufferTextureMultiviewOVR(FramebufferTarget target, FramebufferAttachment attachment, int texture, int level, int baseViewIndex, int numViews) => GLPointers._FramebufferTextureMultiviewOVR_fnptr((uint)target, (uint)attachment, texture, level, baseViewIndex, numViews);
             
         }
         public static unsafe partial class PGI
@@ -17623,27 +17623,27 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             
             /// <summary> <b>[requires: GL_SGIX_list_priority]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetListParameterfvSGIX(DisplayListHandle list, ListParameterName pname, float* parameters) => GLPointers._GetListParameterfvSGIX_fnptr((int)list, (uint)pname, parameters);
+            public static void GetListParameterfvSGIX(int list, ListParameterName pname, float* parameters) => GLPointers._GetListParameterfvSGIX_fnptr(list, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_SGIX_list_priority]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetListParameterivSGIX(DisplayListHandle list, ListParameterName pname, int* parameters) => GLPointers._GetListParameterivSGIX_fnptr((int)list, (uint)pname, parameters);
+            public static void GetListParameterivSGIX(int list, ListParameterName pname, int* parameters) => GLPointers._GetListParameterivSGIX_fnptr(list, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_SGIX_list_priority]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ListParameterfSGIX(DisplayListHandle list, ListParameterName pname, float param) => GLPointers._ListParameterfSGIX_fnptr((int)list, (uint)pname, param);
+            public static void ListParameterfSGIX(int list, ListParameterName pname, float param) => GLPointers._ListParameterfSGIX_fnptr(list, (uint)pname, param);
             
             /// <summary> <b>[requires: GL_SGIX_list_priority]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ListParameterfvSGIX(DisplayListHandle list, ListParameterName pname, float* parameters) => GLPointers._ListParameterfvSGIX_fnptr((int)list, (uint)pname, parameters);
+            public static void ListParameterfvSGIX(int list, ListParameterName pname, float* parameters) => GLPointers._ListParameterfvSGIX_fnptr(list, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_SGIX_list_priority]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ListParameteriSGIX(DisplayListHandle list, ListParameterName pname, int param) => GLPointers._ListParameteriSGIX_fnptr((int)list, (uint)pname, param);
+            public static void ListParameteriSGIX(int list, ListParameterName pname, int param) => GLPointers._ListParameteriSGIX_fnptr(list, (uint)pname, param);
             
             /// <summary> <b>[requires: GL_SGIX_list_priority]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ListParameterivSGIX(DisplayListHandle list, ListParameterName pname, int* parameters) => GLPointers._ListParameterivSGIX_fnptr((int)list, (uint)pname, parameters);
+            public static void ListParameterivSGIX(int list, ListParameterName pname, int* parameters) => GLPointers._ListParameterivSGIX_fnptr(list, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_SGIX_pixel_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>

--- a/src/OpenTK.Graphics/OpenGL/Compatibility/GL.Overloads.cs
+++ b/src/OpenTK.Graphics/OpenGL/Compatibility/GL.Overloads.cs
@@ -3012,44 +3012,44 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="DeleteTextures"/>
-        public static unsafe void DeleteTexture(in TextureHandle texture)
+        public static unsafe void DeleteTexture(in int texture)
         {
             int n = 1;
-            fixed(TextureHandle* textures_handle = &texture)
+            fixed(int* textures_handle = &texture)
             {
                 DeleteTextures(n, textures_handle);
             }
         }
         /// <inheritdoc cref="DeleteTextures"/>
-        public static unsafe void DeleteTextures(ReadOnlySpan<TextureHandle> textures)
+        public static unsafe void DeleteTextures(ReadOnlySpan<int> textures)
         {
             int n = (int)(textures.Length);
-            fixed (TextureHandle* textures_ptr = textures)
+            fixed (int* textures_ptr = textures)
             {
                 DeleteTextures(n, textures_ptr);
             }
         }
         /// <inheritdoc cref="DeleteTextures"/>
-        public static unsafe void DeleteTextures(TextureHandle[] textures)
+        public static unsafe void DeleteTextures(int[] textures)
         {
             int n = (int)(textures.Length);
-            fixed (TextureHandle* textures_ptr = textures)
+            fixed (int* textures_ptr = textures)
             {
                 DeleteTextures(n, textures_ptr);
             }
         }
         /// <inheritdoc cref="DeleteTextures"/>
-        public static unsafe void DeleteTextures(int n, in TextureHandle textures)
+        public static unsafe void DeleteTextures(int n, in int textures)
         {
-            fixed (TextureHandle* textures_ptr = &textures)
+            fixed (int* textures_ptr = &textures)
             {
                 DeleteTextures(n, textures_ptr);
             }
         }
         /// <inheritdoc cref="GenTextures"/>
-        public static unsafe TextureHandle GenTexture()
+        public static unsafe int GenTexture()
         {
-            TextureHandle texture;
+            int texture;
             int n = 1;
             Unsafe.SkipInit(out texture);
             // FIXME: This could be a problem for the overloads that take an out parameter
@@ -3060,12 +3060,12 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            TextureHandle* textures_handle = (TextureHandle*)Unsafe.AsPointer(ref texture);
+            int* textures_handle = (int*)Unsafe.AsPointer(ref texture);
             GenTextures(n, textures_handle);
             return texture;
         }
         /// <inheritdoc cref="GenTextures"/>
-        public static unsafe void GenTexture(out TextureHandle texture)
+        public static unsafe void GenTexture(out int texture)
         {
             int n = 1;
             Unsafe.SkipInit(out texture);
@@ -3077,31 +3077,31 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            TextureHandle* textures_handle = (TextureHandle*)Unsafe.AsPointer(ref texture);
+            int* textures_handle = (int*)Unsafe.AsPointer(ref texture);
             GenTextures(n, textures_handle);
         }
         /// <inheritdoc cref="GenTextures"/>
-        public static unsafe void GenTextures(Span<TextureHandle> textures)
+        public static unsafe void GenTextures(Span<int> textures)
         {
             int n = (int)(textures.Length);
-            fixed (TextureHandle* textures_ptr = textures)
+            fixed (int* textures_ptr = textures)
             {
                 GenTextures(n, textures_ptr);
             }
         }
         /// <inheritdoc cref="GenTextures"/>
-        public static unsafe void GenTextures(TextureHandle[] textures)
+        public static unsafe void GenTextures(int[] textures)
         {
             int n = (int)(textures.Length);
-            fixed (TextureHandle* textures_ptr = textures)
+            fixed (int* textures_ptr = textures)
             {
                 GenTextures(n, textures_ptr);
             }
         }
         /// <inheritdoc cref="GenTextures"/>
-        public static unsafe void GenTextures(int n, ref TextureHandle textures)
+        public static unsafe void GenTextures(int n, ref int textures)
         {
-            fixed (TextureHandle* textures_ptr = &textures)
+            fixed (int* textures_ptr = &textures)
             {
                 GenTextures(n, textures_ptr);
             }
@@ -3338,10 +3338,10 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="AreTexturesResident"/>
-        public static unsafe bool AreTexturesResident(int n, ReadOnlySpan<TextureHandle> textures, Span<bool> residences)
+        public static unsafe bool AreTexturesResident(int n, ReadOnlySpan<int> textures, Span<bool> residences)
         {
             bool returnValue;
-            fixed (TextureHandle* textures_ptr = textures)
+            fixed (int* textures_ptr = textures)
             {
                 fixed (bool* residences_ptr = residences)
                 {
@@ -3351,10 +3351,10 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             return returnValue;
         }
         /// <inheritdoc cref="AreTexturesResident"/>
-        public static unsafe bool AreTexturesResident(int n, TextureHandle[] textures, bool[] residences)
+        public static unsafe bool AreTexturesResident(int n, int[] textures, bool[] residences)
         {
             bool returnValue;
-            fixed (TextureHandle* textures_ptr = textures)
+            fixed (int* textures_ptr = textures)
             {
                 fixed (bool* residences_ptr = residences)
                 {
@@ -3364,10 +3364,10 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             return returnValue;
         }
         /// <inheritdoc cref="AreTexturesResident"/>
-        public static unsafe bool AreTexturesResident(int n, in TextureHandle textures, ref bool residences)
+        public static unsafe bool AreTexturesResident(int n, in int textures, ref bool residences)
         {
             bool returnValue;
-            fixed (TextureHandle* textures_ptr = &textures)
+            fixed (int* textures_ptr = &textures)
             fixed (bool* residences_ptr = &residences)
             {
                 returnValue = AreTexturesResident(n, textures_ptr, residences_ptr);
@@ -3375,9 +3375,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             return returnValue;
         }
         /// <inheritdoc cref="PrioritizeTextures"/>
-        public static unsafe void PrioritizeTextures(int n, ReadOnlySpan<TextureHandle> textures, ReadOnlySpan<float> priorities)
+        public static unsafe void PrioritizeTextures(int n, ReadOnlySpan<int> textures, ReadOnlySpan<float> priorities)
         {
-            fixed (TextureHandle* textures_ptr = textures)
+            fixed (int* textures_ptr = textures)
             {
                 fixed (float* priorities_ptr = priorities)
                 {
@@ -3386,9 +3386,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="PrioritizeTextures"/>
-        public static unsafe void PrioritizeTextures(int n, TextureHandle[] textures, float[] priorities)
+        public static unsafe void PrioritizeTextures(int n, int[] textures, float[] priorities)
         {
-            fixed (TextureHandle* textures_ptr = textures)
+            fixed (int* textures_ptr = textures)
             {
                 fixed (float* priorities_ptr = priorities)
                 {
@@ -3397,9 +3397,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="PrioritizeTextures"/>
-        public static unsafe void PrioritizeTextures(int n, in TextureHandle textures, in float priorities)
+        public static unsafe void PrioritizeTextures(int n, in int textures, in float priorities)
         {
-            fixed (TextureHandle* textures_ptr = &textures)
+            fixed (int* textures_ptr = &textures)
             fixed (float* priorities_ptr = &priorities)
             {
                 PrioritizeTextures(n, textures_ptr, priorities_ptr);
@@ -4611,9 +4611,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GenQueries"/>
-        public static unsafe QueryHandle GenQuery()
+        public static unsafe int GenQuery()
         {
-            QueryHandle id;
+            int id;
             int n = 1;
             Unsafe.SkipInit(out id);
             // FIXME: This could be a problem for the overloads that take an out parameter
@@ -4624,12 +4624,12 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            QueryHandle* ids_handle = (QueryHandle*)Unsafe.AsPointer(ref id);
+            int* ids_handle = (int*)Unsafe.AsPointer(ref id);
             GenQueries(n, ids_handle);
             return id;
         }
         /// <inheritdoc cref="GenQueries"/>
-        public static unsafe void GenQuery(out QueryHandle id)
+        public static unsafe void GenQuery(out int id)
         {
             int n = 1;
             Unsafe.SkipInit(out id);
@@ -4641,66 +4641,66 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            QueryHandle* ids_handle = (QueryHandle*)Unsafe.AsPointer(ref id);
+            int* ids_handle = (int*)Unsafe.AsPointer(ref id);
             GenQueries(n, ids_handle);
         }
         /// <inheritdoc cref="GenQueries"/>
-        public static unsafe void GenQueries(Span<QueryHandle> ids)
+        public static unsafe void GenQueries(Span<int> ids)
         {
             int n = (int)(ids.Length);
-            fixed (QueryHandle* ids_ptr = ids)
+            fixed (int* ids_ptr = ids)
             {
                 GenQueries(n, ids_ptr);
             }
         }
         /// <inheritdoc cref="GenQueries"/>
-        public static unsafe void GenQueries(QueryHandle[] ids)
+        public static unsafe void GenQueries(int[] ids)
         {
             int n = (int)(ids.Length);
-            fixed (QueryHandle* ids_ptr = ids)
+            fixed (int* ids_ptr = ids)
             {
                 GenQueries(n, ids_ptr);
             }
         }
         /// <inheritdoc cref="GenQueries"/>
-        public static unsafe void GenQueries(int n, ref QueryHandle ids)
+        public static unsafe void GenQueries(int n, ref int ids)
         {
-            fixed (QueryHandle* ids_ptr = &ids)
+            fixed (int* ids_ptr = &ids)
             {
                 GenQueries(n, ids_ptr);
             }
         }
         /// <inheritdoc cref="DeleteQueries"/>
-        public static unsafe void DeleteQuery(in QueryHandle id)
+        public static unsafe void DeleteQuery(in int id)
         {
             int n = 1;
-            fixed(QueryHandle* ids_handle = &id)
+            fixed(int* ids_handle = &id)
             {
                 DeleteQueries(n, ids_handle);
             }
         }
         /// <inheritdoc cref="DeleteQueries"/>
-        public static unsafe void DeleteQueries(ReadOnlySpan<QueryHandle> ids)
+        public static unsafe void DeleteQueries(ReadOnlySpan<int> ids)
         {
             int n = (int)(ids.Length);
-            fixed (QueryHandle* ids_ptr = ids)
+            fixed (int* ids_ptr = ids)
             {
                 DeleteQueries(n, ids_ptr);
             }
         }
         /// <inheritdoc cref="DeleteQueries"/>
-        public static unsafe void DeleteQueries(QueryHandle[] ids)
+        public static unsafe void DeleteQueries(int[] ids)
         {
             int n = (int)(ids.Length);
-            fixed (QueryHandle* ids_ptr = ids)
+            fixed (int* ids_ptr = ids)
             {
                 DeleteQueries(n, ids_ptr);
             }
         }
         /// <inheritdoc cref="DeleteQueries"/>
-        public static unsafe void DeleteQueries(int n, in QueryHandle ids)
+        public static unsafe void DeleteQueries(int n, in int ids)
         {
-            fixed (QueryHandle* ids_ptr = &ids)
+            fixed (int* ids_ptr = &ids)
             {
                 DeleteQueries(n, ids_ptr);
             }
@@ -4730,7 +4730,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetQueryObjectiv"/>
-        public static unsafe void GetQueryObjecti(QueryHandle id, QueryObjectParameterName pname, Span<int> parameters)
+        public static unsafe void GetQueryObjecti(int id, QueryObjectParameterName pname, Span<int> parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
@@ -4738,7 +4738,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetQueryObjectiv"/>
-        public static unsafe void GetQueryObjecti(QueryHandle id, QueryObjectParameterName pname, int[] parameters)
+        public static unsafe void GetQueryObjecti(int id, QueryObjectParameterName pname, int[] parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
@@ -4746,7 +4746,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetQueryObjectiv"/>
-        public static unsafe void GetQueryObjecti(QueryHandle id, QueryObjectParameterName pname, ref int parameters)
+        public static unsafe void GetQueryObjecti(int id, QueryObjectParameterName pname, ref int parameters)
         {
             fixed (int* parameters_ptr = &parameters)
             {
@@ -4754,7 +4754,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetQueryObjectuiv"/>
-        public static unsafe void GetQueryObjectui(QueryHandle id, QueryObjectParameterName pname, Span<uint> parameters)
+        public static unsafe void GetQueryObjectui(int id, QueryObjectParameterName pname, Span<uint> parameters)
         {
             fixed (uint* parameters_ptr = parameters)
             {
@@ -4762,7 +4762,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetQueryObjectuiv"/>
-        public static unsafe void GetQueryObjectui(QueryHandle id, QueryObjectParameterName pname, uint[] parameters)
+        public static unsafe void GetQueryObjectui(int id, QueryObjectParameterName pname, uint[] parameters)
         {
             fixed (uint* parameters_ptr = parameters)
             {
@@ -4770,7 +4770,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetQueryObjectuiv"/>
-        public static unsafe void GetQueryObjectui(QueryHandle id, QueryObjectParameterName pname, ref uint parameters)
+        public static unsafe void GetQueryObjectui(int id, QueryObjectParameterName pname, ref uint parameters)
         {
             fixed (uint* parameters_ptr = &parameters)
             {
@@ -4778,44 +4778,44 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="DeleteBuffers"/>
-        public static unsafe void DeleteBuffer(in BufferHandle buffer)
+        public static unsafe void DeleteBuffer(in int buffer)
         {
             int n = 1;
-            fixed(BufferHandle* buffers_handle = &buffer)
+            fixed(int* buffers_handle = &buffer)
             {
                 DeleteBuffers(n, buffers_handle);
             }
         }
         /// <inheritdoc cref="DeleteBuffers"/>
-        public static unsafe void DeleteBuffers(ReadOnlySpan<BufferHandle> buffers)
+        public static unsafe void DeleteBuffers(ReadOnlySpan<int> buffers)
         {
             int n = (int)(buffers.Length);
-            fixed (BufferHandle* buffers_ptr = buffers)
+            fixed (int* buffers_ptr = buffers)
             {
                 DeleteBuffers(n, buffers_ptr);
             }
         }
         /// <inheritdoc cref="DeleteBuffers"/>
-        public static unsafe void DeleteBuffers(BufferHandle[] buffers)
+        public static unsafe void DeleteBuffers(int[] buffers)
         {
             int n = (int)(buffers.Length);
-            fixed (BufferHandle* buffers_ptr = buffers)
+            fixed (int* buffers_ptr = buffers)
             {
                 DeleteBuffers(n, buffers_ptr);
             }
         }
         /// <inheritdoc cref="DeleteBuffers"/>
-        public static unsafe void DeleteBuffers(int n, in BufferHandle buffers)
+        public static unsafe void DeleteBuffers(int n, in int buffers)
         {
-            fixed (BufferHandle* buffers_ptr = &buffers)
+            fixed (int* buffers_ptr = &buffers)
             {
                 DeleteBuffers(n, buffers_ptr);
             }
         }
         /// <inheritdoc cref="GenBuffers"/>
-        public static unsafe BufferHandle GenBuffer()
+        public static unsafe int GenBuffer()
         {
-            BufferHandle buffer;
+            int buffer;
             int n = 1;
             Unsafe.SkipInit(out buffer);
             // FIXME: This could be a problem for the overloads that take an out parameter
@@ -4826,12 +4826,12 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            BufferHandle* buffers_handle = (BufferHandle*)Unsafe.AsPointer(ref buffer);
+            int* buffers_handle = (int*)Unsafe.AsPointer(ref buffer);
             GenBuffers(n, buffers_handle);
             return buffer;
         }
         /// <inheritdoc cref="GenBuffers"/>
-        public static unsafe void GenBuffer(out BufferHandle buffer)
+        public static unsafe void GenBuffer(out int buffer)
         {
             int n = 1;
             Unsafe.SkipInit(out buffer);
@@ -4843,31 +4843,31 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            BufferHandle* buffers_handle = (BufferHandle*)Unsafe.AsPointer(ref buffer);
+            int* buffers_handle = (int*)Unsafe.AsPointer(ref buffer);
             GenBuffers(n, buffers_handle);
         }
         /// <inheritdoc cref="GenBuffers"/>
-        public static unsafe void GenBuffers(Span<BufferHandle> buffers)
+        public static unsafe void GenBuffers(Span<int> buffers)
         {
             int n = (int)(buffers.Length);
-            fixed (BufferHandle* buffers_ptr = buffers)
+            fixed (int* buffers_ptr = buffers)
             {
                 GenBuffers(n, buffers_ptr);
             }
         }
         /// <inheritdoc cref="GenBuffers"/>
-        public static unsafe void GenBuffers(BufferHandle[] buffers)
+        public static unsafe void GenBuffers(int[] buffers)
         {
             int n = (int)(buffers.Length);
-            fixed (BufferHandle* buffers_ptr = buffers)
+            fixed (int* buffers_ptr = buffers)
             {
                 GenBuffers(n, buffers_ptr);
             }
         }
         /// <inheritdoc cref="GenBuffers"/>
-        public static unsafe void GenBuffers(int n, ref BufferHandle buffers)
+        public static unsafe void GenBuffers(int n, ref int buffers)
         {
-            fixed (BufferHandle* buffers_ptr = &buffers)
+            fixed (int* buffers_ptr = &buffers)
             {
                 GenBuffers(n, buffers_ptr);
             }
@@ -5033,14 +5033,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="BindAttribLocation"/>
-        public static unsafe void BindAttribLocation(ProgramHandle program, uint index, string name)
+        public static unsafe void BindAttribLocation(int program, uint index, string name)
         {
             byte* name_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(name);
             BindAttribLocation(program, index, name_ptr);
             Marshal.FreeCoTaskMem((IntPtr)name_ptr);
         }
         /// <inheritdoc cref="GetActiveAttrib"/>
-        public static unsafe string GetActiveAttrib(ProgramHandle program, uint index, int bufSize, Span<int> length, Span<int> size, Span<AttributeType> type)
+        public static unsafe string GetActiveAttrib(int program, uint index, int bufSize, Span<int> length, Span<int> size, Span<AttributeType> type)
         {
             string name;
             fixed (int* length_ptr = length)
@@ -5059,7 +5059,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             return name;
         }
         /// <inheritdoc cref="GetActiveAttrib"/>
-        public static unsafe void GetActiveAttrib(ProgramHandle program, uint index, int bufSize, Span<int> length, Span<int> size, Span<AttributeType> type, out string name)
+        public static unsafe void GetActiveAttrib(int program, uint index, int bufSize, Span<int> length, Span<int> size, Span<AttributeType> type, out string name)
         {
             fixed (int* length_ptr = length)
             {
@@ -5076,7 +5076,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetActiveAttrib"/>
-        public static unsafe string GetActiveAttrib(ProgramHandle program, uint index, int bufSize, int[] length, int[] size, AttributeType[] type)
+        public static unsafe string GetActiveAttrib(int program, uint index, int bufSize, int[] length, int[] size, AttributeType[] type)
         {
             string name;
             fixed (int* length_ptr = length)
@@ -5095,7 +5095,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             return name;
         }
         /// <inheritdoc cref="GetActiveAttrib"/>
-        public static unsafe void GetActiveAttrib(ProgramHandle program, uint index, int bufSize, int[] length, int[] size, AttributeType[] type, out string name)
+        public static unsafe void GetActiveAttrib(int program, uint index, int bufSize, int[] length, int[] size, AttributeType[] type, out string name)
         {
             fixed (int* length_ptr = length)
             {
@@ -5112,7 +5112,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetActiveAttrib"/>
-        public static unsafe string GetActiveAttrib(ProgramHandle program, uint index, int bufSize, ref int length, ref int size, ref AttributeType type)
+        public static unsafe string GetActiveAttrib(int program, uint index, int bufSize, ref int length, ref int size, ref AttributeType type)
         {
             string name;
             fixed (int* length_ptr = &length)
@@ -5127,7 +5127,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             return name;
         }
         /// <inheritdoc cref="GetActiveAttrib"/>
-        public static unsafe void GetActiveAttrib(ProgramHandle program, uint index, int bufSize, ref int length, ref int size, ref AttributeType type, out string name)
+        public static unsafe void GetActiveAttrib(int program, uint index, int bufSize, ref int length, ref int size, ref AttributeType type, out string name)
         {
             fixed (int* length_ptr = &length)
             fixed (int* size_ptr = &size)
@@ -5140,7 +5140,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetActiveUniform"/>
-        public static unsafe string GetActiveUniform(ProgramHandle program, uint index, int bufSize, Span<int> length, Span<int> size, Span<UniformType> type)
+        public static unsafe string GetActiveUniform(int program, uint index, int bufSize, Span<int> length, Span<int> size, Span<UniformType> type)
         {
             string name;
             fixed (int* length_ptr = length)
@@ -5159,7 +5159,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             return name;
         }
         /// <inheritdoc cref="GetActiveUniform"/>
-        public static unsafe void GetActiveUniform(ProgramHandle program, uint index, int bufSize, Span<int> length, Span<int> size, Span<UniformType> type, out string name)
+        public static unsafe void GetActiveUniform(int program, uint index, int bufSize, Span<int> length, Span<int> size, Span<UniformType> type, out string name)
         {
             fixed (int* length_ptr = length)
             {
@@ -5176,7 +5176,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetActiveUniform"/>
-        public static unsafe string GetActiveUniform(ProgramHandle program, uint index, int bufSize, int[] length, int[] size, UniformType[] type)
+        public static unsafe string GetActiveUniform(int program, uint index, int bufSize, int[] length, int[] size, UniformType[] type)
         {
             string name;
             fixed (int* length_ptr = length)
@@ -5195,7 +5195,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             return name;
         }
         /// <inheritdoc cref="GetActiveUniform"/>
-        public static unsafe void GetActiveUniform(ProgramHandle program, uint index, int bufSize, int[] length, int[] size, UniformType[] type, out string name)
+        public static unsafe void GetActiveUniform(int program, uint index, int bufSize, int[] length, int[] size, UniformType[] type, out string name)
         {
             fixed (int* length_ptr = length)
             {
@@ -5212,7 +5212,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetActiveUniform"/>
-        public static unsafe string GetActiveUniform(ProgramHandle program, uint index, int bufSize, ref int length, ref int size, ref UniformType type)
+        public static unsafe string GetActiveUniform(int program, uint index, int bufSize, ref int length, ref int size, ref UniformType type)
         {
             string name;
             fixed (int* length_ptr = &length)
@@ -5227,7 +5227,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             return name;
         }
         /// <inheritdoc cref="GetActiveUniform"/>
-        public static unsafe void GetActiveUniform(ProgramHandle program, uint index, int bufSize, ref int length, ref int size, ref UniformType type, out string name)
+        public static unsafe void GetActiveUniform(int program, uint index, int bufSize, ref int length, ref int size, ref UniformType type, out string name)
         {
             fixed (int* length_ptr = &length)
             fixed (int* size_ptr = &size)
@@ -5240,40 +5240,40 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetAttachedShaders"/>
-        public static unsafe void GetAttachedShaders(ProgramHandle program, Span<int> count, Span<ShaderHandle> shaders)
+        public static unsafe void GetAttachedShaders(int program, Span<int> count, Span<int> shaders)
         {
             fixed (int* count_ptr = count)
             {
                 int maxCount = (int)(shaders.Length);
-                fixed (ShaderHandle* shaders_ptr = shaders)
+                fixed (int* shaders_ptr = shaders)
                 {
                     GetAttachedShaders(program, maxCount, count_ptr, shaders_ptr);
                 }
             }
         }
         /// <inheritdoc cref="GetAttachedShaders"/>
-        public static unsafe void GetAttachedShaders(ProgramHandle program, int[] count, ShaderHandle[] shaders)
+        public static unsafe void GetAttachedShaders(int program, int[] count, int[] shaders)
         {
             fixed (int* count_ptr = count)
             {
                 int maxCount = (int)(shaders.Length);
-                fixed (ShaderHandle* shaders_ptr = shaders)
+                fixed (int* shaders_ptr = shaders)
                 {
                     GetAttachedShaders(program, maxCount, count_ptr, shaders_ptr);
                 }
             }
         }
         /// <inheritdoc cref="GetAttachedShaders"/>
-        public static unsafe void GetAttachedShaders(ProgramHandle program, int maxCount, ref int count, ref ShaderHandle shaders)
+        public static unsafe void GetAttachedShaders(int program, int maxCount, ref int count, ref int shaders)
         {
             fixed (int* count_ptr = &count)
-            fixed (ShaderHandle* shaders_ptr = &shaders)
+            fixed (int* shaders_ptr = &shaders)
             {
                 GetAttachedShaders(program, maxCount, count_ptr, shaders_ptr);
             }
         }
         /// <inheritdoc cref="GetAttribLocation"/>
-        public static unsafe int GetAttribLocation(ProgramHandle program, string name)
+        public static unsafe int GetAttribLocation(int program, string name)
         {
             int returnValue;
             byte* name_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(name);
@@ -5282,7 +5282,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             return returnValue;
         }
         /// <inheritdoc cref="GetProgramiv"/>
-        public static unsafe void GetProgrami(ProgramHandle program, ProgramPropertyARB pname, Span<int> parameters)
+        public static unsafe void GetProgrami(int program, ProgramPropertyARB pname, Span<int> parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
@@ -5290,7 +5290,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetProgramiv"/>
-        public static unsafe void GetProgrami(ProgramHandle program, ProgramPropertyARB pname, int[] parameters)
+        public static unsafe void GetProgrami(int program, ProgramPropertyARB pname, int[] parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
@@ -5298,7 +5298,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetProgramiv"/>
-        public static unsafe void GetProgrami(ProgramHandle program, ProgramPropertyARB pname, ref int parameters)
+        public static unsafe void GetProgrami(int program, ProgramPropertyARB pname, ref int parameters)
         {
             fixed (int* parameters_ptr = &parameters)
             {
@@ -5306,7 +5306,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetProgramInfoLog"/>
-        public static unsafe string GetProgramInfoLog(ProgramHandle program, int bufSize, Span<int> length)
+        public static unsafe string GetProgramInfoLog(int program, int bufSize, Span<int> length)
         {
             string infoLog;
             fixed (int* length_ptr = length)
@@ -5319,7 +5319,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             return infoLog;
         }
         /// <inheritdoc cref="GetProgramInfoLog"/>
-        public static unsafe void GetProgramInfoLog(ProgramHandle program, int bufSize, Span<int> length, out string infoLog)
+        public static unsafe void GetProgramInfoLog(int program, int bufSize, Span<int> length, out string infoLog)
         {
             fixed (int* length_ptr = length)
             {
@@ -5330,7 +5330,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetProgramInfoLog"/>
-        public static unsafe string GetProgramInfoLog(ProgramHandle program, int bufSize, int[] length)
+        public static unsafe string GetProgramInfoLog(int program, int bufSize, int[] length)
         {
             string infoLog;
             fixed (int* length_ptr = length)
@@ -5343,7 +5343,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             return infoLog;
         }
         /// <inheritdoc cref="GetProgramInfoLog"/>
-        public static unsafe void GetProgramInfoLog(ProgramHandle program, int bufSize, int[] length, out string infoLog)
+        public static unsafe void GetProgramInfoLog(int program, int bufSize, int[] length, out string infoLog)
         {
             fixed (int* length_ptr = length)
             {
@@ -5354,7 +5354,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetProgramInfoLog"/>
-        public static unsafe string GetProgramInfoLog(ProgramHandle program, int bufSize, ref int length)
+        public static unsafe string GetProgramInfoLog(int program, int bufSize, ref int length)
         {
             string infoLog;
             fixed (int* length_ptr = &length)
@@ -5367,7 +5367,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             return infoLog;
         }
         /// <inheritdoc cref="GetProgramInfoLog"/>
-        public static unsafe void GetProgramInfoLog(ProgramHandle program, int bufSize, ref int length, out string infoLog)
+        public static unsafe void GetProgramInfoLog(int program, int bufSize, ref int length, out string infoLog)
         {
             fixed (int* length_ptr = &length)
             {
@@ -5378,7 +5378,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetShaderiv"/>
-        public static unsafe void GetShaderi(ShaderHandle shader, ShaderParameterName pname, Span<int> parameters)
+        public static unsafe void GetShaderi(int shader, ShaderParameterName pname, Span<int> parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
@@ -5386,7 +5386,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetShaderiv"/>
-        public static unsafe void GetShaderi(ShaderHandle shader, ShaderParameterName pname, int[] parameters)
+        public static unsafe void GetShaderi(int shader, ShaderParameterName pname, int[] parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
@@ -5394,7 +5394,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetShaderiv"/>
-        public static unsafe void GetShaderi(ShaderHandle shader, ShaderParameterName pname, ref int parameters)
+        public static unsafe void GetShaderi(int shader, ShaderParameterName pname, ref int parameters)
         {
             fixed (int* parameters_ptr = &parameters)
             {
@@ -5402,7 +5402,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetShaderInfoLog"/>
-        public static unsafe string GetShaderInfoLog(ShaderHandle shader, int bufSize, Span<int> length)
+        public static unsafe string GetShaderInfoLog(int shader, int bufSize, Span<int> length)
         {
             string infoLog;
             fixed (int* length_ptr = length)
@@ -5415,7 +5415,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             return infoLog;
         }
         /// <inheritdoc cref="GetShaderInfoLog"/>
-        public static unsafe void GetShaderInfoLog(ShaderHandle shader, int bufSize, Span<int> length, out string infoLog)
+        public static unsafe void GetShaderInfoLog(int shader, int bufSize, Span<int> length, out string infoLog)
         {
             fixed (int* length_ptr = length)
             {
@@ -5426,7 +5426,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetShaderInfoLog"/>
-        public static unsafe string GetShaderInfoLog(ShaderHandle shader, int bufSize, int[] length)
+        public static unsafe string GetShaderInfoLog(int shader, int bufSize, int[] length)
         {
             string infoLog;
             fixed (int* length_ptr = length)
@@ -5439,7 +5439,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             return infoLog;
         }
         /// <inheritdoc cref="GetShaderInfoLog"/>
-        public static unsafe void GetShaderInfoLog(ShaderHandle shader, int bufSize, int[] length, out string infoLog)
+        public static unsafe void GetShaderInfoLog(int shader, int bufSize, int[] length, out string infoLog)
         {
             fixed (int* length_ptr = length)
             {
@@ -5450,7 +5450,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetShaderInfoLog"/>
-        public static unsafe string GetShaderInfoLog(ShaderHandle shader, int bufSize, ref int length)
+        public static unsafe string GetShaderInfoLog(int shader, int bufSize, ref int length)
         {
             string infoLog;
             fixed (int* length_ptr = &length)
@@ -5463,7 +5463,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             return infoLog;
         }
         /// <inheritdoc cref="GetShaderInfoLog"/>
-        public static unsafe void GetShaderInfoLog(ShaderHandle shader, int bufSize, ref int length, out string infoLog)
+        public static unsafe void GetShaderInfoLog(int shader, int bufSize, ref int length, out string infoLog)
         {
             fixed (int* length_ptr = &length)
             {
@@ -5474,7 +5474,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetShaderSource"/>
-        public static unsafe string GetShaderSource(ShaderHandle shader, int bufSize, Span<int> length)
+        public static unsafe string GetShaderSource(int shader, int bufSize, Span<int> length)
         {
             string source;
             fixed (int* length_ptr = length)
@@ -5487,7 +5487,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             return source;
         }
         /// <inheritdoc cref="GetShaderSource"/>
-        public static unsafe void GetShaderSource(ShaderHandle shader, int bufSize, Span<int> length, out string source)
+        public static unsafe void GetShaderSource(int shader, int bufSize, Span<int> length, out string source)
         {
             fixed (int* length_ptr = length)
             {
@@ -5498,7 +5498,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetShaderSource"/>
-        public static unsafe string GetShaderSource(ShaderHandle shader, int bufSize, int[] length)
+        public static unsafe string GetShaderSource(int shader, int bufSize, int[] length)
         {
             string source;
             fixed (int* length_ptr = length)
@@ -5511,7 +5511,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             return source;
         }
         /// <inheritdoc cref="GetShaderSource"/>
-        public static unsafe void GetShaderSource(ShaderHandle shader, int bufSize, int[] length, out string source)
+        public static unsafe void GetShaderSource(int shader, int bufSize, int[] length, out string source)
         {
             fixed (int* length_ptr = length)
             {
@@ -5522,7 +5522,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetShaderSource"/>
-        public static unsafe string GetShaderSource(ShaderHandle shader, int bufSize, ref int length)
+        public static unsafe string GetShaderSource(int shader, int bufSize, ref int length)
         {
             string source;
             fixed (int* length_ptr = &length)
@@ -5535,7 +5535,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             return source;
         }
         /// <inheritdoc cref="GetShaderSource"/>
-        public static unsafe void GetShaderSource(ShaderHandle shader, int bufSize, ref int length, out string source)
+        public static unsafe void GetShaderSource(int shader, int bufSize, ref int length, out string source)
         {
             fixed (int* length_ptr = &length)
             {
@@ -5546,7 +5546,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetUniformLocation"/>
-        public static unsafe int GetUniformLocation(ProgramHandle program, string name)
+        public static unsafe int GetUniformLocation(int program, string name)
         {
             int returnValue;
             byte* name_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(name);
@@ -5555,7 +5555,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             return returnValue;
         }
         /// <inheritdoc cref="GetUniformfv"/>
-        public static unsafe void GetUniformf(ProgramHandle program, int location, Span<float> parameters)
+        public static unsafe void GetUniformf(int program, int location, Span<float> parameters)
         {
             fixed (float* parameters_ptr = parameters)
             {
@@ -5563,7 +5563,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetUniformfv"/>
-        public static unsafe void GetUniformf(ProgramHandle program, int location, float[] parameters)
+        public static unsafe void GetUniformf(int program, int location, float[] parameters)
         {
             fixed (float* parameters_ptr = parameters)
             {
@@ -5571,7 +5571,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetUniformfv"/>
-        public static unsafe void GetUniformf(ProgramHandle program, int location, ref float parameters)
+        public static unsafe void GetUniformf(int program, int location, ref float parameters)
         {
             fixed (float* parameters_ptr = &parameters)
             {
@@ -5579,7 +5579,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetUniformiv"/>
-        public static unsafe void GetUniformi(ProgramHandle program, int location, Span<int> parameters)
+        public static unsafe void GetUniformi(int program, int location, Span<int> parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
@@ -5587,7 +5587,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetUniformiv"/>
-        public static unsafe void GetUniformi(ProgramHandle program, int location, int[] parameters)
+        public static unsafe void GetUniformi(int program, int location, int[] parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
@@ -5595,7 +5595,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetUniformiv"/>
-        public static unsafe void GetUniformi(ProgramHandle program, int location, ref int parameters)
+        public static unsafe void GetUniformi(int program, int location, ref int parameters)
         {
             fixed (int* parameters_ptr = &parameters)
             {
@@ -5680,7 +5680,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             GetVertexAttribPointerv(index, pname, pointer);
         }
         /// <inheritdoc cref="ShaderSource"/>
-        public static unsafe void ShaderSource(ShaderHandle shader, int count, byte** str, ReadOnlySpan<int> length)
+        public static unsafe void ShaderSource(int shader, int count, byte** str, ReadOnlySpan<int> length)
         {
             fixed (int* length_ptr = length)
             {
@@ -5688,7 +5688,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ShaderSource"/>
-        public static unsafe void ShaderSource(ShaderHandle shader, int count, byte** str, int[] length)
+        public static unsafe void ShaderSource(int shader, int count, byte** str, int[] length)
         {
             fixed (int* length_ptr = length)
             {
@@ -5696,7 +5696,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ShaderSource"/>
-        public static unsafe void ShaderSource(ShaderHandle shader, int count, byte** str, in int length)
+        public static unsafe void ShaderSource(int shader, int count, byte** str, in int length)
         {
             fixed (int* length_ptr = &length)
             {
@@ -6821,7 +6821,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetTransformFeedbackVarying"/>
-        public static unsafe string GetTransformFeedbackVarying(ProgramHandle program, uint index, int bufSize, Span<int> length, Span<int> size, Span<AttributeType> type)
+        public static unsafe string GetTransformFeedbackVarying(int program, uint index, int bufSize, Span<int> length, Span<int> size, Span<AttributeType> type)
         {
             string name;
             fixed (int* length_ptr = length)
@@ -6840,7 +6840,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             return name;
         }
         /// <inheritdoc cref="GetTransformFeedbackVarying"/>
-        public static unsafe void GetTransformFeedbackVarying(ProgramHandle program, uint index, int bufSize, Span<int> length, Span<int> size, Span<AttributeType> type, out string name)
+        public static unsafe void GetTransformFeedbackVarying(int program, uint index, int bufSize, Span<int> length, Span<int> size, Span<AttributeType> type, out string name)
         {
             fixed (int* length_ptr = length)
             {
@@ -6857,7 +6857,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetTransformFeedbackVarying"/>
-        public static unsafe string GetTransformFeedbackVarying(ProgramHandle program, uint index, int bufSize, int[] length, int[] size, AttributeType[] type)
+        public static unsafe string GetTransformFeedbackVarying(int program, uint index, int bufSize, int[] length, int[] size, AttributeType[] type)
         {
             string name;
             fixed (int* length_ptr = length)
@@ -6876,7 +6876,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             return name;
         }
         /// <inheritdoc cref="GetTransformFeedbackVarying"/>
-        public static unsafe void GetTransformFeedbackVarying(ProgramHandle program, uint index, int bufSize, int[] length, int[] size, AttributeType[] type, out string name)
+        public static unsafe void GetTransformFeedbackVarying(int program, uint index, int bufSize, int[] length, int[] size, AttributeType[] type, out string name)
         {
             fixed (int* length_ptr = length)
             {
@@ -6893,7 +6893,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetTransformFeedbackVarying"/>
-        public static unsafe string GetTransformFeedbackVarying(ProgramHandle program, uint index, int bufSize, ref int length, ref int size, ref AttributeType type)
+        public static unsafe string GetTransformFeedbackVarying(int program, uint index, int bufSize, ref int length, ref int size, ref AttributeType type)
         {
             string name;
             fixed (int* length_ptr = &length)
@@ -6908,7 +6908,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             return name;
         }
         /// <inheritdoc cref="GetTransformFeedbackVarying"/>
-        public static unsafe void GetTransformFeedbackVarying(ProgramHandle program, uint index, int bufSize, ref int length, ref int size, ref AttributeType type, out string name)
+        public static unsafe void GetTransformFeedbackVarying(int program, uint index, int bufSize, ref int length, ref int size, ref AttributeType type, out string name)
         {
             fixed (int* length_ptr = &length)
             fixed (int* size_ptr = &size)
@@ -7203,7 +7203,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetUniformuiv"/>
-        public static unsafe void GetUniformui(ProgramHandle program, int location, Span<uint> parameters)
+        public static unsafe void GetUniformui(int program, int location, Span<uint> parameters)
         {
             fixed (uint* parameters_ptr = parameters)
             {
@@ -7211,7 +7211,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetUniformuiv"/>
-        public static unsafe void GetUniformui(ProgramHandle program, int location, uint[] parameters)
+        public static unsafe void GetUniformui(int program, int location, uint[] parameters)
         {
             fixed (uint* parameters_ptr = parameters)
             {
@@ -7219,7 +7219,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetUniformuiv"/>
-        public static unsafe void GetUniformui(ProgramHandle program, int location, ref uint parameters)
+        public static unsafe void GetUniformui(int program, int location, ref uint parameters)
         {
             fixed (uint* parameters_ptr = &parameters)
             {
@@ -7227,14 +7227,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="BindFragDataLocation"/>
-        public static unsafe void BindFragDataLocation(ProgramHandle program, uint color, string name)
+        public static unsafe void BindFragDataLocation(int program, uint color, string name)
         {
             byte* name_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(name);
             BindFragDataLocation(program, color, name_ptr);
             Marshal.FreeCoTaskMem((IntPtr)name_ptr);
         }
         /// <inheritdoc cref="GetFragDataLocation"/>
-        public static unsafe int GetFragDataLocation(ProgramHandle program, string name)
+        public static unsafe int GetFragDataLocation(int program, string name)
         {
             int returnValue;
             byte* name_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(name);
@@ -7529,44 +7529,44 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             return returnValue_str;
         }
         /// <inheritdoc cref="DeleteRenderbuffers"/>
-        public static unsafe void DeleteRenderbuffer(in RenderbufferHandle renderbuffer)
+        public static unsafe void DeleteRenderbuffer(in int renderbuffer)
         {
             int n = 1;
-            fixed(RenderbufferHandle* renderbuffers_handle = &renderbuffer)
+            fixed(int* renderbuffers_handle = &renderbuffer)
             {
                 DeleteRenderbuffers(n, renderbuffers_handle);
             }
         }
         /// <inheritdoc cref="DeleteRenderbuffers"/>
-        public static unsafe void DeleteRenderbuffers(ReadOnlySpan<RenderbufferHandle> renderbuffers)
+        public static unsafe void DeleteRenderbuffers(ReadOnlySpan<int> renderbuffers)
         {
             int n = (int)(renderbuffers.Length);
-            fixed (RenderbufferHandle* renderbuffers_ptr = renderbuffers)
+            fixed (int* renderbuffers_ptr = renderbuffers)
             {
                 DeleteRenderbuffers(n, renderbuffers_ptr);
             }
         }
         /// <inheritdoc cref="DeleteRenderbuffers"/>
-        public static unsafe void DeleteRenderbuffers(RenderbufferHandle[] renderbuffers)
+        public static unsafe void DeleteRenderbuffers(int[] renderbuffers)
         {
             int n = (int)(renderbuffers.Length);
-            fixed (RenderbufferHandle* renderbuffers_ptr = renderbuffers)
+            fixed (int* renderbuffers_ptr = renderbuffers)
             {
                 DeleteRenderbuffers(n, renderbuffers_ptr);
             }
         }
         /// <inheritdoc cref="DeleteRenderbuffers"/>
-        public static unsafe void DeleteRenderbuffers(int n, in RenderbufferHandle renderbuffers)
+        public static unsafe void DeleteRenderbuffers(int n, in int renderbuffers)
         {
-            fixed (RenderbufferHandle* renderbuffers_ptr = &renderbuffers)
+            fixed (int* renderbuffers_ptr = &renderbuffers)
             {
                 DeleteRenderbuffers(n, renderbuffers_ptr);
             }
         }
         /// <inheritdoc cref="GenRenderbuffers"/>
-        public static unsafe RenderbufferHandle GenRenderbuffer()
+        public static unsafe int GenRenderbuffer()
         {
-            RenderbufferHandle renderbuffer;
+            int renderbuffer;
             int n = 1;
             Unsafe.SkipInit(out renderbuffer);
             // FIXME: This could be a problem for the overloads that take an out parameter
@@ -7577,12 +7577,12 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            RenderbufferHandle* renderbuffers_handle = (RenderbufferHandle*)Unsafe.AsPointer(ref renderbuffer);
+            int* renderbuffers_handle = (int*)Unsafe.AsPointer(ref renderbuffer);
             GenRenderbuffers(n, renderbuffers_handle);
             return renderbuffer;
         }
         /// <inheritdoc cref="GenRenderbuffers"/>
-        public static unsafe void GenRenderbuffer(out RenderbufferHandle renderbuffer)
+        public static unsafe void GenRenderbuffer(out int renderbuffer)
         {
             int n = 1;
             Unsafe.SkipInit(out renderbuffer);
@@ -7594,31 +7594,31 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            RenderbufferHandle* renderbuffers_handle = (RenderbufferHandle*)Unsafe.AsPointer(ref renderbuffer);
+            int* renderbuffers_handle = (int*)Unsafe.AsPointer(ref renderbuffer);
             GenRenderbuffers(n, renderbuffers_handle);
         }
         /// <inheritdoc cref="GenRenderbuffers"/>
-        public static unsafe void GenRenderbuffers(Span<RenderbufferHandle> renderbuffers)
+        public static unsafe void GenRenderbuffers(Span<int> renderbuffers)
         {
             int n = (int)(renderbuffers.Length);
-            fixed (RenderbufferHandle* renderbuffers_ptr = renderbuffers)
+            fixed (int* renderbuffers_ptr = renderbuffers)
             {
                 GenRenderbuffers(n, renderbuffers_ptr);
             }
         }
         /// <inheritdoc cref="GenRenderbuffers"/>
-        public static unsafe void GenRenderbuffers(RenderbufferHandle[] renderbuffers)
+        public static unsafe void GenRenderbuffers(int[] renderbuffers)
         {
             int n = (int)(renderbuffers.Length);
-            fixed (RenderbufferHandle* renderbuffers_ptr = renderbuffers)
+            fixed (int* renderbuffers_ptr = renderbuffers)
             {
                 GenRenderbuffers(n, renderbuffers_ptr);
             }
         }
         /// <inheritdoc cref="GenRenderbuffers"/>
-        public static unsafe void GenRenderbuffers(int n, ref RenderbufferHandle renderbuffers)
+        public static unsafe void GenRenderbuffers(int n, ref int renderbuffers)
         {
-            fixed (RenderbufferHandle* renderbuffers_ptr = &renderbuffers)
+            fixed (int* renderbuffers_ptr = &renderbuffers)
             {
                 GenRenderbuffers(n, renderbuffers_ptr);
             }
@@ -7648,44 +7648,44 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="DeleteFramebuffers"/>
-        public static unsafe void DeleteFramebuffer(in FramebufferHandle framebuffer)
+        public static unsafe void DeleteFramebuffer(in int framebuffer)
         {
             int n = 1;
-            fixed(FramebufferHandle* framebuffers_handle = &framebuffer)
+            fixed(int* framebuffers_handle = &framebuffer)
             {
                 DeleteFramebuffers(n, framebuffers_handle);
             }
         }
         /// <inheritdoc cref="DeleteFramebuffers"/>
-        public static unsafe void DeleteFramebuffers(ReadOnlySpan<FramebufferHandle> framebuffers)
+        public static unsafe void DeleteFramebuffers(ReadOnlySpan<int> framebuffers)
         {
             int n = (int)(framebuffers.Length);
-            fixed (FramebufferHandle* framebuffers_ptr = framebuffers)
+            fixed (int* framebuffers_ptr = framebuffers)
             {
                 DeleteFramebuffers(n, framebuffers_ptr);
             }
         }
         /// <inheritdoc cref="DeleteFramebuffers"/>
-        public static unsafe void DeleteFramebuffers(FramebufferHandle[] framebuffers)
+        public static unsafe void DeleteFramebuffers(int[] framebuffers)
         {
             int n = (int)(framebuffers.Length);
-            fixed (FramebufferHandle* framebuffers_ptr = framebuffers)
+            fixed (int* framebuffers_ptr = framebuffers)
             {
                 DeleteFramebuffers(n, framebuffers_ptr);
             }
         }
         /// <inheritdoc cref="DeleteFramebuffers"/>
-        public static unsafe void DeleteFramebuffers(int n, in FramebufferHandle framebuffers)
+        public static unsafe void DeleteFramebuffers(int n, in int framebuffers)
         {
-            fixed (FramebufferHandle* framebuffers_ptr = &framebuffers)
+            fixed (int* framebuffers_ptr = &framebuffers)
             {
                 DeleteFramebuffers(n, framebuffers_ptr);
             }
         }
         /// <inheritdoc cref="GenFramebuffers"/>
-        public static unsafe FramebufferHandle GenFramebuffer()
+        public static unsafe int GenFramebuffer()
         {
-            FramebufferHandle framebuffer;
+            int framebuffer;
             int n = 1;
             Unsafe.SkipInit(out framebuffer);
             // FIXME: This could be a problem for the overloads that take an out parameter
@@ -7696,12 +7696,12 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            FramebufferHandle* framebuffers_handle = (FramebufferHandle*)Unsafe.AsPointer(ref framebuffer);
+            int* framebuffers_handle = (int*)Unsafe.AsPointer(ref framebuffer);
             GenFramebuffers(n, framebuffers_handle);
             return framebuffer;
         }
         /// <inheritdoc cref="GenFramebuffers"/>
-        public static unsafe void GenFramebuffer(out FramebufferHandle framebuffer)
+        public static unsafe void GenFramebuffer(out int framebuffer)
         {
             int n = 1;
             Unsafe.SkipInit(out framebuffer);
@@ -7713,31 +7713,31 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            FramebufferHandle* framebuffers_handle = (FramebufferHandle*)Unsafe.AsPointer(ref framebuffer);
+            int* framebuffers_handle = (int*)Unsafe.AsPointer(ref framebuffer);
             GenFramebuffers(n, framebuffers_handle);
         }
         /// <inheritdoc cref="GenFramebuffers"/>
-        public static unsafe void GenFramebuffers(Span<FramebufferHandle> framebuffers)
+        public static unsafe void GenFramebuffers(Span<int> framebuffers)
         {
             int n = (int)(framebuffers.Length);
-            fixed (FramebufferHandle* framebuffers_ptr = framebuffers)
+            fixed (int* framebuffers_ptr = framebuffers)
             {
                 GenFramebuffers(n, framebuffers_ptr);
             }
         }
         /// <inheritdoc cref="GenFramebuffers"/>
-        public static unsafe void GenFramebuffers(FramebufferHandle[] framebuffers)
+        public static unsafe void GenFramebuffers(int[] framebuffers)
         {
             int n = (int)(framebuffers.Length);
-            fixed (FramebufferHandle* framebuffers_ptr = framebuffers)
+            fixed (int* framebuffers_ptr = framebuffers)
             {
                 GenFramebuffers(n, framebuffers_ptr);
             }
         }
         /// <inheritdoc cref="GenFramebuffers"/>
-        public static unsafe void GenFramebuffers(int n, ref FramebufferHandle framebuffers)
+        public static unsafe void GenFramebuffers(int n, ref int framebuffers)
         {
-            fixed (FramebufferHandle* framebuffers_ptr = &framebuffers)
+            fixed (int* framebuffers_ptr = &framebuffers)
             {
                 GenFramebuffers(n, framebuffers_ptr);
             }
@@ -7767,44 +7767,44 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="DeleteVertexArrays"/>
-        public static unsafe void DeleteVertexArray(in VertexArrayHandle array)
+        public static unsafe void DeleteVertexArray(in int array)
         {
             int n = 1;
-            fixed(VertexArrayHandle* arrays_handle = &array)
+            fixed(int* arrays_handle = &array)
             {
                 DeleteVertexArrays(n, arrays_handle);
             }
         }
         /// <inheritdoc cref="DeleteVertexArrays"/>
-        public static unsafe void DeleteVertexArrays(ReadOnlySpan<VertexArrayHandle> arrays)
+        public static unsafe void DeleteVertexArrays(ReadOnlySpan<int> arrays)
         {
             int n = (int)(arrays.Length);
-            fixed (VertexArrayHandle* arrays_ptr = arrays)
+            fixed (int* arrays_ptr = arrays)
             {
                 DeleteVertexArrays(n, arrays_ptr);
             }
         }
         /// <inheritdoc cref="DeleteVertexArrays"/>
-        public static unsafe void DeleteVertexArrays(VertexArrayHandle[] arrays)
+        public static unsafe void DeleteVertexArrays(int[] arrays)
         {
             int n = (int)(arrays.Length);
-            fixed (VertexArrayHandle* arrays_ptr = arrays)
+            fixed (int* arrays_ptr = arrays)
             {
                 DeleteVertexArrays(n, arrays_ptr);
             }
         }
         /// <inheritdoc cref="DeleteVertexArrays"/>
-        public static unsafe void DeleteVertexArrays(int n, in VertexArrayHandle arrays)
+        public static unsafe void DeleteVertexArrays(int n, in int arrays)
         {
-            fixed (VertexArrayHandle* arrays_ptr = &arrays)
+            fixed (int* arrays_ptr = &arrays)
             {
                 DeleteVertexArrays(n, arrays_ptr);
             }
         }
         /// <inheritdoc cref="GenVertexArrays"/>
-        public static unsafe VertexArrayHandle GenVertexArray()
+        public static unsafe int GenVertexArray()
         {
-            VertexArrayHandle array;
+            int array;
             int n = 1;
             Unsafe.SkipInit(out array);
             // FIXME: This could be a problem for the overloads that take an out parameter
@@ -7815,12 +7815,12 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            VertexArrayHandle* arrays_handle = (VertexArrayHandle*)Unsafe.AsPointer(ref array);
+            int* arrays_handle = (int*)Unsafe.AsPointer(ref array);
             GenVertexArrays(n, arrays_handle);
             return array;
         }
         /// <inheritdoc cref="GenVertexArrays"/>
-        public static unsafe void GenVertexArray(out VertexArrayHandle array)
+        public static unsafe void GenVertexArray(out int array)
         {
             int n = 1;
             Unsafe.SkipInit(out array);
@@ -7832,31 +7832,31 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            VertexArrayHandle* arrays_handle = (VertexArrayHandle*)Unsafe.AsPointer(ref array);
+            int* arrays_handle = (int*)Unsafe.AsPointer(ref array);
             GenVertexArrays(n, arrays_handle);
         }
         /// <inheritdoc cref="GenVertexArrays"/>
-        public static unsafe void GenVertexArrays(Span<VertexArrayHandle> arrays)
+        public static unsafe void GenVertexArrays(Span<int> arrays)
         {
             int n = (int)(arrays.Length);
-            fixed (VertexArrayHandle* arrays_ptr = arrays)
+            fixed (int* arrays_ptr = arrays)
             {
                 GenVertexArrays(n, arrays_ptr);
             }
         }
         /// <inheritdoc cref="GenVertexArrays"/>
-        public static unsafe void GenVertexArrays(VertexArrayHandle[] arrays)
+        public static unsafe void GenVertexArrays(int[] arrays)
         {
             int n = (int)(arrays.Length);
-            fixed (VertexArrayHandle* arrays_ptr = arrays)
+            fixed (int* arrays_ptr = arrays)
             {
                 GenVertexArrays(n, arrays_ptr);
             }
         }
         /// <inheritdoc cref="GenVertexArrays"/>
-        public static unsafe void GenVertexArrays(int n, ref VertexArrayHandle arrays)
+        public static unsafe void GenVertexArrays(int n, ref int arrays)
         {
-            fixed (VertexArrayHandle* arrays_ptr = &arrays)
+            fixed (int* arrays_ptr = &arrays)
             {
                 GenVertexArrays(n, arrays_ptr);
             }
@@ -7868,7 +7868,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             DrawElementsInstanced(mode, count, type, indices, instancecount);
         }
         /// <inheritdoc cref="GetUniformIndices"/>
-        public static unsafe void GetUniformIndices(ProgramHandle program, int uniformCount, byte** uniformNames, Span<uint> uniformIndices)
+        public static unsafe void GetUniformIndices(int program, int uniformCount, byte** uniformNames, Span<uint> uniformIndices)
         {
             fixed (uint* uniformIndices_ptr = uniformIndices)
             {
@@ -7876,7 +7876,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetUniformIndices"/>
-        public static unsafe void GetUniformIndices(ProgramHandle program, int uniformCount, byte** uniformNames, uint[] uniformIndices)
+        public static unsafe void GetUniformIndices(int program, int uniformCount, byte** uniformNames, uint[] uniformIndices)
         {
             fixed (uint* uniformIndices_ptr = uniformIndices)
             {
@@ -7884,7 +7884,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetUniformIndices"/>
-        public static unsafe void GetUniformIndices(ProgramHandle program, int uniformCount, byte** uniformNames, ref uint uniformIndices)
+        public static unsafe void GetUniformIndices(int program, int uniformCount, byte** uniformNames, ref uint uniformIndices)
         {
             fixed (uint* uniformIndices_ptr = &uniformIndices)
             {
@@ -7892,7 +7892,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetActiveUniformsiv"/>
-        public static unsafe void GetActiveUniformsi(ProgramHandle program, ReadOnlySpan<uint> uniformIndices, UniformPName pname, Span<int> parameters)
+        public static unsafe void GetActiveUniformsi(int program, ReadOnlySpan<uint> uniformIndices, UniformPName pname, Span<int> parameters)
         {
             int uniformCount = (int)(uniformIndices.Length);
             fixed (uint* uniformIndices_ptr = uniformIndices)
@@ -7904,7 +7904,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetActiveUniformsiv"/>
-        public static unsafe void GetActiveUniformsi(ProgramHandle program, uint[] uniformIndices, UniformPName pname, int[] parameters)
+        public static unsafe void GetActiveUniformsi(int program, uint[] uniformIndices, UniformPName pname, int[] parameters)
         {
             int uniformCount = (int)(uniformIndices.Length);
             fixed (uint* uniformIndices_ptr = uniformIndices)
@@ -7916,7 +7916,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetActiveUniformsiv"/>
-        public static unsafe void GetActiveUniformsi(ProgramHandle program, int uniformCount, in uint uniformIndices, UniformPName pname, ref int parameters)
+        public static unsafe void GetActiveUniformsi(int program, int uniformCount, in uint uniformIndices, UniformPName pname, ref int parameters)
         {
             fixed (uint* uniformIndices_ptr = &uniformIndices)
             fixed (int* parameters_ptr = &parameters)
@@ -7925,7 +7925,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetActiveUniformName"/>
-        public static unsafe string GetActiveUniformName(ProgramHandle program, uint uniformIndex, int bufSize, Span<int> length)
+        public static unsafe string GetActiveUniformName(int program, uint uniformIndex, int bufSize, Span<int> length)
         {
             string uniformName;
             fixed (int* length_ptr = length)
@@ -7938,7 +7938,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             return uniformName;
         }
         /// <inheritdoc cref="GetActiveUniformName"/>
-        public static unsafe void GetActiveUniformName(ProgramHandle program, uint uniformIndex, int bufSize, Span<int> length, out string uniformName)
+        public static unsafe void GetActiveUniformName(int program, uint uniformIndex, int bufSize, Span<int> length, out string uniformName)
         {
             fixed (int* length_ptr = length)
             {
@@ -7949,7 +7949,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetActiveUniformName"/>
-        public static unsafe string GetActiveUniformName(ProgramHandle program, uint uniformIndex, int bufSize, int[] length)
+        public static unsafe string GetActiveUniformName(int program, uint uniformIndex, int bufSize, int[] length)
         {
             string uniformName;
             fixed (int* length_ptr = length)
@@ -7962,7 +7962,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             return uniformName;
         }
         /// <inheritdoc cref="GetActiveUniformName"/>
-        public static unsafe void GetActiveUniformName(ProgramHandle program, uint uniformIndex, int bufSize, int[] length, out string uniformName)
+        public static unsafe void GetActiveUniformName(int program, uint uniformIndex, int bufSize, int[] length, out string uniformName)
         {
             fixed (int* length_ptr = length)
             {
@@ -7973,7 +7973,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetActiveUniformName"/>
-        public static unsafe string GetActiveUniformName(ProgramHandle program, uint uniformIndex, int bufSize, ref int length)
+        public static unsafe string GetActiveUniformName(int program, uint uniformIndex, int bufSize, ref int length)
         {
             string uniformName;
             fixed (int* length_ptr = &length)
@@ -7986,7 +7986,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             return uniformName;
         }
         /// <inheritdoc cref="GetActiveUniformName"/>
-        public static unsafe void GetActiveUniformName(ProgramHandle program, uint uniformIndex, int bufSize, ref int length, out string uniformName)
+        public static unsafe void GetActiveUniformName(int program, uint uniformIndex, int bufSize, ref int length, out string uniformName)
         {
             fixed (int* length_ptr = &length)
             {
@@ -7997,7 +7997,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetUniformBlockIndex"/>
-        public static unsafe uint GetUniformBlockIndex(ProgramHandle program, string uniformBlockName)
+        public static unsafe uint GetUniformBlockIndex(int program, string uniformBlockName)
         {
             uint returnValue;
             byte* uniformBlockName_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(uniformBlockName);
@@ -8006,7 +8006,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             return returnValue;
         }
         /// <inheritdoc cref="GetActiveUniformBlockiv"/>
-        public static unsafe void GetActiveUniformBlocki(ProgramHandle program, uint uniformBlockIndex, UniformBlockPName pname, Span<int> parameters)
+        public static unsafe void GetActiveUniformBlocki(int program, uint uniformBlockIndex, UniformBlockPName pname, Span<int> parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
@@ -8014,7 +8014,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetActiveUniformBlockiv"/>
-        public static unsafe void GetActiveUniformBlocki(ProgramHandle program, uint uniformBlockIndex, UniformBlockPName pname, int[] parameters)
+        public static unsafe void GetActiveUniformBlocki(int program, uint uniformBlockIndex, UniformBlockPName pname, int[] parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
@@ -8022,7 +8022,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetActiveUniformBlockiv"/>
-        public static unsafe void GetActiveUniformBlocki(ProgramHandle program, uint uniformBlockIndex, UniformBlockPName pname, ref int parameters)
+        public static unsafe void GetActiveUniformBlocki(int program, uint uniformBlockIndex, UniformBlockPName pname, ref int parameters)
         {
             fixed (int* parameters_ptr = &parameters)
             {
@@ -8030,7 +8030,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetActiveUniformBlockName"/>
-        public static unsafe string GetActiveUniformBlockName(ProgramHandle program, uint uniformBlockIndex, int bufSize, Span<int> length)
+        public static unsafe string GetActiveUniformBlockName(int program, uint uniformBlockIndex, int bufSize, Span<int> length)
         {
             string uniformBlockName;
             fixed (int* length_ptr = length)
@@ -8043,7 +8043,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             return uniformBlockName;
         }
         /// <inheritdoc cref="GetActiveUniformBlockName"/>
-        public static unsafe void GetActiveUniformBlockName(ProgramHandle program, uint uniformBlockIndex, int bufSize, Span<int> length, out string uniformBlockName)
+        public static unsafe void GetActiveUniformBlockName(int program, uint uniformBlockIndex, int bufSize, Span<int> length, out string uniformBlockName)
         {
             fixed (int* length_ptr = length)
             {
@@ -8054,7 +8054,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetActiveUniformBlockName"/>
-        public static unsafe string GetActiveUniformBlockName(ProgramHandle program, uint uniformBlockIndex, int bufSize, int[] length)
+        public static unsafe string GetActiveUniformBlockName(int program, uint uniformBlockIndex, int bufSize, int[] length)
         {
             string uniformBlockName;
             fixed (int* length_ptr = length)
@@ -8067,7 +8067,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             return uniformBlockName;
         }
         /// <inheritdoc cref="GetActiveUniformBlockName"/>
-        public static unsafe void GetActiveUniformBlockName(ProgramHandle program, uint uniformBlockIndex, int bufSize, int[] length, out string uniformBlockName)
+        public static unsafe void GetActiveUniformBlockName(int program, uint uniformBlockIndex, int bufSize, int[] length, out string uniformBlockName)
         {
             fixed (int* length_ptr = length)
             {
@@ -8078,7 +8078,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetActiveUniformBlockName"/>
-        public static unsafe string GetActiveUniformBlockName(ProgramHandle program, uint uniformBlockIndex, int bufSize, ref int length)
+        public static unsafe string GetActiveUniformBlockName(int program, uint uniformBlockIndex, int bufSize, ref int length)
         {
             string uniformBlockName;
             fixed (int* length_ptr = &length)
@@ -8091,7 +8091,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             return uniformBlockName;
         }
         /// <inheritdoc cref="GetActiveUniformBlockName"/>
-        public static unsafe void GetActiveUniformBlockName(ProgramHandle program, uint uniformBlockIndex, int bufSize, ref int length, out string uniformBlockName)
+        public static unsafe void GetActiveUniformBlockName(int program, uint uniformBlockIndex, int bufSize, ref int length, out string uniformBlockName)
         {
             fixed (int* length_ptr = &length)
             {
@@ -8280,14 +8280,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="BindFragDataLocationIndexed"/>
-        public static unsafe void BindFragDataLocationIndexed(ProgramHandle program, uint colorNumber, uint index, string name)
+        public static unsafe void BindFragDataLocationIndexed(int program, uint colorNumber, uint index, string name)
         {
             byte* name_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(name);
             BindFragDataLocationIndexed(program, colorNumber, index, name_ptr);
             Marshal.FreeCoTaskMem((IntPtr)name_ptr);
         }
         /// <inheritdoc cref="GetFragDataIndex"/>
-        public static unsafe int GetFragDataIndex(ProgramHandle program, string name)
+        public static unsafe int GetFragDataIndex(int program, string name)
         {
             int returnValue;
             byte* name_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(name);
@@ -8296,9 +8296,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             return returnValue;
         }
         /// <inheritdoc cref="GenSamplers"/>
-        public static unsafe SamplerHandle GenSampler()
+        public static unsafe int GenSampler()
         {
-            SamplerHandle sampler;
+            int sampler;
             int count = 1;
             Unsafe.SkipInit(out sampler);
             // FIXME: This could be a problem for the overloads that take an out parameter
@@ -8309,12 +8309,12 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            SamplerHandle* samplers_handle = (SamplerHandle*)Unsafe.AsPointer(ref sampler);
+            int* samplers_handle = (int*)Unsafe.AsPointer(ref sampler);
             GenSamplers(count, samplers_handle);
             return sampler;
         }
         /// <inheritdoc cref="GenSamplers"/>
-        public static unsafe void GenSampler(out SamplerHandle sampler)
+        public static unsafe void GenSampler(out int sampler)
         {
             int count = 1;
             Unsafe.SkipInit(out sampler);
@@ -8326,72 +8326,72 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            SamplerHandle* samplers_handle = (SamplerHandle*)Unsafe.AsPointer(ref sampler);
+            int* samplers_handle = (int*)Unsafe.AsPointer(ref sampler);
             GenSamplers(count, samplers_handle);
         }
         /// <inheritdoc cref="GenSamplers"/>
-        public static unsafe void GenSamplers(Span<SamplerHandle> samplers)
+        public static unsafe void GenSamplers(Span<int> samplers)
         {
             int count = (int)(samplers.Length);
-            fixed (SamplerHandle* samplers_ptr = samplers)
+            fixed (int* samplers_ptr = samplers)
             {
                 GenSamplers(count, samplers_ptr);
             }
         }
         /// <inheritdoc cref="GenSamplers"/>
-        public static unsafe void GenSamplers(SamplerHandle[] samplers)
+        public static unsafe void GenSamplers(int[] samplers)
         {
             int count = (int)(samplers.Length);
-            fixed (SamplerHandle* samplers_ptr = samplers)
+            fixed (int* samplers_ptr = samplers)
             {
                 GenSamplers(count, samplers_ptr);
             }
         }
         /// <inheritdoc cref="GenSamplers"/>
-        public static unsafe void GenSamplers(int count, ref SamplerHandle samplers)
+        public static unsafe void GenSamplers(int count, ref int samplers)
         {
-            fixed (SamplerHandle* samplers_ptr = &samplers)
+            fixed (int* samplers_ptr = &samplers)
             {
                 GenSamplers(count, samplers_ptr);
             }
         }
         /// <inheritdoc cref="DeleteSamplers"/>
-        public static unsafe void DeleteSampler(in SamplerHandle sampler)
+        public static unsafe void DeleteSampler(in int sampler)
         {
             int count = 1;
-            fixed(SamplerHandle* samplers_handle = &sampler)
+            fixed(int* samplers_handle = &sampler)
             {
                 DeleteSamplers(count, samplers_handle);
             }
         }
         /// <inheritdoc cref="DeleteSamplers"/>
-        public static unsafe void DeleteSamplers(ReadOnlySpan<SamplerHandle> samplers)
+        public static unsafe void DeleteSamplers(ReadOnlySpan<int> samplers)
         {
             int count = (int)(samplers.Length);
-            fixed (SamplerHandle* samplers_ptr = samplers)
+            fixed (int* samplers_ptr = samplers)
             {
                 DeleteSamplers(count, samplers_ptr);
             }
         }
         /// <inheritdoc cref="DeleteSamplers"/>
-        public static unsafe void DeleteSamplers(SamplerHandle[] samplers)
+        public static unsafe void DeleteSamplers(int[] samplers)
         {
             int count = (int)(samplers.Length);
-            fixed (SamplerHandle* samplers_ptr = samplers)
+            fixed (int* samplers_ptr = samplers)
             {
                 DeleteSamplers(count, samplers_ptr);
             }
         }
         /// <inheritdoc cref="DeleteSamplers"/>
-        public static unsafe void DeleteSamplers(int count, in SamplerHandle samplers)
+        public static unsafe void DeleteSamplers(int count, in int samplers)
         {
-            fixed (SamplerHandle* samplers_ptr = &samplers)
+            fixed (int* samplers_ptr = &samplers)
             {
                 DeleteSamplers(count, samplers_ptr);
             }
         }
         /// <inheritdoc cref="SamplerParameteriv"/>
-        public static unsafe void SamplerParameteri(SamplerHandle sampler, SamplerParameterI pname, ReadOnlySpan<int> param)
+        public static unsafe void SamplerParameteri(int sampler, SamplerParameterI pname, ReadOnlySpan<int> param)
         {
             fixed (int* param_ptr = param)
             {
@@ -8399,7 +8399,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="SamplerParameteriv"/>
-        public static unsafe void SamplerParameteri(SamplerHandle sampler, SamplerParameterI pname, int[] param)
+        public static unsafe void SamplerParameteri(int sampler, SamplerParameterI pname, int[] param)
         {
             fixed (int* param_ptr = param)
             {
@@ -8407,7 +8407,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="SamplerParameteriv"/>
-        public static unsafe void SamplerParameteri(SamplerHandle sampler, SamplerParameterI pname, in int param)
+        public static unsafe void SamplerParameteri(int sampler, SamplerParameterI pname, in int param)
         {
             fixed (int* param_ptr = &param)
             {
@@ -8415,7 +8415,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="SamplerParameterfv"/>
-        public static unsafe void SamplerParameterf(SamplerHandle sampler, SamplerParameterF pname, ReadOnlySpan<float> param)
+        public static unsafe void SamplerParameterf(int sampler, SamplerParameterF pname, ReadOnlySpan<float> param)
         {
             fixed (float* param_ptr = param)
             {
@@ -8423,7 +8423,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="SamplerParameterfv"/>
-        public static unsafe void SamplerParameterf(SamplerHandle sampler, SamplerParameterF pname, float[] param)
+        public static unsafe void SamplerParameterf(int sampler, SamplerParameterF pname, float[] param)
         {
             fixed (float* param_ptr = param)
             {
@@ -8431,7 +8431,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="SamplerParameterfv"/>
-        public static unsafe void SamplerParameterf(SamplerHandle sampler, SamplerParameterF pname, in float param)
+        public static unsafe void SamplerParameterf(int sampler, SamplerParameterF pname, in float param)
         {
             fixed (float* param_ptr = &param)
             {
@@ -8439,7 +8439,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="SamplerParameterIiv"/>
-        public static unsafe void SamplerParameterIi(SamplerHandle sampler, SamplerParameterI pname, ReadOnlySpan<int> param)
+        public static unsafe void SamplerParameterIi(int sampler, SamplerParameterI pname, ReadOnlySpan<int> param)
         {
             fixed (int* param_ptr = param)
             {
@@ -8447,7 +8447,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="SamplerParameterIiv"/>
-        public static unsafe void SamplerParameterIi(SamplerHandle sampler, SamplerParameterI pname, int[] param)
+        public static unsafe void SamplerParameterIi(int sampler, SamplerParameterI pname, int[] param)
         {
             fixed (int* param_ptr = param)
             {
@@ -8455,7 +8455,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="SamplerParameterIiv"/>
-        public static unsafe void SamplerParameterIi(SamplerHandle sampler, SamplerParameterI pname, in int param)
+        public static unsafe void SamplerParameterIi(int sampler, SamplerParameterI pname, in int param)
         {
             fixed (int* param_ptr = &param)
             {
@@ -8463,7 +8463,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="SamplerParameterIuiv"/>
-        public static unsafe void SamplerParameterIui(SamplerHandle sampler, SamplerParameterI pname, ReadOnlySpan<uint> param)
+        public static unsafe void SamplerParameterIui(int sampler, SamplerParameterI pname, ReadOnlySpan<uint> param)
         {
             fixed (uint* param_ptr = param)
             {
@@ -8471,7 +8471,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="SamplerParameterIuiv"/>
-        public static unsafe void SamplerParameterIui(SamplerHandle sampler, SamplerParameterI pname, uint[] param)
+        public static unsafe void SamplerParameterIui(int sampler, SamplerParameterI pname, uint[] param)
         {
             fixed (uint* param_ptr = param)
             {
@@ -8479,7 +8479,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="SamplerParameterIuiv"/>
-        public static unsafe void SamplerParameterIui(SamplerHandle sampler, SamplerParameterI pname, in uint param)
+        public static unsafe void SamplerParameterIui(int sampler, SamplerParameterI pname, in uint param)
         {
             fixed (uint* param_ptr = &param)
             {
@@ -8487,7 +8487,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetSamplerParameteriv"/>
-        public static unsafe void GetSamplerParameteri(SamplerHandle sampler, SamplerParameterI pname, Span<int> parameters)
+        public static unsafe void GetSamplerParameteri(int sampler, SamplerParameterI pname, Span<int> parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
@@ -8495,7 +8495,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetSamplerParameteriv"/>
-        public static unsafe void GetSamplerParameteri(SamplerHandle sampler, SamplerParameterI pname, int[] parameters)
+        public static unsafe void GetSamplerParameteri(int sampler, SamplerParameterI pname, int[] parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
@@ -8503,7 +8503,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetSamplerParameteriv"/>
-        public static unsafe void GetSamplerParameteri(SamplerHandle sampler, SamplerParameterI pname, ref int parameters)
+        public static unsafe void GetSamplerParameteri(int sampler, SamplerParameterI pname, ref int parameters)
         {
             fixed (int* parameters_ptr = &parameters)
             {
@@ -8511,7 +8511,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetSamplerParameterIiv"/>
-        public static unsafe void GetSamplerParameterIi(SamplerHandle sampler, SamplerParameterI pname, Span<int> parameters)
+        public static unsafe void GetSamplerParameterIi(int sampler, SamplerParameterI pname, Span<int> parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
@@ -8519,7 +8519,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetSamplerParameterIiv"/>
-        public static unsafe void GetSamplerParameterIi(SamplerHandle sampler, SamplerParameterI pname, int[] parameters)
+        public static unsafe void GetSamplerParameterIi(int sampler, SamplerParameterI pname, int[] parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
@@ -8527,7 +8527,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetSamplerParameterIiv"/>
-        public static unsafe void GetSamplerParameterIi(SamplerHandle sampler, SamplerParameterI pname, ref int parameters)
+        public static unsafe void GetSamplerParameterIi(int sampler, SamplerParameterI pname, ref int parameters)
         {
             fixed (int* parameters_ptr = &parameters)
             {
@@ -8535,7 +8535,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetSamplerParameterfv"/>
-        public static unsafe void GetSamplerParameterf(SamplerHandle sampler, SamplerParameterF pname, Span<float> parameters)
+        public static unsafe void GetSamplerParameterf(int sampler, SamplerParameterF pname, Span<float> parameters)
         {
             fixed (float* parameters_ptr = parameters)
             {
@@ -8543,7 +8543,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetSamplerParameterfv"/>
-        public static unsafe void GetSamplerParameterf(SamplerHandle sampler, SamplerParameterF pname, float[] parameters)
+        public static unsafe void GetSamplerParameterf(int sampler, SamplerParameterF pname, float[] parameters)
         {
             fixed (float* parameters_ptr = parameters)
             {
@@ -8551,7 +8551,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetSamplerParameterfv"/>
-        public static unsafe void GetSamplerParameterf(SamplerHandle sampler, SamplerParameterF pname, ref float parameters)
+        public static unsafe void GetSamplerParameterf(int sampler, SamplerParameterF pname, ref float parameters)
         {
             fixed (float* parameters_ptr = &parameters)
             {
@@ -8559,7 +8559,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetSamplerParameterIuiv"/>
-        public static unsafe void GetSamplerParameterIui(SamplerHandle sampler, SamplerParameterI pname, Span<uint> parameters)
+        public static unsafe void GetSamplerParameterIui(int sampler, SamplerParameterI pname, Span<uint> parameters)
         {
             fixed (uint* parameters_ptr = parameters)
             {
@@ -8567,7 +8567,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetSamplerParameterIuiv"/>
-        public static unsafe void GetSamplerParameterIui(SamplerHandle sampler, SamplerParameterI pname, uint[] parameters)
+        public static unsafe void GetSamplerParameterIui(int sampler, SamplerParameterI pname, uint[] parameters)
         {
             fixed (uint* parameters_ptr = parameters)
             {
@@ -8575,7 +8575,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetSamplerParameterIuiv"/>
-        public static unsafe void GetSamplerParameterIui(SamplerHandle sampler, SamplerParameterI pname, ref uint parameters)
+        public static unsafe void GetSamplerParameterIui(int sampler, SamplerParameterI pname, ref uint parameters)
         {
             fixed (uint* parameters_ptr = &parameters)
             {
@@ -8583,7 +8583,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetQueryObjecti64v"/>
-        public static unsafe void GetQueryObjecti64(QueryHandle id, QueryObjectParameterName pname, Span<long> parameters)
+        public static unsafe void GetQueryObjecti64(int id, QueryObjectParameterName pname, Span<long> parameters)
         {
             fixed (long* parameters_ptr = parameters)
             {
@@ -8591,7 +8591,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetQueryObjecti64v"/>
-        public static unsafe void GetQueryObjecti64(QueryHandle id, QueryObjectParameterName pname, long[] parameters)
+        public static unsafe void GetQueryObjecti64(int id, QueryObjectParameterName pname, long[] parameters)
         {
             fixed (long* parameters_ptr = parameters)
             {
@@ -8599,7 +8599,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetQueryObjecti64v"/>
-        public static unsafe void GetQueryObjecti64(QueryHandle id, QueryObjectParameterName pname, ref long parameters)
+        public static unsafe void GetQueryObjecti64(int id, QueryObjectParameterName pname, ref long parameters)
         {
             fixed (long* parameters_ptr = &parameters)
             {
@@ -8607,7 +8607,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetQueryObjectui64v"/>
-        public static unsafe void GetQueryObjectui64(QueryHandle id, QueryObjectParameterName pname, Span<ulong> parameters)
+        public static unsafe void GetQueryObjectui64(int id, QueryObjectParameterName pname, Span<ulong> parameters)
         {
             fixed (ulong* parameters_ptr = parameters)
             {
@@ -8615,7 +8615,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetQueryObjectui64v"/>
-        public static unsafe void GetQueryObjectui64(QueryHandle id, QueryObjectParameterName pname, ulong[] parameters)
+        public static unsafe void GetQueryObjectui64(int id, QueryObjectParameterName pname, ulong[] parameters)
         {
             fixed (ulong* parameters_ptr = parameters)
             {
@@ -8623,7 +8623,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetQueryObjectui64v"/>
-        public static unsafe void GetQueryObjectui64(QueryHandle id, QueryObjectParameterName pname, ref ulong parameters)
+        public static unsafe void GetQueryObjectui64(int id, QueryObjectParameterName pname, ref ulong parameters)
         {
             fixed (ulong* parameters_ptr = &parameters)
             {
@@ -9468,7 +9468,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetUniformdv"/>
-        public static unsafe void GetUniformd(ProgramHandle program, int location, Span<double> parameters)
+        public static unsafe void GetUniformd(int program, int location, Span<double> parameters)
         {
             fixed (double* parameters_ptr = parameters)
             {
@@ -9476,7 +9476,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetUniformdv"/>
-        public static unsafe void GetUniformd(ProgramHandle program, int location, double[] parameters)
+        public static unsafe void GetUniformd(int program, int location, double[] parameters)
         {
             fixed (double* parameters_ptr = parameters)
             {
@@ -9484,7 +9484,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetUniformdv"/>
-        public static unsafe void GetUniformd(ProgramHandle program, int location, ref double parameters)
+        public static unsafe void GetUniformd(int program, int location, ref double parameters)
         {
             fixed (double* parameters_ptr = &parameters)
             {
@@ -9492,7 +9492,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetSubroutineUniformLocation"/>
-        public static unsafe int GetSubroutineUniformLocation(ProgramHandle program, ShaderType shadertype, string name)
+        public static unsafe int GetSubroutineUniformLocation(int program, ShaderType shadertype, string name)
         {
             int returnValue;
             byte* name_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(name);
@@ -9501,7 +9501,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             return returnValue;
         }
         /// <inheritdoc cref="GetSubroutineIndex"/>
-        public static unsafe uint GetSubroutineIndex(ProgramHandle program, ShaderType shadertype, string name)
+        public static unsafe uint GetSubroutineIndex(int program, ShaderType shadertype, string name)
         {
             uint returnValue;
             byte* name_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(name);
@@ -9510,7 +9510,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             return returnValue;
         }
         /// <inheritdoc cref="GetActiveSubroutineUniformiv"/>
-        public static unsafe void GetActiveSubroutineUniformi(ProgramHandle program, ShaderType shadertype, uint index, SubroutineParameterName pname, Span<int> values)
+        public static unsafe void GetActiveSubroutineUniformi(int program, ShaderType shadertype, uint index, SubroutineParameterName pname, Span<int> values)
         {
             fixed (int* values_ptr = values)
             {
@@ -9518,7 +9518,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetActiveSubroutineUniformiv"/>
-        public static unsafe void GetActiveSubroutineUniformi(ProgramHandle program, ShaderType shadertype, uint index, SubroutineParameterName pname, int[] values)
+        public static unsafe void GetActiveSubroutineUniformi(int program, ShaderType shadertype, uint index, SubroutineParameterName pname, int[] values)
         {
             fixed (int* values_ptr = values)
             {
@@ -9526,7 +9526,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetActiveSubroutineUniformiv"/>
-        public static unsafe void GetActiveSubroutineUniformi(ProgramHandle program, ShaderType shadertype, uint index, SubroutineParameterName pname, ref int values)
+        public static unsafe void GetActiveSubroutineUniformi(int program, ShaderType shadertype, uint index, SubroutineParameterName pname, ref int values)
         {
             fixed (int* values_ptr = &values)
             {
@@ -9534,7 +9534,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetActiveSubroutineUniformName"/>
-        public static unsafe string GetActiveSubroutineUniformName(ProgramHandle program, ShaderType shadertype, uint index, int bufSize, Span<int> length)
+        public static unsafe string GetActiveSubroutineUniformName(int program, ShaderType shadertype, uint index, int bufSize, Span<int> length)
         {
             string name;
             fixed (int* length_ptr = length)
@@ -9547,7 +9547,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             return name;
         }
         /// <inheritdoc cref="GetActiveSubroutineUniformName"/>
-        public static unsafe void GetActiveSubroutineUniformName(ProgramHandle program, ShaderType shadertype, uint index, int bufSize, Span<int> length, out string name)
+        public static unsafe void GetActiveSubroutineUniformName(int program, ShaderType shadertype, uint index, int bufSize, Span<int> length, out string name)
         {
             fixed (int* length_ptr = length)
             {
@@ -9558,7 +9558,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetActiveSubroutineUniformName"/>
-        public static unsafe string GetActiveSubroutineUniformName(ProgramHandle program, ShaderType shadertype, uint index, int bufSize, int[] length)
+        public static unsafe string GetActiveSubroutineUniformName(int program, ShaderType shadertype, uint index, int bufSize, int[] length)
         {
             string name;
             fixed (int* length_ptr = length)
@@ -9571,7 +9571,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             return name;
         }
         /// <inheritdoc cref="GetActiveSubroutineUniformName"/>
-        public static unsafe void GetActiveSubroutineUniformName(ProgramHandle program, ShaderType shadertype, uint index, int bufSize, int[] length, out string name)
+        public static unsafe void GetActiveSubroutineUniformName(int program, ShaderType shadertype, uint index, int bufSize, int[] length, out string name)
         {
             fixed (int* length_ptr = length)
             {
@@ -9582,7 +9582,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetActiveSubroutineUniformName"/>
-        public static unsafe string GetActiveSubroutineUniformName(ProgramHandle program, ShaderType shadertype, uint index, int bufSize, ref int length)
+        public static unsafe string GetActiveSubroutineUniformName(int program, ShaderType shadertype, uint index, int bufSize, ref int length)
         {
             string name;
             fixed (int* length_ptr = &length)
@@ -9595,7 +9595,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             return name;
         }
         /// <inheritdoc cref="GetActiveSubroutineUniformName"/>
-        public static unsafe void GetActiveSubroutineUniformName(ProgramHandle program, ShaderType shadertype, uint index, int bufSize, ref int length, out string name)
+        public static unsafe void GetActiveSubroutineUniformName(int program, ShaderType shadertype, uint index, int bufSize, ref int length, out string name)
         {
             fixed (int* length_ptr = &length)
             {
@@ -9606,7 +9606,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetActiveSubroutineName"/>
-        public static unsafe string GetActiveSubroutineName(ProgramHandle program, ShaderType shadertype, uint index, int bufSize, Span<int> length)
+        public static unsafe string GetActiveSubroutineName(int program, ShaderType shadertype, uint index, int bufSize, Span<int> length)
         {
             string name;
             fixed (int* length_ptr = length)
@@ -9619,7 +9619,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             return name;
         }
         /// <inheritdoc cref="GetActiveSubroutineName"/>
-        public static unsafe void GetActiveSubroutineName(ProgramHandle program, ShaderType shadertype, uint index, int bufSize, Span<int> length, out string name)
+        public static unsafe void GetActiveSubroutineName(int program, ShaderType shadertype, uint index, int bufSize, Span<int> length, out string name)
         {
             fixed (int* length_ptr = length)
             {
@@ -9630,7 +9630,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetActiveSubroutineName"/>
-        public static unsafe string GetActiveSubroutineName(ProgramHandle program, ShaderType shadertype, uint index, int bufSize, int[] length)
+        public static unsafe string GetActiveSubroutineName(int program, ShaderType shadertype, uint index, int bufSize, int[] length)
         {
             string name;
             fixed (int* length_ptr = length)
@@ -9643,7 +9643,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             return name;
         }
         /// <inheritdoc cref="GetActiveSubroutineName"/>
-        public static unsafe void GetActiveSubroutineName(ProgramHandle program, ShaderType shadertype, uint index, int bufSize, int[] length, out string name)
+        public static unsafe void GetActiveSubroutineName(int program, ShaderType shadertype, uint index, int bufSize, int[] length, out string name)
         {
             fixed (int* length_ptr = length)
             {
@@ -9654,7 +9654,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetActiveSubroutineName"/>
-        public static unsafe string GetActiveSubroutineName(ProgramHandle program, ShaderType shadertype, uint index, int bufSize, ref int length)
+        public static unsafe string GetActiveSubroutineName(int program, ShaderType shadertype, uint index, int bufSize, ref int length)
         {
             string name;
             fixed (int* length_ptr = &length)
@@ -9667,7 +9667,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             return name;
         }
         /// <inheritdoc cref="GetActiveSubroutineName"/>
-        public static unsafe void GetActiveSubroutineName(ProgramHandle program, ShaderType shadertype, uint index, int bufSize, ref int length, out string name)
+        public static unsafe void GetActiveSubroutineName(int program, ShaderType shadertype, uint index, int bufSize, ref int length, out string name)
         {
             fixed (int* length_ptr = &length)
             {
@@ -9728,7 +9728,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetProgramStageiv"/>
-        public static unsafe void GetProgramStagei(ProgramHandle program, ShaderType shadertype, ProgramStagePName pname, Span<int> values)
+        public static unsafe void GetProgramStagei(int program, ShaderType shadertype, ProgramStagePName pname, Span<int> values)
         {
             fixed (int* values_ptr = values)
             {
@@ -9736,7 +9736,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetProgramStageiv"/>
-        public static unsafe void GetProgramStagei(ProgramHandle program, ShaderType shadertype, ProgramStagePName pname, int[] values)
+        public static unsafe void GetProgramStagei(int program, ShaderType shadertype, ProgramStagePName pname, int[] values)
         {
             fixed (int* values_ptr = values)
             {
@@ -9744,7 +9744,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetProgramStageiv"/>
-        public static unsafe void GetProgramStagei(ProgramHandle program, ShaderType shadertype, ProgramStagePName pname, ref int values)
+        public static unsafe void GetProgramStagei(int program, ShaderType shadertype, ProgramStagePName pname, ref int values)
         {
             fixed (int* values_ptr = &values)
             {
@@ -9776,44 +9776,44 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="DeleteTransformFeedbacks"/>
-        public static unsafe void DeleteTransformFeedback(in TransformFeedbackHandle id)
+        public static unsafe void DeleteTransformFeedback(in int id)
         {
             int n = 1;
-            fixed(TransformFeedbackHandle* ids_handle = &id)
+            fixed(int* ids_handle = &id)
             {
                 DeleteTransformFeedbacks(n, ids_handle);
             }
         }
         /// <inheritdoc cref="DeleteTransformFeedbacks"/>
-        public static unsafe void DeleteTransformFeedbacks(ReadOnlySpan<TransformFeedbackHandle> ids)
+        public static unsafe void DeleteTransformFeedbacks(ReadOnlySpan<int> ids)
         {
             int n = (int)(ids.Length);
-            fixed (TransformFeedbackHandle* ids_ptr = ids)
+            fixed (int* ids_ptr = ids)
             {
                 DeleteTransformFeedbacks(n, ids_ptr);
             }
         }
         /// <inheritdoc cref="DeleteTransformFeedbacks"/>
-        public static unsafe void DeleteTransformFeedbacks(TransformFeedbackHandle[] ids)
+        public static unsafe void DeleteTransformFeedbacks(int[] ids)
         {
             int n = (int)(ids.Length);
-            fixed (TransformFeedbackHandle* ids_ptr = ids)
+            fixed (int* ids_ptr = ids)
             {
                 DeleteTransformFeedbacks(n, ids_ptr);
             }
         }
         /// <inheritdoc cref="DeleteTransformFeedbacks"/>
-        public static unsafe void DeleteTransformFeedbacks(int n, in TransformFeedbackHandle ids)
+        public static unsafe void DeleteTransformFeedbacks(int n, in int ids)
         {
-            fixed (TransformFeedbackHandle* ids_ptr = &ids)
+            fixed (int* ids_ptr = &ids)
             {
                 DeleteTransformFeedbacks(n, ids_ptr);
             }
         }
         /// <inheritdoc cref="GenTransformFeedbacks"/>
-        public static unsafe TransformFeedbackHandle GenTransformFeedback()
+        public static unsafe int GenTransformFeedback()
         {
-            TransformFeedbackHandle id;
+            int id;
             int n = 1;
             Unsafe.SkipInit(out id);
             // FIXME: This could be a problem for the overloads that take an out parameter
@@ -9824,12 +9824,12 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            TransformFeedbackHandle* ids_handle = (TransformFeedbackHandle*)Unsafe.AsPointer(ref id);
+            int* ids_handle = (int*)Unsafe.AsPointer(ref id);
             GenTransformFeedbacks(n, ids_handle);
             return id;
         }
         /// <inheritdoc cref="GenTransformFeedbacks"/>
-        public static unsafe void GenTransformFeedback(out TransformFeedbackHandle id)
+        public static unsafe void GenTransformFeedback(out int id)
         {
             int n = 1;
             Unsafe.SkipInit(out id);
@@ -9841,31 +9841,31 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            TransformFeedbackHandle* ids_handle = (TransformFeedbackHandle*)Unsafe.AsPointer(ref id);
+            int* ids_handle = (int*)Unsafe.AsPointer(ref id);
             GenTransformFeedbacks(n, ids_handle);
         }
         /// <inheritdoc cref="GenTransformFeedbacks"/>
-        public static unsafe void GenTransformFeedbacks(Span<TransformFeedbackHandle> ids)
+        public static unsafe void GenTransformFeedbacks(Span<int> ids)
         {
             int n = (int)(ids.Length);
-            fixed (TransformFeedbackHandle* ids_ptr = ids)
+            fixed (int* ids_ptr = ids)
             {
                 GenTransformFeedbacks(n, ids_ptr);
             }
         }
         /// <inheritdoc cref="GenTransformFeedbacks"/>
-        public static unsafe void GenTransformFeedbacks(TransformFeedbackHandle[] ids)
+        public static unsafe void GenTransformFeedbacks(int[] ids)
         {
             int n = (int)(ids.Length);
-            fixed (TransformFeedbackHandle* ids_ptr = ids)
+            fixed (int* ids_ptr = ids)
             {
                 GenTransformFeedbacks(n, ids_ptr);
             }
         }
         /// <inheritdoc cref="GenTransformFeedbacks"/>
-        public static unsafe void GenTransformFeedbacks(int n, ref TransformFeedbackHandle ids)
+        public static unsafe void GenTransformFeedbacks(int n, ref int ids)
         {
-            fixed (TransformFeedbackHandle* ids_ptr = &ids)
+            fixed (int* ids_ptr = &ids)
             {
                 GenTransformFeedbacks(n, ids_ptr);
             }
@@ -9895,40 +9895,40 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ShaderBinary"/>
-        public static unsafe void ShaderBinary(ReadOnlySpan<ShaderHandle> shaders, ShaderBinaryFormat binaryFormat, IntPtr binary, int length)
+        public static unsafe void ShaderBinary(ReadOnlySpan<int> shaders, ShaderBinaryFormat binaryFormat, IntPtr binary, int length)
         {
             int count = (int)(shaders.Length);
-            fixed (ShaderHandle* shaders_ptr = shaders)
+            fixed (int* shaders_ptr = shaders)
             {
                 void* binary_vptr = (void*)binary;
                 ShaderBinary(count, shaders_ptr, binaryFormat, binary_vptr, length);
             }
         }
         /// <inheritdoc cref="ShaderBinary"/>
-        public static unsafe void ShaderBinary(ShaderHandle[] shaders, ShaderBinaryFormat binaryFormat, IntPtr binary, int length)
+        public static unsafe void ShaderBinary(int[] shaders, ShaderBinaryFormat binaryFormat, IntPtr binary, int length)
         {
             int count = (int)(shaders.Length);
-            fixed (ShaderHandle* shaders_ptr = shaders)
+            fixed (int* shaders_ptr = shaders)
             {
                 void* binary_vptr = (void*)binary;
                 ShaderBinary(count, shaders_ptr, binaryFormat, binary_vptr, length);
             }
         }
         /// <inheritdoc cref="ShaderBinary"/>
-        public static unsafe void ShaderBinary(int count, in ShaderHandle shaders, ShaderBinaryFormat binaryFormat, IntPtr binary, int length)
+        public static unsafe void ShaderBinary(int count, in int shaders, ShaderBinaryFormat binaryFormat, IntPtr binary, int length)
         {
-            fixed (ShaderHandle* shaders_ptr = &shaders)
+            fixed (int* shaders_ptr = &shaders)
             {
                 void* binary_vptr = (void*)binary;
                 ShaderBinary(count, shaders_ptr, binaryFormat, binary_vptr, length);
             }
         }
         /// <inheritdoc cref="ShaderBinary"/>
-        public static unsafe void ShaderBinary<T1>(ReadOnlySpan<ShaderHandle> shaders, ShaderBinaryFormat binaryFormat, ReadOnlySpan<T1> binary)
+        public static unsafe void ShaderBinary<T1>(ReadOnlySpan<int> shaders, ShaderBinaryFormat binaryFormat, ReadOnlySpan<T1> binary)
             where T1 : unmanaged
         {
             int count = (int)(shaders.Length);
-            fixed (ShaderHandle* shaders_ptr = shaders)
+            fixed (int* shaders_ptr = shaders)
             {
                 int length = (int)(binary.Length * sizeof(T1));
                 fixed (void* binary_ptr = binary)
@@ -9938,11 +9938,11 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ShaderBinary"/>
-        public static unsafe void ShaderBinary<T1>(ShaderHandle[] shaders, ShaderBinaryFormat binaryFormat, T1[] binary)
+        public static unsafe void ShaderBinary<T1>(int[] shaders, ShaderBinaryFormat binaryFormat, T1[] binary)
             where T1 : unmanaged
         {
             int count = (int)(shaders.Length);
-            fixed (ShaderHandle* shaders_ptr = shaders)
+            fixed (int* shaders_ptr = shaders)
             {
                 int length = (int)(binary.Length * sizeof(T1));
                 fixed (void* binary_ptr = binary)
@@ -9952,10 +9952,10 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ShaderBinary"/>
-        public static unsafe void ShaderBinary<T1>(int count, in ShaderHandle shaders, ShaderBinaryFormat binaryFormat, in T1 binary, int length)
+        public static unsafe void ShaderBinary<T1>(int count, in int shaders, ShaderBinaryFormat binaryFormat, in T1 binary, int length)
             where T1 : unmanaged
         {
-            fixed (ShaderHandle* shaders_ptr = &shaders)
+            fixed (int* shaders_ptr = &shaders)
             fixed (void* binary_ptr = &binary)
             {
                 ShaderBinary(count, shaders_ptr, binaryFormat, binary_ptr, length);
@@ -9993,7 +9993,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetProgramBinary"/>
-        public static unsafe void GetProgramBinary(ProgramHandle program, int bufSize, Span<int> length, Span<All> binaryFormat, IntPtr binary)
+        public static unsafe void GetProgramBinary(int program, int bufSize, Span<int> length, Span<All> binaryFormat, IntPtr binary)
         {
             fixed (int* length_ptr = length)
             {
@@ -10005,7 +10005,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetProgramBinary"/>
-        public static unsafe void GetProgramBinary(ProgramHandle program, int bufSize, int[] length, All[] binaryFormat, IntPtr binary)
+        public static unsafe void GetProgramBinary(int program, int bufSize, int[] length, All[] binaryFormat, IntPtr binary)
         {
             fixed (int* length_ptr = length)
             {
@@ -10017,7 +10017,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetProgramBinary"/>
-        public static unsafe void GetProgramBinary(ProgramHandle program, int bufSize, ref int length, ref All binaryFormat, IntPtr binary)
+        public static unsafe void GetProgramBinary(int program, int bufSize, ref int length, ref All binaryFormat, IntPtr binary)
         {
             fixed (int* length_ptr = &length)
             fixed (All* binaryFormat_ptr = &binaryFormat)
@@ -10027,7 +10027,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetProgramBinary"/>
-        public static unsafe void GetProgramBinary<T1>(ProgramHandle program, Span<int> length, Span<All> binaryFormat, Span<T1> binary)
+        public static unsafe void GetProgramBinary<T1>(int program, Span<int> length, Span<All> binaryFormat, Span<T1> binary)
             where T1 : unmanaged
         {
             fixed (int* length_ptr = length)
@@ -10043,7 +10043,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetProgramBinary"/>
-        public static unsafe void GetProgramBinary<T1>(ProgramHandle program, int[] length, All[] binaryFormat, T1[] binary)
+        public static unsafe void GetProgramBinary<T1>(int program, int[] length, All[] binaryFormat, T1[] binary)
             where T1 : unmanaged
         {
             fixed (int* length_ptr = length)
@@ -10059,7 +10059,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetProgramBinary"/>
-        public static unsafe void GetProgramBinary<T1>(ProgramHandle program, int bufSize, ref int length, ref All binaryFormat, ref T1 binary)
+        public static unsafe void GetProgramBinary<T1>(int program, int bufSize, ref int length, ref All binaryFormat, ref T1 binary)
             where T1 : unmanaged
         {
             fixed (int* length_ptr = &length)
@@ -10070,13 +10070,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramBinary"/>
-        public static unsafe void ProgramBinary(ProgramHandle program, All binaryFormat, IntPtr binary, int length)
+        public static unsafe void ProgramBinary(int program, All binaryFormat, IntPtr binary, int length)
         {
             void* binary_vptr = (void*)binary;
             ProgramBinary(program, binaryFormat, binary_vptr, length);
         }
         /// <inheritdoc cref="ProgramBinary"/>
-        public static unsafe void ProgramBinary<T1>(ProgramHandle program, All binaryFormat, ReadOnlySpan<T1> binary)
+        public static unsafe void ProgramBinary<T1>(int program, All binaryFormat, ReadOnlySpan<T1> binary)
             where T1 : unmanaged
         {
             int length = (int)(binary.Length * sizeof(T1));
@@ -10086,7 +10086,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramBinary"/>
-        public static unsafe void ProgramBinary<T1>(ProgramHandle program, All binaryFormat, T1[] binary)
+        public static unsafe void ProgramBinary<T1>(int program, All binaryFormat, T1[] binary)
             where T1 : unmanaged
         {
             int length = (int)(binary.Length * sizeof(T1));
@@ -10096,7 +10096,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramBinary"/>
-        public static unsafe void ProgramBinary<T1>(ProgramHandle program, All binaryFormat, in T1 binary, int length)
+        public static unsafe void ProgramBinary<T1>(int program, All binaryFormat, in T1 binary, int length)
             where T1 : unmanaged
         {
             fixed (void* binary_ptr = &binary)
@@ -10105,51 +10105,51 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="CreateShaderProgramv"/>
-        public static unsafe ProgramHandle CreateShaderProgram(ShaderType type, int count, byte** strings)
+        public static unsafe int CreateShaderProgram(ShaderType type, int count, byte** strings)
         {
-            ProgramHandle returnValue;
+            int returnValue;
             returnValue = CreateShaderProgramv(type, count, strings);
             return returnValue;
         }
         /// <inheritdoc cref="DeleteProgramPipelines"/>
-        public static unsafe void DeleteProgramPipeline(in ProgramPipelineHandle pipeline)
+        public static unsafe void DeleteProgramPipeline(in int pipeline)
         {
             int n = 1;
-            fixed(ProgramPipelineHandle* pipelines_handle = &pipeline)
+            fixed(int* pipelines_handle = &pipeline)
             {
                 DeleteProgramPipelines(n, pipelines_handle);
             }
         }
         /// <inheritdoc cref="DeleteProgramPipelines"/>
-        public static unsafe void DeleteProgramPipelines(ReadOnlySpan<ProgramPipelineHandle> pipelines)
+        public static unsafe void DeleteProgramPipelines(ReadOnlySpan<int> pipelines)
         {
             int n = (int)(pipelines.Length);
-            fixed (ProgramPipelineHandle* pipelines_ptr = pipelines)
+            fixed (int* pipelines_ptr = pipelines)
             {
                 DeleteProgramPipelines(n, pipelines_ptr);
             }
         }
         /// <inheritdoc cref="DeleteProgramPipelines"/>
-        public static unsafe void DeleteProgramPipelines(ProgramPipelineHandle[] pipelines)
+        public static unsafe void DeleteProgramPipelines(int[] pipelines)
         {
             int n = (int)(pipelines.Length);
-            fixed (ProgramPipelineHandle* pipelines_ptr = pipelines)
+            fixed (int* pipelines_ptr = pipelines)
             {
                 DeleteProgramPipelines(n, pipelines_ptr);
             }
         }
         /// <inheritdoc cref="DeleteProgramPipelines"/>
-        public static unsafe void DeleteProgramPipelines(int n, in ProgramPipelineHandle pipelines)
+        public static unsafe void DeleteProgramPipelines(int n, in int pipelines)
         {
-            fixed (ProgramPipelineHandle* pipelines_ptr = &pipelines)
+            fixed (int* pipelines_ptr = &pipelines)
             {
                 DeleteProgramPipelines(n, pipelines_ptr);
             }
         }
         /// <inheritdoc cref="GenProgramPipelines"/>
-        public static unsafe ProgramPipelineHandle GenProgramPipeline()
+        public static unsafe int GenProgramPipeline()
         {
-            ProgramPipelineHandle pipeline;
+            int pipeline;
             int n = 1;
             Unsafe.SkipInit(out pipeline);
             // FIXME: This could be a problem for the overloads that take an out parameter
@@ -10160,12 +10160,12 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            ProgramPipelineHandle* pipelines_handle = (ProgramPipelineHandle*)Unsafe.AsPointer(ref pipeline);
+            int* pipelines_handle = (int*)Unsafe.AsPointer(ref pipeline);
             GenProgramPipelines(n, pipelines_handle);
             return pipeline;
         }
         /// <inheritdoc cref="GenProgramPipelines"/>
-        public static unsafe void GenProgramPipeline(out ProgramPipelineHandle pipeline)
+        public static unsafe void GenProgramPipeline(out int pipeline)
         {
             int n = 1;
             Unsafe.SkipInit(out pipeline);
@@ -10177,37 +10177,37 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            ProgramPipelineHandle* pipelines_handle = (ProgramPipelineHandle*)Unsafe.AsPointer(ref pipeline);
+            int* pipelines_handle = (int*)Unsafe.AsPointer(ref pipeline);
             GenProgramPipelines(n, pipelines_handle);
         }
         /// <inheritdoc cref="GenProgramPipelines"/>
-        public static unsafe void GenProgramPipelines(Span<ProgramPipelineHandle> pipelines)
+        public static unsafe void GenProgramPipelines(Span<int> pipelines)
         {
             int n = (int)(pipelines.Length);
-            fixed (ProgramPipelineHandle* pipelines_ptr = pipelines)
+            fixed (int* pipelines_ptr = pipelines)
             {
                 GenProgramPipelines(n, pipelines_ptr);
             }
         }
         /// <inheritdoc cref="GenProgramPipelines"/>
-        public static unsafe void GenProgramPipelines(ProgramPipelineHandle[] pipelines)
+        public static unsafe void GenProgramPipelines(int[] pipelines)
         {
             int n = (int)(pipelines.Length);
-            fixed (ProgramPipelineHandle* pipelines_ptr = pipelines)
+            fixed (int* pipelines_ptr = pipelines)
             {
                 GenProgramPipelines(n, pipelines_ptr);
             }
         }
         /// <inheritdoc cref="GenProgramPipelines"/>
-        public static unsafe void GenProgramPipelines(int n, ref ProgramPipelineHandle pipelines)
+        public static unsafe void GenProgramPipelines(int n, ref int pipelines)
         {
-            fixed (ProgramPipelineHandle* pipelines_ptr = &pipelines)
+            fixed (int* pipelines_ptr = &pipelines)
             {
                 GenProgramPipelines(n, pipelines_ptr);
             }
         }
         /// <inheritdoc cref="GetProgramPipelineiv"/>
-        public static unsafe void GetProgramPipelinei(ProgramPipelineHandle pipeline, PipelineParameterName pname, Span<int> parameters)
+        public static unsafe void GetProgramPipelinei(int pipeline, PipelineParameterName pname, Span<int> parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
@@ -10215,7 +10215,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetProgramPipelineiv"/>
-        public static unsafe void GetProgramPipelinei(ProgramPipelineHandle pipeline, PipelineParameterName pname, int[] parameters)
+        public static unsafe void GetProgramPipelinei(int pipeline, PipelineParameterName pname, int[] parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
@@ -10223,7 +10223,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetProgramPipelineiv"/>
-        public static unsafe void GetProgramPipelinei(ProgramPipelineHandle pipeline, PipelineParameterName pname, ref int parameters)
+        public static unsafe void GetProgramPipelinei(int pipeline, PipelineParameterName pname, ref int parameters)
         {
             fixed (int* parameters_ptr = &parameters)
             {
@@ -10231,7 +10231,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform1iv"/>
-        public static unsafe void ProgramUniform1iv(ProgramHandle program, int location, ReadOnlySpan<int> value)
+        public static unsafe void ProgramUniform1iv(int program, int location, ReadOnlySpan<int> value)
         {
             int count = (int)(value.Length);
             fixed (int* value_ptr = value)
@@ -10240,7 +10240,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform1iv"/>
-        public static unsafe void ProgramUniform1iv(ProgramHandle program, int location, int[] value)
+        public static unsafe void ProgramUniform1iv(int program, int location, int[] value)
         {
             int count = (int)(value.Length);
             fixed (int* value_ptr = value)
@@ -10249,7 +10249,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform1iv"/>
-        public static unsafe void ProgramUniform1iv(ProgramHandle program, int location, int count, in int value)
+        public static unsafe void ProgramUniform1iv(int program, int location, int count, in int value)
         {
             fixed (int* value_ptr = &value)
             {
@@ -10257,7 +10257,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform1fv"/>
-        public static unsafe void ProgramUniform1fv(ProgramHandle program, int location, ReadOnlySpan<float> value)
+        public static unsafe void ProgramUniform1fv(int program, int location, ReadOnlySpan<float> value)
         {
             int count = (int)(value.Length);
             fixed (float* value_ptr = value)
@@ -10266,7 +10266,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform1fv"/>
-        public static unsafe void ProgramUniform1fv(ProgramHandle program, int location, float[] value)
+        public static unsafe void ProgramUniform1fv(int program, int location, float[] value)
         {
             int count = (int)(value.Length);
             fixed (float* value_ptr = value)
@@ -10275,7 +10275,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform1fv"/>
-        public static unsafe void ProgramUniform1fv(ProgramHandle program, int location, int count, in float value)
+        public static unsafe void ProgramUniform1fv(int program, int location, int count, in float value)
         {
             fixed (float* value_ptr = &value)
             {
@@ -10283,7 +10283,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform1dv"/>
-        public static unsafe void ProgramUniform1dv(ProgramHandle program, int location, ReadOnlySpan<double> value)
+        public static unsafe void ProgramUniform1dv(int program, int location, ReadOnlySpan<double> value)
         {
             int count = (int)(value.Length);
             fixed (double* value_ptr = value)
@@ -10292,7 +10292,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform1dv"/>
-        public static unsafe void ProgramUniform1dv(ProgramHandle program, int location, double[] value)
+        public static unsafe void ProgramUniform1dv(int program, int location, double[] value)
         {
             int count = (int)(value.Length);
             fixed (double* value_ptr = value)
@@ -10301,7 +10301,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform1dv"/>
-        public static unsafe void ProgramUniform1dv(ProgramHandle program, int location, int count, in double value)
+        public static unsafe void ProgramUniform1dv(int program, int location, int count, in double value)
         {
             fixed (double* value_ptr = &value)
             {
@@ -10309,7 +10309,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform1uiv"/>
-        public static unsafe void ProgramUniform1ui(ProgramHandle program, int location, ReadOnlySpan<uint> value)
+        public static unsafe void ProgramUniform1ui(int program, int location, ReadOnlySpan<uint> value)
         {
             int count = (int)(value.Length);
             fixed (uint* value_ptr = value)
@@ -10318,7 +10318,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform1uiv"/>
-        public static unsafe void ProgramUniform1ui(ProgramHandle program, int location, uint[] value)
+        public static unsafe void ProgramUniform1ui(int program, int location, uint[] value)
         {
             int count = (int)(value.Length);
             fixed (uint* value_ptr = value)
@@ -10327,7 +10327,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform1uiv"/>
-        public static unsafe void ProgramUniform1ui(ProgramHandle program, int location, int count, in uint value)
+        public static unsafe void ProgramUniform1ui(int program, int location, int count, in uint value)
         {
             fixed (uint* value_ptr = &value)
             {
@@ -10335,7 +10335,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform2iv"/>
-        public static unsafe void ProgramUniform2i(ProgramHandle program, int location, int count, in Vector2i value)
+        public static unsafe void ProgramUniform2i(int program, int location, int count, in Vector2i value)
         {
             fixed (Vector2i* tmp_vecPtr = &value)
             {
@@ -10344,7 +10344,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform2iv"/>
-        public static unsafe void ProgramUniform2i(ProgramHandle program, int location, int count, ReadOnlySpan<Vector2i> value)
+        public static unsafe void ProgramUniform2i(int program, int location, int count, ReadOnlySpan<Vector2i> value)
         {
             fixed (Vector2i* tmp_vecPtr = value)
             {
@@ -10353,7 +10353,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform2iv"/>
-        public static unsafe void ProgramUniform2i(ProgramHandle program, int location, int count, Vector2i[] value)
+        public static unsafe void ProgramUniform2i(int program, int location, int count, Vector2i[] value)
         {
             fixed (Vector2i* tmp_vecPtr = value)
             {
@@ -10362,7 +10362,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform2fv"/>
-        public static unsafe void ProgramUniform2f(ProgramHandle program, int location, int count, in Vector2 value)
+        public static unsafe void ProgramUniform2f(int program, int location, int count, in Vector2 value)
         {
             fixed (Vector2* tmp_vecPtr = &value)
             {
@@ -10371,7 +10371,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform2fv"/>
-        public static unsafe void ProgramUniform2f(ProgramHandle program, int location, int count, ReadOnlySpan<Vector2> value)
+        public static unsafe void ProgramUniform2f(int program, int location, int count, ReadOnlySpan<Vector2> value)
         {
             fixed (Vector2* tmp_vecPtr = value)
             {
@@ -10380,7 +10380,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform2fv"/>
-        public static unsafe void ProgramUniform2f(ProgramHandle program, int location, int count, Vector2[] value)
+        public static unsafe void ProgramUniform2f(int program, int location, int count, Vector2[] value)
         {
             fixed (Vector2* tmp_vecPtr = value)
             {
@@ -10389,7 +10389,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform2fv"/>
-        public static unsafe void ProgramUniform2f(ProgramHandle program, int location, int count, in System.Numerics.Vector2 value)
+        public static unsafe void ProgramUniform2f(int program, int location, int count, in System.Numerics.Vector2 value)
         {
             fixed (System.Numerics.Vector2* tmp_vecPtr = &value)
             {
@@ -10398,7 +10398,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform2fv"/>
-        public static unsafe void ProgramUniform2f(ProgramHandle program, int location, int count, ReadOnlySpan<System.Numerics.Vector2> value)
+        public static unsafe void ProgramUniform2f(int program, int location, int count, ReadOnlySpan<System.Numerics.Vector2> value)
         {
             fixed (System.Numerics.Vector2* tmp_vecPtr = value)
             {
@@ -10407,7 +10407,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform2fv"/>
-        public static unsafe void ProgramUniform2f(ProgramHandle program, int location, int count, System.Numerics.Vector2[] value)
+        public static unsafe void ProgramUniform2f(int program, int location, int count, System.Numerics.Vector2[] value)
         {
             fixed (System.Numerics.Vector2* tmp_vecPtr = value)
             {
@@ -10416,7 +10416,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform2dv"/>
-        public static unsafe void ProgramUniform2d(ProgramHandle program, int location, int count, in Vector2d value)
+        public static unsafe void ProgramUniform2d(int program, int location, int count, in Vector2d value)
         {
             fixed (Vector2d* tmp_vecPtr = &value)
             {
@@ -10425,7 +10425,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform2dv"/>
-        public static unsafe void ProgramUniform2d(ProgramHandle program, int location, int count, ReadOnlySpan<Vector2d> value)
+        public static unsafe void ProgramUniform2d(int program, int location, int count, ReadOnlySpan<Vector2d> value)
         {
             fixed (Vector2d* tmp_vecPtr = value)
             {
@@ -10434,7 +10434,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform2dv"/>
-        public static unsafe void ProgramUniform2d(ProgramHandle program, int location, int count, Vector2d[] value)
+        public static unsafe void ProgramUniform2d(int program, int location, int count, Vector2d[] value)
         {
             fixed (Vector2d* tmp_vecPtr = value)
             {
@@ -10443,7 +10443,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform2uiv"/>
-        public static unsafe void ProgramUniform2ui(ProgramHandle program, int location, ReadOnlySpan<uint> value)
+        public static unsafe void ProgramUniform2ui(int program, int location, ReadOnlySpan<uint> value)
         {
             int count = (int)(value.Length / 2);
             fixed (uint* value_ptr = value)
@@ -10452,7 +10452,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform2uiv"/>
-        public static unsafe void ProgramUniform2ui(ProgramHandle program, int location, uint[] value)
+        public static unsafe void ProgramUniform2ui(int program, int location, uint[] value)
         {
             int count = (int)(value.Length / 2);
             fixed (uint* value_ptr = value)
@@ -10461,7 +10461,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform2uiv"/>
-        public static unsafe void ProgramUniform2ui(ProgramHandle program, int location, int count, in uint value)
+        public static unsafe void ProgramUniform2ui(int program, int location, int count, in uint value)
         {
             fixed (uint* value_ptr = &value)
             {
@@ -10469,7 +10469,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform3iv"/>
-        public static unsafe void ProgramUniform3i(ProgramHandle program, int location, int count, in Vector3i value)
+        public static unsafe void ProgramUniform3i(int program, int location, int count, in Vector3i value)
         {
             fixed (Vector3i* tmp_vecPtr = &value)
             {
@@ -10478,7 +10478,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform3iv"/>
-        public static unsafe void ProgramUniform3i(ProgramHandle program, int location, int count, ReadOnlySpan<Vector3i> value)
+        public static unsafe void ProgramUniform3i(int program, int location, int count, ReadOnlySpan<Vector3i> value)
         {
             fixed (Vector3i* tmp_vecPtr = value)
             {
@@ -10487,7 +10487,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform3iv"/>
-        public static unsafe void ProgramUniform3i(ProgramHandle program, int location, int count, Vector3i[] value)
+        public static unsafe void ProgramUniform3i(int program, int location, int count, Vector3i[] value)
         {
             fixed (Vector3i* tmp_vecPtr = value)
             {
@@ -10496,7 +10496,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform3fv"/>
-        public static unsafe void ProgramUniform3f(ProgramHandle program, int location, int count, in Vector3 value)
+        public static unsafe void ProgramUniform3f(int program, int location, int count, in Vector3 value)
         {
             fixed (Vector3* tmp_vecPtr = &value)
             {
@@ -10505,7 +10505,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform3fv"/>
-        public static unsafe void ProgramUniform3f(ProgramHandle program, int location, int count, ReadOnlySpan<Vector3> value)
+        public static unsafe void ProgramUniform3f(int program, int location, int count, ReadOnlySpan<Vector3> value)
         {
             fixed (Vector3* tmp_vecPtr = value)
             {
@@ -10514,7 +10514,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform3fv"/>
-        public static unsafe void ProgramUniform3f(ProgramHandle program, int location, int count, Vector3[] value)
+        public static unsafe void ProgramUniform3f(int program, int location, int count, Vector3[] value)
         {
             fixed (Vector3* tmp_vecPtr = value)
             {
@@ -10523,7 +10523,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform3fv"/>
-        public static unsafe void ProgramUniform3f(ProgramHandle program, int location, int count, in System.Numerics.Vector3 value)
+        public static unsafe void ProgramUniform3f(int program, int location, int count, in System.Numerics.Vector3 value)
         {
             fixed (System.Numerics.Vector3* tmp_vecPtr = &value)
             {
@@ -10532,7 +10532,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform3fv"/>
-        public static unsafe void ProgramUniform3f(ProgramHandle program, int location, int count, ReadOnlySpan<System.Numerics.Vector3> value)
+        public static unsafe void ProgramUniform3f(int program, int location, int count, ReadOnlySpan<System.Numerics.Vector3> value)
         {
             fixed (System.Numerics.Vector3* tmp_vecPtr = value)
             {
@@ -10541,7 +10541,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform3fv"/>
-        public static unsafe void ProgramUniform3f(ProgramHandle program, int location, int count, System.Numerics.Vector3[] value)
+        public static unsafe void ProgramUniform3f(int program, int location, int count, System.Numerics.Vector3[] value)
         {
             fixed (System.Numerics.Vector3* tmp_vecPtr = value)
             {
@@ -10550,7 +10550,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform3dv"/>
-        public static unsafe void ProgramUniform3d(ProgramHandle program, int location, int count, in Vector3d value)
+        public static unsafe void ProgramUniform3d(int program, int location, int count, in Vector3d value)
         {
             fixed (Vector3d* tmp_vecPtr = &value)
             {
@@ -10559,7 +10559,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform3dv"/>
-        public static unsafe void ProgramUniform3d(ProgramHandle program, int location, int count, ReadOnlySpan<Vector3d> value)
+        public static unsafe void ProgramUniform3d(int program, int location, int count, ReadOnlySpan<Vector3d> value)
         {
             fixed (Vector3d* tmp_vecPtr = value)
             {
@@ -10568,7 +10568,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform3dv"/>
-        public static unsafe void ProgramUniform3d(ProgramHandle program, int location, int count, Vector3d[] value)
+        public static unsafe void ProgramUniform3d(int program, int location, int count, Vector3d[] value)
         {
             fixed (Vector3d* tmp_vecPtr = value)
             {
@@ -10577,7 +10577,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform3uiv"/>
-        public static unsafe void ProgramUniform3ui(ProgramHandle program, int location, ReadOnlySpan<uint> value)
+        public static unsafe void ProgramUniform3ui(int program, int location, ReadOnlySpan<uint> value)
         {
             int count = (int)(value.Length / 3);
             fixed (uint* value_ptr = value)
@@ -10586,7 +10586,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform3uiv"/>
-        public static unsafe void ProgramUniform3ui(ProgramHandle program, int location, uint[] value)
+        public static unsafe void ProgramUniform3ui(int program, int location, uint[] value)
         {
             int count = (int)(value.Length / 3);
             fixed (uint* value_ptr = value)
@@ -10595,7 +10595,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform3uiv"/>
-        public static unsafe void ProgramUniform3ui(ProgramHandle program, int location, int count, in uint value)
+        public static unsafe void ProgramUniform3ui(int program, int location, int count, in uint value)
         {
             fixed (uint* value_ptr = &value)
             {
@@ -10603,7 +10603,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform4iv"/>
-        public static unsafe void ProgramUniform4i(ProgramHandle program, int location, int count, in Vector4i value)
+        public static unsafe void ProgramUniform4i(int program, int location, int count, in Vector4i value)
         {
             fixed (Vector4i* tmp_vecPtr = &value)
             {
@@ -10612,7 +10612,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform4iv"/>
-        public static unsafe void ProgramUniform4i(ProgramHandle program, int location, int count, ReadOnlySpan<Vector4i> value)
+        public static unsafe void ProgramUniform4i(int program, int location, int count, ReadOnlySpan<Vector4i> value)
         {
             fixed (Vector4i* tmp_vecPtr = value)
             {
@@ -10621,7 +10621,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform4iv"/>
-        public static unsafe void ProgramUniform4i(ProgramHandle program, int location, int count, Vector4i[] value)
+        public static unsafe void ProgramUniform4i(int program, int location, int count, Vector4i[] value)
         {
             fixed (Vector4i* tmp_vecPtr = value)
             {
@@ -10630,7 +10630,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform4fv"/>
-        public static unsafe void ProgramUniform4f(ProgramHandle program, int location, int count, in Vector4 value)
+        public static unsafe void ProgramUniform4f(int program, int location, int count, in Vector4 value)
         {
             fixed (Vector4* tmp_vecPtr = &value)
             {
@@ -10639,7 +10639,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform4fv"/>
-        public static unsafe void ProgramUniform4f(ProgramHandle program, int location, int count, ReadOnlySpan<Vector4> value)
+        public static unsafe void ProgramUniform4f(int program, int location, int count, ReadOnlySpan<Vector4> value)
         {
             fixed (Vector4* tmp_vecPtr = value)
             {
@@ -10648,7 +10648,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform4fv"/>
-        public static unsafe void ProgramUniform4f(ProgramHandle program, int location, int count, Vector4[] value)
+        public static unsafe void ProgramUniform4f(int program, int location, int count, Vector4[] value)
         {
             fixed (Vector4* tmp_vecPtr = value)
             {
@@ -10657,7 +10657,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform4fv"/>
-        public static unsafe void ProgramUniform4f(ProgramHandle program, int location, int count, in System.Numerics.Vector4 value)
+        public static unsafe void ProgramUniform4f(int program, int location, int count, in System.Numerics.Vector4 value)
         {
             fixed (System.Numerics.Vector4* tmp_vecPtr = &value)
             {
@@ -10666,7 +10666,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform4fv"/>
-        public static unsafe void ProgramUniform4f(ProgramHandle program, int location, int count, ReadOnlySpan<System.Numerics.Vector4> value)
+        public static unsafe void ProgramUniform4f(int program, int location, int count, ReadOnlySpan<System.Numerics.Vector4> value)
         {
             fixed (System.Numerics.Vector4* tmp_vecPtr = value)
             {
@@ -10675,7 +10675,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform4fv"/>
-        public static unsafe void ProgramUniform4f(ProgramHandle program, int location, int count, System.Numerics.Vector4[] value)
+        public static unsafe void ProgramUniform4f(int program, int location, int count, System.Numerics.Vector4[] value)
         {
             fixed (System.Numerics.Vector4* tmp_vecPtr = value)
             {
@@ -10684,7 +10684,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform4dv"/>
-        public static unsafe void ProgramUniform4d(ProgramHandle program, int location, int count, in Vector4d value)
+        public static unsafe void ProgramUniform4d(int program, int location, int count, in Vector4d value)
         {
             fixed (Vector4d* tmp_vecPtr = &value)
             {
@@ -10693,7 +10693,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform4dv"/>
-        public static unsafe void ProgramUniform4d(ProgramHandle program, int location, int count, ReadOnlySpan<Vector4d> value)
+        public static unsafe void ProgramUniform4d(int program, int location, int count, ReadOnlySpan<Vector4d> value)
         {
             fixed (Vector4d* tmp_vecPtr = value)
             {
@@ -10702,7 +10702,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform4dv"/>
-        public static unsafe void ProgramUniform4d(ProgramHandle program, int location, int count, Vector4d[] value)
+        public static unsafe void ProgramUniform4d(int program, int location, int count, Vector4d[] value)
         {
             fixed (Vector4d* tmp_vecPtr = value)
             {
@@ -10711,7 +10711,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform4uiv"/>
-        public static unsafe void ProgramUniform4ui(ProgramHandle program, int location, ReadOnlySpan<uint> value)
+        public static unsafe void ProgramUniform4ui(int program, int location, ReadOnlySpan<uint> value)
         {
             int count = (int)(value.Length / 4);
             fixed (uint* value_ptr = value)
@@ -10720,7 +10720,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform4uiv"/>
-        public static unsafe void ProgramUniform4ui(ProgramHandle program, int location, uint[] value)
+        public static unsafe void ProgramUniform4ui(int program, int location, uint[] value)
         {
             int count = (int)(value.Length / 4);
             fixed (uint* value_ptr = value)
@@ -10729,7 +10729,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniform4uiv"/>
-        public static unsafe void ProgramUniform4ui(ProgramHandle program, int location, int count, in uint value)
+        public static unsafe void ProgramUniform4ui(int program, int location, int count, in uint value)
         {
             fixed (uint* value_ptr = &value)
             {
@@ -10737,7 +10737,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2fv"/>
-        public static unsafe void ProgramUniformMatrix2f(ProgramHandle program, int location, int count, bool transpose, in Matrix2 value)
+        public static unsafe void ProgramUniformMatrix2f(int program, int location, int count, bool transpose, in Matrix2 value)
         {
             fixed (Matrix2* tmp_vecPtr = &value)
             {
@@ -10746,7 +10746,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2fv"/>
-        public static unsafe void ProgramUniformMatrix2f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix2> value)
+        public static unsafe void ProgramUniformMatrix2f(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix2> value)
         {
             fixed (Matrix2* tmp_vecPtr = value)
             {
@@ -10755,7 +10755,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2fv"/>
-        public static unsafe void ProgramUniformMatrix2f(ProgramHandle program, int location, int count, bool transpose, Matrix2[] value)
+        public static unsafe void ProgramUniformMatrix2f(int program, int location, int count, bool transpose, Matrix2[] value)
         {
             fixed (Matrix2* tmp_vecPtr = value)
             {
@@ -10764,7 +10764,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3fv"/>
-        public static unsafe void ProgramUniformMatrix3f(ProgramHandle program, int location, int count, bool transpose, in Matrix3 value)
+        public static unsafe void ProgramUniformMatrix3f(int program, int location, int count, bool transpose, in Matrix3 value)
         {
             fixed (Matrix3* tmp_vecPtr = &value)
             {
@@ -10773,7 +10773,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3fv"/>
-        public static unsafe void ProgramUniformMatrix3f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix3> value)
+        public static unsafe void ProgramUniformMatrix3f(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix3> value)
         {
             fixed (Matrix3* tmp_vecPtr = value)
             {
@@ -10782,7 +10782,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3fv"/>
-        public static unsafe void ProgramUniformMatrix3f(ProgramHandle program, int location, int count, bool transpose, Matrix3[] value)
+        public static unsafe void ProgramUniformMatrix3f(int program, int location, int count, bool transpose, Matrix3[] value)
         {
             fixed (Matrix3* tmp_vecPtr = value)
             {
@@ -10791,7 +10791,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
-        public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, int count, bool transpose, in Matrix4 value)
+        public static unsafe void ProgramUniformMatrix4f(int program, int location, int count, bool transpose, in Matrix4 value)
         {
             fixed (Matrix4* tmp_vecPtr = &value)
             {
@@ -10800,7 +10800,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
-        public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix4> value)
+        public static unsafe void ProgramUniformMatrix4f(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix4> value)
         {
             fixed (Matrix4* tmp_vecPtr = value)
             {
@@ -10809,7 +10809,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
-        public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, int count, bool transpose, Matrix4[] value)
+        public static unsafe void ProgramUniformMatrix4f(int program, int location, int count, bool transpose, Matrix4[] value)
         {
             fixed (Matrix4* tmp_vecPtr = value)
             {
@@ -10818,7 +10818,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
-        public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, int count, bool transpose, in System.Numerics.Matrix4x4 value)
+        public static unsafe void ProgramUniformMatrix4f(int program, int location, int count, bool transpose, in System.Numerics.Matrix4x4 value)
         {
             fixed (System.Numerics.Matrix4x4* tmp_vecPtr = &value)
             {
@@ -10827,7 +10827,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
-        public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<System.Numerics.Matrix4x4> value)
+        public static unsafe void ProgramUniformMatrix4f(int program, int location, int count, bool transpose, ReadOnlySpan<System.Numerics.Matrix4x4> value)
         {
             fixed (System.Numerics.Matrix4x4* tmp_vecPtr = value)
             {
@@ -10836,7 +10836,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
-        public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, int count, bool transpose, System.Numerics.Matrix4x4[] value)
+        public static unsafe void ProgramUniformMatrix4f(int program, int location, int count, bool transpose, System.Numerics.Matrix4x4[] value)
         {
             fixed (System.Numerics.Matrix4x4* tmp_vecPtr = value)
             {
@@ -10845,7 +10845,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2dv"/>
-        public static unsafe void ProgramUniformMatrix2d(ProgramHandle program, int location, int count, bool transpose, in Matrix2d value)
+        public static unsafe void ProgramUniformMatrix2d(int program, int location, int count, bool transpose, in Matrix2d value)
         {
             fixed (Matrix2d* tmp_vecPtr = &value)
             {
@@ -10854,7 +10854,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2dv"/>
-        public static unsafe void ProgramUniformMatrix2d(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix2d> value)
+        public static unsafe void ProgramUniformMatrix2d(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix2d> value)
         {
             fixed (Matrix2d* tmp_vecPtr = value)
             {
@@ -10863,7 +10863,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2dv"/>
-        public static unsafe void ProgramUniformMatrix2d(ProgramHandle program, int location, int count, bool transpose, Matrix2d[] value)
+        public static unsafe void ProgramUniformMatrix2d(int program, int location, int count, bool transpose, Matrix2d[] value)
         {
             fixed (Matrix2d* tmp_vecPtr = value)
             {
@@ -10872,7 +10872,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3dv"/>
-        public static unsafe void ProgramUniformMatrix3d(ProgramHandle program, int location, int count, bool transpose, in Matrix3d value)
+        public static unsafe void ProgramUniformMatrix3d(int program, int location, int count, bool transpose, in Matrix3d value)
         {
             fixed (Matrix3d* tmp_vecPtr = &value)
             {
@@ -10881,7 +10881,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3dv"/>
-        public static unsafe void ProgramUniformMatrix3d(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix3d> value)
+        public static unsafe void ProgramUniformMatrix3d(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix3d> value)
         {
             fixed (Matrix3d* tmp_vecPtr = value)
             {
@@ -10890,7 +10890,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3dv"/>
-        public static unsafe void ProgramUniformMatrix3d(ProgramHandle program, int location, int count, bool transpose, Matrix3d[] value)
+        public static unsafe void ProgramUniformMatrix3d(int program, int location, int count, bool transpose, Matrix3d[] value)
         {
             fixed (Matrix3d* tmp_vecPtr = value)
             {
@@ -10899,7 +10899,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4dv"/>
-        public static unsafe void ProgramUniformMatrix4d(ProgramHandle program, int location, int count, bool transpose, in Matrix4d value)
+        public static unsafe void ProgramUniformMatrix4d(int program, int location, int count, bool transpose, in Matrix4d value)
         {
             fixed (Matrix4d* tmp_vecPtr = &value)
             {
@@ -10908,7 +10908,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4dv"/>
-        public static unsafe void ProgramUniformMatrix4d(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix4d> value)
+        public static unsafe void ProgramUniformMatrix4d(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix4d> value)
         {
             fixed (Matrix4d* tmp_vecPtr = value)
             {
@@ -10917,7 +10917,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4dv"/>
-        public static unsafe void ProgramUniformMatrix4d(ProgramHandle program, int location, int count, bool transpose, Matrix4d[] value)
+        public static unsafe void ProgramUniformMatrix4d(int program, int location, int count, bool transpose, Matrix4d[] value)
         {
             fixed (Matrix4d* tmp_vecPtr = value)
             {
@@ -10926,7 +10926,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x3fv"/>
-        public static unsafe void ProgramUniformMatrix2x3f(ProgramHandle program, int location, int count, bool transpose, in Matrix2x3 value)
+        public static unsafe void ProgramUniformMatrix2x3f(int program, int location, int count, bool transpose, in Matrix2x3 value)
         {
             fixed (Matrix2x3* tmp_vecPtr = &value)
             {
@@ -10935,7 +10935,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x3fv"/>
-        public static unsafe void ProgramUniformMatrix2x3f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix2x3> value)
+        public static unsafe void ProgramUniformMatrix2x3f(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix2x3> value)
         {
             fixed (Matrix2x3* tmp_vecPtr = value)
             {
@@ -10944,7 +10944,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x3fv"/>
-        public static unsafe void ProgramUniformMatrix2x3f(ProgramHandle program, int location, int count, bool transpose, Matrix2x3[] value)
+        public static unsafe void ProgramUniformMatrix2x3f(int program, int location, int count, bool transpose, Matrix2x3[] value)
         {
             fixed (Matrix2x3* tmp_vecPtr = value)
             {
@@ -10953,7 +10953,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
-        public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, int count, bool transpose, in Matrix3x2 value)
+        public static unsafe void ProgramUniformMatrix3x2f(int program, int location, int count, bool transpose, in Matrix3x2 value)
         {
             fixed (Matrix3x2* tmp_vecPtr = &value)
             {
@@ -10962,7 +10962,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
-        public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix3x2> value)
+        public static unsafe void ProgramUniformMatrix3x2f(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix3x2> value)
         {
             fixed (Matrix3x2* tmp_vecPtr = value)
             {
@@ -10971,7 +10971,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
-        public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, int count, bool transpose, Matrix3x2[] value)
+        public static unsafe void ProgramUniformMatrix3x2f(int program, int location, int count, bool transpose, Matrix3x2[] value)
         {
             fixed (Matrix3x2* tmp_vecPtr = value)
             {
@@ -10980,7 +10980,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
-        public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, int count, bool transpose, in System.Numerics.Matrix3x2 value)
+        public static unsafe void ProgramUniformMatrix3x2f(int program, int location, int count, bool transpose, in System.Numerics.Matrix3x2 value)
         {
             fixed (System.Numerics.Matrix3x2* tmp_vecPtr = &value)
             {
@@ -10989,7 +10989,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
-        public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<System.Numerics.Matrix3x2> value)
+        public static unsafe void ProgramUniformMatrix3x2f(int program, int location, int count, bool transpose, ReadOnlySpan<System.Numerics.Matrix3x2> value)
         {
             fixed (System.Numerics.Matrix3x2* tmp_vecPtr = value)
             {
@@ -10998,7 +10998,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
-        public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, int count, bool transpose, System.Numerics.Matrix3x2[] value)
+        public static unsafe void ProgramUniformMatrix3x2f(int program, int location, int count, bool transpose, System.Numerics.Matrix3x2[] value)
         {
             fixed (System.Numerics.Matrix3x2* tmp_vecPtr = value)
             {
@@ -11007,7 +11007,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x4fv"/>
-        public static unsafe void ProgramUniformMatrix2x4f(ProgramHandle program, int location, int count, bool transpose, in Matrix2x4 value)
+        public static unsafe void ProgramUniformMatrix2x4f(int program, int location, int count, bool transpose, in Matrix2x4 value)
         {
             fixed (Matrix2x4* tmp_vecPtr = &value)
             {
@@ -11016,7 +11016,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x4fv"/>
-        public static unsafe void ProgramUniformMatrix2x4f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix2x4> value)
+        public static unsafe void ProgramUniformMatrix2x4f(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix2x4> value)
         {
             fixed (Matrix2x4* tmp_vecPtr = value)
             {
@@ -11025,7 +11025,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x4fv"/>
-        public static unsafe void ProgramUniformMatrix2x4f(ProgramHandle program, int location, int count, bool transpose, Matrix2x4[] value)
+        public static unsafe void ProgramUniformMatrix2x4f(int program, int location, int count, bool transpose, Matrix2x4[] value)
         {
             fixed (Matrix2x4* tmp_vecPtr = value)
             {
@@ -11034,7 +11034,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x2fv"/>
-        public static unsafe void ProgramUniformMatrix4x2f(ProgramHandle program, int location, int count, bool transpose, in Matrix4x2 value)
+        public static unsafe void ProgramUniformMatrix4x2f(int program, int location, int count, bool transpose, in Matrix4x2 value)
         {
             fixed (Matrix4x2* tmp_vecPtr = &value)
             {
@@ -11043,7 +11043,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x2fv"/>
-        public static unsafe void ProgramUniformMatrix4x2f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix4x2> value)
+        public static unsafe void ProgramUniformMatrix4x2f(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix4x2> value)
         {
             fixed (Matrix4x2* tmp_vecPtr = value)
             {
@@ -11052,7 +11052,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x2fv"/>
-        public static unsafe void ProgramUniformMatrix4x2f(ProgramHandle program, int location, int count, bool transpose, Matrix4x2[] value)
+        public static unsafe void ProgramUniformMatrix4x2f(int program, int location, int count, bool transpose, Matrix4x2[] value)
         {
             fixed (Matrix4x2* tmp_vecPtr = value)
             {
@@ -11061,7 +11061,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x4fv"/>
-        public static unsafe void ProgramUniformMatrix3x4f(ProgramHandle program, int location, int count, bool transpose, in Matrix3x4 value)
+        public static unsafe void ProgramUniformMatrix3x4f(int program, int location, int count, bool transpose, in Matrix3x4 value)
         {
             fixed (Matrix3x4* tmp_vecPtr = &value)
             {
@@ -11070,7 +11070,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x4fv"/>
-        public static unsafe void ProgramUniformMatrix3x4f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix3x4> value)
+        public static unsafe void ProgramUniformMatrix3x4f(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix3x4> value)
         {
             fixed (Matrix3x4* tmp_vecPtr = value)
             {
@@ -11079,7 +11079,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x4fv"/>
-        public static unsafe void ProgramUniformMatrix3x4f(ProgramHandle program, int location, int count, bool transpose, Matrix3x4[] value)
+        public static unsafe void ProgramUniformMatrix3x4f(int program, int location, int count, bool transpose, Matrix3x4[] value)
         {
             fixed (Matrix3x4* tmp_vecPtr = value)
             {
@@ -11088,7 +11088,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x3fv"/>
-        public static unsafe void ProgramUniformMatrix4x3f(ProgramHandle program, int location, int count, bool transpose, in Matrix4x3 value)
+        public static unsafe void ProgramUniformMatrix4x3f(int program, int location, int count, bool transpose, in Matrix4x3 value)
         {
             fixed (Matrix4x3* tmp_vecPtr = &value)
             {
@@ -11097,7 +11097,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x3fv"/>
-        public static unsafe void ProgramUniformMatrix4x3f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix4x3> value)
+        public static unsafe void ProgramUniformMatrix4x3f(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix4x3> value)
         {
             fixed (Matrix4x3* tmp_vecPtr = value)
             {
@@ -11106,7 +11106,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x3fv"/>
-        public static unsafe void ProgramUniformMatrix4x3f(ProgramHandle program, int location, int count, bool transpose, Matrix4x3[] value)
+        public static unsafe void ProgramUniformMatrix4x3f(int program, int location, int count, bool transpose, Matrix4x3[] value)
         {
             fixed (Matrix4x3* tmp_vecPtr = value)
             {
@@ -11115,7 +11115,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x3dv"/>
-        public static unsafe void ProgramUniformMatrix2x3d(ProgramHandle program, int location, int count, bool transpose, in Matrix2x3d value)
+        public static unsafe void ProgramUniformMatrix2x3d(int program, int location, int count, bool transpose, in Matrix2x3d value)
         {
             fixed (Matrix2x3d* tmp_vecPtr = &value)
             {
@@ -11124,7 +11124,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x3dv"/>
-        public static unsafe void ProgramUniformMatrix2x3d(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix2x3d> value)
+        public static unsafe void ProgramUniformMatrix2x3d(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix2x3d> value)
         {
             fixed (Matrix2x3d* tmp_vecPtr = value)
             {
@@ -11133,7 +11133,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x3dv"/>
-        public static unsafe void ProgramUniformMatrix2x3d(ProgramHandle program, int location, int count, bool transpose, Matrix2x3d[] value)
+        public static unsafe void ProgramUniformMatrix2x3d(int program, int location, int count, bool transpose, Matrix2x3d[] value)
         {
             fixed (Matrix2x3d* tmp_vecPtr = value)
             {
@@ -11142,7 +11142,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x2dv"/>
-        public static unsafe void ProgramUniformMatrix3x2d(ProgramHandle program, int location, int count, bool transpose, in Matrix3x2d value)
+        public static unsafe void ProgramUniformMatrix3x2d(int program, int location, int count, bool transpose, in Matrix3x2d value)
         {
             fixed (Matrix3x2d* tmp_vecPtr = &value)
             {
@@ -11151,7 +11151,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x2dv"/>
-        public static unsafe void ProgramUniformMatrix3x2d(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix3x2d> value)
+        public static unsafe void ProgramUniformMatrix3x2d(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix3x2d> value)
         {
             fixed (Matrix3x2d* tmp_vecPtr = value)
             {
@@ -11160,7 +11160,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x2dv"/>
-        public static unsafe void ProgramUniformMatrix3x2d(ProgramHandle program, int location, int count, bool transpose, Matrix3x2d[] value)
+        public static unsafe void ProgramUniformMatrix3x2d(int program, int location, int count, bool transpose, Matrix3x2d[] value)
         {
             fixed (Matrix3x2d* tmp_vecPtr = value)
             {
@@ -11169,7 +11169,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x4dv"/>
-        public static unsafe void ProgramUniformMatrix2x4d(ProgramHandle program, int location, int count, bool transpose, in Matrix2x4d value)
+        public static unsafe void ProgramUniformMatrix2x4d(int program, int location, int count, bool transpose, in Matrix2x4d value)
         {
             fixed (Matrix2x4d* tmp_vecPtr = &value)
             {
@@ -11178,7 +11178,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x4dv"/>
-        public static unsafe void ProgramUniformMatrix2x4d(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix2x4d> value)
+        public static unsafe void ProgramUniformMatrix2x4d(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix2x4d> value)
         {
             fixed (Matrix2x4d* tmp_vecPtr = value)
             {
@@ -11187,7 +11187,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x4dv"/>
-        public static unsafe void ProgramUniformMatrix2x4d(ProgramHandle program, int location, int count, bool transpose, Matrix2x4d[] value)
+        public static unsafe void ProgramUniformMatrix2x4d(int program, int location, int count, bool transpose, Matrix2x4d[] value)
         {
             fixed (Matrix2x4d* tmp_vecPtr = value)
             {
@@ -11196,7 +11196,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x2dv"/>
-        public static unsafe void ProgramUniformMatrix4x2d(ProgramHandle program, int location, int count, bool transpose, in Matrix4x2d value)
+        public static unsafe void ProgramUniformMatrix4x2d(int program, int location, int count, bool transpose, in Matrix4x2d value)
         {
             fixed (Matrix4x2d* tmp_vecPtr = &value)
             {
@@ -11205,7 +11205,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x2dv"/>
-        public static unsafe void ProgramUniformMatrix4x2d(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix4x2d> value)
+        public static unsafe void ProgramUniformMatrix4x2d(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix4x2d> value)
         {
             fixed (Matrix4x2d* tmp_vecPtr = value)
             {
@@ -11214,7 +11214,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x2dv"/>
-        public static unsafe void ProgramUniformMatrix4x2d(ProgramHandle program, int location, int count, bool transpose, Matrix4x2d[] value)
+        public static unsafe void ProgramUniformMatrix4x2d(int program, int location, int count, bool transpose, Matrix4x2d[] value)
         {
             fixed (Matrix4x2d* tmp_vecPtr = value)
             {
@@ -11223,7 +11223,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x4dv"/>
-        public static unsafe void ProgramUniformMatrix3x4d(ProgramHandle program, int location, int count, bool transpose, in Matrix3x4d value)
+        public static unsafe void ProgramUniformMatrix3x4d(int program, int location, int count, bool transpose, in Matrix3x4d value)
         {
             fixed (Matrix3x4d* tmp_vecPtr = &value)
             {
@@ -11232,7 +11232,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x4dv"/>
-        public static unsafe void ProgramUniformMatrix3x4d(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix3x4d> value)
+        public static unsafe void ProgramUniformMatrix3x4d(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix3x4d> value)
         {
             fixed (Matrix3x4d* tmp_vecPtr = value)
             {
@@ -11241,7 +11241,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x4dv"/>
-        public static unsafe void ProgramUniformMatrix3x4d(ProgramHandle program, int location, int count, bool transpose, Matrix3x4d[] value)
+        public static unsafe void ProgramUniformMatrix3x4d(int program, int location, int count, bool transpose, Matrix3x4d[] value)
         {
             fixed (Matrix3x4d* tmp_vecPtr = value)
             {
@@ -11250,7 +11250,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x3dv"/>
-        public static unsafe void ProgramUniformMatrix4x3d(ProgramHandle program, int location, int count, bool transpose, in Matrix4x3d value)
+        public static unsafe void ProgramUniformMatrix4x3d(int program, int location, int count, bool transpose, in Matrix4x3d value)
         {
             fixed (Matrix4x3d* tmp_vecPtr = &value)
             {
@@ -11259,7 +11259,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x3dv"/>
-        public static unsafe void ProgramUniformMatrix4x3d(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix4x3d> value)
+        public static unsafe void ProgramUniformMatrix4x3d(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix4x3d> value)
         {
             fixed (Matrix4x3d* tmp_vecPtr = value)
             {
@@ -11268,7 +11268,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x3dv"/>
-        public static unsafe void ProgramUniformMatrix4x3d(ProgramHandle program, int location, int count, bool transpose, Matrix4x3d[] value)
+        public static unsafe void ProgramUniformMatrix4x3d(int program, int location, int count, bool transpose, Matrix4x3d[] value)
         {
             fixed (Matrix4x3d* tmp_vecPtr = value)
             {
@@ -11277,7 +11277,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetProgramPipelineInfoLog"/>
-        public static unsafe string GetProgramPipelineInfoLog(ProgramPipelineHandle pipeline, int bufSize, Span<int> length)
+        public static unsafe string GetProgramPipelineInfoLog(int pipeline, int bufSize, Span<int> length)
         {
             string infoLog;
             fixed (int* length_ptr = length)
@@ -11290,7 +11290,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             return infoLog;
         }
         /// <inheritdoc cref="GetProgramPipelineInfoLog"/>
-        public static unsafe void GetProgramPipelineInfoLog(ProgramPipelineHandle pipeline, int bufSize, Span<int> length, out string infoLog)
+        public static unsafe void GetProgramPipelineInfoLog(int pipeline, int bufSize, Span<int> length, out string infoLog)
         {
             fixed (int* length_ptr = length)
             {
@@ -11301,7 +11301,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetProgramPipelineInfoLog"/>
-        public static unsafe string GetProgramPipelineInfoLog(ProgramPipelineHandle pipeline, int bufSize, int[] length)
+        public static unsafe string GetProgramPipelineInfoLog(int pipeline, int bufSize, int[] length)
         {
             string infoLog;
             fixed (int* length_ptr = length)
@@ -11314,7 +11314,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             return infoLog;
         }
         /// <inheritdoc cref="GetProgramPipelineInfoLog"/>
-        public static unsafe void GetProgramPipelineInfoLog(ProgramPipelineHandle pipeline, int bufSize, int[] length, out string infoLog)
+        public static unsafe void GetProgramPipelineInfoLog(int pipeline, int bufSize, int[] length, out string infoLog)
         {
             fixed (int* length_ptr = length)
             {
@@ -11325,7 +11325,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetProgramPipelineInfoLog"/>
-        public static unsafe string GetProgramPipelineInfoLog(ProgramPipelineHandle pipeline, int bufSize, ref int length)
+        public static unsafe string GetProgramPipelineInfoLog(int pipeline, int bufSize, ref int length)
         {
             string infoLog;
             fixed (int* length_ptr = &length)
@@ -11338,7 +11338,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             return infoLog;
         }
         /// <inheritdoc cref="GetProgramPipelineInfoLog"/>
-        public static unsafe void GetProgramPipelineInfoLog(ProgramPipelineHandle pipeline, int bufSize, ref int length, out string infoLog)
+        public static unsafe void GetProgramPipelineInfoLog(int pipeline, int bufSize, ref int length, out string infoLog)
         {
             fixed (int* length_ptr = &length)
             {
@@ -11621,7 +11621,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetActiveAtomicCounterBufferiv"/>
-        public static unsafe void GetActiveAtomicCounterBufferi(ProgramHandle program, uint bufferIndex, AtomicCounterBufferPName pname, Span<int> parameters)
+        public static unsafe void GetActiveAtomicCounterBufferi(int program, uint bufferIndex, AtomicCounterBufferPName pname, Span<int> parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
@@ -11629,7 +11629,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetActiveAtomicCounterBufferiv"/>
-        public static unsafe void GetActiveAtomicCounterBufferi(ProgramHandle program, uint bufferIndex, AtomicCounterBufferPName pname, int[] parameters)
+        public static unsafe void GetActiveAtomicCounterBufferi(int program, uint bufferIndex, AtomicCounterBufferPName pname, int[] parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
@@ -11637,7 +11637,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetActiveAtomicCounterBufferiv"/>
-        public static unsafe void GetActiveAtomicCounterBufferi(ProgramHandle program, uint bufferIndex, AtomicCounterBufferPName pname, ref int parameters)
+        public static unsafe void GetActiveAtomicCounterBufferi(int program, uint bufferIndex, AtomicCounterBufferPName pname, ref int parameters)
         {
             fixed (int* parameters_ptr = &parameters)
             {
@@ -11879,7 +11879,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetProgramInterfaceiv"/>
-        public static unsafe void GetProgramInterfacei(ProgramHandle program, ProgramInterface programInterface, ProgramInterfacePName pname, Span<int> parameters)
+        public static unsafe void GetProgramInterfacei(int program, ProgramInterface programInterface, ProgramInterfacePName pname, Span<int> parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
@@ -11887,7 +11887,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetProgramInterfaceiv"/>
-        public static unsafe void GetProgramInterfacei(ProgramHandle program, ProgramInterface programInterface, ProgramInterfacePName pname, int[] parameters)
+        public static unsafe void GetProgramInterfacei(int program, ProgramInterface programInterface, ProgramInterfacePName pname, int[] parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
@@ -11895,7 +11895,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetProgramInterfaceiv"/>
-        public static unsafe void GetProgramInterfacei(ProgramHandle program, ProgramInterface programInterface, ProgramInterfacePName pname, ref int parameters)
+        public static unsafe void GetProgramInterfacei(int program, ProgramInterface programInterface, ProgramInterfacePName pname, ref int parameters)
         {
             fixed (int* parameters_ptr = &parameters)
             {
@@ -11903,7 +11903,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetProgramResourceIndex"/>
-        public static unsafe uint GetProgramResourceIndex(ProgramHandle program, ProgramInterface programInterface, string name)
+        public static unsafe uint GetProgramResourceIndex(int program, ProgramInterface programInterface, string name)
         {
             uint returnValue;
             byte* name_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(name);
@@ -11912,7 +11912,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             return returnValue;
         }
         /// <inheritdoc cref="GetProgramResourceName"/>
-        public static unsafe string GetProgramResourceName(ProgramHandle program, ProgramInterface programInterface, uint index, int bufSize, Span<int> length)
+        public static unsafe string GetProgramResourceName(int program, ProgramInterface programInterface, uint index, int bufSize, Span<int> length)
         {
             string name;
             fixed (int* length_ptr = length)
@@ -11925,7 +11925,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             return name;
         }
         /// <inheritdoc cref="GetProgramResourceName"/>
-        public static unsafe void GetProgramResourceName(ProgramHandle program, ProgramInterface programInterface, uint index, int bufSize, Span<int> length, out string name)
+        public static unsafe void GetProgramResourceName(int program, ProgramInterface programInterface, uint index, int bufSize, Span<int> length, out string name)
         {
             fixed (int* length_ptr = length)
             {
@@ -11936,7 +11936,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetProgramResourceName"/>
-        public static unsafe string GetProgramResourceName(ProgramHandle program, ProgramInterface programInterface, uint index, int bufSize, int[] length)
+        public static unsafe string GetProgramResourceName(int program, ProgramInterface programInterface, uint index, int bufSize, int[] length)
         {
             string name;
             fixed (int* length_ptr = length)
@@ -11949,7 +11949,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             return name;
         }
         /// <inheritdoc cref="GetProgramResourceName"/>
-        public static unsafe void GetProgramResourceName(ProgramHandle program, ProgramInterface programInterface, uint index, int bufSize, int[] length, out string name)
+        public static unsafe void GetProgramResourceName(int program, ProgramInterface programInterface, uint index, int bufSize, int[] length, out string name)
         {
             fixed (int* length_ptr = length)
             {
@@ -11960,7 +11960,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetProgramResourceName"/>
-        public static unsafe string GetProgramResourceName(ProgramHandle program, ProgramInterface programInterface, uint index, int bufSize, ref int length)
+        public static unsafe string GetProgramResourceName(int program, ProgramInterface programInterface, uint index, int bufSize, ref int length)
         {
             string name;
             fixed (int* length_ptr = &length)
@@ -11973,7 +11973,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             return name;
         }
         /// <inheritdoc cref="GetProgramResourceName"/>
-        public static unsafe void GetProgramResourceName(ProgramHandle program, ProgramInterface programInterface, uint index, int bufSize, ref int length, out string name)
+        public static unsafe void GetProgramResourceName(int program, ProgramInterface programInterface, uint index, int bufSize, ref int length, out string name)
         {
             fixed (int* length_ptr = &length)
             {
@@ -11984,7 +11984,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetProgramResourceiv"/>
-        public static unsafe void GetProgramResourcei(ProgramHandle program, ProgramInterface programInterface, uint index, ReadOnlySpan<ProgramResourceProperty> props, Span<int> length, Span<int> parameters)
+        public static unsafe void GetProgramResourcei(int program, ProgramInterface programInterface, uint index, ReadOnlySpan<ProgramResourceProperty> props, Span<int> length, Span<int> parameters)
         {
             int propCount = (int)(props.Length);
             fixed (ProgramResourceProperty* props_ptr = props)
@@ -12000,7 +12000,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetProgramResourceiv"/>
-        public static unsafe void GetProgramResourcei(ProgramHandle program, ProgramInterface programInterface, uint index, ProgramResourceProperty[] props, int[] length, int[] parameters)
+        public static unsafe void GetProgramResourcei(int program, ProgramInterface programInterface, uint index, ProgramResourceProperty[] props, int[] length, int[] parameters)
         {
             int propCount = (int)(props.Length);
             fixed (ProgramResourceProperty* props_ptr = props)
@@ -12016,7 +12016,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetProgramResourceiv"/>
-        public static unsafe void GetProgramResourcei(ProgramHandle program, ProgramInterface programInterface, uint index, int propCount, in ProgramResourceProperty props, int count, ref int length, ref int parameters)
+        public static unsafe void GetProgramResourcei(int program, ProgramInterface programInterface, uint index, int propCount, in ProgramResourceProperty props, int count, ref int length, ref int parameters)
         {
             fixed (ProgramResourceProperty* props_ptr = &props)
             fixed (int* length_ptr = &length)
@@ -12026,7 +12026,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetProgramResourceLocation"/>
-        public static unsafe int GetProgramResourceLocation(ProgramHandle program, ProgramInterface programInterface, string name)
+        public static unsafe int GetProgramResourceLocation(int program, ProgramInterface programInterface, string name)
         {
             int returnValue;
             byte* name_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(name);
@@ -12035,7 +12035,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             return returnValue;
         }
         /// <inheritdoc cref="GetProgramResourceLocationIndex"/>
-        public static unsafe int GetProgramResourceLocationIndex(ProgramHandle program, ProgramInterface programInterface, string name)
+        public static unsafe int GetProgramResourceLocationIndex(int program, ProgramInterface programInterface, string name)
         {
             int returnValue;
             byte* name_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(name);
@@ -12471,13 +12471,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ClearTexImage"/>
-        public static unsafe void ClearTexImage(TextureHandle texture, int level, PixelFormat format, PixelType type, IntPtr data)
+        public static unsafe void ClearTexImage(int texture, int level, PixelFormat format, PixelType type, IntPtr data)
         {
             void* data_vptr = (void*)data;
             ClearTexImage(texture, level, format, type, data_vptr);
         }
         /// <inheritdoc cref="ClearTexImage"/>
-        public static unsafe void ClearTexImage<T1>(TextureHandle texture, int level, PixelFormat format, PixelType type, ReadOnlySpan<T1> data)
+        public static unsafe void ClearTexImage<T1>(int texture, int level, PixelFormat format, PixelType type, ReadOnlySpan<T1> data)
             where T1 : unmanaged
         {
             fixed (void* data_ptr = data)
@@ -12486,7 +12486,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ClearTexImage"/>
-        public static unsafe void ClearTexImage<T1>(TextureHandle texture, int level, PixelFormat format, PixelType type, T1[] data)
+        public static unsafe void ClearTexImage<T1>(int texture, int level, PixelFormat format, PixelType type, T1[] data)
             where T1 : unmanaged
         {
             fixed (void* data_ptr = data)
@@ -12495,7 +12495,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ClearTexImage"/>
-        public static unsafe void ClearTexImage<T1>(TextureHandle texture, int level, PixelFormat format, PixelType type, in T1 data)
+        public static unsafe void ClearTexImage<T1>(int texture, int level, PixelFormat format, PixelType type, in T1 data)
             where T1 : unmanaged
         {
             fixed (void* data_ptr = &data)
@@ -12504,13 +12504,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ClearTexSubImage"/>
-        public static unsafe void ClearTexSubImage(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, IntPtr data)
+        public static unsafe void ClearTexSubImage(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, IntPtr data)
         {
             void* data_vptr = (void*)data;
             ClearTexSubImage(texture, level, xoffset, yoffset, zoffset, width, height, depth, format, type, data_vptr);
         }
         /// <inheritdoc cref="ClearTexSubImage"/>
-        public static unsafe void ClearTexSubImage<T1>(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, ReadOnlySpan<T1> data)
+        public static unsafe void ClearTexSubImage<T1>(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, ReadOnlySpan<T1> data)
             where T1 : unmanaged
         {
             fixed (void* data_ptr = data)
@@ -12519,7 +12519,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ClearTexSubImage"/>
-        public static unsafe void ClearTexSubImage<T1>(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, T1[] data)
+        public static unsafe void ClearTexSubImage<T1>(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, T1[] data)
             where T1 : unmanaged
         {
             fixed (void* data_ptr = data)
@@ -12528,7 +12528,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ClearTexSubImage"/>
-        public static unsafe void ClearTexSubImage<T1>(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, in T1 data)
+        public static unsafe void ClearTexSubImage<T1>(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, in T1 data)
             where T1 : unmanaged
         {
             fixed (void* data_ptr = &data)
@@ -12537,35 +12537,35 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="BindBuffersBase"/>
-        public static unsafe void BindBuffersBase(BufferTargetARB target, uint first, ReadOnlySpan<BufferHandle> buffers)
+        public static unsafe void BindBuffersBase(BufferTargetARB target, uint first, ReadOnlySpan<int> buffers)
         {
             int count = (int)(buffers.Length);
-            fixed (BufferHandle* buffers_ptr = buffers)
+            fixed (int* buffers_ptr = buffers)
             {
                 BindBuffersBase(target, first, count, buffers_ptr);
             }
         }
         /// <inheritdoc cref="BindBuffersBase"/>
-        public static unsafe void BindBuffersBase(BufferTargetARB target, uint first, BufferHandle[] buffers)
+        public static unsafe void BindBuffersBase(BufferTargetARB target, uint first, int[] buffers)
         {
             int count = (int)(buffers.Length);
-            fixed (BufferHandle* buffers_ptr = buffers)
+            fixed (int* buffers_ptr = buffers)
             {
                 BindBuffersBase(target, first, count, buffers_ptr);
             }
         }
         /// <inheritdoc cref="BindBuffersBase"/>
-        public static unsafe void BindBuffersBase(BufferTargetARB target, uint first, int count, in BufferHandle buffers)
+        public static unsafe void BindBuffersBase(BufferTargetARB target, uint first, int count, in int buffers)
         {
-            fixed (BufferHandle* buffers_ptr = &buffers)
+            fixed (int* buffers_ptr = &buffers)
             {
                 BindBuffersBase(target, first, count, buffers_ptr);
             }
         }
         /// <inheritdoc cref="BindBuffersRange"/>
-        public static unsafe void BindBuffersRange(BufferTargetARB target, uint first, int count, ReadOnlySpan<BufferHandle> buffers, ReadOnlySpan<IntPtr> offsets, ReadOnlySpan<nint> sizes)
+        public static unsafe void BindBuffersRange(BufferTargetARB target, uint first, int count, ReadOnlySpan<int> buffers, ReadOnlySpan<IntPtr> offsets, ReadOnlySpan<nint> sizes)
         {
-            fixed (BufferHandle* buffers_ptr = buffers)
+            fixed (int* buffers_ptr = buffers)
             {
                 fixed (IntPtr* offsets_ptr = offsets)
                 {
@@ -12577,9 +12577,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="BindBuffersRange"/>
-        public static unsafe void BindBuffersRange(BufferTargetARB target, uint first, int count, BufferHandle[] buffers, IntPtr[] offsets, nint[] sizes)
+        public static unsafe void BindBuffersRange(BufferTargetARB target, uint first, int count, int[] buffers, IntPtr[] offsets, nint[] sizes)
         {
-            fixed (BufferHandle* buffers_ptr = buffers)
+            fixed (int* buffers_ptr = buffers)
             {
                 fixed (IntPtr* offsets_ptr = offsets)
                 {
@@ -12591,9 +12591,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="BindBuffersRange"/>
-        public static unsafe void BindBuffersRange(BufferTargetARB target, uint first, int count, in BufferHandle buffers, in IntPtr offsets, in nint sizes)
+        public static unsafe void BindBuffersRange(BufferTargetARB target, uint first, int count, in int buffers, in IntPtr offsets, in nint sizes)
         {
-            fixed (BufferHandle* buffers_ptr = &buffers)
+            fixed (int* buffers_ptr = &buffers)
             fixed (IntPtr* offsets_ptr = &offsets)
             fixed (nint* sizes_ptr = &sizes)
             {
@@ -12601,87 +12601,87 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="BindTextures"/>
-        public static unsafe void BindTextures(uint first, ReadOnlySpan<TextureHandle> textures)
+        public static unsafe void BindTextures(uint first, ReadOnlySpan<int> textures)
         {
             int count = (int)(textures.Length);
-            fixed (TextureHandle* textures_ptr = textures)
+            fixed (int* textures_ptr = textures)
             {
                 BindTextures(first, count, textures_ptr);
             }
         }
         /// <inheritdoc cref="BindTextures"/>
-        public static unsafe void BindTextures(uint first, TextureHandle[] textures)
+        public static unsafe void BindTextures(uint first, int[] textures)
         {
             int count = (int)(textures.Length);
-            fixed (TextureHandle* textures_ptr = textures)
+            fixed (int* textures_ptr = textures)
             {
                 BindTextures(first, count, textures_ptr);
             }
         }
         /// <inheritdoc cref="BindTextures"/>
-        public static unsafe void BindTextures(uint first, int count, in TextureHandle textures)
+        public static unsafe void BindTextures(uint first, int count, in int textures)
         {
-            fixed (TextureHandle* textures_ptr = &textures)
+            fixed (int* textures_ptr = &textures)
             {
                 BindTextures(first, count, textures_ptr);
             }
         }
         /// <inheritdoc cref="BindSamplers"/>
-        public static unsafe void BindSamplers(uint first, ReadOnlySpan<SamplerHandle> samplers)
+        public static unsafe void BindSamplers(uint first, ReadOnlySpan<int> samplers)
         {
             int count = (int)(samplers.Length);
-            fixed (SamplerHandle* samplers_ptr = samplers)
+            fixed (int* samplers_ptr = samplers)
             {
                 BindSamplers(first, count, samplers_ptr);
             }
         }
         /// <inheritdoc cref="BindSamplers"/>
-        public static unsafe void BindSamplers(uint first, SamplerHandle[] samplers)
+        public static unsafe void BindSamplers(uint first, int[] samplers)
         {
             int count = (int)(samplers.Length);
-            fixed (SamplerHandle* samplers_ptr = samplers)
+            fixed (int* samplers_ptr = samplers)
             {
                 BindSamplers(first, count, samplers_ptr);
             }
         }
         /// <inheritdoc cref="BindSamplers"/>
-        public static unsafe void BindSamplers(uint first, int count, in SamplerHandle samplers)
+        public static unsafe void BindSamplers(uint first, int count, in int samplers)
         {
-            fixed (SamplerHandle* samplers_ptr = &samplers)
+            fixed (int* samplers_ptr = &samplers)
             {
                 BindSamplers(first, count, samplers_ptr);
             }
         }
         /// <inheritdoc cref="BindImageTextures"/>
-        public static unsafe void BindImageTextures(uint first, ReadOnlySpan<TextureHandle> textures)
+        public static unsafe void BindImageTextures(uint first, ReadOnlySpan<int> textures)
         {
             int count = (int)(textures.Length);
-            fixed (TextureHandle* textures_ptr = textures)
+            fixed (int* textures_ptr = textures)
             {
                 BindImageTextures(first, count, textures_ptr);
             }
         }
         /// <inheritdoc cref="BindImageTextures"/>
-        public static unsafe void BindImageTextures(uint first, TextureHandle[] textures)
+        public static unsafe void BindImageTextures(uint first, int[] textures)
         {
             int count = (int)(textures.Length);
-            fixed (TextureHandle* textures_ptr = textures)
+            fixed (int* textures_ptr = textures)
             {
                 BindImageTextures(first, count, textures_ptr);
             }
         }
         /// <inheritdoc cref="BindImageTextures"/>
-        public static unsafe void BindImageTextures(uint first, int count, in TextureHandle textures)
+        public static unsafe void BindImageTextures(uint first, int count, in int textures)
         {
-            fixed (TextureHandle* textures_ptr = &textures)
+            fixed (int* textures_ptr = &textures)
             {
                 BindImageTextures(first, count, textures_ptr);
             }
         }
         /// <inheritdoc cref="BindVertexBuffers"/>
-        public static unsafe void BindVertexBuffers(uint first, int count, ReadOnlySpan<BufferHandle> buffers, ReadOnlySpan<IntPtr> offsets, ReadOnlySpan<int> strides)
+        public static unsafe void BindVertexBuffers(uint first, int count, ReadOnlySpan<int> buffers, ReadOnlySpan<IntPtr> offsets, ReadOnlySpan<int> strides)
         {
-            fixed (BufferHandle* buffers_ptr = buffers)
+            fixed (int* buffers_ptr = buffers)
             {
                 fixed (IntPtr* offsets_ptr = offsets)
                 {
@@ -12693,9 +12693,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="BindVertexBuffers"/>
-        public static unsafe void BindVertexBuffers(uint first, int count, BufferHandle[] buffers, IntPtr[] offsets, int[] strides)
+        public static unsafe void BindVertexBuffers(uint first, int count, int[] buffers, IntPtr[] offsets, int[] strides)
         {
-            fixed (BufferHandle* buffers_ptr = buffers)
+            fixed (int* buffers_ptr = buffers)
             {
                 fixed (IntPtr* offsets_ptr = offsets)
                 {
@@ -12707,9 +12707,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="BindVertexBuffers"/>
-        public static unsafe void BindVertexBuffers(uint first, int count, in BufferHandle buffers, in IntPtr offsets, in int strides)
+        public static unsafe void BindVertexBuffers(uint first, int count, in int buffers, in IntPtr offsets, in int strides)
         {
-            fixed (BufferHandle* buffers_ptr = &buffers)
+            fixed (int* buffers_ptr = &buffers)
             fixed (IntPtr* offsets_ptr = &offsets)
             fixed (int* strides_ptr = &strides)
             {
@@ -12717,9 +12717,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="CreateTransformFeedbacks"/>
-        public static unsafe TransformFeedbackHandle CreateTransformFeedback()
+        public static unsafe int CreateTransformFeedback()
         {
-            TransformFeedbackHandle id;
+            int id;
             int n = 1;
             Unsafe.SkipInit(out id);
             // FIXME: This could be a problem for the overloads that take an out parameter
@@ -12730,12 +12730,12 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            TransformFeedbackHandle* ids_handle = (TransformFeedbackHandle*)Unsafe.AsPointer(ref id);
+            int* ids_handle = (int*)Unsafe.AsPointer(ref id);
             CreateTransformFeedbacks(n, ids_handle);
             return id;
         }
         /// <inheritdoc cref="CreateTransformFeedbacks"/>
-        public static unsafe void CreateTransformFeedback(out TransformFeedbackHandle id)
+        public static unsafe void CreateTransformFeedback(out int id)
         {
             int n = 1;
             Unsafe.SkipInit(out id);
@@ -12747,37 +12747,37 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            TransformFeedbackHandle* ids_handle = (TransformFeedbackHandle*)Unsafe.AsPointer(ref id);
+            int* ids_handle = (int*)Unsafe.AsPointer(ref id);
             CreateTransformFeedbacks(n, ids_handle);
         }
         /// <inheritdoc cref="CreateTransformFeedbacks"/>
-        public static unsafe void CreateTransformFeedbacks(Span<TransformFeedbackHandle> ids)
+        public static unsafe void CreateTransformFeedbacks(Span<int> ids)
         {
             int n = (int)(ids.Length);
-            fixed (TransformFeedbackHandle* ids_ptr = ids)
+            fixed (int* ids_ptr = ids)
             {
                 CreateTransformFeedbacks(n, ids_ptr);
             }
         }
         /// <inheritdoc cref="CreateTransformFeedbacks"/>
-        public static unsafe void CreateTransformFeedbacks(TransformFeedbackHandle[] ids)
+        public static unsafe void CreateTransformFeedbacks(int[] ids)
         {
             int n = (int)(ids.Length);
-            fixed (TransformFeedbackHandle* ids_ptr = ids)
+            fixed (int* ids_ptr = ids)
             {
                 CreateTransformFeedbacks(n, ids_ptr);
             }
         }
         /// <inheritdoc cref="CreateTransformFeedbacks"/>
-        public static unsafe void CreateTransformFeedbacks(int n, ref TransformFeedbackHandle ids)
+        public static unsafe void CreateTransformFeedbacks(int n, ref int ids)
         {
-            fixed (TransformFeedbackHandle* ids_ptr = &ids)
+            fixed (int* ids_ptr = &ids)
             {
                 CreateTransformFeedbacks(n, ids_ptr);
             }
         }
         /// <inheritdoc cref="GetTransformFeedbackiv"/>
-        public static unsafe void GetTransformFeedbacki(TransformFeedbackHandle xfb, TransformFeedbackPName pname, ref int param)
+        public static unsafe void GetTransformFeedbacki(int xfb, TransformFeedbackPName pname, ref int param)
         {
             fixed (int* param_ptr = &param)
             {
@@ -12785,7 +12785,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetTransformFeedbacki_v"/>
-        public static unsafe void GetTransformFeedback(TransformFeedbackHandle xfb, TransformFeedbackPName pname, uint index, ref int param)
+        public static unsafe void GetTransformFeedback(int xfb, TransformFeedbackPName pname, uint index, ref int param)
         {
             fixed (int* param_ptr = &param)
             {
@@ -12793,7 +12793,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetTransformFeedbacki64_v"/>
-        public static unsafe void GetTransformFeedbacki64_(TransformFeedbackHandle xfb, TransformFeedbackPName pname, uint index, ref long param)
+        public static unsafe void GetTransformFeedbacki64_(int xfb, TransformFeedbackPName pname, uint index, ref long param)
         {
             fixed (long* param_ptr = &param)
             {
@@ -12801,9 +12801,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="CreateBuffers"/>
-        public static unsafe BufferHandle CreateBuffer()
+        public static unsafe int CreateBuffer()
         {
-            BufferHandle buffer;
+            int buffer;
             int n = 1;
             Unsafe.SkipInit(out buffer);
             // FIXME: This could be a problem for the overloads that take an out parameter
@@ -12814,12 +12814,12 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            BufferHandle* buffers_handle = (BufferHandle*)Unsafe.AsPointer(ref buffer);
+            int* buffers_handle = (int*)Unsafe.AsPointer(ref buffer);
             CreateBuffers(n, buffers_handle);
             return buffer;
         }
         /// <inheritdoc cref="CreateBuffers"/>
-        public static unsafe void CreateBuffer(out BufferHandle buffer)
+        public static unsafe void CreateBuffer(out int buffer)
         {
             int n = 1;
             Unsafe.SkipInit(out buffer);
@@ -12831,43 +12831,43 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            BufferHandle* buffers_handle = (BufferHandle*)Unsafe.AsPointer(ref buffer);
+            int* buffers_handle = (int*)Unsafe.AsPointer(ref buffer);
             CreateBuffers(n, buffers_handle);
         }
         /// <inheritdoc cref="CreateBuffers"/>
-        public static unsafe void CreateBuffers(Span<BufferHandle> buffers)
+        public static unsafe void CreateBuffers(Span<int> buffers)
         {
             int n = (int)(buffers.Length);
-            fixed (BufferHandle* buffers_ptr = buffers)
+            fixed (int* buffers_ptr = buffers)
             {
                 CreateBuffers(n, buffers_ptr);
             }
         }
         /// <inheritdoc cref="CreateBuffers"/>
-        public static unsafe void CreateBuffers(BufferHandle[] buffers)
+        public static unsafe void CreateBuffers(int[] buffers)
         {
             int n = (int)(buffers.Length);
-            fixed (BufferHandle* buffers_ptr = buffers)
+            fixed (int* buffers_ptr = buffers)
             {
                 CreateBuffers(n, buffers_ptr);
             }
         }
         /// <inheritdoc cref="CreateBuffers"/>
-        public static unsafe void CreateBuffers(int n, ref BufferHandle buffers)
+        public static unsafe void CreateBuffers(int n, ref int buffers)
         {
-            fixed (BufferHandle* buffers_ptr = &buffers)
+            fixed (int* buffers_ptr = &buffers)
             {
                 CreateBuffers(n, buffers_ptr);
             }
         }
         /// <inheritdoc cref="NamedBufferStorage"/>
-        public static unsafe void NamedBufferStorage(BufferHandle buffer, nint size, IntPtr data, BufferStorageMask flags)
+        public static unsafe void NamedBufferStorage(int buffer, nint size, IntPtr data, BufferStorageMask flags)
         {
             void* data_vptr = (void*)data;
             NamedBufferStorage(buffer, size, data_vptr, flags);
         }
         /// <inheritdoc cref="NamedBufferStorage"/>
-        public static unsafe void NamedBufferStorage<T1>(BufferHandle buffer, ReadOnlySpan<T1> data, BufferStorageMask flags)
+        public static unsafe void NamedBufferStorage<T1>(int buffer, ReadOnlySpan<T1> data, BufferStorageMask flags)
             where T1 : unmanaged
         {
             nint size = (nint)(data.Length * sizeof(T1));
@@ -12877,7 +12877,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="NamedBufferStorage"/>
-        public static unsafe void NamedBufferStorage<T1>(BufferHandle buffer, T1[] data, BufferStorageMask flags)
+        public static unsafe void NamedBufferStorage<T1>(int buffer, T1[] data, BufferStorageMask flags)
             where T1 : unmanaged
         {
             nint size = (nint)(data.Length * sizeof(T1));
@@ -12887,7 +12887,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="NamedBufferStorage"/>
-        public static unsafe void NamedBufferStorage<T1>(BufferHandle buffer, nint size, in T1 data, BufferStorageMask flags)
+        public static unsafe void NamedBufferStorage<T1>(int buffer, nint size, in T1 data, BufferStorageMask flags)
             where T1 : unmanaged
         {
             fixed (void* data_ptr = &data)
@@ -12896,13 +12896,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="NamedBufferData"/>
-        public static unsafe void NamedBufferData(BufferHandle buffer, nint size, IntPtr data, VertexBufferObjectUsage usage)
+        public static unsafe void NamedBufferData(int buffer, nint size, IntPtr data, VertexBufferObjectUsage usage)
         {
             void* data_vptr = (void*)data;
             NamedBufferData(buffer, size, data_vptr, usage);
         }
         /// <inheritdoc cref="NamedBufferData"/>
-        public static unsafe void NamedBufferData<T1>(BufferHandle buffer, ReadOnlySpan<T1> data, VertexBufferObjectUsage usage)
+        public static unsafe void NamedBufferData<T1>(int buffer, ReadOnlySpan<T1> data, VertexBufferObjectUsage usage)
             where T1 : unmanaged
         {
             nint size = (nint)(data.Length * sizeof(T1));
@@ -12912,7 +12912,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="NamedBufferData"/>
-        public static unsafe void NamedBufferData<T1>(BufferHandle buffer, T1[] data, VertexBufferObjectUsage usage)
+        public static unsafe void NamedBufferData<T1>(int buffer, T1[] data, VertexBufferObjectUsage usage)
             where T1 : unmanaged
         {
             nint size = (nint)(data.Length * sizeof(T1));
@@ -12922,7 +12922,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="NamedBufferData"/>
-        public static unsafe void NamedBufferData<T1>(BufferHandle buffer, nint size, in T1 data, VertexBufferObjectUsage usage)
+        public static unsafe void NamedBufferData<T1>(int buffer, nint size, in T1 data, VertexBufferObjectUsage usage)
             where T1 : unmanaged
         {
             fixed (void* data_ptr = &data)
@@ -12931,13 +12931,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="NamedBufferSubData"/>
-        public static unsafe void NamedBufferSubData(BufferHandle buffer, IntPtr offset, nint size, IntPtr data)
+        public static unsafe void NamedBufferSubData(int buffer, IntPtr offset, nint size, IntPtr data)
         {
             void* data_vptr = (void*)data;
             NamedBufferSubData(buffer, offset, size, data_vptr);
         }
         /// <inheritdoc cref="NamedBufferSubData"/>
-        public static unsafe void NamedBufferSubData<T1>(BufferHandle buffer, IntPtr offset, ReadOnlySpan<T1> data)
+        public static unsafe void NamedBufferSubData<T1>(int buffer, IntPtr offset, ReadOnlySpan<T1> data)
             where T1 : unmanaged
         {
             nint size = (nint)(data.Length * sizeof(T1));
@@ -12947,7 +12947,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="NamedBufferSubData"/>
-        public static unsafe void NamedBufferSubData<T1>(BufferHandle buffer, IntPtr offset, T1[] data)
+        public static unsafe void NamedBufferSubData<T1>(int buffer, IntPtr offset, T1[] data)
             where T1 : unmanaged
         {
             nint size = (nint)(data.Length * sizeof(T1));
@@ -12957,7 +12957,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="NamedBufferSubData"/>
-        public static unsafe void NamedBufferSubData<T1>(BufferHandle buffer, IntPtr offset, nint size, in T1 data)
+        public static unsafe void NamedBufferSubData<T1>(int buffer, IntPtr offset, nint size, in T1 data)
             where T1 : unmanaged
         {
             fixed (void* data_ptr = &data)
@@ -12966,13 +12966,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ClearNamedBufferData"/>
-        public static unsafe void ClearNamedBufferData(BufferHandle buffer, SizedInternalFormat internalformat, PixelFormat format, PixelType type, IntPtr data)
+        public static unsafe void ClearNamedBufferData(int buffer, SizedInternalFormat internalformat, PixelFormat format, PixelType type, IntPtr data)
         {
             void* data_vptr = (void*)data;
             ClearNamedBufferData(buffer, internalformat, format, type, data_vptr);
         }
         /// <inheritdoc cref="ClearNamedBufferData"/>
-        public static unsafe void ClearNamedBufferData<T1>(BufferHandle buffer, SizedInternalFormat internalformat, PixelFormat format, PixelType type, in T1 data)
+        public static unsafe void ClearNamedBufferData<T1>(int buffer, SizedInternalFormat internalformat, PixelFormat format, PixelType type, in T1 data)
             where T1 : unmanaged
         {
             fixed (void* data_ptr = &data)
@@ -12981,13 +12981,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ClearNamedBufferSubData"/>
-        public static unsafe void ClearNamedBufferSubData(BufferHandle buffer, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, IntPtr data)
+        public static unsafe void ClearNamedBufferSubData(int buffer, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, IntPtr data)
         {
             void* data_vptr = (void*)data;
             ClearNamedBufferSubData(buffer, internalformat, offset, size, format, type, data_vptr);
         }
         /// <inheritdoc cref="ClearNamedBufferSubData"/>
-        public static unsafe void ClearNamedBufferSubData<T1>(BufferHandle buffer, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, ReadOnlySpan<T1> data)
+        public static unsafe void ClearNamedBufferSubData<T1>(int buffer, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, ReadOnlySpan<T1> data)
             where T1 : unmanaged
         {
             fixed (void* data_ptr = data)
@@ -12996,7 +12996,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ClearNamedBufferSubData"/>
-        public static unsafe void ClearNamedBufferSubData<T1>(BufferHandle buffer, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, T1[] data)
+        public static unsafe void ClearNamedBufferSubData<T1>(int buffer, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, T1[] data)
             where T1 : unmanaged
         {
             fixed (void* data_ptr = data)
@@ -13005,7 +13005,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ClearNamedBufferSubData"/>
-        public static unsafe void ClearNamedBufferSubData<T1>(BufferHandle buffer, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, in T1 data)
+        public static unsafe void ClearNamedBufferSubData<T1>(int buffer, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, in T1 data)
             where T1 : unmanaged
         {
             fixed (void* data_ptr = &data)
@@ -13014,7 +13014,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetNamedBufferParameteriv"/>
-        public static unsafe void GetNamedBufferParameteri(BufferHandle buffer, BufferPNameARB pname, ref int parameters)
+        public static unsafe void GetNamedBufferParameteri(int buffer, BufferPNameARB pname, ref int parameters)
         {
             fixed (int* parameters_ptr = &parameters)
             {
@@ -13022,7 +13022,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetNamedBufferParameteri64v"/>
-        public static unsafe void GetNamedBufferParameteri64(BufferHandle buffer, BufferPNameARB pname, ref long parameters)
+        public static unsafe void GetNamedBufferParameteri64(int buffer, BufferPNameARB pname, ref long parameters)
         {
             fixed (long* parameters_ptr = &parameters)
             {
@@ -13030,18 +13030,18 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetNamedBufferPointerv"/>
-        public static unsafe void GetNamedBufferPointer(BufferHandle buffer, BufferPointerNameARB pname, void** parameters)
+        public static unsafe void GetNamedBufferPointer(int buffer, BufferPointerNameARB pname, void** parameters)
         {
             GetNamedBufferPointerv(buffer, pname, parameters);
         }
         /// <inheritdoc cref="GetNamedBufferSubData"/>
-        public static unsafe void GetNamedBufferSubData(BufferHandle buffer, IntPtr offset, nint size, IntPtr data)
+        public static unsafe void GetNamedBufferSubData(int buffer, IntPtr offset, nint size, IntPtr data)
         {
             void* data_vptr = (void*)data;
             GetNamedBufferSubData(buffer, offset, size, data_vptr);
         }
         /// <inheritdoc cref="GetNamedBufferSubData"/>
-        public static unsafe void GetNamedBufferSubData<T1>(BufferHandle buffer, IntPtr offset, nint size, ref T1 data)
+        public static unsafe void GetNamedBufferSubData<T1>(int buffer, IntPtr offset, nint size, ref T1 data)
             where T1 : unmanaged
         {
             fixed (void* data_ptr = &data)
@@ -13050,9 +13050,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="CreateFramebuffers"/>
-        public static unsafe FramebufferHandle CreateFramebuffer()
+        public static unsafe int CreateFramebuffer()
         {
-            FramebufferHandle framebuffer;
+            int framebuffer;
             int n = 1;
             Unsafe.SkipInit(out framebuffer);
             // FIXME: This could be a problem for the overloads that take an out parameter
@@ -13063,12 +13063,12 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            FramebufferHandle* framebuffers_handle = (FramebufferHandle*)Unsafe.AsPointer(ref framebuffer);
+            int* framebuffers_handle = (int*)Unsafe.AsPointer(ref framebuffer);
             CreateFramebuffers(n, framebuffers_handle);
             return framebuffer;
         }
         /// <inheritdoc cref="CreateFramebuffers"/>
-        public static unsafe void CreateFramebuffer(out FramebufferHandle framebuffer)
+        public static unsafe void CreateFramebuffer(out int framebuffer)
         {
             int n = 1;
             Unsafe.SkipInit(out framebuffer);
@@ -13080,37 +13080,37 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            FramebufferHandle* framebuffers_handle = (FramebufferHandle*)Unsafe.AsPointer(ref framebuffer);
+            int* framebuffers_handle = (int*)Unsafe.AsPointer(ref framebuffer);
             CreateFramebuffers(n, framebuffers_handle);
         }
         /// <inheritdoc cref="CreateFramebuffers"/>
-        public static unsafe void CreateFramebuffers(Span<FramebufferHandle> framebuffers)
+        public static unsafe void CreateFramebuffers(Span<int> framebuffers)
         {
             int n = (int)(framebuffers.Length);
-            fixed (FramebufferHandle* framebuffers_ptr = framebuffers)
+            fixed (int* framebuffers_ptr = framebuffers)
             {
                 CreateFramebuffers(n, framebuffers_ptr);
             }
         }
         /// <inheritdoc cref="CreateFramebuffers"/>
-        public static unsafe void CreateFramebuffers(FramebufferHandle[] framebuffers)
+        public static unsafe void CreateFramebuffers(int[] framebuffers)
         {
             int n = (int)(framebuffers.Length);
-            fixed (FramebufferHandle* framebuffers_ptr = framebuffers)
+            fixed (int* framebuffers_ptr = framebuffers)
             {
                 CreateFramebuffers(n, framebuffers_ptr);
             }
         }
         /// <inheritdoc cref="CreateFramebuffers"/>
-        public static unsafe void CreateFramebuffers(int n, ref FramebufferHandle framebuffers)
+        public static unsafe void CreateFramebuffers(int n, ref int framebuffers)
         {
-            fixed (FramebufferHandle* framebuffers_ptr = &framebuffers)
+            fixed (int* framebuffers_ptr = &framebuffers)
             {
                 CreateFramebuffers(n, framebuffers_ptr);
             }
         }
         /// <inheritdoc cref="NamedFramebufferDrawBuffers"/>
-        public static unsafe void NamedFramebufferDrawBuffers(FramebufferHandle framebuffer, ReadOnlySpan<ColorBuffer> bufs)
+        public static unsafe void NamedFramebufferDrawBuffers(int framebuffer, ReadOnlySpan<ColorBuffer> bufs)
         {
             int n = (int)(bufs.Length);
             fixed (ColorBuffer* bufs_ptr = bufs)
@@ -13119,7 +13119,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="NamedFramebufferDrawBuffers"/>
-        public static unsafe void NamedFramebufferDrawBuffers(FramebufferHandle framebuffer, ColorBuffer[] bufs)
+        public static unsafe void NamedFramebufferDrawBuffers(int framebuffer, ColorBuffer[] bufs)
         {
             int n = (int)(bufs.Length);
             fixed (ColorBuffer* bufs_ptr = bufs)
@@ -13128,7 +13128,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="NamedFramebufferDrawBuffers"/>
-        public static unsafe void NamedFramebufferDrawBuffers(FramebufferHandle framebuffer, int n, in ColorBuffer bufs)
+        public static unsafe void NamedFramebufferDrawBuffers(int framebuffer, int n, in ColorBuffer bufs)
         {
             fixed (ColorBuffer* bufs_ptr = &bufs)
             {
@@ -13136,7 +13136,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="InvalidateNamedFramebufferData"/>
-        public static unsafe void InvalidateNamedFramebufferData(FramebufferHandle framebuffer, ReadOnlySpan<FramebufferAttachment> attachments)
+        public static unsafe void InvalidateNamedFramebufferData(int framebuffer, ReadOnlySpan<FramebufferAttachment> attachments)
         {
             int numAttachments = (int)(attachments.Length);
             fixed (FramebufferAttachment* attachments_ptr = attachments)
@@ -13145,7 +13145,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="InvalidateNamedFramebufferData"/>
-        public static unsafe void InvalidateNamedFramebufferData(FramebufferHandle framebuffer, FramebufferAttachment[] attachments)
+        public static unsafe void InvalidateNamedFramebufferData(int framebuffer, FramebufferAttachment[] attachments)
         {
             int numAttachments = (int)(attachments.Length);
             fixed (FramebufferAttachment* attachments_ptr = attachments)
@@ -13154,7 +13154,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="InvalidateNamedFramebufferData"/>
-        public static unsafe void InvalidateNamedFramebufferData(FramebufferHandle framebuffer, int numAttachments, in FramebufferAttachment attachments)
+        public static unsafe void InvalidateNamedFramebufferData(int framebuffer, int numAttachments, in FramebufferAttachment attachments)
         {
             fixed (FramebufferAttachment* attachments_ptr = &attachments)
             {
@@ -13162,7 +13162,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="InvalidateNamedFramebufferSubData"/>
-        public static unsafe void InvalidateNamedFramebufferSubData(FramebufferHandle framebuffer, ReadOnlySpan<FramebufferAttachment> attachments, int x, int y, int width, int height)
+        public static unsafe void InvalidateNamedFramebufferSubData(int framebuffer, ReadOnlySpan<FramebufferAttachment> attachments, int x, int y, int width, int height)
         {
             int numAttachments = (int)(attachments.Length);
             fixed (FramebufferAttachment* attachments_ptr = attachments)
@@ -13171,7 +13171,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="InvalidateNamedFramebufferSubData"/>
-        public static unsafe void InvalidateNamedFramebufferSubData(FramebufferHandle framebuffer, FramebufferAttachment[] attachments, int x, int y, int width, int height)
+        public static unsafe void InvalidateNamedFramebufferSubData(int framebuffer, FramebufferAttachment[] attachments, int x, int y, int width, int height)
         {
             int numAttachments = (int)(attachments.Length);
             fixed (FramebufferAttachment* attachments_ptr = attachments)
@@ -13180,7 +13180,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="InvalidateNamedFramebufferSubData"/>
-        public static unsafe void InvalidateNamedFramebufferSubData(FramebufferHandle framebuffer, int numAttachments, in FramebufferAttachment attachments, int x, int y, int width, int height)
+        public static unsafe void InvalidateNamedFramebufferSubData(int framebuffer, int numAttachments, in FramebufferAttachment attachments, int x, int y, int width, int height)
         {
             fixed (FramebufferAttachment* attachments_ptr = &attachments)
             {
@@ -13188,7 +13188,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ClearNamedFramebufferiv"/>
-        public static unsafe void ClearNamedFramebufferi(FramebufferHandle framebuffer, Buffer buffer, int drawbuffer, ReadOnlySpan<int> value)
+        public static unsafe void ClearNamedFramebufferi(int framebuffer, Buffer buffer, int drawbuffer, ReadOnlySpan<int> value)
         {
             fixed (int* value_ptr = value)
             {
@@ -13196,7 +13196,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ClearNamedFramebufferiv"/>
-        public static unsafe void ClearNamedFramebufferi(FramebufferHandle framebuffer, Buffer buffer, int drawbuffer, int[] value)
+        public static unsafe void ClearNamedFramebufferi(int framebuffer, Buffer buffer, int drawbuffer, int[] value)
         {
             fixed (int* value_ptr = value)
             {
@@ -13204,7 +13204,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ClearNamedFramebufferiv"/>
-        public static unsafe void ClearNamedFramebufferi(FramebufferHandle framebuffer, Buffer buffer, int drawbuffer, in int value)
+        public static unsafe void ClearNamedFramebufferi(int framebuffer, Buffer buffer, int drawbuffer, in int value)
         {
             fixed (int* value_ptr = &value)
             {
@@ -13212,7 +13212,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ClearNamedFramebufferuiv"/>
-        public static unsafe void ClearNamedFramebufferui(FramebufferHandle framebuffer, Buffer buffer, int drawbuffer, ReadOnlySpan<uint> value)
+        public static unsafe void ClearNamedFramebufferui(int framebuffer, Buffer buffer, int drawbuffer, ReadOnlySpan<uint> value)
         {
             fixed (uint* value_ptr = value)
             {
@@ -13220,7 +13220,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ClearNamedFramebufferuiv"/>
-        public static unsafe void ClearNamedFramebufferui(FramebufferHandle framebuffer, Buffer buffer, int drawbuffer, uint[] value)
+        public static unsafe void ClearNamedFramebufferui(int framebuffer, Buffer buffer, int drawbuffer, uint[] value)
         {
             fixed (uint* value_ptr = value)
             {
@@ -13228,7 +13228,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ClearNamedFramebufferuiv"/>
-        public static unsafe void ClearNamedFramebufferui(FramebufferHandle framebuffer, Buffer buffer, int drawbuffer, in uint value)
+        public static unsafe void ClearNamedFramebufferui(int framebuffer, Buffer buffer, int drawbuffer, in uint value)
         {
             fixed (uint* value_ptr = &value)
             {
@@ -13236,7 +13236,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ClearNamedFramebufferfv"/>
-        public static unsafe void ClearNamedFramebufferf(FramebufferHandle framebuffer, Buffer buffer, int drawbuffer, ReadOnlySpan<float> value)
+        public static unsafe void ClearNamedFramebufferf(int framebuffer, Buffer buffer, int drawbuffer, ReadOnlySpan<float> value)
         {
             fixed (float* value_ptr = value)
             {
@@ -13244,7 +13244,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ClearNamedFramebufferfv"/>
-        public static unsafe void ClearNamedFramebufferf(FramebufferHandle framebuffer, Buffer buffer, int drawbuffer, float[] value)
+        public static unsafe void ClearNamedFramebufferf(int framebuffer, Buffer buffer, int drawbuffer, float[] value)
         {
             fixed (float* value_ptr = value)
             {
@@ -13252,7 +13252,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ClearNamedFramebufferfv"/>
-        public static unsafe void ClearNamedFramebufferf(FramebufferHandle framebuffer, Buffer buffer, int drawbuffer, in float value)
+        public static unsafe void ClearNamedFramebufferf(int framebuffer, Buffer buffer, int drawbuffer, in float value)
         {
             fixed (float* value_ptr = &value)
             {
@@ -13260,12 +13260,12 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="ClearNamedFramebufferfi"/>
-        public static unsafe void ClearNamedFramebuffer(FramebufferHandle framebuffer, Buffer buffer, int drawbuffer, float depth, int stencil)
+        public static unsafe void ClearNamedFramebuffer(int framebuffer, Buffer buffer, int drawbuffer, float depth, int stencil)
         {
             ClearNamedFramebufferfi(framebuffer, buffer, drawbuffer, depth, stencil);
         }
         /// <inheritdoc cref="GetNamedFramebufferParameteriv"/>
-        public static unsafe void GetNamedFramebufferParameteri(FramebufferHandle framebuffer, GetFramebufferParameter pname, ref int param)
+        public static unsafe void GetNamedFramebufferParameteri(int framebuffer, GetFramebufferParameter pname, ref int param)
         {
             fixed (int* param_ptr = &param)
             {
@@ -13273,7 +13273,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetNamedFramebufferAttachmentParameteriv"/>
-        public static unsafe void GetNamedFramebufferAttachmentParameteri(FramebufferHandle framebuffer, FramebufferAttachment attachment, FramebufferAttachmentParameterName pname, ref int parameters)
+        public static unsafe void GetNamedFramebufferAttachmentParameteri(int framebuffer, FramebufferAttachment attachment, FramebufferAttachmentParameterName pname, ref int parameters)
         {
             fixed (int* parameters_ptr = &parameters)
             {
@@ -13281,9 +13281,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="CreateRenderbuffers"/>
-        public static unsafe RenderbufferHandle CreateRenderbuffer()
+        public static unsafe int CreateRenderbuffer()
         {
-            RenderbufferHandle renderbuffer;
+            int renderbuffer;
             int n = 1;
             Unsafe.SkipInit(out renderbuffer);
             // FIXME: This could be a problem for the overloads that take an out parameter
@@ -13294,12 +13294,12 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            RenderbufferHandle* renderbuffers_handle = (RenderbufferHandle*)Unsafe.AsPointer(ref renderbuffer);
+            int* renderbuffers_handle = (int*)Unsafe.AsPointer(ref renderbuffer);
             CreateRenderbuffers(n, renderbuffers_handle);
             return renderbuffer;
         }
         /// <inheritdoc cref="CreateRenderbuffers"/>
-        public static unsafe void CreateRenderbuffer(out RenderbufferHandle renderbuffer)
+        public static unsafe void CreateRenderbuffer(out int renderbuffer)
         {
             int n = 1;
             Unsafe.SkipInit(out renderbuffer);
@@ -13311,37 +13311,37 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            RenderbufferHandle* renderbuffers_handle = (RenderbufferHandle*)Unsafe.AsPointer(ref renderbuffer);
+            int* renderbuffers_handle = (int*)Unsafe.AsPointer(ref renderbuffer);
             CreateRenderbuffers(n, renderbuffers_handle);
         }
         /// <inheritdoc cref="CreateRenderbuffers"/>
-        public static unsafe void CreateRenderbuffers(Span<RenderbufferHandle> renderbuffers)
+        public static unsafe void CreateRenderbuffers(Span<int> renderbuffers)
         {
             int n = (int)(renderbuffers.Length);
-            fixed (RenderbufferHandle* renderbuffers_ptr = renderbuffers)
+            fixed (int* renderbuffers_ptr = renderbuffers)
             {
                 CreateRenderbuffers(n, renderbuffers_ptr);
             }
         }
         /// <inheritdoc cref="CreateRenderbuffers"/>
-        public static unsafe void CreateRenderbuffers(RenderbufferHandle[] renderbuffers)
+        public static unsafe void CreateRenderbuffers(int[] renderbuffers)
         {
             int n = (int)(renderbuffers.Length);
-            fixed (RenderbufferHandle* renderbuffers_ptr = renderbuffers)
+            fixed (int* renderbuffers_ptr = renderbuffers)
             {
                 CreateRenderbuffers(n, renderbuffers_ptr);
             }
         }
         /// <inheritdoc cref="CreateRenderbuffers"/>
-        public static unsafe void CreateRenderbuffers(int n, ref RenderbufferHandle renderbuffers)
+        public static unsafe void CreateRenderbuffers(int n, ref int renderbuffers)
         {
-            fixed (RenderbufferHandle* renderbuffers_ptr = &renderbuffers)
+            fixed (int* renderbuffers_ptr = &renderbuffers)
             {
                 CreateRenderbuffers(n, renderbuffers_ptr);
             }
         }
         /// <inheritdoc cref="GetNamedRenderbufferParameteriv"/>
-        public static unsafe void GetNamedRenderbufferParameteri(RenderbufferHandle renderbuffer, RenderbufferParameterName pname, ref int parameters)
+        public static unsafe void GetNamedRenderbufferParameteri(int renderbuffer, RenderbufferParameterName pname, ref int parameters)
         {
             fixed (int* parameters_ptr = &parameters)
             {
@@ -13349,9 +13349,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="CreateTextures"/>
-        public static unsafe TextureHandle CreateTexture(TextureTarget target)
+        public static unsafe int CreateTexture(TextureTarget target)
         {
-            TextureHandle texture;
+            int texture;
             int n = 1;
             Unsafe.SkipInit(out texture);
             // FIXME: This could be a problem for the overloads that take an out parameter
@@ -13362,12 +13362,12 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            TextureHandle* textures_handle = (TextureHandle*)Unsafe.AsPointer(ref texture);
+            int* textures_handle = (int*)Unsafe.AsPointer(ref texture);
             CreateTextures(target, n, textures_handle);
             return texture;
         }
         /// <inheritdoc cref="CreateTextures"/>
-        public static unsafe void CreateTexture(TextureTarget target, out TextureHandle texture)
+        public static unsafe void CreateTexture(TextureTarget target, out int texture)
         {
             int n = 1;
             Unsafe.SkipInit(out texture);
@@ -13379,43 +13379,43 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            TextureHandle* textures_handle = (TextureHandle*)Unsafe.AsPointer(ref texture);
+            int* textures_handle = (int*)Unsafe.AsPointer(ref texture);
             CreateTextures(target, n, textures_handle);
         }
         /// <inheritdoc cref="CreateTextures"/>
-        public static unsafe void CreateTextures(TextureTarget target, Span<TextureHandle> textures)
+        public static unsafe void CreateTextures(TextureTarget target, Span<int> textures)
         {
             int n = (int)(textures.Length);
-            fixed (TextureHandle* textures_ptr = textures)
+            fixed (int* textures_ptr = textures)
             {
                 CreateTextures(target, n, textures_ptr);
             }
         }
         /// <inheritdoc cref="CreateTextures"/>
-        public static unsafe void CreateTextures(TextureTarget target, TextureHandle[] textures)
+        public static unsafe void CreateTextures(TextureTarget target, int[] textures)
         {
             int n = (int)(textures.Length);
-            fixed (TextureHandle* textures_ptr = textures)
+            fixed (int* textures_ptr = textures)
             {
                 CreateTextures(target, n, textures_ptr);
             }
         }
         /// <inheritdoc cref="CreateTextures"/>
-        public static unsafe void CreateTextures(TextureTarget target, int n, ref TextureHandle textures)
+        public static unsafe void CreateTextures(TextureTarget target, int n, ref int textures)
         {
-            fixed (TextureHandle* textures_ptr = &textures)
+            fixed (int* textures_ptr = &textures)
             {
                 CreateTextures(target, n, textures_ptr);
             }
         }
         /// <inheritdoc cref="TextureSubImage1D"/>
-        public static unsafe void TextureSubImage1D(TextureHandle texture, int level, int xoffset, int width, PixelFormat format, PixelType type, IntPtr pixels)
+        public static unsafe void TextureSubImage1D(int texture, int level, int xoffset, int width, PixelFormat format, PixelType type, IntPtr pixels)
         {
             void* pixels_vptr = (void*)pixels;
             TextureSubImage1D(texture, level, xoffset, width, format, type, pixels_vptr);
         }
         /// <inheritdoc cref="TextureSubImage1D"/>
-        public static unsafe void TextureSubImage1D<T1>(TextureHandle texture, int level, int xoffset, int width, PixelFormat format, PixelType type, in T1 pixels)
+        public static unsafe void TextureSubImage1D<T1>(int texture, int level, int xoffset, int width, PixelFormat format, PixelType type, in T1 pixels)
             where T1 : unmanaged
         {
             fixed (void* pixels_ptr = &pixels)
@@ -13424,13 +13424,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="TextureSubImage2D"/>
-        public static unsafe void TextureSubImage2D(TextureHandle texture, int level, int xoffset, int yoffset, int width, int height, PixelFormat format, PixelType type, IntPtr pixels)
+        public static unsafe void TextureSubImage2D(int texture, int level, int xoffset, int yoffset, int width, int height, PixelFormat format, PixelType type, IntPtr pixels)
         {
             void* pixels_vptr = (void*)pixels;
             TextureSubImage2D(texture, level, xoffset, yoffset, width, height, format, type, pixels_vptr);
         }
         /// <inheritdoc cref="TextureSubImage2D"/>
-        public static unsafe void TextureSubImage2D<T1>(TextureHandle texture, int level, int xoffset, int yoffset, int width, int height, PixelFormat format, PixelType type, in T1 pixels)
+        public static unsafe void TextureSubImage2D<T1>(int texture, int level, int xoffset, int yoffset, int width, int height, PixelFormat format, PixelType type, in T1 pixels)
             where T1 : unmanaged
         {
             fixed (void* pixels_ptr = &pixels)
@@ -13439,13 +13439,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="TextureSubImage3D"/>
-        public static unsafe void TextureSubImage3D(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, IntPtr pixels)
+        public static unsafe void TextureSubImage3D(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, IntPtr pixels)
         {
             void* pixels_vptr = (void*)pixels;
             TextureSubImage3D(texture, level, xoffset, yoffset, zoffset, width, height, depth, format, type, pixels_vptr);
         }
         /// <inheritdoc cref="TextureSubImage3D"/>
-        public static unsafe void TextureSubImage3D<T1>(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, in T1 pixels)
+        public static unsafe void TextureSubImage3D<T1>(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, in T1 pixels)
             where T1 : unmanaged
         {
             fixed (void* pixels_ptr = &pixels)
@@ -13454,13 +13454,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="CompressedTextureSubImage1D"/>
-        public static unsafe void CompressedTextureSubImage1D(TextureHandle texture, int level, int xoffset, int width, InternalFormat format, int imageSize, IntPtr data)
+        public static unsafe void CompressedTextureSubImage1D(int texture, int level, int xoffset, int width, InternalFormat format, int imageSize, IntPtr data)
         {
             void* data_vptr = (void*)data;
             CompressedTextureSubImage1D(texture, level, xoffset, width, format, imageSize, data_vptr);
         }
         /// <inheritdoc cref="CompressedTextureSubImage1D"/>
-        public static unsafe void CompressedTextureSubImage1D<T1>(TextureHandle texture, int level, int xoffset, int width, InternalFormat format, int imageSize, in T1 data)
+        public static unsafe void CompressedTextureSubImage1D<T1>(int texture, int level, int xoffset, int width, InternalFormat format, int imageSize, in T1 data)
             where T1 : unmanaged
         {
             fixed (void* data_ptr = &data)
@@ -13469,13 +13469,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="CompressedTextureSubImage2D"/>
-        public static unsafe void CompressedTextureSubImage2D(TextureHandle texture, int level, int xoffset, int yoffset, int width, int height, InternalFormat format, int imageSize, IntPtr data)
+        public static unsafe void CompressedTextureSubImage2D(int texture, int level, int xoffset, int yoffset, int width, int height, InternalFormat format, int imageSize, IntPtr data)
         {
             void* data_vptr = (void*)data;
             CompressedTextureSubImage2D(texture, level, xoffset, yoffset, width, height, format, imageSize, data_vptr);
         }
         /// <inheritdoc cref="CompressedTextureSubImage2D"/>
-        public static unsafe void CompressedTextureSubImage2D<T1>(TextureHandle texture, int level, int xoffset, int yoffset, int width, int height, InternalFormat format, int imageSize, in T1 data)
+        public static unsafe void CompressedTextureSubImage2D<T1>(int texture, int level, int xoffset, int yoffset, int width, int height, InternalFormat format, int imageSize, in T1 data)
             where T1 : unmanaged
         {
             fixed (void* data_ptr = &data)
@@ -13484,13 +13484,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="CompressedTextureSubImage3D"/>
-        public static unsafe void CompressedTextureSubImage3D(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, InternalFormat format, int imageSize, IntPtr data)
+        public static unsafe void CompressedTextureSubImage3D(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, InternalFormat format, int imageSize, IntPtr data)
         {
             void* data_vptr = (void*)data;
             CompressedTextureSubImage3D(texture, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, data_vptr);
         }
         /// <inheritdoc cref="CompressedTextureSubImage3D"/>
-        public static unsafe void CompressedTextureSubImage3D<T1>(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, InternalFormat format, int imageSize, in T1 data)
+        public static unsafe void CompressedTextureSubImage3D<T1>(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, InternalFormat format, int imageSize, in T1 data)
             where T1 : unmanaged
         {
             fixed (void* data_ptr = &data)
@@ -13499,7 +13499,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="TextureParameterfv"/>
-        public static unsafe void TextureParameterf(TextureHandle texture, TextureParameterName pname, ReadOnlySpan<float> param)
+        public static unsafe void TextureParameterf(int texture, TextureParameterName pname, ReadOnlySpan<float> param)
         {
             fixed (float* param_ptr = param)
             {
@@ -13507,7 +13507,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="TextureParameterfv"/>
-        public static unsafe void TextureParameterf(TextureHandle texture, TextureParameterName pname, float[] param)
+        public static unsafe void TextureParameterf(int texture, TextureParameterName pname, float[] param)
         {
             fixed (float* param_ptr = param)
             {
@@ -13515,7 +13515,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="TextureParameterfv"/>
-        public static unsafe void TextureParameterf(TextureHandle texture, TextureParameterName pname, in float param)
+        public static unsafe void TextureParameterf(int texture, TextureParameterName pname, in float param)
         {
             fixed (float* param_ptr = &param)
             {
@@ -13523,7 +13523,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="TextureParameterIiv"/>
-        public static unsafe void TextureParameterIi(TextureHandle texture, TextureParameterName pname, ReadOnlySpan<int> parameters)
+        public static unsafe void TextureParameterIi(int texture, TextureParameterName pname, ReadOnlySpan<int> parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
@@ -13531,7 +13531,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="TextureParameterIiv"/>
-        public static unsafe void TextureParameterIi(TextureHandle texture, TextureParameterName pname, int[] parameters)
+        public static unsafe void TextureParameterIi(int texture, TextureParameterName pname, int[] parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
@@ -13539,7 +13539,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="TextureParameterIiv"/>
-        public static unsafe void TextureParameterIi(TextureHandle texture, TextureParameterName pname, in int parameters)
+        public static unsafe void TextureParameterIi(int texture, TextureParameterName pname, in int parameters)
         {
             fixed (int* parameters_ptr = &parameters)
             {
@@ -13547,7 +13547,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="TextureParameterIuiv"/>
-        public static unsafe void TextureParameterIui(TextureHandle texture, TextureParameterName pname, ReadOnlySpan<uint> parameters)
+        public static unsafe void TextureParameterIui(int texture, TextureParameterName pname, ReadOnlySpan<uint> parameters)
         {
             fixed (uint* parameters_ptr = parameters)
             {
@@ -13555,7 +13555,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="TextureParameterIuiv"/>
-        public static unsafe void TextureParameterIui(TextureHandle texture, TextureParameterName pname, uint[] parameters)
+        public static unsafe void TextureParameterIui(int texture, TextureParameterName pname, uint[] parameters)
         {
             fixed (uint* parameters_ptr = parameters)
             {
@@ -13563,7 +13563,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="TextureParameterIuiv"/>
-        public static unsafe void TextureParameterIui(TextureHandle texture, TextureParameterName pname, in uint parameters)
+        public static unsafe void TextureParameterIui(int texture, TextureParameterName pname, in uint parameters)
         {
             fixed (uint* parameters_ptr = &parameters)
             {
@@ -13571,7 +13571,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="TextureParameteriv"/>
-        public static unsafe void TextureParameteri(TextureHandle texture, TextureParameterName pname, ReadOnlySpan<int> param)
+        public static unsafe void TextureParameteri(int texture, TextureParameterName pname, ReadOnlySpan<int> param)
         {
             fixed (int* param_ptr = param)
             {
@@ -13579,7 +13579,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="TextureParameteriv"/>
-        public static unsafe void TextureParameteri(TextureHandle texture, TextureParameterName pname, int[] param)
+        public static unsafe void TextureParameteri(int texture, TextureParameterName pname, int[] param)
         {
             fixed (int* param_ptr = param)
             {
@@ -13587,7 +13587,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="TextureParameteriv"/>
-        public static unsafe void TextureParameteri(TextureHandle texture, TextureParameterName pname, in int param)
+        public static unsafe void TextureParameteri(int texture, TextureParameterName pname, in int param)
         {
             fixed (int* param_ptr = &param)
             {
@@ -13595,13 +13595,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetTextureImage"/>
-        public static unsafe void GetTextureImage(TextureHandle texture, int level, PixelFormat format, PixelType type, int bufSize, IntPtr pixels)
+        public static unsafe void GetTextureImage(int texture, int level, PixelFormat format, PixelType type, int bufSize, IntPtr pixels)
         {
             void* pixels_vptr = (void*)pixels;
             GetTextureImage(texture, level, format, type, bufSize, pixels_vptr);
         }
         /// <inheritdoc cref="GetTextureImage"/>
-        public static unsafe void GetTextureImage<T1>(TextureHandle texture, int level, PixelFormat format, PixelType type, Span<T1> pixels)
+        public static unsafe void GetTextureImage<T1>(int texture, int level, PixelFormat format, PixelType type, Span<T1> pixels)
             where T1 : unmanaged
         {
             int bufSize = (int)(pixels.Length * sizeof(T1));
@@ -13611,7 +13611,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetTextureImage"/>
-        public static unsafe void GetTextureImage<T1>(TextureHandle texture, int level, PixelFormat format, PixelType type, T1[] pixels)
+        public static unsafe void GetTextureImage<T1>(int texture, int level, PixelFormat format, PixelType type, T1[] pixels)
             where T1 : unmanaged
         {
             int bufSize = (int)(pixels.Length * sizeof(T1));
@@ -13621,7 +13621,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetTextureImage"/>
-        public static unsafe void GetTextureImage<T1>(TextureHandle texture, int level, PixelFormat format, PixelType type, int bufSize, ref T1 pixels)
+        public static unsafe void GetTextureImage<T1>(int texture, int level, PixelFormat format, PixelType type, int bufSize, ref T1 pixels)
             where T1 : unmanaged
         {
             fixed (void* pixels_ptr = &pixels)
@@ -13630,13 +13630,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetCompressedTextureImage"/>
-        public static unsafe void GetCompressedTextureImage(TextureHandle texture, int level, int bufSize, IntPtr pixels)
+        public static unsafe void GetCompressedTextureImage(int texture, int level, int bufSize, IntPtr pixels)
         {
             void* pixels_vptr = (void*)pixels;
             GetCompressedTextureImage(texture, level, bufSize, pixels_vptr);
         }
         /// <inheritdoc cref="GetCompressedTextureImage"/>
-        public static unsafe void GetCompressedTextureImage<T1>(TextureHandle texture, int level, Span<T1> pixels)
+        public static unsafe void GetCompressedTextureImage<T1>(int texture, int level, Span<T1> pixels)
             where T1 : unmanaged
         {
             int bufSize = (int)(pixels.Length * sizeof(T1));
@@ -13646,7 +13646,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetCompressedTextureImage"/>
-        public static unsafe void GetCompressedTextureImage<T1>(TextureHandle texture, int level, T1[] pixels)
+        public static unsafe void GetCompressedTextureImage<T1>(int texture, int level, T1[] pixels)
             where T1 : unmanaged
         {
             int bufSize = (int)(pixels.Length * sizeof(T1));
@@ -13656,7 +13656,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetCompressedTextureImage"/>
-        public static unsafe void GetCompressedTextureImage<T1>(TextureHandle texture, int level, int bufSize, ref T1 pixels)
+        public static unsafe void GetCompressedTextureImage<T1>(int texture, int level, int bufSize, ref T1 pixels)
             where T1 : unmanaged
         {
             fixed (void* pixels_ptr = &pixels)
@@ -13665,7 +13665,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetTextureLevelParameterfv"/>
-        public static unsafe void GetTextureLevelParameterf(TextureHandle texture, int level, GetTextureParameter pname, ref float parameters)
+        public static unsafe void GetTextureLevelParameterf(int texture, int level, GetTextureParameter pname, ref float parameters)
         {
             fixed (float* parameters_ptr = &parameters)
             {
@@ -13673,7 +13673,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetTextureLevelParameteriv"/>
-        public static unsafe void GetTextureLevelParameteri(TextureHandle texture, int level, GetTextureParameter pname, ref int parameters)
+        public static unsafe void GetTextureLevelParameteri(int texture, int level, GetTextureParameter pname, ref int parameters)
         {
             fixed (int* parameters_ptr = &parameters)
             {
@@ -13681,7 +13681,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetTextureParameterfv"/>
-        public static unsafe void GetTextureParameterf(TextureHandle texture, GetTextureParameter pname, ref float parameters)
+        public static unsafe void GetTextureParameterf(int texture, GetTextureParameter pname, ref float parameters)
         {
             fixed (float* parameters_ptr = &parameters)
             {
@@ -13689,7 +13689,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetTextureParameterIiv"/>
-        public static unsafe void GetTextureParameterIi(TextureHandle texture, GetTextureParameter pname, ref int parameters)
+        public static unsafe void GetTextureParameterIi(int texture, GetTextureParameter pname, ref int parameters)
         {
             fixed (int* parameters_ptr = &parameters)
             {
@@ -13697,7 +13697,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetTextureParameterIuiv"/>
-        public static unsafe void GetTextureParameterIui(TextureHandle texture, GetTextureParameter pname, ref uint parameters)
+        public static unsafe void GetTextureParameterIui(int texture, GetTextureParameter pname, ref uint parameters)
         {
             fixed (uint* parameters_ptr = &parameters)
             {
@@ -13705,7 +13705,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetTextureParameteriv"/>
-        public static unsafe void GetTextureParameteri(TextureHandle texture, GetTextureParameter pname, ref int parameters)
+        public static unsafe void GetTextureParameteri(int texture, GetTextureParameter pname, ref int parameters)
         {
             fixed (int* parameters_ptr = &parameters)
             {
@@ -13713,9 +13713,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="CreateVertexArrays"/>
-        public static unsafe VertexArrayHandle CreateVertexArray()
+        public static unsafe int CreateVertexArray()
         {
-            VertexArrayHandle array;
+            int array;
             int n = 1;
             Unsafe.SkipInit(out array);
             // FIXME: This could be a problem for the overloads that take an out parameter
@@ -13726,12 +13726,12 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            VertexArrayHandle* arrays_handle = (VertexArrayHandle*)Unsafe.AsPointer(ref array);
+            int* arrays_handle = (int*)Unsafe.AsPointer(ref array);
             CreateVertexArrays(n, arrays_handle);
             return array;
         }
         /// <inheritdoc cref="CreateVertexArrays"/>
-        public static unsafe void CreateVertexArray(out VertexArrayHandle array)
+        public static unsafe void CreateVertexArray(out int array)
         {
             int n = 1;
             Unsafe.SkipInit(out array);
@@ -13743,39 +13743,39 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            VertexArrayHandle* arrays_handle = (VertexArrayHandle*)Unsafe.AsPointer(ref array);
+            int* arrays_handle = (int*)Unsafe.AsPointer(ref array);
             CreateVertexArrays(n, arrays_handle);
         }
         /// <inheritdoc cref="CreateVertexArrays"/>
-        public static unsafe void CreateVertexArrays(Span<VertexArrayHandle> arrays)
+        public static unsafe void CreateVertexArrays(Span<int> arrays)
         {
             int n = (int)(arrays.Length);
-            fixed (VertexArrayHandle* arrays_ptr = arrays)
+            fixed (int* arrays_ptr = arrays)
             {
                 CreateVertexArrays(n, arrays_ptr);
             }
         }
         /// <inheritdoc cref="CreateVertexArrays"/>
-        public static unsafe void CreateVertexArrays(VertexArrayHandle[] arrays)
+        public static unsafe void CreateVertexArrays(int[] arrays)
         {
             int n = (int)(arrays.Length);
-            fixed (VertexArrayHandle* arrays_ptr = arrays)
+            fixed (int* arrays_ptr = arrays)
             {
                 CreateVertexArrays(n, arrays_ptr);
             }
         }
         /// <inheritdoc cref="CreateVertexArrays"/>
-        public static unsafe void CreateVertexArrays(int n, ref VertexArrayHandle arrays)
+        public static unsafe void CreateVertexArrays(int n, ref int arrays)
         {
-            fixed (VertexArrayHandle* arrays_ptr = &arrays)
+            fixed (int* arrays_ptr = &arrays)
             {
                 CreateVertexArrays(n, arrays_ptr);
             }
         }
         /// <inheritdoc cref="VertexArrayVertexBuffers"/>
-        public static unsafe void VertexArrayVertexBuffers(VertexArrayHandle vaobj, uint first, int count, ReadOnlySpan<BufferHandle> buffers, ReadOnlySpan<IntPtr> offsets, ReadOnlySpan<int> strides)
+        public static unsafe void VertexArrayVertexBuffers(int vaobj, uint first, int count, ReadOnlySpan<int> buffers, ReadOnlySpan<IntPtr> offsets, ReadOnlySpan<int> strides)
         {
-            fixed (BufferHandle* buffers_ptr = buffers)
+            fixed (int* buffers_ptr = buffers)
             {
                 fixed (IntPtr* offsets_ptr = offsets)
                 {
@@ -13787,9 +13787,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="VertexArrayVertexBuffers"/>
-        public static unsafe void VertexArrayVertexBuffers(VertexArrayHandle vaobj, uint first, int count, BufferHandle[] buffers, IntPtr[] offsets, int[] strides)
+        public static unsafe void VertexArrayVertexBuffers(int vaobj, uint first, int count, int[] buffers, IntPtr[] offsets, int[] strides)
         {
-            fixed (BufferHandle* buffers_ptr = buffers)
+            fixed (int* buffers_ptr = buffers)
             {
                 fixed (IntPtr* offsets_ptr = offsets)
                 {
@@ -13801,9 +13801,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="VertexArrayVertexBuffers"/>
-        public static unsafe void VertexArrayVertexBuffers(VertexArrayHandle vaobj, uint first, int count, in BufferHandle buffers, in IntPtr offsets, in int strides)
+        public static unsafe void VertexArrayVertexBuffers(int vaobj, uint first, int count, in int buffers, in IntPtr offsets, in int strides)
         {
-            fixed (BufferHandle* buffers_ptr = &buffers)
+            fixed (int* buffers_ptr = &buffers)
             fixed (IntPtr* offsets_ptr = &offsets)
             fixed (int* strides_ptr = &strides)
             {
@@ -13811,7 +13811,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetVertexArrayiv"/>
-        public static unsafe void GetVertexArrayi(VertexArrayHandle vaobj, VertexArrayPName pname, ref int param)
+        public static unsafe void GetVertexArrayi(int vaobj, VertexArrayPName pname, ref int param)
         {
             fixed (int* param_ptr = &param)
             {
@@ -13819,7 +13819,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetVertexArrayIndexediv"/>
-        public static unsafe void GetVertexArrayIndexedi(VertexArrayHandle vaobj, uint index, VertexArrayPName pname, ref int param)
+        public static unsafe void GetVertexArrayIndexedi(int vaobj, uint index, VertexArrayPName pname, ref int param)
         {
             fixed (int* param_ptr = &param)
             {
@@ -13827,7 +13827,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetVertexArrayIndexed64iv"/>
-        public static unsafe void GetVertexArrayIndexed64iv(VertexArrayHandle vaobj, uint index, VertexArrayPName pname, ref long param)
+        public static unsafe void GetVertexArrayIndexed64iv(int vaobj, uint index, VertexArrayPName pname, ref long param)
         {
             fixed (long* param_ptr = &param)
             {
@@ -13835,9 +13835,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="CreateSamplers"/>
-        public static unsafe SamplerHandle CreateSampler()
+        public static unsafe int CreateSampler()
         {
-            SamplerHandle sampler;
+            int sampler;
             int n = 1;
             Unsafe.SkipInit(out sampler);
             // FIXME: This could be a problem for the overloads that take an out parameter
@@ -13848,12 +13848,12 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            SamplerHandle* samplers_handle = (SamplerHandle*)Unsafe.AsPointer(ref sampler);
+            int* samplers_handle = (int*)Unsafe.AsPointer(ref sampler);
             CreateSamplers(n, samplers_handle);
             return sampler;
         }
         /// <inheritdoc cref="CreateSamplers"/>
-        public static unsafe void CreateSampler(out SamplerHandle sampler)
+        public static unsafe void CreateSampler(out int sampler)
         {
             int n = 1;
             Unsafe.SkipInit(out sampler);
@@ -13865,39 +13865,39 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            SamplerHandle* samplers_handle = (SamplerHandle*)Unsafe.AsPointer(ref sampler);
+            int* samplers_handle = (int*)Unsafe.AsPointer(ref sampler);
             CreateSamplers(n, samplers_handle);
         }
         /// <inheritdoc cref="CreateSamplers"/>
-        public static unsafe void CreateSamplers(Span<SamplerHandle> samplers)
+        public static unsafe void CreateSamplers(Span<int> samplers)
         {
             int n = (int)(samplers.Length);
-            fixed (SamplerHandle* samplers_ptr = samplers)
+            fixed (int* samplers_ptr = samplers)
             {
                 CreateSamplers(n, samplers_ptr);
             }
         }
         /// <inheritdoc cref="CreateSamplers"/>
-        public static unsafe void CreateSamplers(SamplerHandle[] samplers)
+        public static unsafe void CreateSamplers(int[] samplers)
         {
             int n = (int)(samplers.Length);
-            fixed (SamplerHandle* samplers_ptr = samplers)
+            fixed (int* samplers_ptr = samplers)
             {
                 CreateSamplers(n, samplers_ptr);
             }
         }
         /// <inheritdoc cref="CreateSamplers"/>
-        public static unsafe void CreateSamplers(int n, ref SamplerHandle samplers)
+        public static unsafe void CreateSamplers(int n, ref int samplers)
         {
-            fixed (SamplerHandle* samplers_ptr = &samplers)
+            fixed (int* samplers_ptr = &samplers)
             {
                 CreateSamplers(n, samplers_ptr);
             }
         }
         /// <inheritdoc cref="CreateProgramPipelines"/>
-        public static unsafe ProgramPipelineHandle CreateProgramPipeline()
+        public static unsafe int CreateProgramPipeline()
         {
-            ProgramPipelineHandle pipeline;
+            int pipeline;
             int n = 1;
             Unsafe.SkipInit(out pipeline);
             // FIXME: This could be a problem for the overloads that take an out parameter
@@ -13908,12 +13908,12 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            ProgramPipelineHandle* pipelines_handle = (ProgramPipelineHandle*)Unsafe.AsPointer(ref pipeline);
+            int* pipelines_handle = (int*)Unsafe.AsPointer(ref pipeline);
             CreateProgramPipelines(n, pipelines_handle);
             return pipeline;
         }
         /// <inheritdoc cref="CreateProgramPipelines"/>
-        public static unsafe void CreateProgramPipeline(out ProgramPipelineHandle pipeline)
+        public static unsafe void CreateProgramPipeline(out int pipeline)
         {
             int n = 1;
             Unsafe.SkipInit(out pipeline);
@@ -13925,39 +13925,39 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            ProgramPipelineHandle* pipelines_handle = (ProgramPipelineHandle*)Unsafe.AsPointer(ref pipeline);
+            int* pipelines_handle = (int*)Unsafe.AsPointer(ref pipeline);
             CreateProgramPipelines(n, pipelines_handle);
         }
         /// <inheritdoc cref="CreateProgramPipelines"/>
-        public static unsafe void CreateProgramPipelines(Span<ProgramPipelineHandle> pipelines)
+        public static unsafe void CreateProgramPipelines(Span<int> pipelines)
         {
             int n = (int)(pipelines.Length);
-            fixed (ProgramPipelineHandle* pipelines_ptr = pipelines)
+            fixed (int* pipelines_ptr = pipelines)
             {
                 CreateProgramPipelines(n, pipelines_ptr);
             }
         }
         /// <inheritdoc cref="CreateProgramPipelines"/>
-        public static unsafe void CreateProgramPipelines(ProgramPipelineHandle[] pipelines)
+        public static unsafe void CreateProgramPipelines(int[] pipelines)
         {
             int n = (int)(pipelines.Length);
-            fixed (ProgramPipelineHandle* pipelines_ptr = pipelines)
+            fixed (int* pipelines_ptr = pipelines)
             {
                 CreateProgramPipelines(n, pipelines_ptr);
             }
         }
         /// <inheritdoc cref="CreateProgramPipelines"/>
-        public static unsafe void CreateProgramPipelines(int n, ref ProgramPipelineHandle pipelines)
+        public static unsafe void CreateProgramPipelines(int n, ref int pipelines)
         {
-            fixed (ProgramPipelineHandle* pipelines_ptr = &pipelines)
+            fixed (int* pipelines_ptr = &pipelines)
             {
                 CreateProgramPipelines(n, pipelines_ptr);
             }
         }
         /// <inheritdoc cref="CreateQueries"/>
-        public static unsafe QueryHandle CreateQuery(QueryTarget target)
+        public static unsafe int CreateQuery(QueryTarget target)
         {
-            QueryHandle id;
+            int id;
             int n = 1;
             Unsafe.SkipInit(out id);
             // FIXME: This could be a problem for the overloads that take an out parameter
@@ -13968,12 +13968,12 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            QueryHandle* ids_handle = (QueryHandle*)Unsafe.AsPointer(ref id);
+            int* ids_handle = (int*)Unsafe.AsPointer(ref id);
             CreateQueries(target, n, ids_handle);
             return id;
         }
         /// <inheritdoc cref="CreateQueries"/>
-        public static unsafe void CreateQuery(QueryTarget target, out QueryHandle id)
+        public static unsafe void CreateQuery(QueryTarget target, out int id)
         {
             int n = 1;
             Unsafe.SkipInit(out id);
@@ -13985,63 +13985,63 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            QueryHandle* ids_handle = (QueryHandle*)Unsafe.AsPointer(ref id);
+            int* ids_handle = (int*)Unsafe.AsPointer(ref id);
             CreateQueries(target, n, ids_handle);
         }
         /// <inheritdoc cref="CreateQueries"/>
-        public static unsafe void CreateQueries(QueryTarget target, Span<QueryHandle> ids)
+        public static unsafe void CreateQueries(QueryTarget target, Span<int> ids)
         {
             int n = (int)(ids.Length);
-            fixed (QueryHandle* ids_ptr = ids)
+            fixed (int* ids_ptr = ids)
             {
                 CreateQueries(target, n, ids_ptr);
             }
         }
         /// <inheritdoc cref="CreateQueries"/>
-        public static unsafe void CreateQueries(QueryTarget target, QueryHandle[] ids)
+        public static unsafe void CreateQueries(QueryTarget target, int[] ids)
         {
             int n = (int)(ids.Length);
-            fixed (QueryHandle* ids_ptr = ids)
+            fixed (int* ids_ptr = ids)
             {
                 CreateQueries(target, n, ids_ptr);
             }
         }
         /// <inheritdoc cref="CreateQueries"/>
-        public static unsafe void CreateQueries(QueryTarget target, int n, ref QueryHandle ids)
+        public static unsafe void CreateQueries(QueryTarget target, int n, ref int ids)
         {
-            fixed (QueryHandle* ids_ptr = &ids)
+            fixed (int* ids_ptr = &ids)
             {
                 CreateQueries(target, n, ids_ptr);
             }
         }
         /// <inheritdoc cref="GetQueryBufferObjecti64v"/>
-        public static unsafe void GetQueryBufferObjecti64(QueryHandle id, BufferHandle buffer, QueryObjectParameterName pname, IntPtr offset)
+        public static unsafe void GetQueryBufferObjecti64(int id, int buffer, QueryObjectParameterName pname, IntPtr offset)
         {
             GetQueryBufferObjecti64v(id, buffer, pname, offset);
         }
         /// <inheritdoc cref="GetQueryBufferObjectiv"/>
-        public static unsafe void GetQueryBufferObjecti(QueryHandle id, BufferHandle buffer, QueryObjectParameterName pname, IntPtr offset)
+        public static unsafe void GetQueryBufferObjecti(int id, int buffer, QueryObjectParameterName pname, IntPtr offset)
         {
             GetQueryBufferObjectiv(id, buffer, pname, offset);
         }
         /// <inheritdoc cref="GetQueryBufferObjectui64v"/>
-        public static unsafe void GetQueryBufferObjectui64(QueryHandle id, BufferHandle buffer, QueryObjectParameterName pname, IntPtr offset)
+        public static unsafe void GetQueryBufferObjectui64(int id, int buffer, QueryObjectParameterName pname, IntPtr offset)
         {
             GetQueryBufferObjectui64v(id, buffer, pname, offset);
         }
         /// <inheritdoc cref="GetQueryBufferObjectuiv"/>
-        public static unsafe void GetQueryBufferObjectui(QueryHandle id, BufferHandle buffer, QueryObjectParameterName pname, IntPtr offset)
+        public static unsafe void GetQueryBufferObjectui(int id, int buffer, QueryObjectParameterName pname, IntPtr offset)
         {
             GetQueryBufferObjectuiv(id, buffer, pname, offset);
         }
         /// <inheritdoc cref="GetTextureSubImage"/>
-        public static unsafe void GetTextureSubImage(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, int bufSize, IntPtr pixels)
+        public static unsafe void GetTextureSubImage(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, int bufSize, IntPtr pixels)
         {
             void* pixels_vptr = (void*)pixels;
             GetTextureSubImage(texture, level, xoffset, yoffset, zoffset, width, height, depth, format, type, bufSize, pixels_vptr);
         }
         /// <inheritdoc cref="GetTextureSubImage"/>
-        public static unsafe void GetTextureSubImage<T1>(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, Span<T1> pixels)
+        public static unsafe void GetTextureSubImage<T1>(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, Span<T1> pixels)
             where T1 : unmanaged
         {
             int bufSize = (int)(pixels.Length * sizeof(T1));
@@ -14051,7 +14051,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetTextureSubImage"/>
-        public static unsafe void GetTextureSubImage<T1>(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, T1[] pixels)
+        public static unsafe void GetTextureSubImage<T1>(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, T1[] pixels)
             where T1 : unmanaged
         {
             int bufSize = (int)(pixels.Length * sizeof(T1));
@@ -14061,7 +14061,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetTextureSubImage"/>
-        public static unsafe void GetTextureSubImage<T1>(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, int bufSize, ref T1 pixels)
+        public static unsafe void GetTextureSubImage<T1>(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, int bufSize, ref T1 pixels)
             where T1 : unmanaged
         {
             fixed (void* pixels_ptr = &pixels)
@@ -14070,13 +14070,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetCompressedTextureSubImage"/>
-        public static unsafe void GetCompressedTextureSubImage(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, int bufSize, IntPtr pixels)
+        public static unsafe void GetCompressedTextureSubImage(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, int bufSize, IntPtr pixels)
         {
             void* pixels_vptr = (void*)pixels;
             GetCompressedTextureSubImage(texture, level, xoffset, yoffset, zoffset, width, height, depth, bufSize, pixels_vptr);
         }
         /// <inheritdoc cref="GetCompressedTextureSubImage"/>
-        public static unsafe void GetCompressedTextureSubImage<T1>(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, Span<T1> pixels)
+        public static unsafe void GetCompressedTextureSubImage<T1>(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, Span<T1> pixels)
             where T1 : unmanaged
         {
             int bufSize = (int)(pixels.Length * sizeof(T1));
@@ -14086,7 +14086,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetCompressedTextureSubImage"/>
-        public static unsafe void GetCompressedTextureSubImage<T1>(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, T1[] pixels)
+        public static unsafe void GetCompressedTextureSubImage<T1>(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, T1[] pixels)
             where T1 : unmanaged
         {
             int bufSize = (int)(pixels.Length * sizeof(T1));
@@ -14096,7 +14096,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetCompressedTextureSubImage"/>
-        public static unsafe void GetCompressedTextureSubImage<T1>(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, int bufSize, ref T1 pixels)
+        public static unsafe void GetCompressedTextureSubImage<T1>(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, int bufSize, ref T1 pixels)
             where T1 : unmanaged
         {
             fixed (void* pixels_ptr = &pixels)
@@ -14175,7 +14175,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetnUniformdv"/>
-        public static unsafe void GetnUniformd(ProgramHandle program, int location, Span<double> parameters)
+        public static unsafe void GetnUniformd(int program, int location, Span<double> parameters)
         {
             int bufSize = (int)(parameters.Length * 8);
             fixed (double* parameters_ptr = parameters)
@@ -14184,7 +14184,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetnUniformdv"/>
-        public static unsafe void GetnUniformd(ProgramHandle program, int location, double[] parameters)
+        public static unsafe void GetnUniformd(int program, int location, double[] parameters)
         {
             int bufSize = (int)(parameters.Length * 8);
             fixed (double* parameters_ptr = parameters)
@@ -14193,7 +14193,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetnUniformdv"/>
-        public static unsafe void GetnUniformd(ProgramHandle program, int location, int bufSize, ref double parameters)
+        public static unsafe void GetnUniformd(int program, int location, int bufSize, ref double parameters)
         {
             fixed (double* parameters_ptr = &parameters)
             {
@@ -14201,7 +14201,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetnUniformfv"/>
-        public static unsafe void GetnUniformf(ProgramHandle program, int location, Span<float> parameters)
+        public static unsafe void GetnUniformf(int program, int location, Span<float> parameters)
         {
             int bufSize = (int)(parameters.Length * 4);
             fixed (float* parameters_ptr = parameters)
@@ -14210,7 +14210,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetnUniformfv"/>
-        public static unsafe void GetnUniformf(ProgramHandle program, int location, float[] parameters)
+        public static unsafe void GetnUniformf(int program, int location, float[] parameters)
         {
             int bufSize = (int)(parameters.Length * 4);
             fixed (float* parameters_ptr = parameters)
@@ -14219,7 +14219,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetnUniformfv"/>
-        public static unsafe void GetnUniformf(ProgramHandle program, int location, int bufSize, ref float parameters)
+        public static unsafe void GetnUniformf(int program, int location, int bufSize, ref float parameters)
         {
             fixed (float* parameters_ptr = &parameters)
             {
@@ -14227,7 +14227,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetnUniformiv"/>
-        public static unsafe void GetnUniformi(ProgramHandle program, int location, Span<int> parameters)
+        public static unsafe void GetnUniformi(int program, int location, Span<int> parameters)
         {
             int bufSize = (int)(parameters.Length * 4);
             fixed (int* parameters_ptr = parameters)
@@ -14236,7 +14236,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetnUniformiv"/>
-        public static unsafe void GetnUniformi(ProgramHandle program, int location, int[] parameters)
+        public static unsafe void GetnUniformi(int program, int location, int[] parameters)
         {
             int bufSize = (int)(parameters.Length * 4);
             fixed (int* parameters_ptr = parameters)
@@ -14245,7 +14245,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetnUniformiv"/>
-        public static unsafe void GetnUniformi(ProgramHandle program, int location, int bufSize, ref int parameters)
+        public static unsafe void GetnUniformi(int program, int location, int bufSize, ref int parameters)
         {
             fixed (int* parameters_ptr = &parameters)
             {
@@ -14253,7 +14253,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetnUniformuiv"/>
-        public static unsafe void GetnUniformui(ProgramHandle program, int location, Span<uint> parameters)
+        public static unsafe void GetnUniformui(int program, int location, Span<uint> parameters)
         {
             int bufSize = (int)(parameters.Length * 4);
             fixed (uint* parameters_ptr = parameters)
@@ -14262,7 +14262,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetnUniformuiv"/>
-        public static unsafe void GetnUniformui(ProgramHandle program, int location, uint[] parameters)
+        public static unsafe void GetnUniformui(int program, int location, uint[] parameters)
         {
             int bufSize = (int)(parameters.Length * 4);
             fixed (uint* parameters_ptr = parameters)
@@ -14271,7 +14271,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="GetnUniformuiv"/>
-        public static unsafe void GetnUniformui(ProgramHandle program, int location, int bufSize, ref uint parameters)
+        public static unsafe void GetnUniformui(int program, int location, int bufSize, ref uint parameters)
         {
             fixed (uint* parameters_ptr = &parameters)
             {
@@ -14619,7 +14619,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="SpecializeShader"/>
-        public static unsafe void SpecializeShader(ShaderHandle shader, string pEntryPoint, uint numSpecializationConstants, ReadOnlySpan<uint> pConstantIndex, ReadOnlySpan<uint> pConstantValue)
+        public static unsafe void SpecializeShader(int shader, string pEntryPoint, uint numSpecializationConstants, ReadOnlySpan<uint> pConstantIndex, ReadOnlySpan<uint> pConstantValue)
         {
             fixed (uint* pConstantIndex_ptr = pConstantIndex)
             {
@@ -14632,7 +14632,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="SpecializeShader"/>
-        public static unsafe void SpecializeShader(ShaderHandle shader, string pEntryPoint, uint numSpecializationConstants, uint[] pConstantIndex, uint[] pConstantValue)
+        public static unsafe void SpecializeShader(int shader, string pEntryPoint, uint numSpecializationConstants, uint[] pConstantIndex, uint[] pConstantValue)
         {
             fixed (uint* pConstantIndex_ptr = pConstantIndex)
             {
@@ -14645,7 +14645,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             }
         }
         /// <inheritdoc cref="SpecializeShader"/>
-        public static unsafe void SpecializeShader(ShaderHandle shader, string pEntryPoint, uint numSpecializationConstants, in uint pConstantIndex, in uint pConstantValue)
+        public static unsafe void SpecializeShader(int shader, string pEntryPoint, uint numSpecializationConstants, in uint pConstantIndex, in uint pConstantValue)
         {
             fixed (uint* pConstantIndex_ptr = &pConstantIndex)
             fixed (uint* pConstantValue_ptr = &pConstantValue)
@@ -14809,7 +14809,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="NamedFramebufferSamplePositionsfvAMD"/>
-            public static unsafe void NamedFramebufferSamplePositionsfvAMD(FramebufferHandle framebuffer, uint numsamples, uint pixelindex, in float values)
+            public static unsafe void NamedFramebufferSamplePositionsfvAMD(int framebuffer, uint numsamples, uint pixelindex, in float values)
             {
                 fixed (float* values_ptr = &values)
                 {
@@ -14825,7 +14825,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetNamedFramebufferParameterfvAMD"/>
-            public static unsafe void GetNamedFramebufferParameterfvAMD(FramebufferHandle framebuffer, All pname, uint numsamples, uint pixelindex, int size, ref float values)
+            public static unsafe void GetNamedFramebufferParameterfvAMD(int framebuffer, All pname, uint numsamples, uint pixelindex, int size, ref float values)
             {
                 fixed (float* values_ptr = &values)
                 {
@@ -15041,7 +15041,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetUniformi64vNV"/>
-            public static unsafe void GetUniformi64vNV(ProgramHandle program, int location, Span<long> parameters)
+            public static unsafe void GetUniformi64vNV(int program, int location, Span<long> parameters)
             {
                 fixed (long* parameters_ptr = parameters)
                 {
@@ -15049,7 +15049,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetUniformi64vNV"/>
-            public static unsafe void GetUniformi64vNV(ProgramHandle program, int location, long[] parameters)
+            public static unsafe void GetUniformi64vNV(int program, int location, long[] parameters)
             {
                 fixed (long* parameters_ptr = parameters)
                 {
@@ -15057,7 +15057,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetUniformi64vNV"/>
-            public static unsafe void GetUniformi64vNV(ProgramHandle program, int location, ref long parameters)
+            public static unsafe void GetUniformi64vNV(int program, int location, ref long parameters)
             {
                 fixed (long* parameters_ptr = &parameters)
                 {
@@ -15065,7 +15065,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetUniformui64vNV"/>
-            public static unsafe void GetUniformui64vNV(ProgramHandle program, int location, Span<ulong> parameters)
+            public static unsafe void GetUniformui64vNV(int program, int location, Span<ulong> parameters)
             {
                 fixed (ulong* parameters_ptr = parameters)
                 {
@@ -15073,7 +15073,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetUniformui64vNV"/>
-            public static unsafe void GetUniformui64vNV(ProgramHandle program, int location, ulong[] parameters)
+            public static unsafe void GetUniformui64vNV(int program, int location, ulong[] parameters)
             {
                 fixed (ulong* parameters_ptr = parameters)
                 {
@@ -15081,7 +15081,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetUniformui64vNV"/>
-            public static unsafe void GetUniformui64vNV(ProgramHandle program, int location, ref ulong parameters)
+            public static unsafe void GetUniformui64vNV(int program, int location, ref ulong parameters)
             {
                 fixed (ulong* parameters_ptr = &parameters)
                 {
@@ -15089,7 +15089,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform1i64vNV"/>
-            public static unsafe void ProgramUniform1i64vNV(ProgramHandle program, int location, ReadOnlySpan<long> value)
+            public static unsafe void ProgramUniform1i64vNV(int program, int location, ReadOnlySpan<long> value)
             {
                 int count = (int)(value.Length);
                 fixed (long* value_ptr = value)
@@ -15098,7 +15098,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform1i64vNV"/>
-            public static unsafe void ProgramUniform1i64vNV(ProgramHandle program, int location, long[] value)
+            public static unsafe void ProgramUniform1i64vNV(int program, int location, long[] value)
             {
                 int count = (int)(value.Length);
                 fixed (long* value_ptr = value)
@@ -15107,7 +15107,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform1i64vNV"/>
-            public static unsafe void ProgramUniform1i64vNV(ProgramHandle program, int location, int count, in long value)
+            public static unsafe void ProgramUniform1i64vNV(int program, int location, int count, in long value)
             {
                 fixed (long* value_ptr = &value)
                 {
@@ -15115,7 +15115,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform2i64vNV"/>
-            public static unsafe void ProgramUniform2i64vNV(ProgramHandle program, int location, ReadOnlySpan<long> value)
+            public static unsafe void ProgramUniform2i64vNV(int program, int location, ReadOnlySpan<long> value)
             {
                 int count = (int)(value.Length / 2);
                 fixed (long* value_ptr = value)
@@ -15124,7 +15124,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform2i64vNV"/>
-            public static unsafe void ProgramUniform2i64vNV(ProgramHandle program, int location, long[] value)
+            public static unsafe void ProgramUniform2i64vNV(int program, int location, long[] value)
             {
                 int count = (int)(value.Length / 2);
                 fixed (long* value_ptr = value)
@@ -15133,7 +15133,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform2i64vNV"/>
-            public static unsafe void ProgramUniform2i64vNV(ProgramHandle program, int location, int count, in long value)
+            public static unsafe void ProgramUniform2i64vNV(int program, int location, int count, in long value)
             {
                 fixed (long* value_ptr = &value)
                 {
@@ -15141,7 +15141,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform3i64vNV"/>
-            public static unsafe void ProgramUniform3i64vNV(ProgramHandle program, int location, ReadOnlySpan<long> value)
+            public static unsafe void ProgramUniform3i64vNV(int program, int location, ReadOnlySpan<long> value)
             {
                 int count = (int)(value.Length / 3);
                 fixed (long* value_ptr = value)
@@ -15150,7 +15150,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform3i64vNV"/>
-            public static unsafe void ProgramUniform3i64vNV(ProgramHandle program, int location, long[] value)
+            public static unsafe void ProgramUniform3i64vNV(int program, int location, long[] value)
             {
                 int count = (int)(value.Length / 3);
                 fixed (long* value_ptr = value)
@@ -15159,7 +15159,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform3i64vNV"/>
-            public static unsafe void ProgramUniform3i64vNV(ProgramHandle program, int location, int count, in long value)
+            public static unsafe void ProgramUniform3i64vNV(int program, int location, int count, in long value)
             {
                 fixed (long* value_ptr = &value)
                 {
@@ -15167,7 +15167,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform4i64vNV"/>
-            public static unsafe void ProgramUniform4i64vNV(ProgramHandle program, int location, ReadOnlySpan<long> value)
+            public static unsafe void ProgramUniform4i64vNV(int program, int location, ReadOnlySpan<long> value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (long* value_ptr = value)
@@ -15176,7 +15176,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform4i64vNV"/>
-            public static unsafe void ProgramUniform4i64vNV(ProgramHandle program, int location, long[] value)
+            public static unsafe void ProgramUniform4i64vNV(int program, int location, long[] value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (long* value_ptr = value)
@@ -15185,7 +15185,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform4i64vNV"/>
-            public static unsafe void ProgramUniform4i64vNV(ProgramHandle program, int location, int count, in long value)
+            public static unsafe void ProgramUniform4i64vNV(int program, int location, int count, in long value)
             {
                 fixed (long* value_ptr = &value)
                 {
@@ -15193,7 +15193,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform1ui64vNV"/>
-            public static unsafe void ProgramUniform1ui64vNV(ProgramHandle program, int location, ReadOnlySpan<ulong> value)
+            public static unsafe void ProgramUniform1ui64vNV(int program, int location, ReadOnlySpan<ulong> value)
             {
                 int count = (int)(value.Length);
                 fixed (ulong* value_ptr = value)
@@ -15202,7 +15202,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform1ui64vNV"/>
-            public static unsafe void ProgramUniform1ui64vNV(ProgramHandle program, int location, ulong[] value)
+            public static unsafe void ProgramUniform1ui64vNV(int program, int location, ulong[] value)
             {
                 int count = (int)(value.Length);
                 fixed (ulong* value_ptr = value)
@@ -15211,7 +15211,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform1ui64vNV"/>
-            public static unsafe void ProgramUniform1ui64vNV(ProgramHandle program, int location, int count, in ulong value)
+            public static unsafe void ProgramUniform1ui64vNV(int program, int location, int count, in ulong value)
             {
                 fixed (ulong* value_ptr = &value)
                 {
@@ -15219,7 +15219,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform2ui64vNV"/>
-            public static unsafe void ProgramUniform2ui64vNV(ProgramHandle program, int location, ReadOnlySpan<ulong> value)
+            public static unsafe void ProgramUniform2ui64vNV(int program, int location, ReadOnlySpan<ulong> value)
             {
                 int count = (int)(value.Length / 2);
                 fixed (ulong* value_ptr = value)
@@ -15228,7 +15228,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform2ui64vNV"/>
-            public static unsafe void ProgramUniform2ui64vNV(ProgramHandle program, int location, ulong[] value)
+            public static unsafe void ProgramUniform2ui64vNV(int program, int location, ulong[] value)
             {
                 int count = (int)(value.Length / 2);
                 fixed (ulong* value_ptr = value)
@@ -15237,7 +15237,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform2ui64vNV"/>
-            public static unsafe void ProgramUniform2ui64vNV(ProgramHandle program, int location, int count, in ulong value)
+            public static unsafe void ProgramUniform2ui64vNV(int program, int location, int count, in ulong value)
             {
                 fixed (ulong* value_ptr = &value)
                 {
@@ -15245,7 +15245,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform3ui64vNV"/>
-            public static unsafe void ProgramUniform3ui64vNV(ProgramHandle program, int location, ReadOnlySpan<ulong> value)
+            public static unsafe void ProgramUniform3ui64vNV(int program, int location, ReadOnlySpan<ulong> value)
             {
                 int count = (int)(value.Length / 3);
                 fixed (ulong* value_ptr = value)
@@ -15254,7 +15254,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform3ui64vNV"/>
-            public static unsafe void ProgramUniform3ui64vNV(ProgramHandle program, int location, ulong[] value)
+            public static unsafe void ProgramUniform3ui64vNV(int program, int location, ulong[] value)
             {
                 int count = (int)(value.Length / 3);
                 fixed (ulong* value_ptr = value)
@@ -15263,7 +15263,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform3ui64vNV"/>
-            public static unsafe void ProgramUniform3ui64vNV(ProgramHandle program, int location, int count, in ulong value)
+            public static unsafe void ProgramUniform3ui64vNV(int program, int location, int count, in ulong value)
             {
                 fixed (ulong* value_ptr = &value)
                 {
@@ -15271,7 +15271,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform4ui64vNV"/>
-            public static unsafe void ProgramUniform4ui64vNV(ProgramHandle program, int location, ReadOnlySpan<ulong> value)
+            public static unsafe void ProgramUniform4ui64vNV(int program, int location, ReadOnlySpan<ulong> value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (ulong* value_ptr = value)
@@ -15280,7 +15280,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform4ui64vNV"/>
-            public static unsafe void ProgramUniform4ui64vNV(ProgramHandle program, int location, ulong[] value)
+            public static unsafe void ProgramUniform4ui64vNV(int program, int location, ulong[] value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (ulong* value_ptr = value)
@@ -15289,7 +15289,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform4ui64vNV"/>
-            public static unsafe void ProgramUniform4ui64vNV(ProgramHandle program, int location, int count, in ulong value)
+            public static unsafe void ProgramUniform4ui64vNV(int program, int location, int count, in ulong value)
             {
                 fixed (ulong* value_ptr = &value)
                 {
@@ -16009,53 +16009,53 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="DeleteVertexArraysAPPLE"/>
-            public static unsafe void DeleteVertexArraysAPPLE(ReadOnlySpan<VertexArrayHandle> arrays)
+            public static unsafe void DeleteVertexArraysAPPLE(ReadOnlySpan<int> arrays)
             {
                 int n = (int)(arrays.Length);
-                fixed (VertexArrayHandle* arrays_ptr = arrays)
+                fixed (int* arrays_ptr = arrays)
                 {
                     DeleteVertexArraysAPPLE(n, arrays_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteVertexArraysAPPLE"/>
-            public static unsafe void DeleteVertexArraysAPPLE(VertexArrayHandle[] arrays)
+            public static unsafe void DeleteVertexArraysAPPLE(int[] arrays)
             {
                 int n = (int)(arrays.Length);
-                fixed (VertexArrayHandle* arrays_ptr = arrays)
+                fixed (int* arrays_ptr = arrays)
                 {
                     DeleteVertexArraysAPPLE(n, arrays_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteVertexArraysAPPLE"/>
-            public static unsafe void DeleteVertexArraysAPPLE(int n, in VertexArrayHandle arrays)
+            public static unsafe void DeleteVertexArraysAPPLE(int n, in int arrays)
             {
-                fixed (VertexArrayHandle* arrays_ptr = &arrays)
+                fixed (int* arrays_ptr = &arrays)
                 {
                     DeleteVertexArraysAPPLE(n, arrays_ptr);
                 }
             }
             /// <inheritdoc cref="GenVertexArraysAPPLE"/>
-            public static unsafe void GenVertexArraysAPPLE(Span<VertexArrayHandle> arrays)
+            public static unsafe void GenVertexArraysAPPLE(Span<int> arrays)
             {
                 int n = (int)(arrays.Length);
-                fixed (VertexArrayHandle* arrays_ptr = arrays)
+                fixed (int* arrays_ptr = arrays)
                 {
                     GenVertexArraysAPPLE(n, arrays_ptr);
                 }
             }
             /// <inheritdoc cref="GenVertexArraysAPPLE"/>
-            public static unsafe void GenVertexArraysAPPLE(VertexArrayHandle[] arrays)
+            public static unsafe void GenVertexArraysAPPLE(int[] arrays)
             {
                 int n = (int)(arrays.Length);
-                fixed (VertexArrayHandle* arrays_ptr = arrays)
+                fixed (int* arrays_ptr = arrays)
                 {
                     GenVertexArraysAPPLE(n, arrays_ptr);
                 }
             }
             /// <inheritdoc cref="GenVertexArraysAPPLE"/>
-            public static unsafe void GenVertexArraysAPPLE(int n, ref VertexArrayHandle arrays)
+            public static unsafe void GenVertexArraysAPPLE(int n, ref int arrays)
             {
-                fixed (VertexArrayHandle* arrays_ptr = &arrays)
+                fixed (int* arrays_ptr = &arrays)
                 {
                     GenVertexArraysAPPLE(n, arrays_ptr);
                 }
@@ -16230,40 +16230,40 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         public static unsafe partial class ARB
         {
             /// <inheritdoc cref="ShaderBinary"/>
-            public static unsafe void ShaderBinary(ReadOnlySpan<ShaderHandle> shaders, ShaderBinaryFormat binaryFormat, IntPtr binary, int length)
+            public static unsafe void ShaderBinary(ReadOnlySpan<int> shaders, ShaderBinaryFormat binaryFormat, IntPtr binary, int length)
             {
                 int count = (int)(shaders.Length);
-                fixed (ShaderHandle* shaders_ptr = shaders)
+                fixed (int* shaders_ptr = shaders)
                 {
                     void* binary_vptr = (void*)binary;
                     ShaderBinary(count, shaders_ptr, binaryFormat, binary_vptr, length);
                 }
             }
             /// <inheritdoc cref="ShaderBinary"/>
-            public static unsafe void ShaderBinary(ShaderHandle[] shaders, ShaderBinaryFormat binaryFormat, IntPtr binary, int length)
+            public static unsafe void ShaderBinary(int[] shaders, ShaderBinaryFormat binaryFormat, IntPtr binary, int length)
             {
                 int count = (int)(shaders.Length);
-                fixed (ShaderHandle* shaders_ptr = shaders)
+                fixed (int* shaders_ptr = shaders)
                 {
                     void* binary_vptr = (void*)binary;
                     ShaderBinary(count, shaders_ptr, binaryFormat, binary_vptr, length);
                 }
             }
             /// <inheritdoc cref="ShaderBinary"/>
-            public static unsafe void ShaderBinary(int count, in ShaderHandle shaders, ShaderBinaryFormat binaryFormat, IntPtr binary, int length)
+            public static unsafe void ShaderBinary(int count, in int shaders, ShaderBinaryFormat binaryFormat, IntPtr binary, int length)
             {
-                fixed (ShaderHandle* shaders_ptr = &shaders)
+                fixed (int* shaders_ptr = &shaders)
                 {
                     void* binary_vptr = (void*)binary;
                     ShaderBinary(count, shaders_ptr, binaryFormat, binary_vptr, length);
                 }
             }
             /// <inheritdoc cref="ShaderBinary"/>
-            public static unsafe void ShaderBinary<T1>(ReadOnlySpan<ShaderHandle> shaders, ShaderBinaryFormat binaryFormat, ReadOnlySpan<T1> binary)
+            public static unsafe void ShaderBinary<T1>(ReadOnlySpan<int> shaders, ShaderBinaryFormat binaryFormat, ReadOnlySpan<T1> binary)
                 where T1 : unmanaged
             {
                 int count = (int)(shaders.Length);
-                fixed (ShaderHandle* shaders_ptr = shaders)
+                fixed (int* shaders_ptr = shaders)
                 {
                     int length = (int)(binary.Length * sizeof(T1));
                     fixed (void* binary_ptr = binary)
@@ -16273,11 +16273,11 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ShaderBinary"/>
-            public static unsafe void ShaderBinary<T1>(ShaderHandle[] shaders, ShaderBinaryFormat binaryFormat, T1[] binary)
+            public static unsafe void ShaderBinary<T1>(int[] shaders, ShaderBinaryFormat binaryFormat, T1[] binary)
                 where T1 : unmanaged
             {
                 int count = (int)(shaders.Length);
-                fixed (ShaderHandle* shaders_ptr = shaders)
+                fixed (int* shaders_ptr = shaders)
                 {
                     int length = (int)(binary.Length * sizeof(T1));
                     fixed (void* binary_ptr = binary)
@@ -16287,10 +16287,10 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ShaderBinary"/>
-            public static unsafe void ShaderBinary<T1>(int count, in ShaderHandle shaders, ShaderBinaryFormat binaryFormat, in T1 binary, int length)
+            public static unsafe void ShaderBinary<T1>(int count, in int shaders, ShaderBinaryFormat binaryFormat, in T1 binary, int length)
                 where T1 : unmanaged
             {
-                fixed (ShaderHandle* shaders_ptr = &shaders)
+                fixed (int* shaders_ptr = &shaders)
                 fixed (void* binary_ptr = &binary)
                 {
                     ShaderBinary(count, shaders_ptr, binaryFormat, binary_ptr, length);
@@ -16366,7 +16366,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformHandleui64vARB"/>
-            public static unsafe void ProgramUniformHandleui64vARB(ProgramHandle program, int location, ReadOnlySpan<ulong> values)
+            public static unsafe void ProgramUniformHandleui64vARB(int program, int location, ReadOnlySpan<ulong> values)
             {
                 int count = (int)(values.Length);
                 fixed (ulong* values_ptr = values)
@@ -16375,7 +16375,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformHandleui64vARB"/>
-            public static unsafe void ProgramUniformHandleui64vARB(ProgramHandle program, int location, ulong[] values)
+            public static unsafe void ProgramUniformHandleui64vARB(int program, int location, ulong[] values)
             {
                 int count = (int)(values.Length);
                 fixed (ulong* values_ptr = values)
@@ -16384,7 +16384,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformHandleui64vARB"/>
-            public static unsafe void ProgramUniformHandleui64vARB(ProgramHandle program, int location, int count, in ulong values)
+            public static unsafe void ProgramUniformHandleui64vARB(int program, int location, int count, in ulong values)
             {
                 fixed (ulong* values_ptr = &values)
                 {
@@ -16408,14 +16408,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="BindFragDataLocationIndexed"/>
-            public static unsafe void BindFragDataLocationIndexed(ProgramHandle program, uint colorNumber, uint index, string name)
+            public static unsafe void BindFragDataLocationIndexed(int program, uint colorNumber, uint index, string name)
             {
                 byte* name_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(name);
                 BindFragDataLocationIndexed(program, colorNumber, index, name_ptr);
                 Marshal.FreeCoTaskMem((IntPtr)name_ptr);
             }
             /// <inheritdoc cref="GetFragDataIndex"/>
-            public static unsafe int GetFragDataIndex(ProgramHandle program, string name)
+            public static unsafe int GetFragDataIndex(int program, string name)
             {
                 int returnValue;
                 byte* name_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(name);
@@ -16536,13 +16536,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ClearTexImage"/>
-            public static unsafe void ClearTexImage(TextureHandle texture, int level, PixelFormat format, PixelType type, IntPtr data)
+            public static unsafe void ClearTexImage(int texture, int level, PixelFormat format, PixelType type, IntPtr data)
             {
                 void* data_vptr = (void*)data;
                 ClearTexImage(texture, level, format, type, data_vptr);
             }
             /// <inheritdoc cref="ClearTexImage"/>
-            public static unsafe void ClearTexImage<T1>(TextureHandle texture, int level, PixelFormat format, PixelType type, ReadOnlySpan<T1> data)
+            public static unsafe void ClearTexImage<T1>(int texture, int level, PixelFormat format, PixelType type, ReadOnlySpan<T1> data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = data)
@@ -16551,7 +16551,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ClearTexImage"/>
-            public static unsafe void ClearTexImage<T1>(TextureHandle texture, int level, PixelFormat format, PixelType type, T1[] data)
+            public static unsafe void ClearTexImage<T1>(int texture, int level, PixelFormat format, PixelType type, T1[] data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = data)
@@ -16560,7 +16560,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ClearTexImage"/>
-            public static unsafe void ClearTexImage<T1>(TextureHandle texture, int level, PixelFormat format, PixelType type, in T1 data)
+            public static unsafe void ClearTexImage<T1>(int texture, int level, PixelFormat format, PixelType type, in T1 data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = &data)
@@ -16569,13 +16569,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ClearTexSubImage"/>
-            public static unsafe void ClearTexSubImage(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, IntPtr data)
+            public static unsafe void ClearTexSubImage(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, IntPtr data)
             {
                 void* data_vptr = (void*)data;
                 ClearTexSubImage(texture, level, xoffset, yoffset, zoffset, width, height, depth, format, type, data_vptr);
             }
             /// <inheritdoc cref="ClearTexSubImage"/>
-            public static unsafe void ClearTexSubImage<T1>(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, ReadOnlySpan<T1> data)
+            public static unsafe void ClearTexSubImage<T1>(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, ReadOnlySpan<T1> data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = data)
@@ -16584,7 +16584,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ClearTexSubImage"/>
-            public static unsafe void ClearTexSubImage<T1>(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, T1[] data)
+            public static unsafe void ClearTexSubImage<T1>(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, T1[] data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = data)
@@ -16593,7 +16593,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ClearTexSubImage"/>
-            public static unsafe void ClearTexSubImage<T1>(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, in T1 data)
+            public static unsafe void ClearTexSubImage<T1>(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, in T1 data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = &data)
@@ -16739,9 +16739,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return returnValue;
             }
             /// <inheritdoc cref="CreateTransformFeedbacks"/>
-            public static unsafe TransformFeedbackHandle CreateTransformFeedback()
+            public static unsafe int CreateTransformFeedback()
             {
-                TransformFeedbackHandle id;
+                int id;
                 int n = 1;
                 Unsafe.SkipInit(out id);
                 // FIXME: This could be a problem for the overloads that take an out parameter
@@ -16752,12 +16752,12 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                TransformFeedbackHandle* ids_handle = (TransformFeedbackHandle*)Unsafe.AsPointer(ref id);
+                int* ids_handle = (int*)Unsafe.AsPointer(ref id);
                 CreateTransformFeedbacks(n, ids_handle);
                 return id;
             }
             /// <inheritdoc cref="CreateTransformFeedbacks"/>
-            public static unsafe void CreateTransformFeedback(out TransformFeedbackHandle id)
+            public static unsafe void CreateTransformFeedback(out int id)
             {
                 int n = 1;
                 Unsafe.SkipInit(out id);
@@ -16769,37 +16769,37 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                TransformFeedbackHandle* ids_handle = (TransformFeedbackHandle*)Unsafe.AsPointer(ref id);
+                int* ids_handle = (int*)Unsafe.AsPointer(ref id);
                 CreateTransformFeedbacks(n, ids_handle);
             }
             /// <inheritdoc cref="CreateTransformFeedbacks"/>
-            public static unsafe void CreateTransformFeedbacks(Span<TransformFeedbackHandle> ids)
+            public static unsafe void CreateTransformFeedbacks(Span<int> ids)
             {
                 int n = (int)(ids.Length);
-                fixed (TransformFeedbackHandle* ids_ptr = ids)
+                fixed (int* ids_ptr = ids)
                 {
                     CreateTransformFeedbacks(n, ids_ptr);
                 }
             }
             /// <inheritdoc cref="CreateTransformFeedbacks"/>
-            public static unsafe void CreateTransformFeedbacks(TransformFeedbackHandle[] ids)
+            public static unsafe void CreateTransformFeedbacks(int[] ids)
             {
                 int n = (int)(ids.Length);
-                fixed (TransformFeedbackHandle* ids_ptr = ids)
+                fixed (int* ids_ptr = ids)
                 {
                     CreateTransformFeedbacks(n, ids_ptr);
                 }
             }
             /// <inheritdoc cref="CreateTransformFeedbacks"/>
-            public static unsafe void CreateTransformFeedbacks(int n, ref TransformFeedbackHandle ids)
+            public static unsafe void CreateTransformFeedbacks(int n, ref int ids)
             {
-                fixed (TransformFeedbackHandle* ids_ptr = &ids)
+                fixed (int* ids_ptr = &ids)
                 {
                     CreateTransformFeedbacks(n, ids_ptr);
                 }
             }
             /// <inheritdoc cref="GetTransformFeedbackiv"/>
-            public static unsafe void GetTransformFeedbacki(TransformFeedbackHandle xfb, TransformFeedbackPName pname, ref int param)
+            public static unsafe void GetTransformFeedbacki(int xfb, TransformFeedbackPName pname, ref int param)
             {
                 fixed (int* param_ptr = &param)
                 {
@@ -16807,7 +16807,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetTransformFeedbacki_v"/>
-            public static unsafe void GetTransformFeedback(TransformFeedbackHandle xfb, TransformFeedbackPName pname, uint index, ref int param)
+            public static unsafe void GetTransformFeedback(int xfb, TransformFeedbackPName pname, uint index, ref int param)
             {
                 fixed (int* param_ptr = &param)
                 {
@@ -16815,7 +16815,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetTransformFeedbacki64_v"/>
-            public static unsafe void GetTransformFeedbacki64_(TransformFeedbackHandle xfb, TransformFeedbackPName pname, uint index, ref long param)
+            public static unsafe void GetTransformFeedbacki64_(int xfb, TransformFeedbackPName pname, uint index, ref long param)
             {
                 fixed (long* param_ptr = &param)
                 {
@@ -16823,9 +16823,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="CreateBuffers"/>
-            public static unsafe BufferHandle CreateBuffer()
+            public static unsafe int CreateBuffer()
             {
-                BufferHandle buffer;
+                int buffer;
                 int n = 1;
                 Unsafe.SkipInit(out buffer);
                 // FIXME: This could be a problem for the overloads that take an out parameter
@@ -16836,12 +16836,12 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                BufferHandle* buffers_handle = (BufferHandle*)Unsafe.AsPointer(ref buffer);
+                int* buffers_handle = (int*)Unsafe.AsPointer(ref buffer);
                 CreateBuffers(n, buffers_handle);
                 return buffer;
             }
             /// <inheritdoc cref="CreateBuffers"/>
-            public static unsafe void CreateBuffer(out BufferHandle buffer)
+            public static unsafe void CreateBuffer(out int buffer)
             {
                 int n = 1;
                 Unsafe.SkipInit(out buffer);
@@ -16853,43 +16853,43 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                BufferHandle* buffers_handle = (BufferHandle*)Unsafe.AsPointer(ref buffer);
+                int* buffers_handle = (int*)Unsafe.AsPointer(ref buffer);
                 CreateBuffers(n, buffers_handle);
             }
             /// <inheritdoc cref="CreateBuffers"/>
-            public static unsafe void CreateBuffers(Span<BufferHandle> buffers)
+            public static unsafe void CreateBuffers(Span<int> buffers)
             {
                 int n = (int)(buffers.Length);
-                fixed (BufferHandle* buffers_ptr = buffers)
+                fixed (int* buffers_ptr = buffers)
                 {
                     CreateBuffers(n, buffers_ptr);
                 }
             }
             /// <inheritdoc cref="CreateBuffers"/>
-            public static unsafe void CreateBuffers(BufferHandle[] buffers)
+            public static unsafe void CreateBuffers(int[] buffers)
             {
                 int n = (int)(buffers.Length);
-                fixed (BufferHandle* buffers_ptr = buffers)
+                fixed (int* buffers_ptr = buffers)
                 {
                     CreateBuffers(n, buffers_ptr);
                 }
             }
             /// <inheritdoc cref="CreateBuffers"/>
-            public static unsafe void CreateBuffers(int n, ref BufferHandle buffers)
+            public static unsafe void CreateBuffers(int n, ref int buffers)
             {
-                fixed (BufferHandle* buffers_ptr = &buffers)
+                fixed (int* buffers_ptr = &buffers)
                 {
                     CreateBuffers(n, buffers_ptr);
                 }
             }
             /// <inheritdoc cref="NamedBufferStorage"/>
-            public static unsafe void NamedBufferStorage(BufferHandle buffer, nint size, IntPtr data, BufferStorageMask flags)
+            public static unsafe void NamedBufferStorage(int buffer, nint size, IntPtr data, BufferStorageMask flags)
             {
                 void* data_vptr = (void*)data;
                 NamedBufferStorage(buffer, size, data_vptr, flags);
             }
             /// <inheritdoc cref="NamedBufferStorage"/>
-            public static unsafe void NamedBufferStorage<T1>(BufferHandle buffer, ReadOnlySpan<T1> data, BufferStorageMask flags)
+            public static unsafe void NamedBufferStorage<T1>(int buffer, ReadOnlySpan<T1> data, BufferStorageMask flags)
                 where T1 : unmanaged
             {
                 nint size = (nint)(data.Length * sizeof(T1));
@@ -16899,7 +16899,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="NamedBufferStorage"/>
-            public static unsafe void NamedBufferStorage<T1>(BufferHandle buffer, T1[] data, BufferStorageMask flags)
+            public static unsafe void NamedBufferStorage<T1>(int buffer, T1[] data, BufferStorageMask flags)
                 where T1 : unmanaged
             {
                 nint size = (nint)(data.Length * sizeof(T1));
@@ -16909,7 +16909,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="NamedBufferStorage"/>
-            public static unsafe void NamedBufferStorage<T1>(BufferHandle buffer, nint size, in T1 data, BufferStorageMask flags)
+            public static unsafe void NamedBufferStorage<T1>(int buffer, nint size, in T1 data, BufferStorageMask flags)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = &data)
@@ -16918,13 +16918,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="NamedBufferData"/>
-            public static unsafe void NamedBufferData(BufferHandle buffer, nint size, IntPtr data, VertexBufferObjectUsage usage)
+            public static unsafe void NamedBufferData(int buffer, nint size, IntPtr data, VertexBufferObjectUsage usage)
             {
                 void* data_vptr = (void*)data;
                 NamedBufferData(buffer, size, data_vptr, usage);
             }
             /// <inheritdoc cref="NamedBufferData"/>
-            public static unsafe void NamedBufferData<T1>(BufferHandle buffer, ReadOnlySpan<T1> data, VertexBufferObjectUsage usage)
+            public static unsafe void NamedBufferData<T1>(int buffer, ReadOnlySpan<T1> data, VertexBufferObjectUsage usage)
                 where T1 : unmanaged
             {
                 nint size = (nint)(data.Length * sizeof(T1));
@@ -16934,7 +16934,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="NamedBufferData"/>
-            public static unsafe void NamedBufferData<T1>(BufferHandle buffer, T1[] data, VertexBufferObjectUsage usage)
+            public static unsafe void NamedBufferData<T1>(int buffer, T1[] data, VertexBufferObjectUsage usage)
                 where T1 : unmanaged
             {
                 nint size = (nint)(data.Length * sizeof(T1));
@@ -16944,7 +16944,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="NamedBufferData"/>
-            public static unsafe void NamedBufferData<T1>(BufferHandle buffer, nint size, in T1 data, VertexBufferObjectUsage usage)
+            public static unsafe void NamedBufferData<T1>(int buffer, nint size, in T1 data, VertexBufferObjectUsage usage)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = &data)
@@ -16953,13 +16953,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="NamedBufferSubData"/>
-            public static unsafe void NamedBufferSubData(BufferHandle buffer, IntPtr offset, nint size, IntPtr data)
+            public static unsafe void NamedBufferSubData(int buffer, IntPtr offset, nint size, IntPtr data)
             {
                 void* data_vptr = (void*)data;
                 NamedBufferSubData(buffer, offset, size, data_vptr);
             }
             /// <inheritdoc cref="NamedBufferSubData"/>
-            public static unsafe void NamedBufferSubData<T1>(BufferHandle buffer, IntPtr offset, ReadOnlySpan<T1> data)
+            public static unsafe void NamedBufferSubData<T1>(int buffer, IntPtr offset, ReadOnlySpan<T1> data)
                 where T1 : unmanaged
             {
                 nint size = (nint)(data.Length * sizeof(T1));
@@ -16969,7 +16969,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="NamedBufferSubData"/>
-            public static unsafe void NamedBufferSubData<T1>(BufferHandle buffer, IntPtr offset, T1[] data)
+            public static unsafe void NamedBufferSubData<T1>(int buffer, IntPtr offset, T1[] data)
                 where T1 : unmanaged
             {
                 nint size = (nint)(data.Length * sizeof(T1));
@@ -16979,7 +16979,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="NamedBufferSubData"/>
-            public static unsafe void NamedBufferSubData<T1>(BufferHandle buffer, IntPtr offset, nint size, in T1 data)
+            public static unsafe void NamedBufferSubData<T1>(int buffer, IntPtr offset, nint size, in T1 data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = &data)
@@ -16988,13 +16988,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ClearNamedBufferData"/>
-            public static unsafe void ClearNamedBufferData(BufferHandle buffer, SizedInternalFormat internalformat, PixelFormat format, PixelType type, IntPtr data)
+            public static unsafe void ClearNamedBufferData(int buffer, SizedInternalFormat internalformat, PixelFormat format, PixelType type, IntPtr data)
             {
                 void* data_vptr = (void*)data;
                 ClearNamedBufferData(buffer, internalformat, format, type, data_vptr);
             }
             /// <inheritdoc cref="ClearNamedBufferData"/>
-            public static unsafe void ClearNamedBufferData<T1>(BufferHandle buffer, SizedInternalFormat internalformat, PixelFormat format, PixelType type, in T1 data)
+            public static unsafe void ClearNamedBufferData<T1>(int buffer, SizedInternalFormat internalformat, PixelFormat format, PixelType type, in T1 data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = &data)
@@ -17003,13 +17003,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ClearNamedBufferSubData"/>
-            public static unsafe void ClearNamedBufferSubData(BufferHandle buffer, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, IntPtr data)
+            public static unsafe void ClearNamedBufferSubData(int buffer, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, IntPtr data)
             {
                 void* data_vptr = (void*)data;
                 ClearNamedBufferSubData(buffer, internalformat, offset, size, format, type, data_vptr);
             }
             /// <inheritdoc cref="ClearNamedBufferSubData"/>
-            public static unsafe void ClearNamedBufferSubData<T1>(BufferHandle buffer, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, ReadOnlySpan<T1> data)
+            public static unsafe void ClearNamedBufferSubData<T1>(int buffer, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, ReadOnlySpan<T1> data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = data)
@@ -17018,7 +17018,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ClearNamedBufferSubData"/>
-            public static unsafe void ClearNamedBufferSubData<T1>(BufferHandle buffer, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, T1[] data)
+            public static unsafe void ClearNamedBufferSubData<T1>(int buffer, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, T1[] data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = data)
@@ -17027,7 +17027,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ClearNamedBufferSubData"/>
-            public static unsafe void ClearNamedBufferSubData<T1>(BufferHandle buffer, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, in T1 data)
+            public static unsafe void ClearNamedBufferSubData<T1>(int buffer, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, in T1 data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = &data)
@@ -17036,7 +17036,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetNamedBufferParameteriv"/>
-            public static unsafe void GetNamedBufferParameteri(BufferHandle buffer, BufferPNameARB pname, ref int parameters)
+            public static unsafe void GetNamedBufferParameteri(int buffer, BufferPNameARB pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -17044,7 +17044,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetNamedBufferParameteri64v"/>
-            public static unsafe void GetNamedBufferParameteri64(BufferHandle buffer, BufferPNameARB pname, ref long parameters)
+            public static unsafe void GetNamedBufferParameteri64(int buffer, BufferPNameARB pname, ref long parameters)
             {
                 fixed (long* parameters_ptr = &parameters)
                 {
@@ -17052,18 +17052,18 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetNamedBufferPointerv"/>
-            public static unsafe void GetNamedBufferPointer(BufferHandle buffer, BufferPointerNameARB pname, void** parameters)
+            public static unsafe void GetNamedBufferPointer(int buffer, BufferPointerNameARB pname, void** parameters)
             {
                 GetNamedBufferPointerv(buffer, pname, parameters);
             }
             /// <inheritdoc cref="GetNamedBufferSubData"/>
-            public static unsafe void GetNamedBufferSubData(BufferHandle buffer, IntPtr offset, nint size, IntPtr data)
+            public static unsafe void GetNamedBufferSubData(int buffer, IntPtr offset, nint size, IntPtr data)
             {
                 void* data_vptr = (void*)data;
                 GetNamedBufferSubData(buffer, offset, size, data_vptr);
             }
             /// <inheritdoc cref="GetNamedBufferSubData"/>
-            public static unsafe void GetNamedBufferSubData<T1>(BufferHandle buffer, IntPtr offset, nint size, ref T1 data)
+            public static unsafe void GetNamedBufferSubData<T1>(int buffer, IntPtr offset, nint size, ref T1 data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = &data)
@@ -17072,9 +17072,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="CreateFramebuffers"/>
-            public static unsafe FramebufferHandle CreateFramebuffer()
+            public static unsafe int CreateFramebuffer()
             {
-                FramebufferHandle framebuffer;
+                int framebuffer;
                 int n = 1;
                 Unsafe.SkipInit(out framebuffer);
                 // FIXME: This could be a problem for the overloads that take an out parameter
@@ -17085,12 +17085,12 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                FramebufferHandle* framebuffers_handle = (FramebufferHandle*)Unsafe.AsPointer(ref framebuffer);
+                int* framebuffers_handle = (int*)Unsafe.AsPointer(ref framebuffer);
                 CreateFramebuffers(n, framebuffers_handle);
                 return framebuffer;
             }
             /// <inheritdoc cref="CreateFramebuffers"/>
-            public static unsafe void CreateFramebuffer(out FramebufferHandle framebuffer)
+            public static unsafe void CreateFramebuffer(out int framebuffer)
             {
                 int n = 1;
                 Unsafe.SkipInit(out framebuffer);
@@ -17102,37 +17102,37 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                FramebufferHandle* framebuffers_handle = (FramebufferHandle*)Unsafe.AsPointer(ref framebuffer);
+                int* framebuffers_handle = (int*)Unsafe.AsPointer(ref framebuffer);
                 CreateFramebuffers(n, framebuffers_handle);
             }
             /// <inheritdoc cref="CreateFramebuffers"/>
-            public static unsafe void CreateFramebuffers(Span<FramebufferHandle> framebuffers)
+            public static unsafe void CreateFramebuffers(Span<int> framebuffers)
             {
                 int n = (int)(framebuffers.Length);
-                fixed (FramebufferHandle* framebuffers_ptr = framebuffers)
+                fixed (int* framebuffers_ptr = framebuffers)
                 {
                     CreateFramebuffers(n, framebuffers_ptr);
                 }
             }
             /// <inheritdoc cref="CreateFramebuffers"/>
-            public static unsafe void CreateFramebuffers(FramebufferHandle[] framebuffers)
+            public static unsafe void CreateFramebuffers(int[] framebuffers)
             {
                 int n = (int)(framebuffers.Length);
-                fixed (FramebufferHandle* framebuffers_ptr = framebuffers)
+                fixed (int* framebuffers_ptr = framebuffers)
                 {
                     CreateFramebuffers(n, framebuffers_ptr);
                 }
             }
             /// <inheritdoc cref="CreateFramebuffers"/>
-            public static unsafe void CreateFramebuffers(int n, ref FramebufferHandle framebuffers)
+            public static unsafe void CreateFramebuffers(int n, ref int framebuffers)
             {
-                fixed (FramebufferHandle* framebuffers_ptr = &framebuffers)
+                fixed (int* framebuffers_ptr = &framebuffers)
                 {
                     CreateFramebuffers(n, framebuffers_ptr);
                 }
             }
             /// <inheritdoc cref="NamedFramebufferDrawBuffers"/>
-            public static unsafe void NamedFramebufferDrawBuffers(FramebufferHandle framebuffer, ReadOnlySpan<ColorBuffer> bufs)
+            public static unsafe void NamedFramebufferDrawBuffers(int framebuffer, ReadOnlySpan<ColorBuffer> bufs)
             {
                 int n = (int)(bufs.Length);
                 fixed (ColorBuffer* bufs_ptr = bufs)
@@ -17141,7 +17141,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="NamedFramebufferDrawBuffers"/>
-            public static unsafe void NamedFramebufferDrawBuffers(FramebufferHandle framebuffer, ColorBuffer[] bufs)
+            public static unsafe void NamedFramebufferDrawBuffers(int framebuffer, ColorBuffer[] bufs)
             {
                 int n = (int)(bufs.Length);
                 fixed (ColorBuffer* bufs_ptr = bufs)
@@ -17150,7 +17150,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="NamedFramebufferDrawBuffers"/>
-            public static unsafe void NamedFramebufferDrawBuffers(FramebufferHandle framebuffer, int n, in ColorBuffer bufs)
+            public static unsafe void NamedFramebufferDrawBuffers(int framebuffer, int n, in ColorBuffer bufs)
             {
                 fixed (ColorBuffer* bufs_ptr = &bufs)
                 {
@@ -17158,7 +17158,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="InvalidateNamedFramebufferData"/>
-            public static unsafe void InvalidateNamedFramebufferData(FramebufferHandle framebuffer, ReadOnlySpan<FramebufferAttachment> attachments)
+            public static unsafe void InvalidateNamedFramebufferData(int framebuffer, ReadOnlySpan<FramebufferAttachment> attachments)
             {
                 int numAttachments = (int)(attachments.Length);
                 fixed (FramebufferAttachment* attachments_ptr = attachments)
@@ -17167,7 +17167,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="InvalidateNamedFramebufferData"/>
-            public static unsafe void InvalidateNamedFramebufferData(FramebufferHandle framebuffer, FramebufferAttachment[] attachments)
+            public static unsafe void InvalidateNamedFramebufferData(int framebuffer, FramebufferAttachment[] attachments)
             {
                 int numAttachments = (int)(attachments.Length);
                 fixed (FramebufferAttachment* attachments_ptr = attachments)
@@ -17176,7 +17176,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="InvalidateNamedFramebufferData"/>
-            public static unsafe void InvalidateNamedFramebufferData(FramebufferHandle framebuffer, int numAttachments, in FramebufferAttachment attachments)
+            public static unsafe void InvalidateNamedFramebufferData(int framebuffer, int numAttachments, in FramebufferAttachment attachments)
             {
                 fixed (FramebufferAttachment* attachments_ptr = &attachments)
                 {
@@ -17184,7 +17184,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="InvalidateNamedFramebufferSubData"/>
-            public static unsafe void InvalidateNamedFramebufferSubData(FramebufferHandle framebuffer, ReadOnlySpan<FramebufferAttachment> attachments, int x, int y, int width, int height)
+            public static unsafe void InvalidateNamedFramebufferSubData(int framebuffer, ReadOnlySpan<FramebufferAttachment> attachments, int x, int y, int width, int height)
             {
                 int numAttachments = (int)(attachments.Length);
                 fixed (FramebufferAttachment* attachments_ptr = attachments)
@@ -17193,7 +17193,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="InvalidateNamedFramebufferSubData"/>
-            public static unsafe void InvalidateNamedFramebufferSubData(FramebufferHandle framebuffer, FramebufferAttachment[] attachments, int x, int y, int width, int height)
+            public static unsafe void InvalidateNamedFramebufferSubData(int framebuffer, FramebufferAttachment[] attachments, int x, int y, int width, int height)
             {
                 int numAttachments = (int)(attachments.Length);
                 fixed (FramebufferAttachment* attachments_ptr = attachments)
@@ -17202,7 +17202,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="InvalidateNamedFramebufferSubData"/>
-            public static unsafe void InvalidateNamedFramebufferSubData(FramebufferHandle framebuffer, int numAttachments, in FramebufferAttachment attachments, int x, int y, int width, int height)
+            public static unsafe void InvalidateNamedFramebufferSubData(int framebuffer, int numAttachments, in FramebufferAttachment attachments, int x, int y, int width, int height)
             {
                 fixed (FramebufferAttachment* attachments_ptr = &attachments)
                 {
@@ -17210,7 +17210,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ClearNamedFramebufferiv"/>
-            public static unsafe void ClearNamedFramebufferi(FramebufferHandle framebuffer, Buffer buffer, int drawbuffer, ReadOnlySpan<int> value)
+            public static unsafe void ClearNamedFramebufferi(int framebuffer, Buffer buffer, int drawbuffer, ReadOnlySpan<int> value)
             {
                 fixed (int* value_ptr = value)
                 {
@@ -17218,7 +17218,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ClearNamedFramebufferiv"/>
-            public static unsafe void ClearNamedFramebufferi(FramebufferHandle framebuffer, Buffer buffer, int drawbuffer, int[] value)
+            public static unsafe void ClearNamedFramebufferi(int framebuffer, Buffer buffer, int drawbuffer, int[] value)
             {
                 fixed (int* value_ptr = value)
                 {
@@ -17226,7 +17226,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ClearNamedFramebufferiv"/>
-            public static unsafe void ClearNamedFramebufferi(FramebufferHandle framebuffer, Buffer buffer, int drawbuffer, in int value)
+            public static unsafe void ClearNamedFramebufferi(int framebuffer, Buffer buffer, int drawbuffer, in int value)
             {
                 fixed (int* value_ptr = &value)
                 {
@@ -17234,7 +17234,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ClearNamedFramebufferuiv"/>
-            public static unsafe void ClearNamedFramebufferui(FramebufferHandle framebuffer, Buffer buffer, int drawbuffer, ReadOnlySpan<uint> value)
+            public static unsafe void ClearNamedFramebufferui(int framebuffer, Buffer buffer, int drawbuffer, ReadOnlySpan<uint> value)
             {
                 fixed (uint* value_ptr = value)
                 {
@@ -17242,7 +17242,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ClearNamedFramebufferuiv"/>
-            public static unsafe void ClearNamedFramebufferui(FramebufferHandle framebuffer, Buffer buffer, int drawbuffer, uint[] value)
+            public static unsafe void ClearNamedFramebufferui(int framebuffer, Buffer buffer, int drawbuffer, uint[] value)
             {
                 fixed (uint* value_ptr = value)
                 {
@@ -17250,7 +17250,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ClearNamedFramebufferuiv"/>
-            public static unsafe void ClearNamedFramebufferui(FramebufferHandle framebuffer, Buffer buffer, int drawbuffer, in uint value)
+            public static unsafe void ClearNamedFramebufferui(int framebuffer, Buffer buffer, int drawbuffer, in uint value)
             {
                 fixed (uint* value_ptr = &value)
                 {
@@ -17258,7 +17258,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ClearNamedFramebufferfv"/>
-            public static unsafe void ClearNamedFramebufferf(FramebufferHandle framebuffer, Buffer buffer, int drawbuffer, ReadOnlySpan<float> value)
+            public static unsafe void ClearNamedFramebufferf(int framebuffer, Buffer buffer, int drawbuffer, ReadOnlySpan<float> value)
             {
                 fixed (float* value_ptr = value)
                 {
@@ -17266,7 +17266,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ClearNamedFramebufferfv"/>
-            public static unsafe void ClearNamedFramebufferf(FramebufferHandle framebuffer, Buffer buffer, int drawbuffer, float[] value)
+            public static unsafe void ClearNamedFramebufferf(int framebuffer, Buffer buffer, int drawbuffer, float[] value)
             {
                 fixed (float* value_ptr = value)
                 {
@@ -17274,7 +17274,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ClearNamedFramebufferfv"/>
-            public static unsafe void ClearNamedFramebufferf(FramebufferHandle framebuffer, Buffer buffer, int drawbuffer, in float value)
+            public static unsafe void ClearNamedFramebufferf(int framebuffer, Buffer buffer, int drawbuffer, in float value)
             {
                 fixed (float* value_ptr = &value)
                 {
@@ -17282,12 +17282,12 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ClearNamedFramebufferfi"/>
-            public static unsafe void ClearNamedFramebuffer(FramebufferHandle framebuffer, Buffer buffer, int drawbuffer, float depth, int stencil)
+            public static unsafe void ClearNamedFramebuffer(int framebuffer, Buffer buffer, int drawbuffer, float depth, int stencil)
             {
                 ClearNamedFramebufferfi(framebuffer, buffer, drawbuffer, depth, stencil);
             }
             /// <inheritdoc cref="GetNamedFramebufferParameteriv"/>
-            public static unsafe void GetNamedFramebufferParameteri(FramebufferHandle framebuffer, GetFramebufferParameter pname, ref int param)
+            public static unsafe void GetNamedFramebufferParameteri(int framebuffer, GetFramebufferParameter pname, ref int param)
             {
                 fixed (int* param_ptr = &param)
                 {
@@ -17295,7 +17295,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetNamedFramebufferAttachmentParameteriv"/>
-            public static unsafe void GetNamedFramebufferAttachmentParameteri(FramebufferHandle framebuffer, FramebufferAttachment attachment, FramebufferAttachmentParameterName pname, ref int parameters)
+            public static unsafe void GetNamedFramebufferAttachmentParameteri(int framebuffer, FramebufferAttachment attachment, FramebufferAttachmentParameterName pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -17303,9 +17303,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="CreateRenderbuffers"/>
-            public static unsafe RenderbufferHandle CreateRenderbuffer()
+            public static unsafe int CreateRenderbuffer()
             {
-                RenderbufferHandle renderbuffer;
+                int renderbuffer;
                 int n = 1;
                 Unsafe.SkipInit(out renderbuffer);
                 // FIXME: This could be a problem for the overloads that take an out parameter
@@ -17316,12 +17316,12 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                RenderbufferHandle* renderbuffers_handle = (RenderbufferHandle*)Unsafe.AsPointer(ref renderbuffer);
+                int* renderbuffers_handle = (int*)Unsafe.AsPointer(ref renderbuffer);
                 CreateRenderbuffers(n, renderbuffers_handle);
                 return renderbuffer;
             }
             /// <inheritdoc cref="CreateRenderbuffers"/>
-            public static unsafe void CreateRenderbuffer(out RenderbufferHandle renderbuffer)
+            public static unsafe void CreateRenderbuffer(out int renderbuffer)
             {
                 int n = 1;
                 Unsafe.SkipInit(out renderbuffer);
@@ -17333,37 +17333,37 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                RenderbufferHandle* renderbuffers_handle = (RenderbufferHandle*)Unsafe.AsPointer(ref renderbuffer);
+                int* renderbuffers_handle = (int*)Unsafe.AsPointer(ref renderbuffer);
                 CreateRenderbuffers(n, renderbuffers_handle);
             }
             /// <inheritdoc cref="CreateRenderbuffers"/>
-            public static unsafe void CreateRenderbuffers(Span<RenderbufferHandle> renderbuffers)
+            public static unsafe void CreateRenderbuffers(Span<int> renderbuffers)
             {
                 int n = (int)(renderbuffers.Length);
-                fixed (RenderbufferHandle* renderbuffers_ptr = renderbuffers)
+                fixed (int* renderbuffers_ptr = renderbuffers)
                 {
                     CreateRenderbuffers(n, renderbuffers_ptr);
                 }
             }
             /// <inheritdoc cref="CreateRenderbuffers"/>
-            public static unsafe void CreateRenderbuffers(RenderbufferHandle[] renderbuffers)
+            public static unsafe void CreateRenderbuffers(int[] renderbuffers)
             {
                 int n = (int)(renderbuffers.Length);
-                fixed (RenderbufferHandle* renderbuffers_ptr = renderbuffers)
+                fixed (int* renderbuffers_ptr = renderbuffers)
                 {
                     CreateRenderbuffers(n, renderbuffers_ptr);
                 }
             }
             /// <inheritdoc cref="CreateRenderbuffers"/>
-            public static unsafe void CreateRenderbuffers(int n, ref RenderbufferHandle renderbuffers)
+            public static unsafe void CreateRenderbuffers(int n, ref int renderbuffers)
             {
-                fixed (RenderbufferHandle* renderbuffers_ptr = &renderbuffers)
+                fixed (int* renderbuffers_ptr = &renderbuffers)
                 {
                     CreateRenderbuffers(n, renderbuffers_ptr);
                 }
             }
             /// <inheritdoc cref="GetNamedRenderbufferParameteriv"/>
-            public static unsafe void GetNamedRenderbufferParameteri(RenderbufferHandle renderbuffer, RenderbufferParameterName pname, ref int parameters)
+            public static unsafe void GetNamedRenderbufferParameteri(int renderbuffer, RenderbufferParameterName pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -17371,9 +17371,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="CreateTextures"/>
-            public static unsafe TextureHandle CreateTexture(TextureTarget target)
+            public static unsafe int CreateTexture(TextureTarget target)
             {
-                TextureHandle texture;
+                int texture;
                 int n = 1;
                 Unsafe.SkipInit(out texture);
                 // FIXME: This could be a problem for the overloads that take an out parameter
@@ -17384,12 +17384,12 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                TextureHandle* textures_handle = (TextureHandle*)Unsafe.AsPointer(ref texture);
+                int* textures_handle = (int*)Unsafe.AsPointer(ref texture);
                 CreateTextures(target, n, textures_handle);
                 return texture;
             }
             /// <inheritdoc cref="CreateTextures"/>
-            public static unsafe void CreateTexture(TextureTarget target, out TextureHandle texture)
+            public static unsafe void CreateTexture(TextureTarget target, out int texture)
             {
                 int n = 1;
                 Unsafe.SkipInit(out texture);
@@ -17401,43 +17401,43 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                TextureHandle* textures_handle = (TextureHandle*)Unsafe.AsPointer(ref texture);
+                int* textures_handle = (int*)Unsafe.AsPointer(ref texture);
                 CreateTextures(target, n, textures_handle);
             }
             /// <inheritdoc cref="CreateTextures"/>
-            public static unsafe void CreateTextures(TextureTarget target, Span<TextureHandle> textures)
+            public static unsafe void CreateTextures(TextureTarget target, Span<int> textures)
             {
                 int n = (int)(textures.Length);
-                fixed (TextureHandle* textures_ptr = textures)
+                fixed (int* textures_ptr = textures)
                 {
                     CreateTextures(target, n, textures_ptr);
                 }
             }
             /// <inheritdoc cref="CreateTextures"/>
-            public static unsafe void CreateTextures(TextureTarget target, TextureHandle[] textures)
+            public static unsafe void CreateTextures(TextureTarget target, int[] textures)
             {
                 int n = (int)(textures.Length);
-                fixed (TextureHandle* textures_ptr = textures)
+                fixed (int* textures_ptr = textures)
                 {
                     CreateTextures(target, n, textures_ptr);
                 }
             }
             /// <inheritdoc cref="CreateTextures"/>
-            public static unsafe void CreateTextures(TextureTarget target, int n, ref TextureHandle textures)
+            public static unsafe void CreateTextures(TextureTarget target, int n, ref int textures)
             {
-                fixed (TextureHandle* textures_ptr = &textures)
+                fixed (int* textures_ptr = &textures)
                 {
                     CreateTextures(target, n, textures_ptr);
                 }
             }
             /// <inheritdoc cref="TextureSubImage1D"/>
-            public static unsafe void TextureSubImage1D(TextureHandle texture, int level, int xoffset, int width, PixelFormat format, PixelType type, IntPtr pixels)
+            public static unsafe void TextureSubImage1D(int texture, int level, int xoffset, int width, PixelFormat format, PixelType type, IntPtr pixels)
             {
                 void* pixels_vptr = (void*)pixels;
                 TextureSubImage1D(texture, level, xoffset, width, format, type, pixels_vptr);
             }
             /// <inheritdoc cref="TextureSubImage1D"/>
-            public static unsafe void TextureSubImage1D<T1>(TextureHandle texture, int level, int xoffset, int width, PixelFormat format, PixelType type, in T1 pixels)
+            public static unsafe void TextureSubImage1D<T1>(int texture, int level, int xoffset, int width, PixelFormat format, PixelType type, in T1 pixels)
                 where T1 : unmanaged
             {
                 fixed (void* pixels_ptr = &pixels)
@@ -17446,13 +17446,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="TextureSubImage2D"/>
-            public static unsafe void TextureSubImage2D(TextureHandle texture, int level, int xoffset, int yoffset, int width, int height, PixelFormat format, PixelType type, IntPtr pixels)
+            public static unsafe void TextureSubImage2D(int texture, int level, int xoffset, int yoffset, int width, int height, PixelFormat format, PixelType type, IntPtr pixels)
             {
                 void* pixels_vptr = (void*)pixels;
                 TextureSubImage2D(texture, level, xoffset, yoffset, width, height, format, type, pixels_vptr);
             }
             /// <inheritdoc cref="TextureSubImage2D"/>
-            public static unsafe void TextureSubImage2D<T1>(TextureHandle texture, int level, int xoffset, int yoffset, int width, int height, PixelFormat format, PixelType type, in T1 pixels)
+            public static unsafe void TextureSubImage2D<T1>(int texture, int level, int xoffset, int yoffset, int width, int height, PixelFormat format, PixelType type, in T1 pixels)
                 where T1 : unmanaged
             {
                 fixed (void* pixels_ptr = &pixels)
@@ -17461,13 +17461,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="TextureSubImage3D"/>
-            public static unsafe void TextureSubImage3D(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, IntPtr pixels)
+            public static unsafe void TextureSubImage3D(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, IntPtr pixels)
             {
                 void* pixels_vptr = (void*)pixels;
                 TextureSubImage3D(texture, level, xoffset, yoffset, zoffset, width, height, depth, format, type, pixels_vptr);
             }
             /// <inheritdoc cref="TextureSubImage3D"/>
-            public static unsafe void TextureSubImage3D<T1>(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, in T1 pixels)
+            public static unsafe void TextureSubImage3D<T1>(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, in T1 pixels)
                 where T1 : unmanaged
             {
                 fixed (void* pixels_ptr = &pixels)
@@ -17476,13 +17476,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="CompressedTextureSubImage1D"/>
-            public static unsafe void CompressedTextureSubImage1D(TextureHandle texture, int level, int xoffset, int width, InternalFormat format, int imageSize, IntPtr data)
+            public static unsafe void CompressedTextureSubImage1D(int texture, int level, int xoffset, int width, InternalFormat format, int imageSize, IntPtr data)
             {
                 void* data_vptr = (void*)data;
                 CompressedTextureSubImage1D(texture, level, xoffset, width, format, imageSize, data_vptr);
             }
             /// <inheritdoc cref="CompressedTextureSubImage1D"/>
-            public static unsafe void CompressedTextureSubImage1D<T1>(TextureHandle texture, int level, int xoffset, int width, InternalFormat format, int imageSize, in T1 data)
+            public static unsafe void CompressedTextureSubImage1D<T1>(int texture, int level, int xoffset, int width, InternalFormat format, int imageSize, in T1 data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = &data)
@@ -17491,13 +17491,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="CompressedTextureSubImage2D"/>
-            public static unsafe void CompressedTextureSubImage2D(TextureHandle texture, int level, int xoffset, int yoffset, int width, int height, InternalFormat format, int imageSize, IntPtr data)
+            public static unsafe void CompressedTextureSubImage2D(int texture, int level, int xoffset, int yoffset, int width, int height, InternalFormat format, int imageSize, IntPtr data)
             {
                 void* data_vptr = (void*)data;
                 CompressedTextureSubImage2D(texture, level, xoffset, yoffset, width, height, format, imageSize, data_vptr);
             }
             /// <inheritdoc cref="CompressedTextureSubImage2D"/>
-            public static unsafe void CompressedTextureSubImage2D<T1>(TextureHandle texture, int level, int xoffset, int yoffset, int width, int height, InternalFormat format, int imageSize, in T1 data)
+            public static unsafe void CompressedTextureSubImage2D<T1>(int texture, int level, int xoffset, int yoffset, int width, int height, InternalFormat format, int imageSize, in T1 data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = &data)
@@ -17506,13 +17506,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="CompressedTextureSubImage3D"/>
-            public static unsafe void CompressedTextureSubImage3D(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, InternalFormat format, int imageSize, IntPtr data)
+            public static unsafe void CompressedTextureSubImage3D(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, InternalFormat format, int imageSize, IntPtr data)
             {
                 void* data_vptr = (void*)data;
                 CompressedTextureSubImage3D(texture, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, data_vptr);
             }
             /// <inheritdoc cref="CompressedTextureSubImage3D"/>
-            public static unsafe void CompressedTextureSubImage3D<T1>(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, InternalFormat format, int imageSize, in T1 data)
+            public static unsafe void CompressedTextureSubImage3D<T1>(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, InternalFormat format, int imageSize, in T1 data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = &data)
@@ -17521,7 +17521,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="TextureParameterfv"/>
-            public static unsafe void TextureParameterf(TextureHandle texture, TextureParameterName pname, ReadOnlySpan<float> param)
+            public static unsafe void TextureParameterf(int texture, TextureParameterName pname, ReadOnlySpan<float> param)
             {
                 fixed (float* param_ptr = param)
                 {
@@ -17529,7 +17529,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="TextureParameterfv"/>
-            public static unsafe void TextureParameterf(TextureHandle texture, TextureParameterName pname, float[] param)
+            public static unsafe void TextureParameterf(int texture, TextureParameterName pname, float[] param)
             {
                 fixed (float* param_ptr = param)
                 {
@@ -17537,7 +17537,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="TextureParameterfv"/>
-            public static unsafe void TextureParameterf(TextureHandle texture, TextureParameterName pname, in float param)
+            public static unsafe void TextureParameterf(int texture, TextureParameterName pname, in float param)
             {
                 fixed (float* param_ptr = &param)
                 {
@@ -17545,7 +17545,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="TextureParameterIiv"/>
-            public static unsafe void TextureParameterIi(TextureHandle texture, TextureParameterName pname, ReadOnlySpan<int> parameters)
+            public static unsafe void TextureParameterIi(int texture, TextureParameterName pname, ReadOnlySpan<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -17553,7 +17553,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="TextureParameterIiv"/>
-            public static unsafe void TextureParameterIi(TextureHandle texture, TextureParameterName pname, int[] parameters)
+            public static unsafe void TextureParameterIi(int texture, TextureParameterName pname, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -17561,7 +17561,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="TextureParameterIiv"/>
-            public static unsafe void TextureParameterIi(TextureHandle texture, TextureParameterName pname, in int parameters)
+            public static unsafe void TextureParameterIi(int texture, TextureParameterName pname, in int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -17569,7 +17569,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="TextureParameterIuiv"/>
-            public static unsafe void TextureParameterIui(TextureHandle texture, TextureParameterName pname, ReadOnlySpan<uint> parameters)
+            public static unsafe void TextureParameterIui(int texture, TextureParameterName pname, ReadOnlySpan<uint> parameters)
             {
                 fixed (uint* parameters_ptr = parameters)
                 {
@@ -17577,7 +17577,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="TextureParameterIuiv"/>
-            public static unsafe void TextureParameterIui(TextureHandle texture, TextureParameterName pname, uint[] parameters)
+            public static unsafe void TextureParameterIui(int texture, TextureParameterName pname, uint[] parameters)
             {
                 fixed (uint* parameters_ptr = parameters)
                 {
@@ -17585,7 +17585,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="TextureParameterIuiv"/>
-            public static unsafe void TextureParameterIui(TextureHandle texture, TextureParameterName pname, in uint parameters)
+            public static unsafe void TextureParameterIui(int texture, TextureParameterName pname, in uint parameters)
             {
                 fixed (uint* parameters_ptr = &parameters)
                 {
@@ -17593,7 +17593,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="TextureParameteriv"/>
-            public static unsafe void TextureParameteri(TextureHandle texture, TextureParameterName pname, ReadOnlySpan<int> param)
+            public static unsafe void TextureParameteri(int texture, TextureParameterName pname, ReadOnlySpan<int> param)
             {
                 fixed (int* param_ptr = param)
                 {
@@ -17601,7 +17601,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="TextureParameteriv"/>
-            public static unsafe void TextureParameteri(TextureHandle texture, TextureParameterName pname, int[] param)
+            public static unsafe void TextureParameteri(int texture, TextureParameterName pname, int[] param)
             {
                 fixed (int* param_ptr = param)
                 {
@@ -17609,7 +17609,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="TextureParameteriv"/>
-            public static unsafe void TextureParameteri(TextureHandle texture, TextureParameterName pname, in int param)
+            public static unsafe void TextureParameteri(int texture, TextureParameterName pname, in int param)
             {
                 fixed (int* param_ptr = &param)
                 {
@@ -17617,13 +17617,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetTextureImage"/>
-            public static unsafe void GetTextureImage(TextureHandle texture, int level, PixelFormat format, PixelType type, int bufSize, IntPtr pixels)
+            public static unsafe void GetTextureImage(int texture, int level, PixelFormat format, PixelType type, int bufSize, IntPtr pixels)
             {
                 void* pixels_vptr = (void*)pixels;
                 GetTextureImage(texture, level, format, type, bufSize, pixels_vptr);
             }
             /// <inheritdoc cref="GetTextureImage"/>
-            public static unsafe void GetTextureImage<T1>(TextureHandle texture, int level, PixelFormat format, PixelType type, Span<T1> pixels)
+            public static unsafe void GetTextureImage<T1>(int texture, int level, PixelFormat format, PixelType type, Span<T1> pixels)
                 where T1 : unmanaged
             {
                 int bufSize = (int)(pixels.Length * sizeof(T1));
@@ -17633,7 +17633,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetTextureImage"/>
-            public static unsafe void GetTextureImage<T1>(TextureHandle texture, int level, PixelFormat format, PixelType type, T1[] pixels)
+            public static unsafe void GetTextureImage<T1>(int texture, int level, PixelFormat format, PixelType type, T1[] pixels)
                 where T1 : unmanaged
             {
                 int bufSize = (int)(pixels.Length * sizeof(T1));
@@ -17643,7 +17643,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetTextureImage"/>
-            public static unsafe void GetTextureImage<T1>(TextureHandle texture, int level, PixelFormat format, PixelType type, int bufSize, ref T1 pixels)
+            public static unsafe void GetTextureImage<T1>(int texture, int level, PixelFormat format, PixelType type, int bufSize, ref T1 pixels)
                 where T1 : unmanaged
             {
                 fixed (void* pixels_ptr = &pixels)
@@ -17652,13 +17652,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetCompressedTextureImage"/>
-            public static unsafe void GetCompressedTextureImage(TextureHandle texture, int level, int bufSize, IntPtr pixels)
+            public static unsafe void GetCompressedTextureImage(int texture, int level, int bufSize, IntPtr pixels)
             {
                 void* pixels_vptr = (void*)pixels;
                 GetCompressedTextureImage(texture, level, bufSize, pixels_vptr);
             }
             /// <inheritdoc cref="GetCompressedTextureImage"/>
-            public static unsafe void GetCompressedTextureImage<T1>(TextureHandle texture, int level, Span<T1> pixels)
+            public static unsafe void GetCompressedTextureImage<T1>(int texture, int level, Span<T1> pixels)
                 where T1 : unmanaged
             {
                 int bufSize = (int)(pixels.Length * sizeof(T1));
@@ -17668,7 +17668,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetCompressedTextureImage"/>
-            public static unsafe void GetCompressedTextureImage<T1>(TextureHandle texture, int level, T1[] pixels)
+            public static unsafe void GetCompressedTextureImage<T1>(int texture, int level, T1[] pixels)
                 where T1 : unmanaged
             {
                 int bufSize = (int)(pixels.Length * sizeof(T1));
@@ -17678,7 +17678,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetCompressedTextureImage"/>
-            public static unsafe void GetCompressedTextureImage<T1>(TextureHandle texture, int level, int bufSize, ref T1 pixels)
+            public static unsafe void GetCompressedTextureImage<T1>(int texture, int level, int bufSize, ref T1 pixels)
                 where T1 : unmanaged
             {
                 fixed (void* pixels_ptr = &pixels)
@@ -17687,7 +17687,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetTextureLevelParameterfv"/>
-            public static unsafe void GetTextureLevelParameterf(TextureHandle texture, int level, GetTextureParameter pname, ref float parameters)
+            public static unsafe void GetTextureLevelParameterf(int texture, int level, GetTextureParameter pname, ref float parameters)
             {
                 fixed (float* parameters_ptr = &parameters)
                 {
@@ -17695,7 +17695,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetTextureLevelParameteriv"/>
-            public static unsafe void GetTextureLevelParameteri(TextureHandle texture, int level, GetTextureParameter pname, ref int parameters)
+            public static unsafe void GetTextureLevelParameteri(int texture, int level, GetTextureParameter pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -17703,7 +17703,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetTextureParameterfv"/>
-            public static unsafe void GetTextureParameterf(TextureHandle texture, GetTextureParameter pname, ref float parameters)
+            public static unsafe void GetTextureParameterf(int texture, GetTextureParameter pname, ref float parameters)
             {
                 fixed (float* parameters_ptr = &parameters)
                 {
@@ -17711,7 +17711,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetTextureParameterIiv"/>
-            public static unsafe void GetTextureParameterIi(TextureHandle texture, GetTextureParameter pname, ref int parameters)
+            public static unsafe void GetTextureParameterIi(int texture, GetTextureParameter pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -17719,7 +17719,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetTextureParameterIuiv"/>
-            public static unsafe void GetTextureParameterIui(TextureHandle texture, GetTextureParameter pname, ref uint parameters)
+            public static unsafe void GetTextureParameterIui(int texture, GetTextureParameter pname, ref uint parameters)
             {
                 fixed (uint* parameters_ptr = &parameters)
                 {
@@ -17727,7 +17727,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetTextureParameteriv"/>
-            public static unsafe void GetTextureParameteri(TextureHandle texture, GetTextureParameter pname, ref int parameters)
+            public static unsafe void GetTextureParameteri(int texture, GetTextureParameter pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -17735,9 +17735,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="CreateVertexArrays"/>
-            public static unsafe VertexArrayHandle CreateVertexArray()
+            public static unsafe int CreateVertexArray()
             {
-                VertexArrayHandle array;
+                int array;
                 int n = 1;
                 Unsafe.SkipInit(out array);
                 // FIXME: This could be a problem for the overloads that take an out parameter
@@ -17748,12 +17748,12 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                VertexArrayHandle* arrays_handle = (VertexArrayHandle*)Unsafe.AsPointer(ref array);
+                int* arrays_handle = (int*)Unsafe.AsPointer(ref array);
                 CreateVertexArrays(n, arrays_handle);
                 return array;
             }
             /// <inheritdoc cref="CreateVertexArrays"/>
-            public static unsafe void CreateVertexArray(out VertexArrayHandle array)
+            public static unsafe void CreateVertexArray(out int array)
             {
                 int n = 1;
                 Unsafe.SkipInit(out array);
@@ -17765,39 +17765,39 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                VertexArrayHandle* arrays_handle = (VertexArrayHandle*)Unsafe.AsPointer(ref array);
+                int* arrays_handle = (int*)Unsafe.AsPointer(ref array);
                 CreateVertexArrays(n, arrays_handle);
             }
             /// <inheritdoc cref="CreateVertexArrays"/>
-            public static unsafe void CreateVertexArrays(Span<VertexArrayHandle> arrays)
+            public static unsafe void CreateVertexArrays(Span<int> arrays)
             {
                 int n = (int)(arrays.Length);
-                fixed (VertexArrayHandle* arrays_ptr = arrays)
+                fixed (int* arrays_ptr = arrays)
                 {
                     CreateVertexArrays(n, arrays_ptr);
                 }
             }
             /// <inheritdoc cref="CreateVertexArrays"/>
-            public static unsafe void CreateVertexArrays(VertexArrayHandle[] arrays)
+            public static unsafe void CreateVertexArrays(int[] arrays)
             {
                 int n = (int)(arrays.Length);
-                fixed (VertexArrayHandle* arrays_ptr = arrays)
+                fixed (int* arrays_ptr = arrays)
                 {
                     CreateVertexArrays(n, arrays_ptr);
                 }
             }
             /// <inheritdoc cref="CreateVertexArrays"/>
-            public static unsafe void CreateVertexArrays(int n, ref VertexArrayHandle arrays)
+            public static unsafe void CreateVertexArrays(int n, ref int arrays)
             {
-                fixed (VertexArrayHandle* arrays_ptr = &arrays)
+                fixed (int* arrays_ptr = &arrays)
                 {
                     CreateVertexArrays(n, arrays_ptr);
                 }
             }
             /// <inheritdoc cref="VertexArrayVertexBuffers"/>
-            public static unsafe void VertexArrayVertexBuffers(VertexArrayHandle vaobj, uint first, int count, ReadOnlySpan<BufferHandle> buffers, ReadOnlySpan<IntPtr> offsets, ReadOnlySpan<int> strides)
+            public static unsafe void VertexArrayVertexBuffers(int vaobj, uint first, int count, ReadOnlySpan<int> buffers, ReadOnlySpan<IntPtr> offsets, ReadOnlySpan<int> strides)
             {
-                fixed (BufferHandle* buffers_ptr = buffers)
+                fixed (int* buffers_ptr = buffers)
                 {
                     fixed (IntPtr* offsets_ptr = offsets)
                     {
@@ -17809,9 +17809,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="VertexArrayVertexBuffers"/>
-            public static unsafe void VertexArrayVertexBuffers(VertexArrayHandle vaobj, uint first, int count, BufferHandle[] buffers, IntPtr[] offsets, int[] strides)
+            public static unsafe void VertexArrayVertexBuffers(int vaobj, uint first, int count, int[] buffers, IntPtr[] offsets, int[] strides)
             {
-                fixed (BufferHandle* buffers_ptr = buffers)
+                fixed (int* buffers_ptr = buffers)
                 {
                     fixed (IntPtr* offsets_ptr = offsets)
                     {
@@ -17823,9 +17823,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="VertexArrayVertexBuffers"/>
-            public static unsafe void VertexArrayVertexBuffers(VertexArrayHandle vaobj, uint first, int count, in BufferHandle buffers, in IntPtr offsets, in int strides)
+            public static unsafe void VertexArrayVertexBuffers(int vaobj, uint first, int count, in int buffers, in IntPtr offsets, in int strides)
             {
-                fixed (BufferHandle* buffers_ptr = &buffers)
+                fixed (int* buffers_ptr = &buffers)
                 fixed (IntPtr* offsets_ptr = &offsets)
                 fixed (int* strides_ptr = &strides)
                 {
@@ -17833,7 +17833,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetVertexArrayiv"/>
-            public static unsafe void GetVertexArrayi(VertexArrayHandle vaobj, VertexArrayPName pname, ref int param)
+            public static unsafe void GetVertexArrayi(int vaobj, VertexArrayPName pname, ref int param)
             {
                 fixed (int* param_ptr = &param)
                 {
@@ -17841,7 +17841,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetVertexArrayIndexediv"/>
-            public static unsafe void GetVertexArrayIndexedi(VertexArrayHandle vaobj, uint index, VertexArrayPName pname, ref int param)
+            public static unsafe void GetVertexArrayIndexedi(int vaobj, uint index, VertexArrayPName pname, ref int param)
             {
                 fixed (int* param_ptr = &param)
                 {
@@ -17849,7 +17849,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetVertexArrayIndexed64iv"/>
-            public static unsafe void GetVertexArrayIndexed64iv(VertexArrayHandle vaobj, uint index, VertexArrayPName pname, ref long param)
+            public static unsafe void GetVertexArrayIndexed64iv(int vaobj, uint index, VertexArrayPName pname, ref long param)
             {
                 fixed (long* param_ptr = &param)
                 {
@@ -17857,9 +17857,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="CreateSamplers"/>
-            public static unsafe SamplerHandle CreateSampler()
+            public static unsafe int CreateSampler()
             {
-                SamplerHandle sampler;
+                int sampler;
                 int n = 1;
                 Unsafe.SkipInit(out sampler);
                 // FIXME: This could be a problem for the overloads that take an out parameter
@@ -17870,12 +17870,12 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                SamplerHandle* samplers_handle = (SamplerHandle*)Unsafe.AsPointer(ref sampler);
+                int* samplers_handle = (int*)Unsafe.AsPointer(ref sampler);
                 CreateSamplers(n, samplers_handle);
                 return sampler;
             }
             /// <inheritdoc cref="CreateSamplers"/>
-            public static unsafe void CreateSampler(out SamplerHandle sampler)
+            public static unsafe void CreateSampler(out int sampler)
             {
                 int n = 1;
                 Unsafe.SkipInit(out sampler);
@@ -17887,39 +17887,39 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                SamplerHandle* samplers_handle = (SamplerHandle*)Unsafe.AsPointer(ref sampler);
+                int* samplers_handle = (int*)Unsafe.AsPointer(ref sampler);
                 CreateSamplers(n, samplers_handle);
             }
             /// <inheritdoc cref="CreateSamplers"/>
-            public static unsafe void CreateSamplers(Span<SamplerHandle> samplers)
+            public static unsafe void CreateSamplers(Span<int> samplers)
             {
                 int n = (int)(samplers.Length);
-                fixed (SamplerHandle* samplers_ptr = samplers)
+                fixed (int* samplers_ptr = samplers)
                 {
                     CreateSamplers(n, samplers_ptr);
                 }
             }
             /// <inheritdoc cref="CreateSamplers"/>
-            public static unsafe void CreateSamplers(SamplerHandle[] samplers)
+            public static unsafe void CreateSamplers(int[] samplers)
             {
                 int n = (int)(samplers.Length);
-                fixed (SamplerHandle* samplers_ptr = samplers)
+                fixed (int* samplers_ptr = samplers)
                 {
                     CreateSamplers(n, samplers_ptr);
                 }
             }
             /// <inheritdoc cref="CreateSamplers"/>
-            public static unsafe void CreateSamplers(int n, ref SamplerHandle samplers)
+            public static unsafe void CreateSamplers(int n, ref int samplers)
             {
-                fixed (SamplerHandle* samplers_ptr = &samplers)
+                fixed (int* samplers_ptr = &samplers)
                 {
                     CreateSamplers(n, samplers_ptr);
                 }
             }
             /// <inheritdoc cref="CreateProgramPipelines"/>
-            public static unsafe ProgramPipelineHandle CreateProgramPipeline()
+            public static unsafe int CreateProgramPipeline()
             {
-                ProgramPipelineHandle pipeline;
+                int pipeline;
                 int n = 1;
                 Unsafe.SkipInit(out pipeline);
                 // FIXME: This could be a problem for the overloads that take an out parameter
@@ -17930,12 +17930,12 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                ProgramPipelineHandle* pipelines_handle = (ProgramPipelineHandle*)Unsafe.AsPointer(ref pipeline);
+                int* pipelines_handle = (int*)Unsafe.AsPointer(ref pipeline);
                 CreateProgramPipelines(n, pipelines_handle);
                 return pipeline;
             }
             /// <inheritdoc cref="CreateProgramPipelines"/>
-            public static unsafe void CreateProgramPipeline(out ProgramPipelineHandle pipeline)
+            public static unsafe void CreateProgramPipeline(out int pipeline)
             {
                 int n = 1;
                 Unsafe.SkipInit(out pipeline);
@@ -17947,39 +17947,39 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                ProgramPipelineHandle* pipelines_handle = (ProgramPipelineHandle*)Unsafe.AsPointer(ref pipeline);
+                int* pipelines_handle = (int*)Unsafe.AsPointer(ref pipeline);
                 CreateProgramPipelines(n, pipelines_handle);
             }
             /// <inheritdoc cref="CreateProgramPipelines"/>
-            public static unsafe void CreateProgramPipelines(Span<ProgramPipelineHandle> pipelines)
+            public static unsafe void CreateProgramPipelines(Span<int> pipelines)
             {
                 int n = (int)(pipelines.Length);
-                fixed (ProgramPipelineHandle* pipelines_ptr = pipelines)
+                fixed (int* pipelines_ptr = pipelines)
                 {
                     CreateProgramPipelines(n, pipelines_ptr);
                 }
             }
             /// <inheritdoc cref="CreateProgramPipelines"/>
-            public static unsafe void CreateProgramPipelines(ProgramPipelineHandle[] pipelines)
+            public static unsafe void CreateProgramPipelines(int[] pipelines)
             {
                 int n = (int)(pipelines.Length);
-                fixed (ProgramPipelineHandle* pipelines_ptr = pipelines)
+                fixed (int* pipelines_ptr = pipelines)
                 {
                     CreateProgramPipelines(n, pipelines_ptr);
                 }
             }
             /// <inheritdoc cref="CreateProgramPipelines"/>
-            public static unsafe void CreateProgramPipelines(int n, ref ProgramPipelineHandle pipelines)
+            public static unsafe void CreateProgramPipelines(int n, ref int pipelines)
             {
-                fixed (ProgramPipelineHandle* pipelines_ptr = &pipelines)
+                fixed (int* pipelines_ptr = &pipelines)
                 {
                     CreateProgramPipelines(n, pipelines_ptr);
                 }
             }
             /// <inheritdoc cref="CreateQueries"/>
-            public static unsafe QueryHandle CreateQuery(QueryTarget target)
+            public static unsafe int CreateQuery(QueryTarget target)
             {
-                QueryHandle id;
+                int id;
                 int n = 1;
                 Unsafe.SkipInit(out id);
                 // FIXME: This could be a problem for the overloads that take an out parameter
@@ -17990,12 +17990,12 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                QueryHandle* ids_handle = (QueryHandle*)Unsafe.AsPointer(ref id);
+                int* ids_handle = (int*)Unsafe.AsPointer(ref id);
                 CreateQueries(target, n, ids_handle);
                 return id;
             }
             /// <inheritdoc cref="CreateQueries"/>
-            public static unsafe void CreateQuery(QueryTarget target, out QueryHandle id)
+            public static unsafe void CreateQuery(QueryTarget target, out int id)
             {
                 int n = 1;
                 Unsafe.SkipInit(out id);
@@ -18007,52 +18007,52 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                QueryHandle* ids_handle = (QueryHandle*)Unsafe.AsPointer(ref id);
+                int* ids_handle = (int*)Unsafe.AsPointer(ref id);
                 CreateQueries(target, n, ids_handle);
             }
             /// <inheritdoc cref="CreateQueries"/>
-            public static unsafe void CreateQueries(QueryTarget target, Span<QueryHandle> ids)
+            public static unsafe void CreateQueries(QueryTarget target, Span<int> ids)
             {
                 int n = (int)(ids.Length);
-                fixed (QueryHandle* ids_ptr = ids)
+                fixed (int* ids_ptr = ids)
                 {
                     CreateQueries(target, n, ids_ptr);
                 }
             }
             /// <inheritdoc cref="CreateQueries"/>
-            public static unsafe void CreateQueries(QueryTarget target, QueryHandle[] ids)
+            public static unsafe void CreateQueries(QueryTarget target, int[] ids)
             {
                 int n = (int)(ids.Length);
-                fixed (QueryHandle* ids_ptr = ids)
+                fixed (int* ids_ptr = ids)
                 {
                     CreateQueries(target, n, ids_ptr);
                 }
             }
             /// <inheritdoc cref="CreateQueries"/>
-            public static unsafe void CreateQueries(QueryTarget target, int n, ref QueryHandle ids)
+            public static unsafe void CreateQueries(QueryTarget target, int n, ref int ids)
             {
-                fixed (QueryHandle* ids_ptr = &ids)
+                fixed (int* ids_ptr = &ids)
                 {
                     CreateQueries(target, n, ids_ptr);
                 }
             }
             /// <inheritdoc cref="GetQueryBufferObjecti64v"/>
-            public static unsafe void GetQueryBufferObjecti64(QueryHandle id, BufferHandle buffer, QueryObjectParameterName pname, IntPtr offset)
+            public static unsafe void GetQueryBufferObjecti64(int id, int buffer, QueryObjectParameterName pname, IntPtr offset)
             {
                 GetQueryBufferObjecti64v(id, buffer, pname, offset);
             }
             /// <inheritdoc cref="GetQueryBufferObjectiv"/>
-            public static unsafe void GetQueryBufferObjecti(QueryHandle id, BufferHandle buffer, QueryObjectParameterName pname, IntPtr offset)
+            public static unsafe void GetQueryBufferObjecti(int id, int buffer, QueryObjectParameterName pname, IntPtr offset)
             {
                 GetQueryBufferObjectiv(id, buffer, pname, offset);
             }
             /// <inheritdoc cref="GetQueryBufferObjectui64v"/>
-            public static unsafe void GetQueryBufferObjectui64(QueryHandle id, BufferHandle buffer, QueryObjectParameterName pname, IntPtr offset)
+            public static unsafe void GetQueryBufferObjectui64(int id, int buffer, QueryObjectParameterName pname, IntPtr offset)
             {
                 GetQueryBufferObjectui64v(id, buffer, pname, offset);
             }
             /// <inheritdoc cref="GetQueryBufferObjectuiv"/>
-            public static unsafe void GetQueryBufferObjectui(QueryHandle id, BufferHandle buffer, QueryObjectParameterName pname, IntPtr offset)
+            public static unsafe void GetQueryBufferObjectui(int id, int buffer, QueryObjectParameterName pname, IntPtr offset)
             {
                 GetQueryBufferObjectuiv(id, buffer, pname, offset);
             }
@@ -18203,53 +18203,53 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="DeleteProgramsARB"/>
-            public static unsafe void DeleteProgramsARB(ReadOnlySpan<ProgramHandle> programs)
+            public static unsafe void DeleteProgramsARB(ReadOnlySpan<int> programs)
             {
                 int n = (int)(programs.Length);
-                fixed (ProgramHandle* programs_ptr = programs)
+                fixed (int* programs_ptr = programs)
                 {
                     DeleteProgramsARB(n, programs_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteProgramsARB"/>
-            public static unsafe void DeleteProgramsARB(ProgramHandle[] programs)
+            public static unsafe void DeleteProgramsARB(int[] programs)
             {
                 int n = (int)(programs.Length);
-                fixed (ProgramHandle* programs_ptr = programs)
+                fixed (int* programs_ptr = programs)
                 {
                     DeleteProgramsARB(n, programs_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteProgramsARB"/>
-            public static unsafe void DeleteProgramsARB(int n, in ProgramHandle programs)
+            public static unsafe void DeleteProgramsARB(int n, in int programs)
             {
-                fixed (ProgramHandle* programs_ptr = &programs)
+                fixed (int* programs_ptr = &programs)
                 {
                     DeleteProgramsARB(n, programs_ptr);
                 }
             }
             /// <inheritdoc cref="GenProgramsARB"/>
-            public static unsafe void GenProgramsARB(Span<ProgramHandle> programs)
+            public static unsafe void GenProgramsARB(Span<int> programs)
             {
                 int n = (int)(programs.Length);
-                fixed (ProgramHandle* programs_ptr = programs)
+                fixed (int* programs_ptr = programs)
                 {
                     GenProgramsARB(n, programs_ptr);
                 }
             }
             /// <inheritdoc cref="GenProgramsARB"/>
-            public static unsafe void GenProgramsARB(ProgramHandle[] programs)
+            public static unsafe void GenProgramsARB(int[] programs)
             {
                 int n = (int)(programs.Length);
-                fixed (ProgramHandle* programs_ptr = programs)
+                fixed (int* programs_ptr = programs)
                 {
                     GenProgramsARB(n, programs_ptr);
                 }
             }
             /// <inheritdoc cref="GenProgramsARB"/>
-            public static unsafe void GenProgramsARB(int n, ref ProgramHandle programs)
+            public static unsafe void GenProgramsARB(int n, ref int programs)
             {
-                fixed (ProgramHandle* programs_ptr = &programs)
+                fixed (int* programs_ptr = &programs)
                 {
                     GenProgramsARB(n, programs_ptr);
                 }
@@ -18528,44 +18528,44 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="DeleteRenderbuffers"/>
-            public static unsafe void DeleteRenderbuffer(in RenderbufferHandle renderbuffer)
+            public static unsafe void DeleteRenderbuffer(in int renderbuffer)
             {
                 int n = 1;
-                fixed(RenderbufferHandle* renderbuffers_handle = &renderbuffer)
+                fixed(int* renderbuffers_handle = &renderbuffer)
                 {
                     DeleteRenderbuffers(n, renderbuffers_handle);
                 }
             }
             /// <inheritdoc cref="DeleteRenderbuffers"/>
-            public static unsafe void DeleteRenderbuffers(ReadOnlySpan<RenderbufferHandle> renderbuffers)
+            public static unsafe void DeleteRenderbuffers(ReadOnlySpan<int> renderbuffers)
             {
                 int n = (int)(renderbuffers.Length);
-                fixed (RenderbufferHandle* renderbuffers_ptr = renderbuffers)
+                fixed (int* renderbuffers_ptr = renderbuffers)
                 {
                     DeleteRenderbuffers(n, renderbuffers_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteRenderbuffers"/>
-            public static unsafe void DeleteRenderbuffers(RenderbufferHandle[] renderbuffers)
+            public static unsafe void DeleteRenderbuffers(int[] renderbuffers)
             {
                 int n = (int)(renderbuffers.Length);
-                fixed (RenderbufferHandle* renderbuffers_ptr = renderbuffers)
+                fixed (int* renderbuffers_ptr = renderbuffers)
                 {
                     DeleteRenderbuffers(n, renderbuffers_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteRenderbuffers"/>
-            public static unsafe void DeleteRenderbuffers(int n, in RenderbufferHandle renderbuffers)
+            public static unsafe void DeleteRenderbuffers(int n, in int renderbuffers)
             {
-                fixed (RenderbufferHandle* renderbuffers_ptr = &renderbuffers)
+                fixed (int* renderbuffers_ptr = &renderbuffers)
                 {
                     DeleteRenderbuffers(n, renderbuffers_ptr);
                 }
             }
             /// <inheritdoc cref="GenRenderbuffers"/>
-            public static unsafe RenderbufferHandle GenRenderbuffer()
+            public static unsafe int GenRenderbuffer()
             {
-                RenderbufferHandle renderbuffer;
+                int renderbuffer;
                 int n = 1;
                 Unsafe.SkipInit(out renderbuffer);
                 // FIXME: This could be a problem for the overloads that take an out parameter
@@ -18576,12 +18576,12 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                RenderbufferHandle* renderbuffers_handle = (RenderbufferHandle*)Unsafe.AsPointer(ref renderbuffer);
+                int* renderbuffers_handle = (int*)Unsafe.AsPointer(ref renderbuffer);
                 GenRenderbuffers(n, renderbuffers_handle);
                 return renderbuffer;
             }
             /// <inheritdoc cref="GenRenderbuffers"/>
-            public static unsafe void GenRenderbuffer(out RenderbufferHandle renderbuffer)
+            public static unsafe void GenRenderbuffer(out int renderbuffer)
             {
                 int n = 1;
                 Unsafe.SkipInit(out renderbuffer);
@@ -18593,31 +18593,31 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                RenderbufferHandle* renderbuffers_handle = (RenderbufferHandle*)Unsafe.AsPointer(ref renderbuffer);
+                int* renderbuffers_handle = (int*)Unsafe.AsPointer(ref renderbuffer);
                 GenRenderbuffers(n, renderbuffers_handle);
             }
             /// <inheritdoc cref="GenRenderbuffers"/>
-            public static unsafe void GenRenderbuffers(Span<RenderbufferHandle> renderbuffers)
+            public static unsafe void GenRenderbuffers(Span<int> renderbuffers)
             {
                 int n = (int)(renderbuffers.Length);
-                fixed (RenderbufferHandle* renderbuffers_ptr = renderbuffers)
+                fixed (int* renderbuffers_ptr = renderbuffers)
                 {
                     GenRenderbuffers(n, renderbuffers_ptr);
                 }
             }
             /// <inheritdoc cref="GenRenderbuffers"/>
-            public static unsafe void GenRenderbuffers(RenderbufferHandle[] renderbuffers)
+            public static unsafe void GenRenderbuffers(int[] renderbuffers)
             {
                 int n = (int)(renderbuffers.Length);
-                fixed (RenderbufferHandle* renderbuffers_ptr = renderbuffers)
+                fixed (int* renderbuffers_ptr = renderbuffers)
                 {
                     GenRenderbuffers(n, renderbuffers_ptr);
                 }
             }
             /// <inheritdoc cref="GenRenderbuffers"/>
-            public static unsafe void GenRenderbuffers(int n, ref RenderbufferHandle renderbuffers)
+            public static unsafe void GenRenderbuffers(int n, ref int renderbuffers)
             {
-                fixed (RenderbufferHandle* renderbuffers_ptr = &renderbuffers)
+                fixed (int* renderbuffers_ptr = &renderbuffers)
                 {
                     GenRenderbuffers(n, renderbuffers_ptr);
                 }
@@ -18647,44 +18647,44 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="DeleteFramebuffers"/>
-            public static unsafe void DeleteFramebuffer(in FramebufferHandle framebuffer)
+            public static unsafe void DeleteFramebuffer(in int framebuffer)
             {
                 int n = 1;
-                fixed(FramebufferHandle* framebuffers_handle = &framebuffer)
+                fixed(int* framebuffers_handle = &framebuffer)
                 {
                     DeleteFramebuffers(n, framebuffers_handle);
                 }
             }
             /// <inheritdoc cref="DeleteFramebuffers"/>
-            public static unsafe void DeleteFramebuffers(ReadOnlySpan<FramebufferHandle> framebuffers)
+            public static unsafe void DeleteFramebuffers(ReadOnlySpan<int> framebuffers)
             {
                 int n = (int)(framebuffers.Length);
-                fixed (FramebufferHandle* framebuffers_ptr = framebuffers)
+                fixed (int* framebuffers_ptr = framebuffers)
                 {
                     DeleteFramebuffers(n, framebuffers_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteFramebuffers"/>
-            public static unsafe void DeleteFramebuffers(FramebufferHandle[] framebuffers)
+            public static unsafe void DeleteFramebuffers(int[] framebuffers)
             {
                 int n = (int)(framebuffers.Length);
-                fixed (FramebufferHandle* framebuffers_ptr = framebuffers)
+                fixed (int* framebuffers_ptr = framebuffers)
                 {
                     DeleteFramebuffers(n, framebuffers_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteFramebuffers"/>
-            public static unsafe void DeleteFramebuffers(int n, in FramebufferHandle framebuffers)
+            public static unsafe void DeleteFramebuffers(int n, in int framebuffers)
             {
-                fixed (FramebufferHandle* framebuffers_ptr = &framebuffers)
+                fixed (int* framebuffers_ptr = &framebuffers)
                 {
                     DeleteFramebuffers(n, framebuffers_ptr);
                 }
             }
             /// <inheritdoc cref="GenFramebuffers"/>
-            public static unsafe FramebufferHandle GenFramebuffer()
+            public static unsafe int GenFramebuffer()
             {
-                FramebufferHandle framebuffer;
+                int framebuffer;
                 int n = 1;
                 Unsafe.SkipInit(out framebuffer);
                 // FIXME: This could be a problem for the overloads that take an out parameter
@@ -18695,12 +18695,12 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                FramebufferHandle* framebuffers_handle = (FramebufferHandle*)Unsafe.AsPointer(ref framebuffer);
+                int* framebuffers_handle = (int*)Unsafe.AsPointer(ref framebuffer);
                 GenFramebuffers(n, framebuffers_handle);
                 return framebuffer;
             }
             /// <inheritdoc cref="GenFramebuffers"/>
-            public static unsafe void GenFramebuffer(out FramebufferHandle framebuffer)
+            public static unsafe void GenFramebuffer(out int framebuffer)
             {
                 int n = 1;
                 Unsafe.SkipInit(out framebuffer);
@@ -18712,31 +18712,31 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                FramebufferHandle* framebuffers_handle = (FramebufferHandle*)Unsafe.AsPointer(ref framebuffer);
+                int* framebuffers_handle = (int*)Unsafe.AsPointer(ref framebuffer);
                 GenFramebuffers(n, framebuffers_handle);
             }
             /// <inheritdoc cref="GenFramebuffers"/>
-            public static unsafe void GenFramebuffers(Span<FramebufferHandle> framebuffers)
+            public static unsafe void GenFramebuffers(Span<int> framebuffers)
             {
                 int n = (int)(framebuffers.Length);
-                fixed (FramebufferHandle* framebuffers_ptr = framebuffers)
+                fixed (int* framebuffers_ptr = framebuffers)
                 {
                     GenFramebuffers(n, framebuffers_ptr);
                 }
             }
             /// <inheritdoc cref="GenFramebuffers"/>
-            public static unsafe void GenFramebuffers(FramebufferHandle[] framebuffers)
+            public static unsafe void GenFramebuffers(int[] framebuffers)
             {
                 int n = (int)(framebuffers.Length);
-                fixed (FramebufferHandle* framebuffers_ptr = framebuffers)
+                fixed (int* framebuffers_ptr = framebuffers)
                 {
                     GenFramebuffers(n, framebuffers_ptr);
                 }
             }
             /// <inheritdoc cref="GenFramebuffers"/>
-            public static unsafe void GenFramebuffers(int n, ref FramebufferHandle framebuffers)
+            public static unsafe void GenFramebuffers(int n, ref int framebuffers)
             {
-                fixed (FramebufferHandle* framebuffers_ptr = &framebuffers)
+                fixed (int* framebuffers_ptr = &framebuffers)
                 {
                     GenFramebuffers(n, framebuffers_ptr);
                 }
@@ -18766,7 +18766,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetProgramBinary"/>
-            public static unsafe void GetProgramBinary(ProgramHandle program, int bufSize, Span<int> length, Span<All> binaryFormat, IntPtr binary)
+            public static unsafe void GetProgramBinary(int program, int bufSize, Span<int> length, Span<All> binaryFormat, IntPtr binary)
             {
                 fixed (int* length_ptr = length)
                 {
@@ -18778,7 +18778,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetProgramBinary"/>
-            public static unsafe void GetProgramBinary(ProgramHandle program, int bufSize, int[] length, All[] binaryFormat, IntPtr binary)
+            public static unsafe void GetProgramBinary(int program, int bufSize, int[] length, All[] binaryFormat, IntPtr binary)
             {
                 fixed (int* length_ptr = length)
                 {
@@ -18790,7 +18790,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetProgramBinary"/>
-            public static unsafe void GetProgramBinary(ProgramHandle program, int bufSize, ref int length, ref All binaryFormat, IntPtr binary)
+            public static unsafe void GetProgramBinary(int program, int bufSize, ref int length, ref All binaryFormat, IntPtr binary)
             {
                 fixed (int* length_ptr = &length)
                 fixed (All* binaryFormat_ptr = &binaryFormat)
@@ -18800,7 +18800,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetProgramBinary"/>
-            public static unsafe void GetProgramBinary<T1>(ProgramHandle program, Span<int> length, Span<All> binaryFormat, Span<T1> binary)
+            public static unsafe void GetProgramBinary<T1>(int program, Span<int> length, Span<All> binaryFormat, Span<T1> binary)
                 where T1 : unmanaged
             {
                 fixed (int* length_ptr = length)
@@ -18816,7 +18816,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetProgramBinary"/>
-            public static unsafe void GetProgramBinary<T1>(ProgramHandle program, int[] length, All[] binaryFormat, T1[] binary)
+            public static unsafe void GetProgramBinary<T1>(int program, int[] length, All[] binaryFormat, T1[] binary)
                 where T1 : unmanaged
             {
                 fixed (int* length_ptr = length)
@@ -18832,7 +18832,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetProgramBinary"/>
-            public static unsafe void GetProgramBinary<T1>(ProgramHandle program, int bufSize, ref int length, ref All binaryFormat, ref T1 binary)
+            public static unsafe void GetProgramBinary<T1>(int program, int bufSize, ref int length, ref All binaryFormat, ref T1 binary)
                 where T1 : unmanaged
             {
                 fixed (int* length_ptr = &length)
@@ -18843,13 +18843,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramBinary"/>
-            public static unsafe void ProgramBinary(ProgramHandle program, All binaryFormat, IntPtr binary, int length)
+            public static unsafe void ProgramBinary(int program, All binaryFormat, IntPtr binary, int length)
             {
                 void* binary_vptr = (void*)binary;
                 ProgramBinary(program, binaryFormat, binary_vptr, length);
             }
             /// <inheritdoc cref="ProgramBinary"/>
-            public static unsafe void ProgramBinary<T1>(ProgramHandle program, All binaryFormat, ReadOnlySpan<T1> binary)
+            public static unsafe void ProgramBinary<T1>(int program, All binaryFormat, ReadOnlySpan<T1> binary)
                 where T1 : unmanaged
             {
                 int length = (int)(binary.Length * sizeof(T1));
@@ -18859,7 +18859,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramBinary"/>
-            public static unsafe void ProgramBinary<T1>(ProgramHandle program, All binaryFormat, T1[] binary)
+            public static unsafe void ProgramBinary<T1>(int program, All binaryFormat, T1[] binary)
                 where T1 : unmanaged
             {
                 int length = (int)(binary.Length * sizeof(T1));
@@ -18869,7 +18869,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramBinary"/>
-            public static unsafe void ProgramBinary<T1>(ProgramHandle program, All binaryFormat, in T1 binary, int length)
+            public static unsafe void ProgramBinary<T1>(int program, All binaryFormat, in T1 binary, int length)
                 where T1 : unmanaged
             {
                 fixed (void* binary_ptr = &binary)
@@ -18878,13 +18878,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetTextureSubImage"/>
-            public static unsafe void GetTextureSubImage(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, int bufSize, IntPtr pixels)
+            public static unsafe void GetTextureSubImage(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, int bufSize, IntPtr pixels)
             {
                 void* pixels_vptr = (void*)pixels;
                 GetTextureSubImage(texture, level, xoffset, yoffset, zoffset, width, height, depth, format, type, bufSize, pixels_vptr);
             }
             /// <inheritdoc cref="GetTextureSubImage"/>
-            public static unsafe void GetTextureSubImage<T1>(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, Span<T1> pixels)
+            public static unsafe void GetTextureSubImage<T1>(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, Span<T1> pixels)
                 where T1 : unmanaged
             {
                 int bufSize = (int)(pixels.Length * sizeof(T1));
@@ -18894,7 +18894,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetTextureSubImage"/>
-            public static unsafe void GetTextureSubImage<T1>(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, T1[] pixels)
+            public static unsafe void GetTextureSubImage<T1>(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, T1[] pixels)
                 where T1 : unmanaged
             {
                 int bufSize = (int)(pixels.Length * sizeof(T1));
@@ -18904,7 +18904,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetTextureSubImage"/>
-            public static unsafe void GetTextureSubImage<T1>(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, int bufSize, ref T1 pixels)
+            public static unsafe void GetTextureSubImage<T1>(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, int bufSize, ref T1 pixels)
                 where T1 : unmanaged
             {
                 fixed (void* pixels_ptr = &pixels)
@@ -18913,13 +18913,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetCompressedTextureSubImage"/>
-            public static unsafe void GetCompressedTextureSubImage(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, int bufSize, IntPtr pixels)
+            public static unsafe void GetCompressedTextureSubImage(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, int bufSize, IntPtr pixels)
             {
                 void* pixels_vptr = (void*)pixels;
                 GetCompressedTextureSubImage(texture, level, xoffset, yoffset, zoffset, width, height, depth, bufSize, pixels_vptr);
             }
             /// <inheritdoc cref="GetCompressedTextureSubImage"/>
-            public static unsafe void GetCompressedTextureSubImage<T1>(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, Span<T1> pixels)
+            public static unsafe void GetCompressedTextureSubImage<T1>(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, Span<T1> pixels)
                 where T1 : unmanaged
             {
                 int bufSize = (int)(pixels.Length * sizeof(T1));
@@ -18929,7 +18929,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetCompressedTextureSubImage"/>
-            public static unsafe void GetCompressedTextureSubImage<T1>(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, T1[] pixels)
+            public static unsafe void GetCompressedTextureSubImage<T1>(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, T1[] pixels)
                 where T1 : unmanaged
             {
                 int bufSize = (int)(pixels.Length * sizeof(T1));
@@ -18939,7 +18939,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetCompressedTextureSubImage"/>
-            public static unsafe void GetCompressedTextureSubImage<T1>(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, int bufSize, ref T1 pixels)
+            public static unsafe void GetCompressedTextureSubImage<T1>(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, int bufSize, ref T1 pixels)
                 where T1 : unmanaged
             {
                 fixed (void* pixels_ptr = &pixels)
@@ -18948,7 +18948,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="SpecializeShaderARB"/>
-            public static unsafe void SpecializeShaderARB(ShaderHandle shader, string pEntryPoint, uint numSpecializationConstants, in uint pConstantIndex, in uint pConstantValue)
+            public static unsafe void SpecializeShaderARB(int shader, string pEntryPoint, uint numSpecializationConstants, in uint pConstantIndex, in uint pConstantValue)
             {
                 fixed (uint* pConstantIndex_ptr = &pConstantIndex)
                 fixed (uint* pConstantValue_ptr = &pConstantValue)
@@ -19310,7 +19310,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetUniformdv"/>
-            public static unsafe void GetUniformd(ProgramHandle program, int location, Span<double> parameters)
+            public static unsafe void GetUniformd(int program, int location, Span<double> parameters)
             {
                 fixed (double* parameters_ptr = parameters)
                 {
@@ -19318,7 +19318,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetUniformdv"/>
-            public static unsafe void GetUniformd(ProgramHandle program, int location, double[] parameters)
+            public static unsafe void GetUniformd(int program, int location, double[] parameters)
             {
                 fixed (double* parameters_ptr = parameters)
                 {
@@ -19326,7 +19326,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetUniformdv"/>
-            public static unsafe void GetUniformd(ProgramHandle program, int location, ref double parameters)
+            public static unsafe void GetUniformd(int program, int location, ref double parameters)
             {
                 fixed (double* parameters_ptr = &parameters)
                 {
@@ -19542,7 +19542,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetUniformi64vARB"/>
-            public static unsafe void GetUniformi64vARB(ProgramHandle program, int location, Span<long> parameters)
+            public static unsafe void GetUniformi64vARB(int program, int location, Span<long> parameters)
             {
                 fixed (long* parameters_ptr = parameters)
                 {
@@ -19550,7 +19550,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetUniformi64vARB"/>
-            public static unsafe void GetUniformi64vARB(ProgramHandle program, int location, long[] parameters)
+            public static unsafe void GetUniformi64vARB(int program, int location, long[] parameters)
             {
                 fixed (long* parameters_ptr = parameters)
                 {
@@ -19558,7 +19558,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetUniformi64vARB"/>
-            public static unsafe void GetUniformi64vARB(ProgramHandle program, int location, ref long parameters)
+            public static unsafe void GetUniformi64vARB(int program, int location, ref long parameters)
             {
                 fixed (long* parameters_ptr = &parameters)
                 {
@@ -19566,7 +19566,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetUniformui64vARB"/>
-            public static unsafe void GetUniformui64vARB(ProgramHandle program, int location, Span<ulong> parameters)
+            public static unsafe void GetUniformui64vARB(int program, int location, Span<ulong> parameters)
             {
                 fixed (ulong* parameters_ptr = parameters)
                 {
@@ -19574,7 +19574,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetUniformui64vARB"/>
-            public static unsafe void GetUniformui64vARB(ProgramHandle program, int location, ulong[] parameters)
+            public static unsafe void GetUniformui64vARB(int program, int location, ulong[] parameters)
             {
                 fixed (ulong* parameters_ptr = parameters)
                 {
@@ -19582,7 +19582,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetUniformui64vARB"/>
-            public static unsafe void GetUniformui64vARB(ProgramHandle program, int location, ref ulong parameters)
+            public static unsafe void GetUniformui64vARB(int program, int location, ref ulong parameters)
             {
                 fixed (ulong* parameters_ptr = &parameters)
                 {
@@ -19590,7 +19590,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetnUniformi64vARB"/>
-            public static unsafe void GetnUniformi64vARB(ProgramHandle program, int location, Span<long> parameters)
+            public static unsafe void GetnUniformi64vARB(int program, int location, Span<long> parameters)
             {
                 int bufSize = (int)(parameters.Length * 8);
                 fixed (long* parameters_ptr = parameters)
@@ -19599,7 +19599,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetnUniformi64vARB"/>
-            public static unsafe void GetnUniformi64vARB(ProgramHandle program, int location, long[] parameters)
+            public static unsafe void GetnUniformi64vARB(int program, int location, long[] parameters)
             {
                 int bufSize = (int)(parameters.Length * 8);
                 fixed (long* parameters_ptr = parameters)
@@ -19608,7 +19608,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetnUniformi64vARB"/>
-            public static unsafe void GetnUniformi64vARB(ProgramHandle program, int location, int bufSize, ref long parameters)
+            public static unsafe void GetnUniformi64vARB(int program, int location, int bufSize, ref long parameters)
             {
                 fixed (long* parameters_ptr = &parameters)
                 {
@@ -19616,7 +19616,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetnUniformui64vARB"/>
-            public static unsafe void GetnUniformui64vARB(ProgramHandle program, int location, Span<ulong> parameters)
+            public static unsafe void GetnUniformui64vARB(int program, int location, Span<ulong> parameters)
             {
                 int bufSize = (int)(parameters.Length * 8);
                 fixed (ulong* parameters_ptr = parameters)
@@ -19625,7 +19625,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetnUniformui64vARB"/>
-            public static unsafe void GetnUniformui64vARB(ProgramHandle program, int location, ulong[] parameters)
+            public static unsafe void GetnUniformui64vARB(int program, int location, ulong[] parameters)
             {
                 int bufSize = (int)(parameters.Length * 8);
                 fixed (ulong* parameters_ptr = parameters)
@@ -19634,7 +19634,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetnUniformui64vARB"/>
-            public static unsafe void GetnUniformui64vARB(ProgramHandle program, int location, int bufSize, ref ulong parameters)
+            public static unsafe void GetnUniformui64vARB(int program, int location, int bufSize, ref ulong parameters)
             {
                 fixed (ulong* parameters_ptr = &parameters)
                 {
@@ -19642,7 +19642,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform1i64vARB"/>
-            public static unsafe void ProgramUniform1i64vARB(ProgramHandle program, int location, ReadOnlySpan<long> value)
+            public static unsafe void ProgramUniform1i64vARB(int program, int location, ReadOnlySpan<long> value)
             {
                 int count = (int)(value.Length);
                 fixed (long* value_ptr = value)
@@ -19651,7 +19651,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform1i64vARB"/>
-            public static unsafe void ProgramUniform1i64vARB(ProgramHandle program, int location, long[] value)
+            public static unsafe void ProgramUniform1i64vARB(int program, int location, long[] value)
             {
                 int count = (int)(value.Length);
                 fixed (long* value_ptr = value)
@@ -19660,7 +19660,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform1i64vARB"/>
-            public static unsafe void ProgramUniform1i64vARB(ProgramHandle program, int location, int count, in long value)
+            public static unsafe void ProgramUniform1i64vARB(int program, int location, int count, in long value)
             {
                 fixed (long* value_ptr = &value)
                 {
@@ -19668,7 +19668,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform2i64vARB"/>
-            public static unsafe void ProgramUniform2i64vARB(ProgramHandle program, int location, ReadOnlySpan<long> value)
+            public static unsafe void ProgramUniform2i64vARB(int program, int location, ReadOnlySpan<long> value)
             {
                 int count = (int)(value.Length / 2);
                 fixed (long* value_ptr = value)
@@ -19677,7 +19677,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform2i64vARB"/>
-            public static unsafe void ProgramUniform2i64vARB(ProgramHandle program, int location, long[] value)
+            public static unsafe void ProgramUniform2i64vARB(int program, int location, long[] value)
             {
                 int count = (int)(value.Length / 2);
                 fixed (long* value_ptr = value)
@@ -19686,7 +19686,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform2i64vARB"/>
-            public static unsafe void ProgramUniform2i64vARB(ProgramHandle program, int location, int count, in long value)
+            public static unsafe void ProgramUniform2i64vARB(int program, int location, int count, in long value)
             {
                 fixed (long* value_ptr = &value)
                 {
@@ -19694,7 +19694,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform3i64vARB"/>
-            public static unsafe void ProgramUniform3i64vARB(ProgramHandle program, int location, ReadOnlySpan<long> value)
+            public static unsafe void ProgramUniform3i64vARB(int program, int location, ReadOnlySpan<long> value)
             {
                 int count = (int)(value.Length / 3);
                 fixed (long* value_ptr = value)
@@ -19703,7 +19703,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform3i64vARB"/>
-            public static unsafe void ProgramUniform3i64vARB(ProgramHandle program, int location, long[] value)
+            public static unsafe void ProgramUniform3i64vARB(int program, int location, long[] value)
             {
                 int count = (int)(value.Length / 3);
                 fixed (long* value_ptr = value)
@@ -19712,7 +19712,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform3i64vARB"/>
-            public static unsafe void ProgramUniform3i64vARB(ProgramHandle program, int location, int count, in long value)
+            public static unsafe void ProgramUniform3i64vARB(int program, int location, int count, in long value)
             {
                 fixed (long* value_ptr = &value)
                 {
@@ -19720,7 +19720,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform4i64vARB"/>
-            public static unsafe void ProgramUniform4i64vARB(ProgramHandle program, int location, ReadOnlySpan<long> value)
+            public static unsafe void ProgramUniform4i64vARB(int program, int location, ReadOnlySpan<long> value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (long* value_ptr = value)
@@ -19729,7 +19729,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform4i64vARB"/>
-            public static unsafe void ProgramUniform4i64vARB(ProgramHandle program, int location, long[] value)
+            public static unsafe void ProgramUniform4i64vARB(int program, int location, long[] value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (long* value_ptr = value)
@@ -19738,7 +19738,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform4i64vARB"/>
-            public static unsafe void ProgramUniform4i64vARB(ProgramHandle program, int location, int count, in long value)
+            public static unsafe void ProgramUniform4i64vARB(int program, int location, int count, in long value)
             {
                 fixed (long* value_ptr = &value)
                 {
@@ -19746,7 +19746,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform1ui64vARB"/>
-            public static unsafe void ProgramUniform1ui64vARB(ProgramHandle program, int location, ReadOnlySpan<ulong> value)
+            public static unsafe void ProgramUniform1ui64vARB(int program, int location, ReadOnlySpan<ulong> value)
             {
                 int count = (int)(value.Length);
                 fixed (ulong* value_ptr = value)
@@ -19755,7 +19755,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform1ui64vARB"/>
-            public static unsafe void ProgramUniform1ui64vARB(ProgramHandle program, int location, ulong[] value)
+            public static unsafe void ProgramUniform1ui64vARB(int program, int location, ulong[] value)
             {
                 int count = (int)(value.Length);
                 fixed (ulong* value_ptr = value)
@@ -19764,7 +19764,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform1ui64vARB"/>
-            public static unsafe void ProgramUniform1ui64vARB(ProgramHandle program, int location, int count, in ulong value)
+            public static unsafe void ProgramUniform1ui64vARB(int program, int location, int count, in ulong value)
             {
                 fixed (ulong* value_ptr = &value)
                 {
@@ -19772,7 +19772,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform2ui64vARB"/>
-            public static unsafe void ProgramUniform2ui64vARB(ProgramHandle program, int location, ReadOnlySpan<ulong> value)
+            public static unsafe void ProgramUniform2ui64vARB(int program, int location, ReadOnlySpan<ulong> value)
             {
                 int count = (int)(value.Length / 2);
                 fixed (ulong* value_ptr = value)
@@ -19781,7 +19781,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform2ui64vARB"/>
-            public static unsafe void ProgramUniform2ui64vARB(ProgramHandle program, int location, ulong[] value)
+            public static unsafe void ProgramUniform2ui64vARB(int program, int location, ulong[] value)
             {
                 int count = (int)(value.Length / 2);
                 fixed (ulong* value_ptr = value)
@@ -19790,7 +19790,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform2ui64vARB"/>
-            public static unsafe void ProgramUniform2ui64vARB(ProgramHandle program, int location, int count, in ulong value)
+            public static unsafe void ProgramUniform2ui64vARB(int program, int location, int count, in ulong value)
             {
                 fixed (ulong* value_ptr = &value)
                 {
@@ -19798,7 +19798,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform3ui64vARB"/>
-            public static unsafe void ProgramUniform3ui64vARB(ProgramHandle program, int location, ReadOnlySpan<ulong> value)
+            public static unsafe void ProgramUniform3ui64vARB(int program, int location, ReadOnlySpan<ulong> value)
             {
                 int count = (int)(value.Length / 3);
                 fixed (ulong* value_ptr = value)
@@ -19807,7 +19807,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform3ui64vARB"/>
-            public static unsafe void ProgramUniform3ui64vARB(ProgramHandle program, int location, ulong[] value)
+            public static unsafe void ProgramUniform3ui64vARB(int program, int location, ulong[] value)
             {
                 int count = (int)(value.Length / 3);
                 fixed (ulong* value_ptr = value)
@@ -19816,7 +19816,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform3ui64vARB"/>
-            public static unsafe void ProgramUniform3ui64vARB(ProgramHandle program, int location, int count, in ulong value)
+            public static unsafe void ProgramUniform3ui64vARB(int program, int location, int count, in ulong value)
             {
                 fixed (ulong* value_ptr = &value)
                 {
@@ -19824,7 +19824,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform4ui64vARB"/>
-            public static unsafe void ProgramUniform4ui64vARB(ProgramHandle program, int location, ReadOnlySpan<ulong> value)
+            public static unsafe void ProgramUniform4ui64vARB(int program, int location, ReadOnlySpan<ulong> value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (ulong* value_ptr = value)
@@ -19833,7 +19833,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform4ui64vARB"/>
-            public static unsafe void ProgramUniform4ui64vARB(ProgramHandle program, int location, ulong[] value)
+            public static unsafe void ProgramUniform4ui64vARB(int program, int location, ulong[] value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (ulong* value_ptr = value)
@@ -19842,7 +19842,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform4ui64vARB"/>
-            public static unsafe void ProgramUniform4ui64vARB(ProgramHandle program, int location, int count, in ulong value)
+            public static unsafe void ProgramUniform4ui64vARB(int program, int location, int count, in ulong value)
             {
                 fixed (ulong* value_ptr = &value)
                 {
@@ -20746,35 +20746,35 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="BindBuffersBase"/>
-            public static unsafe void BindBuffersBase(BufferTargetARB target, uint first, ReadOnlySpan<BufferHandle> buffers)
+            public static unsafe void BindBuffersBase(BufferTargetARB target, uint first, ReadOnlySpan<int> buffers)
             {
                 int count = (int)(buffers.Length);
-                fixed (BufferHandle* buffers_ptr = buffers)
+                fixed (int* buffers_ptr = buffers)
                 {
                     BindBuffersBase(target, first, count, buffers_ptr);
                 }
             }
             /// <inheritdoc cref="BindBuffersBase"/>
-            public static unsafe void BindBuffersBase(BufferTargetARB target, uint first, BufferHandle[] buffers)
+            public static unsafe void BindBuffersBase(BufferTargetARB target, uint first, int[] buffers)
             {
                 int count = (int)(buffers.Length);
-                fixed (BufferHandle* buffers_ptr = buffers)
+                fixed (int* buffers_ptr = buffers)
                 {
                     BindBuffersBase(target, first, count, buffers_ptr);
                 }
             }
             /// <inheritdoc cref="BindBuffersBase"/>
-            public static unsafe void BindBuffersBase(BufferTargetARB target, uint first, int count, in BufferHandle buffers)
+            public static unsafe void BindBuffersBase(BufferTargetARB target, uint first, int count, in int buffers)
             {
-                fixed (BufferHandle* buffers_ptr = &buffers)
+                fixed (int* buffers_ptr = &buffers)
                 {
                     BindBuffersBase(target, first, count, buffers_ptr);
                 }
             }
             /// <inheritdoc cref="BindBuffersRange"/>
-            public static unsafe void BindBuffersRange(BufferTargetARB target, uint first, int count, ReadOnlySpan<BufferHandle> buffers, ReadOnlySpan<IntPtr> offsets, ReadOnlySpan<nint> sizes)
+            public static unsafe void BindBuffersRange(BufferTargetARB target, uint first, int count, ReadOnlySpan<int> buffers, ReadOnlySpan<IntPtr> offsets, ReadOnlySpan<nint> sizes)
             {
-                fixed (BufferHandle* buffers_ptr = buffers)
+                fixed (int* buffers_ptr = buffers)
                 {
                     fixed (IntPtr* offsets_ptr = offsets)
                     {
@@ -20786,9 +20786,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="BindBuffersRange"/>
-            public static unsafe void BindBuffersRange(BufferTargetARB target, uint first, int count, BufferHandle[] buffers, IntPtr[] offsets, nint[] sizes)
+            public static unsafe void BindBuffersRange(BufferTargetARB target, uint first, int count, int[] buffers, IntPtr[] offsets, nint[] sizes)
             {
-                fixed (BufferHandle* buffers_ptr = buffers)
+                fixed (int* buffers_ptr = buffers)
                 {
                     fixed (IntPtr* offsets_ptr = offsets)
                     {
@@ -20800,9 +20800,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="BindBuffersRange"/>
-            public static unsafe void BindBuffersRange(BufferTargetARB target, uint first, int count, in BufferHandle buffers, in IntPtr offsets, in nint sizes)
+            public static unsafe void BindBuffersRange(BufferTargetARB target, uint first, int count, in int buffers, in IntPtr offsets, in nint sizes)
             {
-                fixed (BufferHandle* buffers_ptr = &buffers)
+                fixed (int* buffers_ptr = &buffers)
                 fixed (IntPtr* offsets_ptr = &offsets)
                 fixed (nint* sizes_ptr = &sizes)
                 {
@@ -20810,87 +20810,87 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="BindTextures"/>
-            public static unsafe void BindTextures(uint first, ReadOnlySpan<TextureHandle> textures)
+            public static unsafe void BindTextures(uint first, ReadOnlySpan<int> textures)
             {
                 int count = (int)(textures.Length);
-                fixed (TextureHandle* textures_ptr = textures)
+                fixed (int* textures_ptr = textures)
                 {
                     BindTextures(first, count, textures_ptr);
                 }
             }
             /// <inheritdoc cref="BindTextures"/>
-            public static unsafe void BindTextures(uint first, TextureHandle[] textures)
+            public static unsafe void BindTextures(uint first, int[] textures)
             {
                 int count = (int)(textures.Length);
-                fixed (TextureHandle* textures_ptr = textures)
+                fixed (int* textures_ptr = textures)
                 {
                     BindTextures(first, count, textures_ptr);
                 }
             }
             /// <inheritdoc cref="BindTextures"/>
-            public static unsafe void BindTextures(uint first, int count, in TextureHandle textures)
+            public static unsafe void BindTextures(uint first, int count, in int textures)
             {
-                fixed (TextureHandle* textures_ptr = &textures)
+                fixed (int* textures_ptr = &textures)
                 {
                     BindTextures(first, count, textures_ptr);
                 }
             }
             /// <inheritdoc cref="BindSamplers"/>
-            public static unsafe void BindSamplers(uint first, ReadOnlySpan<SamplerHandle> samplers)
+            public static unsafe void BindSamplers(uint first, ReadOnlySpan<int> samplers)
             {
                 int count = (int)(samplers.Length);
-                fixed (SamplerHandle* samplers_ptr = samplers)
+                fixed (int* samplers_ptr = samplers)
                 {
                     BindSamplers(first, count, samplers_ptr);
                 }
             }
             /// <inheritdoc cref="BindSamplers"/>
-            public static unsafe void BindSamplers(uint first, SamplerHandle[] samplers)
+            public static unsafe void BindSamplers(uint first, int[] samplers)
             {
                 int count = (int)(samplers.Length);
-                fixed (SamplerHandle* samplers_ptr = samplers)
+                fixed (int* samplers_ptr = samplers)
                 {
                     BindSamplers(first, count, samplers_ptr);
                 }
             }
             /// <inheritdoc cref="BindSamplers"/>
-            public static unsafe void BindSamplers(uint first, int count, in SamplerHandle samplers)
+            public static unsafe void BindSamplers(uint first, int count, in int samplers)
             {
-                fixed (SamplerHandle* samplers_ptr = &samplers)
+                fixed (int* samplers_ptr = &samplers)
                 {
                     BindSamplers(first, count, samplers_ptr);
                 }
             }
             /// <inheritdoc cref="BindImageTextures"/>
-            public static unsafe void BindImageTextures(uint first, ReadOnlySpan<TextureHandle> textures)
+            public static unsafe void BindImageTextures(uint first, ReadOnlySpan<int> textures)
             {
                 int count = (int)(textures.Length);
-                fixed (TextureHandle* textures_ptr = textures)
+                fixed (int* textures_ptr = textures)
                 {
                     BindImageTextures(first, count, textures_ptr);
                 }
             }
             /// <inheritdoc cref="BindImageTextures"/>
-            public static unsafe void BindImageTextures(uint first, TextureHandle[] textures)
+            public static unsafe void BindImageTextures(uint first, int[] textures)
             {
                 int count = (int)(textures.Length);
-                fixed (TextureHandle* textures_ptr = textures)
+                fixed (int* textures_ptr = textures)
                 {
                     BindImageTextures(first, count, textures_ptr);
                 }
             }
             /// <inheritdoc cref="BindImageTextures"/>
-            public static unsafe void BindImageTextures(uint first, int count, in TextureHandle textures)
+            public static unsafe void BindImageTextures(uint first, int count, in int textures)
             {
-                fixed (TextureHandle* textures_ptr = &textures)
+                fixed (int* textures_ptr = &textures)
                 {
                     BindImageTextures(first, count, textures_ptr);
                 }
             }
             /// <inheritdoc cref="BindVertexBuffers"/>
-            public static unsafe void BindVertexBuffers(uint first, int count, ReadOnlySpan<BufferHandle> buffers, ReadOnlySpan<IntPtr> offsets, ReadOnlySpan<int> strides)
+            public static unsafe void BindVertexBuffers(uint first, int count, ReadOnlySpan<int> buffers, ReadOnlySpan<IntPtr> offsets, ReadOnlySpan<int> strides)
             {
-                fixed (BufferHandle* buffers_ptr = buffers)
+                fixed (int* buffers_ptr = buffers)
                 {
                     fixed (IntPtr* offsets_ptr = offsets)
                     {
@@ -20902,9 +20902,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="BindVertexBuffers"/>
-            public static unsafe void BindVertexBuffers(uint first, int count, BufferHandle[] buffers, IntPtr[] offsets, int[] strides)
+            public static unsafe void BindVertexBuffers(uint first, int count, int[] buffers, IntPtr[] offsets, int[] strides)
             {
-                fixed (BufferHandle* buffers_ptr = buffers)
+                fixed (int* buffers_ptr = buffers)
                 {
                     fixed (IntPtr* offsets_ptr = offsets)
                     {
@@ -20916,9 +20916,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="BindVertexBuffers"/>
-            public static unsafe void BindVertexBuffers(uint first, int count, in BufferHandle buffers, in IntPtr offsets, in int strides)
+            public static unsafe void BindVertexBuffers(uint first, int count, in int buffers, in IntPtr offsets, in int strides)
             {
-                fixed (BufferHandle* buffers_ptr = &buffers)
+                fixed (int* buffers_ptr = &buffers)
                 fixed (IntPtr* offsets_ptr = &offsets)
                 fixed (int* strides_ptr = &strides)
                 {
@@ -21376,53 +21376,53 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GenQueriesARB"/>
-            public static unsafe void GenQueriesARB(Span<QueryHandle> ids)
+            public static unsafe void GenQueriesARB(Span<int> ids)
             {
                 int n = (int)(ids.Length);
-                fixed (QueryHandle* ids_ptr = ids)
+                fixed (int* ids_ptr = ids)
                 {
                     GenQueriesARB(n, ids_ptr);
                 }
             }
             /// <inheritdoc cref="GenQueriesARB"/>
-            public static unsafe void GenQueriesARB(QueryHandle[] ids)
+            public static unsafe void GenQueriesARB(int[] ids)
             {
                 int n = (int)(ids.Length);
-                fixed (QueryHandle* ids_ptr = ids)
+                fixed (int* ids_ptr = ids)
                 {
                     GenQueriesARB(n, ids_ptr);
                 }
             }
             /// <inheritdoc cref="GenQueriesARB"/>
-            public static unsafe void GenQueriesARB(int n, ref QueryHandle ids)
+            public static unsafe void GenQueriesARB(int n, ref int ids)
             {
-                fixed (QueryHandle* ids_ptr = &ids)
+                fixed (int* ids_ptr = &ids)
                 {
                     GenQueriesARB(n, ids_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteQueriesARB"/>
-            public static unsafe void DeleteQueriesARB(ReadOnlySpan<QueryHandle> ids)
+            public static unsafe void DeleteQueriesARB(ReadOnlySpan<int> ids)
             {
                 int n = (int)(ids.Length);
-                fixed (QueryHandle* ids_ptr = ids)
+                fixed (int* ids_ptr = ids)
                 {
                     DeleteQueriesARB(n, ids_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteQueriesARB"/>
-            public static unsafe void DeleteQueriesARB(QueryHandle[] ids)
+            public static unsafe void DeleteQueriesARB(int[] ids)
             {
                 int n = (int)(ids.Length);
-                fixed (QueryHandle* ids_ptr = ids)
+                fixed (int* ids_ptr = ids)
                 {
                     DeleteQueriesARB(n, ids_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteQueriesARB"/>
-            public static unsafe void DeleteQueriesARB(int n, in QueryHandle ids)
+            public static unsafe void DeleteQueriesARB(int n, in int ids)
             {
-                fixed (QueryHandle* ids_ptr = &ids)
+                fixed (int* ids_ptr = &ids)
                 {
                     DeleteQueriesARB(n, ids_ptr);
                 }
@@ -21452,7 +21452,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetQueryObjectivARB"/>
-            public static unsafe void GetQueryObjectivARB(QueryHandle id, QueryObjectParameterName pname, Span<int> parameters)
+            public static unsafe void GetQueryObjectivARB(int id, QueryObjectParameterName pname, Span<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -21460,7 +21460,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetQueryObjectivARB"/>
-            public static unsafe void GetQueryObjectivARB(QueryHandle id, QueryObjectParameterName pname, int[] parameters)
+            public static unsafe void GetQueryObjectivARB(int id, QueryObjectParameterName pname, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -21468,7 +21468,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetQueryObjectivARB"/>
-            public static unsafe void GetQueryObjectivARB(QueryHandle id, QueryObjectParameterName pname, ref int parameters)
+            public static unsafe void GetQueryObjectivARB(int id, QueryObjectParameterName pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -21476,7 +21476,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetQueryObjectuivARB"/>
-            public static unsafe void GetQueryObjectuivARB(QueryHandle id, QueryObjectParameterName pname, Span<uint> parameters)
+            public static unsafe void GetQueryObjectuivARB(int id, QueryObjectParameterName pname, Span<uint> parameters)
             {
                 fixed (uint* parameters_ptr = parameters)
                 {
@@ -21484,7 +21484,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetQueryObjectuivARB"/>
-            public static unsafe void GetQueryObjectuivARB(QueryHandle id, QueryObjectParameterName pname, uint[] parameters)
+            public static unsafe void GetQueryObjectuivARB(int id, QueryObjectParameterName pname, uint[] parameters)
             {
                 fixed (uint* parameters_ptr = parameters)
                 {
@@ -21492,7 +21492,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetQueryObjectuivARB"/>
-            public static unsafe void GetQueryObjectuivARB(QueryHandle id, QueryObjectParameterName pname, ref uint parameters)
+            public static unsafe void GetQueryObjectuivARB(int id, QueryObjectParameterName pname, ref uint parameters)
             {
                 fixed (uint* parameters_ptr = &parameters)
                 {
@@ -21524,7 +21524,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetProgramInterfaceiv"/>
-            public static unsafe void GetProgramInterfacei(ProgramHandle program, ProgramInterface programInterface, ProgramInterfacePName pname, Span<int> parameters)
+            public static unsafe void GetProgramInterfacei(int program, ProgramInterface programInterface, ProgramInterfacePName pname, Span<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -21532,7 +21532,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetProgramInterfaceiv"/>
-            public static unsafe void GetProgramInterfacei(ProgramHandle program, ProgramInterface programInterface, ProgramInterfacePName pname, int[] parameters)
+            public static unsafe void GetProgramInterfacei(int program, ProgramInterface programInterface, ProgramInterfacePName pname, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -21540,7 +21540,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetProgramInterfaceiv"/>
-            public static unsafe void GetProgramInterfacei(ProgramHandle program, ProgramInterface programInterface, ProgramInterfacePName pname, ref int parameters)
+            public static unsafe void GetProgramInterfacei(int program, ProgramInterface programInterface, ProgramInterfacePName pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -21548,7 +21548,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetProgramResourceIndex"/>
-            public static unsafe uint GetProgramResourceIndex(ProgramHandle program, ProgramInterface programInterface, string name)
+            public static unsafe uint GetProgramResourceIndex(int program, ProgramInterface programInterface, string name)
             {
                 uint returnValue;
                 byte* name_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(name);
@@ -21557,7 +21557,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return returnValue;
             }
             /// <inheritdoc cref="GetProgramResourceName"/>
-            public static unsafe string GetProgramResourceName(ProgramHandle program, ProgramInterface programInterface, uint index, int bufSize, Span<int> length)
+            public static unsafe string GetProgramResourceName(int program, ProgramInterface programInterface, uint index, int bufSize, Span<int> length)
             {
                 string name;
                 fixed (int* length_ptr = length)
@@ -21570,7 +21570,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return name;
             }
             /// <inheritdoc cref="GetProgramResourceName"/>
-            public static unsafe void GetProgramResourceName(ProgramHandle program, ProgramInterface programInterface, uint index, int bufSize, Span<int> length, out string name)
+            public static unsafe void GetProgramResourceName(int program, ProgramInterface programInterface, uint index, int bufSize, Span<int> length, out string name)
             {
                 fixed (int* length_ptr = length)
                 {
@@ -21581,7 +21581,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetProgramResourceName"/>
-            public static unsafe string GetProgramResourceName(ProgramHandle program, ProgramInterface programInterface, uint index, int bufSize, int[] length)
+            public static unsafe string GetProgramResourceName(int program, ProgramInterface programInterface, uint index, int bufSize, int[] length)
             {
                 string name;
                 fixed (int* length_ptr = length)
@@ -21594,7 +21594,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return name;
             }
             /// <inheritdoc cref="GetProgramResourceName"/>
-            public static unsafe void GetProgramResourceName(ProgramHandle program, ProgramInterface programInterface, uint index, int bufSize, int[] length, out string name)
+            public static unsafe void GetProgramResourceName(int program, ProgramInterface programInterface, uint index, int bufSize, int[] length, out string name)
             {
                 fixed (int* length_ptr = length)
                 {
@@ -21605,7 +21605,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetProgramResourceName"/>
-            public static unsafe string GetProgramResourceName(ProgramHandle program, ProgramInterface programInterface, uint index, int bufSize, ref int length)
+            public static unsafe string GetProgramResourceName(int program, ProgramInterface programInterface, uint index, int bufSize, ref int length)
             {
                 string name;
                 fixed (int* length_ptr = &length)
@@ -21618,7 +21618,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return name;
             }
             /// <inheritdoc cref="GetProgramResourceName"/>
-            public static unsafe void GetProgramResourceName(ProgramHandle program, ProgramInterface programInterface, uint index, int bufSize, ref int length, out string name)
+            public static unsafe void GetProgramResourceName(int program, ProgramInterface programInterface, uint index, int bufSize, ref int length, out string name)
             {
                 fixed (int* length_ptr = &length)
                 {
@@ -21629,7 +21629,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetProgramResourceiv"/>
-            public static unsafe void GetProgramResourcei(ProgramHandle program, ProgramInterface programInterface, uint index, ReadOnlySpan<ProgramResourceProperty> props, Span<int> length, Span<int> parameters)
+            public static unsafe void GetProgramResourcei(int program, ProgramInterface programInterface, uint index, ReadOnlySpan<ProgramResourceProperty> props, Span<int> length, Span<int> parameters)
             {
                 int propCount = (int)(props.Length);
                 fixed (ProgramResourceProperty* props_ptr = props)
@@ -21645,7 +21645,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetProgramResourceiv"/>
-            public static unsafe void GetProgramResourcei(ProgramHandle program, ProgramInterface programInterface, uint index, ProgramResourceProperty[] props, int[] length, int[] parameters)
+            public static unsafe void GetProgramResourcei(int program, ProgramInterface programInterface, uint index, ProgramResourceProperty[] props, int[] length, int[] parameters)
             {
                 int propCount = (int)(props.Length);
                 fixed (ProgramResourceProperty* props_ptr = props)
@@ -21661,7 +21661,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetProgramResourceiv"/>
-            public static unsafe void GetProgramResourcei(ProgramHandle program, ProgramInterface programInterface, uint index, int propCount, in ProgramResourceProperty props, int count, ref int length, ref int parameters)
+            public static unsafe void GetProgramResourcei(int program, ProgramInterface programInterface, uint index, int propCount, in ProgramResourceProperty props, int count, ref int length, ref int parameters)
             {
                 fixed (ProgramResourceProperty* props_ptr = &props)
                 fixed (int* length_ptr = &length)
@@ -21671,7 +21671,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetProgramResourceLocation"/>
-            public static unsafe int GetProgramResourceLocation(ProgramHandle program, ProgramInterface programInterface, string name)
+            public static unsafe int GetProgramResourceLocation(int program, ProgramInterface programInterface, string name)
             {
                 int returnValue;
                 byte* name_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(name);
@@ -21680,7 +21680,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return returnValue;
             }
             /// <inheritdoc cref="GetProgramResourceLocationIndex"/>
-            public static unsafe int GetProgramResourceLocationIndex(ProgramHandle program, ProgramInterface programInterface, string name)
+            public static unsafe int GetProgramResourceLocationIndex(int program, ProgramInterface programInterface, string name)
             {
                 int returnValue;
                 byte* name_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(name);
@@ -21794,7 +21794,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetnUniformfvARB"/>
-            public static unsafe void GetnUniformfvARB(ProgramHandle program, int location, Span<float> parameters)
+            public static unsafe void GetnUniformfvARB(int program, int location, Span<float> parameters)
             {
                 int bufSize = (int)(parameters.Length * 4);
                 fixed (float* parameters_ptr = parameters)
@@ -21803,7 +21803,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetnUniformfvARB"/>
-            public static unsafe void GetnUniformfvARB(ProgramHandle program, int location, float[] parameters)
+            public static unsafe void GetnUniformfvARB(int program, int location, float[] parameters)
             {
                 int bufSize = (int)(parameters.Length * 4);
                 fixed (float* parameters_ptr = parameters)
@@ -21812,7 +21812,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetnUniformfvARB"/>
-            public static unsafe void GetnUniformfvARB(ProgramHandle program, int location, int bufSize, ref float parameters)
+            public static unsafe void GetnUniformfvARB(int program, int location, int bufSize, ref float parameters)
             {
                 fixed (float* parameters_ptr = &parameters)
                 {
@@ -21820,7 +21820,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetnUniformivARB"/>
-            public static unsafe void GetnUniformivARB(ProgramHandle program, int location, Span<int> parameters)
+            public static unsafe void GetnUniformivARB(int program, int location, Span<int> parameters)
             {
                 int bufSize = (int)(parameters.Length * 4);
                 fixed (int* parameters_ptr = parameters)
@@ -21829,7 +21829,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetnUniformivARB"/>
-            public static unsafe void GetnUniformivARB(ProgramHandle program, int location, int[] parameters)
+            public static unsafe void GetnUniformivARB(int program, int location, int[] parameters)
             {
                 int bufSize = (int)(parameters.Length * 4);
                 fixed (int* parameters_ptr = parameters)
@@ -21838,7 +21838,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetnUniformivARB"/>
-            public static unsafe void GetnUniformivARB(ProgramHandle program, int location, int bufSize, ref int parameters)
+            public static unsafe void GetnUniformivARB(int program, int location, int bufSize, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -21846,7 +21846,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetnUniformuivARB"/>
-            public static unsafe void GetnUniformuivARB(ProgramHandle program, int location, Span<uint> parameters)
+            public static unsafe void GetnUniformuivARB(int program, int location, Span<uint> parameters)
             {
                 int bufSize = (int)(parameters.Length * 4);
                 fixed (uint* parameters_ptr = parameters)
@@ -21855,7 +21855,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetnUniformuivARB"/>
-            public static unsafe void GetnUniformuivARB(ProgramHandle program, int location, uint[] parameters)
+            public static unsafe void GetnUniformuivARB(int program, int location, uint[] parameters)
             {
                 int bufSize = (int)(parameters.Length * 4);
                 fixed (uint* parameters_ptr = parameters)
@@ -21864,7 +21864,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetnUniformuivARB"/>
-            public static unsafe void GetnUniformuivARB(ProgramHandle program, int location, int bufSize, ref uint parameters)
+            public static unsafe void GetnUniformuivARB(int program, int location, int bufSize, ref uint parameters)
             {
                 fixed (uint* parameters_ptr = &parameters)
                 {
@@ -21872,7 +21872,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetnUniformdvARB"/>
-            public static unsafe void GetnUniformdvARB(ProgramHandle program, int location, Span<double> parameters)
+            public static unsafe void GetnUniformdvARB(int program, int location, Span<double> parameters)
             {
                 int bufSize = (int)(parameters.Length * 8);
                 fixed (double* parameters_ptr = parameters)
@@ -21881,7 +21881,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetnUniformdvARB"/>
-            public static unsafe void GetnUniformdvARB(ProgramHandle program, int location, double[] parameters)
+            public static unsafe void GetnUniformdvARB(int program, int location, double[] parameters)
             {
                 int bufSize = (int)(parameters.Length * 8);
                 fixed (double* parameters_ptr = parameters)
@@ -21890,7 +21890,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetnUniformdvARB"/>
-            public static unsafe void GetnUniformdvARB(ProgramHandle program, int location, int bufSize, ref double parameters)
+            public static unsafe void GetnUniformdvARB(int program, int location, int bufSize, ref double parameters)
             {
                 fixed (double* parameters_ptr = &parameters)
                 {
@@ -22287,7 +22287,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="NamedFramebufferSampleLocationsfvARB"/>
-            public static unsafe void NamedFramebufferSampleLocationsfvARB(FramebufferHandle framebuffer, uint start, int count, in float v)
+            public static unsafe void NamedFramebufferSampleLocationsfvARB(int framebuffer, uint start, int count, in float v)
             {
                 fixed (float* v_ptr = &v)
                 {
@@ -22295,9 +22295,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GenSamplers"/>
-            public static unsafe SamplerHandle GenSampler()
+            public static unsafe int GenSampler()
             {
-                SamplerHandle sampler;
+                int sampler;
                 int count = 1;
                 Unsafe.SkipInit(out sampler);
                 // FIXME: This could be a problem for the overloads that take an out parameter
@@ -22308,12 +22308,12 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                SamplerHandle* samplers_handle = (SamplerHandle*)Unsafe.AsPointer(ref sampler);
+                int* samplers_handle = (int*)Unsafe.AsPointer(ref sampler);
                 GenSamplers(count, samplers_handle);
                 return sampler;
             }
             /// <inheritdoc cref="GenSamplers"/>
-            public static unsafe void GenSampler(out SamplerHandle sampler)
+            public static unsafe void GenSampler(out int sampler)
             {
                 int count = 1;
                 Unsafe.SkipInit(out sampler);
@@ -22325,72 +22325,72 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                SamplerHandle* samplers_handle = (SamplerHandle*)Unsafe.AsPointer(ref sampler);
+                int* samplers_handle = (int*)Unsafe.AsPointer(ref sampler);
                 GenSamplers(count, samplers_handle);
             }
             /// <inheritdoc cref="GenSamplers"/>
-            public static unsafe void GenSamplers(Span<SamplerHandle> samplers)
+            public static unsafe void GenSamplers(Span<int> samplers)
             {
                 int count = (int)(samplers.Length);
-                fixed (SamplerHandle* samplers_ptr = samplers)
+                fixed (int* samplers_ptr = samplers)
                 {
                     GenSamplers(count, samplers_ptr);
                 }
             }
             /// <inheritdoc cref="GenSamplers"/>
-            public static unsafe void GenSamplers(SamplerHandle[] samplers)
+            public static unsafe void GenSamplers(int[] samplers)
             {
                 int count = (int)(samplers.Length);
-                fixed (SamplerHandle* samplers_ptr = samplers)
+                fixed (int* samplers_ptr = samplers)
                 {
                     GenSamplers(count, samplers_ptr);
                 }
             }
             /// <inheritdoc cref="GenSamplers"/>
-            public static unsafe void GenSamplers(int count, ref SamplerHandle samplers)
+            public static unsafe void GenSamplers(int count, ref int samplers)
             {
-                fixed (SamplerHandle* samplers_ptr = &samplers)
+                fixed (int* samplers_ptr = &samplers)
                 {
                     GenSamplers(count, samplers_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteSamplers"/>
-            public static unsafe void DeleteSampler(in SamplerHandle sampler)
+            public static unsafe void DeleteSampler(in int sampler)
             {
                 int count = 1;
-                fixed(SamplerHandle* samplers_handle = &sampler)
+                fixed(int* samplers_handle = &sampler)
                 {
                     DeleteSamplers(count, samplers_handle);
                 }
             }
             /// <inheritdoc cref="DeleteSamplers"/>
-            public static unsafe void DeleteSamplers(ReadOnlySpan<SamplerHandle> samplers)
+            public static unsafe void DeleteSamplers(ReadOnlySpan<int> samplers)
             {
                 int count = (int)(samplers.Length);
-                fixed (SamplerHandle* samplers_ptr = samplers)
+                fixed (int* samplers_ptr = samplers)
                 {
                     DeleteSamplers(count, samplers_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteSamplers"/>
-            public static unsafe void DeleteSamplers(SamplerHandle[] samplers)
+            public static unsafe void DeleteSamplers(int[] samplers)
             {
                 int count = (int)(samplers.Length);
-                fixed (SamplerHandle* samplers_ptr = samplers)
+                fixed (int* samplers_ptr = samplers)
                 {
                     DeleteSamplers(count, samplers_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteSamplers"/>
-            public static unsafe void DeleteSamplers(int count, in SamplerHandle samplers)
+            public static unsafe void DeleteSamplers(int count, in int samplers)
             {
-                fixed (SamplerHandle* samplers_ptr = &samplers)
+                fixed (int* samplers_ptr = &samplers)
                 {
                     DeleteSamplers(count, samplers_ptr);
                 }
             }
             /// <inheritdoc cref="SamplerParameteriv"/>
-            public static unsafe void SamplerParameteri(SamplerHandle sampler, SamplerParameterI pname, ReadOnlySpan<int> param)
+            public static unsafe void SamplerParameteri(int sampler, SamplerParameterI pname, ReadOnlySpan<int> param)
             {
                 fixed (int* param_ptr = param)
                 {
@@ -22398,7 +22398,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="SamplerParameteriv"/>
-            public static unsafe void SamplerParameteri(SamplerHandle sampler, SamplerParameterI pname, int[] param)
+            public static unsafe void SamplerParameteri(int sampler, SamplerParameterI pname, int[] param)
             {
                 fixed (int* param_ptr = param)
                 {
@@ -22406,7 +22406,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="SamplerParameteriv"/>
-            public static unsafe void SamplerParameteri(SamplerHandle sampler, SamplerParameterI pname, in int param)
+            public static unsafe void SamplerParameteri(int sampler, SamplerParameterI pname, in int param)
             {
                 fixed (int* param_ptr = &param)
                 {
@@ -22414,7 +22414,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="SamplerParameterfv"/>
-            public static unsafe void SamplerParameterf(SamplerHandle sampler, SamplerParameterF pname, ReadOnlySpan<float> param)
+            public static unsafe void SamplerParameterf(int sampler, SamplerParameterF pname, ReadOnlySpan<float> param)
             {
                 fixed (float* param_ptr = param)
                 {
@@ -22422,7 +22422,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="SamplerParameterfv"/>
-            public static unsafe void SamplerParameterf(SamplerHandle sampler, SamplerParameterF pname, float[] param)
+            public static unsafe void SamplerParameterf(int sampler, SamplerParameterF pname, float[] param)
             {
                 fixed (float* param_ptr = param)
                 {
@@ -22430,7 +22430,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="SamplerParameterfv"/>
-            public static unsafe void SamplerParameterf(SamplerHandle sampler, SamplerParameterF pname, in float param)
+            public static unsafe void SamplerParameterf(int sampler, SamplerParameterF pname, in float param)
             {
                 fixed (float* param_ptr = &param)
                 {
@@ -22438,7 +22438,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="SamplerParameterIiv"/>
-            public static unsafe void SamplerParameterIi(SamplerHandle sampler, SamplerParameterI pname, ReadOnlySpan<int> param)
+            public static unsafe void SamplerParameterIi(int sampler, SamplerParameterI pname, ReadOnlySpan<int> param)
             {
                 fixed (int* param_ptr = param)
                 {
@@ -22446,7 +22446,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="SamplerParameterIiv"/>
-            public static unsafe void SamplerParameterIi(SamplerHandle sampler, SamplerParameterI pname, int[] param)
+            public static unsafe void SamplerParameterIi(int sampler, SamplerParameterI pname, int[] param)
             {
                 fixed (int* param_ptr = param)
                 {
@@ -22454,7 +22454,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="SamplerParameterIiv"/>
-            public static unsafe void SamplerParameterIi(SamplerHandle sampler, SamplerParameterI pname, in int param)
+            public static unsafe void SamplerParameterIi(int sampler, SamplerParameterI pname, in int param)
             {
                 fixed (int* param_ptr = &param)
                 {
@@ -22462,7 +22462,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="SamplerParameterIuiv"/>
-            public static unsafe void SamplerParameterIui(SamplerHandle sampler, SamplerParameterI pname, ReadOnlySpan<uint> param)
+            public static unsafe void SamplerParameterIui(int sampler, SamplerParameterI pname, ReadOnlySpan<uint> param)
             {
                 fixed (uint* param_ptr = param)
                 {
@@ -22470,7 +22470,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="SamplerParameterIuiv"/>
-            public static unsafe void SamplerParameterIui(SamplerHandle sampler, SamplerParameterI pname, uint[] param)
+            public static unsafe void SamplerParameterIui(int sampler, SamplerParameterI pname, uint[] param)
             {
                 fixed (uint* param_ptr = param)
                 {
@@ -22478,7 +22478,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="SamplerParameterIuiv"/>
-            public static unsafe void SamplerParameterIui(SamplerHandle sampler, SamplerParameterI pname, in uint param)
+            public static unsafe void SamplerParameterIui(int sampler, SamplerParameterI pname, in uint param)
             {
                 fixed (uint* param_ptr = &param)
                 {
@@ -22486,7 +22486,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetSamplerParameteriv"/>
-            public static unsafe void GetSamplerParameteri(SamplerHandle sampler, SamplerParameterI pname, Span<int> parameters)
+            public static unsafe void GetSamplerParameteri(int sampler, SamplerParameterI pname, Span<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -22494,7 +22494,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetSamplerParameteriv"/>
-            public static unsafe void GetSamplerParameteri(SamplerHandle sampler, SamplerParameterI pname, int[] parameters)
+            public static unsafe void GetSamplerParameteri(int sampler, SamplerParameterI pname, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -22502,7 +22502,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetSamplerParameteriv"/>
-            public static unsafe void GetSamplerParameteri(SamplerHandle sampler, SamplerParameterI pname, ref int parameters)
+            public static unsafe void GetSamplerParameteri(int sampler, SamplerParameterI pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -22510,7 +22510,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetSamplerParameterIiv"/>
-            public static unsafe void GetSamplerParameterIi(SamplerHandle sampler, SamplerParameterI pname, Span<int> parameters)
+            public static unsafe void GetSamplerParameterIi(int sampler, SamplerParameterI pname, Span<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -22518,7 +22518,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetSamplerParameterIiv"/>
-            public static unsafe void GetSamplerParameterIi(SamplerHandle sampler, SamplerParameterI pname, int[] parameters)
+            public static unsafe void GetSamplerParameterIi(int sampler, SamplerParameterI pname, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -22526,7 +22526,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetSamplerParameterIiv"/>
-            public static unsafe void GetSamplerParameterIi(SamplerHandle sampler, SamplerParameterI pname, ref int parameters)
+            public static unsafe void GetSamplerParameterIi(int sampler, SamplerParameterI pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -22534,7 +22534,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetSamplerParameterfv"/>
-            public static unsafe void GetSamplerParameterf(SamplerHandle sampler, SamplerParameterF pname, Span<float> parameters)
+            public static unsafe void GetSamplerParameterf(int sampler, SamplerParameterF pname, Span<float> parameters)
             {
                 fixed (float* parameters_ptr = parameters)
                 {
@@ -22542,7 +22542,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetSamplerParameterfv"/>
-            public static unsafe void GetSamplerParameterf(SamplerHandle sampler, SamplerParameterF pname, float[] parameters)
+            public static unsafe void GetSamplerParameterf(int sampler, SamplerParameterF pname, float[] parameters)
             {
                 fixed (float* parameters_ptr = parameters)
                 {
@@ -22550,7 +22550,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetSamplerParameterfv"/>
-            public static unsafe void GetSamplerParameterf(SamplerHandle sampler, SamplerParameterF pname, ref float parameters)
+            public static unsafe void GetSamplerParameterf(int sampler, SamplerParameterF pname, ref float parameters)
             {
                 fixed (float* parameters_ptr = &parameters)
                 {
@@ -22558,7 +22558,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetSamplerParameterIuiv"/>
-            public static unsafe void GetSamplerParameterIui(SamplerHandle sampler, SamplerParameterI pname, Span<uint> parameters)
+            public static unsafe void GetSamplerParameterIui(int sampler, SamplerParameterI pname, Span<uint> parameters)
             {
                 fixed (uint* parameters_ptr = parameters)
                 {
@@ -22566,7 +22566,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetSamplerParameterIuiv"/>
-            public static unsafe void GetSamplerParameterIui(SamplerHandle sampler, SamplerParameterI pname, uint[] parameters)
+            public static unsafe void GetSamplerParameterIui(int sampler, SamplerParameterI pname, uint[] parameters)
             {
                 fixed (uint* parameters_ptr = parameters)
                 {
@@ -22574,7 +22574,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetSamplerParameterIuiv"/>
-            public static unsafe void GetSamplerParameterIui(SamplerHandle sampler, SamplerParameterI pname, ref uint parameters)
+            public static unsafe void GetSamplerParameterIui(int sampler, SamplerParameterI pname, ref uint parameters)
             {
                 fixed (uint* parameters_ptr = &parameters)
                 {
@@ -22582,51 +22582,51 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="CreateShaderProgramv"/>
-            public static unsafe ProgramHandle CreateShaderProgram(ShaderType type, int count, byte** strings)
+            public static unsafe int CreateShaderProgram(ShaderType type, int count, byte** strings)
             {
-                ProgramHandle returnValue;
+                int returnValue;
                 returnValue = CreateShaderProgramv(type, count, strings);
                 return returnValue;
             }
             /// <inheritdoc cref="DeleteProgramPipelines"/>
-            public static unsafe void DeleteProgramPipeline(in ProgramPipelineHandle pipeline)
+            public static unsafe void DeleteProgramPipeline(in int pipeline)
             {
                 int n = 1;
-                fixed(ProgramPipelineHandle* pipelines_handle = &pipeline)
+                fixed(int* pipelines_handle = &pipeline)
                 {
                     DeleteProgramPipelines(n, pipelines_handle);
                 }
             }
             /// <inheritdoc cref="DeleteProgramPipelines"/>
-            public static unsafe void DeleteProgramPipelines(ReadOnlySpan<ProgramPipelineHandle> pipelines)
+            public static unsafe void DeleteProgramPipelines(ReadOnlySpan<int> pipelines)
             {
                 int n = (int)(pipelines.Length);
-                fixed (ProgramPipelineHandle* pipelines_ptr = pipelines)
+                fixed (int* pipelines_ptr = pipelines)
                 {
                     DeleteProgramPipelines(n, pipelines_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteProgramPipelines"/>
-            public static unsafe void DeleteProgramPipelines(ProgramPipelineHandle[] pipelines)
+            public static unsafe void DeleteProgramPipelines(int[] pipelines)
             {
                 int n = (int)(pipelines.Length);
-                fixed (ProgramPipelineHandle* pipelines_ptr = pipelines)
+                fixed (int* pipelines_ptr = pipelines)
                 {
                     DeleteProgramPipelines(n, pipelines_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteProgramPipelines"/>
-            public static unsafe void DeleteProgramPipelines(int n, in ProgramPipelineHandle pipelines)
+            public static unsafe void DeleteProgramPipelines(int n, in int pipelines)
             {
-                fixed (ProgramPipelineHandle* pipelines_ptr = &pipelines)
+                fixed (int* pipelines_ptr = &pipelines)
                 {
                     DeleteProgramPipelines(n, pipelines_ptr);
                 }
             }
             /// <inheritdoc cref="GenProgramPipelines"/>
-            public static unsafe ProgramPipelineHandle GenProgramPipeline()
+            public static unsafe int GenProgramPipeline()
             {
-                ProgramPipelineHandle pipeline;
+                int pipeline;
                 int n = 1;
                 Unsafe.SkipInit(out pipeline);
                 // FIXME: This could be a problem for the overloads that take an out parameter
@@ -22637,12 +22637,12 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                ProgramPipelineHandle* pipelines_handle = (ProgramPipelineHandle*)Unsafe.AsPointer(ref pipeline);
+                int* pipelines_handle = (int*)Unsafe.AsPointer(ref pipeline);
                 GenProgramPipelines(n, pipelines_handle);
                 return pipeline;
             }
             /// <inheritdoc cref="GenProgramPipelines"/>
-            public static unsafe void GenProgramPipeline(out ProgramPipelineHandle pipeline)
+            public static unsafe void GenProgramPipeline(out int pipeline)
             {
                 int n = 1;
                 Unsafe.SkipInit(out pipeline);
@@ -22654,37 +22654,37 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                ProgramPipelineHandle* pipelines_handle = (ProgramPipelineHandle*)Unsafe.AsPointer(ref pipeline);
+                int* pipelines_handle = (int*)Unsafe.AsPointer(ref pipeline);
                 GenProgramPipelines(n, pipelines_handle);
             }
             /// <inheritdoc cref="GenProgramPipelines"/>
-            public static unsafe void GenProgramPipelines(Span<ProgramPipelineHandle> pipelines)
+            public static unsafe void GenProgramPipelines(Span<int> pipelines)
             {
                 int n = (int)(pipelines.Length);
-                fixed (ProgramPipelineHandle* pipelines_ptr = pipelines)
+                fixed (int* pipelines_ptr = pipelines)
                 {
                     GenProgramPipelines(n, pipelines_ptr);
                 }
             }
             /// <inheritdoc cref="GenProgramPipelines"/>
-            public static unsafe void GenProgramPipelines(ProgramPipelineHandle[] pipelines)
+            public static unsafe void GenProgramPipelines(int[] pipelines)
             {
                 int n = (int)(pipelines.Length);
-                fixed (ProgramPipelineHandle* pipelines_ptr = pipelines)
+                fixed (int* pipelines_ptr = pipelines)
                 {
                     GenProgramPipelines(n, pipelines_ptr);
                 }
             }
             /// <inheritdoc cref="GenProgramPipelines"/>
-            public static unsafe void GenProgramPipelines(int n, ref ProgramPipelineHandle pipelines)
+            public static unsafe void GenProgramPipelines(int n, ref int pipelines)
             {
-                fixed (ProgramPipelineHandle* pipelines_ptr = &pipelines)
+                fixed (int* pipelines_ptr = &pipelines)
                 {
                     GenProgramPipelines(n, pipelines_ptr);
                 }
             }
             /// <inheritdoc cref="GetProgramPipelineiv"/>
-            public static unsafe void GetProgramPipelinei(ProgramPipelineHandle pipeline, PipelineParameterName pname, Span<int> parameters)
+            public static unsafe void GetProgramPipelinei(int pipeline, PipelineParameterName pname, Span<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -22692,7 +22692,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetProgramPipelineiv"/>
-            public static unsafe void GetProgramPipelinei(ProgramPipelineHandle pipeline, PipelineParameterName pname, int[] parameters)
+            public static unsafe void GetProgramPipelinei(int pipeline, PipelineParameterName pname, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -22700,7 +22700,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetProgramPipelineiv"/>
-            public static unsafe void GetProgramPipelinei(ProgramPipelineHandle pipeline, PipelineParameterName pname, ref int parameters)
+            public static unsafe void GetProgramPipelinei(int pipeline, PipelineParameterName pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -22708,7 +22708,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform1iv"/>
-            public static unsafe void ProgramUniform1iv(ProgramHandle program, int location, ReadOnlySpan<int> value)
+            public static unsafe void ProgramUniform1iv(int program, int location, ReadOnlySpan<int> value)
             {
                 int count = (int)(value.Length);
                 fixed (int* value_ptr = value)
@@ -22717,7 +22717,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform1iv"/>
-            public static unsafe void ProgramUniform1iv(ProgramHandle program, int location, int[] value)
+            public static unsafe void ProgramUniform1iv(int program, int location, int[] value)
             {
                 int count = (int)(value.Length);
                 fixed (int* value_ptr = value)
@@ -22726,7 +22726,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform1iv"/>
-            public static unsafe void ProgramUniform1iv(ProgramHandle program, int location, int count, in int value)
+            public static unsafe void ProgramUniform1iv(int program, int location, int count, in int value)
             {
                 fixed (int* value_ptr = &value)
                 {
@@ -22734,7 +22734,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform1fv"/>
-            public static unsafe void ProgramUniform1fv(ProgramHandle program, int location, ReadOnlySpan<float> value)
+            public static unsafe void ProgramUniform1fv(int program, int location, ReadOnlySpan<float> value)
             {
                 int count = (int)(value.Length);
                 fixed (float* value_ptr = value)
@@ -22743,7 +22743,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform1fv"/>
-            public static unsafe void ProgramUniform1fv(ProgramHandle program, int location, float[] value)
+            public static unsafe void ProgramUniform1fv(int program, int location, float[] value)
             {
                 int count = (int)(value.Length);
                 fixed (float* value_ptr = value)
@@ -22752,7 +22752,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform1fv"/>
-            public static unsafe void ProgramUniform1fv(ProgramHandle program, int location, int count, in float value)
+            public static unsafe void ProgramUniform1fv(int program, int location, int count, in float value)
             {
                 fixed (float* value_ptr = &value)
                 {
@@ -22760,7 +22760,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform1dv"/>
-            public static unsafe void ProgramUniform1dv(ProgramHandle program, int location, ReadOnlySpan<double> value)
+            public static unsafe void ProgramUniform1dv(int program, int location, ReadOnlySpan<double> value)
             {
                 int count = (int)(value.Length);
                 fixed (double* value_ptr = value)
@@ -22769,7 +22769,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform1dv"/>
-            public static unsafe void ProgramUniform1dv(ProgramHandle program, int location, double[] value)
+            public static unsafe void ProgramUniform1dv(int program, int location, double[] value)
             {
                 int count = (int)(value.Length);
                 fixed (double* value_ptr = value)
@@ -22778,7 +22778,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform1dv"/>
-            public static unsafe void ProgramUniform1dv(ProgramHandle program, int location, int count, in double value)
+            public static unsafe void ProgramUniform1dv(int program, int location, int count, in double value)
             {
                 fixed (double* value_ptr = &value)
                 {
@@ -22786,7 +22786,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform1uiv"/>
-            public static unsafe void ProgramUniform1ui(ProgramHandle program, int location, ReadOnlySpan<uint> value)
+            public static unsafe void ProgramUniform1ui(int program, int location, ReadOnlySpan<uint> value)
             {
                 int count = (int)(value.Length);
                 fixed (uint* value_ptr = value)
@@ -22795,7 +22795,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform1uiv"/>
-            public static unsafe void ProgramUniform1ui(ProgramHandle program, int location, uint[] value)
+            public static unsafe void ProgramUniform1ui(int program, int location, uint[] value)
             {
                 int count = (int)(value.Length);
                 fixed (uint* value_ptr = value)
@@ -22804,7 +22804,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform1uiv"/>
-            public static unsafe void ProgramUniform1ui(ProgramHandle program, int location, int count, in uint value)
+            public static unsafe void ProgramUniform1ui(int program, int location, int count, in uint value)
             {
                 fixed (uint* value_ptr = &value)
                 {
@@ -22812,7 +22812,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform2iv"/>
-            public static unsafe void ProgramUniform2i(ProgramHandle program, int location, int count, in Vector2i value)
+            public static unsafe void ProgramUniform2i(int program, int location, int count, in Vector2i value)
             {
                 fixed (Vector2i* tmp_vecPtr = &value)
                 {
@@ -22821,7 +22821,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform2iv"/>
-            public static unsafe void ProgramUniform2i(ProgramHandle program, int location, int count, ReadOnlySpan<Vector2i> value)
+            public static unsafe void ProgramUniform2i(int program, int location, int count, ReadOnlySpan<Vector2i> value)
             {
                 fixed (Vector2i* tmp_vecPtr = value)
                 {
@@ -22830,7 +22830,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform2iv"/>
-            public static unsafe void ProgramUniform2i(ProgramHandle program, int location, int count, Vector2i[] value)
+            public static unsafe void ProgramUniform2i(int program, int location, int count, Vector2i[] value)
             {
                 fixed (Vector2i* tmp_vecPtr = value)
                 {
@@ -22839,7 +22839,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform2fv"/>
-            public static unsafe void ProgramUniform2f(ProgramHandle program, int location, int count, in Vector2 value)
+            public static unsafe void ProgramUniform2f(int program, int location, int count, in Vector2 value)
             {
                 fixed (Vector2* tmp_vecPtr = &value)
                 {
@@ -22848,7 +22848,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform2fv"/>
-            public static unsafe void ProgramUniform2f(ProgramHandle program, int location, int count, ReadOnlySpan<Vector2> value)
+            public static unsafe void ProgramUniform2f(int program, int location, int count, ReadOnlySpan<Vector2> value)
             {
                 fixed (Vector2* tmp_vecPtr = value)
                 {
@@ -22857,7 +22857,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform2fv"/>
-            public static unsafe void ProgramUniform2f(ProgramHandle program, int location, int count, Vector2[] value)
+            public static unsafe void ProgramUniform2f(int program, int location, int count, Vector2[] value)
             {
                 fixed (Vector2* tmp_vecPtr = value)
                 {
@@ -22866,7 +22866,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform2fv"/>
-            public static unsafe void ProgramUniform2f(ProgramHandle program, int location, int count, in System.Numerics.Vector2 value)
+            public static unsafe void ProgramUniform2f(int program, int location, int count, in System.Numerics.Vector2 value)
             {
                 fixed (System.Numerics.Vector2* tmp_vecPtr = &value)
                 {
@@ -22875,7 +22875,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform2fv"/>
-            public static unsafe void ProgramUniform2f(ProgramHandle program, int location, int count, ReadOnlySpan<System.Numerics.Vector2> value)
+            public static unsafe void ProgramUniform2f(int program, int location, int count, ReadOnlySpan<System.Numerics.Vector2> value)
             {
                 fixed (System.Numerics.Vector2* tmp_vecPtr = value)
                 {
@@ -22884,7 +22884,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform2fv"/>
-            public static unsafe void ProgramUniform2f(ProgramHandle program, int location, int count, System.Numerics.Vector2[] value)
+            public static unsafe void ProgramUniform2f(int program, int location, int count, System.Numerics.Vector2[] value)
             {
                 fixed (System.Numerics.Vector2* tmp_vecPtr = value)
                 {
@@ -22893,7 +22893,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform2dv"/>
-            public static unsafe void ProgramUniform2d(ProgramHandle program, int location, int count, in Vector2d value)
+            public static unsafe void ProgramUniform2d(int program, int location, int count, in Vector2d value)
             {
                 fixed (Vector2d* tmp_vecPtr = &value)
                 {
@@ -22902,7 +22902,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform2dv"/>
-            public static unsafe void ProgramUniform2d(ProgramHandle program, int location, int count, ReadOnlySpan<Vector2d> value)
+            public static unsafe void ProgramUniform2d(int program, int location, int count, ReadOnlySpan<Vector2d> value)
             {
                 fixed (Vector2d* tmp_vecPtr = value)
                 {
@@ -22911,7 +22911,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform2dv"/>
-            public static unsafe void ProgramUniform2d(ProgramHandle program, int location, int count, Vector2d[] value)
+            public static unsafe void ProgramUniform2d(int program, int location, int count, Vector2d[] value)
             {
                 fixed (Vector2d* tmp_vecPtr = value)
                 {
@@ -22920,7 +22920,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform2uiv"/>
-            public static unsafe void ProgramUniform2ui(ProgramHandle program, int location, ReadOnlySpan<uint> value)
+            public static unsafe void ProgramUniform2ui(int program, int location, ReadOnlySpan<uint> value)
             {
                 int count = (int)(value.Length / 2);
                 fixed (uint* value_ptr = value)
@@ -22929,7 +22929,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform2uiv"/>
-            public static unsafe void ProgramUniform2ui(ProgramHandle program, int location, uint[] value)
+            public static unsafe void ProgramUniform2ui(int program, int location, uint[] value)
             {
                 int count = (int)(value.Length / 2);
                 fixed (uint* value_ptr = value)
@@ -22938,7 +22938,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform2uiv"/>
-            public static unsafe void ProgramUniform2ui(ProgramHandle program, int location, int count, in uint value)
+            public static unsafe void ProgramUniform2ui(int program, int location, int count, in uint value)
             {
                 fixed (uint* value_ptr = &value)
                 {
@@ -22946,7 +22946,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform3iv"/>
-            public static unsafe void ProgramUniform3i(ProgramHandle program, int location, int count, in Vector3i value)
+            public static unsafe void ProgramUniform3i(int program, int location, int count, in Vector3i value)
             {
                 fixed (Vector3i* tmp_vecPtr = &value)
                 {
@@ -22955,7 +22955,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform3iv"/>
-            public static unsafe void ProgramUniform3i(ProgramHandle program, int location, int count, ReadOnlySpan<Vector3i> value)
+            public static unsafe void ProgramUniform3i(int program, int location, int count, ReadOnlySpan<Vector3i> value)
             {
                 fixed (Vector3i* tmp_vecPtr = value)
                 {
@@ -22964,7 +22964,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform3iv"/>
-            public static unsafe void ProgramUniform3i(ProgramHandle program, int location, int count, Vector3i[] value)
+            public static unsafe void ProgramUniform3i(int program, int location, int count, Vector3i[] value)
             {
                 fixed (Vector3i* tmp_vecPtr = value)
                 {
@@ -22973,7 +22973,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform3fv"/>
-            public static unsafe void ProgramUniform3f(ProgramHandle program, int location, int count, in Vector3 value)
+            public static unsafe void ProgramUniform3f(int program, int location, int count, in Vector3 value)
             {
                 fixed (Vector3* tmp_vecPtr = &value)
                 {
@@ -22982,7 +22982,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform3fv"/>
-            public static unsafe void ProgramUniform3f(ProgramHandle program, int location, int count, ReadOnlySpan<Vector3> value)
+            public static unsafe void ProgramUniform3f(int program, int location, int count, ReadOnlySpan<Vector3> value)
             {
                 fixed (Vector3* tmp_vecPtr = value)
                 {
@@ -22991,7 +22991,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform3fv"/>
-            public static unsafe void ProgramUniform3f(ProgramHandle program, int location, int count, Vector3[] value)
+            public static unsafe void ProgramUniform3f(int program, int location, int count, Vector3[] value)
             {
                 fixed (Vector3* tmp_vecPtr = value)
                 {
@@ -23000,7 +23000,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform3fv"/>
-            public static unsafe void ProgramUniform3f(ProgramHandle program, int location, int count, in System.Numerics.Vector3 value)
+            public static unsafe void ProgramUniform3f(int program, int location, int count, in System.Numerics.Vector3 value)
             {
                 fixed (System.Numerics.Vector3* tmp_vecPtr = &value)
                 {
@@ -23009,7 +23009,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform3fv"/>
-            public static unsafe void ProgramUniform3f(ProgramHandle program, int location, int count, ReadOnlySpan<System.Numerics.Vector3> value)
+            public static unsafe void ProgramUniform3f(int program, int location, int count, ReadOnlySpan<System.Numerics.Vector3> value)
             {
                 fixed (System.Numerics.Vector3* tmp_vecPtr = value)
                 {
@@ -23018,7 +23018,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform3fv"/>
-            public static unsafe void ProgramUniform3f(ProgramHandle program, int location, int count, System.Numerics.Vector3[] value)
+            public static unsafe void ProgramUniform3f(int program, int location, int count, System.Numerics.Vector3[] value)
             {
                 fixed (System.Numerics.Vector3* tmp_vecPtr = value)
                 {
@@ -23027,7 +23027,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform3dv"/>
-            public static unsafe void ProgramUniform3d(ProgramHandle program, int location, int count, in Vector3d value)
+            public static unsafe void ProgramUniform3d(int program, int location, int count, in Vector3d value)
             {
                 fixed (Vector3d* tmp_vecPtr = &value)
                 {
@@ -23036,7 +23036,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform3dv"/>
-            public static unsafe void ProgramUniform3d(ProgramHandle program, int location, int count, ReadOnlySpan<Vector3d> value)
+            public static unsafe void ProgramUniform3d(int program, int location, int count, ReadOnlySpan<Vector3d> value)
             {
                 fixed (Vector3d* tmp_vecPtr = value)
                 {
@@ -23045,7 +23045,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform3dv"/>
-            public static unsafe void ProgramUniform3d(ProgramHandle program, int location, int count, Vector3d[] value)
+            public static unsafe void ProgramUniform3d(int program, int location, int count, Vector3d[] value)
             {
                 fixed (Vector3d* tmp_vecPtr = value)
                 {
@@ -23054,7 +23054,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform3uiv"/>
-            public static unsafe void ProgramUniform3ui(ProgramHandle program, int location, ReadOnlySpan<uint> value)
+            public static unsafe void ProgramUniform3ui(int program, int location, ReadOnlySpan<uint> value)
             {
                 int count = (int)(value.Length / 3);
                 fixed (uint* value_ptr = value)
@@ -23063,7 +23063,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform3uiv"/>
-            public static unsafe void ProgramUniform3ui(ProgramHandle program, int location, uint[] value)
+            public static unsafe void ProgramUniform3ui(int program, int location, uint[] value)
             {
                 int count = (int)(value.Length / 3);
                 fixed (uint* value_ptr = value)
@@ -23072,7 +23072,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform3uiv"/>
-            public static unsafe void ProgramUniform3ui(ProgramHandle program, int location, int count, in uint value)
+            public static unsafe void ProgramUniform3ui(int program, int location, int count, in uint value)
             {
                 fixed (uint* value_ptr = &value)
                 {
@@ -23080,7 +23080,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform4iv"/>
-            public static unsafe void ProgramUniform4i(ProgramHandle program, int location, int count, in Vector4i value)
+            public static unsafe void ProgramUniform4i(int program, int location, int count, in Vector4i value)
             {
                 fixed (Vector4i* tmp_vecPtr = &value)
                 {
@@ -23089,7 +23089,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform4iv"/>
-            public static unsafe void ProgramUniform4i(ProgramHandle program, int location, int count, ReadOnlySpan<Vector4i> value)
+            public static unsafe void ProgramUniform4i(int program, int location, int count, ReadOnlySpan<Vector4i> value)
             {
                 fixed (Vector4i* tmp_vecPtr = value)
                 {
@@ -23098,7 +23098,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform4iv"/>
-            public static unsafe void ProgramUniform4i(ProgramHandle program, int location, int count, Vector4i[] value)
+            public static unsafe void ProgramUniform4i(int program, int location, int count, Vector4i[] value)
             {
                 fixed (Vector4i* tmp_vecPtr = value)
                 {
@@ -23107,7 +23107,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform4fv"/>
-            public static unsafe void ProgramUniform4f(ProgramHandle program, int location, int count, in Vector4 value)
+            public static unsafe void ProgramUniform4f(int program, int location, int count, in Vector4 value)
             {
                 fixed (Vector4* tmp_vecPtr = &value)
                 {
@@ -23116,7 +23116,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform4fv"/>
-            public static unsafe void ProgramUniform4f(ProgramHandle program, int location, int count, ReadOnlySpan<Vector4> value)
+            public static unsafe void ProgramUniform4f(int program, int location, int count, ReadOnlySpan<Vector4> value)
             {
                 fixed (Vector4* tmp_vecPtr = value)
                 {
@@ -23125,7 +23125,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform4fv"/>
-            public static unsafe void ProgramUniform4f(ProgramHandle program, int location, int count, Vector4[] value)
+            public static unsafe void ProgramUniform4f(int program, int location, int count, Vector4[] value)
             {
                 fixed (Vector4* tmp_vecPtr = value)
                 {
@@ -23134,7 +23134,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform4fv"/>
-            public static unsafe void ProgramUniform4f(ProgramHandle program, int location, int count, in System.Numerics.Vector4 value)
+            public static unsafe void ProgramUniform4f(int program, int location, int count, in System.Numerics.Vector4 value)
             {
                 fixed (System.Numerics.Vector4* tmp_vecPtr = &value)
                 {
@@ -23143,7 +23143,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform4fv"/>
-            public static unsafe void ProgramUniform4f(ProgramHandle program, int location, int count, ReadOnlySpan<System.Numerics.Vector4> value)
+            public static unsafe void ProgramUniform4f(int program, int location, int count, ReadOnlySpan<System.Numerics.Vector4> value)
             {
                 fixed (System.Numerics.Vector4* tmp_vecPtr = value)
                 {
@@ -23152,7 +23152,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform4fv"/>
-            public static unsafe void ProgramUniform4f(ProgramHandle program, int location, int count, System.Numerics.Vector4[] value)
+            public static unsafe void ProgramUniform4f(int program, int location, int count, System.Numerics.Vector4[] value)
             {
                 fixed (System.Numerics.Vector4* tmp_vecPtr = value)
                 {
@@ -23161,7 +23161,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform4dv"/>
-            public static unsafe void ProgramUniform4d(ProgramHandle program, int location, int count, in Vector4d value)
+            public static unsafe void ProgramUniform4d(int program, int location, int count, in Vector4d value)
             {
                 fixed (Vector4d* tmp_vecPtr = &value)
                 {
@@ -23170,7 +23170,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform4dv"/>
-            public static unsafe void ProgramUniform4d(ProgramHandle program, int location, int count, ReadOnlySpan<Vector4d> value)
+            public static unsafe void ProgramUniform4d(int program, int location, int count, ReadOnlySpan<Vector4d> value)
             {
                 fixed (Vector4d* tmp_vecPtr = value)
                 {
@@ -23179,7 +23179,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform4dv"/>
-            public static unsafe void ProgramUniform4d(ProgramHandle program, int location, int count, Vector4d[] value)
+            public static unsafe void ProgramUniform4d(int program, int location, int count, Vector4d[] value)
             {
                 fixed (Vector4d* tmp_vecPtr = value)
                 {
@@ -23188,7 +23188,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform4uiv"/>
-            public static unsafe void ProgramUniform4ui(ProgramHandle program, int location, ReadOnlySpan<uint> value)
+            public static unsafe void ProgramUniform4ui(int program, int location, ReadOnlySpan<uint> value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (uint* value_ptr = value)
@@ -23197,7 +23197,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform4uiv"/>
-            public static unsafe void ProgramUniform4ui(ProgramHandle program, int location, uint[] value)
+            public static unsafe void ProgramUniform4ui(int program, int location, uint[] value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (uint* value_ptr = value)
@@ -23206,7 +23206,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform4uiv"/>
-            public static unsafe void ProgramUniform4ui(ProgramHandle program, int location, int count, in uint value)
+            public static unsafe void ProgramUniform4ui(int program, int location, int count, in uint value)
             {
                 fixed (uint* value_ptr = &value)
                 {
@@ -23214,7 +23214,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2fv"/>
-            public static unsafe void ProgramUniformMatrix2f(ProgramHandle program, int location, int count, bool transpose, in Matrix2 value)
+            public static unsafe void ProgramUniformMatrix2f(int program, int location, int count, bool transpose, in Matrix2 value)
             {
                 fixed (Matrix2* tmp_vecPtr = &value)
                 {
@@ -23223,7 +23223,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2fv"/>
-            public static unsafe void ProgramUniformMatrix2f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix2> value)
+            public static unsafe void ProgramUniformMatrix2f(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix2> value)
             {
                 fixed (Matrix2* tmp_vecPtr = value)
                 {
@@ -23232,7 +23232,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2fv"/>
-            public static unsafe void ProgramUniformMatrix2f(ProgramHandle program, int location, int count, bool transpose, Matrix2[] value)
+            public static unsafe void ProgramUniformMatrix2f(int program, int location, int count, bool transpose, Matrix2[] value)
             {
                 fixed (Matrix2* tmp_vecPtr = value)
                 {
@@ -23241,7 +23241,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3fv"/>
-            public static unsafe void ProgramUniformMatrix3f(ProgramHandle program, int location, int count, bool transpose, in Matrix3 value)
+            public static unsafe void ProgramUniformMatrix3f(int program, int location, int count, bool transpose, in Matrix3 value)
             {
                 fixed (Matrix3* tmp_vecPtr = &value)
                 {
@@ -23250,7 +23250,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3fv"/>
-            public static unsafe void ProgramUniformMatrix3f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix3> value)
+            public static unsafe void ProgramUniformMatrix3f(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix3> value)
             {
                 fixed (Matrix3* tmp_vecPtr = value)
                 {
@@ -23259,7 +23259,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3fv"/>
-            public static unsafe void ProgramUniformMatrix3f(ProgramHandle program, int location, int count, bool transpose, Matrix3[] value)
+            public static unsafe void ProgramUniformMatrix3f(int program, int location, int count, bool transpose, Matrix3[] value)
             {
                 fixed (Matrix3* tmp_vecPtr = value)
                 {
@@ -23268,7 +23268,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
-            public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, int count, bool transpose, in Matrix4 value)
+            public static unsafe void ProgramUniformMatrix4f(int program, int location, int count, bool transpose, in Matrix4 value)
             {
                 fixed (Matrix4* tmp_vecPtr = &value)
                 {
@@ -23277,7 +23277,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
-            public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix4> value)
+            public static unsafe void ProgramUniformMatrix4f(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix4> value)
             {
                 fixed (Matrix4* tmp_vecPtr = value)
                 {
@@ -23286,7 +23286,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
-            public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, int count, bool transpose, Matrix4[] value)
+            public static unsafe void ProgramUniformMatrix4f(int program, int location, int count, bool transpose, Matrix4[] value)
             {
                 fixed (Matrix4* tmp_vecPtr = value)
                 {
@@ -23295,7 +23295,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
-            public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, int count, bool transpose, in System.Numerics.Matrix4x4 value)
+            public static unsafe void ProgramUniformMatrix4f(int program, int location, int count, bool transpose, in System.Numerics.Matrix4x4 value)
             {
                 fixed (System.Numerics.Matrix4x4* tmp_vecPtr = &value)
                 {
@@ -23304,7 +23304,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
-            public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<System.Numerics.Matrix4x4> value)
+            public static unsafe void ProgramUniformMatrix4f(int program, int location, int count, bool transpose, ReadOnlySpan<System.Numerics.Matrix4x4> value)
             {
                 fixed (System.Numerics.Matrix4x4* tmp_vecPtr = value)
                 {
@@ -23313,7 +23313,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
-            public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, int count, bool transpose, System.Numerics.Matrix4x4[] value)
+            public static unsafe void ProgramUniformMatrix4f(int program, int location, int count, bool transpose, System.Numerics.Matrix4x4[] value)
             {
                 fixed (System.Numerics.Matrix4x4* tmp_vecPtr = value)
                 {
@@ -23322,7 +23322,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2dv"/>
-            public static unsafe void ProgramUniformMatrix2d(ProgramHandle program, int location, int count, bool transpose, in Matrix2d value)
+            public static unsafe void ProgramUniformMatrix2d(int program, int location, int count, bool transpose, in Matrix2d value)
             {
                 fixed (Matrix2d* tmp_vecPtr = &value)
                 {
@@ -23331,7 +23331,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2dv"/>
-            public static unsafe void ProgramUniformMatrix2d(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix2d> value)
+            public static unsafe void ProgramUniformMatrix2d(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix2d> value)
             {
                 fixed (Matrix2d* tmp_vecPtr = value)
                 {
@@ -23340,7 +23340,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2dv"/>
-            public static unsafe void ProgramUniformMatrix2d(ProgramHandle program, int location, int count, bool transpose, Matrix2d[] value)
+            public static unsafe void ProgramUniformMatrix2d(int program, int location, int count, bool transpose, Matrix2d[] value)
             {
                 fixed (Matrix2d* tmp_vecPtr = value)
                 {
@@ -23349,7 +23349,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3dv"/>
-            public static unsafe void ProgramUniformMatrix3d(ProgramHandle program, int location, int count, bool transpose, in Matrix3d value)
+            public static unsafe void ProgramUniformMatrix3d(int program, int location, int count, bool transpose, in Matrix3d value)
             {
                 fixed (Matrix3d* tmp_vecPtr = &value)
                 {
@@ -23358,7 +23358,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3dv"/>
-            public static unsafe void ProgramUniformMatrix3d(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix3d> value)
+            public static unsafe void ProgramUniformMatrix3d(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix3d> value)
             {
                 fixed (Matrix3d* tmp_vecPtr = value)
                 {
@@ -23367,7 +23367,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3dv"/>
-            public static unsafe void ProgramUniformMatrix3d(ProgramHandle program, int location, int count, bool transpose, Matrix3d[] value)
+            public static unsafe void ProgramUniformMatrix3d(int program, int location, int count, bool transpose, Matrix3d[] value)
             {
                 fixed (Matrix3d* tmp_vecPtr = value)
                 {
@@ -23376,7 +23376,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4dv"/>
-            public static unsafe void ProgramUniformMatrix4d(ProgramHandle program, int location, int count, bool transpose, in Matrix4d value)
+            public static unsafe void ProgramUniformMatrix4d(int program, int location, int count, bool transpose, in Matrix4d value)
             {
                 fixed (Matrix4d* tmp_vecPtr = &value)
                 {
@@ -23385,7 +23385,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4dv"/>
-            public static unsafe void ProgramUniformMatrix4d(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix4d> value)
+            public static unsafe void ProgramUniformMatrix4d(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix4d> value)
             {
                 fixed (Matrix4d* tmp_vecPtr = value)
                 {
@@ -23394,7 +23394,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4dv"/>
-            public static unsafe void ProgramUniformMatrix4d(ProgramHandle program, int location, int count, bool transpose, Matrix4d[] value)
+            public static unsafe void ProgramUniformMatrix4d(int program, int location, int count, bool transpose, Matrix4d[] value)
             {
                 fixed (Matrix4d* tmp_vecPtr = value)
                 {
@@ -23403,7 +23403,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x3fv"/>
-            public static unsafe void ProgramUniformMatrix2x3f(ProgramHandle program, int location, int count, bool transpose, in Matrix2x3 value)
+            public static unsafe void ProgramUniformMatrix2x3f(int program, int location, int count, bool transpose, in Matrix2x3 value)
             {
                 fixed (Matrix2x3* tmp_vecPtr = &value)
                 {
@@ -23412,7 +23412,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x3fv"/>
-            public static unsafe void ProgramUniformMatrix2x3f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix2x3> value)
+            public static unsafe void ProgramUniformMatrix2x3f(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix2x3> value)
             {
                 fixed (Matrix2x3* tmp_vecPtr = value)
                 {
@@ -23421,7 +23421,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x3fv"/>
-            public static unsafe void ProgramUniformMatrix2x3f(ProgramHandle program, int location, int count, bool transpose, Matrix2x3[] value)
+            public static unsafe void ProgramUniformMatrix2x3f(int program, int location, int count, bool transpose, Matrix2x3[] value)
             {
                 fixed (Matrix2x3* tmp_vecPtr = value)
                 {
@@ -23430,7 +23430,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
-            public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, int count, bool transpose, in Matrix3x2 value)
+            public static unsafe void ProgramUniformMatrix3x2f(int program, int location, int count, bool transpose, in Matrix3x2 value)
             {
                 fixed (Matrix3x2* tmp_vecPtr = &value)
                 {
@@ -23439,7 +23439,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
-            public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix3x2> value)
+            public static unsafe void ProgramUniformMatrix3x2f(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix3x2> value)
             {
                 fixed (Matrix3x2* tmp_vecPtr = value)
                 {
@@ -23448,7 +23448,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
-            public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, int count, bool transpose, Matrix3x2[] value)
+            public static unsafe void ProgramUniformMatrix3x2f(int program, int location, int count, bool transpose, Matrix3x2[] value)
             {
                 fixed (Matrix3x2* tmp_vecPtr = value)
                 {
@@ -23457,7 +23457,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
-            public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, int count, bool transpose, in System.Numerics.Matrix3x2 value)
+            public static unsafe void ProgramUniformMatrix3x2f(int program, int location, int count, bool transpose, in System.Numerics.Matrix3x2 value)
             {
                 fixed (System.Numerics.Matrix3x2* tmp_vecPtr = &value)
                 {
@@ -23466,7 +23466,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
-            public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<System.Numerics.Matrix3x2> value)
+            public static unsafe void ProgramUniformMatrix3x2f(int program, int location, int count, bool transpose, ReadOnlySpan<System.Numerics.Matrix3x2> value)
             {
                 fixed (System.Numerics.Matrix3x2* tmp_vecPtr = value)
                 {
@@ -23475,7 +23475,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
-            public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, int count, bool transpose, System.Numerics.Matrix3x2[] value)
+            public static unsafe void ProgramUniformMatrix3x2f(int program, int location, int count, bool transpose, System.Numerics.Matrix3x2[] value)
             {
                 fixed (System.Numerics.Matrix3x2* tmp_vecPtr = value)
                 {
@@ -23484,7 +23484,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x4fv"/>
-            public static unsafe void ProgramUniformMatrix2x4f(ProgramHandle program, int location, int count, bool transpose, in Matrix2x4 value)
+            public static unsafe void ProgramUniformMatrix2x4f(int program, int location, int count, bool transpose, in Matrix2x4 value)
             {
                 fixed (Matrix2x4* tmp_vecPtr = &value)
                 {
@@ -23493,7 +23493,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x4fv"/>
-            public static unsafe void ProgramUniformMatrix2x4f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix2x4> value)
+            public static unsafe void ProgramUniformMatrix2x4f(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix2x4> value)
             {
                 fixed (Matrix2x4* tmp_vecPtr = value)
                 {
@@ -23502,7 +23502,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x4fv"/>
-            public static unsafe void ProgramUniformMatrix2x4f(ProgramHandle program, int location, int count, bool transpose, Matrix2x4[] value)
+            public static unsafe void ProgramUniformMatrix2x4f(int program, int location, int count, bool transpose, Matrix2x4[] value)
             {
                 fixed (Matrix2x4* tmp_vecPtr = value)
                 {
@@ -23511,7 +23511,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x2fv"/>
-            public static unsafe void ProgramUniformMatrix4x2f(ProgramHandle program, int location, int count, bool transpose, in Matrix4x2 value)
+            public static unsafe void ProgramUniformMatrix4x2f(int program, int location, int count, bool transpose, in Matrix4x2 value)
             {
                 fixed (Matrix4x2* tmp_vecPtr = &value)
                 {
@@ -23520,7 +23520,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x2fv"/>
-            public static unsafe void ProgramUniformMatrix4x2f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix4x2> value)
+            public static unsafe void ProgramUniformMatrix4x2f(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix4x2> value)
             {
                 fixed (Matrix4x2* tmp_vecPtr = value)
                 {
@@ -23529,7 +23529,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x2fv"/>
-            public static unsafe void ProgramUniformMatrix4x2f(ProgramHandle program, int location, int count, bool transpose, Matrix4x2[] value)
+            public static unsafe void ProgramUniformMatrix4x2f(int program, int location, int count, bool transpose, Matrix4x2[] value)
             {
                 fixed (Matrix4x2* tmp_vecPtr = value)
                 {
@@ -23538,7 +23538,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x4fv"/>
-            public static unsafe void ProgramUniformMatrix3x4f(ProgramHandle program, int location, int count, bool transpose, in Matrix3x4 value)
+            public static unsafe void ProgramUniformMatrix3x4f(int program, int location, int count, bool transpose, in Matrix3x4 value)
             {
                 fixed (Matrix3x4* tmp_vecPtr = &value)
                 {
@@ -23547,7 +23547,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x4fv"/>
-            public static unsafe void ProgramUniformMatrix3x4f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix3x4> value)
+            public static unsafe void ProgramUniformMatrix3x4f(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix3x4> value)
             {
                 fixed (Matrix3x4* tmp_vecPtr = value)
                 {
@@ -23556,7 +23556,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x4fv"/>
-            public static unsafe void ProgramUniformMatrix3x4f(ProgramHandle program, int location, int count, bool transpose, Matrix3x4[] value)
+            public static unsafe void ProgramUniformMatrix3x4f(int program, int location, int count, bool transpose, Matrix3x4[] value)
             {
                 fixed (Matrix3x4* tmp_vecPtr = value)
                 {
@@ -23565,7 +23565,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x3fv"/>
-            public static unsafe void ProgramUniformMatrix4x3f(ProgramHandle program, int location, int count, bool transpose, in Matrix4x3 value)
+            public static unsafe void ProgramUniformMatrix4x3f(int program, int location, int count, bool transpose, in Matrix4x3 value)
             {
                 fixed (Matrix4x3* tmp_vecPtr = &value)
                 {
@@ -23574,7 +23574,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x3fv"/>
-            public static unsafe void ProgramUniformMatrix4x3f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix4x3> value)
+            public static unsafe void ProgramUniformMatrix4x3f(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix4x3> value)
             {
                 fixed (Matrix4x3* tmp_vecPtr = value)
                 {
@@ -23583,7 +23583,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x3fv"/>
-            public static unsafe void ProgramUniformMatrix4x3f(ProgramHandle program, int location, int count, bool transpose, Matrix4x3[] value)
+            public static unsafe void ProgramUniformMatrix4x3f(int program, int location, int count, bool transpose, Matrix4x3[] value)
             {
                 fixed (Matrix4x3* tmp_vecPtr = value)
                 {
@@ -23592,7 +23592,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x3dv"/>
-            public static unsafe void ProgramUniformMatrix2x3d(ProgramHandle program, int location, int count, bool transpose, in Matrix2x3d value)
+            public static unsafe void ProgramUniformMatrix2x3d(int program, int location, int count, bool transpose, in Matrix2x3d value)
             {
                 fixed (Matrix2x3d* tmp_vecPtr = &value)
                 {
@@ -23601,7 +23601,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x3dv"/>
-            public static unsafe void ProgramUniformMatrix2x3d(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix2x3d> value)
+            public static unsafe void ProgramUniformMatrix2x3d(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix2x3d> value)
             {
                 fixed (Matrix2x3d* tmp_vecPtr = value)
                 {
@@ -23610,7 +23610,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x3dv"/>
-            public static unsafe void ProgramUniformMatrix2x3d(ProgramHandle program, int location, int count, bool transpose, Matrix2x3d[] value)
+            public static unsafe void ProgramUniformMatrix2x3d(int program, int location, int count, bool transpose, Matrix2x3d[] value)
             {
                 fixed (Matrix2x3d* tmp_vecPtr = value)
                 {
@@ -23619,7 +23619,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2dv"/>
-            public static unsafe void ProgramUniformMatrix3x2d(ProgramHandle program, int location, int count, bool transpose, in Matrix3x2d value)
+            public static unsafe void ProgramUniformMatrix3x2d(int program, int location, int count, bool transpose, in Matrix3x2d value)
             {
                 fixed (Matrix3x2d* tmp_vecPtr = &value)
                 {
@@ -23628,7 +23628,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2dv"/>
-            public static unsafe void ProgramUniformMatrix3x2d(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix3x2d> value)
+            public static unsafe void ProgramUniformMatrix3x2d(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix3x2d> value)
             {
                 fixed (Matrix3x2d* tmp_vecPtr = value)
                 {
@@ -23637,7 +23637,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2dv"/>
-            public static unsafe void ProgramUniformMatrix3x2d(ProgramHandle program, int location, int count, bool transpose, Matrix3x2d[] value)
+            public static unsafe void ProgramUniformMatrix3x2d(int program, int location, int count, bool transpose, Matrix3x2d[] value)
             {
                 fixed (Matrix3x2d* tmp_vecPtr = value)
                 {
@@ -23646,7 +23646,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x4dv"/>
-            public static unsafe void ProgramUniformMatrix2x4d(ProgramHandle program, int location, int count, bool transpose, in Matrix2x4d value)
+            public static unsafe void ProgramUniformMatrix2x4d(int program, int location, int count, bool transpose, in Matrix2x4d value)
             {
                 fixed (Matrix2x4d* tmp_vecPtr = &value)
                 {
@@ -23655,7 +23655,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x4dv"/>
-            public static unsafe void ProgramUniformMatrix2x4d(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix2x4d> value)
+            public static unsafe void ProgramUniformMatrix2x4d(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix2x4d> value)
             {
                 fixed (Matrix2x4d* tmp_vecPtr = value)
                 {
@@ -23664,7 +23664,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x4dv"/>
-            public static unsafe void ProgramUniformMatrix2x4d(ProgramHandle program, int location, int count, bool transpose, Matrix2x4d[] value)
+            public static unsafe void ProgramUniformMatrix2x4d(int program, int location, int count, bool transpose, Matrix2x4d[] value)
             {
                 fixed (Matrix2x4d* tmp_vecPtr = value)
                 {
@@ -23673,7 +23673,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x2dv"/>
-            public static unsafe void ProgramUniformMatrix4x2d(ProgramHandle program, int location, int count, bool transpose, in Matrix4x2d value)
+            public static unsafe void ProgramUniformMatrix4x2d(int program, int location, int count, bool transpose, in Matrix4x2d value)
             {
                 fixed (Matrix4x2d* tmp_vecPtr = &value)
                 {
@@ -23682,7 +23682,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x2dv"/>
-            public static unsafe void ProgramUniformMatrix4x2d(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix4x2d> value)
+            public static unsafe void ProgramUniformMatrix4x2d(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix4x2d> value)
             {
                 fixed (Matrix4x2d* tmp_vecPtr = value)
                 {
@@ -23691,7 +23691,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x2dv"/>
-            public static unsafe void ProgramUniformMatrix4x2d(ProgramHandle program, int location, int count, bool transpose, Matrix4x2d[] value)
+            public static unsafe void ProgramUniformMatrix4x2d(int program, int location, int count, bool transpose, Matrix4x2d[] value)
             {
                 fixed (Matrix4x2d* tmp_vecPtr = value)
                 {
@@ -23700,7 +23700,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x4dv"/>
-            public static unsafe void ProgramUniformMatrix3x4d(ProgramHandle program, int location, int count, bool transpose, in Matrix3x4d value)
+            public static unsafe void ProgramUniformMatrix3x4d(int program, int location, int count, bool transpose, in Matrix3x4d value)
             {
                 fixed (Matrix3x4d* tmp_vecPtr = &value)
                 {
@@ -23709,7 +23709,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x4dv"/>
-            public static unsafe void ProgramUniformMatrix3x4d(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix3x4d> value)
+            public static unsafe void ProgramUniformMatrix3x4d(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix3x4d> value)
             {
                 fixed (Matrix3x4d* tmp_vecPtr = value)
                 {
@@ -23718,7 +23718,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x4dv"/>
-            public static unsafe void ProgramUniformMatrix3x4d(ProgramHandle program, int location, int count, bool transpose, Matrix3x4d[] value)
+            public static unsafe void ProgramUniformMatrix3x4d(int program, int location, int count, bool transpose, Matrix3x4d[] value)
             {
                 fixed (Matrix3x4d* tmp_vecPtr = value)
                 {
@@ -23727,7 +23727,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x3dv"/>
-            public static unsafe void ProgramUniformMatrix4x3d(ProgramHandle program, int location, int count, bool transpose, in Matrix4x3d value)
+            public static unsafe void ProgramUniformMatrix4x3d(int program, int location, int count, bool transpose, in Matrix4x3d value)
             {
                 fixed (Matrix4x3d* tmp_vecPtr = &value)
                 {
@@ -23736,7 +23736,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x3dv"/>
-            public static unsafe void ProgramUniformMatrix4x3d(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix4x3d> value)
+            public static unsafe void ProgramUniformMatrix4x3d(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix4x3d> value)
             {
                 fixed (Matrix4x3d* tmp_vecPtr = value)
                 {
@@ -23745,7 +23745,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x3dv"/>
-            public static unsafe void ProgramUniformMatrix4x3d(ProgramHandle program, int location, int count, bool transpose, Matrix4x3d[] value)
+            public static unsafe void ProgramUniformMatrix4x3d(int program, int location, int count, bool transpose, Matrix4x3d[] value)
             {
                 fixed (Matrix4x3d* tmp_vecPtr = value)
                 {
@@ -23754,7 +23754,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetProgramPipelineInfoLog"/>
-            public static unsafe string GetProgramPipelineInfoLog(ProgramPipelineHandle pipeline, int bufSize, Span<int> length)
+            public static unsafe string GetProgramPipelineInfoLog(int pipeline, int bufSize, Span<int> length)
             {
                 string infoLog;
                 fixed (int* length_ptr = length)
@@ -23767,7 +23767,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return infoLog;
             }
             /// <inheritdoc cref="GetProgramPipelineInfoLog"/>
-            public static unsafe void GetProgramPipelineInfoLog(ProgramPipelineHandle pipeline, int bufSize, Span<int> length, out string infoLog)
+            public static unsafe void GetProgramPipelineInfoLog(int pipeline, int bufSize, Span<int> length, out string infoLog)
             {
                 fixed (int* length_ptr = length)
                 {
@@ -23778,7 +23778,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetProgramPipelineInfoLog"/>
-            public static unsafe string GetProgramPipelineInfoLog(ProgramPipelineHandle pipeline, int bufSize, int[] length)
+            public static unsafe string GetProgramPipelineInfoLog(int pipeline, int bufSize, int[] length)
             {
                 string infoLog;
                 fixed (int* length_ptr = length)
@@ -23791,7 +23791,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return infoLog;
             }
             /// <inheritdoc cref="GetProgramPipelineInfoLog"/>
-            public static unsafe void GetProgramPipelineInfoLog(ProgramPipelineHandle pipeline, int bufSize, int[] length, out string infoLog)
+            public static unsafe void GetProgramPipelineInfoLog(int pipeline, int bufSize, int[] length, out string infoLog)
             {
                 fixed (int* length_ptr = length)
                 {
@@ -23802,7 +23802,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetProgramPipelineInfoLog"/>
-            public static unsafe string GetProgramPipelineInfoLog(ProgramPipelineHandle pipeline, int bufSize, ref int length)
+            public static unsafe string GetProgramPipelineInfoLog(int pipeline, int bufSize, ref int length)
             {
                 string infoLog;
                 fixed (int* length_ptr = &length)
@@ -23815,7 +23815,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return infoLog;
             }
             /// <inheritdoc cref="GetProgramPipelineInfoLog"/>
-            public static unsafe void GetProgramPipelineInfoLog(ProgramPipelineHandle pipeline, int bufSize, ref int length, out string infoLog)
+            public static unsafe void GetProgramPipelineInfoLog(int pipeline, int bufSize, ref int length, out string infoLog)
             {
                 fixed (int* length_ptr = &length)
                 {
@@ -23826,7 +23826,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetActiveAtomicCounterBufferiv"/>
-            public static unsafe void GetActiveAtomicCounterBufferi(ProgramHandle program, uint bufferIndex, AtomicCounterBufferPName pname, Span<int> parameters)
+            public static unsafe void GetActiveAtomicCounterBufferi(int program, uint bufferIndex, AtomicCounterBufferPName pname, Span<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -23834,7 +23834,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetActiveAtomicCounterBufferiv"/>
-            public static unsafe void GetActiveAtomicCounterBufferi(ProgramHandle program, uint bufferIndex, AtomicCounterBufferPName pname, int[] parameters)
+            public static unsafe void GetActiveAtomicCounterBufferi(int program, uint bufferIndex, AtomicCounterBufferPName pname, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -23842,7 +23842,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetActiveAtomicCounterBufferiv"/>
-            public static unsafe void GetActiveAtomicCounterBufferi(ProgramHandle program, uint bufferIndex, AtomicCounterBufferPName pname, ref int parameters)
+            public static unsafe void GetActiveAtomicCounterBufferi(int program, uint bufferIndex, AtomicCounterBufferPName pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -24542,7 +24542,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetSubroutineUniformLocation"/>
-            public static unsafe int GetSubroutineUniformLocation(ProgramHandle program, ShaderType shadertype, string name)
+            public static unsafe int GetSubroutineUniformLocation(int program, ShaderType shadertype, string name)
             {
                 int returnValue;
                 byte* name_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(name);
@@ -24551,7 +24551,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return returnValue;
             }
             /// <inheritdoc cref="GetSubroutineIndex"/>
-            public static unsafe uint GetSubroutineIndex(ProgramHandle program, ShaderType shadertype, string name)
+            public static unsafe uint GetSubroutineIndex(int program, ShaderType shadertype, string name)
             {
                 uint returnValue;
                 byte* name_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(name);
@@ -24560,7 +24560,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return returnValue;
             }
             /// <inheritdoc cref="GetActiveSubroutineUniformiv"/>
-            public static unsafe void GetActiveSubroutineUniformi(ProgramHandle program, ShaderType shadertype, uint index, SubroutineParameterName pname, Span<int> values)
+            public static unsafe void GetActiveSubroutineUniformi(int program, ShaderType shadertype, uint index, SubroutineParameterName pname, Span<int> values)
             {
                 fixed (int* values_ptr = values)
                 {
@@ -24568,7 +24568,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetActiveSubroutineUniformiv"/>
-            public static unsafe void GetActiveSubroutineUniformi(ProgramHandle program, ShaderType shadertype, uint index, SubroutineParameterName pname, int[] values)
+            public static unsafe void GetActiveSubroutineUniformi(int program, ShaderType shadertype, uint index, SubroutineParameterName pname, int[] values)
             {
                 fixed (int* values_ptr = values)
                 {
@@ -24576,7 +24576,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetActiveSubroutineUniformiv"/>
-            public static unsafe void GetActiveSubroutineUniformi(ProgramHandle program, ShaderType shadertype, uint index, SubroutineParameterName pname, ref int values)
+            public static unsafe void GetActiveSubroutineUniformi(int program, ShaderType shadertype, uint index, SubroutineParameterName pname, ref int values)
             {
                 fixed (int* values_ptr = &values)
                 {
@@ -24584,7 +24584,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetActiveSubroutineUniformName"/>
-            public static unsafe string GetActiveSubroutineUniformName(ProgramHandle program, ShaderType shadertype, uint index, int bufSize, Span<int> length)
+            public static unsafe string GetActiveSubroutineUniformName(int program, ShaderType shadertype, uint index, int bufSize, Span<int> length)
             {
                 string name;
                 fixed (int* length_ptr = length)
@@ -24597,7 +24597,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return name;
             }
             /// <inheritdoc cref="GetActiveSubroutineUniformName"/>
-            public static unsafe void GetActiveSubroutineUniformName(ProgramHandle program, ShaderType shadertype, uint index, int bufSize, Span<int> length, out string name)
+            public static unsafe void GetActiveSubroutineUniformName(int program, ShaderType shadertype, uint index, int bufSize, Span<int> length, out string name)
             {
                 fixed (int* length_ptr = length)
                 {
@@ -24608,7 +24608,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetActiveSubroutineUniformName"/>
-            public static unsafe string GetActiveSubroutineUniformName(ProgramHandle program, ShaderType shadertype, uint index, int bufSize, int[] length)
+            public static unsafe string GetActiveSubroutineUniformName(int program, ShaderType shadertype, uint index, int bufSize, int[] length)
             {
                 string name;
                 fixed (int* length_ptr = length)
@@ -24621,7 +24621,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return name;
             }
             /// <inheritdoc cref="GetActiveSubroutineUniformName"/>
-            public static unsafe void GetActiveSubroutineUniformName(ProgramHandle program, ShaderType shadertype, uint index, int bufSize, int[] length, out string name)
+            public static unsafe void GetActiveSubroutineUniformName(int program, ShaderType shadertype, uint index, int bufSize, int[] length, out string name)
             {
                 fixed (int* length_ptr = length)
                 {
@@ -24632,7 +24632,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetActiveSubroutineUniformName"/>
-            public static unsafe string GetActiveSubroutineUniformName(ProgramHandle program, ShaderType shadertype, uint index, int bufSize, ref int length)
+            public static unsafe string GetActiveSubroutineUniformName(int program, ShaderType shadertype, uint index, int bufSize, ref int length)
             {
                 string name;
                 fixed (int* length_ptr = &length)
@@ -24645,7 +24645,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return name;
             }
             /// <inheritdoc cref="GetActiveSubroutineUniformName"/>
-            public static unsafe void GetActiveSubroutineUniformName(ProgramHandle program, ShaderType shadertype, uint index, int bufSize, ref int length, out string name)
+            public static unsafe void GetActiveSubroutineUniformName(int program, ShaderType shadertype, uint index, int bufSize, ref int length, out string name)
             {
                 fixed (int* length_ptr = &length)
                 {
@@ -24656,7 +24656,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetActiveSubroutineName"/>
-            public static unsafe string GetActiveSubroutineName(ProgramHandle program, ShaderType shadertype, uint index, int bufSize, Span<int> length)
+            public static unsafe string GetActiveSubroutineName(int program, ShaderType shadertype, uint index, int bufSize, Span<int> length)
             {
                 string name;
                 fixed (int* length_ptr = length)
@@ -24669,7 +24669,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return name;
             }
             /// <inheritdoc cref="GetActiveSubroutineName"/>
-            public static unsafe void GetActiveSubroutineName(ProgramHandle program, ShaderType shadertype, uint index, int bufSize, Span<int> length, out string name)
+            public static unsafe void GetActiveSubroutineName(int program, ShaderType shadertype, uint index, int bufSize, Span<int> length, out string name)
             {
                 fixed (int* length_ptr = length)
                 {
@@ -24680,7 +24680,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetActiveSubroutineName"/>
-            public static unsafe string GetActiveSubroutineName(ProgramHandle program, ShaderType shadertype, uint index, int bufSize, int[] length)
+            public static unsafe string GetActiveSubroutineName(int program, ShaderType shadertype, uint index, int bufSize, int[] length)
             {
                 string name;
                 fixed (int* length_ptr = length)
@@ -24693,7 +24693,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return name;
             }
             /// <inheritdoc cref="GetActiveSubroutineName"/>
-            public static unsafe void GetActiveSubroutineName(ProgramHandle program, ShaderType shadertype, uint index, int bufSize, int[] length, out string name)
+            public static unsafe void GetActiveSubroutineName(int program, ShaderType shadertype, uint index, int bufSize, int[] length, out string name)
             {
                 fixed (int* length_ptr = length)
                 {
@@ -24704,7 +24704,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetActiveSubroutineName"/>
-            public static unsafe string GetActiveSubroutineName(ProgramHandle program, ShaderType shadertype, uint index, int bufSize, ref int length)
+            public static unsafe string GetActiveSubroutineName(int program, ShaderType shadertype, uint index, int bufSize, ref int length)
             {
                 string name;
                 fixed (int* length_ptr = &length)
@@ -24717,7 +24717,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return name;
             }
             /// <inheritdoc cref="GetActiveSubroutineName"/>
-            public static unsafe void GetActiveSubroutineName(ProgramHandle program, ShaderType shadertype, uint index, int bufSize, ref int length, out string name)
+            public static unsafe void GetActiveSubroutineName(int program, ShaderType shadertype, uint index, int bufSize, ref int length, out string name)
             {
                 fixed (int* length_ptr = &length)
                 {
@@ -24778,7 +24778,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetProgramStageiv"/>
-            public static unsafe void GetProgramStagei(ProgramHandle program, ShaderType shadertype, ProgramStagePName pname, Span<int> values)
+            public static unsafe void GetProgramStagei(int program, ShaderType shadertype, ProgramStagePName pname, Span<int> values)
             {
                 fixed (int* values_ptr = values)
                 {
@@ -24786,7 +24786,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetProgramStageiv"/>
-            public static unsafe void GetProgramStagei(ProgramHandle program, ShaderType shadertype, ProgramStagePName pname, int[] values)
+            public static unsafe void GetProgramStagei(int program, ShaderType shadertype, ProgramStagePName pname, int[] values)
             {
                 fixed (int* values_ptr = values)
                 {
@@ -24794,7 +24794,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetProgramStageiv"/>
-            public static unsafe void GetProgramStagei(ProgramHandle program, ShaderType shadertype, ProgramStagePName pname, ref int values)
+            public static unsafe void GetProgramStagei(int program, ShaderType shadertype, ProgramStagePName pname, ref int values)
             {
                 fixed (int* values_ptr = &values)
                 {
@@ -24818,7 +24818,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 Marshal.FreeCoTaskMem((IntPtr)name_ptr);
             }
             /// <inheritdoc cref="CompileShaderIncludeARB"/>
-            public static unsafe void CompileShaderIncludeARB(ShaderHandle shader, int count, byte** path, ReadOnlySpan<int> length)
+            public static unsafe void CompileShaderIncludeARB(int shader, int count, byte** path, ReadOnlySpan<int> length)
             {
                 fixed (int* length_ptr = length)
                 {
@@ -24826,7 +24826,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="CompileShaderIncludeARB"/>
-            public static unsafe void CompileShaderIncludeARB(ShaderHandle shader, int count, byte** path, int[] length)
+            public static unsafe void CompileShaderIncludeARB(int shader, int count, byte** path, int[] length)
             {
                 fixed (int* length_ptr = length)
                 {
@@ -24834,7 +24834,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="CompileShaderIncludeARB"/>
-            public static unsafe void CompileShaderIncludeARB(ShaderHandle shader, int count, byte** path, in int length)
+            public static unsafe void CompileShaderIncludeARB(int shader, int count, byte** path, in int length)
             {
                 fixed (int* length_ptr = &length)
                 {
@@ -25313,7 +25313,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetQueryObjecti64v"/>
-            public static unsafe void GetQueryObjecti64(QueryHandle id, QueryObjectParameterName pname, Span<long> parameters)
+            public static unsafe void GetQueryObjecti64(int id, QueryObjectParameterName pname, Span<long> parameters)
             {
                 fixed (long* parameters_ptr = parameters)
                 {
@@ -25321,7 +25321,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetQueryObjecti64v"/>
-            public static unsafe void GetQueryObjecti64(QueryHandle id, QueryObjectParameterName pname, long[] parameters)
+            public static unsafe void GetQueryObjecti64(int id, QueryObjectParameterName pname, long[] parameters)
             {
                 fixed (long* parameters_ptr = parameters)
                 {
@@ -25329,7 +25329,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetQueryObjecti64v"/>
-            public static unsafe void GetQueryObjecti64(QueryHandle id, QueryObjectParameterName pname, ref long parameters)
+            public static unsafe void GetQueryObjecti64(int id, QueryObjectParameterName pname, ref long parameters)
             {
                 fixed (long* parameters_ptr = &parameters)
                 {
@@ -25337,7 +25337,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetQueryObjectui64v"/>
-            public static unsafe void GetQueryObjectui64(QueryHandle id, QueryObjectParameterName pname, Span<ulong> parameters)
+            public static unsafe void GetQueryObjectui64(int id, QueryObjectParameterName pname, Span<ulong> parameters)
             {
                 fixed (ulong* parameters_ptr = parameters)
                 {
@@ -25345,7 +25345,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetQueryObjectui64v"/>
-            public static unsafe void GetQueryObjectui64(QueryHandle id, QueryObjectParameterName pname, ulong[] parameters)
+            public static unsafe void GetQueryObjectui64(int id, QueryObjectParameterName pname, ulong[] parameters)
             {
                 fixed (ulong* parameters_ptr = parameters)
                 {
@@ -25353,7 +25353,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetQueryObjectui64v"/>
-            public static unsafe void GetQueryObjectui64(QueryHandle id, QueryObjectParameterName pname, ref ulong parameters)
+            public static unsafe void GetQueryObjectui64(int id, QueryObjectParameterName pname, ref ulong parameters)
             {
                 fixed (ulong* parameters_ptr = &parameters)
                 {
@@ -25361,44 +25361,44 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="DeleteTransformFeedbacks"/>
-            public static unsafe void DeleteTransformFeedback(in TransformFeedbackHandle id)
+            public static unsafe void DeleteTransformFeedback(in int id)
             {
                 int n = 1;
-                fixed(TransformFeedbackHandle* ids_handle = &id)
+                fixed(int* ids_handle = &id)
                 {
                     DeleteTransformFeedbacks(n, ids_handle);
                 }
             }
             /// <inheritdoc cref="DeleteTransformFeedbacks"/>
-            public static unsafe void DeleteTransformFeedbacks(ReadOnlySpan<TransformFeedbackHandle> ids)
+            public static unsafe void DeleteTransformFeedbacks(ReadOnlySpan<int> ids)
             {
                 int n = (int)(ids.Length);
-                fixed (TransformFeedbackHandle* ids_ptr = ids)
+                fixed (int* ids_ptr = ids)
                 {
                     DeleteTransformFeedbacks(n, ids_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteTransformFeedbacks"/>
-            public static unsafe void DeleteTransformFeedbacks(TransformFeedbackHandle[] ids)
+            public static unsafe void DeleteTransformFeedbacks(int[] ids)
             {
                 int n = (int)(ids.Length);
-                fixed (TransformFeedbackHandle* ids_ptr = ids)
+                fixed (int* ids_ptr = ids)
                 {
                     DeleteTransformFeedbacks(n, ids_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteTransformFeedbacks"/>
-            public static unsafe void DeleteTransformFeedbacks(int n, in TransformFeedbackHandle ids)
+            public static unsafe void DeleteTransformFeedbacks(int n, in int ids)
             {
-                fixed (TransformFeedbackHandle* ids_ptr = &ids)
+                fixed (int* ids_ptr = &ids)
                 {
                     DeleteTransformFeedbacks(n, ids_ptr);
                 }
             }
             /// <inheritdoc cref="GenTransformFeedbacks"/>
-            public static unsafe TransformFeedbackHandle GenTransformFeedback()
+            public static unsafe int GenTransformFeedback()
             {
-                TransformFeedbackHandle id;
+                int id;
                 int n = 1;
                 Unsafe.SkipInit(out id);
                 // FIXME: This could be a problem for the overloads that take an out parameter
@@ -25409,12 +25409,12 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                TransformFeedbackHandle* ids_handle = (TransformFeedbackHandle*)Unsafe.AsPointer(ref id);
+                int* ids_handle = (int*)Unsafe.AsPointer(ref id);
                 GenTransformFeedbacks(n, ids_handle);
                 return id;
             }
             /// <inheritdoc cref="GenTransformFeedbacks"/>
-            public static unsafe void GenTransformFeedback(out TransformFeedbackHandle id)
+            public static unsafe void GenTransformFeedback(out int id)
             {
                 int n = 1;
                 Unsafe.SkipInit(out id);
@@ -25426,31 +25426,31 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                TransformFeedbackHandle* ids_handle = (TransformFeedbackHandle*)Unsafe.AsPointer(ref id);
+                int* ids_handle = (int*)Unsafe.AsPointer(ref id);
                 GenTransformFeedbacks(n, ids_handle);
             }
             /// <inheritdoc cref="GenTransformFeedbacks"/>
-            public static unsafe void GenTransformFeedbacks(Span<TransformFeedbackHandle> ids)
+            public static unsafe void GenTransformFeedbacks(Span<int> ids)
             {
                 int n = (int)(ids.Length);
-                fixed (TransformFeedbackHandle* ids_ptr = ids)
+                fixed (int* ids_ptr = ids)
                 {
                     GenTransformFeedbacks(n, ids_ptr);
                 }
             }
             /// <inheritdoc cref="GenTransformFeedbacks"/>
-            public static unsafe void GenTransformFeedbacks(TransformFeedbackHandle[] ids)
+            public static unsafe void GenTransformFeedbacks(int[] ids)
             {
                 int n = (int)(ids.Length);
-                fixed (TransformFeedbackHandle* ids_ptr = ids)
+                fixed (int* ids_ptr = ids)
                 {
                     GenTransformFeedbacks(n, ids_ptr);
                 }
             }
             /// <inheritdoc cref="GenTransformFeedbacks"/>
-            public static unsafe void GenTransformFeedbacks(int n, ref TransformFeedbackHandle ids)
+            public static unsafe void GenTransformFeedbacks(int n, ref int ids)
             {
-                fixed (TransformFeedbackHandle* ids_ptr = &ids)
+                fixed (int* ids_ptr = &ids)
                 {
                     GenTransformFeedbacks(n, ids_ptr);
                 }
@@ -25576,7 +25576,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetUniformIndices"/>
-            public static unsafe void GetUniformIndices(ProgramHandle program, int uniformCount, byte** uniformNames, Span<uint> uniformIndices)
+            public static unsafe void GetUniformIndices(int program, int uniformCount, byte** uniformNames, Span<uint> uniformIndices)
             {
                 fixed (uint* uniformIndices_ptr = uniformIndices)
                 {
@@ -25584,7 +25584,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetUniformIndices"/>
-            public static unsafe void GetUniformIndices(ProgramHandle program, int uniformCount, byte** uniformNames, uint[] uniformIndices)
+            public static unsafe void GetUniformIndices(int program, int uniformCount, byte** uniformNames, uint[] uniformIndices)
             {
                 fixed (uint* uniformIndices_ptr = uniformIndices)
                 {
@@ -25592,7 +25592,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetUniformIndices"/>
-            public static unsafe void GetUniformIndices(ProgramHandle program, int uniformCount, byte** uniformNames, ref uint uniformIndices)
+            public static unsafe void GetUniformIndices(int program, int uniformCount, byte** uniformNames, ref uint uniformIndices)
             {
                 fixed (uint* uniformIndices_ptr = &uniformIndices)
                 {
@@ -25600,7 +25600,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetActiveUniformsiv"/>
-            public static unsafe void GetActiveUniformsi(ProgramHandle program, ReadOnlySpan<uint> uniformIndices, UniformPName pname, Span<int> parameters)
+            public static unsafe void GetActiveUniformsi(int program, ReadOnlySpan<uint> uniformIndices, UniformPName pname, Span<int> parameters)
             {
                 int uniformCount = (int)(uniformIndices.Length);
                 fixed (uint* uniformIndices_ptr = uniformIndices)
@@ -25612,7 +25612,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetActiveUniformsiv"/>
-            public static unsafe void GetActiveUniformsi(ProgramHandle program, uint[] uniformIndices, UniformPName pname, int[] parameters)
+            public static unsafe void GetActiveUniformsi(int program, uint[] uniformIndices, UniformPName pname, int[] parameters)
             {
                 int uniformCount = (int)(uniformIndices.Length);
                 fixed (uint* uniformIndices_ptr = uniformIndices)
@@ -25624,7 +25624,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetActiveUniformsiv"/>
-            public static unsafe void GetActiveUniformsi(ProgramHandle program, int uniformCount, in uint uniformIndices, UniformPName pname, ref int parameters)
+            public static unsafe void GetActiveUniformsi(int program, int uniformCount, in uint uniformIndices, UniformPName pname, ref int parameters)
             {
                 fixed (uint* uniformIndices_ptr = &uniformIndices)
                 fixed (int* parameters_ptr = &parameters)
@@ -25633,7 +25633,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetActiveUniformName"/>
-            public static unsafe string GetActiveUniformName(ProgramHandle program, uint uniformIndex, int bufSize, Span<int> length)
+            public static unsafe string GetActiveUniformName(int program, uint uniformIndex, int bufSize, Span<int> length)
             {
                 string uniformName;
                 fixed (int* length_ptr = length)
@@ -25646,7 +25646,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return uniformName;
             }
             /// <inheritdoc cref="GetActiveUniformName"/>
-            public static unsafe void GetActiveUniformName(ProgramHandle program, uint uniformIndex, int bufSize, Span<int> length, out string uniformName)
+            public static unsafe void GetActiveUniformName(int program, uint uniformIndex, int bufSize, Span<int> length, out string uniformName)
             {
                 fixed (int* length_ptr = length)
                 {
@@ -25657,7 +25657,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetActiveUniformName"/>
-            public static unsafe string GetActiveUniformName(ProgramHandle program, uint uniformIndex, int bufSize, int[] length)
+            public static unsafe string GetActiveUniformName(int program, uint uniformIndex, int bufSize, int[] length)
             {
                 string uniformName;
                 fixed (int* length_ptr = length)
@@ -25670,7 +25670,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return uniformName;
             }
             /// <inheritdoc cref="GetActiveUniformName"/>
-            public static unsafe void GetActiveUniformName(ProgramHandle program, uint uniformIndex, int bufSize, int[] length, out string uniformName)
+            public static unsafe void GetActiveUniformName(int program, uint uniformIndex, int bufSize, int[] length, out string uniformName)
             {
                 fixed (int* length_ptr = length)
                 {
@@ -25681,7 +25681,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetActiveUniformName"/>
-            public static unsafe string GetActiveUniformName(ProgramHandle program, uint uniformIndex, int bufSize, ref int length)
+            public static unsafe string GetActiveUniformName(int program, uint uniformIndex, int bufSize, ref int length)
             {
                 string uniformName;
                 fixed (int* length_ptr = &length)
@@ -25694,7 +25694,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return uniformName;
             }
             /// <inheritdoc cref="GetActiveUniformName"/>
-            public static unsafe void GetActiveUniformName(ProgramHandle program, uint uniformIndex, int bufSize, ref int length, out string uniformName)
+            public static unsafe void GetActiveUniformName(int program, uint uniformIndex, int bufSize, ref int length, out string uniformName)
             {
                 fixed (int* length_ptr = &length)
                 {
@@ -25705,7 +25705,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetUniformBlockIndex"/>
-            public static unsafe uint GetUniformBlockIndex(ProgramHandle program, string uniformBlockName)
+            public static unsafe uint GetUniformBlockIndex(int program, string uniformBlockName)
             {
                 uint returnValue;
                 byte* uniformBlockName_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(uniformBlockName);
@@ -25714,7 +25714,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return returnValue;
             }
             /// <inheritdoc cref="GetActiveUniformBlockiv"/>
-            public static unsafe void GetActiveUniformBlocki(ProgramHandle program, uint uniformBlockIndex, UniformBlockPName pname, Span<int> parameters)
+            public static unsafe void GetActiveUniformBlocki(int program, uint uniformBlockIndex, UniformBlockPName pname, Span<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -25722,7 +25722,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetActiveUniformBlockiv"/>
-            public static unsafe void GetActiveUniformBlocki(ProgramHandle program, uint uniformBlockIndex, UniformBlockPName pname, int[] parameters)
+            public static unsafe void GetActiveUniformBlocki(int program, uint uniformBlockIndex, UniformBlockPName pname, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -25730,7 +25730,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetActiveUniformBlockiv"/>
-            public static unsafe void GetActiveUniformBlocki(ProgramHandle program, uint uniformBlockIndex, UniformBlockPName pname, ref int parameters)
+            public static unsafe void GetActiveUniformBlocki(int program, uint uniformBlockIndex, UniformBlockPName pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -25738,7 +25738,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetActiveUniformBlockName"/>
-            public static unsafe string GetActiveUniformBlockName(ProgramHandle program, uint uniformBlockIndex, int bufSize, Span<int> length)
+            public static unsafe string GetActiveUniformBlockName(int program, uint uniformBlockIndex, int bufSize, Span<int> length)
             {
                 string uniformBlockName;
                 fixed (int* length_ptr = length)
@@ -25751,7 +25751,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return uniformBlockName;
             }
             /// <inheritdoc cref="GetActiveUniformBlockName"/>
-            public static unsafe void GetActiveUniformBlockName(ProgramHandle program, uint uniformBlockIndex, int bufSize, Span<int> length, out string uniformBlockName)
+            public static unsafe void GetActiveUniformBlockName(int program, uint uniformBlockIndex, int bufSize, Span<int> length, out string uniformBlockName)
             {
                 fixed (int* length_ptr = length)
                 {
@@ -25762,7 +25762,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetActiveUniformBlockName"/>
-            public static unsafe string GetActiveUniformBlockName(ProgramHandle program, uint uniformBlockIndex, int bufSize, int[] length)
+            public static unsafe string GetActiveUniformBlockName(int program, uint uniformBlockIndex, int bufSize, int[] length)
             {
                 string uniformBlockName;
                 fixed (int* length_ptr = length)
@@ -25775,7 +25775,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return uniformBlockName;
             }
             /// <inheritdoc cref="GetActiveUniformBlockName"/>
-            public static unsafe void GetActiveUniformBlockName(ProgramHandle program, uint uniformBlockIndex, int bufSize, int[] length, out string uniformBlockName)
+            public static unsafe void GetActiveUniformBlockName(int program, uint uniformBlockIndex, int bufSize, int[] length, out string uniformBlockName)
             {
                 fixed (int* length_ptr = length)
                 {
@@ -25786,7 +25786,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetActiveUniformBlockName"/>
-            public static unsafe string GetActiveUniformBlockName(ProgramHandle program, uint uniformBlockIndex, int bufSize, ref int length)
+            public static unsafe string GetActiveUniformBlockName(int program, uint uniformBlockIndex, int bufSize, ref int length)
             {
                 string uniformBlockName;
                 fixed (int* length_ptr = &length)
@@ -25799,7 +25799,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return uniformBlockName;
             }
             /// <inheritdoc cref="GetActiveUniformBlockName"/>
-            public static unsafe void GetActiveUniformBlockName(ProgramHandle program, uint uniformBlockIndex, int bufSize, ref int length, out string uniformBlockName)
+            public static unsafe void GetActiveUniformBlockName(int program, uint uniformBlockIndex, int bufSize, ref int length, out string uniformBlockName)
             {
                 fixed (int* length_ptr = &length)
                 {
@@ -25834,44 +25834,44 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="DeleteVertexArrays"/>
-            public static unsafe void DeleteVertexArray(in VertexArrayHandle array)
+            public static unsafe void DeleteVertexArray(in int array)
             {
                 int n = 1;
-                fixed(VertexArrayHandle* arrays_handle = &array)
+                fixed(int* arrays_handle = &array)
                 {
                     DeleteVertexArrays(n, arrays_handle);
                 }
             }
             /// <inheritdoc cref="DeleteVertexArrays"/>
-            public static unsafe void DeleteVertexArrays(ReadOnlySpan<VertexArrayHandle> arrays)
+            public static unsafe void DeleteVertexArrays(ReadOnlySpan<int> arrays)
             {
                 int n = (int)(arrays.Length);
-                fixed (VertexArrayHandle* arrays_ptr = arrays)
+                fixed (int* arrays_ptr = arrays)
                 {
                     DeleteVertexArrays(n, arrays_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteVertexArrays"/>
-            public static unsafe void DeleteVertexArrays(VertexArrayHandle[] arrays)
+            public static unsafe void DeleteVertexArrays(int[] arrays)
             {
                 int n = (int)(arrays.Length);
-                fixed (VertexArrayHandle* arrays_ptr = arrays)
+                fixed (int* arrays_ptr = arrays)
                 {
                     DeleteVertexArrays(n, arrays_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteVertexArrays"/>
-            public static unsafe void DeleteVertexArrays(int n, in VertexArrayHandle arrays)
+            public static unsafe void DeleteVertexArrays(int n, in int arrays)
             {
-                fixed (VertexArrayHandle* arrays_ptr = &arrays)
+                fixed (int* arrays_ptr = &arrays)
                 {
                     DeleteVertexArrays(n, arrays_ptr);
                 }
             }
             /// <inheritdoc cref="GenVertexArrays"/>
-            public static unsafe VertexArrayHandle GenVertexArray()
+            public static unsafe int GenVertexArray()
             {
-                VertexArrayHandle array;
+                int array;
                 int n = 1;
                 Unsafe.SkipInit(out array);
                 // FIXME: This could be a problem for the overloads that take an out parameter
@@ -25882,12 +25882,12 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                VertexArrayHandle* arrays_handle = (VertexArrayHandle*)Unsafe.AsPointer(ref array);
+                int* arrays_handle = (int*)Unsafe.AsPointer(ref array);
                 GenVertexArrays(n, arrays_handle);
                 return array;
             }
             /// <inheritdoc cref="GenVertexArrays"/>
-            public static unsafe void GenVertexArray(out VertexArrayHandle array)
+            public static unsafe void GenVertexArray(out int array)
             {
                 int n = 1;
                 Unsafe.SkipInit(out array);
@@ -25899,31 +25899,31 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                VertexArrayHandle* arrays_handle = (VertexArrayHandle*)Unsafe.AsPointer(ref array);
+                int* arrays_handle = (int*)Unsafe.AsPointer(ref array);
                 GenVertexArrays(n, arrays_handle);
             }
             /// <inheritdoc cref="GenVertexArrays"/>
-            public static unsafe void GenVertexArrays(Span<VertexArrayHandle> arrays)
+            public static unsafe void GenVertexArrays(Span<int> arrays)
             {
                 int n = (int)(arrays.Length);
-                fixed (VertexArrayHandle* arrays_ptr = arrays)
+                fixed (int* arrays_ptr = arrays)
                 {
                     GenVertexArrays(n, arrays_ptr);
                 }
             }
             /// <inheritdoc cref="GenVertexArrays"/>
-            public static unsafe void GenVertexArrays(VertexArrayHandle[] arrays)
+            public static unsafe void GenVertexArrays(int[] arrays)
             {
                 int n = (int)(arrays.Length);
-                fixed (VertexArrayHandle* arrays_ptr = arrays)
+                fixed (int* arrays_ptr = arrays)
                 {
                     GenVertexArrays(n, arrays_ptr);
                 }
             }
             /// <inheritdoc cref="GenVertexArrays"/>
-            public static unsafe void GenVertexArrays(int n, ref VertexArrayHandle arrays)
+            public static unsafe void GenVertexArrays(int n, ref int arrays)
             {
-                fixed (VertexArrayHandle* arrays_ptr = &arrays)
+                fixed (int* arrays_ptr = &arrays)
                 {
                     GenVertexArrays(n, arrays_ptr);
                 }
@@ -26236,53 +26236,53 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="DeleteBuffersARB"/>
-            public static unsafe void DeleteBuffersARB(ReadOnlySpan<BufferHandle> buffers)
+            public static unsafe void DeleteBuffersARB(ReadOnlySpan<int> buffers)
             {
                 int n = (int)(buffers.Length);
-                fixed (BufferHandle* buffers_ptr = buffers)
+                fixed (int* buffers_ptr = buffers)
                 {
                     DeleteBuffersARB(n, buffers_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteBuffersARB"/>
-            public static unsafe void DeleteBuffersARB(BufferHandle[] buffers)
+            public static unsafe void DeleteBuffersARB(int[] buffers)
             {
                 int n = (int)(buffers.Length);
-                fixed (BufferHandle* buffers_ptr = buffers)
+                fixed (int* buffers_ptr = buffers)
                 {
                     DeleteBuffersARB(n, buffers_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteBuffersARB"/>
-            public static unsafe void DeleteBuffersARB(int n, in BufferHandle buffers)
+            public static unsafe void DeleteBuffersARB(int n, in int buffers)
             {
-                fixed (BufferHandle* buffers_ptr = &buffers)
+                fixed (int* buffers_ptr = &buffers)
                 {
                     DeleteBuffersARB(n, buffers_ptr);
                 }
             }
             /// <inheritdoc cref="GenBuffersARB"/>
-            public static unsafe void GenBuffersARB(Span<BufferHandle> buffers)
+            public static unsafe void GenBuffersARB(Span<int> buffers)
             {
                 int n = (int)(buffers.Length);
-                fixed (BufferHandle* buffers_ptr = buffers)
+                fixed (int* buffers_ptr = buffers)
                 {
                     GenBuffersARB(n, buffers_ptr);
                 }
             }
             /// <inheritdoc cref="GenBuffersARB"/>
-            public static unsafe void GenBuffersARB(BufferHandle[] buffers)
+            public static unsafe void GenBuffersARB(int[] buffers)
             {
                 int n = (int)(buffers.Length);
-                fixed (BufferHandle* buffers_ptr = buffers)
+                fixed (int* buffers_ptr = buffers)
                 {
                     GenBuffersARB(n, buffers_ptr);
                 }
             }
             /// <inheritdoc cref="GenBuffersARB"/>
-            public static unsafe void GenBuffersARB(int n, ref BufferHandle buffers)
+            public static unsafe void GenBuffersARB(int n, ref int buffers)
             {
-                fixed (BufferHandle* buffers_ptr = &buffers)
+                fixed (int* buffers_ptr = &buffers)
                 {
                     GenBuffersARB(n, buffers_ptr);
                 }
@@ -28239,13 +28239,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return returnValue;
             }
             /// <inheritdoc cref="UpdateObjectBufferATI"/>
-            public static unsafe void UpdateObjectBufferATI(BufferHandle buffer, uint offset, int size, IntPtr pointer, PreserveModeATI preserve)
+            public static unsafe void UpdateObjectBufferATI(int buffer, uint offset, int size, IntPtr pointer, PreserveModeATI preserve)
             {
                 void* pointer_vptr = (void*)pointer;
                 UpdateObjectBufferATI(buffer, offset, size, pointer_vptr, preserve);
             }
             /// <inheritdoc cref="UpdateObjectBufferATI"/>
-            public static unsafe void UpdateObjectBufferATI<T1>(BufferHandle buffer, uint offset, ReadOnlySpan<T1> pointer, PreserveModeATI preserve)
+            public static unsafe void UpdateObjectBufferATI<T1>(int buffer, uint offset, ReadOnlySpan<T1> pointer, PreserveModeATI preserve)
                 where T1 : unmanaged
             {
                 int size = (int)(pointer.Length * sizeof(T1));
@@ -28255,7 +28255,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="UpdateObjectBufferATI"/>
-            public static unsafe void UpdateObjectBufferATI<T1>(BufferHandle buffer, uint offset, T1[] pointer, PreserveModeATI preserve)
+            public static unsafe void UpdateObjectBufferATI<T1>(int buffer, uint offset, T1[] pointer, PreserveModeATI preserve)
                 where T1 : unmanaged
             {
                 int size = (int)(pointer.Length * sizeof(T1));
@@ -28265,7 +28265,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="UpdateObjectBufferATI"/>
-            public static unsafe void UpdateObjectBufferATI<T1>(BufferHandle buffer, uint offset, int size, in T1 pointer, PreserveModeATI preserve)
+            public static unsafe void UpdateObjectBufferATI<T1>(int buffer, uint offset, int size, in T1 pointer, PreserveModeATI preserve)
                 where T1 : unmanaged
             {
                 fixed (void* pointer_ptr = &pointer)
@@ -28274,7 +28274,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetObjectBufferfvATI"/>
-            public static unsafe void GetObjectBufferfvATI(BufferHandle buffer, ArrayObjectPNameATI pname, Span<float> parameters)
+            public static unsafe void GetObjectBufferfvATI(int buffer, ArrayObjectPNameATI pname, Span<float> parameters)
             {
                 fixed (float* parameters_ptr = parameters)
                 {
@@ -28282,7 +28282,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetObjectBufferfvATI"/>
-            public static unsafe void GetObjectBufferfvATI(BufferHandle buffer, ArrayObjectPNameATI pname, float[] parameters)
+            public static unsafe void GetObjectBufferfvATI(int buffer, ArrayObjectPNameATI pname, float[] parameters)
             {
                 fixed (float* parameters_ptr = parameters)
                 {
@@ -28290,7 +28290,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetObjectBufferfvATI"/>
-            public static unsafe void GetObjectBufferfvATI(BufferHandle buffer, ArrayObjectPNameATI pname, ref float parameters)
+            public static unsafe void GetObjectBufferfvATI(int buffer, ArrayObjectPNameATI pname, ref float parameters)
             {
                 fixed (float* parameters_ptr = &parameters)
                 {
@@ -28298,7 +28298,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetObjectBufferivATI"/>
-            public static unsafe void GetObjectBufferivATI(BufferHandle buffer, ArrayObjectPNameATI pname, Span<int> parameters)
+            public static unsafe void GetObjectBufferivATI(int buffer, ArrayObjectPNameATI pname, Span<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -28306,7 +28306,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetObjectBufferivATI"/>
-            public static unsafe void GetObjectBufferivATI(BufferHandle buffer, ArrayObjectPNameATI pname, int[] parameters)
+            public static unsafe void GetObjectBufferivATI(int buffer, ArrayObjectPNameATI pname, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -28314,7 +28314,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetObjectBufferivATI"/>
-            public static unsafe void GetObjectBufferivATI(BufferHandle buffer, ArrayObjectPNameATI pname, ref int parameters)
+            public static unsafe void GetObjectBufferivATI(int buffer, ArrayObjectPNameATI pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -28992,7 +28992,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="EGLImageTargetTextureStorageEXT"/>
-            public static unsafe void EGLImageTargetTextureStorageEXT(TextureHandle texture, IntPtr image, in int attrib_list)
+            public static unsafe void EGLImageTargetTextureStorageEXT(int texture, IntPtr image, in int attrib_list)
             {
                 fixed (int* attrib_list_ptr = &attrib_list)
                 {
@@ -29001,7 +29001,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="EGLImageTargetTextureStorageEXT"/>
-            public static unsafe void EGLImageTargetTextureStorageEXT<T1>(TextureHandle texture, ref T1 image, in int attrib_list)
+            public static unsafe void EGLImageTargetTextureStorageEXT<T1>(int texture, ref T1 image, in int attrib_list)
                 where T1 : unmanaged
             {
                 fixed (void* image_ptr = &image)
@@ -29881,7 +29881,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="TextureParameterfvEXT"/>
-            public static unsafe void TextureParameterfvEXT(TextureHandle texture, TextureTarget target, TextureParameterName pname, ReadOnlySpan<float> parameters)
+            public static unsafe void TextureParameterfvEXT(int texture, TextureTarget target, TextureParameterName pname, ReadOnlySpan<float> parameters)
             {
                 fixed (float* parameters_ptr = parameters)
                 {
@@ -29889,7 +29889,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="TextureParameterfvEXT"/>
-            public static unsafe void TextureParameterfvEXT(TextureHandle texture, TextureTarget target, TextureParameterName pname, float[] parameters)
+            public static unsafe void TextureParameterfvEXT(int texture, TextureTarget target, TextureParameterName pname, float[] parameters)
             {
                 fixed (float* parameters_ptr = parameters)
                 {
@@ -29897,7 +29897,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="TextureParameterfvEXT"/>
-            public static unsafe void TextureParameterfvEXT(TextureHandle texture, TextureTarget target, TextureParameterName pname, in float parameters)
+            public static unsafe void TextureParameterfvEXT(int texture, TextureTarget target, TextureParameterName pname, in float parameters)
             {
                 fixed (float* parameters_ptr = &parameters)
                 {
@@ -29905,7 +29905,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="TextureParameterivEXT"/>
-            public static unsafe void TextureParameterivEXT(TextureHandle texture, TextureTarget target, TextureParameterName pname, ReadOnlySpan<int> parameters)
+            public static unsafe void TextureParameterivEXT(int texture, TextureTarget target, TextureParameterName pname, ReadOnlySpan<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -29913,7 +29913,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="TextureParameterivEXT"/>
-            public static unsafe void TextureParameterivEXT(TextureHandle texture, TextureTarget target, TextureParameterName pname, int[] parameters)
+            public static unsafe void TextureParameterivEXT(int texture, TextureTarget target, TextureParameterName pname, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -29921,7 +29921,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="TextureParameterivEXT"/>
-            public static unsafe void TextureParameterivEXT(TextureHandle texture, TextureTarget target, TextureParameterName pname, in int parameters)
+            public static unsafe void TextureParameterivEXT(int texture, TextureTarget target, TextureParameterName pname, in int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -29929,13 +29929,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="TextureImage1DEXT"/>
-            public static unsafe void TextureImage1DEXT(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int width, int border, PixelFormat format, PixelType type, IntPtr pixels)
+            public static unsafe void TextureImage1DEXT(int texture, TextureTarget target, int level, InternalFormat internalformat, int width, int border, PixelFormat format, PixelType type, IntPtr pixels)
             {
                 void* pixels_vptr = (void*)pixels;
                 TextureImage1DEXT(texture, target, level, internalformat, width, border, format, type, pixels_vptr);
             }
             /// <inheritdoc cref="TextureImage1DEXT"/>
-            public static unsafe void TextureImage1DEXT<T1>(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int width, int border, PixelFormat format, PixelType type, ReadOnlySpan<T1> pixels)
+            public static unsafe void TextureImage1DEXT<T1>(int texture, TextureTarget target, int level, InternalFormat internalformat, int width, int border, PixelFormat format, PixelType type, ReadOnlySpan<T1> pixels)
                 where T1 : unmanaged
             {
                 fixed (void* pixels_ptr = pixels)
@@ -29944,7 +29944,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="TextureImage1DEXT"/>
-            public static unsafe void TextureImage1DEXT<T1>(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int width, int border, PixelFormat format, PixelType type, T1[] pixels)
+            public static unsafe void TextureImage1DEXT<T1>(int texture, TextureTarget target, int level, InternalFormat internalformat, int width, int border, PixelFormat format, PixelType type, T1[] pixels)
                 where T1 : unmanaged
             {
                 fixed (void* pixels_ptr = pixels)
@@ -29953,7 +29953,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="TextureImage1DEXT"/>
-            public static unsafe void TextureImage1DEXT<T1>(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int width, int border, PixelFormat format, PixelType type, in T1 pixels)
+            public static unsafe void TextureImage1DEXT<T1>(int texture, TextureTarget target, int level, InternalFormat internalformat, int width, int border, PixelFormat format, PixelType type, in T1 pixels)
                 where T1 : unmanaged
             {
                 fixed (void* pixels_ptr = &pixels)
@@ -29962,13 +29962,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="TextureImage2DEXT"/>
-            public static unsafe void TextureImage2DEXT(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int border, PixelFormat format, PixelType type, IntPtr pixels)
+            public static unsafe void TextureImage2DEXT(int texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int border, PixelFormat format, PixelType type, IntPtr pixels)
             {
                 void* pixels_vptr = (void*)pixels;
                 TextureImage2DEXT(texture, target, level, internalformat, width, height, border, format, type, pixels_vptr);
             }
             /// <inheritdoc cref="TextureImage2DEXT"/>
-            public static unsafe void TextureImage2DEXT<T1>(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int border, PixelFormat format, PixelType type, ReadOnlySpan<T1> pixels)
+            public static unsafe void TextureImage2DEXT<T1>(int texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int border, PixelFormat format, PixelType type, ReadOnlySpan<T1> pixels)
                 where T1 : unmanaged
             {
                 fixed (void* pixels_ptr = pixels)
@@ -29977,7 +29977,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="TextureImage2DEXT"/>
-            public static unsafe void TextureImage2DEXT<T1>(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int border, PixelFormat format, PixelType type, T1[] pixels)
+            public static unsafe void TextureImage2DEXT<T1>(int texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int border, PixelFormat format, PixelType type, T1[] pixels)
                 where T1 : unmanaged
             {
                 fixed (void* pixels_ptr = pixels)
@@ -29986,7 +29986,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="TextureImage2DEXT"/>
-            public static unsafe void TextureImage2DEXT<T1>(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int border, PixelFormat format, PixelType type, in T1 pixels)
+            public static unsafe void TextureImage2DEXT<T1>(int texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int border, PixelFormat format, PixelType type, in T1 pixels)
                 where T1 : unmanaged
             {
                 fixed (void* pixels_ptr = &pixels)
@@ -29995,13 +29995,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="TextureSubImage1DEXT"/>
-            public static unsafe void TextureSubImage1DEXT(TextureHandle texture, TextureTarget target, int level, int xoffset, int width, PixelFormat format, PixelType type, IntPtr pixels)
+            public static unsafe void TextureSubImage1DEXT(int texture, TextureTarget target, int level, int xoffset, int width, PixelFormat format, PixelType type, IntPtr pixels)
             {
                 void* pixels_vptr = (void*)pixels;
                 TextureSubImage1DEXT(texture, target, level, xoffset, width, format, type, pixels_vptr);
             }
             /// <inheritdoc cref="TextureSubImage1DEXT"/>
-            public static unsafe void TextureSubImage1DEXT<T1>(TextureHandle texture, TextureTarget target, int level, int xoffset, int width, PixelFormat format, PixelType type, ReadOnlySpan<T1> pixels)
+            public static unsafe void TextureSubImage1DEXT<T1>(int texture, TextureTarget target, int level, int xoffset, int width, PixelFormat format, PixelType type, ReadOnlySpan<T1> pixels)
                 where T1 : unmanaged
             {
                 fixed (void* pixels_ptr = pixels)
@@ -30010,7 +30010,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="TextureSubImage1DEXT"/>
-            public static unsafe void TextureSubImage1DEXT<T1>(TextureHandle texture, TextureTarget target, int level, int xoffset, int width, PixelFormat format, PixelType type, T1[] pixels)
+            public static unsafe void TextureSubImage1DEXT<T1>(int texture, TextureTarget target, int level, int xoffset, int width, PixelFormat format, PixelType type, T1[] pixels)
                 where T1 : unmanaged
             {
                 fixed (void* pixels_ptr = pixels)
@@ -30019,7 +30019,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="TextureSubImage1DEXT"/>
-            public static unsafe void TextureSubImage1DEXT<T1>(TextureHandle texture, TextureTarget target, int level, int xoffset, int width, PixelFormat format, PixelType type, in T1 pixels)
+            public static unsafe void TextureSubImage1DEXT<T1>(int texture, TextureTarget target, int level, int xoffset, int width, PixelFormat format, PixelType type, in T1 pixels)
                 where T1 : unmanaged
             {
                 fixed (void* pixels_ptr = &pixels)
@@ -30028,13 +30028,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="TextureSubImage2DEXT"/>
-            public static unsafe void TextureSubImage2DEXT(TextureHandle texture, TextureTarget target, int level, int xoffset, int yoffset, int width, int height, PixelFormat format, PixelType type, IntPtr pixels)
+            public static unsafe void TextureSubImage2DEXT(int texture, TextureTarget target, int level, int xoffset, int yoffset, int width, int height, PixelFormat format, PixelType type, IntPtr pixels)
             {
                 void* pixels_vptr = (void*)pixels;
                 TextureSubImage2DEXT(texture, target, level, xoffset, yoffset, width, height, format, type, pixels_vptr);
             }
             /// <inheritdoc cref="TextureSubImage2DEXT"/>
-            public static unsafe void TextureSubImage2DEXT<T1>(TextureHandle texture, TextureTarget target, int level, int xoffset, int yoffset, int width, int height, PixelFormat format, PixelType type, ReadOnlySpan<T1> pixels)
+            public static unsafe void TextureSubImage2DEXT<T1>(int texture, TextureTarget target, int level, int xoffset, int yoffset, int width, int height, PixelFormat format, PixelType type, ReadOnlySpan<T1> pixels)
                 where T1 : unmanaged
             {
                 fixed (void* pixels_ptr = pixels)
@@ -30043,7 +30043,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="TextureSubImage2DEXT"/>
-            public static unsafe void TextureSubImage2DEXT<T1>(TextureHandle texture, TextureTarget target, int level, int xoffset, int yoffset, int width, int height, PixelFormat format, PixelType type, T1[] pixels)
+            public static unsafe void TextureSubImage2DEXT<T1>(int texture, TextureTarget target, int level, int xoffset, int yoffset, int width, int height, PixelFormat format, PixelType type, T1[] pixels)
                 where T1 : unmanaged
             {
                 fixed (void* pixels_ptr = pixels)
@@ -30052,7 +30052,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="TextureSubImage2DEXT"/>
-            public static unsafe void TextureSubImage2DEXT<T1>(TextureHandle texture, TextureTarget target, int level, int xoffset, int yoffset, int width, int height, PixelFormat format, PixelType type, in T1 pixels)
+            public static unsafe void TextureSubImage2DEXT<T1>(int texture, TextureTarget target, int level, int xoffset, int yoffset, int width, int height, PixelFormat format, PixelType type, in T1 pixels)
                 where T1 : unmanaged
             {
                 fixed (void* pixels_ptr = &pixels)
@@ -30061,13 +30061,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetTextureImageEXT"/>
-            public static unsafe void GetTextureImageEXT(TextureHandle texture, TextureTarget target, int level, PixelFormat format, PixelType type, IntPtr pixels)
+            public static unsafe void GetTextureImageEXT(int texture, TextureTarget target, int level, PixelFormat format, PixelType type, IntPtr pixels)
             {
                 void* pixels_vptr = (void*)pixels;
                 GetTextureImageEXT(texture, target, level, format, type, pixels_vptr);
             }
             /// <inheritdoc cref="GetTextureImageEXT"/>
-            public static unsafe void GetTextureImageEXT<T1>(TextureHandle texture, TextureTarget target, int level, PixelFormat format, PixelType type, Span<T1> pixels)
+            public static unsafe void GetTextureImageEXT<T1>(int texture, TextureTarget target, int level, PixelFormat format, PixelType type, Span<T1> pixels)
                 where T1 : unmanaged
             {
                 fixed (void* pixels_ptr = pixels)
@@ -30076,7 +30076,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetTextureImageEXT"/>
-            public static unsafe void GetTextureImageEXT<T1>(TextureHandle texture, TextureTarget target, int level, PixelFormat format, PixelType type, T1[] pixels)
+            public static unsafe void GetTextureImageEXT<T1>(int texture, TextureTarget target, int level, PixelFormat format, PixelType type, T1[] pixels)
                 where T1 : unmanaged
             {
                 fixed (void* pixels_ptr = pixels)
@@ -30085,7 +30085,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetTextureImageEXT"/>
-            public static unsafe void GetTextureImageEXT<T1>(TextureHandle texture, TextureTarget target, int level, PixelFormat format, PixelType type, ref T1 pixels)
+            public static unsafe void GetTextureImageEXT<T1>(int texture, TextureTarget target, int level, PixelFormat format, PixelType type, ref T1 pixels)
                 where T1 : unmanaged
             {
                 fixed (void* pixels_ptr = &pixels)
@@ -30094,7 +30094,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetTextureParameterfvEXT"/>
-            public static unsafe void GetTextureParameterfvEXT(TextureHandle texture, TextureTarget target, GetTextureParameter pname, Span<float> parameters)
+            public static unsafe void GetTextureParameterfvEXT(int texture, TextureTarget target, GetTextureParameter pname, Span<float> parameters)
             {
                 fixed (float* parameters_ptr = parameters)
                 {
@@ -30102,7 +30102,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetTextureParameterfvEXT"/>
-            public static unsafe void GetTextureParameterfvEXT(TextureHandle texture, TextureTarget target, GetTextureParameter pname, float[] parameters)
+            public static unsafe void GetTextureParameterfvEXT(int texture, TextureTarget target, GetTextureParameter pname, float[] parameters)
             {
                 fixed (float* parameters_ptr = parameters)
                 {
@@ -30110,7 +30110,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetTextureParameterfvEXT"/>
-            public static unsafe void GetTextureParameterfvEXT(TextureHandle texture, TextureTarget target, GetTextureParameter pname, ref float parameters)
+            public static unsafe void GetTextureParameterfvEXT(int texture, TextureTarget target, GetTextureParameter pname, ref float parameters)
             {
                 fixed (float* parameters_ptr = &parameters)
                 {
@@ -30118,7 +30118,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetTextureParameterivEXT"/>
-            public static unsafe void GetTextureParameterivEXT(TextureHandle texture, TextureTarget target, GetTextureParameter pname, Span<int> parameters)
+            public static unsafe void GetTextureParameterivEXT(int texture, TextureTarget target, GetTextureParameter pname, Span<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -30126,7 +30126,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetTextureParameterivEXT"/>
-            public static unsafe void GetTextureParameterivEXT(TextureHandle texture, TextureTarget target, GetTextureParameter pname, int[] parameters)
+            public static unsafe void GetTextureParameterivEXT(int texture, TextureTarget target, GetTextureParameter pname, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -30134,7 +30134,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetTextureParameterivEXT"/>
-            public static unsafe void GetTextureParameterivEXT(TextureHandle texture, TextureTarget target, GetTextureParameter pname, ref int parameters)
+            public static unsafe void GetTextureParameterivEXT(int texture, TextureTarget target, GetTextureParameter pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -30142,7 +30142,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetTextureLevelParameterfvEXT"/>
-            public static unsafe void GetTextureLevelParameterfvEXT(TextureHandle texture, TextureTarget target, int level, GetTextureParameter pname, Span<float> parameters)
+            public static unsafe void GetTextureLevelParameterfvEXT(int texture, TextureTarget target, int level, GetTextureParameter pname, Span<float> parameters)
             {
                 fixed (float* parameters_ptr = parameters)
                 {
@@ -30150,7 +30150,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetTextureLevelParameterfvEXT"/>
-            public static unsafe void GetTextureLevelParameterfvEXT(TextureHandle texture, TextureTarget target, int level, GetTextureParameter pname, float[] parameters)
+            public static unsafe void GetTextureLevelParameterfvEXT(int texture, TextureTarget target, int level, GetTextureParameter pname, float[] parameters)
             {
                 fixed (float* parameters_ptr = parameters)
                 {
@@ -30158,7 +30158,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetTextureLevelParameterfvEXT"/>
-            public static unsafe void GetTextureLevelParameterfvEXT(TextureHandle texture, TextureTarget target, int level, GetTextureParameter pname, ref float parameters)
+            public static unsafe void GetTextureLevelParameterfvEXT(int texture, TextureTarget target, int level, GetTextureParameter pname, ref float parameters)
             {
                 fixed (float* parameters_ptr = &parameters)
                 {
@@ -30166,7 +30166,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetTextureLevelParameterivEXT"/>
-            public static unsafe void GetTextureLevelParameterivEXT(TextureHandle texture, TextureTarget target, int level, GetTextureParameter pname, Span<int> parameters)
+            public static unsafe void GetTextureLevelParameterivEXT(int texture, TextureTarget target, int level, GetTextureParameter pname, Span<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -30174,7 +30174,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetTextureLevelParameterivEXT"/>
-            public static unsafe void GetTextureLevelParameterivEXT(TextureHandle texture, TextureTarget target, int level, GetTextureParameter pname, int[] parameters)
+            public static unsafe void GetTextureLevelParameterivEXT(int texture, TextureTarget target, int level, GetTextureParameter pname, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -30182,7 +30182,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetTextureLevelParameterivEXT"/>
-            public static unsafe void GetTextureLevelParameterivEXT(TextureHandle texture, TextureTarget target, int level, GetTextureParameter pname, ref int parameters)
+            public static unsafe void GetTextureLevelParameterivEXT(int texture, TextureTarget target, int level, GetTextureParameter pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -30190,13 +30190,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="TextureImage3DEXT"/>
-            public static unsafe void TextureImage3DEXT(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int depth, int border, PixelFormat format, PixelType type, IntPtr pixels)
+            public static unsafe void TextureImage3DEXT(int texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int depth, int border, PixelFormat format, PixelType type, IntPtr pixels)
             {
                 void* pixels_vptr = (void*)pixels;
                 TextureImage3DEXT(texture, target, level, internalformat, width, height, depth, border, format, type, pixels_vptr);
             }
             /// <inheritdoc cref="TextureImage3DEXT"/>
-            public static unsafe void TextureImage3DEXT<T1>(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int depth, int border, PixelFormat format, PixelType type, ReadOnlySpan<T1> pixels)
+            public static unsafe void TextureImage3DEXT<T1>(int texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int depth, int border, PixelFormat format, PixelType type, ReadOnlySpan<T1> pixels)
                 where T1 : unmanaged
             {
                 fixed (void* pixels_ptr = pixels)
@@ -30205,7 +30205,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="TextureImage3DEXT"/>
-            public static unsafe void TextureImage3DEXT<T1>(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int depth, int border, PixelFormat format, PixelType type, T1[] pixels)
+            public static unsafe void TextureImage3DEXT<T1>(int texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int depth, int border, PixelFormat format, PixelType type, T1[] pixels)
                 where T1 : unmanaged
             {
                 fixed (void* pixels_ptr = pixels)
@@ -30214,7 +30214,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="TextureImage3DEXT"/>
-            public static unsafe void TextureImage3DEXT<T1>(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int depth, int border, PixelFormat format, PixelType type, in T1 pixels)
+            public static unsafe void TextureImage3DEXT<T1>(int texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int depth, int border, PixelFormat format, PixelType type, in T1 pixels)
                 where T1 : unmanaged
             {
                 fixed (void* pixels_ptr = &pixels)
@@ -30223,13 +30223,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="TextureSubImage3DEXT"/>
-            public static unsafe void TextureSubImage3DEXT(TextureHandle texture, TextureTarget target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, IntPtr pixels)
+            public static unsafe void TextureSubImage3DEXT(int texture, TextureTarget target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, IntPtr pixels)
             {
                 void* pixels_vptr = (void*)pixels;
                 TextureSubImage3DEXT(texture, target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, pixels_vptr);
             }
             /// <inheritdoc cref="TextureSubImage3DEXT"/>
-            public static unsafe void TextureSubImage3DEXT<T1>(TextureHandle texture, TextureTarget target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, ReadOnlySpan<T1> pixels)
+            public static unsafe void TextureSubImage3DEXT<T1>(int texture, TextureTarget target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, ReadOnlySpan<T1> pixels)
                 where T1 : unmanaged
             {
                 fixed (void* pixels_ptr = pixels)
@@ -30238,7 +30238,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="TextureSubImage3DEXT"/>
-            public static unsafe void TextureSubImage3DEXT<T1>(TextureHandle texture, TextureTarget target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, T1[] pixels)
+            public static unsafe void TextureSubImage3DEXT<T1>(int texture, TextureTarget target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, T1[] pixels)
                 where T1 : unmanaged
             {
                 fixed (void* pixels_ptr = pixels)
@@ -30247,7 +30247,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="TextureSubImage3DEXT"/>
-            public static unsafe void TextureSubImage3DEXT<T1>(TextureHandle texture, TextureTarget target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, in T1 pixels)
+            public static unsafe void TextureSubImage3DEXT<T1>(int texture, TextureTarget target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, in T1 pixels)
                 where T1 : unmanaged
             {
                 fixed (void* pixels_ptr = &pixels)
@@ -31000,13 +31000,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="CompressedTextureImage3DEXT"/>
-            public static unsafe void CompressedTextureImage3DEXT(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int depth, int border, int imageSize, IntPtr bits)
+            public static unsafe void CompressedTextureImage3DEXT(int texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int depth, int border, int imageSize, IntPtr bits)
             {
                 void* bits_vptr = (void*)bits;
                 CompressedTextureImage3DEXT(texture, target, level, internalformat, width, height, depth, border, imageSize, bits_vptr);
             }
             /// <inheritdoc cref="CompressedTextureImage3DEXT"/>
-            public static unsafe void CompressedTextureImage3DEXT<T1>(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int depth, int border, ReadOnlySpan<T1> bits)
+            public static unsafe void CompressedTextureImage3DEXT<T1>(int texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int depth, int border, ReadOnlySpan<T1> bits)
                 where T1 : unmanaged
             {
                 int imageSize = (int)(bits.Length * sizeof(T1));
@@ -31016,7 +31016,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="CompressedTextureImage3DEXT"/>
-            public static unsafe void CompressedTextureImage3DEXT<T1>(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int depth, int border, T1[] bits)
+            public static unsafe void CompressedTextureImage3DEXT<T1>(int texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int depth, int border, T1[] bits)
                 where T1 : unmanaged
             {
                 int imageSize = (int)(bits.Length * sizeof(T1));
@@ -31026,7 +31026,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="CompressedTextureImage3DEXT"/>
-            public static unsafe void CompressedTextureImage3DEXT<T1>(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int depth, int border, int imageSize, in T1 bits)
+            public static unsafe void CompressedTextureImage3DEXT<T1>(int texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int depth, int border, int imageSize, in T1 bits)
                 where T1 : unmanaged
             {
                 fixed (void* bits_ptr = &bits)
@@ -31035,13 +31035,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="CompressedTextureImage2DEXT"/>
-            public static unsafe void CompressedTextureImage2DEXT(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int border, int imageSize, IntPtr bits)
+            public static unsafe void CompressedTextureImage2DEXT(int texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int border, int imageSize, IntPtr bits)
             {
                 void* bits_vptr = (void*)bits;
                 CompressedTextureImage2DEXT(texture, target, level, internalformat, width, height, border, imageSize, bits_vptr);
             }
             /// <inheritdoc cref="CompressedTextureImage2DEXT"/>
-            public static unsafe void CompressedTextureImage2DEXT<T1>(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int border, ReadOnlySpan<T1> bits)
+            public static unsafe void CompressedTextureImage2DEXT<T1>(int texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int border, ReadOnlySpan<T1> bits)
                 where T1 : unmanaged
             {
                 int imageSize = (int)(bits.Length * sizeof(T1));
@@ -31051,7 +31051,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="CompressedTextureImage2DEXT"/>
-            public static unsafe void CompressedTextureImage2DEXT<T1>(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int border, T1[] bits)
+            public static unsafe void CompressedTextureImage2DEXT<T1>(int texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int border, T1[] bits)
                 where T1 : unmanaged
             {
                 int imageSize = (int)(bits.Length * sizeof(T1));
@@ -31061,7 +31061,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="CompressedTextureImage2DEXT"/>
-            public static unsafe void CompressedTextureImage2DEXT<T1>(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int border, int imageSize, in T1 bits)
+            public static unsafe void CompressedTextureImage2DEXT<T1>(int texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int border, int imageSize, in T1 bits)
                 where T1 : unmanaged
             {
                 fixed (void* bits_ptr = &bits)
@@ -31070,13 +31070,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="CompressedTextureImage1DEXT"/>
-            public static unsafe void CompressedTextureImage1DEXT(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int width, int border, int imageSize, IntPtr bits)
+            public static unsafe void CompressedTextureImage1DEXT(int texture, TextureTarget target, int level, InternalFormat internalformat, int width, int border, int imageSize, IntPtr bits)
             {
                 void* bits_vptr = (void*)bits;
                 CompressedTextureImage1DEXT(texture, target, level, internalformat, width, border, imageSize, bits_vptr);
             }
             /// <inheritdoc cref="CompressedTextureImage1DEXT"/>
-            public static unsafe void CompressedTextureImage1DEXT<T1>(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int width, int border, ReadOnlySpan<T1> bits)
+            public static unsafe void CompressedTextureImage1DEXT<T1>(int texture, TextureTarget target, int level, InternalFormat internalformat, int width, int border, ReadOnlySpan<T1> bits)
                 where T1 : unmanaged
             {
                 int imageSize = (int)(bits.Length * sizeof(T1));
@@ -31086,7 +31086,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="CompressedTextureImage1DEXT"/>
-            public static unsafe void CompressedTextureImage1DEXT<T1>(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int width, int border, T1[] bits)
+            public static unsafe void CompressedTextureImage1DEXT<T1>(int texture, TextureTarget target, int level, InternalFormat internalformat, int width, int border, T1[] bits)
                 where T1 : unmanaged
             {
                 int imageSize = (int)(bits.Length * sizeof(T1));
@@ -31096,7 +31096,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="CompressedTextureImage1DEXT"/>
-            public static unsafe void CompressedTextureImage1DEXT<T1>(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int width, int border, int imageSize, in T1 bits)
+            public static unsafe void CompressedTextureImage1DEXT<T1>(int texture, TextureTarget target, int level, InternalFormat internalformat, int width, int border, int imageSize, in T1 bits)
                 where T1 : unmanaged
             {
                 fixed (void* bits_ptr = &bits)
@@ -31105,13 +31105,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="CompressedTextureSubImage3DEXT"/>
-            public static unsafe void CompressedTextureSubImage3DEXT(TextureHandle texture, TextureTarget target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, InternalFormat format, int imageSize, IntPtr bits)
+            public static unsafe void CompressedTextureSubImage3DEXT(int texture, TextureTarget target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, InternalFormat format, int imageSize, IntPtr bits)
             {
                 void* bits_vptr = (void*)bits;
                 CompressedTextureSubImage3DEXT(texture, target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, bits_vptr);
             }
             /// <inheritdoc cref="CompressedTextureSubImage3DEXT"/>
-            public static unsafe void CompressedTextureSubImage3DEXT<T1>(TextureHandle texture, TextureTarget target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, InternalFormat format, ReadOnlySpan<T1> bits)
+            public static unsafe void CompressedTextureSubImage3DEXT<T1>(int texture, TextureTarget target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, InternalFormat format, ReadOnlySpan<T1> bits)
                 where T1 : unmanaged
             {
                 int imageSize = (int)(bits.Length * sizeof(T1));
@@ -31121,7 +31121,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="CompressedTextureSubImage3DEXT"/>
-            public static unsafe void CompressedTextureSubImage3DEXT<T1>(TextureHandle texture, TextureTarget target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, InternalFormat format, T1[] bits)
+            public static unsafe void CompressedTextureSubImage3DEXT<T1>(int texture, TextureTarget target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, InternalFormat format, T1[] bits)
                 where T1 : unmanaged
             {
                 int imageSize = (int)(bits.Length * sizeof(T1));
@@ -31131,7 +31131,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="CompressedTextureSubImage3DEXT"/>
-            public static unsafe void CompressedTextureSubImage3DEXT<T1>(TextureHandle texture, TextureTarget target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, InternalFormat format, int imageSize, in T1 bits)
+            public static unsafe void CompressedTextureSubImage3DEXT<T1>(int texture, TextureTarget target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, InternalFormat format, int imageSize, in T1 bits)
                 where T1 : unmanaged
             {
                 fixed (void* bits_ptr = &bits)
@@ -31140,13 +31140,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="CompressedTextureSubImage2DEXT"/>
-            public static unsafe void CompressedTextureSubImage2DEXT(TextureHandle texture, TextureTarget target, int level, int xoffset, int yoffset, int width, int height, InternalFormat format, int imageSize, IntPtr bits)
+            public static unsafe void CompressedTextureSubImage2DEXT(int texture, TextureTarget target, int level, int xoffset, int yoffset, int width, int height, InternalFormat format, int imageSize, IntPtr bits)
             {
                 void* bits_vptr = (void*)bits;
                 CompressedTextureSubImage2DEXT(texture, target, level, xoffset, yoffset, width, height, format, imageSize, bits_vptr);
             }
             /// <inheritdoc cref="CompressedTextureSubImage2DEXT"/>
-            public static unsafe void CompressedTextureSubImage2DEXT<T1>(TextureHandle texture, TextureTarget target, int level, int xoffset, int yoffset, int width, int height, InternalFormat format, ReadOnlySpan<T1> bits)
+            public static unsafe void CompressedTextureSubImage2DEXT<T1>(int texture, TextureTarget target, int level, int xoffset, int yoffset, int width, int height, InternalFormat format, ReadOnlySpan<T1> bits)
                 where T1 : unmanaged
             {
                 int imageSize = (int)(bits.Length * sizeof(T1));
@@ -31156,7 +31156,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="CompressedTextureSubImage2DEXT"/>
-            public static unsafe void CompressedTextureSubImage2DEXT<T1>(TextureHandle texture, TextureTarget target, int level, int xoffset, int yoffset, int width, int height, InternalFormat format, T1[] bits)
+            public static unsafe void CompressedTextureSubImage2DEXT<T1>(int texture, TextureTarget target, int level, int xoffset, int yoffset, int width, int height, InternalFormat format, T1[] bits)
                 where T1 : unmanaged
             {
                 int imageSize = (int)(bits.Length * sizeof(T1));
@@ -31166,7 +31166,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="CompressedTextureSubImage2DEXT"/>
-            public static unsafe void CompressedTextureSubImage2DEXT<T1>(TextureHandle texture, TextureTarget target, int level, int xoffset, int yoffset, int width, int height, InternalFormat format, int imageSize, in T1 bits)
+            public static unsafe void CompressedTextureSubImage2DEXT<T1>(int texture, TextureTarget target, int level, int xoffset, int yoffset, int width, int height, InternalFormat format, int imageSize, in T1 bits)
                 where T1 : unmanaged
             {
                 fixed (void* bits_ptr = &bits)
@@ -31175,13 +31175,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="CompressedTextureSubImage1DEXT"/>
-            public static unsafe void CompressedTextureSubImage1DEXT(TextureHandle texture, TextureTarget target, int level, int xoffset, int width, InternalFormat format, int imageSize, IntPtr bits)
+            public static unsafe void CompressedTextureSubImage1DEXT(int texture, TextureTarget target, int level, int xoffset, int width, InternalFormat format, int imageSize, IntPtr bits)
             {
                 void* bits_vptr = (void*)bits;
                 CompressedTextureSubImage1DEXT(texture, target, level, xoffset, width, format, imageSize, bits_vptr);
             }
             /// <inheritdoc cref="CompressedTextureSubImage1DEXT"/>
-            public static unsafe void CompressedTextureSubImage1DEXT<T1>(TextureHandle texture, TextureTarget target, int level, int xoffset, int width, InternalFormat format, ReadOnlySpan<T1> bits)
+            public static unsafe void CompressedTextureSubImage1DEXT<T1>(int texture, TextureTarget target, int level, int xoffset, int width, InternalFormat format, ReadOnlySpan<T1> bits)
                 where T1 : unmanaged
             {
                 int imageSize = (int)(bits.Length * sizeof(T1));
@@ -31191,7 +31191,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="CompressedTextureSubImage1DEXT"/>
-            public static unsafe void CompressedTextureSubImage1DEXT<T1>(TextureHandle texture, TextureTarget target, int level, int xoffset, int width, InternalFormat format, T1[] bits)
+            public static unsafe void CompressedTextureSubImage1DEXT<T1>(int texture, TextureTarget target, int level, int xoffset, int width, InternalFormat format, T1[] bits)
                 where T1 : unmanaged
             {
                 int imageSize = (int)(bits.Length * sizeof(T1));
@@ -31201,7 +31201,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="CompressedTextureSubImage1DEXT"/>
-            public static unsafe void CompressedTextureSubImage1DEXT<T1>(TextureHandle texture, TextureTarget target, int level, int xoffset, int width, InternalFormat format, int imageSize, in T1 bits)
+            public static unsafe void CompressedTextureSubImage1DEXT<T1>(int texture, TextureTarget target, int level, int xoffset, int width, InternalFormat format, int imageSize, in T1 bits)
                 where T1 : unmanaged
             {
                 fixed (void* bits_ptr = &bits)
@@ -31210,13 +31210,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetCompressedTextureImageEXT"/>
-            public static unsafe void GetCompressedTextureImageEXT(TextureHandle texture, TextureTarget target, int lod, IntPtr img)
+            public static unsafe void GetCompressedTextureImageEXT(int texture, TextureTarget target, int lod, IntPtr img)
             {
                 void* img_vptr = (void*)img;
                 GetCompressedTextureImageEXT(texture, target, lod, img_vptr);
             }
             /// <inheritdoc cref="GetCompressedTextureImageEXT"/>
-            public static unsafe void GetCompressedTextureImageEXT<T1>(TextureHandle texture, TextureTarget target, int lod, Span<T1> img)
+            public static unsafe void GetCompressedTextureImageEXT<T1>(int texture, TextureTarget target, int lod, Span<T1> img)
                 where T1 : unmanaged
             {
                 fixed (void* img_ptr = img)
@@ -31225,7 +31225,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetCompressedTextureImageEXT"/>
-            public static unsafe void GetCompressedTextureImageEXT<T1>(TextureHandle texture, TextureTarget target, int lod, T1[] img)
+            public static unsafe void GetCompressedTextureImageEXT<T1>(int texture, TextureTarget target, int lod, T1[] img)
                 where T1 : unmanaged
             {
                 fixed (void* img_ptr = img)
@@ -31234,7 +31234,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetCompressedTextureImageEXT"/>
-            public static unsafe void GetCompressedTextureImageEXT<T1>(TextureHandle texture, TextureTarget target, int lod, ref T1 img)
+            public static unsafe void GetCompressedTextureImageEXT<T1>(int texture, TextureTarget target, int lod, ref T1 img)
                 where T1 : unmanaged
             {
                 fixed (void* img_ptr = &img)
@@ -31582,13 +31582,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="NamedBufferDataEXT"/>
-            public static unsafe void NamedBufferDataEXT(BufferHandle buffer, nint size, IntPtr data, VertexBufferObjectUsage usage)
+            public static unsafe void NamedBufferDataEXT(int buffer, nint size, IntPtr data, VertexBufferObjectUsage usage)
             {
                 void* data_vptr = (void*)data;
                 NamedBufferDataEXT(buffer, size, data_vptr, usage);
             }
             /// <inheritdoc cref="NamedBufferDataEXT"/>
-            public static unsafe void NamedBufferDataEXT<T1>(BufferHandle buffer, nint size, ReadOnlySpan<T1> data, VertexBufferObjectUsage usage)
+            public static unsafe void NamedBufferDataEXT<T1>(int buffer, nint size, ReadOnlySpan<T1> data, VertexBufferObjectUsage usage)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = data)
@@ -31597,7 +31597,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="NamedBufferDataEXT"/>
-            public static unsafe void NamedBufferDataEXT<T1>(BufferHandle buffer, nint size, T1[] data, VertexBufferObjectUsage usage)
+            public static unsafe void NamedBufferDataEXT<T1>(int buffer, nint size, T1[] data, VertexBufferObjectUsage usage)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = data)
@@ -31606,7 +31606,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="NamedBufferDataEXT"/>
-            public static unsafe void NamedBufferDataEXT<T1>(BufferHandle buffer, nint size, in T1 data, VertexBufferObjectUsage usage)
+            public static unsafe void NamedBufferDataEXT<T1>(int buffer, nint size, in T1 data, VertexBufferObjectUsage usage)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = &data)
@@ -31615,13 +31615,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="NamedBufferSubDataEXT"/>
-            public static unsafe void NamedBufferSubDataEXT(BufferHandle buffer, IntPtr offset, nint size, IntPtr data)
+            public static unsafe void NamedBufferSubDataEXT(int buffer, IntPtr offset, nint size, IntPtr data)
             {
                 void* data_vptr = (void*)data;
                 NamedBufferSubDataEXT(buffer, offset, size, data_vptr);
             }
             /// <inheritdoc cref="NamedBufferSubDataEXT"/>
-            public static unsafe void NamedBufferSubDataEXT<T1>(BufferHandle buffer, IntPtr offset, nint size, ReadOnlySpan<T1> data)
+            public static unsafe void NamedBufferSubDataEXT<T1>(int buffer, IntPtr offset, nint size, ReadOnlySpan<T1> data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = data)
@@ -31630,7 +31630,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="NamedBufferSubDataEXT"/>
-            public static unsafe void NamedBufferSubDataEXT<T1>(BufferHandle buffer, IntPtr offset, nint size, T1[] data)
+            public static unsafe void NamedBufferSubDataEXT<T1>(int buffer, IntPtr offset, nint size, T1[] data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = data)
@@ -31639,7 +31639,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="NamedBufferSubDataEXT"/>
-            public static unsafe void NamedBufferSubDataEXT<T1>(BufferHandle buffer, IntPtr offset, nint size, in T1 data)
+            public static unsafe void NamedBufferSubDataEXT<T1>(int buffer, IntPtr offset, nint size, in T1 data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = &data)
@@ -31648,7 +31648,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetNamedBufferParameterivEXT"/>
-            public static unsafe void GetNamedBufferParameterivEXT(BufferHandle buffer, BufferPNameARB pname, Span<int> parameters)
+            public static unsafe void GetNamedBufferParameterivEXT(int buffer, BufferPNameARB pname, Span<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -31656,7 +31656,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetNamedBufferParameterivEXT"/>
-            public static unsafe void GetNamedBufferParameterivEXT(BufferHandle buffer, BufferPNameARB pname, int[] parameters)
+            public static unsafe void GetNamedBufferParameterivEXT(int buffer, BufferPNameARB pname, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -31664,7 +31664,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetNamedBufferParameterivEXT"/>
-            public static unsafe void GetNamedBufferParameterivEXT(BufferHandle buffer, BufferPNameARB pname, ref int parameters)
+            public static unsafe void GetNamedBufferParameterivEXT(int buffer, BufferPNameARB pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -31672,13 +31672,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetNamedBufferSubDataEXT"/>
-            public static unsafe void GetNamedBufferSubDataEXT(BufferHandle buffer, IntPtr offset, nint size, IntPtr data)
+            public static unsafe void GetNamedBufferSubDataEXT(int buffer, IntPtr offset, nint size, IntPtr data)
             {
                 void* data_vptr = (void*)data;
                 GetNamedBufferSubDataEXT(buffer, offset, size, data_vptr);
             }
             /// <inheritdoc cref="GetNamedBufferSubDataEXT"/>
-            public static unsafe void GetNamedBufferSubDataEXT<T1>(BufferHandle buffer, IntPtr offset, nint size, Span<T1> data)
+            public static unsafe void GetNamedBufferSubDataEXT<T1>(int buffer, IntPtr offset, nint size, Span<T1> data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = data)
@@ -31687,7 +31687,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetNamedBufferSubDataEXT"/>
-            public static unsafe void GetNamedBufferSubDataEXT<T1>(BufferHandle buffer, IntPtr offset, nint size, T1[] data)
+            public static unsafe void GetNamedBufferSubDataEXT<T1>(int buffer, IntPtr offset, nint size, T1[] data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = data)
@@ -31696,7 +31696,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetNamedBufferSubDataEXT"/>
-            public static unsafe void GetNamedBufferSubDataEXT<T1>(BufferHandle buffer, IntPtr offset, nint size, ref T1 data)
+            public static unsafe void GetNamedBufferSubDataEXT<T1>(int buffer, IntPtr offset, nint size, ref T1 data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = &data)
@@ -31705,7 +31705,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform1fvEXT"/>
-            public static unsafe void ProgramUniform1fvEXT(ProgramHandle program, int location, ReadOnlySpan<float> value)
+            public static unsafe void ProgramUniform1fvEXT(int program, int location, ReadOnlySpan<float> value)
             {
                 int count = (int)(value.Length);
                 fixed (float* value_ptr = value)
@@ -31714,7 +31714,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform1fvEXT"/>
-            public static unsafe void ProgramUniform1fvEXT(ProgramHandle program, int location, float[] value)
+            public static unsafe void ProgramUniform1fvEXT(int program, int location, float[] value)
             {
                 int count = (int)(value.Length);
                 fixed (float* value_ptr = value)
@@ -31723,7 +31723,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform1fvEXT"/>
-            public static unsafe void ProgramUniform1fvEXT(ProgramHandle program, int location, int count, in float value)
+            public static unsafe void ProgramUniform1fvEXT(int program, int location, int count, in float value)
             {
                 fixed (float* value_ptr = &value)
                 {
@@ -31731,7 +31731,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform2fvEXT"/>
-            public static unsafe void ProgramUniform2fvEXT(ProgramHandle program, int location, ReadOnlySpan<float> value)
+            public static unsafe void ProgramUniform2fvEXT(int program, int location, ReadOnlySpan<float> value)
             {
                 int count = (int)(value.Length / 2);
                 fixed (float* value_ptr = value)
@@ -31740,7 +31740,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform2fvEXT"/>
-            public static unsafe void ProgramUniform2fvEXT(ProgramHandle program, int location, float[] value)
+            public static unsafe void ProgramUniform2fvEXT(int program, int location, float[] value)
             {
                 int count = (int)(value.Length / 2);
                 fixed (float* value_ptr = value)
@@ -31749,7 +31749,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform2fvEXT"/>
-            public static unsafe void ProgramUniform2fvEXT(ProgramHandle program, int location, int count, in float value)
+            public static unsafe void ProgramUniform2fvEXT(int program, int location, int count, in float value)
             {
                 fixed (float* value_ptr = &value)
                 {
@@ -31757,7 +31757,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform3fvEXT"/>
-            public static unsafe void ProgramUniform3fvEXT(ProgramHandle program, int location, ReadOnlySpan<float> value)
+            public static unsafe void ProgramUniform3fvEXT(int program, int location, ReadOnlySpan<float> value)
             {
                 int count = (int)(value.Length / 3);
                 fixed (float* value_ptr = value)
@@ -31766,7 +31766,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform3fvEXT"/>
-            public static unsafe void ProgramUniform3fvEXT(ProgramHandle program, int location, float[] value)
+            public static unsafe void ProgramUniform3fvEXT(int program, int location, float[] value)
             {
                 int count = (int)(value.Length / 3);
                 fixed (float* value_ptr = value)
@@ -31775,7 +31775,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform3fvEXT"/>
-            public static unsafe void ProgramUniform3fvEXT(ProgramHandle program, int location, int count, in float value)
+            public static unsafe void ProgramUniform3fvEXT(int program, int location, int count, in float value)
             {
                 fixed (float* value_ptr = &value)
                 {
@@ -31783,7 +31783,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform4fvEXT"/>
-            public static unsafe void ProgramUniform4fvEXT(ProgramHandle program, int location, ReadOnlySpan<float> value)
+            public static unsafe void ProgramUniform4fvEXT(int program, int location, ReadOnlySpan<float> value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (float* value_ptr = value)
@@ -31792,7 +31792,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform4fvEXT"/>
-            public static unsafe void ProgramUniform4fvEXT(ProgramHandle program, int location, float[] value)
+            public static unsafe void ProgramUniform4fvEXT(int program, int location, float[] value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (float* value_ptr = value)
@@ -31801,7 +31801,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform4fvEXT"/>
-            public static unsafe void ProgramUniform4fvEXT(ProgramHandle program, int location, int count, in float value)
+            public static unsafe void ProgramUniform4fvEXT(int program, int location, int count, in float value)
             {
                 fixed (float* value_ptr = &value)
                 {
@@ -31809,7 +31809,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform1ivEXT"/>
-            public static unsafe void ProgramUniform1ivEXT(ProgramHandle program, int location, ReadOnlySpan<int> value)
+            public static unsafe void ProgramUniform1ivEXT(int program, int location, ReadOnlySpan<int> value)
             {
                 int count = (int)(value.Length);
                 fixed (int* value_ptr = value)
@@ -31818,7 +31818,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform1ivEXT"/>
-            public static unsafe void ProgramUniform1ivEXT(ProgramHandle program, int location, int[] value)
+            public static unsafe void ProgramUniform1ivEXT(int program, int location, int[] value)
             {
                 int count = (int)(value.Length);
                 fixed (int* value_ptr = value)
@@ -31827,7 +31827,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform1ivEXT"/>
-            public static unsafe void ProgramUniform1ivEXT(ProgramHandle program, int location, int count, in int value)
+            public static unsafe void ProgramUniform1ivEXT(int program, int location, int count, in int value)
             {
                 fixed (int* value_ptr = &value)
                 {
@@ -31835,7 +31835,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform2ivEXT"/>
-            public static unsafe void ProgramUniform2ivEXT(ProgramHandle program, int location, ReadOnlySpan<int> value)
+            public static unsafe void ProgramUniform2ivEXT(int program, int location, ReadOnlySpan<int> value)
             {
                 int count = (int)(value.Length / 2);
                 fixed (int* value_ptr = value)
@@ -31844,7 +31844,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform2ivEXT"/>
-            public static unsafe void ProgramUniform2ivEXT(ProgramHandle program, int location, int[] value)
+            public static unsafe void ProgramUniform2ivEXT(int program, int location, int[] value)
             {
                 int count = (int)(value.Length / 2);
                 fixed (int* value_ptr = value)
@@ -31853,7 +31853,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform2ivEXT"/>
-            public static unsafe void ProgramUniform2ivEXT(ProgramHandle program, int location, int count, in int value)
+            public static unsafe void ProgramUniform2ivEXT(int program, int location, int count, in int value)
             {
                 fixed (int* value_ptr = &value)
                 {
@@ -31861,7 +31861,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform3ivEXT"/>
-            public static unsafe void ProgramUniform3ivEXT(ProgramHandle program, int location, ReadOnlySpan<int> value)
+            public static unsafe void ProgramUniform3ivEXT(int program, int location, ReadOnlySpan<int> value)
             {
                 int count = (int)(value.Length / 3);
                 fixed (int* value_ptr = value)
@@ -31870,7 +31870,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform3ivEXT"/>
-            public static unsafe void ProgramUniform3ivEXT(ProgramHandle program, int location, int[] value)
+            public static unsafe void ProgramUniform3ivEXT(int program, int location, int[] value)
             {
                 int count = (int)(value.Length / 3);
                 fixed (int* value_ptr = value)
@@ -31879,7 +31879,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform3ivEXT"/>
-            public static unsafe void ProgramUniform3ivEXT(ProgramHandle program, int location, int count, in int value)
+            public static unsafe void ProgramUniform3ivEXT(int program, int location, int count, in int value)
             {
                 fixed (int* value_ptr = &value)
                 {
@@ -31887,7 +31887,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform4ivEXT"/>
-            public static unsafe void ProgramUniform4ivEXT(ProgramHandle program, int location, ReadOnlySpan<int> value)
+            public static unsafe void ProgramUniform4ivEXT(int program, int location, ReadOnlySpan<int> value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (int* value_ptr = value)
@@ -31896,7 +31896,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform4ivEXT"/>
-            public static unsafe void ProgramUniform4ivEXT(ProgramHandle program, int location, int[] value)
+            public static unsafe void ProgramUniform4ivEXT(int program, int location, int[] value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (int* value_ptr = value)
@@ -31905,7 +31905,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform4ivEXT"/>
-            public static unsafe void ProgramUniform4ivEXT(ProgramHandle program, int location, int count, in int value)
+            public static unsafe void ProgramUniform4ivEXT(int program, int location, int count, in int value)
             {
                 fixed (int* value_ptr = &value)
                 {
@@ -31913,7 +31913,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2fvEXT"/>
-            public static unsafe void ProgramUniformMatrix2fvEXT(ProgramHandle program, int location, bool transpose, ReadOnlySpan<float> value)
+            public static unsafe void ProgramUniformMatrix2fvEXT(int program, int location, bool transpose, ReadOnlySpan<float> value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (float* value_ptr = value)
@@ -31922,7 +31922,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2fvEXT"/>
-            public static unsafe void ProgramUniformMatrix2fvEXT(ProgramHandle program, int location, bool transpose, float[] value)
+            public static unsafe void ProgramUniformMatrix2fvEXT(int program, int location, bool transpose, float[] value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (float* value_ptr = value)
@@ -31931,7 +31931,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2fvEXT"/>
-            public static unsafe void ProgramUniformMatrix2fvEXT(ProgramHandle program, int location, int count, bool transpose, in float value)
+            public static unsafe void ProgramUniformMatrix2fvEXT(int program, int location, int count, bool transpose, in float value)
             {
                 fixed (float* value_ptr = &value)
                 {
@@ -31939,7 +31939,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3fvEXT"/>
-            public static unsafe void ProgramUniformMatrix3fvEXT(ProgramHandle program, int location, bool transpose, ReadOnlySpan<float> value)
+            public static unsafe void ProgramUniformMatrix3fvEXT(int program, int location, bool transpose, ReadOnlySpan<float> value)
             {
                 int count = (int)(value.Length / 9);
                 fixed (float* value_ptr = value)
@@ -31948,7 +31948,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3fvEXT"/>
-            public static unsafe void ProgramUniformMatrix3fvEXT(ProgramHandle program, int location, bool transpose, float[] value)
+            public static unsafe void ProgramUniformMatrix3fvEXT(int program, int location, bool transpose, float[] value)
             {
                 int count = (int)(value.Length / 9);
                 fixed (float* value_ptr = value)
@@ -31957,7 +31957,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3fvEXT"/>
-            public static unsafe void ProgramUniformMatrix3fvEXT(ProgramHandle program, int location, int count, bool transpose, in float value)
+            public static unsafe void ProgramUniformMatrix3fvEXT(int program, int location, int count, bool transpose, in float value)
             {
                 fixed (float* value_ptr = &value)
                 {
@@ -31965,7 +31965,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4fvEXT"/>
-            public static unsafe void ProgramUniformMatrix4fvEXT(ProgramHandle program, int location, bool transpose, ReadOnlySpan<float> value)
+            public static unsafe void ProgramUniformMatrix4fvEXT(int program, int location, bool transpose, ReadOnlySpan<float> value)
             {
                 int count = (int)(value.Length / 16);
                 fixed (float* value_ptr = value)
@@ -31974,7 +31974,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4fvEXT"/>
-            public static unsafe void ProgramUniformMatrix4fvEXT(ProgramHandle program, int location, bool transpose, float[] value)
+            public static unsafe void ProgramUniformMatrix4fvEXT(int program, int location, bool transpose, float[] value)
             {
                 int count = (int)(value.Length / 16);
                 fixed (float* value_ptr = value)
@@ -31983,7 +31983,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4fvEXT"/>
-            public static unsafe void ProgramUniformMatrix4fvEXT(ProgramHandle program, int location, int count, bool transpose, in float value)
+            public static unsafe void ProgramUniformMatrix4fvEXT(int program, int location, int count, bool transpose, in float value)
             {
                 fixed (float* value_ptr = &value)
                 {
@@ -31991,7 +31991,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x3fvEXT"/>
-            public static unsafe void ProgramUniformMatrix2x3fvEXT(ProgramHandle program, int location, bool transpose, ReadOnlySpan<float> value)
+            public static unsafe void ProgramUniformMatrix2x3fvEXT(int program, int location, bool transpose, ReadOnlySpan<float> value)
             {
                 int count = (int)(value.Length / 6);
                 fixed (float* value_ptr = value)
@@ -32000,7 +32000,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x3fvEXT"/>
-            public static unsafe void ProgramUniformMatrix2x3fvEXT(ProgramHandle program, int location, bool transpose, float[] value)
+            public static unsafe void ProgramUniformMatrix2x3fvEXT(int program, int location, bool transpose, float[] value)
             {
                 int count = (int)(value.Length / 6);
                 fixed (float* value_ptr = value)
@@ -32009,7 +32009,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x3fvEXT"/>
-            public static unsafe void ProgramUniformMatrix2x3fvEXT(ProgramHandle program, int location, int count, bool transpose, in float value)
+            public static unsafe void ProgramUniformMatrix2x3fvEXT(int program, int location, int count, bool transpose, in float value)
             {
                 fixed (float* value_ptr = &value)
                 {
@@ -32017,7 +32017,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2fvEXT"/>
-            public static unsafe void ProgramUniformMatrix3x2fvEXT(ProgramHandle program, int location, bool transpose, ReadOnlySpan<float> value)
+            public static unsafe void ProgramUniformMatrix3x2fvEXT(int program, int location, bool transpose, ReadOnlySpan<float> value)
             {
                 int count = (int)(value.Length / 6);
                 fixed (float* value_ptr = value)
@@ -32026,7 +32026,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2fvEXT"/>
-            public static unsafe void ProgramUniformMatrix3x2fvEXT(ProgramHandle program, int location, bool transpose, float[] value)
+            public static unsafe void ProgramUniformMatrix3x2fvEXT(int program, int location, bool transpose, float[] value)
             {
                 int count = (int)(value.Length / 6);
                 fixed (float* value_ptr = value)
@@ -32035,7 +32035,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2fvEXT"/>
-            public static unsafe void ProgramUniformMatrix3x2fvEXT(ProgramHandle program, int location, int count, bool transpose, in float value)
+            public static unsafe void ProgramUniformMatrix3x2fvEXT(int program, int location, int count, bool transpose, in float value)
             {
                 fixed (float* value_ptr = &value)
                 {
@@ -32043,7 +32043,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x4fvEXT"/>
-            public static unsafe void ProgramUniformMatrix2x4fvEXT(ProgramHandle program, int location, bool transpose, ReadOnlySpan<float> value)
+            public static unsafe void ProgramUniformMatrix2x4fvEXT(int program, int location, bool transpose, ReadOnlySpan<float> value)
             {
                 int count = (int)(value.Length / 8);
                 fixed (float* value_ptr = value)
@@ -32052,7 +32052,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x4fvEXT"/>
-            public static unsafe void ProgramUniformMatrix2x4fvEXT(ProgramHandle program, int location, bool transpose, float[] value)
+            public static unsafe void ProgramUniformMatrix2x4fvEXT(int program, int location, bool transpose, float[] value)
             {
                 int count = (int)(value.Length / 8);
                 fixed (float* value_ptr = value)
@@ -32061,7 +32061,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x4fvEXT"/>
-            public static unsafe void ProgramUniformMatrix2x4fvEXT(ProgramHandle program, int location, int count, bool transpose, in float value)
+            public static unsafe void ProgramUniformMatrix2x4fvEXT(int program, int location, int count, bool transpose, in float value)
             {
                 fixed (float* value_ptr = &value)
                 {
@@ -32069,7 +32069,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x2fvEXT"/>
-            public static unsafe void ProgramUniformMatrix4x2fvEXT(ProgramHandle program, int location, bool transpose, ReadOnlySpan<float> value)
+            public static unsafe void ProgramUniformMatrix4x2fvEXT(int program, int location, bool transpose, ReadOnlySpan<float> value)
             {
                 int count = (int)(value.Length / 8);
                 fixed (float* value_ptr = value)
@@ -32078,7 +32078,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x2fvEXT"/>
-            public static unsafe void ProgramUniformMatrix4x2fvEXT(ProgramHandle program, int location, bool transpose, float[] value)
+            public static unsafe void ProgramUniformMatrix4x2fvEXT(int program, int location, bool transpose, float[] value)
             {
                 int count = (int)(value.Length / 8);
                 fixed (float* value_ptr = value)
@@ -32087,7 +32087,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x2fvEXT"/>
-            public static unsafe void ProgramUniformMatrix4x2fvEXT(ProgramHandle program, int location, int count, bool transpose, in float value)
+            public static unsafe void ProgramUniformMatrix4x2fvEXT(int program, int location, int count, bool transpose, in float value)
             {
                 fixed (float* value_ptr = &value)
                 {
@@ -32095,7 +32095,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x4fvEXT"/>
-            public static unsafe void ProgramUniformMatrix3x4fvEXT(ProgramHandle program, int location, bool transpose, ReadOnlySpan<float> value)
+            public static unsafe void ProgramUniformMatrix3x4fvEXT(int program, int location, bool transpose, ReadOnlySpan<float> value)
             {
                 int count = (int)(value.Length / 12);
                 fixed (float* value_ptr = value)
@@ -32104,7 +32104,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x4fvEXT"/>
-            public static unsafe void ProgramUniformMatrix3x4fvEXT(ProgramHandle program, int location, bool transpose, float[] value)
+            public static unsafe void ProgramUniformMatrix3x4fvEXT(int program, int location, bool transpose, float[] value)
             {
                 int count = (int)(value.Length / 12);
                 fixed (float* value_ptr = value)
@@ -32113,7 +32113,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x4fvEXT"/>
-            public static unsafe void ProgramUniformMatrix3x4fvEXT(ProgramHandle program, int location, int count, bool transpose, in float value)
+            public static unsafe void ProgramUniformMatrix3x4fvEXT(int program, int location, int count, bool transpose, in float value)
             {
                 fixed (float* value_ptr = &value)
                 {
@@ -32121,7 +32121,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x3fvEXT"/>
-            public static unsafe void ProgramUniformMatrix4x3fvEXT(ProgramHandle program, int location, bool transpose, ReadOnlySpan<float> value)
+            public static unsafe void ProgramUniformMatrix4x3fvEXT(int program, int location, bool transpose, ReadOnlySpan<float> value)
             {
                 int count = (int)(value.Length / 12);
                 fixed (float* value_ptr = value)
@@ -32130,7 +32130,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x3fvEXT"/>
-            public static unsafe void ProgramUniformMatrix4x3fvEXT(ProgramHandle program, int location, bool transpose, float[] value)
+            public static unsafe void ProgramUniformMatrix4x3fvEXT(int program, int location, bool transpose, float[] value)
             {
                 int count = (int)(value.Length / 12);
                 fixed (float* value_ptr = value)
@@ -32139,7 +32139,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x3fvEXT"/>
-            public static unsafe void ProgramUniformMatrix4x3fvEXT(ProgramHandle program, int location, int count, bool transpose, in float value)
+            public static unsafe void ProgramUniformMatrix4x3fvEXT(int program, int location, int count, bool transpose, in float value)
             {
                 fixed (float* value_ptr = &value)
                 {
@@ -32147,7 +32147,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="TextureParameterIivEXT"/>
-            public static unsafe void TextureParameterIivEXT(TextureHandle texture, TextureTarget target, TextureParameterName pname, ReadOnlySpan<int> parameters)
+            public static unsafe void TextureParameterIivEXT(int texture, TextureTarget target, TextureParameterName pname, ReadOnlySpan<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -32155,7 +32155,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="TextureParameterIivEXT"/>
-            public static unsafe void TextureParameterIivEXT(TextureHandle texture, TextureTarget target, TextureParameterName pname, int[] parameters)
+            public static unsafe void TextureParameterIivEXT(int texture, TextureTarget target, TextureParameterName pname, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -32163,7 +32163,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="TextureParameterIivEXT"/>
-            public static unsafe void TextureParameterIivEXT(TextureHandle texture, TextureTarget target, TextureParameterName pname, in int parameters)
+            public static unsafe void TextureParameterIivEXT(int texture, TextureTarget target, TextureParameterName pname, in int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -32171,7 +32171,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="TextureParameterIuivEXT"/>
-            public static unsafe void TextureParameterIuivEXT(TextureHandle texture, TextureTarget target, TextureParameterName pname, ReadOnlySpan<uint> parameters)
+            public static unsafe void TextureParameterIuivEXT(int texture, TextureTarget target, TextureParameterName pname, ReadOnlySpan<uint> parameters)
             {
                 fixed (uint* parameters_ptr = parameters)
                 {
@@ -32179,7 +32179,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="TextureParameterIuivEXT"/>
-            public static unsafe void TextureParameterIuivEXT(TextureHandle texture, TextureTarget target, TextureParameterName pname, uint[] parameters)
+            public static unsafe void TextureParameterIuivEXT(int texture, TextureTarget target, TextureParameterName pname, uint[] parameters)
             {
                 fixed (uint* parameters_ptr = parameters)
                 {
@@ -32187,7 +32187,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="TextureParameterIuivEXT"/>
-            public static unsafe void TextureParameterIuivEXT(TextureHandle texture, TextureTarget target, TextureParameterName pname, in uint parameters)
+            public static unsafe void TextureParameterIuivEXT(int texture, TextureTarget target, TextureParameterName pname, in uint parameters)
             {
                 fixed (uint* parameters_ptr = &parameters)
                 {
@@ -32195,7 +32195,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetTextureParameterIivEXT"/>
-            public static unsafe void GetTextureParameterIivEXT(TextureHandle texture, TextureTarget target, GetTextureParameter pname, Span<int> parameters)
+            public static unsafe void GetTextureParameterIivEXT(int texture, TextureTarget target, GetTextureParameter pname, Span<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -32203,7 +32203,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetTextureParameterIivEXT"/>
-            public static unsafe void GetTextureParameterIivEXT(TextureHandle texture, TextureTarget target, GetTextureParameter pname, int[] parameters)
+            public static unsafe void GetTextureParameterIivEXT(int texture, TextureTarget target, GetTextureParameter pname, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -32211,7 +32211,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetTextureParameterIivEXT"/>
-            public static unsafe void GetTextureParameterIivEXT(TextureHandle texture, TextureTarget target, GetTextureParameter pname, ref int parameters)
+            public static unsafe void GetTextureParameterIivEXT(int texture, TextureTarget target, GetTextureParameter pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -32219,7 +32219,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetTextureParameterIuivEXT"/>
-            public static unsafe void GetTextureParameterIuivEXT(TextureHandle texture, TextureTarget target, GetTextureParameter pname, Span<uint> parameters)
+            public static unsafe void GetTextureParameterIuivEXT(int texture, TextureTarget target, GetTextureParameter pname, Span<uint> parameters)
             {
                 fixed (uint* parameters_ptr = parameters)
                 {
@@ -32227,7 +32227,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetTextureParameterIuivEXT"/>
-            public static unsafe void GetTextureParameterIuivEXT(TextureHandle texture, TextureTarget target, GetTextureParameter pname, uint[] parameters)
+            public static unsafe void GetTextureParameterIuivEXT(int texture, TextureTarget target, GetTextureParameter pname, uint[] parameters)
             {
                 fixed (uint* parameters_ptr = parameters)
                 {
@@ -32235,7 +32235,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetTextureParameterIuivEXT"/>
-            public static unsafe void GetTextureParameterIuivEXT(TextureHandle texture, TextureTarget target, GetTextureParameter pname, ref uint parameters)
+            public static unsafe void GetTextureParameterIuivEXT(int texture, TextureTarget target, GetTextureParameter pname, ref uint parameters)
             {
                 fixed (uint* parameters_ptr = &parameters)
                 {
@@ -32339,7 +32339,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform1uivEXT"/>
-            public static unsafe void ProgramUniform1uivEXT(ProgramHandle program, int location, ReadOnlySpan<uint> value)
+            public static unsafe void ProgramUniform1uivEXT(int program, int location, ReadOnlySpan<uint> value)
             {
                 int count = (int)(value.Length);
                 fixed (uint* value_ptr = value)
@@ -32348,7 +32348,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform1uivEXT"/>
-            public static unsafe void ProgramUniform1uivEXT(ProgramHandle program, int location, uint[] value)
+            public static unsafe void ProgramUniform1uivEXT(int program, int location, uint[] value)
             {
                 int count = (int)(value.Length);
                 fixed (uint* value_ptr = value)
@@ -32357,7 +32357,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform1uivEXT"/>
-            public static unsafe void ProgramUniform1uivEXT(ProgramHandle program, int location, int count, in uint value)
+            public static unsafe void ProgramUniform1uivEXT(int program, int location, int count, in uint value)
             {
                 fixed (uint* value_ptr = &value)
                 {
@@ -32365,7 +32365,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform2uivEXT"/>
-            public static unsafe void ProgramUniform2uivEXT(ProgramHandle program, int location, ReadOnlySpan<uint> value)
+            public static unsafe void ProgramUniform2uivEXT(int program, int location, ReadOnlySpan<uint> value)
             {
                 int count = (int)(value.Length / 2);
                 fixed (uint* value_ptr = value)
@@ -32374,7 +32374,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform2uivEXT"/>
-            public static unsafe void ProgramUniform2uivEXT(ProgramHandle program, int location, uint[] value)
+            public static unsafe void ProgramUniform2uivEXT(int program, int location, uint[] value)
             {
                 int count = (int)(value.Length / 2);
                 fixed (uint* value_ptr = value)
@@ -32383,7 +32383,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform2uivEXT"/>
-            public static unsafe void ProgramUniform2uivEXT(ProgramHandle program, int location, int count, in uint value)
+            public static unsafe void ProgramUniform2uivEXT(int program, int location, int count, in uint value)
             {
                 fixed (uint* value_ptr = &value)
                 {
@@ -32391,7 +32391,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform3uivEXT"/>
-            public static unsafe void ProgramUniform3uivEXT(ProgramHandle program, int location, ReadOnlySpan<uint> value)
+            public static unsafe void ProgramUniform3uivEXT(int program, int location, ReadOnlySpan<uint> value)
             {
                 int count = (int)(value.Length / 3);
                 fixed (uint* value_ptr = value)
@@ -32400,7 +32400,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform3uivEXT"/>
-            public static unsafe void ProgramUniform3uivEXT(ProgramHandle program, int location, uint[] value)
+            public static unsafe void ProgramUniform3uivEXT(int program, int location, uint[] value)
             {
                 int count = (int)(value.Length / 3);
                 fixed (uint* value_ptr = value)
@@ -32409,7 +32409,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform3uivEXT"/>
-            public static unsafe void ProgramUniform3uivEXT(ProgramHandle program, int location, int count, in uint value)
+            public static unsafe void ProgramUniform3uivEXT(int program, int location, int count, in uint value)
             {
                 fixed (uint* value_ptr = &value)
                 {
@@ -32417,7 +32417,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform4uivEXT"/>
-            public static unsafe void ProgramUniform4uivEXT(ProgramHandle program, int location, ReadOnlySpan<uint> value)
+            public static unsafe void ProgramUniform4uivEXT(int program, int location, ReadOnlySpan<uint> value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (uint* value_ptr = value)
@@ -32426,7 +32426,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform4uivEXT"/>
-            public static unsafe void ProgramUniform4uivEXT(ProgramHandle program, int location, uint[] value)
+            public static unsafe void ProgramUniform4uivEXT(int program, int location, uint[] value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (uint* value_ptr = value)
@@ -32435,7 +32435,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform4uivEXT"/>
-            public static unsafe void ProgramUniform4uivEXT(ProgramHandle program, int location, int count, in uint value)
+            public static unsafe void ProgramUniform4uivEXT(int program, int location, int count, in uint value)
             {
                 fixed (uint* value_ptr = &value)
                 {
@@ -32443,7 +32443,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="NamedProgramLocalParameters4fvEXT"/>
-            public static unsafe void NamedProgramLocalParameters4fvEXT(ProgramHandle program, ProgramTarget target, uint index, ReadOnlySpan<float> parameters)
+            public static unsafe void NamedProgramLocalParameters4fvEXT(int program, ProgramTarget target, uint index, ReadOnlySpan<float> parameters)
             {
                 int count = (int)(parameters.Length / 4);
                 fixed (float* parameters_ptr = parameters)
@@ -32452,7 +32452,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="NamedProgramLocalParameters4fvEXT"/>
-            public static unsafe void NamedProgramLocalParameters4fvEXT(ProgramHandle program, ProgramTarget target, uint index, float[] parameters)
+            public static unsafe void NamedProgramLocalParameters4fvEXT(int program, ProgramTarget target, uint index, float[] parameters)
             {
                 int count = (int)(parameters.Length / 4);
                 fixed (float* parameters_ptr = parameters)
@@ -32461,7 +32461,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="NamedProgramLocalParameters4fvEXT"/>
-            public static unsafe void NamedProgramLocalParameters4fvEXT(ProgramHandle program, ProgramTarget target, uint index, int count, in float parameters)
+            public static unsafe void NamedProgramLocalParameters4fvEXT(int program, ProgramTarget target, uint index, int count, in float parameters)
             {
                 fixed (float* parameters_ptr = &parameters)
                 {
@@ -32469,7 +32469,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="NamedProgramLocalParameterI4ivEXT"/>
-            public static unsafe void NamedProgramLocalParameterI4ivEXT(ProgramHandle program, ProgramTarget target, uint index, ReadOnlySpan<int> parameters)
+            public static unsafe void NamedProgramLocalParameterI4ivEXT(int program, ProgramTarget target, uint index, ReadOnlySpan<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -32477,7 +32477,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="NamedProgramLocalParameterI4ivEXT"/>
-            public static unsafe void NamedProgramLocalParameterI4ivEXT(ProgramHandle program, ProgramTarget target, uint index, int[] parameters)
+            public static unsafe void NamedProgramLocalParameterI4ivEXT(int program, ProgramTarget target, uint index, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -32485,7 +32485,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="NamedProgramLocalParameterI4ivEXT"/>
-            public static unsafe void NamedProgramLocalParameterI4ivEXT(ProgramHandle program, ProgramTarget target, uint index, in int parameters)
+            public static unsafe void NamedProgramLocalParameterI4ivEXT(int program, ProgramTarget target, uint index, in int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -32493,7 +32493,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="NamedProgramLocalParametersI4ivEXT"/>
-            public static unsafe void NamedProgramLocalParametersI4ivEXT(ProgramHandle program, ProgramTarget target, uint index, ReadOnlySpan<int> parameters)
+            public static unsafe void NamedProgramLocalParametersI4ivEXT(int program, ProgramTarget target, uint index, ReadOnlySpan<int> parameters)
             {
                 int count = (int)(parameters.Length / 4);
                 fixed (int* parameters_ptr = parameters)
@@ -32502,7 +32502,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="NamedProgramLocalParametersI4ivEXT"/>
-            public static unsafe void NamedProgramLocalParametersI4ivEXT(ProgramHandle program, ProgramTarget target, uint index, int[] parameters)
+            public static unsafe void NamedProgramLocalParametersI4ivEXT(int program, ProgramTarget target, uint index, int[] parameters)
             {
                 int count = (int)(parameters.Length / 4);
                 fixed (int* parameters_ptr = parameters)
@@ -32511,7 +32511,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="NamedProgramLocalParametersI4ivEXT"/>
-            public static unsafe void NamedProgramLocalParametersI4ivEXT(ProgramHandle program, ProgramTarget target, uint index, int count, in int parameters)
+            public static unsafe void NamedProgramLocalParametersI4ivEXT(int program, ProgramTarget target, uint index, int count, in int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -32519,7 +32519,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="NamedProgramLocalParameterI4uivEXT"/>
-            public static unsafe void NamedProgramLocalParameterI4uivEXT(ProgramHandle program, ProgramTarget target, uint index, ReadOnlySpan<uint> parameters)
+            public static unsafe void NamedProgramLocalParameterI4uivEXT(int program, ProgramTarget target, uint index, ReadOnlySpan<uint> parameters)
             {
                 fixed (uint* parameters_ptr = parameters)
                 {
@@ -32527,7 +32527,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="NamedProgramLocalParameterI4uivEXT"/>
-            public static unsafe void NamedProgramLocalParameterI4uivEXT(ProgramHandle program, ProgramTarget target, uint index, uint[] parameters)
+            public static unsafe void NamedProgramLocalParameterI4uivEXT(int program, ProgramTarget target, uint index, uint[] parameters)
             {
                 fixed (uint* parameters_ptr = parameters)
                 {
@@ -32535,7 +32535,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="NamedProgramLocalParameterI4uivEXT"/>
-            public static unsafe void NamedProgramLocalParameterI4uivEXT(ProgramHandle program, ProgramTarget target, uint index, in uint parameters)
+            public static unsafe void NamedProgramLocalParameterI4uivEXT(int program, ProgramTarget target, uint index, in uint parameters)
             {
                 fixed (uint* parameters_ptr = &parameters)
                 {
@@ -32543,7 +32543,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="NamedProgramLocalParametersI4uivEXT"/>
-            public static unsafe void NamedProgramLocalParametersI4uivEXT(ProgramHandle program, ProgramTarget target, uint index, ReadOnlySpan<uint> parameters)
+            public static unsafe void NamedProgramLocalParametersI4uivEXT(int program, ProgramTarget target, uint index, ReadOnlySpan<uint> parameters)
             {
                 int count = (int)(parameters.Length / 4);
                 fixed (uint* parameters_ptr = parameters)
@@ -32552,7 +32552,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="NamedProgramLocalParametersI4uivEXT"/>
-            public static unsafe void NamedProgramLocalParametersI4uivEXT(ProgramHandle program, ProgramTarget target, uint index, uint[] parameters)
+            public static unsafe void NamedProgramLocalParametersI4uivEXT(int program, ProgramTarget target, uint index, uint[] parameters)
             {
                 int count = (int)(parameters.Length / 4);
                 fixed (uint* parameters_ptr = parameters)
@@ -32561,7 +32561,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="NamedProgramLocalParametersI4uivEXT"/>
-            public static unsafe void NamedProgramLocalParametersI4uivEXT(ProgramHandle program, ProgramTarget target, uint index, int count, in uint parameters)
+            public static unsafe void NamedProgramLocalParametersI4uivEXT(int program, ProgramTarget target, uint index, int count, in uint parameters)
             {
                 fixed (uint* parameters_ptr = &parameters)
                 {
@@ -32569,7 +32569,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetNamedProgramLocalParameterIivEXT"/>
-            public static unsafe void GetNamedProgramLocalParameterIivEXT(ProgramHandle program, ProgramTarget target, uint index, Span<int> parameters)
+            public static unsafe void GetNamedProgramLocalParameterIivEXT(int program, ProgramTarget target, uint index, Span<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -32577,7 +32577,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetNamedProgramLocalParameterIivEXT"/>
-            public static unsafe void GetNamedProgramLocalParameterIivEXT(ProgramHandle program, ProgramTarget target, uint index, int[] parameters)
+            public static unsafe void GetNamedProgramLocalParameterIivEXT(int program, ProgramTarget target, uint index, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -32585,7 +32585,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetNamedProgramLocalParameterIivEXT"/>
-            public static unsafe void GetNamedProgramLocalParameterIivEXT(ProgramHandle program, ProgramTarget target, uint index, ref int parameters)
+            public static unsafe void GetNamedProgramLocalParameterIivEXT(int program, ProgramTarget target, uint index, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -32593,7 +32593,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetNamedProgramLocalParameterIuivEXT"/>
-            public static unsafe void GetNamedProgramLocalParameterIuivEXT(ProgramHandle program, ProgramTarget target, uint index, Span<uint> parameters)
+            public static unsafe void GetNamedProgramLocalParameterIuivEXT(int program, ProgramTarget target, uint index, Span<uint> parameters)
             {
                 fixed (uint* parameters_ptr = parameters)
                 {
@@ -32601,7 +32601,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetNamedProgramLocalParameterIuivEXT"/>
-            public static unsafe void GetNamedProgramLocalParameterIuivEXT(ProgramHandle program, ProgramTarget target, uint index, uint[] parameters)
+            public static unsafe void GetNamedProgramLocalParameterIuivEXT(int program, ProgramTarget target, uint index, uint[] parameters)
             {
                 fixed (uint* parameters_ptr = parameters)
                 {
@@ -32609,7 +32609,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetNamedProgramLocalParameterIuivEXT"/>
-            public static unsafe void GetNamedProgramLocalParameterIuivEXT(ProgramHandle program, ProgramTarget target, uint index, ref uint parameters)
+            public static unsafe void GetNamedProgramLocalParameterIuivEXT(int program, ProgramTarget target, uint index, ref uint parameters)
             {
                 fixed (uint* parameters_ptr = &parameters)
                 {
@@ -32665,13 +32665,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="NamedProgramStringEXT"/>
-            public static unsafe void NamedProgramStringEXT(ProgramHandle program, ProgramTarget target, ProgramFormat format, int len, IntPtr str)
+            public static unsafe void NamedProgramStringEXT(int program, ProgramTarget target, ProgramFormat format, int len, IntPtr str)
             {
                 void* str_vptr = (void*)str;
                 NamedProgramStringEXT(program, target, format, len, str_vptr);
             }
             /// <inheritdoc cref="NamedProgramStringEXT"/>
-            public static unsafe void NamedProgramStringEXT<T1>(ProgramHandle program, ProgramTarget target, ProgramFormat format, ReadOnlySpan<T1> str)
+            public static unsafe void NamedProgramStringEXT<T1>(int program, ProgramTarget target, ProgramFormat format, ReadOnlySpan<T1> str)
                 where T1 : unmanaged
             {
                 int len = (int)(str.Length * sizeof(T1));
@@ -32681,7 +32681,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="NamedProgramStringEXT"/>
-            public static unsafe void NamedProgramStringEXT<T1>(ProgramHandle program, ProgramTarget target, ProgramFormat format, T1[] str)
+            public static unsafe void NamedProgramStringEXT<T1>(int program, ProgramTarget target, ProgramFormat format, T1[] str)
                 where T1 : unmanaged
             {
                 int len = (int)(str.Length * sizeof(T1));
@@ -32691,7 +32691,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="NamedProgramStringEXT"/>
-            public static unsafe void NamedProgramStringEXT<T1>(ProgramHandle program, ProgramTarget target, ProgramFormat format, int len, in T1 str)
+            public static unsafe void NamedProgramStringEXT<T1>(int program, ProgramTarget target, ProgramFormat format, int len, in T1 str)
                 where T1 : unmanaged
             {
                 fixed (void* str_ptr = &str)
@@ -32700,7 +32700,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="NamedProgramLocalParameter4dvEXT"/>
-            public static unsafe void NamedProgramLocalParameter4dvEXT(ProgramHandle program, ProgramTarget target, uint index, ReadOnlySpan<double> parameters)
+            public static unsafe void NamedProgramLocalParameter4dvEXT(int program, ProgramTarget target, uint index, ReadOnlySpan<double> parameters)
             {
                 fixed (double* parameters_ptr = parameters)
                 {
@@ -32708,7 +32708,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="NamedProgramLocalParameter4dvEXT"/>
-            public static unsafe void NamedProgramLocalParameter4dvEXT(ProgramHandle program, ProgramTarget target, uint index, double[] parameters)
+            public static unsafe void NamedProgramLocalParameter4dvEXT(int program, ProgramTarget target, uint index, double[] parameters)
             {
                 fixed (double* parameters_ptr = parameters)
                 {
@@ -32716,7 +32716,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="NamedProgramLocalParameter4dvEXT"/>
-            public static unsafe void NamedProgramLocalParameter4dvEXT(ProgramHandle program, ProgramTarget target, uint index, in double parameters)
+            public static unsafe void NamedProgramLocalParameter4dvEXT(int program, ProgramTarget target, uint index, in double parameters)
             {
                 fixed (double* parameters_ptr = &parameters)
                 {
@@ -32724,7 +32724,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="NamedProgramLocalParameter4fvEXT"/>
-            public static unsafe void NamedProgramLocalParameter4fvEXT(ProgramHandle program, ProgramTarget target, uint index, ReadOnlySpan<float> parameters)
+            public static unsafe void NamedProgramLocalParameter4fvEXT(int program, ProgramTarget target, uint index, ReadOnlySpan<float> parameters)
             {
                 fixed (float* parameters_ptr = parameters)
                 {
@@ -32732,7 +32732,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="NamedProgramLocalParameter4fvEXT"/>
-            public static unsafe void NamedProgramLocalParameter4fvEXT(ProgramHandle program, ProgramTarget target, uint index, float[] parameters)
+            public static unsafe void NamedProgramLocalParameter4fvEXT(int program, ProgramTarget target, uint index, float[] parameters)
             {
                 fixed (float* parameters_ptr = parameters)
                 {
@@ -32740,7 +32740,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="NamedProgramLocalParameter4fvEXT"/>
-            public static unsafe void NamedProgramLocalParameter4fvEXT(ProgramHandle program, ProgramTarget target, uint index, in float parameters)
+            public static unsafe void NamedProgramLocalParameter4fvEXT(int program, ProgramTarget target, uint index, in float parameters)
             {
                 fixed (float* parameters_ptr = &parameters)
                 {
@@ -32748,7 +32748,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetNamedProgramLocalParameterdvEXT"/>
-            public static unsafe void GetNamedProgramLocalParameterdvEXT(ProgramHandle program, ProgramTarget target, uint index, Span<double> parameters)
+            public static unsafe void GetNamedProgramLocalParameterdvEXT(int program, ProgramTarget target, uint index, Span<double> parameters)
             {
                 fixed (double* parameters_ptr = parameters)
                 {
@@ -32756,7 +32756,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetNamedProgramLocalParameterdvEXT"/>
-            public static unsafe void GetNamedProgramLocalParameterdvEXT(ProgramHandle program, ProgramTarget target, uint index, double[] parameters)
+            public static unsafe void GetNamedProgramLocalParameterdvEXT(int program, ProgramTarget target, uint index, double[] parameters)
             {
                 fixed (double* parameters_ptr = parameters)
                 {
@@ -32764,7 +32764,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetNamedProgramLocalParameterdvEXT"/>
-            public static unsafe void GetNamedProgramLocalParameterdvEXT(ProgramHandle program, ProgramTarget target, uint index, ref double parameters)
+            public static unsafe void GetNamedProgramLocalParameterdvEXT(int program, ProgramTarget target, uint index, ref double parameters)
             {
                 fixed (double* parameters_ptr = &parameters)
                 {
@@ -32772,7 +32772,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetNamedProgramLocalParameterfvEXT"/>
-            public static unsafe void GetNamedProgramLocalParameterfvEXT(ProgramHandle program, ProgramTarget target, uint index, Span<float> parameters)
+            public static unsafe void GetNamedProgramLocalParameterfvEXT(int program, ProgramTarget target, uint index, Span<float> parameters)
             {
                 fixed (float* parameters_ptr = parameters)
                 {
@@ -32780,7 +32780,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetNamedProgramLocalParameterfvEXT"/>
-            public static unsafe void GetNamedProgramLocalParameterfvEXT(ProgramHandle program, ProgramTarget target, uint index, float[] parameters)
+            public static unsafe void GetNamedProgramLocalParameterfvEXT(int program, ProgramTarget target, uint index, float[] parameters)
             {
                 fixed (float* parameters_ptr = parameters)
                 {
@@ -32788,7 +32788,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetNamedProgramLocalParameterfvEXT"/>
-            public static unsafe void GetNamedProgramLocalParameterfvEXT(ProgramHandle program, ProgramTarget target, uint index, ref float parameters)
+            public static unsafe void GetNamedProgramLocalParameterfvEXT(int program, ProgramTarget target, uint index, ref float parameters)
             {
                 fixed (float* parameters_ptr = &parameters)
                 {
@@ -32796,7 +32796,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetNamedProgramivEXT"/>
-            public static unsafe void GetNamedProgramivEXT(ProgramHandle program, ProgramTarget target, ProgramPropertyARB pname, Span<int> parameters)
+            public static unsafe void GetNamedProgramivEXT(int program, ProgramTarget target, ProgramPropertyARB pname, Span<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -32804,7 +32804,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetNamedProgramivEXT"/>
-            public static unsafe void GetNamedProgramivEXT(ProgramHandle program, ProgramTarget target, ProgramPropertyARB pname, int[] parameters)
+            public static unsafe void GetNamedProgramivEXT(int program, ProgramTarget target, ProgramPropertyARB pname, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -32812,7 +32812,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetNamedProgramivEXT"/>
-            public static unsafe void GetNamedProgramivEXT(ProgramHandle program, ProgramTarget target, ProgramPropertyARB pname, ref int parameters)
+            public static unsafe void GetNamedProgramivEXT(int program, ProgramTarget target, ProgramPropertyARB pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -32820,13 +32820,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetNamedProgramStringEXT"/>
-            public static unsafe void GetNamedProgramStringEXT(ProgramHandle program, ProgramTarget target, ProgramStringProperty pname, IntPtr str)
+            public static unsafe void GetNamedProgramStringEXT(int program, ProgramTarget target, ProgramStringProperty pname, IntPtr str)
             {
                 void* str_vptr = (void*)str;
                 GetNamedProgramStringEXT(program, target, pname, str_vptr);
             }
             /// <inheritdoc cref="GetNamedProgramStringEXT"/>
-            public static unsafe void GetNamedProgramStringEXT<T1>(ProgramHandle program, ProgramTarget target, ProgramStringProperty pname, Span<T1> str)
+            public static unsafe void GetNamedProgramStringEXT<T1>(int program, ProgramTarget target, ProgramStringProperty pname, Span<T1> str)
                 where T1 : unmanaged
             {
                 fixed (void* str_ptr = str)
@@ -32835,7 +32835,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetNamedProgramStringEXT"/>
-            public static unsafe void GetNamedProgramStringEXT<T1>(ProgramHandle program, ProgramTarget target, ProgramStringProperty pname, T1[] str)
+            public static unsafe void GetNamedProgramStringEXT<T1>(int program, ProgramTarget target, ProgramStringProperty pname, T1[] str)
                 where T1 : unmanaged
             {
                 fixed (void* str_ptr = str)
@@ -32844,7 +32844,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetNamedProgramStringEXT"/>
-            public static unsafe void GetNamedProgramStringEXT<T1>(ProgramHandle program, ProgramTarget target, ProgramStringProperty pname, ref T1 str)
+            public static unsafe void GetNamedProgramStringEXT<T1>(int program, ProgramTarget target, ProgramStringProperty pname, ref T1 str)
                 where T1 : unmanaged
             {
                 fixed (void* str_ptr = &str)
@@ -32853,7 +32853,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetNamedRenderbufferParameterivEXT"/>
-            public static unsafe void GetNamedRenderbufferParameterivEXT(RenderbufferHandle renderbuffer, RenderbufferParameterName pname, Span<int> parameters)
+            public static unsafe void GetNamedRenderbufferParameterivEXT(int renderbuffer, RenderbufferParameterName pname, Span<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -32861,7 +32861,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetNamedRenderbufferParameterivEXT"/>
-            public static unsafe void GetNamedRenderbufferParameterivEXT(RenderbufferHandle renderbuffer, RenderbufferParameterName pname, int[] parameters)
+            public static unsafe void GetNamedRenderbufferParameterivEXT(int renderbuffer, RenderbufferParameterName pname, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -32869,7 +32869,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetNamedRenderbufferParameterivEXT"/>
-            public static unsafe void GetNamedRenderbufferParameterivEXT(RenderbufferHandle renderbuffer, RenderbufferParameterName pname, ref int parameters)
+            public static unsafe void GetNamedRenderbufferParameterivEXT(int renderbuffer, RenderbufferParameterName pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -32877,7 +32877,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetNamedFramebufferAttachmentParameterivEXT"/>
-            public static unsafe void GetNamedFramebufferAttachmentParameterivEXT(FramebufferHandle framebuffer, FramebufferAttachment attachment, FramebufferAttachmentParameterName pname, Span<int> parameters)
+            public static unsafe void GetNamedFramebufferAttachmentParameterivEXT(int framebuffer, FramebufferAttachment attachment, FramebufferAttachmentParameterName pname, Span<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -32885,7 +32885,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetNamedFramebufferAttachmentParameterivEXT"/>
-            public static unsafe void GetNamedFramebufferAttachmentParameterivEXT(FramebufferHandle framebuffer, FramebufferAttachment attachment, FramebufferAttachmentParameterName pname, int[] parameters)
+            public static unsafe void GetNamedFramebufferAttachmentParameterivEXT(int framebuffer, FramebufferAttachment attachment, FramebufferAttachmentParameterName pname, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -32893,7 +32893,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetNamedFramebufferAttachmentParameterivEXT"/>
-            public static unsafe void GetNamedFramebufferAttachmentParameterivEXT(FramebufferHandle framebuffer, FramebufferAttachment attachment, FramebufferAttachmentParameterName pname, ref int parameters)
+            public static unsafe void GetNamedFramebufferAttachmentParameterivEXT(int framebuffer, FramebufferAttachment attachment, FramebufferAttachmentParameterName pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -32901,7 +32901,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="FramebufferDrawBuffersEXT"/>
-            public static unsafe void FramebufferDrawBuffersEXT(FramebufferHandle framebuffer, ReadOnlySpan<DrawBufferMode> bufs)
+            public static unsafe void FramebufferDrawBuffersEXT(int framebuffer, ReadOnlySpan<DrawBufferMode> bufs)
             {
                 int n = (int)(bufs.Length);
                 fixed (DrawBufferMode* bufs_ptr = bufs)
@@ -32910,7 +32910,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="FramebufferDrawBuffersEXT"/>
-            public static unsafe void FramebufferDrawBuffersEXT(FramebufferHandle framebuffer, DrawBufferMode[] bufs)
+            public static unsafe void FramebufferDrawBuffersEXT(int framebuffer, DrawBufferMode[] bufs)
             {
                 int n = (int)(bufs.Length);
                 fixed (DrawBufferMode* bufs_ptr = bufs)
@@ -32919,7 +32919,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="FramebufferDrawBuffersEXT"/>
-            public static unsafe void FramebufferDrawBuffersEXT(FramebufferHandle framebuffer, int n, in DrawBufferMode bufs)
+            public static unsafe void FramebufferDrawBuffersEXT(int framebuffer, int n, in DrawBufferMode bufs)
             {
                 fixed (DrawBufferMode* bufs_ptr = &bufs)
                 {
@@ -32927,7 +32927,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetFramebufferParameterivEXT"/>
-            public static unsafe void GetFramebufferParameterivEXT(FramebufferHandle framebuffer, GetFramebufferParameter pname, Span<int> parameters)
+            public static unsafe void GetFramebufferParameterivEXT(int framebuffer, GetFramebufferParameter pname, Span<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -32935,7 +32935,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetFramebufferParameterivEXT"/>
-            public static unsafe void GetFramebufferParameterivEXT(FramebufferHandle framebuffer, GetFramebufferParameter pname, int[] parameters)
+            public static unsafe void GetFramebufferParameterivEXT(int framebuffer, GetFramebufferParameter pname, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -32943,7 +32943,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetFramebufferParameterivEXT"/>
-            public static unsafe void GetFramebufferParameterivEXT(FramebufferHandle framebuffer, GetFramebufferParameter pname, ref int parameters)
+            public static unsafe void GetFramebufferParameterivEXT(int framebuffer, GetFramebufferParameter pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -32951,7 +32951,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetVertexArrayIntegervEXT"/>
-            public static unsafe void GetVertexArrayIntegervEXT(VertexArrayHandle vaobj, VertexArrayPName pname, ref int param)
+            public static unsafe void GetVertexArrayIntegervEXT(int vaobj, VertexArrayPName pname, ref int param)
             {
                 fixed (int* param_ptr = &param)
                 {
@@ -32959,7 +32959,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetVertexArrayIntegeri_vEXT"/>
-            public static unsafe void GetVertexArrayIntegeri_vEXT(VertexArrayHandle vaobj, uint index, VertexArrayPName pname, ref int param)
+            public static unsafe void GetVertexArrayIntegeri_vEXT(int vaobj, uint index, VertexArrayPName pname, ref int param)
             {
                 fixed (int* param_ptr = &param)
                 {
@@ -32967,13 +32967,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="NamedBufferStorageEXT"/>
-            public static unsafe void NamedBufferStorageEXT(BufferHandle buffer, nint size, IntPtr data, BufferStorageMask flags)
+            public static unsafe void NamedBufferStorageEXT(int buffer, nint size, IntPtr data, BufferStorageMask flags)
             {
                 void* data_vptr = (void*)data;
                 NamedBufferStorageEXT(buffer, size, data_vptr, flags);
             }
             /// <inheritdoc cref="NamedBufferStorageEXT"/>
-            public static unsafe void NamedBufferStorageEXT<T1>(BufferHandle buffer, ReadOnlySpan<T1> data, BufferStorageMask flags)
+            public static unsafe void NamedBufferStorageEXT<T1>(int buffer, ReadOnlySpan<T1> data, BufferStorageMask flags)
                 where T1 : unmanaged
             {
                 nint size = (nint)(data.Length * sizeof(T1));
@@ -32983,7 +32983,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="NamedBufferStorageEXT"/>
-            public static unsafe void NamedBufferStorageEXT<T1>(BufferHandle buffer, T1[] data, BufferStorageMask flags)
+            public static unsafe void NamedBufferStorageEXT<T1>(int buffer, T1[] data, BufferStorageMask flags)
                 where T1 : unmanaged
             {
                 nint size = (nint)(data.Length * sizeof(T1));
@@ -32993,7 +32993,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="NamedBufferStorageEXT"/>
-            public static unsafe void NamedBufferStorageEXT<T1>(BufferHandle buffer, nint size, in T1 data, BufferStorageMask flags)
+            public static unsafe void NamedBufferStorageEXT<T1>(int buffer, nint size, in T1 data, BufferStorageMask flags)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = &data)
@@ -33002,13 +33002,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ClearNamedBufferDataEXT"/>
-            public static unsafe void ClearNamedBufferDataEXT(BufferHandle buffer, SizedInternalFormat internalformat, PixelFormat format, PixelType type, IntPtr data)
+            public static unsafe void ClearNamedBufferDataEXT(int buffer, SizedInternalFormat internalformat, PixelFormat format, PixelType type, IntPtr data)
             {
                 void* data_vptr = (void*)data;
                 ClearNamedBufferDataEXT(buffer, internalformat, format, type, data_vptr);
             }
             /// <inheritdoc cref="ClearNamedBufferDataEXT"/>
-            public static unsafe void ClearNamedBufferDataEXT<T1>(BufferHandle buffer, SizedInternalFormat internalformat, PixelFormat format, PixelType type, ReadOnlySpan<T1> data)
+            public static unsafe void ClearNamedBufferDataEXT<T1>(int buffer, SizedInternalFormat internalformat, PixelFormat format, PixelType type, ReadOnlySpan<T1> data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = data)
@@ -33017,7 +33017,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ClearNamedBufferDataEXT"/>
-            public static unsafe void ClearNamedBufferDataEXT<T1>(BufferHandle buffer, SizedInternalFormat internalformat, PixelFormat format, PixelType type, T1[] data)
+            public static unsafe void ClearNamedBufferDataEXT<T1>(int buffer, SizedInternalFormat internalformat, PixelFormat format, PixelType type, T1[] data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = data)
@@ -33026,7 +33026,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ClearNamedBufferDataEXT"/>
-            public static unsafe void ClearNamedBufferDataEXT<T1>(BufferHandle buffer, SizedInternalFormat internalformat, PixelFormat format, PixelType type, in T1 data)
+            public static unsafe void ClearNamedBufferDataEXT<T1>(int buffer, SizedInternalFormat internalformat, PixelFormat format, PixelType type, in T1 data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = &data)
@@ -33035,13 +33035,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ClearNamedBufferSubDataEXT"/>
-            public static unsafe void ClearNamedBufferSubDataEXT(BufferHandle buffer, SizedInternalFormat internalformat, nint offset, nint size, PixelFormat format, PixelType type, IntPtr data)
+            public static unsafe void ClearNamedBufferSubDataEXT(int buffer, SizedInternalFormat internalformat, nint offset, nint size, PixelFormat format, PixelType type, IntPtr data)
             {
                 void* data_vptr = (void*)data;
                 ClearNamedBufferSubDataEXT(buffer, internalformat, offset, size, format, type, data_vptr);
             }
             /// <inheritdoc cref="ClearNamedBufferSubDataEXT"/>
-            public static unsafe void ClearNamedBufferSubDataEXT<T1>(BufferHandle buffer, SizedInternalFormat internalformat, nint offset, nint size, PixelFormat format, PixelType type, ReadOnlySpan<T1> data)
+            public static unsafe void ClearNamedBufferSubDataEXT<T1>(int buffer, SizedInternalFormat internalformat, nint offset, nint size, PixelFormat format, PixelType type, ReadOnlySpan<T1> data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = data)
@@ -33050,7 +33050,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ClearNamedBufferSubDataEXT"/>
-            public static unsafe void ClearNamedBufferSubDataEXT<T1>(BufferHandle buffer, SizedInternalFormat internalformat, nint offset, nint size, PixelFormat format, PixelType type, T1[] data)
+            public static unsafe void ClearNamedBufferSubDataEXT<T1>(int buffer, SizedInternalFormat internalformat, nint offset, nint size, PixelFormat format, PixelType type, T1[] data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = data)
@@ -33059,7 +33059,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ClearNamedBufferSubDataEXT"/>
-            public static unsafe void ClearNamedBufferSubDataEXT<T1>(BufferHandle buffer, SizedInternalFormat internalformat, nint offset, nint size, PixelFormat format, PixelType type, in T1 data)
+            public static unsafe void ClearNamedBufferSubDataEXT<T1>(int buffer, SizedInternalFormat internalformat, nint offset, nint size, PixelFormat format, PixelType type, in T1 data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = &data)
@@ -33068,7 +33068,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetNamedFramebufferParameterivEXT"/>
-            public static unsafe void GetNamedFramebufferParameterivEXT(FramebufferHandle framebuffer, GetFramebufferParameter pname, Span<int> parameters)
+            public static unsafe void GetNamedFramebufferParameterivEXT(int framebuffer, GetFramebufferParameter pname, Span<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -33076,7 +33076,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetNamedFramebufferParameterivEXT"/>
-            public static unsafe void GetNamedFramebufferParameterivEXT(FramebufferHandle framebuffer, GetFramebufferParameter pname, int[] parameters)
+            public static unsafe void GetNamedFramebufferParameterivEXT(int framebuffer, GetFramebufferParameter pname, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -33084,7 +33084,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetNamedFramebufferParameterivEXT"/>
-            public static unsafe void GetNamedFramebufferParameterivEXT(FramebufferHandle framebuffer, GetFramebufferParameter pname, ref int parameters)
+            public static unsafe void GetNamedFramebufferParameterivEXT(int framebuffer, GetFramebufferParameter pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -33092,7 +33092,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform1dvEXT"/>
-            public static unsafe void ProgramUniform1dvEXT(ProgramHandle program, int location, ReadOnlySpan<double> value)
+            public static unsafe void ProgramUniform1dvEXT(int program, int location, ReadOnlySpan<double> value)
             {
                 int count = (int)(value.Length);
                 fixed (double* value_ptr = value)
@@ -33101,7 +33101,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform1dvEXT"/>
-            public static unsafe void ProgramUniform1dvEXT(ProgramHandle program, int location, double[] value)
+            public static unsafe void ProgramUniform1dvEXT(int program, int location, double[] value)
             {
                 int count = (int)(value.Length);
                 fixed (double* value_ptr = value)
@@ -33110,7 +33110,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform1dvEXT"/>
-            public static unsafe void ProgramUniform1dvEXT(ProgramHandle program, int location, int count, in double value)
+            public static unsafe void ProgramUniform1dvEXT(int program, int location, int count, in double value)
             {
                 fixed (double* value_ptr = &value)
                 {
@@ -33118,7 +33118,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform2dvEXT"/>
-            public static unsafe void ProgramUniform2dvEXT(ProgramHandle program, int location, ReadOnlySpan<double> value)
+            public static unsafe void ProgramUniform2dvEXT(int program, int location, ReadOnlySpan<double> value)
             {
                 int count = (int)(value.Length / 2);
                 fixed (double* value_ptr = value)
@@ -33127,7 +33127,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform2dvEXT"/>
-            public static unsafe void ProgramUniform2dvEXT(ProgramHandle program, int location, double[] value)
+            public static unsafe void ProgramUniform2dvEXT(int program, int location, double[] value)
             {
                 int count = (int)(value.Length / 2);
                 fixed (double* value_ptr = value)
@@ -33136,7 +33136,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform2dvEXT"/>
-            public static unsafe void ProgramUniform2dvEXT(ProgramHandle program, int location, int count, in double value)
+            public static unsafe void ProgramUniform2dvEXT(int program, int location, int count, in double value)
             {
                 fixed (double* value_ptr = &value)
                 {
@@ -33144,7 +33144,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform3dvEXT"/>
-            public static unsafe void ProgramUniform3dvEXT(ProgramHandle program, int location, ReadOnlySpan<double> value)
+            public static unsafe void ProgramUniform3dvEXT(int program, int location, ReadOnlySpan<double> value)
             {
                 int count = (int)(value.Length / 3);
                 fixed (double* value_ptr = value)
@@ -33153,7 +33153,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform3dvEXT"/>
-            public static unsafe void ProgramUniform3dvEXT(ProgramHandle program, int location, double[] value)
+            public static unsafe void ProgramUniform3dvEXT(int program, int location, double[] value)
             {
                 int count = (int)(value.Length / 3);
                 fixed (double* value_ptr = value)
@@ -33162,7 +33162,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform3dvEXT"/>
-            public static unsafe void ProgramUniform3dvEXT(ProgramHandle program, int location, int count, in double value)
+            public static unsafe void ProgramUniform3dvEXT(int program, int location, int count, in double value)
             {
                 fixed (double* value_ptr = &value)
                 {
@@ -33170,7 +33170,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform4dvEXT"/>
-            public static unsafe void ProgramUniform4dvEXT(ProgramHandle program, int location, ReadOnlySpan<double> value)
+            public static unsafe void ProgramUniform4dvEXT(int program, int location, ReadOnlySpan<double> value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (double* value_ptr = value)
@@ -33179,7 +33179,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform4dvEXT"/>
-            public static unsafe void ProgramUniform4dvEXT(ProgramHandle program, int location, double[] value)
+            public static unsafe void ProgramUniform4dvEXT(int program, int location, double[] value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (double* value_ptr = value)
@@ -33188,7 +33188,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform4dvEXT"/>
-            public static unsafe void ProgramUniform4dvEXT(ProgramHandle program, int location, int count, in double value)
+            public static unsafe void ProgramUniform4dvEXT(int program, int location, int count, in double value)
             {
                 fixed (double* value_ptr = &value)
                 {
@@ -33196,7 +33196,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2dvEXT"/>
-            public static unsafe void ProgramUniformMatrix2dvEXT(ProgramHandle program, int location, bool transpose, ReadOnlySpan<double> value)
+            public static unsafe void ProgramUniformMatrix2dvEXT(int program, int location, bool transpose, ReadOnlySpan<double> value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (double* value_ptr = value)
@@ -33205,7 +33205,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2dvEXT"/>
-            public static unsafe void ProgramUniformMatrix2dvEXT(ProgramHandle program, int location, bool transpose, double[] value)
+            public static unsafe void ProgramUniformMatrix2dvEXT(int program, int location, bool transpose, double[] value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (double* value_ptr = value)
@@ -33214,7 +33214,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2dvEXT"/>
-            public static unsafe void ProgramUniformMatrix2dvEXT(ProgramHandle program, int location, int count, bool transpose, in double value)
+            public static unsafe void ProgramUniformMatrix2dvEXT(int program, int location, int count, bool transpose, in double value)
             {
                 fixed (double* value_ptr = &value)
                 {
@@ -33222,7 +33222,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3dvEXT"/>
-            public static unsafe void ProgramUniformMatrix3dvEXT(ProgramHandle program, int location, bool transpose, ReadOnlySpan<double> value)
+            public static unsafe void ProgramUniformMatrix3dvEXT(int program, int location, bool transpose, ReadOnlySpan<double> value)
             {
                 int count = (int)(value.Length / 9);
                 fixed (double* value_ptr = value)
@@ -33231,7 +33231,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3dvEXT"/>
-            public static unsafe void ProgramUniformMatrix3dvEXT(ProgramHandle program, int location, bool transpose, double[] value)
+            public static unsafe void ProgramUniformMatrix3dvEXT(int program, int location, bool transpose, double[] value)
             {
                 int count = (int)(value.Length / 9);
                 fixed (double* value_ptr = value)
@@ -33240,7 +33240,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3dvEXT"/>
-            public static unsafe void ProgramUniformMatrix3dvEXT(ProgramHandle program, int location, int count, bool transpose, in double value)
+            public static unsafe void ProgramUniformMatrix3dvEXT(int program, int location, int count, bool transpose, in double value)
             {
                 fixed (double* value_ptr = &value)
                 {
@@ -33248,7 +33248,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4dvEXT"/>
-            public static unsafe void ProgramUniformMatrix4dvEXT(ProgramHandle program, int location, bool transpose, ReadOnlySpan<double> value)
+            public static unsafe void ProgramUniformMatrix4dvEXT(int program, int location, bool transpose, ReadOnlySpan<double> value)
             {
                 int count = (int)(value.Length / 16);
                 fixed (double* value_ptr = value)
@@ -33257,7 +33257,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4dvEXT"/>
-            public static unsafe void ProgramUniformMatrix4dvEXT(ProgramHandle program, int location, bool transpose, double[] value)
+            public static unsafe void ProgramUniformMatrix4dvEXT(int program, int location, bool transpose, double[] value)
             {
                 int count = (int)(value.Length / 16);
                 fixed (double* value_ptr = value)
@@ -33266,7 +33266,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4dvEXT"/>
-            public static unsafe void ProgramUniformMatrix4dvEXT(ProgramHandle program, int location, int count, bool transpose, in double value)
+            public static unsafe void ProgramUniformMatrix4dvEXT(int program, int location, int count, bool transpose, in double value)
             {
                 fixed (double* value_ptr = &value)
                 {
@@ -33274,7 +33274,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x3dvEXT"/>
-            public static unsafe void ProgramUniformMatrix2x3dvEXT(ProgramHandle program, int location, bool transpose, ReadOnlySpan<double> value)
+            public static unsafe void ProgramUniformMatrix2x3dvEXT(int program, int location, bool transpose, ReadOnlySpan<double> value)
             {
                 int count = (int)(value.Length / 6);
                 fixed (double* value_ptr = value)
@@ -33283,7 +33283,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x3dvEXT"/>
-            public static unsafe void ProgramUniformMatrix2x3dvEXT(ProgramHandle program, int location, bool transpose, double[] value)
+            public static unsafe void ProgramUniformMatrix2x3dvEXT(int program, int location, bool transpose, double[] value)
             {
                 int count = (int)(value.Length / 6);
                 fixed (double* value_ptr = value)
@@ -33292,7 +33292,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x3dvEXT"/>
-            public static unsafe void ProgramUniformMatrix2x3dvEXT(ProgramHandle program, int location, int count, bool transpose, in double value)
+            public static unsafe void ProgramUniformMatrix2x3dvEXT(int program, int location, int count, bool transpose, in double value)
             {
                 fixed (double* value_ptr = &value)
                 {
@@ -33300,7 +33300,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x4dvEXT"/>
-            public static unsafe void ProgramUniformMatrix2x4dvEXT(ProgramHandle program, int location, bool transpose, ReadOnlySpan<double> value)
+            public static unsafe void ProgramUniformMatrix2x4dvEXT(int program, int location, bool transpose, ReadOnlySpan<double> value)
             {
                 int count = (int)(value.Length / 8);
                 fixed (double* value_ptr = value)
@@ -33309,7 +33309,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x4dvEXT"/>
-            public static unsafe void ProgramUniformMatrix2x4dvEXT(ProgramHandle program, int location, bool transpose, double[] value)
+            public static unsafe void ProgramUniformMatrix2x4dvEXT(int program, int location, bool transpose, double[] value)
             {
                 int count = (int)(value.Length / 8);
                 fixed (double* value_ptr = value)
@@ -33318,7 +33318,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x4dvEXT"/>
-            public static unsafe void ProgramUniformMatrix2x4dvEXT(ProgramHandle program, int location, int count, bool transpose, in double value)
+            public static unsafe void ProgramUniformMatrix2x4dvEXT(int program, int location, int count, bool transpose, in double value)
             {
                 fixed (double* value_ptr = &value)
                 {
@@ -33326,7 +33326,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2dvEXT"/>
-            public static unsafe void ProgramUniformMatrix3x2dvEXT(ProgramHandle program, int location, bool transpose, ReadOnlySpan<double> value)
+            public static unsafe void ProgramUniformMatrix3x2dvEXT(int program, int location, bool transpose, ReadOnlySpan<double> value)
             {
                 int count = (int)(value.Length / 6);
                 fixed (double* value_ptr = value)
@@ -33335,7 +33335,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2dvEXT"/>
-            public static unsafe void ProgramUniformMatrix3x2dvEXT(ProgramHandle program, int location, bool transpose, double[] value)
+            public static unsafe void ProgramUniformMatrix3x2dvEXT(int program, int location, bool transpose, double[] value)
             {
                 int count = (int)(value.Length / 6);
                 fixed (double* value_ptr = value)
@@ -33344,7 +33344,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2dvEXT"/>
-            public static unsafe void ProgramUniformMatrix3x2dvEXT(ProgramHandle program, int location, int count, bool transpose, in double value)
+            public static unsafe void ProgramUniformMatrix3x2dvEXT(int program, int location, int count, bool transpose, in double value)
             {
                 fixed (double* value_ptr = &value)
                 {
@@ -33352,7 +33352,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x4dvEXT"/>
-            public static unsafe void ProgramUniformMatrix3x4dvEXT(ProgramHandle program, int location, bool transpose, ReadOnlySpan<double> value)
+            public static unsafe void ProgramUniformMatrix3x4dvEXT(int program, int location, bool transpose, ReadOnlySpan<double> value)
             {
                 int count = (int)(value.Length / 12);
                 fixed (double* value_ptr = value)
@@ -33361,7 +33361,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x4dvEXT"/>
-            public static unsafe void ProgramUniformMatrix3x4dvEXT(ProgramHandle program, int location, bool transpose, double[] value)
+            public static unsafe void ProgramUniformMatrix3x4dvEXT(int program, int location, bool transpose, double[] value)
             {
                 int count = (int)(value.Length / 12);
                 fixed (double* value_ptr = value)
@@ -33370,7 +33370,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x4dvEXT"/>
-            public static unsafe void ProgramUniformMatrix3x4dvEXT(ProgramHandle program, int location, int count, bool transpose, in double value)
+            public static unsafe void ProgramUniformMatrix3x4dvEXT(int program, int location, int count, bool transpose, in double value)
             {
                 fixed (double* value_ptr = &value)
                 {
@@ -33378,7 +33378,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x2dvEXT"/>
-            public static unsafe void ProgramUniformMatrix4x2dvEXT(ProgramHandle program, int location, bool transpose, ReadOnlySpan<double> value)
+            public static unsafe void ProgramUniformMatrix4x2dvEXT(int program, int location, bool transpose, ReadOnlySpan<double> value)
             {
                 int count = (int)(value.Length / 8);
                 fixed (double* value_ptr = value)
@@ -33387,7 +33387,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x2dvEXT"/>
-            public static unsafe void ProgramUniformMatrix4x2dvEXT(ProgramHandle program, int location, bool transpose, double[] value)
+            public static unsafe void ProgramUniformMatrix4x2dvEXT(int program, int location, bool transpose, double[] value)
             {
                 int count = (int)(value.Length / 8);
                 fixed (double* value_ptr = value)
@@ -33396,7 +33396,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x2dvEXT"/>
-            public static unsafe void ProgramUniformMatrix4x2dvEXT(ProgramHandle program, int location, int count, bool transpose, in double value)
+            public static unsafe void ProgramUniformMatrix4x2dvEXT(int program, int location, int count, bool transpose, in double value)
             {
                 fixed (double* value_ptr = &value)
                 {
@@ -33404,7 +33404,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x3dvEXT"/>
-            public static unsafe void ProgramUniformMatrix4x3dvEXT(ProgramHandle program, int location, bool transpose, ReadOnlySpan<double> value)
+            public static unsafe void ProgramUniformMatrix4x3dvEXT(int program, int location, bool transpose, ReadOnlySpan<double> value)
             {
                 int count = (int)(value.Length / 12);
                 fixed (double* value_ptr = value)
@@ -33413,7 +33413,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x3dvEXT"/>
-            public static unsafe void ProgramUniformMatrix4x3dvEXT(ProgramHandle program, int location, bool transpose, double[] value)
+            public static unsafe void ProgramUniformMatrix4x3dvEXT(int program, int location, bool transpose, double[] value)
             {
                 int count = (int)(value.Length / 12);
                 fixed (double* value_ptr = value)
@@ -33422,7 +33422,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x3dvEXT"/>
-            public static unsafe void ProgramUniformMatrix4x3dvEXT(ProgramHandle program, int location, int count, bool transpose, in double value)
+            public static unsafe void ProgramUniformMatrix4x3dvEXT(int program, int location, int count, bool transpose, in double value)
             {
                 fixed (double* value_ptr = &value)
                 {
@@ -33457,13 +33457,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="NamedBufferStorageExternalEXT"/>
-            public static unsafe void NamedBufferStorageExternalEXT(BufferHandle buffer, IntPtr offset, nint size, IntPtr clientBuffer, BufferStorageMask flags)
+            public static unsafe void NamedBufferStorageExternalEXT(int buffer, IntPtr offset, nint size, IntPtr clientBuffer, BufferStorageMask flags)
             {
                 void* clientBuffer_vptr = (void*)clientBuffer;
                 NamedBufferStorageExternalEXT(buffer, offset, size, clientBuffer_vptr, flags);
             }
             /// <inheritdoc cref="NamedBufferStorageExternalEXT"/>
-            public static unsafe void NamedBufferStorageExternalEXT<T1>(BufferHandle buffer, IntPtr offset, nint size, ref T1 clientBuffer, BufferStorageMask flags)
+            public static unsafe void NamedBufferStorageExternalEXT<T1>(int buffer, IntPtr offset, nint size, ref T1 clientBuffer, BufferStorageMask flags)
                 where T1 : unmanaged
             {
                 fixed (void* clientBuffer_ptr = &clientBuffer)
@@ -33553,53 +33553,53 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="DeleteRenderbuffersEXT"/>
-            public static unsafe void DeleteRenderbuffersEXT(ReadOnlySpan<RenderbufferHandle> renderbuffers)
+            public static unsafe void DeleteRenderbuffersEXT(ReadOnlySpan<int> renderbuffers)
             {
                 int n = (int)(renderbuffers.Length);
-                fixed (RenderbufferHandle* renderbuffers_ptr = renderbuffers)
+                fixed (int* renderbuffers_ptr = renderbuffers)
                 {
                     DeleteRenderbuffersEXT(n, renderbuffers_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteRenderbuffersEXT"/>
-            public static unsafe void DeleteRenderbuffersEXT(RenderbufferHandle[] renderbuffers)
+            public static unsafe void DeleteRenderbuffersEXT(int[] renderbuffers)
             {
                 int n = (int)(renderbuffers.Length);
-                fixed (RenderbufferHandle* renderbuffers_ptr = renderbuffers)
+                fixed (int* renderbuffers_ptr = renderbuffers)
                 {
                     DeleteRenderbuffersEXT(n, renderbuffers_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteRenderbuffersEXT"/>
-            public static unsafe void DeleteRenderbuffersEXT(int n, in RenderbufferHandle renderbuffers)
+            public static unsafe void DeleteRenderbuffersEXT(int n, in int renderbuffers)
             {
-                fixed (RenderbufferHandle* renderbuffers_ptr = &renderbuffers)
+                fixed (int* renderbuffers_ptr = &renderbuffers)
                 {
                     DeleteRenderbuffersEXT(n, renderbuffers_ptr);
                 }
             }
             /// <inheritdoc cref="GenRenderbuffersEXT"/>
-            public static unsafe void GenRenderbuffersEXT(Span<RenderbufferHandle> renderbuffers)
+            public static unsafe void GenRenderbuffersEXT(Span<int> renderbuffers)
             {
                 int n = (int)(renderbuffers.Length);
-                fixed (RenderbufferHandle* renderbuffers_ptr = renderbuffers)
+                fixed (int* renderbuffers_ptr = renderbuffers)
                 {
                     GenRenderbuffersEXT(n, renderbuffers_ptr);
                 }
             }
             /// <inheritdoc cref="GenRenderbuffersEXT"/>
-            public static unsafe void GenRenderbuffersEXT(RenderbufferHandle[] renderbuffers)
+            public static unsafe void GenRenderbuffersEXT(int[] renderbuffers)
             {
                 int n = (int)(renderbuffers.Length);
-                fixed (RenderbufferHandle* renderbuffers_ptr = renderbuffers)
+                fixed (int* renderbuffers_ptr = renderbuffers)
                 {
                     GenRenderbuffersEXT(n, renderbuffers_ptr);
                 }
             }
             /// <inheritdoc cref="GenRenderbuffersEXT"/>
-            public static unsafe void GenRenderbuffersEXT(int n, ref RenderbufferHandle renderbuffers)
+            public static unsafe void GenRenderbuffersEXT(int n, ref int renderbuffers)
             {
-                fixed (RenderbufferHandle* renderbuffers_ptr = &renderbuffers)
+                fixed (int* renderbuffers_ptr = &renderbuffers)
                 {
                     GenRenderbuffersEXT(n, renderbuffers_ptr);
                 }
@@ -33629,53 +33629,53 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="DeleteFramebuffersEXT"/>
-            public static unsafe void DeleteFramebuffersEXT(ReadOnlySpan<FramebufferHandle> framebuffers)
+            public static unsafe void DeleteFramebuffersEXT(ReadOnlySpan<int> framebuffers)
             {
                 int n = (int)(framebuffers.Length);
-                fixed (FramebufferHandle* framebuffers_ptr = framebuffers)
+                fixed (int* framebuffers_ptr = framebuffers)
                 {
                     DeleteFramebuffersEXT(n, framebuffers_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteFramebuffersEXT"/>
-            public static unsafe void DeleteFramebuffersEXT(FramebufferHandle[] framebuffers)
+            public static unsafe void DeleteFramebuffersEXT(int[] framebuffers)
             {
                 int n = (int)(framebuffers.Length);
-                fixed (FramebufferHandle* framebuffers_ptr = framebuffers)
+                fixed (int* framebuffers_ptr = framebuffers)
                 {
                     DeleteFramebuffersEXT(n, framebuffers_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteFramebuffersEXT"/>
-            public static unsafe void DeleteFramebuffersEXT(int n, in FramebufferHandle framebuffers)
+            public static unsafe void DeleteFramebuffersEXT(int n, in int framebuffers)
             {
-                fixed (FramebufferHandle* framebuffers_ptr = &framebuffers)
+                fixed (int* framebuffers_ptr = &framebuffers)
                 {
                     DeleteFramebuffersEXT(n, framebuffers_ptr);
                 }
             }
             /// <inheritdoc cref="GenFramebuffersEXT"/>
-            public static unsafe void GenFramebuffersEXT(Span<FramebufferHandle> framebuffers)
+            public static unsafe void GenFramebuffersEXT(Span<int> framebuffers)
             {
                 int n = (int)(framebuffers.Length);
-                fixed (FramebufferHandle* framebuffers_ptr = framebuffers)
+                fixed (int* framebuffers_ptr = framebuffers)
                 {
                     GenFramebuffersEXT(n, framebuffers_ptr);
                 }
             }
             /// <inheritdoc cref="GenFramebuffersEXT"/>
-            public static unsafe void GenFramebuffersEXT(FramebufferHandle[] framebuffers)
+            public static unsafe void GenFramebuffersEXT(int[] framebuffers)
             {
                 int n = (int)(framebuffers.Length);
-                fixed (FramebufferHandle* framebuffers_ptr = framebuffers)
+                fixed (int* framebuffers_ptr = framebuffers)
                 {
                     GenFramebuffersEXT(n, framebuffers_ptr);
                 }
             }
             /// <inheritdoc cref="GenFramebuffersEXT"/>
-            public static unsafe void GenFramebuffersEXT(int n, ref FramebufferHandle framebuffers)
+            public static unsafe void GenFramebuffersEXT(int n, ref int framebuffers)
             {
-                fixed (FramebufferHandle* framebuffers_ptr = &framebuffers)
+                fixed (int* framebuffers_ptr = &framebuffers)
                 {
                     GenFramebuffersEXT(n, framebuffers_ptr);
                 }
@@ -33757,7 +33757,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetUniformuivEXT"/>
-            public static unsafe void GetUniformuivEXT(ProgramHandle program, int location, Span<uint> parameters)
+            public static unsafe void GetUniformuivEXT(int program, int location, Span<uint> parameters)
             {
                 fixed (uint* parameters_ptr = parameters)
                 {
@@ -33765,7 +33765,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetUniformuivEXT"/>
-            public static unsafe void GetUniformuivEXT(ProgramHandle program, int location, uint[] parameters)
+            public static unsafe void GetUniformuivEXT(int program, int location, uint[] parameters)
             {
                 fixed (uint* parameters_ptr = parameters)
                 {
@@ -33773,7 +33773,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetUniformuivEXT"/>
-            public static unsafe void GetUniformuivEXT(ProgramHandle program, int location, ref uint parameters)
+            public static unsafe void GetUniformuivEXT(int program, int location, ref uint parameters)
             {
                 fixed (uint* parameters_ptr = &parameters)
                 {
@@ -33781,14 +33781,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="BindFragDataLocationEXT"/>
-            public static unsafe void BindFragDataLocationEXT(ProgramHandle program, uint color, string name)
+            public static unsafe void BindFragDataLocationEXT(int program, uint color, string name)
             {
                 byte* name_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(name);
                 BindFragDataLocationEXT(program, color, name_ptr);
                 Marshal.FreeCoTaskMem((IntPtr)name_ptr);
             }
             /// <inheritdoc cref="GetFragDataLocationEXT"/>
-            public static unsafe int GetFragDataLocationEXT(ProgramHandle program, string name)
+            public static unsafe int GetFragDataLocationEXT(int program, string name)
             {
                 int returnValue;
                 byte* name_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(name);
@@ -34917,11 +34917,11 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="WaitSemaphoreEXT"/>
-            public static unsafe void WaitSemaphoreEXT(uint semaphore, uint numBufferBarriers, ReadOnlySpan<BufferHandle> buffers, uint numTextureBarriers, ReadOnlySpan<TextureHandle> textures, ReadOnlySpan<TextureLayout> srcLayouts)
+            public static unsafe void WaitSemaphoreEXT(uint semaphore, uint numBufferBarriers, ReadOnlySpan<int> buffers, uint numTextureBarriers, ReadOnlySpan<int> textures, ReadOnlySpan<TextureLayout> srcLayouts)
             {
-                fixed (BufferHandle* buffers_ptr = buffers)
+                fixed (int* buffers_ptr = buffers)
                 {
-                    fixed (TextureHandle* textures_ptr = textures)
+                    fixed (int* textures_ptr = textures)
                     {
                         fixed (TextureLayout* srcLayouts_ptr = srcLayouts)
                         {
@@ -34931,11 +34931,11 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="WaitSemaphoreEXT"/>
-            public static unsafe void WaitSemaphoreEXT(uint semaphore, uint numBufferBarriers, BufferHandle[] buffers, uint numTextureBarriers, TextureHandle[] textures, TextureLayout[] srcLayouts)
+            public static unsafe void WaitSemaphoreEXT(uint semaphore, uint numBufferBarriers, int[] buffers, uint numTextureBarriers, int[] textures, TextureLayout[] srcLayouts)
             {
-                fixed (BufferHandle* buffers_ptr = buffers)
+                fixed (int* buffers_ptr = buffers)
                 {
-                    fixed (TextureHandle* textures_ptr = textures)
+                    fixed (int* textures_ptr = textures)
                     {
                         fixed (TextureLayout* srcLayouts_ptr = srcLayouts)
                         {
@@ -34945,21 +34945,21 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="WaitSemaphoreEXT"/>
-            public static unsafe void WaitSemaphoreEXT(uint semaphore, uint numBufferBarriers, in BufferHandle buffers, uint numTextureBarriers, in TextureHandle textures, in TextureLayout srcLayouts)
+            public static unsafe void WaitSemaphoreEXT(uint semaphore, uint numBufferBarriers, in int buffers, uint numTextureBarriers, in int textures, in TextureLayout srcLayouts)
             {
-                fixed (BufferHandle* buffers_ptr = &buffers)
-                fixed (TextureHandle* textures_ptr = &textures)
+                fixed (int* buffers_ptr = &buffers)
+                fixed (int* textures_ptr = &textures)
                 fixed (TextureLayout* srcLayouts_ptr = &srcLayouts)
                 {
                     WaitSemaphoreEXT(semaphore, numBufferBarriers, buffers_ptr, numTextureBarriers, textures_ptr, srcLayouts_ptr);
                 }
             }
             /// <inheritdoc cref="SignalSemaphoreEXT"/>
-            public static unsafe void SignalSemaphoreEXT(uint semaphore, uint numBufferBarriers, ReadOnlySpan<BufferHandle> buffers, uint numTextureBarriers, ReadOnlySpan<TextureHandle> textures, ReadOnlySpan<TextureLayout> dstLayouts)
+            public static unsafe void SignalSemaphoreEXT(uint semaphore, uint numBufferBarriers, ReadOnlySpan<int> buffers, uint numTextureBarriers, ReadOnlySpan<int> textures, ReadOnlySpan<TextureLayout> dstLayouts)
             {
-                fixed (BufferHandle* buffers_ptr = buffers)
+                fixed (int* buffers_ptr = buffers)
                 {
-                    fixed (TextureHandle* textures_ptr = textures)
+                    fixed (int* textures_ptr = textures)
                     {
                         fixed (TextureLayout* dstLayouts_ptr = dstLayouts)
                         {
@@ -34969,11 +34969,11 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="SignalSemaphoreEXT"/>
-            public static unsafe void SignalSemaphoreEXT(uint semaphore, uint numBufferBarriers, BufferHandle[] buffers, uint numTextureBarriers, TextureHandle[] textures, TextureLayout[] dstLayouts)
+            public static unsafe void SignalSemaphoreEXT(uint semaphore, uint numBufferBarriers, int[] buffers, uint numTextureBarriers, int[] textures, TextureLayout[] dstLayouts)
             {
-                fixed (BufferHandle* buffers_ptr = buffers)
+                fixed (int* buffers_ptr = buffers)
                 {
-                    fixed (TextureHandle* textures_ptr = textures)
+                    fixed (int* textures_ptr = textures)
                     {
                         fixed (TextureLayout* dstLayouts_ptr = dstLayouts)
                         {
@@ -34983,10 +34983,10 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="SignalSemaphoreEXT"/>
-            public static unsafe void SignalSemaphoreEXT(uint semaphore, uint numBufferBarriers, in BufferHandle buffers, uint numTextureBarriers, in TextureHandle textures, in TextureLayout dstLayouts)
+            public static unsafe void SignalSemaphoreEXT(uint semaphore, uint numBufferBarriers, in int buffers, uint numTextureBarriers, in int textures, in TextureLayout dstLayouts)
             {
-                fixed (BufferHandle* buffers_ptr = &buffers)
-                fixed (TextureHandle* textures_ptr = &textures)
+                fixed (int* buffers_ptr = &buffers)
+                fixed (int* textures_ptr = &textures)
                 fixed (TextureLayout* dstLayouts_ptr = &dstLayouts)
                 {
                     SignalSemaphoreEXT(semaphore, numBufferBarriers, buffers_ptr, numTextureBarriers, textures_ptr, dstLayouts_ptr);
@@ -35233,68 +35233,68 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="CreateShaderProgramEXT"/>
-            public static unsafe ProgramHandle CreateShaderProgramEXT(ShaderType type, string str)
+            public static unsafe int CreateShaderProgramEXT(ShaderType type, string str)
             {
-                ProgramHandle returnValue;
+                int returnValue;
                 byte* str_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(str);
                 returnValue = CreateShaderProgramEXT(type, str_ptr);
                 Marshal.FreeCoTaskMem((IntPtr)str_ptr);
                 return returnValue;
             }
             /// <inheritdoc cref="DeleteProgramPipelinesEXT"/>
-            public static unsafe void DeleteProgramPipelinesEXT(ReadOnlySpan<ProgramPipelineHandle> pipelines)
+            public static unsafe void DeleteProgramPipelinesEXT(ReadOnlySpan<int> pipelines)
             {
                 int n = (int)(pipelines.Length);
-                fixed (ProgramPipelineHandle* pipelines_ptr = pipelines)
+                fixed (int* pipelines_ptr = pipelines)
                 {
                     DeleteProgramPipelinesEXT(n, pipelines_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteProgramPipelinesEXT"/>
-            public static unsafe void DeleteProgramPipelinesEXT(ProgramPipelineHandle[] pipelines)
+            public static unsafe void DeleteProgramPipelinesEXT(int[] pipelines)
             {
                 int n = (int)(pipelines.Length);
-                fixed (ProgramPipelineHandle* pipelines_ptr = pipelines)
+                fixed (int* pipelines_ptr = pipelines)
                 {
                     DeleteProgramPipelinesEXT(n, pipelines_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteProgramPipelinesEXT"/>
-            public static unsafe void DeleteProgramPipelinesEXT(int n, in ProgramPipelineHandle pipelines)
+            public static unsafe void DeleteProgramPipelinesEXT(int n, in int pipelines)
             {
-                fixed (ProgramPipelineHandle* pipelines_ptr = &pipelines)
+                fixed (int* pipelines_ptr = &pipelines)
                 {
                     DeleteProgramPipelinesEXT(n, pipelines_ptr);
                 }
             }
             /// <inheritdoc cref="GenProgramPipelinesEXT"/>
-            public static unsafe void GenProgramPipelinesEXT(Span<ProgramPipelineHandle> pipelines)
+            public static unsafe void GenProgramPipelinesEXT(Span<int> pipelines)
             {
                 int n = (int)(pipelines.Length);
-                fixed (ProgramPipelineHandle* pipelines_ptr = pipelines)
+                fixed (int* pipelines_ptr = pipelines)
                 {
                     GenProgramPipelinesEXT(n, pipelines_ptr);
                 }
             }
             /// <inheritdoc cref="GenProgramPipelinesEXT"/>
-            public static unsafe void GenProgramPipelinesEXT(ProgramPipelineHandle[] pipelines)
+            public static unsafe void GenProgramPipelinesEXT(int[] pipelines)
             {
                 int n = (int)(pipelines.Length);
-                fixed (ProgramPipelineHandle* pipelines_ptr = pipelines)
+                fixed (int* pipelines_ptr = pipelines)
                 {
                     GenProgramPipelinesEXT(n, pipelines_ptr);
                 }
             }
             /// <inheritdoc cref="GenProgramPipelinesEXT"/>
-            public static unsafe void GenProgramPipelinesEXT(int n, ref ProgramPipelineHandle pipelines)
+            public static unsafe void GenProgramPipelinesEXT(int n, ref int pipelines)
             {
-                fixed (ProgramPipelineHandle* pipelines_ptr = &pipelines)
+                fixed (int* pipelines_ptr = &pipelines)
                 {
                     GenProgramPipelinesEXT(n, pipelines_ptr);
                 }
             }
             /// <inheritdoc cref="GetProgramPipelineInfoLogEXT"/>
-            public static unsafe string GetProgramPipelineInfoLogEXT(ProgramPipelineHandle pipeline, int bufSize, Span<int> length)
+            public static unsafe string GetProgramPipelineInfoLogEXT(int pipeline, int bufSize, Span<int> length)
             {
                 string infoLog;
                 fixed (int* length_ptr = length)
@@ -35307,7 +35307,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return infoLog;
             }
             /// <inheritdoc cref="GetProgramPipelineInfoLogEXT"/>
-            public static unsafe void GetProgramPipelineInfoLogEXT(ProgramPipelineHandle pipeline, int bufSize, Span<int> length, out string infoLog)
+            public static unsafe void GetProgramPipelineInfoLogEXT(int pipeline, int bufSize, Span<int> length, out string infoLog)
             {
                 fixed (int* length_ptr = length)
                 {
@@ -35318,7 +35318,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetProgramPipelineInfoLogEXT"/>
-            public static unsafe string GetProgramPipelineInfoLogEXT(ProgramPipelineHandle pipeline, int bufSize, int[] length)
+            public static unsafe string GetProgramPipelineInfoLogEXT(int pipeline, int bufSize, int[] length)
             {
                 string infoLog;
                 fixed (int* length_ptr = length)
@@ -35331,7 +35331,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return infoLog;
             }
             /// <inheritdoc cref="GetProgramPipelineInfoLogEXT"/>
-            public static unsafe void GetProgramPipelineInfoLogEXT(ProgramPipelineHandle pipeline, int bufSize, int[] length, out string infoLog)
+            public static unsafe void GetProgramPipelineInfoLogEXT(int pipeline, int bufSize, int[] length, out string infoLog)
             {
                 fixed (int* length_ptr = length)
                 {
@@ -35342,7 +35342,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetProgramPipelineInfoLogEXT"/>
-            public static unsafe string GetProgramPipelineInfoLogEXT(ProgramPipelineHandle pipeline, int bufSize, ref int length)
+            public static unsafe string GetProgramPipelineInfoLogEXT(int pipeline, int bufSize, ref int length)
             {
                 string infoLog;
                 fixed (int* length_ptr = &length)
@@ -35355,7 +35355,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return infoLog;
             }
             /// <inheritdoc cref="GetProgramPipelineInfoLogEXT"/>
-            public static unsafe void GetProgramPipelineInfoLogEXT(ProgramPipelineHandle pipeline, int bufSize, ref int length, out string infoLog)
+            public static unsafe void GetProgramPipelineInfoLogEXT(int pipeline, int bufSize, ref int length, out string infoLog)
             {
                 fixed (int* length_ptr = &length)
                 {
@@ -35366,7 +35366,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetProgramPipelineivEXT"/>
-            public static unsafe void GetProgramPipelineivEXT(ProgramPipelineHandle pipeline, PipelineParameterName pname, ref int parameters)
+            public static unsafe void GetProgramPipelineivEXT(int pipeline, PipelineParameterName pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -35602,10 +35602,10 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="AreTexturesResidentEXT"/>
-            public static unsafe bool AreTexturesResidentEXT(int n, ReadOnlySpan<TextureHandle> textures, Span<bool> residences)
+            public static unsafe bool AreTexturesResidentEXT(int n, ReadOnlySpan<int> textures, Span<bool> residences)
             {
                 bool returnValue;
-                fixed (TextureHandle* textures_ptr = textures)
+                fixed (int* textures_ptr = textures)
                 {
                     fixed (bool* residences_ptr = residences)
                     {
@@ -35615,10 +35615,10 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return returnValue;
             }
             /// <inheritdoc cref="AreTexturesResidentEXT"/>
-            public static unsafe bool AreTexturesResidentEXT(int n, TextureHandle[] textures, bool[] residences)
+            public static unsafe bool AreTexturesResidentEXT(int n, int[] textures, bool[] residences)
             {
                 bool returnValue;
-                fixed (TextureHandle* textures_ptr = textures)
+                fixed (int* textures_ptr = textures)
                 {
                     fixed (bool* residences_ptr = residences)
                     {
@@ -35628,10 +35628,10 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return returnValue;
             }
             /// <inheritdoc cref="AreTexturesResidentEXT"/>
-            public static unsafe bool AreTexturesResidentEXT(int n, in TextureHandle textures, ref bool residences)
+            public static unsafe bool AreTexturesResidentEXT(int n, in int textures, ref bool residences)
             {
                 bool returnValue;
-                fixed (TextureHandle* textures_ptr = &textures)
+                fixed (int* textures_ptr = &textures)
                 fixed (bool* residences_ptr = &residences)
                 {
                     returnValue = AreTexturesResidentEXT(n, textures_ptr, residences_ptr);
@@ -35639,61 +35639,61 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return returnValue;
             }
             /// <inheritdoc cref="DeleteTexturesEXT"/>
-            public static unsafe void DeleteTexturesEXT(ReadOnlySpan<TextureHandle> textures)
+            public static unsafe void DeleteTexturesEXT(ReadOnlySpan<int> textures)
             {
                 int n = (int)(textures.Length);
-                fixed (TextureHandle* textures_ptr = textures)
+                fixed (int* textures_ptr = textures)
                 {
                     DeleteTexturesEXT(n, textures_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteTexturesEXT"/>
-            public static unsafe void DeleteTexturesEXT(TextureHandle[] textures)
+            public static unsafe void DeleteTexturesEXT(int[] textures)
             {
                 int n = (int)(textures.Length);
-                fixed (TextureHandle* textures_ptr = textures)
+                fixed (int* textures_ptr = textures)
                 {
                     DeleteTexturesEXT(n, textures_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteTexturesEXT"/>
-            public static unsafe void DeleteTexturesEXT(int n, in TextureHandle textures)
+            public static unsafe void DeleteTexturesEXT(int n, in int textures)
             {
-                fixed (TextureHandle* textures_ptr = &textures)
+                fixed (int* textures_ptr = &textures)
                 {
                     DeleteTexturesEXT(n, textures_ptr);
                 }
             }
             /// <inheritdoc cref="GenTexturesEXT"/>
-            public static unsafe void GenTexturesEXT(Span<TextureHandle> textures)
+            public static unsafe void GenTexturesEXT(Span<int> textures)
             {
                 int n = (int)(textures.Length);
-                fixed (TextureHandle* textures_ptr = textures)
+                fixed (int* textures_ptr = textures)
                 {
                     GenTexturesEXT(n, textures_ptr);
                 }
             }
             /// <inheritdoc cref="GenTexturesEXT"/>
-            public static unsafe void GenTexturesEXT(TextureHandle[] textures)
+            public static unsafe void GenTexturesEXT(int[] textures)
             {
                 int n = (int)(textures.Length);
-                fixed (TextureHandle* textures_ptr = textures)
+                fixed (int* textures_ptr = textures)
                 {
                     GenTexturesEXT(n, textures_ptr);
                 }
             }
             /// <inheritdoc cref="GenTexturesEXT"/>
-            public static unsafe void GenTexturesEXT(int n, ref TextureHandle textures)
+            public static unsafe void GenTexturesEXT(int n, ref int textures)
             {
-                fixed (TextureHandle* textures_ptr = &textures)
+                fixed (int* textures_ptr = &textures)
                 {
                     GenTexturesEXT(n, textures_ptr);
                 }
             }
             /// <inheritdoc cref="PrioritizeTexturesEXT"/>
-            public static unsafe void PrioritizeTexturesEXT(int n, ReadOnlySpan<TextureHandle> textures, ReadOnlySpan<float> priorities)
+            public static unsafe void PrioritizeTexturesEXT(int n, ReadOnlySpan<int> textures, ReadOnlySpan<float> priorities)
             {
-                fixed (TextureHandle* textures_ptr = textures)
+                fixed (int* textures_ptr = textures)
                 {
                     fixed (float* priorities_ptr = priorities)
                     {
@@ -35702,9 +35702,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="PrioritizeTexturesEXT"/>
-            public static unsafe void PrioritizeTexturesEXT(int n, TextureHandle[] textures, float[] priorities)
+            public static unsafe void PrioritizeTexturesEXT(int n, int[] textures, float[] priorities)
             {
-                fixed (TextureHandle* textures_ptr = textures)
+                fixed (int* textures_ptr = textures)
                 {
                     fixed (float* priorities_ptr = priorities)
                     {
@@ -35713,16 +35713,16 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="PrioritizeTexturesEXT"/>
-            public static unsafe void PrioritizeTexturesEXT(int n, in TextureHandle textures, in float priorities)
+            public static unsafe void PrioritizeTexturesEXT(int n, in int textures, in float priorities)
             {
-                fixed (TextureHandle* textures_ptr = &textures)
+                fixed (int* textures_ptr = &textures)
                 fixed (float* priorities_ptr = &priorities)
                 {
                     PrioritizeTexturesEXT(n, textures_ptr, priorities_ptr);
                 }
             }
             /// <inheritdoc cref="GetQueryObjecti64vEXT"/>
-            public static unsafe void GetQueryObjecti64vEXT(QueryHandle id, QueryObjectParameterName pname, Span<long> parameters)
+            public static unsafe void GetQueryObjecti64vEXT(int id, QueryObjectParameterName pname, Span<long> parameters)
             {
                 fixed (long* parameters_ptr = parameters)
                 {
@@ -35730,7 +35730,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetQueryObjecti64vEXT"/>
-            public static unsafe void GetQueryObjecti64vEXT(QueryHandle id, QueryObjectParameterName pname, long[] parameters)
+            public static unsafe void GetQueryObjecti64vEXT(int id, QueryObjectParameterName pname, long[] parameters)
             {
                 fixed (long* parameters_ptr = parameters)
                 {
@@ -35738,7 +35738,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetQueryObjecti64vEXT"/>
-            public static unsafe void GetQueryObjecti64vEXT(QueryHandle id, QueryObjectParameterName pname, ref long parameters)
+            public static unsafe void GetQueryObjecti64vEXT(int id, QueryObjectParameterName pname, ref long parameters)
             {
                 fixed (long* parameters_ptr = &parameters)
                 {
@@ -35746,7 +35746,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetQueryObjectui64vEXT"/>
-            public static unsafe void GetQueryObjectui64vEXT(QueryHandle id, QueryObjectParameterName pname, Span<ulong> parameters)
+            public static unsafe void GetQueryObjectui64vEXT(int id, QueryObjectParameterName pname, Span<ulong> parameters)
             {
                 fixed (ulong* parameters_ptr = parameters)
                 {
@@ -35754,7 +35754,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetQueryObjectui64vEXT"/>
-            public static unsafe void GetQueryObjectui64vEXT(QueryHandle id, QueryObjectParameterName pname, ulong[] parameters)
+            public static unsafe void GetQueryObjectui64vEXT(int id, QueryObjectParameterName pname, ulong[] parameters)
             {
                 fixed (ulong* parameters_ptr = parameters)
                 {
@@ -35762,7 +35762,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetQueryObjectui64vEXT"/>
-            public static unsafe void GetQueryObjectui64vEXT(QueryHandle id, QueryObjectParameterName pname, ref ulong parameters)
+            public static unsafe void GetQueryObjectui64vEXT(int id, QueryObjectParameterName pname, ref ulong parameters)
             {
                 fixed (ulong* parameters_ptr = &parameters)
                 {
@@ -35770,7 +35770,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetTransformFeedbackVaryingEXT"/>
-            public static unsafe string GetTransformFeedbackVaryingEXT(ProgramHandle program, uint index, int bufSize, Span<int> length, Span<int> size, Span<AttributeType> type)
+            public static unsafe string GetTransformFeedbackVaryingEXT(int program, uint index, int bufSize, Span<int> length, Span<int> size, Span<AttributeType> type)
             {
                 string name;
                 fixed (int* length_ptr = length)
@@ -35789,7 +35789,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return name;
             }
             /// <inheritdoc cref="GetTransformFeedbackVaryingEXT"/>
-            public static unsafe void GetTransformFeedbackVaryingEXT(ProgramHandle program, uint index, int bufSize, Span<int> length, Span<int> size, Span<AttributeType> type, out string name)
+            public static unsafe void GetTransformFeedbackVaryingEXT(int program, uint index, int bufSize, Span<int> length, Span<int> size, Span<AttributeType> type, out string name)
             {
                 fixed (int* length_ptr = length)
                 {
@@ -35806,7 +35806,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetTransformFeedbackVaryingEXT"/>
-            public static unsafe string GetTransformFeedbackVaryingEXT(ProgramHandle program, uint index, int bufSize, int[] length, int[] size, AttributeType[] type)
+            public static unsafe string GetTransformFeedbackVaryingEXT(int program, uint index, int bufSize, int[] length, int[] size, AttributeType[] type)
             {
                 string name;
                 fixed (int* length_ptr = length)
@@ -35825,7 +35825,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return name;
             }
             /// <inheritdoc cref="GetTransformFeedbackVaryingEXT"/>
-            public static unsafe void GetTransformFeedbackVaryingEXT(ProgramHandle program, uint index, int bufSize, int[] length, int[] size, AttributeType[] type, out string name)
+            public static unsafe void GetTransformFeedbackVaryingEXT(int program, uint index, int bufSize, int[] length, int[] size, AttributeType[] type, out string name)
             {
                 fixed (int* length_ptr = length)
                 {
@@ -35842,7 +35842,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetTransformFeedbackVaryingEXT"/>
-            public static unsafe string GetTransformFeedbackVaryingEXT(ProgramHandle program, uint index, int bufSize, ref int length, ref int size, ref AttributeType type)
+            public static unsafe string GetTransformFeedbackVaryingEXT(int program, uint index, int bufSize, ref int length, ref int size, ref AttributeType type)
             {
                 string name;
                 fixed (int* length_ptr = &length)
@@ -35857,7 +35857,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return name;
             }
             /// <inheritdoc cref="GetTransformFeedbackVaryingEXT"/>
-            public static unsafe void GetTransformFeedbackVaryingEXT(ProgramHandle program, uint index, int bufSize, ref int length, ref int size, ref AttributeType type, out string name)
+            public static unsafe void GetTransformFeedbackVaryingEXT(int program, uint index, int bufSize, ref int length, ref int size, ref AttributeType type, out string name)
             {
                 fixed (int* length_ptr = &length)
                 fixed (int* size_ptr = &size)
@@ -36933,7 +36933,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformHandleui64vNV"/>
-            public static unsafe void ProgramUniformHandleui64vNV(ProgramHandle program, int location, ReadOnlySpan<ulong> values)
+            public static unsafe void ProgramUniformHandleui64vNV(int program, int location, ReadOnlySpan<ulong> values)
             {
                 int count = (int)(values.Length);
                 fixed (ulong* values_ptr = values)
@@ -36942,7 +36942,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformHandleui64vNV"/>
-            public static unsafe void ProgramUniformHandleui64vNV(ProgramHandle program, int location, ulong[] values)
+            public static unsafe void ProgramUniformHandleui64vNV(int program, int location, ulong[] values)
             {
                 int count = (int)(values.Length);
                 fixed (ulong* values_ptr = values)
@@ -36951,7 +36951,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformHandleui64vNV"/>
-            public static unsafe void ProgramUniformHandleui64vNV(ProgramHandle program, int location, int count, in ulong values)
+            public static unsafe void ProgramUniformHandleui64vNV(int program, int location, int count, in ulong values)
             {
                 fixed (ulong* values_ptr = &values)
                 {
@@ -37029,7 +37029,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="DrawCommandsStatesNV"/>
-            public static unsafe void DrawCommandsStatesNV(BufferHandle buffer, in IntPtr indirects, in int sizes, in uint states, in uint fbos, uint count)
+            public static unsafe void DrawCommandsStatesNV(int buffer, in IntPtr indirects, in int sizes, in uint states, in uint fbos, uint count)
             {
                 fixed (IntPtr* indirects_ptr = &indirects)
                 fixed (int* sizes_ptr = &sizes)
@@ -37460,7 +37460,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramNamedParameter4fNV"/>
-            public static unsafe void ProgramNamedParameter4fNV(ProgramHandle id, int len, ReadOnlySpan<byte> name, float x, float y, float z, float w)
+            public static unsafe void ProgramNamedParameter4fNV(int id, int len, ReadOnlySpan<byte> name, float x, float y, float z, float w)
             {
                 fixed (byte* name_ptr = name)
                 {
@@ -37468,7 +37468,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramNamedParameter4fNV"/>
-            public static unsafe void ProgramNamedParameter4fNV(ProgramHandle id, int len, byte[] name, float x, float y, float z, float w)
+            public static unsafe void ProgramNamedParameter4fNV(int id, int len, byte[] name, float x, float y, float z, float w)
             {
                 fixed (byte* name_ptr = name)
                 {
@@ -37476,7 +37476,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramNamedParameter4fNV"/>
-            public static unsafe void ProgramNamedParameter4fNV(ProgramHandle id, int len, in byte name, float x, float y, float z, float w)
+            public static unsafe void ProgramNamedParameter4fNV(int id, int len, in byte name, float x, float y, float z, float w)
             {
                 fixed (byte* name_ptr = &name)
                 {
@@ -37484,7 +37484,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramNamedParameter4fvNV"/>
-            public static unsafe void ProgramNamedParameter4fvNV(ProgramHandle id, int len, ReadOnlySpan<byte> name, ReadOnlySpan<float> v)
+            public static unsafe void ProgramNamedParameter4fvNV(int id, int len, ReadOnlySpan<byte> name, ReadOnlySpan<float> v)
             {
                 fixed (byte* name_ptr = name)
                 {
@@ -37495,7 +37495,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramNamedParameter4fvNV"/>
-            public static unsafe void ProgramNamedParameter4fvNV(ProgramHandle id, int len, byte[] name, float[] v)
+            public static unsafe void ProgramNamedParameter4fvNV(int id, int len, byte[] name, float[] v)
             {
                 fixed (byte* name_ptr = name)
                 {
@@ -37506,7 +37506,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramNamedParameter4fvNV"/>
-            public static unsafe void ProgramNamedParameter4fvNV(ProgramHandle id, int len, in byte name, in float v)
+            public static unsafe void ProgramNamedParameter4fvNV(int id, int len, in byte name, in float v)
             {
                 fixed (byte* name_ptr = &name)
                 fixed (float* v_ptr = &v)
@@ -37515,7 +37515,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramNamedParameter4dNV"/>
-            public static unsafe void ProgramNamedParameter4dNV(ProgramHandle id, int len, ReadOnlySpan<byte> name, double x, double y, double z, double w)
+            public static unsafe void ProgramNamedParameter4dNV(int id, int len, ReadOnlySpan<byte> name, double x, double y, double z, double w)
             {
                 fixed (byte* name_ptr = name)
                 {
@@ -37523,7 +37523,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramNamedParameter4dNV"/>
-            public static unsafe void ProgramNamedParameter4dNV(ProgramHandle id, int len, byte[] name, double x, double y, double z, double w)
+            public static unsafe void ProgramNamedParameter4dNV(int id, int len, byte[] name, double x, double y, double z, double w)
             {
                 fixed (byte* name_ptr = name)
                 {
@@ -37531,7 +37531,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramNamedParameter4dNV"/>
-            public static unsafe void ProgramNamedParameter4dNV(ProgramHandle id, int len, in byte name, double x, double y, double z, double w)
+            public static unsafe void ProgramNamedParameter4dNV(int id, int len, in byte name, double x, double y, double z, double w)
             {
                 fixed (byte* name_ptr = &name)
                 {
@@ -37539,7 +37539,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramNamedParameter4dvNV"/>
-            public static unsafe void ProgramNamedParameter4dvNV(ProgramHandle id, int len, ReadOnlySpan<byte> name, ReadOnlySpan<double> v)
+            public static unsafe void ProgramNamedParameter4dvNV(int id, int len, ReadOnlySpan<byte> name, ReadOnlySpan<double> v)
             {
                 fixed (byte* name_ptr = name)
                 {
@@ -37550,7 +37550,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramNamedParameter4dvNV"/>
-            public static unsafe void ProgramNamedParameter4dvNV(ProgramHandle id, int len, byte[] name, double[] v)
+            public static unsafe void ProgramNamedParameter4dvNV(int id, int len, byte[] name, double[] v)
             {
                 fixed (byte* name_ptr = name)
                 {
@@ -37561,7 +37561,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramNamedParameter4dvNV"/>
-            public static unsafe void ProgramNamedParameter4dvNV(ProgramHandle id, int len, in byte name, in double v)
+            public static unsafe void ProgramNamedParameter4dvNV(int id, int len, in byte name, in double v)
             {
                 fixed (byte* name_ptr = &name)
                 fixed (double* v_ptr = &v)
@@ -37570,7 +37570,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetProgramNamedParameterfvNV"/>
-            public static unsafe void GetProgramNamedParameterfvNV(ProgramHandle id, int len, ReadOnlySpan<byte> name, Span<float> parameters)
+            public static unsafe void GetProgramNamedParameterfvNV(int id, int len, ReadOnlySpan<byte> name, Span<float> parameters)
             {
                 fixed (byte* name_ptr = name)
                 {
@@ -37581,7 +37581,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetProgramNamedParameterfvNV"/>
-            public static unsafe void GetProgramNamedParameterfvNV(ProgramHandle id, int len, byte[] name, float[] parameters)
+            public static unsafe void GetProgramNamedParameterfvNV(int id, int len, byte[] name, float[] parameters)
             {
                 fixed (byte* name_ptr = name)
                 {
@@ -37592,7 +37592,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetProgramNamedParameterfvNV"/>
-            public static unsafe void GetProgramNamedParameterfvNV(ProgramHandle id, int len, in byte name, ref float parameters)
+            public static unsafe void GetProgramNamedParameterfvNV(int id, int len, in byte name, ref float parameters)
             {
                 fixed (byte* name_ptr = &name)
                 fixed (float* parameters_ptr = &parameters)
@@ -37601,7 +37601,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetProgramNamedParameterdvNV"/>
-            public static unsafe void GetProgramNamedParameterdvNV(ProgramHandle id, int len, ReadOnlySpan<byte> name, Span<double> parameters)
+            public static unsafe void GetProgramNamedParameterdvNV(int id, int len, ReadOnlySpan<byte> name, Span<double> parameters)
             {
                 fixed (byte* name_ptr = name)
                 {
@@ -37612,7 +37612,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetProgramNamedParameterdvNV"/>
-            public static unsafe void GetProgramNamedParameterdvNV(ProgramHandle id, int len, byte[] name, double[] parameters)
+            public static unsafe void GetProgramNamedParameterdvNV(int id, int len, byte[] name, double[] parameters)
             {
                 fixed (byte* name_ptr = name)
                 {
@@ -37623,7 +37623,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetProgramNamedParameterdvNV"/>
-            public static unsafe void GetProgramNamedParameterdvNV(ProgramHandle id, int len, in byte name, ref double parameters)
+            public static unsafe void GetProgramNamedParameterdvNV(int id, int len, in byte name, ref double parameters)
             {
                 fixed (byte* name_ptr = &name)
                 fixed (double* parameters_ptr = &parameters)
@@ -38220,7 +38220,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetUniformi64vNV"/>
-            public static unsafe void GetUniformi64vNV(ProgramHandle program, int location, Span<long> parameters)
+            public static unsafe void GetUniformi64vNV(int program, int location, Span<long> parameters)
             {
                 fixed (long* parameters_ptr = parameters)
                 {
@@ -38228,7 +38228,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetUniformi64vNV"/>
-            public static unsafe void GetUniformi64vNV(ProgramHandle program, int location, long[] parameters)
+            public static unsafe void GetUniformi64vNV(int program, int location, long[] parameters)
             {
                 fixed (long* parameters_ptr = parameters)
                 {
@@ -38236,7 +38236,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetUniformi64vNV"/>
-            public static unsafe void GetUniformi64vNV(ProgramHandle program, int location, ref long parameters)
+            public static unsafe void GetUniformi64vNV(int program, int location, ref long parameters)
             {
                 fixed (long* parameters_ptr = &parameters)
                 {
@@ -38244,7 +38244,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform1i64vNV"/>
-            public static unsafe void ProgramUniform1i64vNV(ProgramHandle program, int location, ReadOnlySpan<long> value)
+            public static unsafe void ProgramUniform1i64vNV(int program, int location, ReadOnlySpan<long> value)
             {
                 int count = (int)(value.Length);
                 fixed (long* value_ptr = value)
@@ -38253,7 +38253,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform1i64vNV"/>
-            public static unsafe void ProgramUniform1i64vNV(ProgramHandle program, int location, long[] value)
+            public static unsafe void ProgramUniform1i64vNV(int program, int location, long[] value)
             {
                 int count = (int)(value.Length);
                 fixed (long* value_ptr = value)
@@ -38262,7 +38262,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform1i64vNV"/>
-            public static unsafe void ProgramUniform1i64vNV(ProgramHandle program, int location, int count, in long value)
+            public static unsafe void ProgramUniform1i64vNV(int program, int location, int count, in long value)
             {
                 fixed (long* value_ptr = &value)
                 {
@@ -38270,7 +38270,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform2i64vNV"/>
-            public static unsafe void ProgramUniform2i64vNV(ProgramHandle program, int location, ReadOnlySpan<long> value)
+            public static unsafe void ProgramUniform2i64vNV(int program, int location, ReadOnlySpan<long> value)
             {
                 int count = (int)(value.Length / 2);
                 fixed (long* value_ptr = value)
@@ -38279,7 +38279,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform2i64vNV"/>
-            public static unsafe void ProgramUniform2i64vNV(ProgramHandle program, int location, long[] value)
+            public static unsafe void ProgramUniform2i64vNV(int program, int location, long[] value)
             {
                 int count = (int)(value.Length / 2);
                 fixed (long* value_ptr = value)
@@ -38288,7 +38288,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform2i64vNV"/>
-            public static unsafe void ProgramUniform2i64vNV(ProgramHandle program, int location, int count, in long value)
+            public static unsafe void ProgramUniform2i64vNV(int program, int location, int count, in long value)
             {
                 fixed (long* value_ptr = &value)
                 {
@@ -38296,7 +38296,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform3i64vNV"/>
-            public static unsafe void ProgramUniform3i64vNV(ProgramHandle program, int location, ReadOnlySpan<long> value)
+            public static unsafe void ProgramUniform3i64vNV(int program, int location, ReadOnlySpan<long> value)
             {
                 int count = (int)(value.Length / 3);
                 fixed (long* value_ptr = value)
@@ -38305,7 +38305,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform3i64vNV"/>
-            public static unsafe void ProgramUniform3i64vNV(ProgramHandle program, int location, long[] value)
+            public static unsafe void ProgramUniform3i64vNV(int program, int location, long[] value)
             {
                 int count = (int)(value.Length / 3);
                 fixed (long* value_ptr = value)
@@ -38314,7 +38314,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform3i64vNV"/>
-            public static unsafe void ProgramUniform3i64vNV(ProgramHandle program, int location, int count, in long value)
+            public static unsafe void ProgramUniform3i64vNV(int program, int location, int count, in long value)
             {
                 fixed (long* value_ptr = &value)
                 {
@@ -38322,7 +38322,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform4i64vNV"/>
-            public static unsafe void ProgramUniform4i64vNV(ProgramHandle program, int location, ReadOnlySpan<long> value)
+            public static unsafe void ProgramUniform4i64vNV(int program, int location, ReadOnlySpan<long> value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (long* value_ptr = value)
@@ -38331,7 +38331,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform4i64vNV"/>
-            public static unsafe void ProgramUniform4i64vNV(ProgramHandle program, int location, long[] value)
+            public static unsafe void ProgramUniform4i64vNV(int program, int location, long[] value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (long* value_ptr = value)
@@ -38340,7 +38340,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform4i64vNV"/>
-            public static unsafe void ProgramUniform4i64vNV(ProgramHandle program, int location, int count, in long value)
+            public static unsafe void ProgramUniform4i64vNV(int program, int location, int count, in long value)
             {
                 fixed (long* value_ptr = &value)
                 {
@@ -38348,7 +38348,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform1ui64vNV"/>
-            public static unsafe void ProgramUniform1ui64vNV(ProgramHandle program, int location, ReadOnlySpan<ulong> value)
+            public static unsafe void ProgramUniform1ui64vNV(int program, int location, ReadOnlySpan<ulong> value)
             {
                 int count = (int)(value.Length);
                 fixed (ulong* value_ptr = value)
@@ -38357,7 +38357,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform1ui64vNV"/>
-            public static unsafe void ProgramUniform1ui64vNV(ProgramHandle program, int location, ulong[] value)
+            public static unsafe void ProgramUniform1ui64vNV(int program, int location, ulong[] value)
             {
                 int count = (int)(value.Length);
                 fixed (ulong* value_ptr = value)
@@ -38366,7 +38366,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform1ui64vNV"/>
-            public static unsafe void ProgramUniform1ui64vNV(ProgramHandle program, int location, int count, in ulong value)
+            public static unsafe void ProgramUniform1ui64vNV(int program, int location, int count, in ulong value)
             {
                 fixed (ulong* value_ptr = &value)
                 {
@@ -38374,7 +38374,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform2ui64vNV"/>
-            public static unsafe void ProgramUniform2ui64vNV(ProgramHandle program, int location, ReadOnlySpan<ulong> value)
+            public static unsafe void ProgramUniform2ui64vNV(int program, int location, ReadOnlySpan<ulong> value)
             {
                 int count = (int)(value.Length / 2);
                 fixed (ulong* value_ptr = value)
@@ -38383,7 +38383,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform2ui64vNV"/>
-            public static unsafe void ProgramUniform2ui64vNV(ProgramHandle program, int location, ulong[] value)
+            public static unsafe void ProgramUniform2ui64vNV(int program, int location, ulong[] value)
             {
                 int count = (int)(value.Length / 2);
                 fixed (ulong* value_ptr = value)
@@ -38392,7 +38392,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform2ui64vNV"/>
-            public static unsafe void ProgramUniform2ui64vNV(ProgramHandle program, int location, int count, in ulong value)
+            public static unsafe void ProgramUniform2ui64vNV(int program, int location, int count, in ulong value)
             {
                 fixed (ulong* value_ptr = &value)
                 {
@@ -38400,7 +38400,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform3ui64vNV"/>
-            public static unsafe void ProgramUniform3ui64vNV(ProgramHandle program, int location, ReadOnlySpan<ulong> value)
+            public static unsafe void ProgramUniform3ui64vNV(int program, int location, ReadOnlySpan<ulong> value)
             {
                 int count = (int)(value.Length / 3);
                 fixed (ulong* value_ptr = value)
@@ -38409,7 +38409,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform3ui64vNV"/>
-            public static unsafe void ProgramUniform3ui64vNV(ProgramHandle program, int location, ulong[] value)
+            public static unsafe void ProgramUniform3ui64vNV(int program, int location, ulong[] value)
             {
                 int count = (int)(value.Length / 3);
                 fixed (ulong* value_ptr = value)
@@ -38418,7 +38418,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform3ui64vNV"/>
-            public static unsafe void ProgramUniform3ui64vNV(ProgramHandle program, int location, int count, in ulong value)
+            public static unsafe void ProgramUniform3ui64vNV(int program, int location, int count, in ulong value)
             {
                 fixed (ulong* value_ptr = &value)
                 {
@@ -38426,7 +38426,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform4ui64vNV"/>
-            public static unsafe void ProgramUniform4ui64vNV(ProgramHandle program, int location, ReadOnlySpan<ulong> value)
+            public static unsafe void ProgramUniform4ui64vNV(int program, int location, ReadOnlySpan<ulong> value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (ulong* value_ptr = value)
@@ -38435,7 +38435,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform4ui64vNV"/>
-            public static unsafe void ProgramUniform4ui64vNV(ProgramHandle program, int location, ulong[] value)
+            public static unsafe void ProgramUniform4ui64vNV(int program, int location, ulong[] value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (ulong* value_ptr = value)
@@ -38444,7 +38444,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniform4ui64vNV"/>
-            public static unsafe void ProgramUniform4ui64vNV(ProgramHandle program, int location, int count, in ulong value)
+            public static unsafe void ProgramUniform4ui64vNV(int program, int location, int count, in ulong value)
             {
                 fixed (ulong* value_ptr = &value)
                 {
@@ -39086,13 +39086,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="MulticastBufferSubDataNV"/>
-            public static unsafe void MulticastBufferSubDataNV(All gpuMask, BufferHandle buffer, IntPtr offset, nint size, IntPtr data)
+            public static unsafe void MulticastBufferSubDataNV(All gpuMask, int buffer, IntPtr offset, nint size, IntPtr data)
             {
                 void* data_vptr = (void*)data;
                 MulticastBufferSubDataNV(gpuMask, buffer, offset, size, data_vptr);
             }
             /// <inheritdoc cref="MulticastBufferSubDataNV"/>
-            public static unsafe void MulticastBufferSubDataNV<T1>(All gpuMask, BufferHandle buffer, IntPtr offset, nint size, in T1 data)
+            public static unsafe void MulticastBufferSubDataNV<T1>(All gpuMask, int buffer, IntPtr offset, nint size, in T1 data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = &data)
@@ -39101,7 +39101,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="MulticastFramebufferSampleLocationsfvNV"/>
-            public static unsafe void MulticastFramebufferSampleLocationsfvNV(uint gpu, FramebufferHandle framebuffer, uint start, int count, in float v)
+            public static unsafe void MulticastFramebufferSampleLocationsfvNV(uint gpu, int framebuffer, uint start, int count, in float v)
             {
                 fixed (float* v_ptr = &v)
                 {
@@ -40606,7 +40606,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return returnValue;
             }
             /// <inheritdoc cref="ProgramPathFragmentInputGenNV"/>
-            public static unsafe void ProgramPathFragmentInputGenNV(ProgramHandle program, int location, All genMode, int components, in float coeffs)
+            public static unsafe void ProgramPathFragmentInputGenNV(int program, int location, All genMode, int components, in float coeffs)
             {
                 fixed (float* coeffs_ptr = &coeffs)
                 {
@@ -40614,7 +40614,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetProgramResourcefvNV"/>
-            public static unsafe void GetProgramResourcefvNV(ProgramHandle program, ProgramInterface programInterface, uint index, int propCount, in All props, Span<int> length, Span<float> parameters)
+            public static unsafe void GetProgramResourcefvNV(int program, ProgramInterface programInterface, uint index, int propCount, in All props, Span<int> length, Span<float> parameters)
             {
                 fixed (All* props_ptr = &props)
                 {
@@ -40629,7 +40629,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetProgramResourcefvNV"/>
-            public static unsafe void GetProgramResourcefvNV(ProgramHandle program, ProgramInterface programInterface, uint index, int propCount, in All props, int[] length, float[] parameters)
+            public static unsafe void GetProgramResourcefvNV(int program, ProgramInterface programInterface, uint index, int propCount, in All props, int[] length, float[] parameters)
             {
                 fixed (All* props_ptr = &props)
                 {
@@ -40644,7 +40644,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetProgramResourcefvNV"/>
-            public static unsafe void GetProgramResourcefvNV(ProgramHandle program, ProgramInterface programInterface, uint index, int propCount, in All props, int count, ref int length, ref float parameters)
+            public static unsafe void GetProgramResourcefvNV(int program, ProgramInterface programInterface, uint index, int propCount, in All props, int count, ref int length, ref float parameters)
             {
                 fixed (All* props_ptr = &props)
                 fixed (int* length_ptr = &length)
@@ -41484,7 +41484,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="NamedFramebufferSampleLocationsfvNV"/>
-            public static unsafe void NamedFramebufferSampleLocationsfvNV(FramebufferHandle framebuffer, uint start, int count, in float v)
+            public static unsafe void NamedFramebufferSampleLocationsfvNV(int framebuffer, uint start, int count, in float v)
             {
                 fixed (float* v_ptr = &v)
                 {
@@ -41540,7 +41540,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetNamedBufferParameterui64vNV"/>
-            public static unsafe void GetNamedBufferParameterui64vNV(BufferHandle buffer, BufferPNameARB pname, Span<ulong> parameters)
+            public static unsafe void GetNamedBufferParameterui64vNV(int buffer, BufferPNameARB pname, Span<ulong> parameters)
             {
                 fixed (ulong* parameters_ptr = parameters)
                 {
@@ -41548,7 +41548,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetNamedBufferParameterui64vNV"/>
-            public static unsafe void GetNamedBufferParameterui64vNV(BufferHandle buffer, BufferPNameARB pname, ulong[] parameters)
+            public static unsafe void GetNamedBufferParameterui64vNV(int buffer, BufferPNameARB pname, ulong[] parameters)
             {
                 fixed (ulong* parameters_ptr = parameters)
                 {
@@ -41556,7 +41556,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetNamedBufferParameterui64vNV"/>
-            public static unsafe void GetNamedBufferParameterui64vNV(BufferHandle buffer, BufferPNameARB pname, ref ulong parameters)
+            public static unsafe void GetNamedBufferParameterui64vNV(int buffer, BufferPNameARB pname, ref ulong parameters)
             {
                 fixed (ulong* parameters_ptr = &parameters)
                 {
@@ -41614,7 +41614,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetUniformui64vNV"/>
-            public static unsafe void GetUniformui64vNV(ProgramHandle program, int location, Span<ulong> parameters)
+            public static unsafe void GetUniformui64vNV(int program, int location, Span<ulong> parameters)
             {
                 fixed (ulong* parameters_ptr = parameters)
                 {
@@ -41622,7 +41622,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetUniformui64vNV"/>
-            public static unsafe void GetUniformui64vNV(ProgramHandle program, int location, ulong[] parameters)
+            public static unsafe void GetUniformui64vNV(int program, int location, ulong[] parameters)
             {
                 fixed (ulong* parameters_ptr = parameters)
                 {
@@ -41630,7 +41630,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetUniformui64vNV"/>
-            public static unsafe void GetUniformui64vNV(ProgramHandle program, int location, ref ulong parameters)
+            public static unsafe void GetUniformui64vNV(int program, int location, ref ulong parameters)
             {
                 fixed (ulong* parameters_ptr = &parameters)
                 {
@@ -41638,7 +41638,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformui64vNV"/>
-            public static unsafe void ProgramUniformui64vNV(ProgramHandle program, int location, ReadOnlySpan<ulong> value)
+            public static unsafe void ProgramUniformui64vNV(int program, int location, ReadOnlySpan<ulong> value)
             {
                 int count = (int)(value.Length);
                 fixed (ulong* value_ptr = value)
@@ -41647,7 +41647,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformui64vNV"/>
-            public static unsafe void ProgramUniformui64vNV(ProgramHandle program, int location, ulong[] value)
+            public static unsafe void ProgramUniformui64vNV(int program, int location, ulong[] value)
             {
                 int count = (int)(value.Length);
                 fixed (ulong* value_ptr = value)
@@ -41656,7 +41656,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ProgramUniformui64vNV"/>
-            public static unsafe void ProgramUniformui64vNV(ProgramHandle program, int location, int count, in ulong value)
+            public static unsafe void ProgramUniformui64vNV(int program, int location, int count, in ulong value)
             {
                 fixed (ulong* value_ptr = &value)
                 {
@@ -41786,7 +41786,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="TransformFeedbackVaryingsNV"/>
-            public static unsafe void TransformFeedbackVaryingsNV(ProgramHandle program, ReadOnlySpan<TransformFeedbackTokenNV> locations, TransformFeedbackBufferMode bufferMode)
+            public static unsafe void TransformFeedbackVaryingsNV(int program, ReadOnlySpan<TransformFeedbackTokenNV> locations, TransformFeedbackBufferMode bufferMode)
             {
                 int count = (int)(locations.Length);
                 fixed (TransformFeedbackTokenNV* locations_ptr = locations)
@@ -41795,7 +41795,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="TransformFeedbackVaryingsNV"/>
-            public static unsafe void TransformFeedbackVaryingsNV(ProgramHandle program, TransformFeedbackTokenNV[] locations, TransformFeedbackBufferMode bufferMode)
+            public static unsafe void TransformFeedbackVaryingsNV(int program, TransformFeedbackTokenNV[] locations, TransformFeedbackBufferMode bufferMode)
             {
                 int count = (int)(locations.Length);
                 fixed (TransformFeedbackTokenNV* locations_ptr = locations)
@@ -41804,7 +41804,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="TransformFeedbackVaryingsNV"/>
-            public static unsafe void TransformFeedbackVaryingsNV(ProgramHandle program, int count, in TransformFeedbackTokenNV locations, TransformFeedbackBufferMode bufferMode)
+            public static unsafe void TransformFeedbackVaryingsNV(int program, int count, in TransformFeedbackTokenNV locations, TransformFeedbackBufferMode bufferMode)
             {
                 fixed (TransformFeedbackTokenNV* locations_ptr = &locations)
                 {
@@ -41812,14 +41812,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ActiveVaryingNV"/>
-            public static unsafe void ActiveVaryingNV(ProgramHandle program, string name)
+            public static unsafe void ActiveVaryingNV(int program, string name)
             {
                 byte* name_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(name);
                 ActiveVaryingNV(program, name_ptr);
                 Marshal.FreeCoTaskMem((IntPtr)name_ptr);
             }
             /// <inheritdoc cref="GetVaryingLocationNV"/>
-            public static unsafe int GetVaryingLocationNV(ProgramHandle program, string name)
+            public static unsafe int GetVaryingLocationNV(int program, string name)
             {
                 int returnValue;
                 byte* name_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(name);
@@ -41828,7 +41828,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return returnValue;
             }
             /// <inheritdoc cref="GetActiveVaryingNV"/>
-            public static unsafe string GetActiveVaryingNV(ProgramHandle program, uint index, int bufSize, Span<int> length, Span<int> size, Span<All> type)
+            public static unsafe string GetActiveVaryingNV(int program, uint index, int bufSize, Span<int> length, Span<int> size, Span<All> type)
             {
                 string name;
                 fixed (int* length_ptr = length)
@@ -41847,7 +41847,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return name;
             }
             /// <inheritdoc cref="GetActiveVaryingNV"/>
-            public static unsafe void GetActiveVaryingNV(ProgramHandle program, uint index, int bufSize, Span<int> length, Span<int> size, Span<All> type, out string name)
+            public static unsafe void GetActiveVaryingNV(int program, uint index, int bufSize, Span<int> length, Span<int> size, Span<All> type, out string name)
             {
                 fixed (int* length_ptr = length)
                 {
@@ -41864,7 +41864,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetActiveVaryingNV"/>
-            public static unsafe string GetActiveVaryingNV(ProgramHandle program, uint index, int bufSize, int[] length, int[] size, All[] type)
+            public static unsafe string GetActiveVaryingNV(int program, uint index, int bufSize, int[] length, int[] size, All[] type)
             {
                 string name;
                 fixed (int* length_ptr = length)
@@ -41883,7 +41883,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return name;
             }
             /// <inheritdoc cref="GetActiveVaryingNV"/>
-            public static unsafe void GetActiveVaryingNV(ProgramHandle program, uint index, int bufSize, int[] length, int[] size, All[] type, out string name)
+            public static unsafe void GetActiveVaryingNV(int program, uint index, int bufSize, int[] length, int[] size, All[] type, out string name)
             {
                 fixed (int* length_ptr = length)
                 {
@@ -41900,7 +41900,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetActiveVaryingNV"/>
-            public static unsafe string GetActiveVaryingNV(ProgramHandle program, uint index, int bufSize, ref int length, ref int size, ref All type)
+            public static unsafe string GetActiveVaryingNV(int program, uint index, int bufSize, ref int length, ref int size, ref All type)
             {
                 string name;
                 fixed (int* length_ptr = &length)
@@ -41915,7 +41915,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return name;
             }
             /// <inheritdoc cref="GetActiveVaryingNV"/>
-            public static unsafe void GetActiveVaryingNV(ProgramHandle program, uint index, int bufSize, ref int length, ref int size, ref All type, out string name)
+            public static unsafe void GetActiveVaryingNV(int program, uint index, int bufSize, ref int length, ref int size, ref All type, out string name)
             {
                 fixed (int* length_ptr = &length)
                 fixed (int* size_ptr = &size)
@@ -41928,7 +41928,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetTransformFeedbackVaryingNV"/>
-            public static unsafe void GetTransformFeedbackVaryingNV(ProgramHandle program, uint index, Span<int> location)
+            public static unsafe void GetTransformFeedbackVaryingNV(int program, uint index, Span<int> location)
             {
                 fixed (int* location_ptr = location)
                 {
@@ -41936,7 +41936,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetTransformFeedbackVaryingNV"/>
-            public static unsafe void GetTransformFeedbackVaryingNV(ProgramHandle program, uint index, int[] location)
+            public static unsafe void GetTransformFeedbackVaryingNV(int program, uint index, int[] location)
             {
                 fixed (int* location_ptr = location)
                 {
@@ -41944,7 +41944,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetTransformFeedbackVaryingNV"/>
-            public static unsafe void GetTransformFeedbackVaryingNV(ProgramHandle program, uint index, ref int location)
+            public static unsafe void GetTransformFeedbackVaryingNV(int program, uint index, ref int location)
             {
                 fixed (int* location_ptr = &location)
                 {
@@ -41987,53 +41987,53 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="DeleteTransformFeedbacksNV"/>
-            public static unsafe void DeleteTransformFeedbacksNV(ReadOnlySpan<TransformFeedbackHandle> ids)
+            public static unsafe void DeleteTransformFeedbacksNV(ReadOnlySpan<int> ids)
             {
                 int n = (int)(ids.Length);
-                fixed (TransformFeedbackHandle* ids_ptr = ids)
+                fixed (int* ids_ptr = ids)
                 {
                     DeleteTransformFeedbacksNV(n, ids_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteTransformFeedbacksNV"/>
-            public static unsafe void DeleteTransformFeedbacksNV(TransformFeedbackHandle[] ids)
+            public static unsafe void DeleteTransformFeedbacksNV(int[] ids)
             {
                 int n = (int)(ids.Length);
-                fixed (TransformFeedbackHandle* ids_ptr = ids)
+                fixed (int* ids_ptr = ids)
                 {
                     DeleteTransformFeedbacksNV(n, ids_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteTransformFeedbacksNV"/>
-            public static unsafe void DeleteTransformFeedbacksNV(int n, in TransformFeedbackHandle ids)
+            public static unsafe void DeleteTransformFeedbacksNV(int n, in int ids)
             {
-                fixed (TransformFeedbackHandle* ids_ptr = &ids)
+                fixed (int* ids_ptr = &ids)
                 {
                     DeleteTransformFeedbacksNV(n, ids_ptr);
                 }
             }
             /// <inheritdoc cref="GenTransformFeedbacksNV"/>
-            public static unsafe void GenTransformFeedbacksNV(Span<TransformFeedbackHandle> ids)
+            public static unsafe void GenTransformFeedbacksNV(Span<int> ids)
             {
                 int n = (int)(ids.Length);
-                fixed (TransformFeedbackHandle* ids_ptr = ids)
+                fixed (int* ids_ptr = ids)
                 {
                     GenTransformFeedbacksNV(n, ids_ptr);
                 }
             }
             /// <inheritdoc cref="GenTransformFeedbacksNV"/>
-            public static unsafe void GenTransformFeedbacksNV(TransformFeedbackHandle[] ids)
+            public static unsafe void GenTransformFeedbacksNV(int[] ids)
             {
                 int n = (int)(ids.Length);
-                fixed (TransformFeedbackHandle* ids_ptr = ids)
+                fixed (int* ids_ptr = ids)
                 {
                     GenTransformFeedbacksNV(n, ids_ptr);
                 }
             }
             /// <inheritdoc cref="GenTransformFeedbacksNV"/>
-            public static unsafe void GenTransformFeedbacksNV(int n, ref TransformFeedbackHandle ids)
+            public static unsafe void GenTransformFeedbacksNV(int n, ref int ids)
             {
-                fixed (TransformFeedbackHandle* ids_ptr = &ids)
+                fixed (int* ids_ptr = &ids)
                 {
                     GenTransformFeedbacksNV(n, ids_ptr);
                 }
@@ -42670,10 +42670,10 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="AreProgramsResidentNV"/>
-            public static unsafe bool AreProgramsResidentNV(int n, ReadOnlySpan<ProgramHandle> programs, Span<bool> residences)
+            public static unsafe bool AreProgramsResidentNV(int n, ReadOnlySpan<int> programs, Span<bool> residences)
             {
                 bool returnValue;
-                fixed (ProgramHandle* programs_ptr = programs)
+                fixed (int* programs_ptr = programs)
                 {
                     fixed (bool* residences_ptr = residences)
                     {
@@ -42683,10 +42683,10 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return returnValue;
             }
             /// <inheritdoc cref="AreProgramsResidentNV"/>
-            public static unsafe bool AreProgramsResidentNV(int n, ProgramHandle[] programs, bool[] residences)
+            public static unsafe bool AreProgramsResidentNV(int n, int[] programs, bool[] residences)
             {
                 bool returnValue;
-                fixed (ProgramHandle* programs_ptr = programs)
+                fixed (int* programs_ptr = programs)
                 {
                     fixed (bool* residences_ptr = residences)
                     {
@@ -42696,10 +42696,10 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return returnValue;
             }
             /// <inheritdoc cref="AreProgramsResidentNV"/>
-            public static unsafe bool AreProgramsResidentNV(int n, in ProgramHandle programs, ref bool residences)
+            public static unsafe bool AreProgramsResidentNV(int n, in int programs, ref bool residences)
             {
                 bool returnValue;
-                fixed (ProgramHandle* programs_ptr = &programs)
+                fixed (int* programs_ptr = &programs)
                 fixed (bool* residences_ptr = &residences)
                 {
                     returnValue = AreProgramsResidentNV(n, programs_ptr, residences_ptr);
@@ -42707,27 +42707,27 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return returnValue;
             }
             /// <inheritdoc cref="DeleteProgramsNV"/>
-            public static unsafe void DeleteProgramsNV(ReadOnlySpan<ProgramHandle> programs)
+            public static unsafe void DeleteProgramsNV(ReadOnlySpan<int> programs)
             {
                 int n = (int)(programs.Length);
-                fixed (ProgramHandle* programs_ptr = programs)
+                fixed (int* programs_ptr = programs)
                 {
                     DeleteProgramsNV(n, programs_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteProgramsNV"/>
-            public static unsafe void DeleteProgramsNV(ProgramHandle[] programs)
+            public static unsafe void DeleteProgramsNV(int[] programs)
             {
                 int n = (int)(programs.Length);
-                fixed (ProgramHandle* programs_ptr = programs)
+                fixed (int* programs_ptr = programs)
                 {
                     DeleteProgramsNV(n, programs_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteProgramsNV"/>
-            public static unsafe void DeleteProgramsNV(int n, in ProgramHandle programs)
+            public static unsafe void DeleteProgramsNV(int n, in int programs)
             {
-                fixed (ProgramHandle* programs_ptr = &programs)
+                fixed (int* programs_ptr = &programs)
                 {
                     DeleteProgramsNV(n, programs_ptr);
                 }
@@ -42757,27 +42757,27 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GenProgramsNV"/>
-            public static unsafe void GenProgramsNV(Span<ProgramHandle> programs)
+            public static unsafe void GenProgramsNV(Span<int> programs)
             {
                 int n = (int)(programs.Length);
-                fixed (ProgramHandle* programs_ptr = programs)
+                fixed (int* programs_ptr = programs)
                 {
                     GenProgramsNV(n, programs_ptr);
                 }
             }
             /// <inheritdoc cref="GenProgramsNV"/>
-            public static unsafe void GenProgramsNV(ProgramHandle[] programs)
+            public static unsafe void GenProgramsNV(int[] programs)
             {
                 int n = (int)(programs.Length);
-                fixed (ProgramHandle* programs_ptr = programs)
+                fixed (int* programs_ptr = programs)
                 {
                     GenProgramsNV(n, programs_ptr);
                 }
             }
             /// <inheritdoc cref="GenProgramsNV"/>
-            public static unsafe void GenProgramsNV(int n, ref ProgramHandle programs)
+            public static unsafe void GenProgramsNV(int n, ref int programs)
             {
-                fixed (ProgramHandle* programs_ptr = &programs)
+                fixed (int* programs_ptr = &programs)
                 {
                     GenProgramsNV(n, programs_ptr);
                 }
@@ -42831,7 +42831,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetProgramivNV"/>
-            public static unsafe void GetProgramivNV(ProgramHandle id, VertexAttribEnumNV pname, Span<int> parameters)
+            public static unsafe void GetProgramivNV(int id, VertexAttribEnumNV pname, Span<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -42839,7 +42839,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetProgramivNV"/>
-            public static unsafe void GetProgramivNV(ProgramHandle id, VertexAttribEnumNV pname, int[] parameters)
+            public static unsafe void GetProgramivNV(int id, VertexAttribEnumNV pname, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -42847,7 +42847,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetProgramivNV"/>
-            public static unsafe void GetProgramivNV(ProgramHandle id, VertexAttribEnumNV pname, ref int parameters)
+            public static unsafe void GetProgramivNV(int id, VertexAttribEnumNV pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -42855,7 +42855,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetProgramStringNV"/>
-            public static unsafe void GetProgramStringNV(ProgramHandle id, VertexAttribEnumNV pname, Span<byte> program)
+            public static unsafe void GetProgramStringNV(int id, VertexAttribEnumNV pname, Span<byte> program)
             {
                 fixed (byte* program_ptr = program)
                 {
@@ -42863,7 +42863,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetProgramStringNV"/>
-            public static unsafe void GetProgramStringNV(ProgramHandle id, VertexAttribEnumNV pname, byte[] program)
+            public static unsafe void GetProgramStringNV(int id, VertexAttribEnumNV pname, byte[] program)
             {
                 fixed (byte* program_ptr = program)
                 {
@@ -42871,7 +42871,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetProgramStringNV"/>
-            public static unsafe void GetProgramStringNV(ProgramHandle id, VertexAttribEnumNV pname, ref byte program)
+            public static unsafe void GetProgramStringNV(int id, VertexAttribEnumNV pname, ref byte program)
             {
                 fixed (byte* program_ptr = &program)
                 {
@@ -43101,27 +43101,27 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="RequestResidentProgramsNV"/>
-            public static unsafe void RequestResidentProgramsNV(ReadOnlySpan<ProgramHandle> programs)
+            public static unsafe void RequestResidentProgramsNV(ReadOnlySpan<int> programs)
             {
                 int n = (int)(programs.Length);
-                fixed (ProgramHandle* programs_ptr = programs)
+                fixed (int* programs_ptr = programs)
                 {
                     RequestResidentProgramsNV(n, programs_ptr);
                 }
             }
             /// <inheritdoc cref="RequestResidentProgramsNV"/>
-            public static unsafe void RequestResidentProgramsNV(ProgramHandle[] programs)
+            public static unsafe void RequestResidentProgramsNV(int[] programs)
             {
                 int n = (int)(programs.Length);
-                fixed (ProgramHandle* programs_ptr = programs)
+                fixed (int* programs_ptr = programs)
                 {
                     RequestResidentProgramsNV(n, programs_ptr);
                 }
             }
             /// <inheritdoc cref="RequestResidentProgramsNV"/>
-            public static unsafe void RequestResidentProgramsNV(int n, in ProgramHandle programs)
+            public static unsafe void RequestResidentProgramsNV(int n, in int programs)
             {
-                fixed (ProgramHandle* programs_ptr = &programs)
+                fixed (int* programs_ptr = &programs)
                 {
                     RequestResidentProgramsNV(n, programs_ptr);
                 }
@@ -44573,7 +44573,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         public static unsafe partial class INTEL
         {
             /// <inheritdoc cref="MapTexture2DINTEL"/>
-            public static unsafe void* MapTexture2DINTEL(TextureHandle texture, int level, All access, Span<int> stride, Span<All> layout)
+            public static unsafe void* MapTexture2DINTEL(int texture, int level, All access, Span<int> stride, Span<All> layout)
             {
                 void* returnValue;
                 fixed (int* stride_ptr = stride)
@@ -44586,7 +44586,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return returnValue;
             }
             /// <inheritdoc cref="MapTexture2DINTEL"/>
-            public static unsafe void* MapTexture2DINTEL(TextureHandle texture, int level, All access, int[] stride, All[] layout)
+            public static unsafe void* MapTexture2DINTEL(int texture, int level, All access, int[] stride, All[] layout)
             {
                 void* returnValue;
                 fixed (int* stride_ptr = stride)
@@ -44599,7 +44599,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return returnValue;
             }
             /// <inheritdoc cref="MapTexture2DINTEL"/>
-            public static unsafe void* MapTexture2DINTEL(TextureHandle texture, int level, All access, ref int stride, ref All layout)
+            public static unsafe void* MapTexture2DINTEL(int texture, int level, All access, ref int stride, ref All layout)
             {
                 void* returnValue;
                 fixed (int* stride_ptr = &stride)
@@ -45470,7 +45470,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetnUniformfv"/>
-            public static unsafe void GetnUniformf(ProgramHandle program, int location, Span<float> parameters)
+            public static unsafe void GetnUniformf(int program, int location, Span<float> parameters)
             {
                 int bufSize = (int)(parameters.Length * 4);
                 fixed (float* parameters_ptr = parameters)
@@ -45479,7 +45479,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetnUniformfv"/>
-            public static unsafe void GetnUniformf(ProgramHandle program, int location, float[] parameters)
+            public static unsafe void GetnUniformf(int program, int location, float[] parameters)
             {
                 int bufSize = (int)(parameters.Length * 4);
                 fixed (float* parameters_ptr = parameters)
@@ -45488,7 +45488,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetnUniformfv"/>
-            public static unsafe void GetnUniformf(ProgramHandle program, int location, int bufSize, ref float parameters)
+            public static unsafe void GetnUniformf(int program, int location, int bufSize, ref float parameters)
             {
                 fixed (float* parameters_ptr = &parameters)
                 {
@@ -45496,7 +45496,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetnUniformiv"/>
-            public static unsafe void GetnUniformi(ProgramHandle program, int location, Span<int> parameters)
+            public static unsafe void GetnUniformi(int program, int location, Span<int> parameters)
             {
                 int bufSize = (int)(parameters.Length * 4);
                 fixed (int* parameters_ptr = parameters)
@@ -45505,7 +45505,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetnUniformiv"/>
-            public static unsafe void GetnUniformi(ProgramHandle program, int location, int[] parameters)
+            public static unsafe void GetnUniformi(int program, int location, int[] parameters)
             {
                 int bufSize = (int)(parameters.Length * 4);
                 fixed (int* parameters_ptr = parameters)
@@ -45514,7 +45514,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetnUniformiv"/>
-            public static unsafe void GetnUniformi(ProgramHandle program, int location, int bufSize, ref int parameters)
+            public static unsafe void GetnUniformi(int program, int location, int bufSize, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -45522,7 +45522,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetnUniformuiv"/>
-            public static unsafe void GetnUniformui(ProgramHandle program, int location, Span<uint> parameters)
+            public static unsafe void GetnUniformui(int program, int location, Span<uint> parameters)
             {
                 int bufSize = (int)(parameters.Length * 4);
                 fixed (uint* parameters_ptr = parameters)
@@ -45531,7 +45531,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetnUniformuiv"/>
-            public static unsafe void GetnUniformui(ProgramHandle program, int location, uint[] parameters)
+            public static unsafe void GetnUniformui(int program, int location, uint[] parameters)
             {
                 int bufSize = (int)(parameters.Length * 4);
                 fixed (uint* parameters_ptr = parameters)
@@ -45540,7 +45540,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetnUniformuiv"/>
-            public static unsafe void GetnUniformui(ProgramHandle program, int location, int bufSize, ref uint parameters)
+            public static unsafe void GetnUniformui(int program, int location, int bufSize, ref uint parameters)
             {
                 fixed (uint* parameters_ptr = &parameters)
                 {
@@ -45583,7 +45583,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetnUniformfvKHR"/>
-            public static unsafe void GetnUniformfvKHR(ProgramHandle program, int location, Span<float> parameters)
+            public static unsafe void GetnUniformfvKHR(int program, int location, Span<float> parameters)
             {
                 int bufSize = (int)(parameters.Length * 4);
                 fixed (float* parameters_ptr = parameters)
@@ -45592,7 +45592,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetnUniformfvKHR"/>
-            public static unsafe void GetnUniformfvKHR(ProgramHandle program, int location, float[] parameters)
+            public static unsafe void GetnUniformfvKHR(int program, int location, float[] parameters)
             {
                 int bufSize = (int)(parameters.Length * 4);
                 fixed (float* parameters_ptr = parameters)
@@ -45601,7 +45601,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetnUniformfvKHR"/>
-            public static unsafe void GetnUniformfvKHR(ProgramHandle program, int location, int bufSize, ref float parameters)
+            public static unsafe void GetnUniformfvKHR(int program, int location, int bufSize, ref float parameters)
             {
                 fixed (float* parameters_ptr = &parameters)
                 {
@@ -45609,7 +45609,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetnUniformivKHR"/>
-            public static unsafe void GetnUniformivKHR(ProgramHandle program, int location, Span<int> parameters)
+            public static unsafe void GetnUniformivKHR(int program, int location, Span<int> parameters)
             {
                 int bufSize = (int)(parameters.Length * 4);
                 fixed (int* parameters_ptr = parameters)
@@ -45618,7 +45618,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetnUniformivKHR"/>
-            public static unsafe void GetnUniformivKHR(ProgramHandle program, int location, int[] parameters)
+            public static unsafe void GetnUniformivKHR(int program, int location, int[] parameters)
             {
                 int bufSize = (int)(parameters.Length * 4);
                 fixed (int* parameters_ptr = parameters)
@@ -45627,7 +45627,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetnUniformivKHR"/>
-            public static unsafe void GetnUniformivKHR(ProgramHandle program, int location, int bufSize, ref int parameters)
+            public static unsafe void GetnUniformivKHR(int program, int location, int bufSize, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -45635,7 +45635,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetnUniformuivKHR"/>
-            public static unsafe void GetnUniformuivKHR(ProgramHandle program, int location, Span<uint> parameters)
+            public static unsafe void GetnUniformuivKHR(int program, int location, Span<uint> parameters)
             {
                 int bufSize = (int)(parameters.Length * 4);
                 fixed (uint* parameters_ptr = parameters)
@@ -45644,7 +45644,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetnUniformuivKHR"/>
-            public static unsafe void GetnUniformuivKHR(ProgramHandle program, int location, uint[] parameters)
+            public static unsafe void GetnUniformuivKHR(int program, int location, uint[] parameters)
             {
                 int bufSize = (int)(parameters.Length * 4);
                 fixed (uint* parameters_ptr = parameters)
@@ -45653,7 +45653,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetnUniformuivKHR"/>
-            public static unsafe void GetnUniformuivKHR(ProgramHandle program, int location, int bufSize, ref uint parameters)
+            public static unsafe void GetnUniformuivKHR(int program, int location, int bufSize, ref uint parameters)
             {
                 fixed (uint* parameters_ptr = &parameters)
                 {
@@ -45979,13 +45979,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         public static unsafe partial class NVX
         {
             /// <inheritdoc cref="LGPUNamedBufferSubDataNVX"/>
-            public static unsafe void LGPUNamedBufferSubDataNVX(All gpuMask, BufferHandle buffer, IntPtr offset, nint size, IntPtr data)
+            public static unsafe void LGPUNamedBufferSubDataNVX(All gpuMask, int buffer, IntPtr offset, nint size, IntPtr data)
             {
                 void* data_vptr = (void*)data;
                 LGPUNamedBufferSubDataNVX(gpuMask, buffer, offset, size, data_vptr);
             }
             /// <inheritdoc cref="LGPUNamedBufferSubDataNVX"/>
-            public static unsafe void LGPUNamedBufferSubDataNVX<T1>(All gpuMask, BufferHandle buffer, IntPtr offset, nint size, in T1 data)
+            public static unsafe void LGPUNamedBufferSubDataNVX<T1>(All gpuMask, int buffer, IntPtr offset, nint size, in T1 data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = &data)
@@ -46042,7 +46042,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="AsyncCopyBufferSubDataNVX"/>
-            public static unsafe uint AsyncCopyBufferSubDataNVX(int waitSemaphoreCount, ReadOnlySpan<uint> waitSemaphoreArray, ReadOnlySpan<ulong> fenceValueArray, uint readGpu, All writeGpuMask, BufferHandle readBuffer, BufferHandle writeBuffer, IntPtr readOffset, IntPtr writeOffset, nint size, int signalSemaphoreCount, ReadOnlySpan<uint> signalSemaphoreArray, ReadOnlySpan<ulong> signalValueArray)
+            public static unsafe uint AsyncCopyBufferSubDataNVX(int waitSemaphoreCount, ReadOnlySpan<uint> waitSemaphoreArray, ReadOnlySpan<ulong> fenceValueArray, uint readGpu, All writeGpuMask, int readBuffer, int writeBuffer, IntPtr readOffset, IntPtr writeOffset, nint size, int signalSemaphoreCount, ReadOnlySpan<uint> signalSemaphoreArray, ReadOnlySpan<ulong> signalValueArray)
             {
                 uint returnValue;
                 fixed (uint* waitSemaphoreArray_ptr = waitSemaphoreArray)
@@ -46061,7 +46061,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return returnValue;
             }
             /// <inheritdoc cref="AsyncCopyBufferSubDataNVX"/>
-            public static unsafe uint AsyncCopyBufferSubDataNVX(int waitSemaphoreCount, uint[] waitSemaphoreArray, ulong[] fenceValueArray, uint readGpu, All writeGpuMask, BufferHandle readBuffer, BufferHandle writeBuffer, IntPtr readOffset, IntPtr writeOffset, nint size, int signalSemaphoreCount, uint[] signalSemaphoreArray, ulong[] signalValueArray)
+            public static unsafe uint AsyncCopyBufferSubDataNVX(int waitSemaphoreCount, uint[] waitSemaphoreArray, ulong[] fenceValueArray, uint readGpu, All writeGpuMask, int readBuffer, int writeBuffer, IntPtr readOffset, IntPtr writeOffset, nint size, int signalSemaphoreCount, uint[] signalSemaphoreArray, ulong[] signalValueArray)
             {
                 uint returnValue;
                 fixed (uint* waitSemaphoreArray_ptr = waitSemaphoreArray)
@@ -46080,7 +46080,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return returnValue;
             }
             /// <inheritdoc cref="AsyncCopyBufferSubDataNVX"/>
-            public static unsafe uint AsyncCopyBufferSubDataNVX(int waitSemaphoreCount, in uint waitSemaphoreArray, in ulong fenceValueArray, uint readGpu, All writeGpuMask, BufferHandle readBuffer, BufferHandle writeBuffer, IntPtr readOffset, IntPtr writeOffset, nint size, int signalSemaphoreCount, in uint signalSemaphoreArray, in ulong signalValueArray)
+            public static unsafe uint AsyncCopyBufferSubDataNVX(int waitSemaphoreCount, in uint waitSemaphoreArray, in ulong fenceValueArray, uint readGpu, All writeGpuMask, int readBuffer, int writeBuffer, IntPtr readOffset, IntPtr writeOffset, nint size, int signalSemaphoreCount, in uint signalSemaphoreArray, in ulong signalValueArray)
             {
                 uint returnValue;
                 fixed (uint* waitSemaphoreArray_ptr = &waitSemaphoreArray)
@@ -47446,9 +47446,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="PrioritizeTexturesxOES"/>
-            public static unsafe void PrioritizeTexturesxOES(int n, ReadOnlySpan<TextureHandle> textures, ReadOnlySpan<int> priorities)
+            public static unsafe void PrioritizeTexturesxOES(int n, ReadOnlySpan<int> textures, ReadOnlySpan<int> priorities)
             {
-                fixed (TextureHandle* textures_ptr = textures)
+                fixed (int* textures_ptr = textures)
                 {
                     fixed (int* priorities_ptr = priorities)
                     {
@@ -47457,9 +47457,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="PrioritizeTexturesxOES"/>
-            public static unsafe void PrioritizeTexturesxOES(int n, TextureHandle[] textures, int[] priorities)
+            public static unsafe void PrioritizeTexturesxOES(int n, int[] textures, int[] priorities)
             {
-                fixed (TextureHandle* textures_ptr = textures)
+                fixed (int* textures_ptr = textures)
                 {
                     fixed (int* priorities_ptr = priorities)
                     {
@@ -47468,9 +47468,9 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="PrioritizeTexturesxOES"/>
-            public static unsafe void PrioritizeTexturesxOES(int n, in TextureHandle textures, in int priorities)
+            public static unsafe void PrioritizeTexturesxOES(int n, in int textures, in int priorities)
             {
-                fixed (TextureHandle* textures_ptr = &textures)
+                fixed (int* textures_ptr = &textures)
                 fixed (int* priorities_ptr = &priorities)
                 {
                     PrioritizeTexturesxOES(n, textures_ptr, priorities_ptr);
@@ -48644,7 +48644,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 return returnValue;
             }
             /// <inheritdoc cref="GetListParameterfvSGIX"/>
-            public static unsafe void GetListParameterfvSGIX(DisplayListHandle list, ListParameterName pname, Span<float> parameters)
+            public static unsafe void GetListParameterfvSGIX(int list, ListParameterName pname, Span<float> parameters)
             {
                 fixed (float* parameters_ptr = parameters)
                 {
@@ -48652,7 +48652,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetListParameterfvSGIX"/>
-            public static unsafe void GetListParameterfvSGIX(DisplayListHandle list, ListParameterName pname, float[] parameters)
+            public static unsafe void GetListParameterfvSGIX(int list, ListParameterName pname, float[] parameters)
             {
                 fixed (float* parameters_ptr = parameters)
                 {
@@ -48660,7 +48660,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetListParameterfvSGIX"/>
-            public static unsafe void GetListParameterfvSGIX(DisplayListHandle list, ListParameterName pname, ref float parameters)
+            public static unsafe void GetListParameterfvSGIX(int list, ListParameterName pname, ref float parameters)
             {
                 fixed (float* parameters_ptr = &parameters)
                 {
@@ -48668,7 +48668,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetListParameterivSGIX"/>
-            public static unsafe void GetListParameterivSGIX(DisplayListHandle list, ListParameterName pname, Span<int> parameters)
+            public static unsafe void GetListParameterivSGIX(int list, ListParameterName pname, Span<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -48676,7 +48676,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetListParameterivSGIX"/>
-            public static unsafe void GetListParameterivSGIX(DisplayListHandle list, ListParameterName pname, int[] parameters)
+            public static unsafe void GetListParameterivSGIX(int list, ListParameterName pname, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -48684,7 +48684,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="GetListParameterivSGIX"/>
-            public static unsafe void GetListParameterivSGIX(DisplayListHandle list, ListParameterName pname, ref int parameters)
+            public static unsafe void GetListParameterivSGIX(int list, ListParameterName pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -48692,7 +48692,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ListParameterfvSGIX"/>
-            public static unsafe void ListParameterfvSGIX(DisplayListHandle list, ListParameterName pname, ReadOnlySpan<float> parameters)
+            public static unsafe void ListParameterfvSGIX(int list, ListParameterName pname, ReadOnlySpan<float> parameters)
             {
                 fixed (float* parameters_ptr = parameters)
                 {
@@ -48700,7 +48700,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ListParameterfvSGIX"/>
-            public static unsafe void ListParameterfvSGIX(DisplayListHandle list, ListParameterName pname, float[] parameters)
+            public static unsafe void ListParameterfvSGIX(int list, ListParameterName pname, float[] parameters)
             {
                 fixed (float* parameters_ptr = parameters)
                 {
@@ -48708,7 +48708,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ListParameterfvSGIX"/>
-            public static unsafe void ListParameterfvSGIX(DisplayListHandle list, ListParameterName pname, in float parameters)
+            public static unsafe void ListParameterfvSGIX(int list, ListParameterName pname, in float parameters)
             {
                 fixed (float* parameters_ptr = &parameters)
                 {
@@ -48716,7 +48716,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ListParameterivSGIX"/>
-            public static unsafe void ListParameterivSGIX(DisplayListHandle list, ListParameterName pname, ReadOnlySpan<int> parameters)
+            public static unsafe void ListParameterivSGIX(int list, ListParameterName pname, ReadOnlySpan<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -48724,7 +48724,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ListParameterivSGIX"/>
-            public static unsafe void ListParameterivSGIX(DisplayListHandle list, ListParameterName pname, int[] parameters)
+            public static unsafe void ListParameterivSGIX(int list, ListParameterName pname, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -48732,7 +48732,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
             /// <inheritdoc cref="ListParameterivSGIX"/>
-            public static unsafe void ListParameterivSGIX(DisplayListHandle list, ListParameterName pname, in int parameters)
+            public static unsafe void ListParameterivSGIX(int list, ListParameterName pname, in int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {

--- a/src/OpenTK.Graphics/OpenGL/GL.Manual.cs
+++ b/src/OpenTK.Graphics/OpenGL/GL.Manual.cs
@@ -4,6 +4,11 @@ using OpenTK.Mathematics;
 
 namespace OpenTK.Graphics.OpenGL
 {
+#if !TYPESAFE_HANDLES
+    using ShaderHandle = System.Int32;
+    using ProgramHandle = System.Int32;
+#endif
+
     // FIXME: Remove this when it's fixed
     // This is here because there in the gl.xml
     // one of the parameters for "glSampleMaskIndexedNV"

--- a/src/OpenTK.Graphics/OpenGL/GL.Native.cs
+++ b/src/OpenTK.Graphics/OpenGL/GL.Native.cs
@@ -407,24 +407,24 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="target"> Specifies the target to which the texture is bound. Must be one of GL_TEXTURE_1D, GL_TEXTURE_2D, GL_TEXTURE_3D, GL_TEXTURE_1D_ARRAY, GL_TEXTURE_2D_ARRAY, GL_TEXTURE_RECTANGLE, GL_TEXTURE_CUBE_MAP, GL_TEXTURE_CUBE_MAP_ARRAY, GL_TEXTURE_BUFFER, GL_TEXTURE_2D_MULTISAMPLE or GL_TEXTURE_2D_MULTISAMPLE_ARRAY. </param>
         /// <param name="texture"> Specifies the name of a texture. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindTexture.xhtml" /></remarks>
-        public static void BindTexture(TextureTarget target, TextureHandle texture) => GLPointers._BindTexture_fnptr((uint)target, (int)texture);
+        public static void BindTexture(TextureTarget target, int texture) => GLPointers._BindTexture_fnptr((uint)target, texture);
         
         /// <summary> <b>[requires: v1.1]</b> Delete named textures. </summary>
         /// <param name="n"> Specifies the number of textures to be deleted. </param>
         /// <param name="textures"> Specifies an array of textures to be deleted. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDeleteTextures.xhtml" /></remarks>
-        public static void DeleteTextures(int n, TextureHandle* textures) => GLPointers._DeleteTextures_fnptr(n, (int*)textures);
+        public static void DeleteTextures(int n, int* textures) => GLPointers._DeleteTextures_fnptr(n, textures);
         
         /// <summary> <b>[requires: v1.1]</b> Generate texture names. </summary>
         /// <param name="n"> Specifies the number of texture names to be generated. </param>
         /// <param name="textures"> Specifies an array in which the generated texture names are stored. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGenTextures.xhtml" /></remarks>
-        public static void GenTextures(int n, TextureHandle* textures) => GLPointers._GenTextures_fnptr(n, (int*)textures);
+        public static void GenTextures(int n, int* textures) => GLPointers._GenTextures_fnptr(n, textures);
         
         /// <summary> <b>[requires: v1.1]</b> Determine if a name corresponds to a texture. </summary>
         /// <param name="texture"> Specifies a value that may be the name of a texture. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsTexture.xhtml" /></remarks>
-        public static bool IsTexture(TextureHandle texture) => GLPointers._IsTexture_fnptr((int)texture) != 0;
+        public static bool IsTexture(int texture) => GLPointers._IsTexture_fnptr(texture) != 0;
         
         /// <summary> <b>[requires: v1.2]</b> Render primitives from array data. </summary>
         /// <param name="mode"> Specifies what kind of primitives to render. Symbolic constants GL_POINTS, GL_LINE_STRIP, GL_LINE_LOOP, GL_LINES, GL_LINE_STRIP_ADJACENCY, GL_LINES_ADJACENCY, GL_TRIANGLE_STRIP, GL_TRIANGLE_FAN, GL_TRIANGLES, GL_TRIANGLE_STRIP_ADJACENCY, GL_TRIANGLES_ADJACENCY and GL_PATCHES are accepted. </param>
@@ -637,24 +637,24 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="n"> Specifies the number of query object names to be generated. </param>
         /// <param name="ids"> Specifies an array in which the generated query object names are stored. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGenQueries.xhtml" /></remarks>
-        public static void GenQueries(int n, QueryHandle* ids) => GLPointers._GenQueries_fnptr(n, (int*)ids);
+        public static void GenQueries(int n, int* ids) => GLPointers._GenQueries_fnptr(n, ids);
         
         /// <summary> <b>[requires: v1.5]</b> Delete named query objects. </summary>
         /// <param name="n"> Specifies the number of query objects to be deleted. </param>
         /// <param name="ids"> Specifies an array of query objects to be deleted. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDeleteQueries.xhtml" /></remarks>
-        public static void DeleteQueries(int n, QueryHandle* ids) => GLPointers._DeleteQueries_fnptr(n, (int*)ids);
+        public static void DeleteQueries(int n, int* ids) => GLPointers._DeleteQueries_fnptr(n, ids);
         
         /// <summary> <b>[requires: v1.5]</b> Determine if a name corresponds to a query object. </summary>
         /// <param name="id"> Specifies a value that may be the name of a query object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsQuery.xhtml" /></remarks>
-        public static bool IsQuery(QueryHandle id) => GLPointers._IsQuery_fnptr((int)id) != 0;
+        public static bool IsQuery(int id) => GLPointers._IsQuery_fnptr(id) != 0;
         
         /// <summary> <b>[requires: v1.5]</b> Delimit the boundaries of a query object. </summary>
         /// <param name="target"> Specifies the target type of query object established between glBeginQuery and the subsequent glEndQuery. The symbolic constant must be one of GL_SAMPLES_PASSED, GL_ANY_SAMPLES_PASSED, GL_ANY_SAMPLES_PASSED_CONSERVATIVE, GL_PRIMITIVES_GENERATED, GL_TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN, or GL_TIME_ELAPSED. </param>
         /// <param name="id"> Specifies the name of a query object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBeginQuery.xhtml" /></remarks>
-        public static void BeginQuery(QueryTarget target, QueryHandle id) => GLPointers._BeginQuery_fnptr((uint)target, (int)id);
+        public static void BeginQuery(QueryTarget target, int id) => GLPointers._BeginQuery_fnptr((uint)target, id);
         
         /// <summary> <b>[requires: v1.5]</b> Delimit the boundaries of a query object. </summary>
         /// <param name="target"> Specifies the target type of query object established between glBeginQuery and the subsequent glEndQuery. The symbolic constant must be one of GL_SAMPLES_PASSED, GL_ANY_SAMPLES_PASSED, GL_ANY_SAMPLES_PASSED_CONSERVATIVE, GL_PRIMITIVES_GENERATED, GL_TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN, or GL_TIME_ELAPSED. </param>
@@ -673,37 +673,37 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="pname"> Specifies the symbolic name of a query object parameter. Accepted values are GL_QUERY_RESULT or GL_QUERY_RESULT_AVAILABLE. </param>
         /// <param name="parameters"> If a buffer is bound to the GL_QUERY_RESULT_BUFFER target, then params is treated as an offset to a location within that buffer's data store to receive the result of the query. If no buffer is bound to GL_QUERY_RESULT_BUFFER, then params is treated as an address in client memory of a variable to receive the resulting data. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetQueryObject.xhtml" /></remarks>
-        public static void GetQueryObjectiv(QueryHandle id, QueryObjectParameterName pname, int* parameters) => GLPointers._GetQueryObjectiv_fnptr((int)id, (uint)pname, parameters);
+        public static void GetQueryObjectiv(int id, QueryObjectParameterName pname, int* parameters) => GLPointers._GetQueryObjectiv_fnptr(id, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v1.5]</b> Return parameters of a query object. </summary>
         /// <param name="id"> Specifies the name of a query object. </param>
         /// <param name="pname"> Specifies the symbolic name of a query object parameter. Accepted values are GL_QUERY_RESULT or GL_QUERY_RESULT_AVAILABLE. </param>
         /// <param name="parameters"> If a buffer is bound to the GL_QUERY_RESULT_BUFFER target, then params is treated as an offset to a location within that buffer's data store to receive the result of the query. If no buffer is bound to GL_QUERY_RESULT_BUFFER, then params is treated as an address in client memory of a variable to receive the resulting data. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetQueryObject.xhtml" /></remarks>
-        public static void GetQueryObjectuiv(QueryHandle id, QueryObjectParameterName pname, uint* parameters) => GLPointers._GetQueryObjectuiv_fnptr((int)id, (uint)pname, parameters);
+        public static void GetQueryObjectuiv(int id, QueryObjectParameterName pname, uint* parameters) => GLPointers._GetQueryObjectuiv_fnptr(id, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v1.5]</b> Bind a named buffer object. </summary>
         /// <param name="target"> Specifies the target to which the buffer object is bound, which must be one of the buffer binding targets in the following table: </param>
         /// <param name="buffer"> Specifies the name of a buffer object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindBuffer.xhtml" /></remarks>
-        public static void BindBuffer(BufferTargetARB target, BufferHandle buffer) => GLPointers._BindBuffer_fnptr((uint)target, (int)buffer);
+        public static void BindBuffer(BufferTargetARB target, int buffer) => GLPointers._BindBuffer_fnptr((uint)target, buffer);
         
         /// <summary> <b>[requires: v1.5]</b> Delete named buffer objects. </summary>
         /// <param name="n"> Specifies the number of buffer objects to be deleted. </param>
         /// <param name="buffers"> Specifies an array of buffer objects to be deleted. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDeleteBuffers.xhtml" /></remarks>
-        public static void DeleteBuffers(int n, BufferHandle* buffers) => GLPointers._DeleteBuffers_fnptr(n, (int*)buffers);
+        public static void DeleteBuffers(int n, int* buffers) => GLPointers._DeleteBuffers_fnptr(n, buffers);
         
         /// <summary> <b>[requires: v1.5]</b> Generate buffer object names. </summary>
         /// <param name="n"> Specifies the number of buffer object names to be generated. </param>
         /// <param name="buffers"> Specifies an array in which the generated buffer object names are stored. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGenBuffers.xhtml" /></remarks>
-        public static void GenBuffers(int n, BufferHandle* buffers) => GLPointers._GenBuffers_fnptr(n, (int*)buffers);
+        public static void GenBuffers(int n, int* buffers) => GLPointers._GenBuffers_fnptr(n, buffers);
         
         /// <summary> <b>[requires: v1.5]</b> Determine if a name corresponds to a buffer object. </summary>
         /// <param name="buffer"> Specifies a value that may be the name of a buffer object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsBuffer.xhtml" /></remarks>
-        public static bool IsBuffer(BufferHandle buffer) => GLPointers._IsBuffer_fnptr((int)buffer) != 0;
+        public static bool IsBuffer(int buffer) => GLPointers._IsBuffer_fnptr(buffer) != 0;
         
         /// <summary> <b>[requires: v1.5]</b> Creates and initializes a buffer object's data    store. </summary>
         /// <param name="target"> Specifies the target to which the buffer object is bound for glBufferData, which must be one of the buffer binding targets in the following table: </param>
@@ -792,44 +792,44 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="program">Specifies the program object to which a shader object will be attached.</param>
         /// <param name="shader">Specifies the shader object that is to be attached.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glAttachShader.xhtml" /></remarks>
-        public static void AttachShader(ProgramHandle program, ShaderHandle shader) => GLPointers._AttachShader_fnptr((int)program, (int)shader);
+        public static void AttachShader(int program, int shader) => GLPointers._AttachShader_fnptr(program, shader);
         
         /// <summary> <b>[requires: v2.0]</b> Associates a generic vertex attribute index with a named attribute variable. </summary>
         /// <param name="program">Specifies the handle of the program object in which the association is to be made.</param>
         /// <param name="index">Specifies the index of the generic vertex attribute to be bound.</param>
         /// <param name="name">Specifies a null terminated string containing the name of the vertex shader attribute variable to which index is to be bound.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindAttribLocation.xhtml" /></remarks>
-        public static void BindAttribLocation(ProgramHandle program, uint index, byte* name) => GLPointers._BindAttribLocation_fnptr((int)program, index, name);
+        public static void BindAttribLocation(int program, uint index, byte* name) => GLPointers._BindAttribLocation_fnptr(program, index, name);
         
         /// <summary> <b>[requires: v2.0]</b> Compiles a shader object. </summary>
         /// <param name="shader">Specifies the shader object to be compiled.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCompileShader.xhtml" /></remarks>
-        public static void CompileShader(ShaderHandle shader) => GLPointers._CompileShader_fnptr((int)shader);
+        public static void CompileShader(int shader) => GLPointers._CompileShader_fnptr(shader);
         
         /// <summary> <b>[requires: v2.0]</b> Creates a program object. </summary>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCreateProgram.xhtml" /></remarks>
-        public static ProgramHandle CreateProgram() => (ProgramHandle) GLPointers._CreateProgram_fnptr();
+        public static int CreateProgram() => GLPointers._CreateProgram_fnptr();
         
         /// <summary> <b>[requires: v2.0]</b> Creates a shader object. </summary>
         /// <param name="shaderType">Specifies the type of shader to be created. Must be one of GL_COMPUTE_SHADER, GL_VERTEX_SHADER, GL_TESS_CONTROL_SHADER, GL_TESS_EVALUATION_SHADER, GL_GEOMETRY_SHADER, or GL_FRAGMENT_SHADER.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCreateShader.xhtml" /></remarks>
-        public static ShaderHandle CreateShader(ShaderType type) => (ShaderHandle) GLPointers._CreateShader_fnptr((uint)type);
+        public static int CreateShader(ShaderType type) => GLPointers._CreateShader_fnptr((uint)type);
         
         /// <summary> <b>[requires: v2.0]</b> Deletes a program object. </summary>
         /// <param name="program">Specifies the program object to be deleted.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDeleteProgram.xhtml" /></remarks>
-        public static void DeleteProgram(ProgramHandle program) => GLPointers._DeleteProgram_fnptr((int)program);
+        public static void DeleteProgram(int program) => GLPointers._DeleteProgram_fnptr(program);
         
         /// <summary> <b>[requires: v2.0]</b> Deletes a shader object. </summary>
         /// <param name="shader">Specifies the shader object to be deleted.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDeleteShader.xhtml" /></remarks>
-        public static void DeleteShader(ShaderHandle shader) => GLPointers._DeleteShader_fnptr((int)shader);
+        public static void DeleteShader(int shader) => GLPointers._DeleteShader_fnptr(shader);
         
         /// <summary> <b>[requires: v2.0]</b> Detaches a shader object from a program object to which it is attached. </summary>
         /// <param name="program">Specifies the program object from which to detach the shader object.</param>
         /// <param name="shader">Specifies the shader object to be detached.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDetachShader.xhtml" /></remarks>
-        public static void DetachShader(ProgramHandle program, ShaderHandle shader) => GLPointers._DetachShader_fnptr((int)program, (int)shader);
+        public static void DetachShader(int program, int shader) => GLPointers._DetachShader_fnptr(program, shader);
         
         /// <summary> <b>[requires: v2.0]</b> Enable or disable a generic vertex attribute    array. </summary>
         /// <param name="index">Specifies the index of the generic vertex attribute to be enabled or disabled.</param>
@@ -850,7 +850,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="type">Returns the data type of the attribute variable.</param>
         /// <param name="name">Returns a null terminated string containing the name of the attribute variable.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetActiveAttrib.xhtml" /></remarks>
-        public static void GetActiveAttrib(ProgramHandle program, uint index, int bufSize, int* length, int* size, AttributeType* type, byte* name) => GLPointers._GetActiveAttrib_fnptr((int)program, index, bufSize, length, size, (uint*)type, name);
+        public static void GetActiveAttrib(int program, uint index, int bufSize, int* length, int* size, AttributeType* type, byte* name) => GLPointers._GetActiveAttrib_fnptr(program, index, bufSize, length, size, (uint*)type, name);
         
         /// <summary> <b>[requires: v2.0]</b> Returns information about an active uniform variable for the specified program object. </summary>
         /// <param name="program">Specifies the program object to be queried.</param>
@@ -861,7 +861,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="type">Returns the data type of the uniform variable.</param>
         /// <param name="name">Returns a null terminated string containing the name of the uniform variable.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetActiveUniform.xhtml" /></remarks>
-        public static void GetActiveUniform(ProgramHandle program, uint index, int bufSize, int* length, int* size, UniformType* type, byte* name) => GLPointers._GetActiveUniform_fnptr((int)program, index, bufSize, length, size, (uint*)type, name);
+        public static void GetActiveUniform(int program, uint index, int bufSize, int* length, int* size, UniformType* type, byte* name) => GLPointers._GetActiveUniform_fnptr(program, index, bufSize, length, size, (uint*)type, name);
         
         /// <summary> <b>[requires: v2.0]</b> Returns the handles of the shader objects attached to a program object. </summary>
         /// <param name="program">Specifies the program object to be queried.</param>
@@ -869,20 +869,20 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="count">Returns the number of names actually returned in shaders.</param>
         /// <param name="shaders">Specifies an array that is used to return the names of attached shader objects.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetAttachedShaders.xhtml" /></remarks>
-        public static void GetAttachedShaders(ProgramHandle program, int maxCount, int* count, ShaderHandle* shaders) => GLPointers._GetAttachedShaders_fnptr((int)program, maxCount, count, (int*)shaders);
+        public static void GetAttachedShaders(int program, int maxCount, int* count, int* shaders) => GLPointers._GetAttachedShaders_fnptr(program, maxCount, count, shaders);
         
         /// <summary> <b>[requires: v2.0]</b> Returns the location of an attribute variable. </summary>
         /// <param name="program">Specifies the program object to be queried.</param>
         /// <param name="name">Points to a null terminated string containing the name of the attribute variable whose location is to be queried.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetAttribLocation.xhtml" /></remarks>
-        public static int GetAttribLocation(ProgramHandle program, byte* name) => GLPointers._GetAttribLocation_fnptr((int)program, name);
+        public static int GetAttribLocation(int program, byte* name) => GLPointers._GetAttribLocation_fnptr(program, name);
         
         /// <summary> <b>[requires: v2.0]</b> Returns a parameter from a program object. </summary>
         /// <param name="program">Specifies the program object to be queried.</param>
         /// <param name="pname">Specifies the object parameter. Accepted symbolic names are GL_DELETE_STATUS, GL_LINK_STATUS, GL_VALIDATE_STATUS, GL_INFO_LOG_LENGTH, GL_ATTACHED_SHADERS, GL_ACTIVE_ATOMIC_COUNTER_BUFFERS, GL_ACTIVE_ATTRIBUTES, GL_ACTIVE_ATTRIBUTE_MAX_LENGTH, GL_ACTIVE_UNIFORMS, GL_ACTIVE_UNIFORM_BLOCKS, GL_ACTIVE_UNIFORM_BLOCK_MAX_NAME_LENGTH, GL_ACTIVE_UNIFORM_MAX_LENGTH, GL_COMPUTE_WORK_GROUP_SIZE GL_PROGRAM_BINARY_LENGTH, GL_TRANSFORM_FEEDBACK_BUFFER_MODE, GL_TRANSFORM_FEEDBACK_VARYINGS, GL_TRANSFORM_FEEDBACK_VARYING_MAX_LENGTH, GL_GEOMETRY_VERTICES_OUT, GL_GEOMETRY_INPUT_TYPE, and GL_GEOMETRY_OUTPUT_TYPE.</param>
         /// <param name="parameters">Returns the requested object parameter.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetProgram.xhtml" /></remarks>
-        public static void GetProgramiv(ProgramHandle program, ProgramPropertyARB pname, int* parameters) => GLPointers._GetProgramiv_fnptr((int)program, (uint)pname, parameters);
+        public static void GetProgramiv(int program, ProgramPropertyARB pname, int* parameters) => GLPointers._GetProgramiv_fnptr(program, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v2.0]</b> Returns the information log for a program object. </summary>
         /// <param name="program">Specifies the program object whose information log is to be queried.</param>
@@ -890,14 +890,14 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="length">Returns the length of the string returned in infoLog (excluding the null terminator).</param>
         /// <param name="infoLog">Specifies an array of characters that is used to return the information log.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetProgramInfoLog.xhtml" /></remarks>
-        public static void GetProgramInfoLog(ProgramHandle program, int bufSize, int* length, byte* infoLog) => GLPointers._GetProgramInfoLog_fnptr((int)program, bufSize, length, infoLog);
+        public static void GetProgramInfoLog(int program, int bufSize, int* length, byte* infoLog) => GLPointers._GetProgramInfoLog_fnptr(program, bufSize, length, infoLog);
         
         /// <summary> <b>[requires: v2.0]</b> Returns a parameter from a shader object. </summary>
         /// <param name="shader">Specifies the shader object to be queried.</param>
         /// <param name="pname">Specifies the object parameter. Accepted symbolic names are GL_SHADER_TYPE, GL_DELETE_STATUS, GL_COMPILE_STATUS, GL_INFO_LOG_LENGTH, GL_SHADER_SOURCE_LENGTH.</param>
         /// <param name="parameters">Returns the requested object parameter.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetShader.xhtml" /></remarks>
-        public static void GetShaderiv(ShaderHandle shader, ShaderParameterName pname, int* parameters) => GLPointers._GetShaderiv_fnptr((int)shader, (uint)pname, parameters);
+        public static void GetShaderiv(int shader, ShaderParameterName pname, int* parameters) => GLPointers._GetShaderiv_fnptr(shader, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v2.0]</b> Returns the information log for a shader object. </summary>
         /// <param name="shader">Specifies the shader object whose information log is to be queried.</param>
@@ -905,7 +905,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="length">Returns the length of the string returned in infoLog (excluding the null terminator).</param>
         /// <param name="infoLog">Specifies an array of characters that is used to return the information log.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetShaderInfoLog.xhtml" /></remarks>
-        public static void GetShaderInfoLog(ShaderHandle shader, int bufSize, int* length, byte* infoLog) => GLPointers._GetShaderInfoLog_fnptr((int)shader, bufSize, length, infoLog);
+        public static void GetShaderInfoLog(int shader, int bufSize, int* length, byte* infoLog) => GLPointers._GetShaderInfoLog_fnptr(shader, bufSize, length, infoLog);
         
         /// <summary> <b>[requires: v2.0]</b> Returns the source code string from a shader object. </summary>
         /// <param name="shader">Specifies the shader object to be queried.</param>
@@ -913,27 +913,27 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="length">Returns the length of the string returned in source (excluding the null terminator).</param>
         /// <param name="source">Specifies an array of characters that is used to return the source code string.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetShaderSource.xhtml" /></remarks>
-        public static void GetShaderSource(ShaderHandle shader, int bufSize, int* length, byte* source) => GLPointers._GetShaderSource_fnptr((int)shader, bufSize, length, source);
+        public static void GetShaderSource(int shader, int bufSize, int* length, byte* source) => GLPointers._GetShaderSource_fnptr(shader, bufSize, length, source);
         
         /// <summary> <b>[requires: v2.0]</b> Returns the location of a uniform variable. </summary>
         /// <param name="program">Specifies the program object to be queried.</param>
         /// <param name="name">Points to a null terminated string containing the name of the uniform variable whose location is to be queried.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetUniformLocation.xhtml" /></remarks>
-        public static int GetUniformLocation(ProgramHandle program, byte* name) => GLPointers._GetUniformLocation_fnptr((int)program, name);
+        public static int GetUniformLocation(int program, byte* name) => GLPointers._GetUniformLocation_fnptr(program, name);
         
         /// <summary> <b>[requires: v2.0]</b> Returns the value of a uniform variable. </summary>
         /// <param name="program">Specifies the program object to be queried.</param>
         /// <param name="location">Specifies the location of the uniform variable to be queried.</param>
         /// <param name="parameters">Returns the value of the specified uniform variable.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetUniform.xhtml" /></remarks>
-        public static void GetUniformfv(ProgramHandle program, int location, float* parameters) => GLPointers._GetUniformfv_fnptr((int)program, location, parameters);
+        public static void GetUniformfv(int program, int location, float* parameters) => GLPointers._GetUniformfv_fnptr(program, location, parameters);
         
         /// <summary> <b>[requires: v2.0]</b> Returns the value of a uniform variable. </summary>
         /// <param name="program">Specifies the program object to be queried.</param>
         /// <param name="location">Specifies the location of the uniform variable to be queried.</param>
         /// <param name="parameters">Returns the value of the specified uniform variable.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetUniform.xhtml" /></remarks>
-        public static void GetUniformiv(ProgramHandle program, int location, int* parameters) => GLPointers._GetUniformiv_fnptr((int)program, location, parameters);
+        public static void GetUniformiv(int program, int location, int* parameters) => GLPointers._GetUniformiv_fnptr(program, location, parameters);
         
         /// <summary> <b>[requires: v2.0]</b> Return a generic vertex attribute parameter. </summary>
         /// <param name="index">Specifies the generic vertex attribute parameter to be queried.</param>
@@ -966,17 +966,17 @@ namespace OpenTK.Graphics.OpenGL
         /// <summary> <b>[requires: v2.0]</b> Determines if a name corresponds to a program object. </summary>
         /// <param name="program">Specifies a potential program object.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsProgram.xhtml" /></remarks>
-        public static bool IsProgram(ProgramHandle program) => GLPointers._IsProgram_fnptr((int)program) != 0;
+        public static bool IsProgram(int program) => GLPointers._IsProgram_fnptr(program) != 0;
         
         /// <summary> <b>[requires: v2.0]</b> Determines if a name corresponds to a shader object. </summary>
         /// <param name="shader">Specifies a potential shader object.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsShader.xhtml" /></remarks>
-        public static bool IsShader(ShaderHandle shader) => GLPointers._IsShader_fnptr((int)shader) != 0;
+        public static bool IsShader(int shader) => GLPointers._IsShader_fnptr(shader) != 0;
         
         /// <summary> <b>[requires: v2.0]</b> Links a program object. </summary>
         /// <param name="program">Specifies the handle of the program object to be linked.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glLinkProgram.xhtml" /></remarks>
-        public static void LinkProgram(ProgramHandle program) => GLPointers._LinkProgram_fnptr((int)program);
+        public static void LinkProgram(int program) => GLPointers._LinkProgram_fnptr(program);
         
         /// <summary> <b>[requires: v2.0]</b> Replaces the source code in a shader object. </summary>
         /// <param name="shader">Specifies the handle of the shader object whose source code is to be replaced.</param>
@@ -984,12 +984,12 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="str">Specifies an array of pointers to strings containing the source code to be loaded into the shader.</param>
         /// <param name="length">Specifies an array of string lengths.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glShaderSource.xhtml" /></remarks>
-        public static void ShaderSource(ShaderHandle shader, int count, byte** str, int* length) => GLPointers._ShaderSource_fnptr((int)shader, count, str, length);
+        public static void ShaderSource(int shader, int count, byte** str, int* length) => GLPointers._ShaderSource_fnptr(shader, count, str, length);
         
         /// <summary> <b>[requires: v2.0]</b> Installs a program object as part of current rendering state. </summary>
         /// <param name="program">Specifies the handle of the program object whose executables are to be used as part of current rendering state.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glUseProgram.xhtml" /></remarks>
-        public static void UseProgram(ProgramHandle program) => GLPointers._UseProgram_fnptr((int)program);
+        public static void UseProgram(int program) => GLPointers._UseProgram_fnptr(program);
         
         /// <summary> <b>[requires: v2.0]</b> Specify the value of a uniform variable for the current program object. </summary>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
@@ -1134,7 +1134,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <summary> <b>[requires: v2.0]</b> Validates a program object. </summary>
         /// <param name="program">Specifies the handle of the program object to be validated.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glValidateProgram.xhtml" /></remarks>
-        public static void ValidateProgram(ProgramHandle program) => GLPointers._ValidateProgram_fnptr((int)program);
+        public static void ValidateProgram(int program) => GLPointers._ValidateProgram_fnptr(program);
         
         /// <summary> <b>[requires: v2.0]</b> Specifies the value of a generic vertex attribute. </summary>
         /// <param name="index">Specifies the index of the generic vertex attribute to be modified.</param>
@@ -1488,14 +1488,14 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="offset"> The starting offset in basic machine units into the buffer object buffer. </param>
         /// <param name="size"> The amount of data in machine units that can be read from the buffer object while used as an indexed target. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindBufferRange.xhtml" /></remarks>
-        public static void BindBufferRange(BufferTargetARB target, uint index, BufferHandle buffer, IntPtr offset, nint size) => GLPointers._BindBufferRange_fnptr((uint)target, index, (int)buffer, offset, size);
+        public static void BindBufferRange(BufferTargetARB target, uint index, int buffer, IntPtr offset, nint size) => GLPointers._BindBufferRange_fnptr((uint)target, index, buffer, offset, size);
         
         /// <summary> <b>[requires: v3.0 | v3.1 | GL_ARB_uniform_buffer_object]</b> Bind a buffer object to an indexed buffer target. </summary>
         /// <param name="target"> Specify the target of the bind operation. target must be one of GL_ATOMIC_COUNTER_BUFFER, GL_TRANSFORM_FEEDBACK_BUFFER, GL_UNIFORM_BUFFER or GL_SHADER_STORAGE_BUFFER. </param>
         /// <param name="index"> Specify the index of the binding point within the array specified by target. </param>
         /// <param name="buffer"> The name of a buffer object to bind to the specified binding point. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindBufferBase.xhtml" /></remarks>
-        public static void BindBufferBase(BufferTargetARB target, uint index, BufferHandle buffer) => GLPointers._BindBufferBase_fnptr((uint)target, index, (int)buffer);
+        public static void BindBufferBase(BufferTargetARB target, uint index, int buffer) => GLPointers._BindBufferBase_fnptr((uint)target, index, buffer);
         
         /// <summary> <b>[requires: v3.0]</b> Specify values to record in transform feedback buffers. </summary>
         /// <param name="program"> The name of the target program object. </param>
@@ -1503,7 +1503,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="varyings"> An array of count zero-terminated strings specifying the names of the varying variables to use for transform feedback. </param>
         /// <param name="bufferMode"> Identifies the mode used to capture the varying variables when transform feedback is active. bufferMode must be GL_INTERLEAVED_ATTRIBS or GL_SEPARATE_ATTRIBS. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTransformFeedbackVaryings.xhtml" /></remarks>
-        public static void TransformFeedbackVaryings(ProgramHandle program, int count, byte** varyings, TransformFeedbackBufferMode bufferMode) => GLPointers._TransformFeedbackVaryings_fnptr((int)program, count, varyings, (uint)bufferMode);
+        public static void TransformFeedbackVaryings(int program, int count, byte** varyings, TransformFeedbackBufferMode bufferMode) => GLPointers._TransformFeedbackVaryings_fnptr(program, count, varyings, (uint)bufferMode);
         
         /// <summary> <b>[requires: v3.0]</b> Retrieve information about varying variables selected for transform feedback. </summary>
         /// <param name="program"> The name of the target program object. </param>
@@ -1514,7 +1514,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="type"> The address of a variable that will receive the type of the varying. </param>
         /// <param name="name"> The address of a buffer into which will be written the name of the varying. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetTransformFeedbackVarying.xhtml" /></remarks>
-        public static void GetTransformFeedbackVarying(ProgramHandle program, uint index, int bufSize, int* length, int* size, AttributeType* type, byte* name) => GLPointers._GetTransformFeedbackVarying_fnptr((int)program, index, bufSize, length, size, (uint*)type, name);
+        public static void GetTransformFeedbackVarying(int program, uint index, int bufSize, int* length, int* size, AttributeType* type, byte* name) => GLPointers._GetTransformFeedbackVarying_fnptr(program, index, bufSize, length, size, (uint*)type, name);
         
         /// <summary> <b>[requires: v3.0]</b> Specify whether data read via glReadPixels should be clamped. </summary>
         /// <param name="target"> Target for color clamping. target must be GL_CLAMP_READ_COLOR. </param>
@@ -1692,20 +1692,20 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="location">Specifies the location of the uniform variable to be queried.</param>
         /// <param name="parameters">Returns the value of the specified uniform variable.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetUniform.xhtml" /></remarks>
-        public static void GetUniformuiv(ProgramHandle program, int location, uint* parameters) => GLPointers._GetUniformuiv_fnptr((int)program, location, parameters);
+        public static void GetUniformuiv(int program, int location, uint* parameters) => GLPointers._GetUniformuiv_fnptr(program, location, parameters);
         
         /// <summary> <b>[requires: v3.0]</b> Bind a user-defined varying out variable to a fragment shader color number. </summary>
         /// <param name="program"> The name of the program containing varying out variable whose binding to modify </param>
         /// <param name="colorNumber"> The color number to bind the user-defined varying out variable to </param>
         /// <param name="name"> The name of the user-defined varying out variable whose binding to modify </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindFragDataLocation.xhtml" /></remarks>
-        public static void BindFragDataLocation(ProgramHandle program, uint color, byte* name) => GLPointers._BindFragDataLocation_fnptr((int)program, color, name);
+        public static void BindFragDataLocation(int program, uint color, byte* name) => GLPointers._BindFragDataLocation_fnptr(program, color, name);
         
         /// <summary> <b>[requires: v3.0]</b> Query the bindings of color numbers to user-defined varying out variables. </summary>
         /// <param name="program"> The name of the program containing varying out variable whose binding to query </param>
         /// <param name="name"> The name of the user-defined varying out variable whose binding to query </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetFragDataLocation.xhtml" /></remarks>
-        public static int GetFragDataLocation(ProgramHandle program, byte* name) => GLPointers._GetFragDataLocation_fnptr((int)program, name);
+        public static int GetFragDataLocation(int program, byte* name) => GLPointers._GetFragDataLocation_fnptr(program, name);
         
         /// <summary> <b>[requires: v3.0]</b> Specify the value of a uniform variable for the current program object. </summary>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
@@ -1831,25 +1831,25 @@ namespace OpenTK.Graphics.OpenGL
         /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Determine if a name corresponds to a renderbuffer object. </summary>
         /// <param name="renderbuffer"> Specifies a value that may be the name of a renderbuffer object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsRenderbuffer.xhtml" /></remarks>
-        public static bool IsRenderbuffer(RenderbufferHandle renderbuffer) => GLPointers._IsRenderbuffer_fnptr((int)renderbuffer) != 0;
+        public static bool IsRenderbuffer(int renderbuffer) => GLPointers._IsRenderbuffer_fnptr(renderbuffer) != 0;
         
         /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Bind a renderbuffer to a renderbuffer target. </summary>
         /// <param name="target"> Specifies the renderbuffer target of the binding operation. target must be GL_RENDERBUFFER. </param>
         /// <param name="renderbuffer"> Specifies the name of the renderbuffer object to bind. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindRenderbuffer.xhtml" /></remarks>
-        public static void BindRenderbuffer(RenderbufferTarget target, RenderbufferHandle renderbuffer) => GLPointers._BindRenderbuffer_fnptr((uint)target, (int)renderbuffer);
+        public static void BindRenderbuffer(RenderbufferTarget target, int renderbuffer) => GLPointers._BindRenderbuffer_fnptr((uint)target, renderbuffer);
         
         /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Delete renderbuffer objects. </summary>
         /// <param name="n"> Specifies the number of renderbuffer objects to be deleted. </param>
         /// <param name="renderbuffers"> A pointer to an array containing n renderbuffer objects to be deleted. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDeleteRenderbuffers.xhtml" /></remarks>
-        public static void DeleteRenderbuffers(int n, RenderbufferHandle* renderbuffers) => GLPointers._DeleteRenderbuffers_fnptr(n, (int*)renderbuffers);
+        public static void DeleteRenderbuffers(int n, int* renderbuffers) => GLPointers._DeleteRenderbuffers_fnptr(n, renderbuffers);
         
         /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Generate renderbuffer object names. </summary>
         /// <param name="n"> Specifies the number of renderbuffer object names to generate. </param>
         /// <param name="renderbuffers"> Specifies an array in which the generated renderbuffer object names are stored. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGenRenderbuffers.xhtml" /></remarks>
-        public static void GenRenderbuffers(int n, RenderbufferHandle* renderbuffers) => GLPointers._GenRenderbuffers_fnptr(n, (int*)renderbuffers);
+        public static void GenRenderbuffers(int n, int* renderbuffers) => GLPointers._GenRenderbuffers_fnptr(n, renderbuffers);
         
         /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Establish data storage, format and dimensions of a    renderbuffer object's image. </summary>
         /// <param name="target">Specifies a binding target of the allocation for glRenderbufferStorage function. Must be GL_RENDERBUFFER.</param>
@@ -1869,25 +1869,25 @@ namespace OpenTK.Graphics.OpenGL
         /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Determine if a name corresponds to a framebuffer object. </summary>
         /// <param name="framebuffer"> Specifies a value that may be the name of a framebuffer object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsFramebuffer.xhtml" /></remarks>
-        public static bool IsFramebuffer(FramebufferHandle framebuffer) => GLPointers._IsFramebuffer_fnptr((int)framebuffer) != 0;
+        public static bool IsFramebuffer(int framebuffer) => GLPointers._IsFramebuffer_fnptr(framebuffer) != 0;
         
         /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Bind a framebuffer to a framebuffer target. </summary>
         /// <param name="target"> Specifies the framebuffer target of the binding operation. </param>
         /// <param name="framebuffer"> Specifies the name of the framebuffer object to bind. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindFramebuffer.xhtml" /></remarks>
-        public static void BindFramebuffer(FramebufferTarget target, FramebufferHandle framebuffer) => GLPointers._BindFramebuffer_fnptr((uint)target, (int)framebuffer);
+        public static void BindFramebuffer(FramebufferTarget target, int framebuffer) => GLPointers._BindFramebuffer_fnptr((uint)target, framebuffer);
         
         /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Delete framebuffer objects. </summary>
         /// <param name="n"> Specifies the number of framebuffer objects to be deleted. </param>
         /// <param name="framebuffers"> A pointer to an array containing n framebuffer objects to be deleted. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDeleteFramebuffers.xhtml" /></remarks>
-        public static void DeleteFramebuffers(int n, FramebufferHandle* framebuffers) => GLPointers._DeleteFramebuffers_fnptr(n, (int*)framebuffers);
+        public static void DeleteFramebuffers(int n, int* framebuffers) => GLPointers._DeleteFramebuffers_fnptr(n, framebuffers);
         
         /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Generate framebuffer object names. </summary>
         /// <param name="n"> Specifies the number of framebuffer object names to generate. </param>
         /// <param name="ids"> Specifies an array in which the generated framebuffer object names are stored. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGenFramebuffers.xhtml" /></remarks>
-        public static void GenFramebuffers(int n, FramebufferHandle* framebuffers) => GLPointers._GenFramebuffers_fnptr(n, (int*)framebuffers);
+        public static void GenFramebuffers(int n, int* framebuffers) => GLPointers._GenFramebuffers_fnptr(n, framebuffers);
         
         /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Check the completeness status of a framebuffer. </summary>
         /// <param name="target"> Specify the target to which the framebuffer is bound for glCheckFramebufferStatus, and the target against which framebuffer completeness of framebuffer is checked for glCheckNamedFramebufferStatus. </param>
@@ -1901,7 +1901,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="texture"> Specifies the name of an existing texture object to attach. </param>
         /// <param name="level"> Specifies the mipmap level of the texture object to attach. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glFramebufferTexture.xhtml" /></remarks>
-        public static void FramebufferTexture1D(FramebufferTarget target, FramebufferAttachment attachment, TextureTarget textarget, TextureHandle texture, int level) => GLPointers._FramebufferTexture1D_fnptr((uint)target, (uint)attachment, (uint)textarget, (int)texture, level);
+        public static void FramebufferTexture1D(FramebufferTarget target, FramebufferAttachment attachment, TextureTarget textarget, int texture, int level) => GLPointers._FramebufferTexture1D_fnptr((uint)target, (uint)attachment, (uint)textarget, texture, level);
         
         /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Attach a level of a texture object as a logical buffer of a framebuffer object. </summary>
         /// <param name="target"> Specifies the target to which the framebuffer is bound for all commands except glNamedFramebufferTexture. </param>
@@ -1910,7 +1910,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="texture"> Specifies the name of an existing texture object to attach. </param>
         /// <param name="level"> Specifies the mipmap level of the texture object to attach. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glFramebufferTexture.xhtml" /></remarks>
-        public static void FramebufferTexture2D(FramebufferTarget target, FramebufferAttachment attachment, TextureTarget textarget, TextureHandle texture, int level) => GLPointers._FramebufferTexture2D_fnptr((uint)target, (uint)attachment, (uint)textarget, (int)texture, level);
+        public static void FramebufferTexture2D(FramebufferTarget target, FramebufferAttachment attachment, TextureTarget textarget, int texture, int level) => GLPointers._FramebufferTexture2D_fnptr((uint)target, (uint)attachment, (uint)textarget, texture, level);
         
         /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Attach a level of a texture object as a logical buffer of a framebuffer object. </summary>
         /// <param name="target"> Specifies the target to which the framebuffer is bound for all commands except glNamedFramebufferTexture. </param>
@@ -1920,7 +1920,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="level"> Specifies the mipmap level of the texture object to attach. </param>
         /// <param name="layer">!!missing documentation!!</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glFramebufferTexture.xhtml" /></remarks>
-        public static void FramebufferTexture3D(FramebufferTarget target, FramebufferAttachment attachment, TextureTarget textarget, TextureHandle texture, int level, int zoffset) => GLPointers._FramebufferTexture3D_fnptr((uint)target, (uint)attachment, (uint)textarget, (int)texture, level, zoffset);
+        public static void FramebufferTexture3D(FramebufferTarget target, FramebufferAttachment attachment, TextureTarget textarget, int texture, int level, int zoffset) => GLPointers._FramebufferTexture3D_fnptr((uint)target, (uint)attachment, (uint)textarget, texture, level, zoffset);
         
         /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Attach a renderbuffer as a logical buffer of a framebuffer object. </summary>
         /// <param name="target"> Specifies the target to which the framebuffer is bound for glFramebufferRenderbuffer. </param>
@@ -1928,7 +1928,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="renderbuffertarget"> Specifies the renderbuffer target. Must be GL_RENDERBUFFER. </param>
         /// <param name="renderbuffer"> Specifies the name of an existing renderbuffer object of type renderbuffertarget to attach. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glFramebufferRenderbuffer.xhtml" /></remarks>
-        public static void FramebufferRenderbuffer(FramebufferTarget target, FramebufferAttachment attachment, RenderbufferTarget renderbuffertarget, RenderbufferHandle renderbuffer) => GLPointers._FramebufferRenderbuffer_fnptr((uint)target, (uint)attachment, (uint)renderbuffertarget, (int)renderbuffer);
+        public static void FramebufferRenderbuffer(FramebufferTarget target, FramebufferAttachment attachment, RenderbufferTarget renderbuffertarget, int renderbuffer) => GLPointers._FramebufferRenderbuffer_fnptr((uint)target, (uint)attachment, (uint)renderbuffertarget, renderbuffer);
         
         /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Retrieve information about attachments of a framebuffer object. </summary>
         /// <param name="target"> Specifies the target to which the framebuffer object is bound for glGetFramebufferAttachmentParameteriv. </param>
@@ -1973,7 +1973,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="level"> Specifies the mipmap level of the texture object to attach. </param>
         /// <param name="layer"> Specifies the layer of the texture object to attach. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glFramebufferTextureLayer.xhtml" /></remarks>
-        public static void FramebufferTextureLayer(FramebufferTarget target, FramebufferAttachment attachment, TextureHandle texture, int level, int layer) => GLPointers._FramebufferTextureLayer_fnptr((uint)target, (uint)attachment, (int)texture, level, layer);
+        public static void FramebufferTextureLayer(FramebufferTarget target, FramebufferAttachment attachment, int texture, int level, int layer) => GLPointers._FramebufferTextureLayer_fnptr((uint)target, (uint)attachment, texture, level, layer);
         
         /// <summary> <b>[requires: v3.0 | GL_ARB_map_buffer_range]</b> Map all or part of a buffer object's data store into the client's address space. </summary>
         /// <param name="target"> Specifies the target to which the buffer object is bound for glMapBufferRange, which must be one of the buffer binding targets in the following table: </param>
@@ -1993,24 +1993,24 @@ namespace OpenTK.Graphics.OpenGL
         /// <summary> <b>[requires: v3.0 | GL_ARB_vertex_array_object]</b> Bind a vertex array object. </summary>
         /// <param name="array"> Specifies the name of the vertex array to bind. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindVertexArray.xhtml" /></remarks>
-        public static void BindVertexArray(VertexArrayHandle array) => GLPointers._BindVertexArray_fnptr((int)array);
+        public static void BindVertexArray(int array) => GLPointers._BindVertexArray_fnptr(array);
         
         /// <summary> <b>[requires: v3.0 | GL_ARB_vertex_array_object]</b> Delete vertex array objects. </summary>
         /// <param name="n"> Specifies the number of vertex array objects to be deleted. </param>
         /// <param name="arrays"> Specifies the address of an array containing the n names of the objects to be deleted. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDeleteVertexArrays.xhtml" /></remarks>
-        public static void DeleteVertexArrays(int n, VertexArrayHandle* arrays) => GLPointers._DeleteVertexArrays_fnptr(n, (int*)arrays);
+        public static void DeleteVertexArrays(int n, int* arrays) => GLPointers._DeleteVertexArrays_fnptr(n, arrays);
         
         /// <summary> <b>[requires: v3.0 | GL_ARB_vertex_array_object]</b> Generate vertex array object names. </summary>
         /// <param name="n"> Specifies the number of vertex array object names to generate. </param>
         /// <param name="arrays"> Specifies an array in which the generated vertex array object names are stored. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGenVertexArrays.xhtml" /></remarks>
-        public static void GenVertexArrays(int n, VertexArrayHandle* arrays) => GLPointers._GenVertexArrays_fnptr(n, (int*)arrays);
+        public static void GenVertexArrays(int n, int* arrays) => GLPointers._GenVertexArrays_fnptr(n, arrays);
         
         /// <summary> <b>[requires: v3.0 | GL_ARB_vertex_array_object]</b> Determine if a name corresponds to a vertex array object. </summary>
         /// <param name="array"> Specifies a value that may be the name of a vertex array object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsVertexArray.xhtml" /></remarks>
-        public static bool IsVertexArray(VertexArrayHandle array) => GLPointers._IsVertexArray_fnptr((int)array) != 0;
+        public static bool IsVertexArray(int array) => GLPointers._IsVertexArray_fnptr(array) != 0;
         
         /// <summary> <b>[requires: v3.1]</b> Draw multiple instances of a range of elements. </summary>
         /// <param name="mode"> Specifies what kind of primitives to render. Symbolic constants GL_POINTS, GL_LINE_STRIP, GL_LINE_LOOP, GL_LINES, GL_TRIANGLE_STRIP, GL_TRIANGLE_FAN, GL_TRIANGLES GL_LINES_ADJACENCY, GL_LINE_STRIP_ADJACENCY, GL_TRIANGLES_ADJACENCY, GL_TRIANGLE_STRIP_ADJACENCY and GL_PATCHES are accepted. </param>
@@ -2034,7 +2034,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="internalformat"> Specifies the internal format of the data in the store belonging to buffer. </param>
         /// <param name="buffer"> Specifies the name of the buffer object whose storage to attach to the active buffer texture. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexBuffer.xhtml" /></remarks>
-        public static void TexBuffer(TextureTarget target, SizedInternalFormat internalformat, BufferHandle buffer) => GLPointers._TexBuffer_fnptr((uint)target, (uint)internalformat, (int)buffer);
+        public static void TexBuffer(TextureTarget target, SizedInternalFormat internalformat, int buffer) => GLPointers._TexBuffer_fnptr((uint)target, (uint)internalformat, buffer);
         
         /// <summary> <b>[requires: v3.1]</b> Specify the primitive restart index. </summary>
         /// <param name="index"> Specifies the value to be interpreted as the primitive restart index. </param>
@@ -2056,7 +2056,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="uniformNames"> Specifies the address of an array of pointers to buffers containing the names of the queried uniforms. </param>
         /// <param name="uniformIndices"> Specifies the address of an array that will receive the indices of the uniforms. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetUniformIndices.xhtml" /></remarks>
-        public static void GetUniformIndices(ProgramHandle program, int uniformCount, byte** uniformNames, uint* uniformIndices) => GLPointers._GetUniformIndices_fnptr((int)program, uniformCount, uniformNames, uniformIndices);
+        public static void GetUniformIndices(int program, int uniformCount, byte** uniformNames, uint* uniformIndices) => GLPointers._GetUniformIndices_fnptr(program, uniformCount, uniformNames, uniformIndices);
         
         /// <summary> <b>[requires: v3.1 | GL_ARB_uniform_buffer_object]</b> Returns information about several active uniform variables for the specified program object. </summary>
         /// <param name="program">Specifies the program object to be queried.</param>
@@ -2065,7 +2065,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="pname">Specifies the property of each uniform in uniformIndices that should be written into the corresponding element of params.</param>
         /// <param name="parameters">Specifies the address of an array of uniformCount integers which are to receive the value of pname for each uniform in uniformIndices.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetActiveUniformsiv.xhtml" /></remarks>
-        public static void GetActiveUniformsiv(ProgramHandle program, int uniformCount, uint* uniformIndices, UniformPName pname, int* parameters) => GLPointers._GetActiveUniformsiv_fnptr((int)program, uniformCount, uniformIndices, (uint)pname, parameters);
+        public static void GetActiveUniformsiv(int program, int uniformCount, uint* uniformIndices, UniformPName pname, int* parameters) => GLPointers._GetActiveUniformsiv_fnptr(program, uniformCount, uniformIndices, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v3.1 | GL_ARB_uniform_buffer_object]</b> Query the name of an active uniform. </summary>
         /// <param name="program"> Specifies the program containing the active uniform index uniformIndex. </param>
@@ -2074,13 +2074,13 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="length"> Specifies the address of a variable that will receive the number of characters that were or would have been written to the buffer addressed by uniformName. </param>
         /// <param name="uniformName"> Specifies the address of a buffer into which the GL will place the name of the active uniform at uniformIndex within program. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetActiveUniformName.xhtml" /></remarks>
-        public static void GetActiveUniformName(ProgramHandle program, uint uniformIndex, int bufSize, int* length, byte* uniformName) => GLPointers._GetActiveUniformName_fnptr((int)program, uniformIndex, bufSize, length, uniformName);
+        public static void GetActiveUniformName(int program, uint uniformIndex, int bufSize, int* length, byte* uniformName) => GLPointers._GetActiveUniformName_fnptr(program, uniformIndex, bufSize, length, uniformName);
         
         /// <summary> <b>[requires: v3.1 | GL_ARB_uniform_buffer_object]</b> Retrieve the index of a named uniform block. </summary>
         /// <param name="program"> Specifies the name of a program containing the uniform block. </param>
         /// <param name="uniformBlockName"> Specifies the address an array of characters to containing the name of the uniform block whose index to retrieve. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetUniformBlockIndex.xhtml" /></remarks>
-        public static uint GetUniformBlockIndex(ProgramHandle program, byte* uniformBlockName) => GLPointers._GetUniformBlockIndex_fnptr((int)program, uniformBlockName);
+        public static uint GetUniformBlockIndex(int program, byte* uniformBlockName) => GLPointers._GetUniformBlockIndex_fnptr(program, uniformBlockName);
         
         /// <summary> <b>[requires: v3.1 | GL_ARB_uniform_buffer_object]</b> Query information about an active uniform block. </summary>
         /// <param name="program"> Specifies the name of a program containing the uniform block. </param>
@@ -2088,7 +2088,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="pname"> Specifies the name of the parameter to query. </param>
         /// <param name="parameters"> Specifies the address of a variable to receive the result of the query. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetActiveUniformBlock.xhtml" /></remarks>
-        public static void GetActiveUniformBlockiv(ProgramHandle program, uint uniformBlockIndex, UniformBlockPName pname, int* parameters) => GLPointers._GetActiveUniformBlockiv_fnptr((int)program, uniformBlockIndex, (uint)pname, parameters);
+        public static void GetActiveUniformBlockiv(int program, uint uniformBlockIndex, UniformBlockPName pname, int* parameters) => GLPointers._GetActiveUniformBlockiv_fnptr(program, uniformBlockIndex, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v3.1 | GL_ARB_uniform_buffer_object]</b> Retrieve the name of an active uniform block. </summary>
         /// <param name="program"> Specifies the name of a program containing the uniform block. </param>
@@ -2097,14 +2097,14 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="length"> Specifies the address of a variable to receive the number of characters that were written to uniformBlockName. </param>
         /// <param name="uniformBlockName"> Specifies the address an array of characters to receive the name of the uniform block at uniformBlockIndex. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetActiveUniformBlockName.xhtml" /></remarks>
-        public static void GetActiveUniformBlockName(ProgramHandle program, uint uniformBlockIndex, int bufSize, int* length, byte* uniformBlockName) => GLPointers._GetActiveUniformBlockName_fnptr((int)program, uniformBlockIndex, bufSize, length, uniformBlockName);
+        public static void GetActiveUniformBlockName(int program, uint uniformBlockIndex, int bufSize, int* length, byte* uniformBlockName) => GLPointers._GetActiveUniformBlockName_fnptr(program, uniformBlockIndex, bufSize, length, uniformBlockName);
         
         /// <summary> <b>[requires: v3.1 | GL_ARB_uniform_buffer_object]</b> Assign a binding point to an active uniform block. </summary>
         /// <param name="program"> The name of a program object containing the active uniform block whose binding to assign. </param>
         /// <param name="uniformBlockIndex"> The index of the active uniform block within program whose binding to assign. </param>
         /// <param name="uniformBlockBinding"> Specifies the binding point to which to bind the uniform block with index uniformBlockIndex within program. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glUniformBlockBinding.xhtml" /></remarks>
-        public static void UniformBlockBinding(ProgramHandle program, uint uniformBlockIndex, uint uniformBlockBinding) => GLPointers._UniformBlockBinding_fnptr((int)program, uniformBlockIndex, uniformBlockBinding);
+        public static void UniformBlockBinding(int program, uint uniformBlockIndex, uint uniformBlockBinding) => GLPointers._UniformBlockBinding_fnptr(program, uniformBlockIndex, uniformBlockBinding);
         
         /// <summary> <b>[requires: v3.2 | GL_ARB_draw_elements_base_vertex]</b> Render primitives from array data with a per-element offset. </summary>
         /// <param name="mode"> Specifies what kind of primitives to render. Symbolic constants GL_POINTS, GL_LINE_STRIP, GL_LINE_LOOP, GL_LINES, GL_TRIANGLE_STRIP, GL_TRIANGLE_FAN, GL_TRIANGLES, GL_LINES_ADJACENCY, GL_LINE_STRIP_ADJACENCY, GL_TRIANGLES_ADJACENCY, GL_TRIANGLE_STRIP_ADJACENCY and GL_PATCHES are accepted. </param>
@@ -2216,7 +2216,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="texture"> Specifies the name of an existing texture object to attach. </param>
         /// <param name="level"> Specifies the mipmap level of the texture object to attach. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glFramebufferTexture.xhtml" /></remarks>
-        public static void FramebufferTexture(FramebufferTarget target, FramebufferAttachment attachment, TextureHandle texture, int level) => GLPointers._FramebufferTexture_fnptr((uint)target, (uint)attachment, (int)texture, level);
+        public static void FramebufferTexture(FramebufferTarget target, FramebufferAttachment attachment, int texture, int level) => GLPointers._FramebufferTexture_fnptr((uint)target, (uint)attachment, texture, level);
         
         /// <summary> <b>[requires: v3.2 | GL_ARB_texture_multisample]</b> Establish the data storage, format, dimensions, and number of samples of a multisample texture's image. </summary>
         /// <param name="target"> Specifies the target of the operation. target must be GL_TEXTURE_2D_MULTISAMPLE or GL_PROXY_TEXTURE_2D_MULTISAMPLE. </param>
@@ -2258,126 +2258,126 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="index"> The index of the color input to bind the user-defined varying out variable to </param>
         /// <param name="name"> The name of the user-defined varying out variable whose binding to modify </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindFragDataLocationIndexed.xhtml" /></remarks>
-        public static void BindFragDataLocationIndexed(ProgramHandle program, uint colorNumber, uint index, byte* name) => GLPointers._BindFragDataLocationIndexed_fnptr((int)program, colorNumber, index, name);
+        public static void BindFragDataLocationIndexed(int program, uint colorNumber, uint index, byte* name) => GLPointers._BindFragDataLocationIndexed_fnptr(program, colorNumber, index, name);
         
         /// <summary> <b>[requires: v3.3 | GL_ARB_blend_func_extended]</b> Query the bindings of color indices to user-defined varying out variables. </summary>
         /// <param name="program"> The name of the program containing varying out variable whose binding to query </param>
         /// <param name="name"> The name of the user-defined varying out variable whose index to query </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetFragDataIndex.xhtml" /></remarks>
-        public static int GetFragDataIndex(ProgramHandle program, byte* name) => GLPointers._GetFragDataIndex_fnptr((int)program, name);
+        public static int GetFragDataIndex(int program, byte* name) => GLPointers._GetFragDataIndex_fnptr(program, name);
         
         /// <summary> <b>[requires: v3.3 | GL_ARB_sampler_objects]</b> Generate sampler object names. </summary>
         /// <param name="n"> Specifies the number of sampler object names to generate. </param>
         /// <param name="samplers"> Specifies an array in which the generated sampler object names are stored. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGenSamplers.xhtml" /></remarks>
-        public static void GenSamplers(int count, SamplerHandle* samplers) => GLPointers._GenSamplers_fnptr(count, (int*)samplers);
+        public static void GenSamplers(int count, int* samplers) => GLPointers._GenSamplers_fnptr(count, samplers);
         
         /// <summary> <b>[requires: v3.3 | GL_ARB_sampler_objects]</b> Delete named sampler objects. </summary>
         /// <param name="n"> Specifies the number of sampler objects to be deleted. </param>
         /// <param name="samplers"> Specifies an array of sampler objects to be deleted. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDeleteSamplers.xhtml" /></remarks>
-        public static void DeleteSamplers(int count, SamplerHandle* samplers) => GLPointers._DeleteSamplers_fnptr(count, (int*)samplers);
+        public static void DeleteSamplers(int count, int* samplers) => GLPointers._DeleteSamplers_fnptr(count, samplers);
         
         /// <summary> <b>[requires: v3.3 | GL_ARB_sampler_objects]</b> Determine if a name corresponds to a sampler object. </summary>
         /// <param name="id"> Specifies a value that may be the name of a sampler object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsSampler.xhtml" /></remarks>
-        public static bool IsSampler(SamplerHandle sampler) => GLPointers._IsSampler_fnptr((int)sampler) != 0;
+        public static bool IsSampler(int sampler) => GLPointers._IsSampler_fnptr(sampler) != 0;
         
         /// <summary> <b>[requires: v3.3 | GL_ARB_sampler_objects]</b> Bind a named sampler to a texturing target. </summary>
         /// <param name="unit"> Specifies the index of the texture unit to which the sampler is bound. </param>
         /// <param name="sampler"> Specifies the name of a sampler. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindSampler.xhtml" /></remarks>
-        public static void BindSampler(uint unit, SamplerHandle sampler) => GLPointers._BindSampler_fnptr(unit, (int)sampler);
+        public static void BindSampler(uint unit, int sampler) => GLPointers._BindSampler_fnptr(unit, sampler);
         
         /// <summary> <b>[requires: v3.3 | GL_ARB_sampler_objects]</b> Set sampler parameters. </summary>
         /// <param name="sampler"> Specifies the sampler object whose parameter to modify. </param>
         /// <param name="pname"> Specifies the symbolic name of a sampler parameter. pname can be one of the following: GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, GL_TEXTURE_WRAP_R, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_BORDER_COLOR, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_LOD_BIAS GL_TEXTURE_COMPARE_MODE, or GL_TEXTURE_COMPARE_FUNC. </param>
         /// <param name="param"> For the scalar commands, specifies the value of pname. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glSamplerParameter.xhtml" /></remarks>
-        public static void SamplerParameteri(SamplerHandle sampler, SamplerParameterI pname, int param) => GLPointers._SamplerParameteri_fnptr((int)sampler, (uint)pname, param);
+        public static void SamplerParameteri(int sampler, SamplerParameterI pname, int param) => GLPointers._SamplerParameteri_fnptr(sampler, (uint)pname, param);
         
         /// <summary> <b>[requires: v3.3 | GL_ARB_sampler_objects]</b> Set sampler parameters. </summary>
         /// <param name="sampler"> Specifies the sampler object whose parameter to modify. </param>
         /// <param name="pname"> Specifies the symbolic name of a sampler parameter. pname can be one of the following: GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, GL_TEXTURE_WRAP_R, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_BORDER_COLOR, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_LOD_BIAS GL_TEXTURE_COMPARE_MODE, or GL_TEXTURE_COMPARE_FUNC. </param>
         /// <param name="parameters"> For the vector commands (glSamplerParameter*v), specifies a pointer to an array where the value or values of pname are stored. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glSamplerParameter.xhtml" /></remarks>
-        public static void SamplerParameteriv(SamplerHandle sampler, SamplerParameterI pname, int* param) => GLPointers._SamplerParameteriv_fnptr((int)sampler, (uint)pname, param);
+        public static void SamplerParameteriv(int sampler, SamplerParameterI pname, int* param) => GLPointers._SamplerParameteriv_fnptr(sampler, (uint)pname, param);
         
         /// <summary> <b>[requires: v3.3 | GL_ARB_sampler_objects]</b> Set sampler parameters. </summary>
         /// <param name="sampler"> Specifies the sampler object whose parameter to modify. </param>
         /// <param name="pname"> Specifies the symbolic name of a sampler parameter. pname can be one of the following: GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, GL_TEXTURE_WRAP_R, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_BORDER_COLOR, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_LOD_BIAS GL_TEXTURE_COMPARE_MODE, or GL_TEXTURE_COMPARE_FUNC. </param>
         /// <param name="param"> For the scalar commands, specifies the value of pname. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glSamplerParameter.xhtml" /></remarks>
-        public static void SamplerParameterf(SamplerHandle sampler, SamplerParameterF pname, float param) => GLPointers._SamplerParameterf_fnptr((int)sampler, (uint)pname, param);
+        public static void SamplerParameterf(int sampler, SamplerParameterF pname, float param) => GLPointers._SamplerParameterf_fnptr(sampler, (uint)pname, param);
         
         /// <summary> <b>[requires: v3.3 | GL_ARB_sampler_objects]</b> Set sampler parameters. </summary>
         /// <param name="sampler"> Specifies the sampler object whose parameter to modify. </param>
         /// <param name="pname"> Specifies the symbolic name of a sampler parameter. pname can be one of the following: GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, GL_TEXTURE_WRAP_R, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_BORDER_COLOR, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_LOD_BIAS GL_TEXTURE_COMPARE_MODE, or GL_TEXTURE_COMPARE_FUNC. </param>
         /// <param name="parameters"> For the vector commands (glSamplerParameter*v), specifies a pointer to an array where the value or values of pname are stored. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glSamplerParameter.xhtml" /></remarks>
-        public static void SamplerParameterfv(SamplerHandle sampler, SamplerParameterF pname, float* param) => GLPointers._SamplerParameterfv_fnptr((int)sampler, (uint)pname, param);
+        public static void SamplerParameterfv(int sampler, SamplerParameterF pname, float* param) => GLPointers._SamplerParameterfv_fnptr(sampler, (uint)pname, param);
         
         /// <summary> <b>[requires: v3.3 | GL_ARB_sampler_objects]</b> Set sampler parameters. </summary>
         /// <param name="sampler"> Specifies the sampler object whose parameter to modify. </param>
         /// <param name="pname"> Specifies the symbolic name of a sampler parameter. pname can be one of the following: GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, GL_TEXTURE_WRAP_R, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_BORDER_COLOR, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_LOD_BIAS GL_TEXTURE_COMPARE_MODE, or GL_TEXTURE_COMPARE_FUNC. </param>
         /// <param name="parameters"> For the vector commands (glSamplerParameter*v), specifies a pointer to an array where the value or values of pname are stored. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glSamplerParameter.xhtml" /></remarks>
-        public static void SamplerParameterIiv(SamplerHandle sampler, SamplerParameterI pname, int* param) => GLPointers._SamplerParameterIiv_fnptr((int)sampler, (uint)pname, param);
+        public static void SamplerParameterIiv(int sampler, SamplerParameterI pname, int* param) => GLPointers._SamplerParameterIiv_fnptr(sampler, (uint)pname, param);
         
         /// <summary> <b>[requires: v3.3 | GL_ARB_sampler_objects]</b> Set sampler parameters. </summary>
         /// <param name="sampler"> Specifies the sampler object whose parameter to modify. </param>
         /// <param name="pname"> Specifies the symbolic name of a sampler parameter. pname can be one of the following: GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, GL_TEXTURE_WRAP_R, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_BORDER_COLOR, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_LOD_BIAS GL_TEXTURE_COMPARE_MODE, or GL_TEXTURE_COMPARE_FUNC. </param>
         /// <param name="parameters"> For the vector commands (glSamplerParameter*v), specifies a pointer to an array where the value or values of pname are stored. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glSamplerParameter.xhtml" /></remarks>
-        public static void SamplerParameterIuiv(SamplerHandle sampler, SamplerParameterI pname, uint* param) => GLPointers._SamplerParameterIuiv_fnptr((int)sampler, (uint)pname, param);
+        public static void SamplerParameterIuiv(int sampler, SamplerParameterI pname, uint* param) => GLPointers._SamplerParameterIuiv_fnptr(sampler, (uint)pname, param);
         
         /// <summary> <b>[requires: v3.3 | GL_ARB_sampler_objects]</b> Return sampler parameter values. </summary>
         /// <param name="sampler"> Specifies name of the sampler object from which to retrieve parameters. </param>
         /// <param name="pname"> Specifies the symbolic name of a sampler parameter. GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_LOD_BIAS, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, GL_TEXTURE_WRAP_R, GL_TEXTURE_BORDER_COLOR, GL_TEXTURE_COMPARE_MODE, and GL_TEXTURE_COMPARE_FUNC are accepted. </param>
         /// <param name="parameters"> Returns the sampler parameters. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetSamplerParameter.xhtml" /></remarks>
-        public static void GetSamplerParameteriv(SamplerHandle sampler, SamplerParameterI pname, int* parameters) => GLPointers._GetSamplerParameteriv_fnptr((int)sampler, (uint)pname, parameters);
+        public static void GetSamplerParameteriv(int sampler, SamplerParameterI pname, int* parameters) => GLPointers._GetSamplerParameteriv_fnptr(sampler, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v3.3 | GL_ARB_sampler_objects]</b> Return sampler parameter values. </summary>
         /// <param name="sampler"> Specifies name of the sampler object from which to retrieve parameters. </param>
         /// <param name="pname"> Specifies the symbolic name of a sampler parameter. GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_LOD_BIAS, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, GL_TEXTURE_WRAP_R, GL_TEXTURE_BORDER_COLOR, GL_TEXTURE_COMPARE_MODE, and GL_TEXTURE_COMPARE_FUNC are accepted. </param>
         /// <param name="parameters"> Returns the sampler parameters. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetSamplerParameter.xhtml" /></remarks>
-        public static void GetSamplerParameterIiv(SamplerHandle sampler, SamplerParameterI pname, int* parameters) => GLPointers._GetSamplerParameterIiv_fnptr((int)sampler, (uint)pname, parameters);
+        public static void GetSamplerParameterIiv(int sampler, SamplerParameterI pname, int* parameters) => GLPointers._GetSamplerParameterIiv_fnptr(sampler, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v3.3 | GL_ARB_sampler_objects]</b> Return sampler parameter values. </summary>
         /// <param name="sampler"> Specifies name of the sampler object from which to retrieve parameters. </param>
         /// <param name="pname"> Specifies the symbolic name of a sampler parameter. GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_LOD_BIAS, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, GL_TEXTURE_WRAP_R, GL_TEXTURE_BORDER_COLOR, GL_TEXTURE_COMPARE_MODE, and GL_TEXTURE_COMPARE_FUNC are accepted. </param>
         /// <param name="parameters"> Returns the sampler parameters. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetSamplerParameter.xhtml" /></remarks>
-        public static void GetSamplerParameterfv(SamplerHandle sampler, SamplerParameterF pname, float* parameters) => GLPointers._GetSamplerParameterfv_fnptr((int)sampler, (uint)pname, parameters);
+        public static void GetSamplerParameterfv(int sampler, SamplerParameterF pname, float* parameters) => GLPointers._GetSamplerParameterfv_fnptr(sampler, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v3.3 | GL_ARB_sampler_objects]</b> Return sampler parameter values. </summary>
         /// <param name="sampler"> Specifies name of the sampler object from which to retrieve parameters. </param>
         /// <param name="pname"> Specifies the symbolic name of a sampler parameter. GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_LOD_BIAS, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, GL_TEXTURE_WRAP_R, GL_TEXTURE_BORDER_COLOR, GL_TEXTURE_COMPARE_MODE, and GL_TEXTURE_COMPARE_FUNC are accepted. </param>
         /// <param name="parameters"> Returns the sampler parameters. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetSamplerParameter.xhtml" /></remarks>
-        public static void GetSamplerParameterIuiv(SamplerHandle sampler, SamplerParameterI pname, uint* parameters) => GLPointers._GetSamplerParameterIuiv_fnptr((int)sampler, (uint)pname, parameters);
+        public static void GetSamplerParameterIuiv(int sampler, SamplerParameterI pname, uint* parameters) => GLPointers._GetSamplerParameterIuiv_fnptr(sampler, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v3.3 | GL_ARB_timer_query]</b> Record the GL time into a query object after all previous commands have reached the GL server but have not yet necessarily executed.. </summary>
         /// <param name="id"> Specify the name of a query object into which to record the GL time. </param>
         /// <param name="target"> Specify the counter to query. target must be GL_TIMESTAMP. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glQueryCounter.xhtml" /></remarks>
-        public static void QueryCounter(QueryHandle id, QueryCounterTarget target) => GLPointers._QueryCounter_fnptr((int)id, (uint)target);
+        public static void QueryCounter(int id, QueryCounterTarget target) => GLPointers._QueryCounter_fnptr(id, (uint)target);
         
         /// <summary> <b>[requires: v3.3 | GL_ARB_timer_query]</b> Return parameters of a query object. </summary>
         /// <param name="id"> Specifies the name of a query object. </param>
         /// <param name="pname"> Specifies the symbolic name of a query object parameter. Accepted values are GL_QUERY_RESULT or GL_QUERY_RESULT_AVAILABLE. </param>
         /// <param name="parameters"> If a buffer is bound to the GL_QUERY_RESULT_BUFFER target, then params is treated as an offset to a location within that buffer's data store to receive the result of the query. If no buffer is bound to GL_QUERY_RESULT_BUFFER, then params is treated as an address in client memory of a variable to receive the resulting data. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetQueryObject.xhtml" /></remarks>
-        public static void GetQueryObjecti64v(QueryHandle id, QueryObjectParameterName pname, long* parameters) => GLPointers._GetQueryObjecti64v_fnptr((int)id, (uint)pname, parameters);
+        public static void GetQueryObjecti64v(int id, QueryObjectParameterName pname, long* parameters) => GLPointers._GetQueryObjecti64v_fnptr(id, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v3.3 | GL_ARB_timer_query]</b> Return parameters of a query object. </summary>
         /// <param name="id"> Specifies the name of a query object. </param>
         /// <param name="pname"> Specifies the symbolic name of a query object parameter. Accepted values are GL_QUERY_RESULT or GL_QUERY_RESULT_AVAILABLE. </param>
         /// <param name="parameters"> If a buffer is bound to the GL_QUERY_RESULT_BUFFER target, then params is treated as an offset to a location within that buffer's data store to receive the result of the query. If no buffer is bound to GL_QUERY_RESULT_BUFFER, then params is treated as an address in client memory of a variable to receive the resulting data. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetQueryObject.xhtml" /></remarks>
-        public static void GetQueryObjectui64v(QueryHandle id, QueryObjectParameterName pname, ulong* parameters) => GLPointers._GetQueryObjectui64v_fnptr((int)id, (uint)pname, parameters);
+        public static void GetQueryObjectui64v(int id, QueryObjectParameterName pname, ulong* parameters) => GLPointers._GetQueryObjectui64v_fnptr(id, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v3.3]</b> Modify the rate at which generic vertex attributes advance during instanced rendering. </summary>
         /// <param name="index"> Specify the index of the generic vertex attribute. </param>
@@ -2553,21 +2553,21 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="location">Specifies the location of the uniform variable to be queried.</param>
         /// <param name="parameters">Returns the value of the specified uniform variable.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetUniform.xhtml" /></remarks>
-        public static void GetUniformdv(ProgramHandle program, int location, double* parameters) => GLPointers._GetUniformdv_fnptr((int)program, location, parameters);
+        public static void GetUniformdv(int program, int location, double* parameters) => GLPointers._GetUniformdv_fnptr(program, location, parameters);
         
         /// <summary> <b>[requires: v4.0 | GL_ARB_shader_subroutine]</b> Retrieve the location of a subroutine uniform of a given shader stage within a program. </summary>
         /// <param name="program"> Specifies the name of the program containing shader stage. </param>
         /// <param name="shadertype"> Specifies the shader stage from which to query for subroutine uniform index. shadertype must be one of GL_VERTEX_SHADER, GL_TESS_CONTROL_SHADER, GL_TESS_EVALUATION_SHADER, GL_GEOMETRY_SHADER or GL_FRAGMENT_SHADER. </param>
         /// <param name="name"> Specifies the name of the subroutine uniform whose index to query. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetSubroutineUniformLocation.xhtml" /></remarks>
-        public static int GetSubroutineUniformLocation(ProgramHandle program, ShaderType shadertype, byte* name) => GLPointers._GetSubroutineUniformLocation_fnptr((int)program, (uint)shadertype, name);
+        public static int GetSubroutineUniformLocation(int program, ShaderType shadertype, byte* name) => GLPointers._GetSubroutineUniformLocation_fnptr(program, (uint)shadertype, name);
         
         /// <summary> <b>[requires: v4.0 | GL_ARB_shader_subroutine]</b> Retrieve the index of a subroutine uniform of a given shader stage within a program. </summary>
         /// <param name="program"> Specifies the name of the program containing shader stage. </param>
         /// <param name="shadertype"> Specifies the shader stage from which to query for subroutine uniform index. shadertype must be one of GL_VERTEX_SHADER, GL_TESS_CONTROL_SHADER, GL_TESS_EVALUATION_SHADER, GL_GEOMETRY_SHADER or GL_FRAGMENT_SHADER. </param>
         /// <param name="name"> Specifies the name of the subroutine uniform whose index to query. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetSubroutineIndex.xhtml" /></remarks>
-        public static uint GetSubroutineIndex(ProgramHandle program, ShaderType shadertype, byte* name) => GLPointers._GetSubroutineIndex_fnptr((int)program, (uint)shadertype, name);
+        public static uint GetSubroutineIndex(int program, ShaderType shadertype, byte* name) => GLPointers._GetSubroutineIndex_fnptr(program, (uint)shadertype, name);
         
         /// <summary> <b>[requires: v4.0 | GL_ARB_shader_subroutine]</b> Query a property of an active shader subroutine uniform. </summary>
         /// <param name="program"> Specifies the name of the program containing the subroutine. </param>
@@ -2576,7 +2576,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="pname"> Specifies the parameter of the shader subroutine uniform to query. pname must be GL_NUM_COMPATIBLE_SUBROUTINES, GL_COMPATIBLE_SUBROUTINES, GL_UNIFORM_SIZE or GL_UNIFORM_NAME_LENGTH. </param>
         /// <param name="values"> Specifies the address of a into which the queried value or values will be placed. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetActiveSubroutineUniform.xhtml" /></remarks>
-        public static void GetActiveSubroutineUniformiv(ProgramHandle program, ShaderType shadertype, uint index, SubroutineParameterName pname, int* values) => GLPointers._GetActiveSubroutineUniformiv_fnptr((int)program, (uint)shadertype, index, (uint)pname, values);
+        public static void GetActiveSubroutineUniformiv(int program, ShaderType shadertype, uint index, SubroutineParameterName pname, int* values) => GLPointers._GetActiveSubroutineUniformiv_fnptr(program, (uint)shadertype, index, (uint)pname, values);
         
         /// <summary> <b>[requires: v4.0 | GL_ARB_shader_subroutine]</b> Query the name of an active shader subroutine uniform. </summary>
         /// <param name="program"> Specifies the name of the program containing the subroutine. </param>
@@ -2586,7 +2586,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="length"> Specifies the address of a variable into which is written the number of characters copied into name. </param>
         /// <param name="name"> Specifies the address of a buffer that will receive the name of the specified shader subroutine uniform. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetActiveSubroutineUniformName.xhtml" /></remarks>
-        public static void GetActiveSubroutineUniformName(ProgramHandle program, ShaderType shadertype, uint index, int bufSize, int* length, byte* name) => GLPointers._GetActiveSubroutineUniformName_fnptr((int)program, (uint)shadertype, index, bufSize, length, name);
+        public static void GetActiveSubroutineUniformName(int program, ShaderType shadertype, uint index, int bufSize, int* length, byte* name) => GLPointers._GetActiveSubroutineUniformName_fnptr(program, (uint)shadertype, index, bufSize, length, name);
         
         /// <summary> <b>[requires: v4.0 | GL_ARB_shader_subroutine]</b> Query the name of an active shader subroutine. </summary>
         /// <param name="program"> Specifies the name of the program containing the subroutine. </param>
@@ -2596,7 +2596,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="length"> Specifies the address of a variable which is to receive the length of the shader subroutine uniform name. </param>
         /// <param name="name"> Specifies the address of an array into which the name of the shader subroutine uniform will be written. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetActiveSubroutineName.xhtml" /></remarks>
-        public static void GetActiveSubroutineName(ProgramHandle program, ShaderType shadertype, uint index, int bufSize, int* length, byte* name) => GLPointers._GetActiveSubroutineName_fnptr((int)program, (uint)shadertype, index, bufSize, length, name);
+        public static void GetActiveSubroutineName(int program, ShaderType shadertype, uint index, int bufSize, int* length, byte* name) => GLPointers._GetActiveSubroutineName_fnptr(program, (uint)shadertype, index, bufSize, length, name);
         
         /// <summary> <b>[requires: v4.0 | GL_ARB_shader_subroutine]</b> Load active subroutine uniforms. </summary>
         /// <param name="shadertype"> Specifies the shader stage from which to query for subroutine uniform index. shadertype must be one of GL_VERTEX_SHADER, GL_TESS_CONTROL_SHADER, GL_TESS_EVALUATION_SHADER, GL_GEOMETRY_SHADER or GL_FRAGMENT_SHADER. </param>
@@ -2618,7 +2618,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="pname"> Specifies the parameter of the shader to query. pname must be GL_ACTIVE_SUBROUTINE_UNIFORMS, GL_ACTIVE_SUBROUTINE_UNIFORM_LOCATIONS, GL_ACTIVE_SUBROUTINES, GL_ACTIVE_SUBROUTINE_UNIFORM_MAX_LENGTH, or GL_ACTIVE_SUBROUTINE_MAX_LENGTH. </param>
         /// <param name="values"> Specifies the address of a variable into which the queried value or values will be placed. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetProgramStage.xhtml" /></remarks>
-        public static void GetProgramStageiv(ProgramHandle program, ShaderType shadertype, ProgramStagePName pname, int* values) => GLPointers._GetProgramStageiv_fnptr((int)program, (uint)shadertype, (uint)pname, values);
+        public static void GetProgramStageiv(int program, ShaderType shadertype, ProgramStagePName pname, int* values) => GLPointers._GetProgramStageiv_fnptr(program, (uint)shadertype, (uint)pname, values);
         
         /// <summary> <b>[requires: v4.0 | GL_ARB_tessellation_shader]</b> Specifies the parameters for patch primitives. </summary>
         /// <param name="pname"> Specifies the name of the parameter to set. The symbolc constants GL_PATCH_VERTICES, GL_PATCH_DEFAULT_OUTER_LEVEL, and GL_PATCH_DEFAULT_INNER_LEVEL are accepted. </param>
@@ -2636,24 +2636,24 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="target"> Specifies the target to which to bind the transform feedback object id. target must be GL_TRANSFORM_FEEDBACK. </param>
         /// <param name="id"> Specifies the name of a transform feedback object reserved by glGenTransformFeedbacks. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindTransformFeedback.xhtml" /></remarks>
-        public static void BindTransformFeedback(BindTransformFeedbackTarget target, TransformFeedbackHandle id) => GLPointers._BindTransformFeedback_fnptr((uint)target, (int)id);
+        public static void BindTransformFeedback(BindTransformFeedbackTarget target, int id) => GLPointers._BindTransformFeedback_fnptr((uint)target, id);
         
         /// <summary> <b>[requires: v4.0 | GL_ARB_transform_feedback2]</b> Delete transform feedback objects. </summary>
         /// <param name="n"> Specifies the number of transform feedback objects to delete. </param>
         /// <param name="ids"> Specifies an array of names of transform feedback objects to delete. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDeleteTransformFeedbacks.xhtml" /></remarks>
-        public static void DeleteTransformFeedbacks(int n, TransformFeedbackHandle* ids) => GLPointers._DeleteTransformFeedbacks_fnptr(n, (int*)ids);
+        public static void DeleteTransformFeedbacks(int n, int* ids) => GLPointers._DeleteTransformFeedbacks_fnptr(n, ids);
         
         /// <summary> <b>[requires: v4.0 | GL_ARB_transform_feedback2]</b> Reserve transform feedback object names. </summary>
         /// <param name="n"> Specifies the number of transform feedback object names to reserve. </param>
         /// <param name="ids"> Specifies an array of into which the reserved names will be written. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGenTransformFeedbacks.xhtml" /></remarks>
-        public static void GenTransformFeedbacks(int n, TransformFeedbackHandle* ids) => GLPointers._GenTransformFeedbacks_fnptr(n, (int*)ids);
+        public static void GenTransformFeedbacks(int n, int* ids) => GLPointers._GenTransformFeedbacks_fnptr(n, ids);
         
         /// <summary> <b>[requires: v4.0 | GL_ARB_transform_feedback2]</b> Determine if a name corresponds to a transform feedback object. </summary>
         /// <param name="id"> Specifies a value that may be the name of a transform feedback object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsTransformFeedback.xhtml" /></remarks>
-        public static bool IsTransformFeedback(TransformFeedbackHandle id) => GLPointers._IsTransformFeedback_fnptr((int)id) != 0;
+        public static bool IsTransformFeedback(int id) => GLPointers._IsTransformFeedback_fnptr(id) != 0;
         
         /// <summary> <b>[requires: v4.0 | GL_ARB_transform_feedback2]</b> Pause transform feedback operations. </summary>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glPauseTransformFeedback.xhtml" /></remarks>
@@ -2667,21 +2667,21 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="mode"> Specifies what kind of primitives to render. Symbolic constants GL_POINTS, GL_LINE_STRIP, GL_LINE_LOOP, GL_LINES, GL_LINE_STRIP_ADJACENCY, GL_LINES_ADJACENCY, GL_TRIANGLE_STRIP, GL_TRIANGLE_FAN, GL_TRIANGLES, GL_TRIANGLE_STRIP_ADJACENCY, GL_TRIANGLES_ADJACENCY, and GL_PATCHES are accepted. </param>
         /// <param name="id"> Specifies the name of a transform feedback object from which to retrieve a primitive count. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDrawTransformFeedback.xhtml" /></remarks>
-        public static void DrawTransformFeedback(PrimitiveType mode, TransformFeedbackHandle id) => GLPointers._DrawTransformFeedback_fnptr((uint)mode, (int)id);
+        public static void DrawTransformFeedback(PrimitiveType mode, int id) => GLPointers._DrawTransformFeedback_fnptr((uint)mode, id);
         
         /// <summary> <b>[requires: v4.0 | GL_ARB_transform_feedback3]</b> Render primitives using a count derived from a specifed stream of a transform feedback object. </summary>
         /// <param name="mode"> Specifies what kind of primitives to render. Symbolic constants GL_POINTS, GL_LINE_STRIP, GL_LINE_LOOP, GL_LINES, GL_LINE_STRIP_ADJACENCY, GL_LINES_ADJACENCY, GL_TRIANGLE_STRIP, GL_TRIANGLE_FAN, GL_TRIANGLES, GL_TRIANGLE_STRIP_ADJACENCY, GL_TRIANGLES_ADJACENCY, and GL_PATCHES are accepted. </param>
         /// <param name="id"> Specifies the name of a transform feedback object from which to retrieve a primitive count. </param>
         /// <param name="stream"> Specifies the index of the transform feedback stream from which to retrieve a primitive count. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDrawTransformFeedbackStream.xhtml" /></remarks>
-        public static void DrawTransformFeedbackStream(PrimitiveType mode, TransformFeedbackHandle id, uint stream) => GLPointers._DrawTransformFeedbackStream_fnptr((uint)mode, (int)id, stream);
+        public static void DrawTransformFeedbackStream(PrimitiveType mode, int id, uint stream) => GLPointers._DrawTransformFeedbackStream_fnptr((uint)mode, id, stream);
         
         /// <summary> <b>[requires: v4.0 | GL_ARB_transform_feedback3]</b> Delimit the boundaries of a query object on an indexed target. </summary>
         /// <param name="target"> Specifies the target type of query object established between glBeginQueryIndexed and the subsequent glEndQueryIndexed. The symbolic constant must be one of GL_SAMPLES_PASSED, GL_ANY_SAMPLES_PASSED, GL_PRIMITIVES_GENERATED, GL_TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN, or GL_TIME_ELAPSED. </param>
         /// <param name="index"> Specifies the index of the query target upon which to begin the query. </param>
         /// <param name="id"> Specifies the name of a query object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBeginQueryIndexed.xhtml" /></remarks>
-        public static void BeginQueryIndexed(QueryTarget target, uint index, QueryHandle id) => GLPointers._BeginQueryIndexed_fnptr((uint)target, index, (int)id);
+        public static void BeginQueryIndexed(QueryTarget target, uint index, int id) => GLPointers._BeginQueryIndexed_fnptr((uint)target, index, id);
         
         /// <summary> <b>[requires: v4.0 | GL_ARB_transform_feedback3]</b> Delimit the boundaries of a query object on an indexed target. </summary>
         /// <param name="target"> Specifies the target type of query object established between glBeginQueryIndexed and the subsequent glEndQueryIndexed. The symbolic constant must be one of GL_SAMPLES_PASSED, GL_ANY_SAMPLES_PASSED, GL_PRIMITIVES_GENERATED, GL_TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN, or GL_TIME_ELAPSED. </param>
@@ -2708,7 +2708,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="binary"> Specifies the address of an array of bytes containing pre-compiled binary shader code. </param>
         /// <param name="length"> Specifies the length of the array whose address is given in binary. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glShaderBinary.xhtml" /></remarks>
-        public static void ShaderBinary(int count, ShaderHandle* shaders, ShaderBinaryFormat binaryFormat, void* binary, int length) => GLPointers._ShaderBinary_fnptr(count, (int*)shaders, (uint)binaryFormat, binary, length);
+        public static void ShaderBinary(int count, int* shaders, ShaderBinaryFormat binaryFormat, void* binary, int length) => GLPointers._ShaderBinary_fnptr(count, shaders, (uint)binaryFormat, binary, length);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_ES2_compatibility]</b> Retrieve the range and precision for numeric formats supported by the shader compiler. </summary>
         /// <param name="shaderType"> Specifies the type of shader whose precision to query. shaderType must be GL_VERTEX_SHADER or GL_FRAGMENT_SHADER. </param>
@@ -2736,7 +2736,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="binaryFormat"> Specifies the address of a variable to receive a token indicating the format of the binary data returned by the GL. </param>
         /// <param name="binary"> Specifies the address an array into which the GL will return program's binary representation. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetProgramBinary.xhtml" /></remarks>
-        public static void GetProgramBinary(ProgramHandle program, int bufSize, int* length, All* binaryFormat, void* binary) => GLPointers._GetProgramBinary_fnptr((int)program, bufSize, length, (uint*)binaryFormat, binary);
+        public static void GetProgramBinary(int program, int bufSize, int* length, All* binaryFormat, void* binary) => GLPointers._GetProgramBinary_fnptr(program, bufSize, length, (uint*)binaryFormat, binary);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_get_program_binary]</b> Load a program object with a program binary. </summary>
         /// <param name="program"> Specifies the name of a program object into which to load a program binary. </param>
@@ -2744,70 +2744,70 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="binary"> Specifies the address an array containing the binary to be loaded into program. </param>
         /// <param name="length"> Specifies the number of bytes contained in binary. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramBinary.xhtml" /></remarks>
-        public static void ProgramBinary(ProgramHandle program, All binaryFormat, void* binary, int length) => GLPointers._ProgramBinary_fnptr((int)program, (uint)binaryFormat, binary, length);
+        public static void ProgramBinary(int program, All binaryFormat, void* binary, int length) => GLPointers._ProgramBinary_fnptr(program, (uint)binaryFormat, binary, length);
         
         /// <summary> <b>[requires: v4.1 | v4.1 | GL_ARB_get_program_binary | GL_ARB_separate_shader_objects]</b> Specify a parameter for a program object. </summary>
         /// <param name="program"> Specifies the name of a program object whose parameter to modify. </param>
         /// <param name="pname"> Specifies the name of the parameter to modify. </param>
         /// <param name="value"> Specifies the new value of the parameter specified by pname for program. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramParameter.xhtml" /></remarks>
-        public static void ProgramParameteri(ProgramHandle program, ProgramParameterPName pname, int value) => GLPointers._ProgramParameteri_fnptr((int)program, (uint)pname, value);
+        public static void ProgramParameteri(int program, ProgramParameterPName pname, int value) => GLPointers._ProgramParameteri_fnptr(program, (uint)pname, value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Bind stages of a program object to a program pipeline. </summary>
         /// <param name="pipeline"> Specifies the program pipeline object to which to bind stages from program. </param>
         /// <param name="stages"> Specifies a set of program stages to bind to the program pipeline object. </param>
         /// <param name="program"> Specifies the program object containing the shader executables to use in pipeline. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glUseProgramStages.xhtml" /></remarks>
-        public static void UseProgramStages(ProgramPipelineHandle pipeline, UseProgramStageMask stages, ProgramHandle program) => GLPointers._UseProgramStages_fnptr((int)pipeline, (uint)stages, (int)program);
+        public static void UseProgramStages(int pipeline, UseProgramStageMask stages, int program) => GLPointers._UseProgramStages_fnptr(pipeline, (uint)stages, program);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Set the active program object for a program pipeline object. </summary>
         /// <param name="pipeline"> Specifies the program pipeline object to set the active program object for. </param>
         /// <param name="program"> Specifies the program object to set as the active program pipeline object pipeline. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glActiveShaderProgram.xhtml" /></remarks>
-        public static void ActiveShaderProgram(ProgramPipelineHandle pipeline, ProgramHandle program) => GLPointers._ActiveShaderProgram_fnptr((int)pipeline, (int)program);
+        public static void ActiveShaderProgram(int pipeline, int program) => GLPointers._ActiveShaderProgram_fnptr(pipeline, program);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Create a stand-alone program from an array of null-terminated source code strings. </summary>
         /// <param name="type"> Specifies the type of shader to create. </param>
         /// <param name="count"> Specifies the number of source code strings in the array strings. </param>
         /// <param name="strings"> Specifies the address of an array of pointers to source code strings from which to create the program object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCreateShaderProgram.xhtml" /></remarks>
-        public static ProgramHandle CreateShaderProgramv(ShaderType type, int count, byte** strings) => (ProgramHandle) GLPointers._CreateShaderProgramv_fnptr((uint)type, count, strings);
+        public static int CreateShaderProgramv(ShaderType type, int count, byte** strings) => GLPointers._CreateShaderProgramv_fnptr((uint)type, count, strings);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Bind a program pipeline to the current context. </summary>
         /// <param name="pipeline"> Specifies the name of the pipeline object to bind to the context. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindProgramPipeline.xhtml" /></remarks>
-        public static void BindProgramPipeline(ProgramPipelineHandle pipeline) => GLPointers._BindProgramPipeline_fnptr((int)pipeline);
+        public static void BindProgramPipeline(int pipeline) => GLPointers._BindProgramPipeline_fnptr(pipeline);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Delete program pipeline objects. </summary>
         /// <param name="n"> Specifies the number of program pipeline objects to delete. </param>
         /// <param name="pipelines"> Specifies an array of names of program pipeline objects to delete. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDeleteProgramPipelines.xhtml" /></remarks>
-        public static void DeleteProgramPipelines(int n, ProgramPipelineHandle* pipelines) => GLPointers._DeleteProgramPipelines_fnptr(n, (int*)pipelines);
+        public static void DeleteProgramPipelines(int n, int* pipelines) => GLPointers._DeleteProgramPipelines_fnptr(n, pipelines);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Reserve program pipeline object names. </summary>
         /// <param name="n"> Specifies the number of program pipeline object names to reserve. </param>
         /// <param name="pipelines"> Specifies an array of into which the reserved names will be written. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGenProgramPipelines.xhtml" /></remarks>
-        public static void GenProgramPipelines(int n, ProgramPipelineHandle* pipelines) => GLPointers._GenProgramPipelines_fnptr(n, (int*)pipelines);
+        public static void GenProgramPipelines(int n, int* pipelines) => GLPointers._GenProgramPipelines_fnptr(n, pipelines);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Determine if a name corresponds to a program pipeline object. </summary>
         /// <param name="pipeline"> Specifies a value that may be the name of a program pipeline object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsProgramPipeline.xhtml" /></remarks>
-        public static bool IsProgramPipeline(ProgramPipelineHandle pipeline) => GLPointers._IsProgramPipeline_fnptr((int)pipeline) != 0;
+        public static bool IsProgramPipeline(int pipeline) => GLPointers._IsProgramPipeline_fnptr(pipeline) != 0;
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Retrieve properties of a program pipeline object. </summary>
         /// <param name="pipeline"> Specifies the name of a program pipeline object whose parameter retrieve. </param>
         /// <param name="pname"> Specifies the name of the parameter to retrieve. </param>
         /// <param name="parameters"> Specifies the address of a variable into which will be written the value or values of pname for pipeline. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetProgramPipeline.xhtml" /></remarks>
-        public static void GetProgramPipelineiv(ProgramPipelineHandle pipeline, PipelineParameterName pname, int* parameters) => GLPointers._GetProgramPipelineiv_fnptr((int)pipeline, (uint)pname, parameters);
+        public static void GetProgramPipelineiv(int pipeline, PipelineParameterName pname, int* parameters) => GLPointers._GetProgramPipelineiv_fnptr(pipeline, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
         /// <param name="v0"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform1i(ProgramHandle program, int location, int v0) => GLPointers._ProgramUniform1i_fnptr((int)program, location, v0);
+        public static void ProgramUniform1i(int program, int location, int v0) => GLPointers._ProgramUniform1i_fnptr(program, location, v0);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -2815,14 +2815,14 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform1iv(ProgramHandle program, int location, int count, int* value) => GLPointers._ProgramUniform1iv_fnptr((int)program, location, count, value);
+        public static void ProgramUniform1iv(int program, int location, int count, int* value) => GLPointers._ProgramUniform1iv_fnptr(program, location, count, value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
         /// <param name="v0"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform1f(ProgramHandle program, int location, float v0) => GLPointers._ProgramUniform1f_fnptr((int)program, location, v0);
+        public static void ProgramUniform1f(int program, int location, float v0) => GLPointers._ProgramUniform1f_fnptr(program, location, v0);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -2830,22 +2830,22 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform1fv(ProgramHandle program, int location, int count, float* value) => GLPointers._ProgramUniform1fv_fnptr((int)program, location, count, value);
+        public static void ProgramUniform1fv(int program, int location, int count, float* value) => GLPointers._ProgramUniform1fv_fnptr(program, location, count, value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void ProgramUniform1d(ProgramHandle program, int location, double v0) => GLPointers._ProgramUniform1d_fnptr((int)program, location, v0);
+        public static void ProgramUniform1d(int program, int location, double v0) => GLPointers._ProgramUniform1d_fnptr(program, location, v0);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void ProgramUniform1dv(ProgramHandle program, int location, int count, double* value) => GLPointers._ProgramUniform1dv_fnptr((int)program, location, count, value);
+        public static void ProgramUniform1dv(int program, int location, int count, double* value) => GLPointers._ProgramUniform1dv_fnptr(program, location, count, value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
         /// <param name="v0"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform1ui(ProgramHandle program, int location, uint v0) => GLPointers._ProgramUniform1ui_fnptr((int)program, location, v0);
+        public static void ProgramUniform1ui(int program, int location, uint v0) => GLPointers._ProgramUniform1ui_fnptr(program, location, v0);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -2853,7 +2853,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform1uiv(ProgramHandle program, int location, int count, uint* value) => GLPointers._ProgramUniform1uiv_fnptr((int)program, location, count, value);
+        public static void ProgramUniform1uiv(int program, int location, int count, uint* value) => GLPointers._ProgramUniform1uiv_fnptr(program, location, count, value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -2861,7 +2861,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="v0"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
         /// <param name="v1"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform2i(ProgramHandle program, int location, int v0, int v1) => GLPointers._ProgramUniform2i_fnptr((int)program, location, v0, v1);
+        public static void ProgramUniform2i(int program, int location, int v0, int v1) => GLPointers._ProgramUniform2i_fnptr(program, location, v0, v1);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -2869,7 +2869,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform2iv(ProgramHandle program, int location, int count, int* value) => GLPointers._ProgramUniform2iv_fnptr((int)program, location, count, value);
+        public static void ProgramUniform2iv(int program, int location, int count, int* value) => GLPointers._ProgramUniform2iv_fnptr(program, location, count, value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -2877,7 +2877,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="v0"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
         /// <param name="v1"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform2f(ProgramHandle program, int location, float v0, float v1) => GLPointers._ProgramUniform2f_fnptr((int)program, location, v0, v1);
+        public static void ProgramUniform2f(int program, int location, float v0, float v1) => GLPointers._ProgramUniform2f_fnptr(program, location, v0, v1);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -2885,15 +2885,15 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform2fv(ProgramHandle program, int location, int count, float* value) => GLPointers._ProgramUniform2fv_fnptr((int)program, location, count, value);
+        public static void ProgramUniform2fv(int program, int location, int count, float* value) => GLPointers._ProgramUniform2fv_fnptr(program, location, count, value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void ProgramUniform2d(ProgramHandle program, int location, double v0, double v1) => GLPointers._ProgramUniform2d_fnptr((int)program, location, v0, v1);
+        public static void ProgramUniform2d(int program, int location, double v0, double v1) => GLPointers._ProgramUniform2d_fnptr(program, location, v0, v1);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void ProgramUniform2dv(ProgramHandle program, int location, int count, double* value) => GLPointers._ProgramUniform2dv_fnptr((int)program, location, count, value);
+        public static void ProgramUniform2dv(int program, int location, int count, double* value) => GLPointers._ProgramUniform2dv_fnptr(program, location, count, value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -2901,7 +2901,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="v0"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
         /// <param name="v1"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform2ui(ProgramHandle program, int location, uint v0, uint v1) => GLPointers._ProgramUniform2ui_fnptr((int)program, location, v0, v1);
+        public static void ProgramUniform2ui(int program, int location, uint v0, uint v1) => GLPointers._ProgramUniform2ui_fnptr(program, location, v0, v1);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -2909,7 +2909,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform2uiv(ProgramHandle program, int location, int count, uint* value) => GLPointers._ProgramUniform2uiv_fnptr((int)program, location, count, value);
+        public static void ProgramUniform2uiv(int program, int location, int count, uint* value) => GLPointers._ProgramUniform2uiv_fnptr(program, location, count, value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -2918,7 +2918,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="v1"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
         /// <param name="v2"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform3i(ProgramHandle program, int location, int v0, int v1, int v2) => GLPointers._ProgramUniform3i_fnptr((int)program, location, v0, v1, v2);
+        public static void ProgramUniform3i(int program, int location, int v0, int v1, int v2) => GLPointers._ProgramUniform3i_fnptr(program, location, v0, v1, v2);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -2926,7 +2926,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform3iv(ProgramHandle program, int location, int count, int* value) => GLPointers._ProgramUniform3iv_fnptr((int)program, location, count, value);
+        public static void ProgramUniform3iv(int program, int location, int count, int* value) => GLPointers._ProgramUniform3iv_fnptr(program, location, count, value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -2935,7 +2935,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="v1"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
         /// <param name="v2"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform3f(ProgramHandle program, int location, float v0, float v1, float v2) => GLPointers._ProgramUniform3f_fnptr((int)program, location, v0, v1, v2);
+        public static void ProgramUniform3f(int program, int location, float v0, float v1, float v2) => GLPointers._ProgramUniform3f_fnptr(program, location, v0, v1, v2);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -2943,15 +2943,15 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform3fv(ProgramHandle program, int location, int count, float* value) => GLPointers._ProgramUniform3fv_fnptr((int)program, location, count, value);
+        public static void ProgramUniform3fv(int program, int location, int count, float* value) => GLPointers._ProgramUniform3fv_fnptr(program, location, count, value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void ProgramUniform3d(ProgramHandle program, int location, double v0, double v1, double v2) => GLPointers._ProgramUniform3d_fnptr((int)program, location, v0, v1, v2);
+        public static void ProgramUniform3d(int program, int location, double v0, double v1, double v2) => GLPointers._ProgramUniform3d_fnptr(program, location, v0, v1, v2);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void ProgramUniform3dv(ProgramHandle program, int location, int count, double* value) => GLPointers._ProgramUniform3dv_fnptr((int)program, location, count, value);
+        public static void ProgramUniform3dv(int program, int location, int count, double* value) => GLPointers._ProgramUniform3dv_fnptr(program, location, count, value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -2960,7 +2960,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="v1"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
         /// <param name="v2"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform3ui(ProgramHandle program, int location, uint v0, uint v1, uint v2) => GLPointers._ProgramUniform3ui_fnptr((int)program, location, v0, v1, v2);
+        public static void ProgramUniform3ui(int program, int location, uint v0, uint v1, uint v2) => GLPointers._ProgramUniform3ui_fnptr(program, location, v0, v1, v2);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -2968,25 +2968,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform3uiv(ProgramHandle program, int location, int count, uint* value) => GLPointers._ProgramUniform3uiv_fnptr((int)program, location, count, value);
-        
-        /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
-        /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
-        /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
-        /// <param name="v0"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
-        /// <param name="v1"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
-        /// <param name="v2"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
-        /// <param name="v3"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
-        /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform4i(ProgramHandle program, int location, int v0, int v1, int v2, int v3) => GLPointers._ProgramUniform4i_fnptr((int)program, location, v0, v1, v2, v3);
-        
-        /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
-        /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
-        /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
-        /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
-        /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
-        /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform4iv(ProgramHandle program, int location, int count, int* value) => GLPointers._ProgramUniform4iv_fnptr((int)program, location, count, value);
+        public static void ProgramUniform3uiv(int program, int location, int count, uint* value) => GLPointers._ProgramUniform3uiv_fnptr(program, location, count, value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -2996,7 +2978,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="v2"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
         /// <param name="v3"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform4f(ProgramHandle program, int location, float v0, float v1, float v2, float v3) => GLPointers._ProgramUniform4f_fnptr((int)program, location, v0, v1, v2, v3);
+        public static void ProgramUniform4i(int program, int location, int v0, int v1, int v2, int v3) => GLPointers._ProgramUniform4i_fnptr(program, location, v0, v1, v2, v3);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -3004,15 +2986,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform4fv(ProgramHandle program, int location, int count, float* value) => GLPointers._ProgramUniform4fv_fnptr((int)program, location, count, value);
-        
-        /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
-        /// <remarks><see href="" /></remarks>
-        public static void ProgramUniform4d(ProgramHandle program, int location, double v0, double v1, double v2, double v3) => GLPointers._ProgramUniform4d_fnptr((int)program, location, v0, v1, v2, v3);
-        
-        /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
-        /// <remarks><see href="" /></remarks>
-        public static void ProgramUniform4dv(ProgramHandle program, int location, int count, double* value) => GLPointers._ProgramUniform4dv_fnptr((int)program, location, count, value);
+        public static void ProgramUniform4iv(int program, int location, int count, int* value) => GLPointers._ProgramUniform4iv_fnptr(program, location, count, value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -3022,7 +2996,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="v2"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
         /// <param name="v3"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform4ui(ProgramHandle program, int location, uint v0, uint v1, uint v2, uint v3) => GLPointers._ProgramUniform4ui_fnptr((int)program, location, v0, v1, v2, v3);
+        public static void ProgramUniform4f(int program, int location, float v0, float v1, float v2, float v3) => GLPointers._ProgramUniform4f_fnptr(program, location, v0, v1, v2, v3);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -3030,7 +3004,33 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform4uiv(ProgramHandle program, int location, int count, uint* value) => GLPointers._ProgramUniform4uiv_fnptr((int)program, location, count, value);
+        public static void ProgramUniform4fv(int program, int location, int count, float* value) => GLPointers._ProgramUniform4fv_fnptr(program, location, count, value);
+        
+        /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
+        /// <remarks><see href="" /></remarks>
+        public static void ProgramUniform4d(int program, int location, double v0, double v1, double v2, double v3) => GLPointers._ProgramUniform4d_fnptr(program, location, v0, v1, v2, v3);
+        
+        /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
+        /// <remarks><see href="" /></remarks>
+        public static void ProgramUniform4dv(int program, int location, int count, double* value) => GLPointers._ProgramUniform4dv_fnptr(program, location, count, value);
+        
+        /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
+        /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
+        /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
+        /// <param name="v0"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
+        /// <param name="v1"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
+        /// <param name="v2"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
+        /// <param name="v3"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
+        /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
+        public static void ProgramUniform4ui(int program, int location, uint v0, uint v1, uint v2, uint v3) => GLPointers._ProgramUniform4ui_fnptr(program, location, v0, v1, v2, v3);
+        
+        /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
+        /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
+        /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
+        /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
+        /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
+        /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
+        public static void ProgramUniform4uiv(int program, int location, int count, uint* value) => GLPointers._ProgramUniform4uiv_fnptr(program, location, count, value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -3039,7 +3039,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniformMatrix2fv(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix2fv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+        public static void ProgramUniformMatrix2fv(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix2fv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -3048,7 +3048,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniformMatrix3fv(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix3fv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+        public static void ProgramUniformMatrix3fv(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix3fv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -3057,19 +3057,19 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniformMatrix4fv(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix4fv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+        public static void ProgramUniformMatrix4fv(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix4fv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void ProgramUniformMatrix2dv(ProgramHandle program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix2dv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+        public static void ProgramUniformMatrix2dv(int program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix2dv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void ProgramUniformMatrix3dv(ProgramHandle program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix3dv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+        public static void ProgramUniformMatrix3dv(int program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix3dv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void ProgramUniformMatrix4dv(ProgramHandle program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix4dv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+        public static void ProgramUniformMatrix4dv(int program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix4dv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -3078,7 +3078,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniformMatrix2x3fv(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix2x3fv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+        public static void ProgramUniformMatrix2x3fv(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix2x3fv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -3087,7 +3087,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniformMatrix3x2fv(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix3x2fv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+        public static void ProgramUniformMatrix3x2fv(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix3x2fv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -3096,7 +3096,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniformMatrix2x4fv(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix2x4fv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+        public static void ProgramUniformMatrix2x4fv(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix2x4fv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -3105,7 +3105,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniformMatrix4x2fv(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix4x2fv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+        public static void ProgramUniformMatrix4x2fv(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix4x2fv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -3114,7 +3114,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniformMatrix3x4fv(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix3x4fv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+        public static void ProgramUniformMatrix3x4fv(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix3x4fv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -3123,36 +3123,36 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniformMatrix4x3fv(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix4x3fv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+        public static void ProgramUniformMatrix4x3fv(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix4x3fv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void ProgramUniformMatrix2x3dv(ProgramHandle program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix2x3dv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+        public static void ProgramUniformMatrix2x3dv(int program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix2x3dv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void ProgramUniformMatrix3x2dv(ProgramHandle program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix3x2dv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+        public static void ProgramUniformMatrix3x2dv(int program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix3x2dv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void ProgramUniformMatrix2x4dv(ProgramHandle program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix2x4dv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+        public static void ProgramUniformMatrix2x4dv(int program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix2x4dv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void ProgramUniformMatrix4x2dv(ProgramHandle program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix4x2dv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+        public static void ProgramUniformMatrix4x2dv(int program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix4x2dv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void ProgramUniformMatrix3x4dv(ProgramHandle program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix3x4dv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+        public static void ProgramUniformMatrix3x4dv(int program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix3x4dv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
         /// <remarks><see href="" /></remarks>
-        public static void ProgramUniformMatrix4x3dv(ProgramHandle program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix4x3dv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+        public static void ProgramUniformMatrix4x3dv(int program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix4x3dv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Validate a program pipeline object against current GL state. </summary>
         /// <param name="pipeline"> Specifies the name of a program pipeline object to validate. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glValidateProgramPipeline.xhtml" /></remarks>
-        public static void ValidateProgramPipeline(ProgramPipelineHandle pipeline) => GLPointers._ValidateProgramPipeline_fnptr((int)pipeline);
+        public static void ValidateProgramPipeline(int pipeline) => GLPointers._ValidateProgramPipeline_fnptr(pipeline);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Retrieve the info log string from a program pipeline object. </summary>
         /// <param name="pipeline"> Specifies the name of a program pipeline object from which to retrieve the info log. </param>
@@ -3160,7 +3160,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="length"> Specifies the address of a variable into which will be written the number of characters written into infoLog. </param>
         /// <param name="infoLog"> Specifies the address of an array of characters into which will be written the info log for pipeline. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetProgramPipelineInfoLog.xhtml" /></remarks>
-        public static void GetProgramPipelineInfoLog(ProgramPipelineHandle pipeline, int bufSize, int* length, byte* infoLog) => GLPointers._GetProgramPipelineInfoLog_fnptr((int)pipeline, bufSize, length, infoLog);
+        public static void GetProgramPipelineInfoLog(int pipeline, int bufSize, int* length, byte* infoLog) => GLPointers._GetProgramPipelineInfoLog_fnptr(pipeline, bufSize, length, infoLog);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_vertex_attrib_64bit]</b> Specifies the value of a generic vertex attribute. </summary>
         /// <param name="index">Specifies the index of the generic vertex attribute to be modified.</param>
@@ -3349,7 +3349,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="pname"> Specifies which parameter of the atomic counter buffer to retrieve. </param>
         /// <param name="parameters"> Specifies the address of a variable into which to write the retrieved information. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetActiveAtomicCounterBufferiv.xhtml" /></remarks>
-        public static void GetActiveAtomicCounterBufferiv(ProgramHandle program, uint bufferIndex, AtomicCounterBufferPName pname, int* parameters) => GLPointers._GetActiveAtomicCounterBufferiv_fnptr((int)program, bufferIndex, (uint)pname, parameters);
+        public static void GetActiveAtomicCounterBufferiv(int program, uint bufferIndex, AtomicCounterBufferPName pname, int* parameters) => GLPointers._GetActiveAtomicCounterBufferiv_fnptr(program, bufferIndex, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v4.2 | GL_ARB_shader_image_load_store]</b> Bind a level of a texture to an image unit. </summary>
         /// <param name="unit"> Specifies the index of the image unit to which to bind the texture </param>
@@ -3360,7 +3360,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="access"> Specifies a token indicating the type of access that will be performed on the image. </param>
         /// <param name="format"> Specifies the format that the elements of the image will be treated as for the purposes of formatted stores. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindImageTexture.xhtml" /></remarks>
-        public static void BindImageTexture(uint unit, TextureHandle texture, int level, bool layered, int layer, BufferAccessARB access, InternalFormat format) => GLPointers._BindImageTexture_fnptr(unit, (int)texture, level, (byte)(layered ? 1 : 0), layer, (uint)access, (uint)format);
+        public static void BindImageTexture(uint unit, int texture, int level, bool layered, int layer, BufferAccessARB access, InternalFormat format) => GLPointers._BindImageTexture_fnptr(unit, texture, level, (byte)(layered ? 1 : 0), layer, (uint)access, (uint)format);
         
         /// <summary> <b>[requires: v4.2 | GL_ARB_shader_image_load_store]</b> Defines a barrier ordering memory transactions. </summary>
         /// <param name="barriers"> Specifies the barriers to insert. </param>
@@ -3399,7 +3399,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="id"> Specifies the name of a transform feedback object from which to retrieve a primitive count. </param>
         /// <param name="instancecount"> Specifies the number of instances of the geometry to render. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDrawTransformFeedbackInstanced.xhtml" /></remarks>
-        public static void DrawTransformFeedbackInstanced(PrimitiveType mode, TransformFeedbackHandle id, int instancecount) => GLPointers._DrawTransformFeedbackInstanced_fnptr((uint)mode, (int)id, instancecount);
+        public static void DrawTransformFeedbackInstanced(PrimitiveType mode, int id, int instancecount) => GLPointers._DrawTransformFeedbackInstanced_fnptr((uint)mode, id, instancecount);
         
         /// <summary> <b>[requires: v4.2 | GL_ARB_transform_feedback_instanced]</b> Render multiple instances of primitives using a count derived from a specifed stream of a transform feedback object. </summary>
         /// <param name="mode"> Specifies what kind of primitives to render. Symbolic constants GL_POINTS, GL_LINE_STRIP, GL_LINE_LOOP, GL_LINES, GL_LINE_STRIP_ADJACENCY, GL_LINES_ADJACENCY, GL_TRIANGLE_STRIP, GL_TRIANGLE_FAN, GL_TRIANGLES, GL_TRIANGLE_STRIP_ADJACENCY, GL_TRIANGLES_ADJACENCY, and GL_PATCHES are accepted. </param>
@@ -3407,7 +3407,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="stream"> Specifies the index of the transform feedback stream from which to retrieve a primitive count. </param>
         /// <param name="instancecount"> Specifies the number of instances of the geometry to render. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDrawTransformFeedbackStreamInstanced.xhtml" /></remarks>
-        public static void DrawTransformFeedbackStreamInstanced(PrimitiveType mode, TransformFeedbackHandle id, uint stream, int instancecount) => GLPointers._DrawTransformFeedbackStreamInstanced_fnptr((uint)mode, (int)id, stream, instancecount);
+        public static void DrawTransformFeedbackStreamInstanced(PrimitiveType mode, int id, uint stream, int instancecount) => GLPointers._DrawTransformFeedbackStreamInstanced_fnptr((uint)mode, id, stream, instancecount);
         
         /// <summary> <b>[requires: v4.3 | GL_ARB_clear_buffer_object]</b> Fill a buffer object's data store with a fixed value. </summary>
         /// <param name="target"> Specifies the target to which the buffer object is bound for glClearBufferData, which must be one of the buffer binding targets in the following table: </param>
@@ -3493,25 +3493,25 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="height"> The height of the region to be invalidated. </param>
         /// <param name="depth"> The depth of the region to be invalidated. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glInvalidateTexSubImage.xhtml" /></remarks>
-        public static void InvalidateTexSubImage(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth) => GLPointers._InvalidateTexSubImage_fnptr((int)texture, level, xoffset, yoffset, zoffset, width, height, depth);
+        public static void InvalidateTexSubImage(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth) => GLPointers._InvalidateTexSubImage_fnptr(texture, level, xoffset, yoffset, zoffset, width, height, depth);
         
         /// <summary> <b>[requires: v4.3 | GL_ARB_invalidate_subdata]</b> Invalidate the entirety a texture image. </summary>
         /// <param name="texture"> The name of a texture object to invalidate. </param>
         /// <param name="level"> The level of detail of the texture object to invalidate. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glInvalidateTexImage.xhtml" /></remarks>
-        public static void InvalidateTexImage(TextureHandle texture, int level) => GLPointers._InvalidateTexImage_fnptr((int)texture, level);
+        public static void InvalidateTexImage(int texture, int level) => GLPointers._InvalidateTexImage_fnptr(texture, level);
         
         /// <summary> <b>[requires: v4.3 | GL_ARB_invalidate_subdata]</b> Invalidate a region of a buffer object's data store. </summary>
         /// <param name="buffer"> The name of a buffer object, a subrange of whose data store to invalidate. </param>
         /// <param name="offset"> The offset within the buffer's data store of the start of the range to be invalidated. </param>
         /// <param name="length"> The length of the range within the buffer's data store to be invalidated. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glInvalidateBufferSubData.xhtml" /></remarks>
-        public static void InvalidateBufferSubData(BufferHandle buffer, IntPtr offset, nint length) => GLPointers._InvalidateBufferSubData_fnptr((int)buffer, offset, length);
+        public static void InvalidateBufferSubData(int buffer, IntPtr offset, nint length) => GLPointers._InvalidateBufferSubData_fnptr(buffer, offset, length);
         
         /// <summary> <b>[requires: v4.3 | GL_ARB_invalidate_subdata]</b> Invalidate the content of a buffer object's data store. </summary>
         /// <param name="buffer"> The name of a buffer object whose data store to invalidate. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glInvalidateBufferData.xhtml" /></remarks>
-        public static void InvalidateBufferData(BufferHandle buffer) => GLPointers._InvalidateBufferData_fnptr((int)buffer);
+        public static void InvalidateBufferData(int buffer) => GLPointers._InvalidateBufferData_fnptr(buffer);
         
         /// <summary> <b>[requires: v4.3 | GL_ARB_invalidate_subdata]</b> Invalidate the content of some or all of a framebuffer's attachments. </summary>
         /// <param name="target"> Specifies the target to which the framebuffer object is attached for glInvalidateFramebuffer. </param>
@@ -3554,14 +3554,14 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="pname"> The name of the parameter within programInterface to query. </param>
         /// <param name="parameters"> The address of a variable to retrieve the value of pname for the program interface. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetProgramInterface.xhtml" /></remarks>
-        public static void GetProgramInterfaceiv(ProgramHandle program, ProgramInterface programInterface, ProgramInterfacePName pname, int* parameters) => GLPointers._GetProgramInterfaceiv_fnptr((int)program, (uint)programInterface, (uint)pname, parameters);
+        public static void GetProgramInterfaceiv(int program, ProgramInterface programInterface, ProgramInterfacePName pname, int* parameters) => GLPointers._GetProgramInterfaceiv_fnptr(program, (uint)programInterface, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v4.3 | GL_ARB_program_interface_query]</b> Query the index of a named resource within a program. </summary>
         /// <param name="program"> The name of a program object whose resources to query. </param>
         /// <param name="programInterface"> A token identifying the interface within program containing the resource named name. </param>
         /// <param name="name"> The name of the resource to query the index of. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetProgramResourceIndex.xhtml" /></remarks>
-        public static uint GetProgramResourceIndex(ProgramHandle program, ProgramInterface programInterface, byte* name) => GLPointers._GetProgramResourceIndex_fnptr((int)program, (uint)programInterface, name);
+        public static uint GetProgramResourceIndex(int program, ProgramInterface programInterface, byte* name) => GLPointers._GetProgramResourceIndex_fnptr(program, (uint)programInterface, name);
         
         /// <summary> <b>[requires: v4.3 | GL_ARB_program_interface_query]</b> Query the name of an indexed resource within a program. </summary>
         /// <param name="program"> The name of a program object whose resources to query. </param>
@@ -3571,7 +3571,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="length"> The address of a variable which will receive the length of the resource name. </param>
         /// <param name="name"> The address of a character array into which will be written the name of the resource. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetProgramResourceName.xhtml" /></remarks>
-        public static void GetProgramResourceName(ProgramHandle program, ProgramInterface programInterface, uint index, int bufSize, int* length, byte* name) => GLPointers._GetProgramResourceName_fnptr((int)program, (uint)programInterface, index, bufSize, length, name);
+        public static void GetProgramResourceName(int program, ProgramInterface programInterface, uint index, int bufSize, int* length, byte* name) => GLPointers._GetProgramResourceName_fnptr(program, (uint)programInterface, index, bufSize, length, name);
         
         /// <summary> <b>[requires: v4.3 | GL_ARB_program_interface_query]</b> Retrieve values for multiple properties of a single active resource within a program object. </summary>
         /// <param name="program"> The name of a program object whose resources to query. </param>
@@ -3583,28 +3583,28 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="length">!!missing documentation!!</param>
         /// <param name="parameters">!!missing documentation!!</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetProgramResource.xhtml" /></remarks>
-        public static void GetProgramResourceiv(ProgramHandle program, ProgramInterface programInterface, uint index, int propCount, ProgramResourceProperty* props, int count, int* length, int* parameters) => GLPointers._GetProgramResourceiv_fnptr((int)program, (uint)programInterface, index, propCount, (uint*)props, count, length, parameters);
+        public static void GetProgramResourceiv(int program, ProgramInterface programInterface, uint index, int propCount, ProgramResourceProperty* props, int count, int* length, int* parameters) => GLPointers._GetProgramResourceiv_fnptr(program, (uint)programInterface, index, propCount, (uint*)props, count, length, parameters);
         
         /// <summary> <b>[requires: v4.3 | GL_ARB_program_interface_query]</b> Query the location of a named resource within a program. </summary>
         /// <param name="program"> The name of a program object whose resources to query. </param>
         /// <param name="programInterface"> A token identifying the interface within program containing the resource named name. </param>
         /// <param name="name"> The name of the resource to query the location of. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetProgramResourceLocation.xhtml" /></remarks>
-        public static int GetProgramResourceLocation(ProgramHandle program, ProgramInterface programInterface, byte* name) => GLPointers._GetProgramResourceLocation_fnptr((int)program, (uint)programInterface, name);
+        public static int GetProgramResourceLocation(int program, ProgramInterface programInterface, byte* name) => GLPointers._GetProgramResourceLocation_fnptr(program, (uint)programInterface, name);
         
         /// <summary> <b>[requires: v4.3 | GL_ARB_program_interface_query]</b> Query the fragment color index of a named variable within a program. </summary>
         /// <param name="program"> The name of a program object whose resources to query. </param>
         /// <param name="programInterface"> A token identifying the interface within program containing the resource named name. </param>
         /// <param name="name"> The name of the resource to query the location of. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetProgramResourceLocationIndex.xhtml" /></remarks>
-        public static int GetProgramResourceLocationIndex(ProgramHandle program, ProgramInterface programInterface, byte* name) => GLPointers._GetProgramResourceLocationIndex_fnptr((int)program, (uint)programInterface, name);
+        public static int GetProgramResourceLocationIndex(int program, ProgramInterface programInterface, byte* name) => GLPointers._GetProgramResourceLocationIndex_fnptr(program, (uint)programInterface, name);
         
         /// <summary> <b>[requires: v4.3 | GL_ARB_shader_storage_buffer_object]</b> Change an active shader storage block binding. </summary>
         /// <param name="program"> The name of the program containing the block whose binding to change. </param>
         /// <param name="storageBlockIndex"> The index storage block within the program. </param>
         /// <param name="storageBlockBinding"> The index storage block binding to associate with the specified storage block. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glShaderStorageBlockBinding.xhtml" /></remarks>
-        public static void ShaderStorageBlockBinding(ProgramHandle program, uint storageBlockIndex, uint storageBlockBinding) => GLPointers._ShaderStorageBlockBinding_fnptr((int)program, storageBlockIndex, storageBlockBinding);
+        public static void ShaderStorageBlockBinding(int program, uint storageBlockIndex, uint storageBlockBinding) => GLPointers._ShaderStorageBlockBinding_fnptr(program, storageBlockIndex, storageBlockBinding);
         
         /// <summary> <b>[requires: v4.3 | GL_ARB_texture_buffer_range]</b> Attach a range of a buffer object's data store to a buffer texture object. </summary>
         /// <param name="target"> Specifies the target to which the texture object is bound for glTexBufferRange. Must be GL_TEXTURE_BUFFER. </param>
@@ -3613,7 +3613,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="offset"> Specifies the offset of the start of the range of the buffer's data store to attach. </param>
         /// <param name="size"> Specifies the size of the range of the buffer's data store to attach. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexBufferRange.xhtml" /></remarks>
-        public static void TexBufferRange(TextureTarget target, SizedInternalFormat internalformat, BufferHandle buffer, IntPtr offset, nint size) => GLPointers._TexBufferRange_fnptr((uint)target, (uint)internalformat, (int)buffer, offset, size);
+        public static void TexBufferRange(TextureTarget target, SizedInternalFormat internalformat, int buffer, IntPtr offset, nint size) => GLPointers._TexBufferRange_fnptr((uint)target, (uint)internalformat, buffer, offset, size);
         
         /// <summary> <b>[requires: v4.3 | GL_ARB_texture_storage_multisample]</b> Specify storage for a two-dimensional multisample texture. </summary>
         /// <param name="target"> Specifies the target to which the texture object is bound for glTexStorage2DMultisample. Must be one of GL_TEXTURE_2D_MULTISAMPLE or GL_PROXY_TEXTURE_2D_MULTISAMPLE. </param>
@@ -3646,7 +3646,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="minlayer"> Specifies the index of the first layer to include in the view. </param>
         /// <param name="numlayers"> Specifies the number of layers to include in the view. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTextureView.xhtml" /></remarks>
-        public static void TextureView(TextureHandle texture, TextureTarget target, TextureHandle origtexture, SizedInternalFormat internalformat, uint minlevel, uint numlevels, uint minlayer, uint numlayers) => GLPointers._TextureView_fnptr((int)texture, (uint)target, (int)origtexture, (uint)internalformat, minlevel, numlevels, minlayer, numlayers);
+        public static void TextureView(int texture, TextureTarget target, int origtexture, SizedInternalFormat internalformat, uint minlevel, uint numlevels, uint minlayer, uint numlayers) => GLPointers._TextureView_fnptr(texture, (uint)target, origtexture, (uint)internalformat, minlevel, numlevels, minlayer, numlayers);
         
         /// <summary> <b>[requires: v4.3 | GL_ARB_vertex_attrib_binding]</b> Bind a buffer to a vertex buffer bind point. </summary>
         /// <param name="bindingindex">The index of the vertex buffer binding point to which to bind the buffer.</param>
@@ -3654,7 +3654,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="offset">The offset of the first element of the buffer.</param>
         /// <param name="stride">The distance between elements within the buffer.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindVertexBuffer.xhtml" /></remarks>
-        public static void BindVertexBuffer(uint bindingindex, BufferHandle buffer, IntPtr offset, int stride) => GLPointers._BindVertexBuffer_fnptr(bindingindex, (int)buffer, offset, stride);
+        public static void BindVertexBuffer(uint bindingindex, int buffer, IntPtr offset, int stride) => GLPointers._BindVertexBuffer_fnptr(bindingindex, buffer, offset, stride);
         
         /// <summary> <b>[requires: v4.3 | GL_ARB_vertex_attrib_binding]</b> Specify the organization of vertex arrays. </summary>
         /// <param name="attribindex">The generic vertex attribute array being described.</param>
@@ -3790,7 +3790,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="type"> The type of the data whose address in memory is given by data. </param>
         /// <param name="data"> The address in memory of the data to be used to clear the specified region. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glClearTexImage.xhtml" /></remarks>
-        public static void ClearTexImage(TextureHandle texture, int level, PixelFormat format, PixelType type, void* data) => GLPointers._ClearTexImage_fnptr((int)texture, level, (uint)format, (uint)type, data);
+        public static void ClearTexImage(int texture, int level, PixelFormat format, PixelType type, void* data) => GLPointers._ClearTexImage_fnptr(texture, level, (uint)format, (uint)type, data);
         
         /// <summary> <b>[requires: v4.4 | GL_ARB_clear_texture]</b> Fills all or part of a texture image with a constant value. </summary>
         /// <param name="texture"> The name of an existing texture object containing the image to be cleared. </param>
@@ -3805,7 +3805,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="type"> The type of the data whose address in memory is given by data. </param>
         /// <param name="data"> The address in memory of the data to be used to clear the specified region. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glClearTexSubImage.xhtml" /></remarks>
-        public static void ClearTexSubImage(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, void* data) => GLPointers._ClearTexSubImage_fnptr((int)texture, level, xoffset, yoffset, zoffset, width, height, depth, (uint)format, (uint)type, data);
+        public static void ClearTexSubImage(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, void* data) => GLPointers._ClearTexSubImage_fnptr(texture, level, xoffset, yoffset, zoffset, width, height, depth, (uint)format, (uint)type, data);
         
         /// <summary> <b>[requires: v4.4 | GL_ARB_multi_bind]</b> Bind one or more buffer objects to a sequence of indexed buffer targets. </summary>
         /// <param name="target"> Specify the target of the bind operation. target must be one of GL_ATOMIC_COUNTER_BUFFER, GL_TRANSFORM_FEEDBACK_BUFFER, GL_UNIFORM_BUFFER or GL_SHADER_STORAGE_BUFFER. </param>
@@ -3813,7 +3813,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="count"> Specify the number of contiguous binding points to which to bind buffers. </param>
         /// <param name="buffers"> A pointer to an array of names of buffer objects to bind to the targets on the specified binding point, or NULL. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindBuffersBase.xhtml" /></remarks>
-        public static void BindBuffersBase(BufferTargetARB target, uint first, int count, BufferHandle* buffers) => GLPointers._BindBuffersBase_fnptr((uint)target, first, count, (int*)buffers);
+        public static void BindBuffersBase(BufferTargetARB target, uint first, int count, int* buffers) => GLPointers._BindBuffersBase_fnptr((uint)target, first, count, buffers);
         
         /// <summary> <b>[requires: v4.4 | GL_ARB_multi_bind]</b> Bind ranges of one or more buffer objects to a sequence of indexed buffer targets. </summary>
         /// <param name="target"> Specify the target of the bind operation. target must be one of GL_ATOMIC_COUNTER_BUFFER, GL_TRANSFORM_FEEDBACK_BUFFER, GL_UNIFORM_BUFFER or GL_SHADER_STORAGE_BUFFER. </param>
@@ -3823,28 +3823,28 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="offsets"> A pointer to an array of offsets into the corresponding buffer in buffers to bind, or NULL if buffers is NULL. </param>
         /// <param name="sizes"> A pointer to an array of sizes of the corresponding buffer in buffers to bind, or NULL if buffers is NULL. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindBuffersRange.xhtml" /></remarks>
-        public static void BindBuffersRange(BufferTargetARB target, uint first, int count, BufferHandle* buffers, IntPtr* offsets, nint* sizes) => GLPointers._BindBuffersRange_fnptr((uint)target, first, count, (int*)buffers, offsets, sizes);
+        public static void BindBuffersRange(BufferTargetARB target, uint first, int count, int* buffers, IntPtr* offsets, nint* sizes) => GLPointers._BindBuffersRange_fnptr((uint)target, first, count, buffers, offsets, sizes);
         
         /// <summary> <b>[requires: v4.4 | GL_ARB_multi_bind]</b> Bind one or more named textures to a sequence of consecutive texture units. </summary>
         /// <param name="first"> Specifies the first texture unit to which a texture is to be bound. </param>
         /// <param name="count"> Specifies the number of textures to bind. </param>
         /// <param name="textures"> Specifies the address of an array of names of existing texture objects. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindTextures.xhtml" /></remarks>
-        public static void BindTextures(uint first, int count, TextureHandle* textures) => GLPointers._BindTextures_fnptr(first, count, (int*)textures);
+        public static void BindTextures(uint first, int count, int* textures) => GLPointers._BindTextures_fnptr(first, count, textures);
         
         /// <summary> <b>[requires: v4.4 | GL_ARB_multi_bind]</b> Bind one or more named sampler objects to a sequence of consecutive sampler units. </summary>
         /// <param name="first"> Specifies the first sampler unit to which a sampler object is to be bound. </param>
         /// <param name="count"> Specifies the number of samplers to bind. </param>
         /// <param name="samplers"> Specifies the address of an array of names of existing sampler objects. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindSamplers.xhtml" /></remarks>
-        public static void BindSamplers(uint first, int count, SamplerHandle* samplers) => GLPointers._BindSamplers_fnptr(first, count, (int*)samplers);
+        public static void BindSamplers(uint first, int count, int* samplers) => GLPointers._BindSamplers_fnptr(first, count, samplers);
         
         /// <summary> <b>[requires: v4.4 | GL_ARB_multi_bind]</b> Bind one or more named texture images to a sequence of consecutive image units. </summary>
         /// <param name="first"> Specifies the first image unit to which a texture is to be bound. </param>
         /// <param name="count"> Specifies the number of textures to bind. </param>
         /// <param name="textures"> Specifies the address of an array of names of existing texture objects. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindImageTextures.xhtml" /></remarks>
-        public static void BindImageTextures(uint first, int count, TextureHandle* textures) => GLPointers._BindImageTextures_fnptr(first, count, (int*)textures);
+        public static void BindImageTextures(uint first, int count, int* textures) => GLPointers._BindImageTextures_fnptr(first, count, textures);
         
         /// <summary> <b>[requires: v4.4 | GL_ARB_multi_bind]</b> Attach multiple buffer objects to a vertex array object. </summary>
         /// <param name="first"> Specifies the first vertex buffer binding point to which a buffer object is to be bound. </param>
@@ -3853,7 +3853,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="offsets"> Specifies the address of an array of offsets to associate with the binding points. </param>
         /// <param name="strides">!!missing documentation!!</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindVertexBuffers.xhtml" /></remarks>
-        public static void BindVertexBuffers(uint first, int count, BufferHandle* buffers, IntPtr* offsets, int* strides) => GLPointers._BindVertexBuffers_fnptr(first, count, (int*)buffers, offsets, strides);
+        public static void BindVertexBuffers(uint first, int count, int* buffers, IntPtr* offsets, int* strides) => GLPointers._BindVertexBuffers_fnptr(first, count, buffers, offsets, strides);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_clip_control]</b> Control clip coordinate to window coordinate behavior. </summary>
         /// <param name="origin"> Specifies the clip control origin. Must be one of GL_LOWER_LEFT or GL_UPPER_LEFT. </param>
@@ -3865,14 +3865,14 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="n"> Number of transform feedback objects to create. </param>
         /// <param name="ids"> Specifies an array in which names of the new transform feedback objects are stored. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCreateTransformFeedbacks.xhtml" /></remarks>
-        public static void CreateTransformFeedbacks(int n, TransformFeedbackHandle* ids) => GLPointers._CreateTransformFeedbacks_fnptr(n, (int*)ids);
+        public static void CreateTransformFeedbacks(int n, int* ids) => GLPointers._CreateTransformFeedbacks_fnptr(n, ids);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Bind a buffer object to a transform feedback buffer object. </summary>
         /// <param name="xfb"> Name of the transform feedback buffer object. </param>
         /// <param name="index"> Index of the binding point within xfb. </param>
         /// <param name="buffer"> Name of the buffer object to bind to the specified binding point. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTransformFeedbackBufferBase.xhtml" /></remarks>
-        public static void TransformFeedbackBufferBase(TransformFeedbackHandle xfb, uint index, BufferHandle buffer) => GLPointers._TransformFeedbackBufferBase_fnptr((int)xfb, index, (int)buffer);
+        public static void TransformFeedbackBufferBase(int xfb, uint index, int buffer) => GLPointers._TransformFeedbackBufferBase_fnptr(xfb, index, buffer);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Bind a range within a buffer object to a transform feedback buffer object. </summary>
         /// <param name="xfb"> Name of the transform feedback buffer object. </param>
@@ -3881,22 +3881,14 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="offset"> The starting offset in basic machine units into the buffer object. </param>
         /// <param name="size"> The amount of data in basic machine units that can be read from or written to the buffer object while used as an indexed target. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTransformFeedbackBufferRange.xhtml" /></remarks>
-        public static void TransformFeedbackBufferRange(TransformFeedbackHandle xfb, uint index, BufferHandle buffer, IntPtr offset, nint size) => GLPointers._TransformFeedbackBufferRange_fnptr((int)xfb, index, (int)buffer, offset, size);
+        public static void TransformFeedbackBufferRange(int xfb, uint index, int buffer, IntPtr offset, nint size) => GLPointers._TransformFeedbackBufferRange_fnptr(xfb, index, buffer, offset, size);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Query the state of a transform feedback object.. </summary>
         /// <param name="xfb">The name of an existing transform feedback object, or zero for the default transform feedback object.</param>
         /// <param name="pname">Property to use for the query. Must be one of the values: GL_TRANSFORM_FEEDBACK_BUFFER_BINDING, GL_TRANSFORM_FEEDBACK_BUFFER_START, GL_TRANSFORM_FEEDBACK_BUFFER_SIZE, GL_TRANSFORM_FEEDBACK_PAUSED, GL_TRANSFORM_FEEDBACK_ACTIVE.</param>
         /// <param name="param">The address of a buffer into which will be written the requested state information.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetTransformFeedback.xhtml" /></remarks>
-        public static void GetTransformFeedbackiv(TransformFeedbackHandle xfb, TransformFeedbackPName pname, int* param) => GLPointers._GetTransformFeedbackiv_fnptr((int)xfb, (uint)pname, param);
-        
-        /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Query the state of a transform feedback object.. </summary>
-        /// <param name="xfb">The name of an existing transform feedback object, or zero for the default transform feedback object.</param>
-        /// <param name="pname">Property to use for the query. Must be one of the values: GL_TRANSFORM_FEEDBACK_BUFFER_BINDING, GL_TRANSFORM_FEEDBACK_BUFFER_START, GL_TRANSFORM_FEEDBACK_BUFFER_SIZE, GL_TRANSFORM_FEEDBACK_PAUSED, GL_TRANSFORM_FEEDBACK_ACTIVE.</param>
-        /// <param name="index">Index of the transform feedback stream (for indexed state).</param>
-        /// <param name="param">The address of a buffer into which will be written the requested state information.</param>
-        /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetTransformFeedback.xhtml" /></remarks>
-        public static void GetTransformFeedbacki_v(TransformFeedbackHandle xfb, TransformFeedbackPName pname, uint index, int* param) => GLPointers._GetTransformFeedbacki_v_fnptr((int)xfb, (uint)pname, index, param);
+        public static void GetTransformFeedbackiv(int xfb, TransformFeedbackPName pname, int* param) => GLPointers._GetTransformFeedbackiv_fnptr(xfb, (uint)pname, param);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Query the state of a transform feedback object.. </summary>
         /// <param name="xfb">The name of an existing transform feedback object, or zero for the default transform feedback object.</param>
@@ -3904,13 +3896,21 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="index">Index of the transform feedback stream (for indexed state).</param>
         /// <param name="param">The address of a buffer into which will be written the requested state information.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetTransformFeedback.xhtml" /></remarks>
-        public static void GetTransformFeedbacki64_v(TransformFeedbackHandle xfb, TransformFeedbackPName pname, uint index, long* param) => GLPointers._GetTransformFeedbacki64_v_fnptr((int)xfb, (uint)pname, index, param);
+        public static void GetTransformFeedbacki_v(int xfb, TransformFeedbackPName pname, uint index, int* param) => GLPointers._GetTransformFeedbacki_v_fnptr(xfb, (uint)pname, index, param);
+        
+        /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Query the state of a transform feedback object.. </summary>
+        /// <param name="xfb">The name of an existing transform feedback object, or zero for the default transform feedback object.</param>
+        /// <param name="pname">Property to use for the query. Must be one of the values: GL_TRANSFORM_FEEDBACK_BUFFER_BINDING, GL_TRANSFORM_FEEDBACK_BUFFER_START, GL_TRANSFORM_FEEDBACK_BUFFER_SIZE, GL_TRANSFORM_FEEDBACK_PAUSED, GL_TRANSFORM_FEEDBACK_ACTIVE.</param>
+        /// <param name="index">Index of the transform feedback stream (for indexed state).</param>
+        /// <param name="param">The address of a buffer into which will be written the requested state information.</param>
+        /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetTransformFeedback.xhtml" /></remarks>
+        public static void GetTransformFeedbacki64_v(int xfb, TransformFeedbackPName pname, uint index, long* param) => GLPointers._GetTransformFeedbacki64_v_fnptr(xfb, (uint)pname, index, param);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Create buffer objects. </summary>
         /// <param name="n"> Specifies the number of buffer objects to create. </param>
         /// <param name="buffers"> Specifies an array in which names of the new buffer objects are stored. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCreateBuffers.xhtml" /></remarks>
-        public static void CreateBuffers(int n, BufferHandle* buffers) => GLPointers._CreateBuffers_fnptr(n, (int*)buffers);
+        public static void CreateBuffers(int n, int* buffers) => GLPointers._CreateBuffers_fnptr(n, buffers);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Creates and initializes a buffer object's immutable data    store. </summary>
         /// <param name="buffer">Specifies the name of the buffer object for glNamedBufferStorage function.</param>
@@ -3918,7 +3918,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="data">Specifies a pointer to data that will be copied into the data store for initialization, or NULL if no data is to be copied.</param>
         /// <param name="flags">Specifies the intended usage of the buffer's data store. Must be a bitwise combination of the following flags. GL_DYNAMIC_STORAGE_BIT, GL_MAP_READ_BIT GL_MAP_WRITE_BIT, GL_MAP_PERSISTENT_BIT, GL_MAP_COHERENT_BIT, and GL_CLIENT_STORAGE_BIT.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBufferStorage.xhtml" /></remarks>
-        public static void NamedBufferStorage(BufferHandle buffer, nint size, void* data, BufferStorageMask flags) => GLPointers._NamedBufferStorage_fnptr((int)buffer, size, data, (uint)flags);
+        public static void NamedBufferStorage(int buffer, nint size, void* data, BufferStorageMask flags) => GLPointers._NamedBufferStorage_fnptr(buffer, size, data, (uint)flags);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Creates and initializes a buffer object's data    store. </summary>
         /// <param name="buffer">Specifies the name of the buffer object for glNamedBufferData function.</param>
@@ -3926,7 +3926,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="data">Specifies a pointer to data that will be copied into the data store for initialization, or NULL if no data is to be copied.</param>
         /// <param name="usage">Specifies the expected usage pattern of the data store. The symbolic constant must be GL_STREAM_DRAW, GL_STREAM_READ, GL_STREAM_COPY, GL_STATIC_DRAW, GL_STATIC_READ, GL_STATIC_COPY, GL_DYNAMIC_DRAW, GL_DYNAMIC_READ, or GL_DYNAMIC_COPY.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBufferData.xhtml" /></remarks>
-        public static void NamedBufferData(BufferHandle buffer, nint size, void* data, VertexBufferObjectUsage usage) => GLPointers._NamedBufferData_fnptr((int)buffer, size, data, (uint)usage);
+        public static void NamedBufferData(int buffer, nint size, void* data, VertexBufferObjectUsage usage) => GLPointers._NamedBufferData_fnptr(buffer, size, data, (uint)usage);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Updates a subset of a buffer object's data store. </summary>
         /// <param name="buffer"> Specifies the name of the buffer object for glNamedBufferSubData. </param>
@@ -3934,7 +3934,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="size"> Specifies the size in bytes of the data store region being replaced. </param>
         /// <param name="data"> Specifies a pointer to the new data that will be copied into the data store. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBufferSubData.xhtml" /></remarks>
-        public static void NamedBufferSubData(BufferHandle buffer, IntPtr offset, nint size, void* data) => GLPointers._NamedBufferSubData_fnptr((int)buffer, offset, size, data);
+        public static void NamedBufferSubData(int buffer, IntPtr offset, nint size, void* data) => GLPointers._NamedBufferSubData_fnptr(buffer, offset, size, data);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Copy all or part of the data store of a buffer object to the data store of another buffer object. </summary>
         /// <param name="readBuffer"> Specifies the name of the source buffer object for glCopyNamedBufferSubData. </param>
@@ -3943,7 +3943,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="writeOffset"> Specifies the offset, in basic machine units, within the data store of the destination buffer object at which data will be written. </param>
         /// <param name="size"> Specifies the size, in basic machine units, of the data to be copied from the source buffer object to the destination buffer object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCopyBufferSubData.xhtml" /></remarks>
-        public static void CopyNamedBufferSubData(BufferHandle readBuffer, BufferHandle writeBuffer, IntPtr readOffset, IntPtr writeOffset, nint size) => GLPointers._CopyNamedBufferSubData_fnptr((int)readBuffer, (int)writeBuffer, readOffset, writeOffset, size);
+        public static void CopyNamedBufferSubData(int readBuffer, int writeBuffer, IntPtr readOffset, IntPtr writeOffset, nint size) => GLPointers._CopyNamedBufferSubData_fnptr(readBuffer, writeBuffer, readOffset, writeOffset, size);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Fill a buffer object's data store with a fixed value. </summary>
         /// <param name="buffer"> Specifies the name of the buffer object for glClearNamedBufferData. </param>
@@ -3952,7 +3952,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="type"> The type of the data in memory addressed by data. </param>
         /// <param name="data"> The address of a memory location storing the data to be replicated into the buffer's data store. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glClearBufferData.xhtml" /></remarks>
-        public static void ClearNamedBufferData(BufferHandle buffer, SizedInternalFormat internalformat, PixelFormat format, PixelType type, void* data) => GLPointers._ClearNamedBufferData_fnptr((int)buffer, (uint)internalformat, (uint)format, (uint)type, data);
+        public static void ClearNamedBufferData(int buffer, SizedInternalFormat internalformat, PixelFormat format, PixelType type, void* data) => GLPointers._ClearNamedBufferData_fnptr(buffer, (uint)internalformat, (uint)format, (uint)type, data);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Fill all or part of buffer object's data store with a fixed value. </summary>
         /// <param name="buffer"> Specifies the name of the buffer object for glClearNamedBufferSubData. </param>
@@ -3963,13 +3963,13 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="type"> The type of the data in memory addressed by data. </param>
         /// <param name="data"> The address of a memory location storing the data to be replicated into the buffer's data store. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glClearBufferSubData.xhtml" /></remarks>
-        public static void ClearNamedBufferSubData(BufferHandle buffer, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, void* data) => GLPointers._ClearNamedBufferSubData_fnptr((int)buffer, (uint)internalformat, offset, size, (uint)format, (uint)type, data);
+        public static void ClearNamedBufferSubData(int buffer, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, void* data) => GLPointers._ClearNamedBufferSubData_fnptr(buffer, (uint)internalformat, offset, size, (uint)format, (uint)type, data);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Map all of a buffer object's data store into the client's address space. </summary>
         /// <param name="buffer"> Specifies the name of the buffer object for glMapNamedBuffer. </param>
         /// <param name="access"> Specifies the access policy for glMapBuffer and glMapNamedBuffer, indicating whether it will be possible to read from, write to, or both read from and write to the buffer object's mapped data store. The symbolic constant must be GL_READ_ONLY, GL_WRITE_ONLY, or GL_READ_WRITE. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glMapBuffer.xhtml" /></remarks>
-        public static void* MapNamedBuffer(BufferHandle buffer, BufferAccessARB access) => GLPointers._MapNamedBuffer_fnptr((int)buffer, (uint)access);
+        public static void* MapNamedBuffer(int buffer, BufferAccessARB access) => GLPointers._MapNamedBuffer_fnptr(buffer, (uint)access);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Map all or part of a buffer object's data store into the client's address space. </summary>
         /// <param name="buffer"> Specifies the name of the buffer object for glMapNamedBufferRange. </param>
@@ -3977,40 +3977,40 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="length"> Specifies the length of the range to be mapped. </param>
         /// <param name="access"> Specifies a combination of access flags indicating the desired access to the mapped range. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glMapBufferRange.xhtml" /></remarks>
-        public static void* MapNamedBufferRange(BufferHandle buffer, IntPtr offset, nint length, MapBufferAccessMask access) => GLPointers._MapNamedBufferRange_fnptr((int)buffer, offset, length, (uint)access);
+        public static void* MapNamedBufferRange(int buffer, IntPtr offset, nint length, MapBufferAccessMask access) => GLPointers._MapNamedBufferRange_fnptr(buffer, offset, length, (uint)access);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Release the mapping of a buffer object's data store into the client's address space. </summary>
         /// <param name="buffer"> Specifies the name of the buffer object for glUnmapNamedBuffer. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glUnmapBuffer.xhtml" /></remarks>
-        public static bool UnmapNamedBuffer(BufferHandle buffer) => GLPointers._UnmapNamedBuffer_fnptr((int)buffer) != 0;
+        public static bool UnmapNamedBuffer(int buffer) => GLPointers._UnmapNamedBuffer_fnptr(buffer) != 0;
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Indicate modifications to a range of a mapped buffer. </summary>
         /// <param name="buffer"> Specifies the name of the buffer object for glFlushMappedNamedBufferRange. </param>
         /// <param name="offset"> Specifies the start of the buffer subrange, in basic machine units. </param>
         /// <param name="length"> Specifies the length of the buffer subrange, in basic machine units. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glFlushMappedBufferRange.xhtml" /></remarks>
-        public static void FlushMappedNamedBufferRange(BufferHandle buffer, IntPtr offset, nint length) => GLPointers._FlushMappedNamedBufferRange_fnptr((int)buffer, offset, length);
+        public static void FlushMappedNamedBufferRange(int buffer, IntPtr offset, nint length) => GLPointers._FlushMappedNamedBufferRange_fnptr(buffer, offset, length);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Return parameters of a buffer object. </summary>
         /// <param name="buffer"> Specifies the name of the buffer object for glGetNamedBufferParameteriv and glGetNamedBufferParameteri64v. </param>
         /// <param name="pname">!!missing documentation!!</param>
         /// <param name="parameters">!!missing documentation!!</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetBufferParameter.xhtml" /></remarks>
-        public static void GetNamedBufferParameteriv(BufferHandle buffer, BufferPNameARB pname, int* parameters) => GLPointers._GetNamedBufferParameteriv_fnptr((int)buffer, (uint)pname, parameters);
+        public static void GetNamedBufferParameteriv(int buffer, BufferPNameARB pname, int* parameters) => GLPointers._GetNamedBufferParameteriv_fnptr(buffer, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Return parameters of a buffer object. </summary>
         /// <param name="buffer"> Specifies the name of the buffer object for glGetNamedBufferParameteriv and glGetNamedBufferParameteri64v. </param>
         /// <param name="pname">!!missing documentation!!</param>
         /// <param name="parameters">!!missing documentation!!</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetBufferParameter.xhtml" /></remarks>
-        public static void GetNamedBufferParameteri64v(BufferHandle buffer, BufferPNameARB pname, long* parameters) => GLPointers._GetNamedBufferParameteri64v_fnptr((int)buffer, (uint)pname, parameters);
+        public static void GetNamedBufferParameteri64v(int buffer, BufferPNameARB pname, long* parameters) => GLPointers._GetNamedBufferParameteri64v_fnptr(buffer, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Return the pointer to a mapped buffer object's data store. </summary>
         /// <param name="buffer"> Specifies the name of the buffer object for glGetNamedBufferPointerv. </param>
         /// <param name="pname"> Specifies the name of the pointer to be returned. Must be GL_BUFFER_MAP_POINTER. </param>
         /// <param name="parameters"> Returns the pointer value specified by pname. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetBufferPointerv.xhtml" /></remarks>
-        public static void GetNamedBufferPointerv(BufferHandle buffer, BufferPointerNameARB pname, void** parameters) => GLPointers._GetNamedBufferPointerv_fnptr((int)buffer, (uint)pname, parameters);
+        public static void GetNamedBufferPointerv(int buffer, BufferPointerNameARB pname, void** parameters) => GLPointers._GetNamedBufferPointerv_fnptr(buffer, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Returns a subset of a buffer object's data store. </summary>
         /// <param name="buffer"> Specifies the name of the buffer object for glGetNamedBufferSubData. </param>
@@ -4018,13 +4018,13 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="size"> Specifies the size in bytes of the data store region being returned. </param>
         /// <param name="data"> Specifies a pointer to the location where buffer object data is returned. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetBufferSubData.xhtml" /></remarks>
-        public static void GetNamedBufferSubData(BufferHandle buffer, IntPtr offset, nint size, void* data) => GLPointers._GetNamedBufferSubData_fnptr((int)buffer, offset, size, data);
+        public static void GetNamedBufferSubData(int buffer, IntPtr offset, nint size, void* data) => GLPointers._GetNamedBufferSubData_fnptr(buffer, offset, size, data);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Create framebuffer objects. </summary>
         /// <param name="n"> Number of framebuffer objects to create. </param>
         /// <param name="framebuffers"> Specifies an array in which names of the new framebuffer objects are stored. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCreateFramebuffers.xhtml" /></remarks>
-        public static void CreateFramebuffers(int n, FramebufferHandle* framebuffers) => GLPointers._CreateFramebuffers_fnptr(n, (int*)framebuffers);
+        public static void CreateFramebuffers(int n, int* framebuffers) => GLPointers._CreateFramebuffers_fnptr(n, framebuffers);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Attach a renderbuffer as a logical buffer of a framebuffer object. </summary>
         /// <param name="framebuffer"> Specifies the name of the framebuffer object for glNamedFramebufferRenderbuffer. </param>
@@ -4032,14 +4032,14 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="renderbuffertarget"> Specifies the renderbuffer target. Must be GL_RENDERBUFFER. </param>
         /// <param name="renderbuffer"> Specifies the name of an existing renderbuffer object of type renderbuffertarget to attach. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glFramebufferRenderbuffer.xhtml" /></remarks>
-        public static void NamedFramebufferRenderbuffer(FramebufferHandle framebuffer, FramebufferAttachment attachment, RenderbufferTarget renderbuffertarget, RenderbufferHandle renderbuffer) => GLPointers._NamedFramebufferRenderbuffer_fnptr((int)framebuffer, (uint)attachment, (uint)renderbuffertarget, (int)renderbuffer);
+        public static void NamedFramebufferRenderbuffer(int framebuffer, FramebufferAttachment attachment, RenderbufferTarget renderbuffertarget, int renderbuffer) => GLPointers._NamedFramebufferRenderbuffer_fnptr(framebuffer, (uint)attachment, (uint)renderbuffertarget, renderbuffer);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Set a named parameter of a framebuffer object. </summary>
         /// <param name="framebuffer"> Specifies the name of the framebuffer object for glNamedFramebufferParameteri. </param>
         /// <param name="pname"> Specifies the framebuffer parameter to be modified. </param>
         /// <param name="param"> The new value for the parameter named pname. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glFramebufferParameteri.xhtml" /></remarks>
-        public static void NamedFramebufferParameteri(FramebufferHandle framebuffer, FramebufferParameterName pname, int param) => GLPointers._NamedFramebufferParameteri_fnptr((int)framebuffer, (uint)pname, param);
+        public static void NamedFramebufferParameteri(int framebuffer, FramebufferParameterName pname, int param) => GLPointers._NamedFramebufferParameteri_fnptr(framebuffer, (uint)pname, param);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Attach a level of a texture object as a logical buffer of a framebuffer object. </summary>
         /// <param name="framebuffer"> Specifies the name of the framebuffer object for glNamedFramebufferTexture. </param>
@@ -4047,7 +4047,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="texture"> Specifies the name of an existing texture object to attach. </param>
         /// <param name="level"> Specifies the mipmap level of the texture object to attach. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glFramebufferTexture.xhtml" /></remarks>
-        public static void NamedFramebufferTexture(FramebufferHandle framebuffer, FramebufferAttachment attachment, TextureHandle texture, int level) => GLPointers._NamedFramebufferTexture_fnptr((int)framebuffer, (uint)attachment, (int)texture, level);
+        public static void NamedFramebufferTexture(int framebuffer, FramebufferAttachment attachment, int texture, int level) => GLPointers._NamedFramebufferTexture_fnptr(framebuffer, (uint)attachment, texture, level);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Attach a single layer of a texture object as a logical buffer of a framebuffer object. </summary>
         /// <param name="framebuffer"> Specifies the name of the framebuffer object for glNamedFramebufferTextureLayer. </param>
@@ -4056,33 +4056,33 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="level"> Specifies the mipmap level of the texture object to attach. </param>
         /// <param name="layer"> Specifies the layer of the texture object to attach. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glFramebufferTextureLayer.xhtml" /></remarks>
-        public static void NamedFramebufferTextureLayer(FramebufferHandle framebuffer, FramebufferAttachment attachment, TextureHandle texture, int level, int layer) => GLPointers._NamedFramebufferTextureLayer_fnptr((int)framebuffer, (uint)attachment, (int)texture, level, layer);
+        public static void NamedFramebufferTextureLayer(int framebuffer, FramebufferAttachment attachment, int texture, int level, int layer) => GLPointers._NamedFramebufferTextureLayer_fnptr(framebuffer, (uint)attachment, texture, level, layer);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specify which color buffers are to be drawn into. </summary>
         /// <param name="framebuffer">Specifies the name of the framebuffer object for glNamedFramebufferDrawBuffer function. Must be zero or the name of a framebuffer object.</param>
         /// <param name="buf">For default framebuffer, the argument specifies up to four color buffers to be drawn into. Symbolic constants GL_NONE, GL_FRONT_LEFT, GL_FRONT_RIGHT, GL_BACK_LEFT, GL_BACK_RIGHT, GL_FRONT, GL_BACK, GL_LEFT, GL_RIGHT, and GL_FRONT_AND_BACK are accepted. The initial value is GL_FRONT for single-buffered contexts, and GL_BACK for double-buffered contexts. For framebuffer objects, GL_COLOR_ATTACHMENT$m$ and GL_NONE enums are accepted, where $m$ is a value between 0 and GL_MAX_COLOR_ATTACHMENTS.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDrawBuffer.xhtml" /></remarks>
-        public static void NamedFramebufferDrawBuffer(FramebufferHandle framebuffer, ColorBuffer buf) => GLPointers._NamedFramebufferDrawBuffer_fnptr((int)framebuffer, (uint)buf);
+        public static void NamedFramebufferDrawBuffer(int framebuffer, ColorBuffer buf) => GLPointers._NamedFramebufferDrawBuffer_fnptr(framebuffer, (uint)buf);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specifies a list of color buffers to be drawn    into. </summary>
         /// <param name="framebuffer">Specifies the name of the framebuffer object for glNamedFramebufferDrawBuffers.</param>
         /// <param name="n">Specifies the number of buffers in bufs.</param>
         /// <param name="bufs">Points to an array of symbolic constants specifying the buffers into which fragment colors or data values will be written.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDrawBuffers.xhtml" /></remarks>
-        public static void NamedFramebufferDrawBuffers(FramebufferHandle framebuffer, int n, ColorBuffer* bufs) => GLPointers._NamedFramebufferDrawBuffers_fnptr((int)framebuffer, n, (uint*)bufs);
+        public static void NamedFramebufferDrawBuffers(int framebuffer, int n, ColorBuffer* bufs) => GLPointers._NamedFramebufferDrawBuffers_fnptr(framebuffer, n, (uint*)bufs);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Select a color buffer source for pixels. </summary>
         /// <param name="framebuffer">Specifies the name of the framebuffer object for glNamedFramebufferReadBuffer function.</param>
         /// <param name="mode">Specifies a color buffer. Accepted values are GL_FRONT_LEFT, GL_FRONT_RIGHT, GL_BACK_LEFT, GL_BACK_RIGHT, GL_FRONT, GL_BACK, GL_LEFT, GL_RIGHT, and the constants GL_COLOR_ATTACHMENTi.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glReadBuffer.xhtml" /></remarks>
-        public static void NamedFramebufferReadBuffer(FramebufferHandle framebuffer, ColorBuffer src) => GLPointers._NamedFramebufferReadBuffer_fnptr((int)framebuffer, (uint)src);
+        public static void NamedFramebufferReadBuffer(int framebuffer, ColorBuffer src) => GLPointers._NamedFramebufferReadBuffer_fnptr(framebuffer, (uint)src);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Invalidate the content of some or all of a framebuffer's attachments. </summary>
         /// <param name="framebuffer"> Specifies the name of the framebuffer object for glInvalidateNamedFramebufferData. </param>
         /// <param name="numAttachments"> Specifies the number of entries in the attachments array. </param>
         /// <param name="attachments"> Specifies a pointer to an array identifying the attachments to be invalidated. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glInvalidateFramebuffer.xhtml" /></remarks>
-        public static void InvalidateNamedFramebufferData(FramebufferHandle framebuffer, int numAttachments, FramebufferAttachment* attachments) => GLPointers._InvalidateNamedFramebufferData_fnptr((int)framebuffer, numAttachments, (uint*)attachments);
+        public static void InvalidateNamedFramebufferData(int framebuffer, int numAttachments, FramebufferAttachment* attachments) => GLPointers._InvalidateNamedFramebufferData_fnptr(framebuffer, numAttachments, (uint*)attachments);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Invalidate the content of a region of some or all of a framebuffer's attachments. </summary>
         /// <param name="framebuffer"> Specifies the name of the framebuffer object for glInvalidateNamedFramebufferSubData. </param>
@@ -4093,7 +4093,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="width"> Specifies the width of the region to be invalidated. </param>
         /// <param name="height"> Specifies the height of the region to be invalidated. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glInvalidateSubFramebuffer.xhtml" /></remarks>
-        public static void InvalidateNamedFramebufferSubData(FramebufferHandle framebuffer, int numAttachments, FramebufferAttachment* attachments, int x, int y, int width, int height) => GLPointers._InvalidateNamedFramebufferSubData_fnptr((int)framebuffer, numAttachments, (uint*)attachments, x, y, width, height);
+        public static void InvalidateNamedFramebufferSubData(int framebuffer, int numAttachments, FramebufferAttachment* attachments, int x, int y, int width, int height) => GLPointers._InvalidateNamedFramebufferSubData_fnptr(framebuffer, numAttachments, (uint*)attachments, x, y, width, height);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Clear individual buffers of a framebuffer. </summary>
         /// <param name="framebuffer"> Specifies the name of the framebuffer object for glClearNamedFramebuffer*. </param>
@@ -4101,7 +4101,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="drawbuffer"> Specify a particular draw buffer to clear. </param>
         /// <param name="value"> A pointer to the value or values to clear the buffer to. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glClearBuffer.xhtml" /></remarks>
-        public static void ClearNamedFramebufferiv(FramebufferHandle framebuffer, Buffer buffer, int drawbuffer, int* value) => GLPointers._ClearNamedFramebufferiv_fnptr((int)framebuffer, (uint)buffer, drawbuffer, value);
+        public static void ClearNamedFramebufferiv(int framebuffer, Buffer buffer, int drawbuffer, int* value) => GLPointers._ClearNamedFramebufferiv_fnptr(framebuffer, (uint)buffer, drawbuffer, value);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Clear individual buffers of a framebuffer. </summary>
         /// <param name="framebuffer"> Specifies the name of the framebuffer object for glClearNamedFramebuffer*. </param>
@@ -4109,7 +4109,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="drawbuffer"> Specify a particular draw buffer to clear. </param>
         /// <param name="value"> A pointer to the value or values to clear the buffer to. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glClearBuffer.xhtml" /></remarks>
-        public static void ClearNamedFramebufferuiv(FramebufferHandle framebuffer, Buffer buffer, int drawbuffer, uint* value) => GLPointers._ClearNamedFramebufferuiv_fnptr((int)framebuffer, (uint)buffer, drawbuffer, value);
+        public static void ClearNamedFramebufferuiv(int framebuffer, Buffer buffer, int drawbuffer, uint* value) => GLPointers._ClearNamedFramebufferuiv_fnptr(framebuffer, (uint)buffer, drawbuffer, value);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Clear individual buffers of a framebuffer. </summary>
         /// <param name="framebuffer"> Specifies the name of the framebuffer object for glClearNamedFramebuffer*. </param>
@@ -4117,7 +4117,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="drawbuffer"> Specify a particular draw buffer to clear. </param>
         /// <param name="value"> A pointer to the value or values to clear the buffer to. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glClearBuffer.xhtml" /></remarks>
-        public static void ClearNamedFramebufferfv(FramebufferHandle framebuffer, Buffer buffer, int drawbuffer, float* value) => GLPointers._ClearNamedFramebufferfv_fnptr((int)framebuffer, (uint)buffer, drawbuffer, value);
+        public static void ClearNamedFramebufferfv(int framebuffer, Buffer buffer, int drawbuffer, float* value) => GLPointers._ClearNamedFramebufferfv_fnptr(framebuffer, (uint)buffer, drawbuffer, value);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Clear individual buffers of a framebuffer. </summary>
         /// <param name="framebuffer"> Specifies the name of the framebuffer object for glClearNamedFramebuffer*. </param>
@@ -4126,7 +4126,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="depth"> The value to clear the depth buffer to. </param>
         /// <param name="stencil"> The value to clear the stencil buffer to. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glClearBuffer.xhtml" /></remarks>
-        public static void ClearNamedFramebufferfi(FramebufferHandle framebuffer, Buffer buffer, int drawbuffer, float depth, int stencil) => GLPointers._ClearNamedFramebufferfi_fnptr((int)framebuffer, (uint)buffer, drawbuffer, depth, stencil);
+        public static void ClearNamedFramebufferfi(int framebuffer, Buffer buffer, int drawbuffer, float depth, int stencil) => GLPointers._ClearNamedFramebufferfi_fnptr(framebuffer, (uint)buffer, drawbuffer, depth, stencil);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Copy a block of pixels from one framebuffer object to another. </summary>
         /// <param name="readFramebuffer"> Specifies the name of the source framebuffer object for glBlitNamedFramebuffer. </param>
@@ -4142,20 +4142,20 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="mask"> The bitwise OR of the flags indicating which buffers are to be copied. The allowed flags are GL_COLOR_BUFFER_BIT, GL_DEPTH_BUFFER_BIT and GL_STENCIL_BUFFER_BIT. </param>
         /// <param name="filter"> Specifies the interpolation to be applied if the image is stretched. Must be GL_NEAREST or GL_LINEAR. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBlitFramebuffer.xhtml" /></remarks>
-        public static void BlitNamedFramebuffer(FramebufferHandle readFramebuffer, FramebufferHandle drawFramebuffer, int srcX0, int srcY0, int srcX1, int srcY1, int dstX0, int dstY0, int dstX1, int dstY1, ClearBufferMask mask, BlitFramebufferFilter filter) => GLPointers._BlitNamedFramebuffer_fnptr((int)readFramebuffer, (int)drawFramebuffer, srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, (uint)mask, (uint)filter);
+        public static void BlitNamedFramebuffer(int readFramebuffer, int drawFramebuffer, int srcX0, int srcY0, int srcX1, int srcY1, int dstX0, int dstY0, int dstX1, int dstY1, ClearBufferMask mask, BlitFramebufferFilter filter) => GLPointers._BlitNamedFramebuffer_fnptr(readFramebuffer, drawFramebuffer, srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, (uint)mask, (uint)filter);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Check the completeness status of a framebuffer. </summary>
         /// <param name="framebuffer"> Specifies the name of the framebuffer object for glCheckNamedFramebufferStatus </param>
         /// <param name="target"> Specify the target to which the framebuffer is bound for glCheckFramebufferStatus, and the target against which framebuffer completeness of framebuffer is checked for glCheckNamedFramebufferStatus. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCheckFramebufferStatus.xhtml" /></remarks>
-        public static FramebufferStatus CheckNamedFramebufferStatus(FramebufferHandle framebuffer, FramebufferTarget target) => (FramebufferStatus) GLPointers._CheckNamedFramebufferStatus_fnptr((int)framebuffer, (uint)target);
+        public static FramebufferStatus CheckNamedFramebufferStatus(int framebuffer, FramebufferTarget target) => (FramebufferStatus) GLPointers._CheckNamedFramebufferStatus_fnptr(framebuffer, (uint)target);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Query a named parameter of a framebuffer object. </summary>
         /// <param name="framebuffer"> Specifies the name of the framebuffer object for glGetNamedFramebufferParameteriv. </param>
         /// <param name="pname"> Specifies the parameter of the framebuffer object to query. </param>
         /// <param name="param">!!missing documentation!!</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetFramebufferParameter.xhtml" /></remarks>
-        public static void GetNamedFramebufferParameteriv(FramebufferHandle framebuffer, GetFramebufferParameter pname, int* param) => GLPointers._GetNamedFramebufferParameteriv_fnptr((int)framebuffer, (uint)pname, param);
+        public static void GetNamedFramebufferParameteriv(int framebuffer, GetFramebufferParameter pname, int* param) => GLPointers._GetNamedFramebufferParameteriv_fnptr(framebuffer, (uint)pname, param);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Retrieve information about attachments of a framebuffer object. </summary>
         /// <param name="framebuffer"> Specifies the name of the framebuffer object for glGetNamedFramebufferAttachmentParameteriv. </param>
@@ -4163,13 +4163,13 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="pname"> Specifies the parameter of attachment to query. </param>
         /// <param name="parameters"> Returns the value of parameter pname for attachment. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetFramebufferAttachmentParameter.xhtml" /></remarks>
-        public static void GetNamedFramebufferAttachmentParameteriv(FramebufferHandle framebuffer, FramebufferAttachment attachment, FramebufferAttachmentParameterName pname, int* parameters) => GLPointers._GetNamedFramebufferAttachmentParameteriv_fnptr((int)framebuffer, (uint)attachment, (uint)pname, parameters);
+        public static void GetNamedFramebufferAttachmentParameteriv(int framebuffer, FramebufferAttachment attachment, FramebufferAttachmentParameterName pname, int* parameters) => GLPointers._GetNamedFramebufferAttachmentParameteriv_fnptr(framebuffer, (uint)attachment, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Create renderbuffer objects. </summary>
         /// <param name="n"> Number of renderbuffer objects to create. </param>
         /// <param name="renderbuffers"> Specifies an array in which names of the new renderbuffer objects are stored. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCreateRenderbuffers.xhtml" /></remarks>
-        public static void CreateRenderbuffers(int n, RenderbufferHandle* renderbuffers) => GLPointers._CreateRenderbuffers_fnptr(n, (int*)renderbuffers);
+        public static void CreateRenderbuffers(int n, int* renderbuffers) => GLPointers._CreateRenderbuffers_fnptr(n, renderbuffers);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Establish data storage, format and dimensions of a    renderbuffer object's image. </summary>
         /// <param name="renderbuffer">Specifies the name of the renderbuffer object for glNamedRenderbufferStorage function.</param>
@@ -4177,7 +4177,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="width">Specifies the width of the renderbuffer, in pixels.</param>
         /// <param name="height">Specifies the height of the renderbuffer, in pixels.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glRenderbufferStorage.xhtml" /></remarks>
-        public static void NamedRenderbufferStorage(RenderbufferHandle renderbuffer, InternalFormat internalformat, int width, int height) => GLPointers._NamedRenderbufferStorage_fnptr((int)renderbuffer, (uint)internalformat, width, height);
+        public static void NamedRenderbufferStorage(int renderbuffer, InternalFormat internalformat, int width, int height) => GLPointers._NamedRenderbufferStorage_fnptr(renderbuffer, (uint)internalformat, width, height);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Establish data storage, format, dimensions and sample count of    a renderbuffer object's image. </summary>
         /// <param name="renderbuffer">Specifies the name of the renderbuffer object for glNamedRenderbufferStorageMultisample function.</param>
@@ -4186,28 +4186,28 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="width">Specifies the width of the renderbuffer, in pixels.</param>
         /// <param name="height">Specifies the height of the renderbuffer, in pixels.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glRenderbufferStorageMultisample.xhtml" /></remarks>
-        public static void NamedRenderbufferStorageMultisample(RenderbufferHandle renderbuffer, int samples, InternalFormat internalformat, int width, int height) => GLPointers._NamedRenderbufferStorageMultisample_fnptr((int)renderbuffer, samples, (uint)internalformat, width, height);
+        public static void NamedRenderbufferStorageMultisample(int renderbuffer, int samples, InternalFormat internalformat, int width, int height) => GLPointers._NamedRenderbufferStorageMultisample_fnptr(renderbuffer, samples, (uint)internalformat, width, height);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Query a named parameter of a renderbuffer object. </summary>
         /// <param name="renderbuffer"> Specifies the name of the renderbuffer object for glGetNamedRenderbufferParameteriv. </param>
         /// <param name="pname"> Specifies the parameter of the renderbuffer object to query. </param>
         /// <param name="parameters"> Returns the value of parameter pname for the renderbuffer object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetRenderbufferParameter.xhtml" /></remarks>
-        public static void GetNamedRenderbufferParameteriv(RenderbufferHandle renderbuffer, RenderbufferParameterName pname, int* parameters) => GLPointers._GetNamedRenderbufferParameteriv_fnptr((int)renderbuffer, (uint)pname, parameters);
+        public static void GetNamedRenderbufferParameteriv(int renderbuffer, RenderbufferParameterName pname, int* parameters) => GLPointers._GetNamedRenderbufferParameteriv_fnptr(renderbuffer, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Create texture objects. </summary>
         /// <param name="target"> Specifies the effective texture target of each created texture. </param>
         /// <param name="n"> Number of texture objects to create. </param>
         /// <param name="textures"> Specifies an array in which names of the new texture objects are stored. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCreateTextures.xhtml" /></remarks>
-        public static void CreateTextures(TextureTarget target, int n, TextureHandle* textures) => GLPointers._CreateTextures_fnptr((uint)target, n, (int*)textures);
+        public static void CreateTextures(TextureTarget target, int n, int* textures) => GLPointers._CreateTextures_fnptr((uint)target, n, textures);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Attach a buffer object's data store to a buffer texture object. </summary>
         /// <param name="texture"> Specifies the texture object name for glTextureBuffer. </param>
         /// <param name="internalformat"> Specifies the internal format of the data in the store belonging to buffer. </param>
         /// <param name="buffer"> Specifies the name of the buffer object whose storage to attach to the active buffer texture. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexBuffer.xhtml" /></remarks>
-        public static void TextureBuffer(TextureHandle texture, SizedInternalFormat internalformat, BufferHandle buffer) => GLPointers._TextureBuffer_fnptr((int)texture, (uint)internalformat, (int)buffer);
+        public static void TextureBuffer(int texture, SizedInternalFormat internalformat, int buffer) => GLPointers._TextureBuffer_fnptr(texture, (uint)internalformat, buffer);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Attach a range of a buffer object's data store to a buffer texture object. </summary>
         /// <param name="texture"> Specifies the texture object name for glTextureBufferRange. </param>
@@ -4216,7 +4216,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="offset"> Specifies the offset of the start of the range of the buffer's data store to attach. </param>
         /// <param name="size"> Specifies the size of the range of the buffer's data store to attach. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexBufferRange.xhtml" /></remarks>
-        public static void TextureBufferRange(TextureHandle texture, SizedInternalFormat internalformat, BufferHandle buffer, IntPtr offset, nint size) => GLPointers._TextureBufferRange_fnptr((int)texture, (uint)internalformat, (int)buffer, offset, size);
+        public static void TextureBufferRange(int texture, SizedInternalFormat internalformat, int buffer, IntPtr offset, nint size) => GLPointers._TextureBufferRange_fnptr(texture, (uint)internalformat, buffer, offset, size);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Simultaneously specify storage for all levels of a one-dimensional texture. </summary>
         /// <param name="texture"> Specifies the texture object name for glTextureStorage1D. The effective target of texture must be one of the valid non-proxy target values above. </param>
@@ -4224,7 +4224,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="internalformat"> Specifies the sized internal format to be used to store texture image data. </param>
         /// <param name="width"> Specifies the width of the texture, in texels. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexStorage1D.xhtml" /></remarks>
-        public static void TextureStorage1D(TextureHandle texture, int levels, SizedInternalFormat internalformat, int width) => GLPointers._TextureStorage1D_fnptr((int)texture, levels, (uint)internalformat, width);
+        public static void TextureStorage1D(int texture, int levels, SizedInternalFormat internalformat, int width) => GLPointers._TextureStorage1D_fnptr(texture, levels, (uint)internalformat, width);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Simultaneously specify storage for all levels of a two-dimensional or one-dimensional array texture. </summary>
         /// <param name="texture"> Specifies the texture object name for glTextureStorage2D. The effective target of texture must be one of the valid non-proxy target values above. </param>
@@ -4233,7 +4233,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="width"> Specifies the width of the texture, in texels. </param>
         /// <param name="height"> Specifies the height of the texture, in texels. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexStorage2D.xhtml" /></remarks>
-        public static void TextureStorage2D(TextureHandle texture, int levels, SizedInternalFormat internalformat, int width, int height) => GLPointers._TextureStorage2D_fnptr((int)texture, levels, (uint)internalformat, width, height);
+        public static void TextureStorage2D(int texture, int levels, SizedInternalFormat internalformat, int width, int height) => GLPointers._TextureStorage2D_fnptr(texture, levels, (uint)internalformat, width, height);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Simultaneously specify storage for all levels of a three-dimensional, two-dimensional array or cube-map array texture. </summary>
         /// <param name="texture"> Specifies the texture object name for glTextureStorage3D. The effective target of texture must be one of the valid non-proxy target values above. </param>
@@ -4243,7 +4243,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="height"> Specifies the height of the texture, in texels. </param>
         /// <param name="depth"> Specifies the depth of the texture, in texels. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexStorage3D.xhtml" /></remarks>
-        public static void TextureStorage3D(TextureHandle texture, int levels, SizedInternalFormat internalformat, int width, int height, int depth) => GLPointers._TextureStorage3D_fnptr((int)texture, levels, (uint)internalformat, width, height, depth);
+        public static void TextureStorage3D(int texture, int levels, SizedInternalFormat internalformat, int width, int height, int depth) => GLPointers._TextureStorage3D_fnptr(texture, levels, (uint)internalformat, width, height, depth);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specify storage for a two-dimensional multisample texture. </summary>
         /// <param name="texture"> Specifies the texture object name for glTextureStorage2DMultisample. The effective target of texture must be one of the valid non-proxy target values above. </param>
@@ -4253,7 +4253,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="height"> Specifies the height of the texture, in texels. </param>
         /// <param name="fixedsamplelocations"> Specifies whether the image will use identical sample locations and the same number of samples for all texels in the image, and the sample locations will not depend on the internal format or size of the image. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexStorage2DMultisample.xhtml" /></remarks>
-        public static void TextureStorage2DMultisample(TextureHandle texture, int samples, SizedInternalFormat internalformat, int width, int height, bool fixedsamplelocations) => GLPointers._TextureStorage2DMultisample_fnptr((int)texture, samples, (uint)internalformat, width, height, (byte)(fixedsamplelocations ? 1 : 0));
+        public static void TextureStorage2DMultisample(int texture, int samples, SizedInternalFormat internalformat, int width, int height, bool fixedsamplelocations) => GLPointers._TextureStorage2DMultisample_fnptr(texture, samples, (uint)internalformat, width, height, (byte)(fixedsamplelocations ? 1 : 0));
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specify storage for a two-dimensional multisample array texture. </summary>
         /// <param name="texture"> Specifies the texture object name for glTextureStorage3DMultisample. The effective target of texture must be one of the valid non-proxy target values above. </param>
@@ -4264,7 +4264,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="depth"> Specifies the depth of the texture, in layers. </param>
         /// <param name="fixedsamplelocations"> Specifies whether the image will use identical sample locations and the same number of samples for all texels in the image, and the sample locations will not depend on the internal format or size of the image. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexStorage3DMultisample.xhtml" /></remarks>
-        public static void TextureStorage3DMultisample(TextureHandle texture, int samples, SizedInternalFormat internalformat, int width, int height, int depth, bool fixedsamplelocations) => GLPointers._TextureStorage3DMultisample_fnptr((int)texture, samples, (uint)internalformat, width, height, depth, (byte)(fixedsamplelocations ? 1 : 0));
+        public static void TextureStorage3DMultisample(int texture, int samples, SizedInternalFormat internalformat, int width, int height, int depth, bool fixedsamplelocations) => GLPointers._TextureStorage3DMultisample_fnptr(texture, samples, (uint)internalformat, width, height, depth, (byte)(fixedsamplelocations ? 1 : 0));
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specify a one-dimensional texture subimage. </summary>
         /// <param name="texture"> Specifies the texture object name for glTextureSubImage1D. The effective target of texture must be one of the valid target values above. </param>
@@ -4275,7 +4275,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="type"> Specifies the data type of the pixel data. The following symbolic values are accepted: GL_UNSIGNED_BYTE, GL_BYTE, GL_UNSIGNED_SHORT, GL_SHORT, GL_UNSIGNED_INT, GL_INT, GL_FLOAT, GL_UNSIGNED_BYTE_3_3_2, GL_UNSIGNED_BYTE_2_3_3_REV, GL_UNSIGNED_SHORT_5_6_5, GL_UNSIGNED_SHORT_5_6_5_REV, GL_UNSIGNED_SHORT_4_4_4_4, GL_UNSIGNED_SHORT_4_4_4_4_REV, GL_UNSIGNED_SHORT_5_5_5_1, GL_UNSIGNED_SHORT_1_5_5_5_REV, GL_UNSIGNED_INT_8_8_8_8, GL_UNSIGNED_INT_8_8_8_8_REV, GL_UNSIGNED_INT_10_10_10_2, and GL_UNSIGNED_INT_2_10_10_10_REV. </param>
         /// <param name="pixels"> Specifies a pointer to the image data in memory. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexSubImage1D.xhtml" /></remarks>
-        public static void TextureSubImage1D(TextureHandle texture, int level, int xoffset, int width, PixelFormat format, PixelType type, void* pixels) => GLPointers._TextureSubImage1D_fnptr((int)texture, level, xoffset, width, (uint)format, (uint)type, pixels);
+        public static void TextureSubImage1D(int texture, int level, int xoffset, int width, PixelFormat format, PixelType type, void* pixels) => GLPointers._TextureSubImage1D_fnptr(texture, level, xoffset, width, (uint)format, (uint)type, pixels);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specify a two-dimensional texture subimage. </summary>
         /// <param name="texture"> Specifies the texture object name for glTextureSubImage2D. The effective target of texture must be one of the valid target values above. </param>
@@ -4288,7 +4288,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="type"> Specifies the data type of the pixel data. The following symbolic values are accepted: GL_UNSIGNED_BYTE, GL_BYTE, GL_UNSIGNED_SHORT, GL_SHORT, GL_UNSIGNED_INT, GL_INT, GL_FLOAT, GL_UNSIGNED_BYTE_3_3_2, GL_UNSIGNED_BYTE_2_3_3_REV, GL_UNSIGNED_SHORT_5_6_5, GL_UNSIGNED_SHORT_5_6_5_REV, GL_UNSIGNED_SHORT_4_4_4_4, GL_UNSIGNED_SHORT_4_4_4_4_REV, GL_UNSIGNED_SHORT_5_5_5_1, GL_UNSIGNED_SHORT_1_5_5_5_REV, GL_UNSIGNED_INT_8_8_8_8, GL_UNSIGNED_INT_8_8_8_8_REV, GL_UNSIGNED_INT_10_10_10_2, and GL_UNSIGNED_INT_2_10_10_10_REV. </param>
         /// <param name="pixels"> Specifies a pointer to the image data in memory. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexSubImage2D.xhtml" /></remarks>
-        public static void TextureSubImage2D(TextureHandle texture, int level, int xoffset, int yoffset, int width, int height, PixelFormat format, PixelType type, void* pixels) => GLPointers._TextureSubImage2D_fnptr((int)texture, level, xoffset, yoffset, width, height, (uint)format, (uint)type, pixels);
+        public static void TextureSubImage2D(int texture, int level, int xoffset, int yoffset, int width, int height, PixelFormat format, PixelType type, void* pixels) => GLPointers._TextureSubImage2D_fnptr(texture, level, xoffset, yoffset, width, height, (uint)format, (uint)type, pixels);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specify a three-dimensional texture subimage. </summary>
         /// <param name="texture"> Specifies the texture object name for glTextureSubImage3D. The effective target of texture must be one of the valid target values above. </param>
@@ -4303,7 +4303,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="type"> Specifies the data type of the pixel data. The following symbolic values are accepted: GL_UNSIGNED_BYTE, GL_BYTE, GL_UNSIGNED_SHORT, GL_SHORT, GL_UNSIGNED_INT, GL_INT, GL_FLOAT, GL_UNSIGNED_BYTE_3_3_2, GL_UNSIGNED_BYTE_2_3_3_REV, GL_UNSIGNED_SHORT_5_6_5, GL_UNSIGNED_SHORT_5_6_5_REV, GL_UNSIGNED_SHORT_4_4_4_4, GL_UNSIGNED_SHORT_4_4_4_4_REV, GL_UNSIGNED_SHORT_5_5_5_1, GL_UNSIGNED_SHORT_1_5_5_5_REV, GL_UNSIGNED_INT_8_8_8_8, GL_UNSIGNED_INT_8_8_8_8_REV, GL_UNSIGNED_INT_10_10_10_2, and GL_UNSIGNED_INT_2_10_10_10_REV. </param>
         /// <param name="pixels"> Specifies a pointer to the image data in memory. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexSubImage3D.xhtml" /></remarks>
-        public static void TextureSubImage3D(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, void* pixels) => GLPointers._TextureSubImage3D_fnptr((int)texture, level, xoffset, yoffset, zoffset, width, height, depth, (uint)format, (uint)type, pixels);
+        public static void TextureSubImage3D(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, void* pixels) => GLPointers._TextureSubImage3D_fnptr(texture, level, xoffset, yoffset, zoffset, width, height, depth, (uint)format, (uint)type, pixels);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specify a one-dimensional texture subimage in a compressed    format. </summary>
         /// <param name="texture">Specifies the texture object name for glCompressedTextureSubImage1D function.</param>
@@ -4314,7 +4314,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="imageSize">Specifies the number of unsigned bytes of image data starting at the address specified by data.</param>
         /// <param name="data">Specifies a pointer to the compressed image data in memory.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCompressedTexSubImage1D.xhtml" /></remarks>
-        public static void CompressedTextureSubImage1D(TextureHandle texture, int level, int xoffset, int width, InternalFormat format, int imageSize, void* data) => GLPointers._CompressedTextureSubImage1D_fnptr((int)texture, level, xoffset, width, (uint)format, imageSize, data);
+        public static void CompressedTextureSubImage1D(int texture, int level, int xoffset, int width, InternalFormat format, int imageSize, void* data) => GLPointers._CompressedTextureSubImage1D_fnptr(texture, level, xoffset, width, (uint)format, imageSize, data);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specify a two-dimensional texture subimage in a compressed format. </summary>
         /// <param name="texture">Specifies the texture object name for glCompressedTextureSubImage2D function.</param>
@@ -4327,7 +4327,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="imageSize">Specifies the number of unsigned bytes of image data starting at the address specified by data.</param>
         /// <param name="data">Specifies a pointer to the compressed image data in memory.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCompressedTexSubImage2D.xhtml" /></remarks>
-        public static void CompressedTextureSubImage2D(TextureHandle texture, int level, int xoffset, int yoffset, int width, int height, InternalFormat format, int imageSize, void* data) => GLPointers._CompressedTextureSubImage2D_fnptr((int)texture, level, xoffset, yoffset, width, height, (uint)format, imageSize, data);
+        public static void CompressedTextureSubImage2D(int texture, int level, int xoffset, int yoffset, int width, int height, InternalFormat format, int imageSize, void* data) => GLPointers._CompressedTextureSubImage2D_fnptr(texture, level, xoffset, yoffset, width, height, (uint)format, imageSize, data);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specify a three-dimensional texture subimage in a compressed format. </summary>
         /// <param name="texture">Specifies the texture object name for glCompressedTextureSubImage3D function.</param>
@@ -4342,7 +4342,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="imageSize">Specifies the number of unsigned bytes of image data starting at the address specified by data.</param>
         /// <param name="data">Specifies a pointer to the compressed image data in memory.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCompressedTexSubImage3D.xhtml" /></remarks>
-        public static void CompressedTextureSubImage3D(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, InternalFormat format, int imageSize, void* data) => GLPointers._CompressedTextureSubImage3D_fnptr((int)texture, level, xoffset, yoffset, zoffset, width, height, depth, (uint)format, imageSize, data);
+        public static void CompressedTextureSubImage3D(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, InternalFormat format, int imageSize, void* data) => GLPointers._CompressedTextureSubImage3D_fnptr(texture, level, xoffset, yoffset, zoffset, width, height, depth, (uint)format, imageSize, data);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Copy a one-dimensional texture subimage. </summary>
         /// <param name="texture">Specifies the texture object name for glCopyTextureSubImage1D function.</param>
@@ -4352,7 +4352,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="y">Specify the window coordinates of the left corner of the row of pixels to be copied.</param>
         /// <param name="width">Specifies the width of the texture subimage.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCopyTexSubImage1D.xhtml" /></remarks>
-        public static void CopyTextureSubImage1D(TextureHandle texture, int level, int xoffset, int x, int y, int width) => GLPointers._CopyTextureSubImage1D_fnptr((int)texture, level, xoffset, x, y, width);
+        public static void CopyTextureSubImage1D(int texture, int level, int xoffset, int x, int y, int width) => GLPointers._CopyTextureSubImage1D_fnptr(texture, level, xoffset, x, y, width);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Copy a two-dimensional texture subimage. </summary>
         /// <param name="texture">Specifies the texture object name for glCopyTextureSubImage2D function.</param>
@@ -4364,7 +4364,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="width">Specifies the width of the texture subimage.</param>
         /// <param name="height">Specifies the height of the texture subimage.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCopyTexSubImage2D.xhtml" /></remarks>
-        public static void CopyTextureSubImage2D(TextureHandle texture, int level, int xoffset, int yoffset, int x, int y, int width, int height) => GLPointers._CopyTextureSubImage2D_fnptr((int)texture, level, xoffset, yoffset, x, y, width, height);
+        public static void CopyTextureSubImage2D(int texture, int level, int xoffset, int yoffset, int x, int y, int width, int height) => GLPointers._CopyTextureSubImage2D_fnptr(texture, level, xoffset, yoffset, x, y, width, height);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Copy a three-dimensional texture subimage. </summary>
         /// <param name="texture">Specifies the texture object name for glCopyTextureSubImage3D function.</param>
@@ -4377,60 +4377,60 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="width">Specifies the width of the texture subimage.</param>
         /// <param name="height">Specifies the height of the texture subimage.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCopyTexSubImage3D.xhtml" /></remarks>
-        public static void CopyTextureSubImage3D(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int x, int y, int width, int height) => GLPointers._CopyTextureSubImage3D_fnptr((int)texture, level, xoffset, yoffset, zoffset, x, y, width, height);
+        public static void CopyTextureSubImage3D(int texture, int level, int xoffset, int yoffset, int zoffset, int x, int y, int width, int height) => GLPointers._CopyTextureSubImage3D_fnptr(texture, level, xoffset, yoffset, zoffset, x, y, width, height);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Set texture parameters. </summary>
         /// <param name="texture">Specifies the texture object name for glTextureParameter functions.</param>
         /// <param name="pname">Specifies the symbolic name of a single-valued texture parameter. pname can be one of the following: GL_DEPTH_STENCIL_TEXTURE_MODE, GL_TEXTURE_BASE_LEVEL, GL_TEXTURE_COMPARE_FUNC, GL_TEXTURE_COMPARE_MODE, GL_TEXTURE_LOD_BIAS, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_MAX_LEVEL, GL_TEXTURE_SWIZZLE_R, GL_TEXTURE_SWIZZLE_G, GL_TEXTURE_SWIZZLE_B, GL_TEXTURE_SWIZZLE_A, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, or GL_TEXTURE_WRAP_R.</param>
         /// <param name="param">For the scalar commands, specifies the value of pname.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexParameter.xhtml" /></remarks>
-        public static void TextureParameterf(TextureHandle texture, TextureParameterName pname, float param) => GLPointers._TextureParameterf_fnptr((int)texture, (uint)pname, param);
+        public static void TextureParameterf(int texture, TextureParameterName pname, float param) => GLPointers._TextureParameterf_fnptr(texture, (uint)pname, param);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Set texture parameters. </summary>
         /// <param name="texture">Specifies the texture object name for glTextureParameter functions.</param>
         /// <param name="pname">Specifies the symbolic name of a single-valued texture parameter. pname can be one of the following: GL_DEPTH_STENCIL_TEXTURE_MODE, GL_TEXTURE_BASE_LEVEL, GL_TEXTURE_COMPARE_FUNC, GL_TEXTURE_COMPARE_MODE, GL_TEXTURE_LOD_BIAS, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_MAX_LEVEL, GL_TEXTURE_SWIZZLE_R, GL_TEXTURE_SWIZZLE_G, GL_TEXTURE_SWIZZLE_B, GL_TEXTURE_SWIZZLE_A, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, or GL_TEXTURE_WRAP_R.</param>
         /// <param name="parameters">For the vector commands, specifies a pointer to an array where the value or values of pname are stored.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexParameter.xhtml" /></remarks>
-        public static void TextureParameterfv(TextureHandle texture, TextureParameterName pname, float* param) => GLPointers._TextureParameterfv_fnptr((int)texture, (uint)pname, param);
+        public static void TextureParameterfv(int texture, TextureParameterName pname, float* param) => GLPointers._TextureParameterfv_fnptr(texture, (uint)pname, param);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Set texture parameters. </summary>
         /// <param name="texture">Specifies the texture object name for glTextureParameter functions.</param>
         /// <param name="pname">Specifies the symbolic name of a single-valued texture parameter. pname can be one of the following: GL_DEPTH_STENCIL_TEXTURE_MODE, GL_TEXTURE_BASE_LEVEL, GL_TEXTURE_COMPARE_FUNC, GL_TEXTURE_COMPARE_MODE, GL_TEXTURE_LOD_BIAS, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_MAX_LEVEL, GL_TEXTURE_SWIZZLE_R, GL_TEXTURE_SWIZZLE_G, GL_TEXTURE_SWIZZLE_B, GL_TEXTURE_SWIZZLE_A, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, or GL_TEXTURE_WRAP_R.</param>
         /// <param name="param">For the scalar commands, specifies the value of pname.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexParameter.xhtml" /></remarks>
-        public static void TextureParameteri(TextureHandle texture, TextureParameterName pname, int param) => GLPointers._TextureParameteri_fnptr((int)texture, (uint)pname, param);
+        public static void TextureParameteri(int texture, TextureParameterName pname, int param) => GLPointers._TextureParameteri_fnptr(texture, (uint)pname, param);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Set texture parameters. </summary>
         /// <param name="texture">Specifies the texture object name for glTextureParameter functions.</param>
         /// <param name="pname">Specifies the symbolic name of a single-valued texture parameter. pname can be one of the following: GL_DEPTH_STENCIL_TEXTURE_MODE, GL_TEXTURE_BASE_LEVEL, GL_TEXTURE_COMPARE_FUNC, GL_TEXTURE_COMPARE_MODE, GL_TEXTURE_LOD_BIAS, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_MAX_LEVEL, GL_TEXTURE_SWIZZLE_R, GL_TEXTURE_SWIZZLE_G, GL_TEXTURE_SWIZZLE_B, GL_TEXTURE_SWIZZLE_A, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, or GL_TEXTURE_WRAP_R.</param>
         /// <param name="parameters">For the vector commands, specifies a pointer to an array where the value or values of pname are stored.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexParameter.xhtml" /></remarks>
-        public static void TextureParameterIiv(TextureHandle texture, TextureParameterName pname, int* parameters) => GLPointers._TextureParameterIiv_fnptr((int)texture, (uint)pname, parameters);
+        public static void TextureParameterIiv(int texture, TextureParameterName pname, int* parameters) => GLPointers._TextureParameterIiv_fnptr(texture, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Set texture parameters. </summary>
         /// <param name="texture">Specifies the texture object name for glTextureParameter functions.</param>
         /// <param name="pname">Specifies the symbolic name of a single-valued texture parameter. pname can be one of the following: GL_DEPTH_STENCIL_TEXTURE_MODE, GL_TEXTURE_BASE_LEVEL, GL_TEXTURE_COMPARE_FUNC, GL_TEXTURE_COMPARE_MODE, GL_TEXTURE_LOD_BIAS, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_MAX_LEVEL, GL_TEXTURE_SWIZZLE_R, GL_TEXTURE_SWIZZLE_G, GL_TEXTURE_SWIZZLE_B, GL_TEXTURE_SWIZZLE_A, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, or GL_TEXTURE_WRAP_R.</param>
         /// <param name="parameters">For the vector commands, specifies a pointer to an array where the value or values of pname are stored.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexParameter.xhtml" /></remarks>
-        public static void TextureParameterIuiv(TextureHandle texture, TextureParameterName pname, uint* parameters) => GLPointers._TextureParameterIuiv_fnptr((int)texture, (uint)pname, parameters);
+        public static void TextureParameterIuiv(int texture, TextureParameterName pname, uint* parameters) => GLPointers._TextureParameterIuiv_fnptr(texture, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Set texture parameters. </summary>
         /// <param name="texture">Specifies the texture object name for glTextureParameter functions.</param>
         /// <param name="pname">Specifies the symbolic name of a single-valued texture parameter. pname can be one of the following: GL_DEPTH_STENCIL_TEXTURE_MODE, GL_TEXTURE_BASE_LEVEL, GL_TEXTURE_COMPARE_FUNC, GL_TEXTURE_COMPARE_MODE, GL_TEXTURE_LOD_BIAS, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_MAX_LEVEL, GL_TEXTURE_SWIZZLE_R, GL_TEXTURE_SWIZZLE_G, GL_TEXTURE_SWIZZLE_B, GL_TEXTURE_SWIZZLE_A, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, or GL_TEXTURE_WRAP_R.</param>
         /// <param name="parameters">For the vector commands, specifies a pointer to an array where the value or values of pname are stored.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexParameter.xhtml" /></remarks>
-        public static void TextureParameteriv(TextureHandle texture, TextureParameterName pname, int* param) => GLPointers._TextureParameteriv_fnptr((int)texture, (uint)pname, param);
+        public static void TextureParameteriv(int texture, TextureParameterName pname, int* param) => GLPointers._TextureParameteriv_fnptr(texture, (uint)pname, param);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Generate mipmaps for a specified texture object. </summary>
         /// <param name="texture"> Specifies the texture object name for glGenerateTextureMipmap. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGenerateMipmap.xhtml" /></remarks>
-        public static void GenerateTextureMipmap(TextureHandle texture) => GLPointers._GenerateTextureMipmap_fnptr((int)texture);
+        public static void GenerateTextureMipmap(int texture) => GLPointers._GenerateTextureMipmap_fnptr(texture);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Bind an existing texture object to the specified texture unit . </summary>
         /// <param name="unit">Specifies the texture unit, to which the texture object should be bound to. </param>
         /// <param name="texture">Specifies the name of a texture. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindTextureUnit.xhtml" /></remarks>
-        public static void BindTextureUnit(uint unit, TextureHandle texture) => GLPointers._BindTextureUnit_fnptr(unit, (int)texture);
+        public static void BindTextureUnit(uint unit, int texture) => GLPointers._BindTextureUnit_fnptr(unit, texture);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Return a texture image. </summary>
         /// <param name="texture"> Specifies the texture object name. </param>
@@ -4440,7 +4440,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="bufSize">Specifies the size of the buffer pixels for glGetnTexImage and glGetTextureImage functions.</param>
         /// <param name="pixels">Returns the texture image. Should be a pointer to an array of the type specified by type.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetTexImage.xhtml" /></remarks>
-        public static void GetTextureImage(TextureHandle texture, int level, PixelFormat format, PixelType type, int bufSize, void* pixels) => GLPointers._GetTextureImage_fnptr((int)texture, level, (uint)format, (uint)type, bufSize, pixels);
+        public static void GetTextureImage(int texture, int level, PixelFormat format, PixelType type, int bufSize, void* pixels) => GLPointers._GetTextureImage_fnptr(texture, level, (uint)format, (uint)type, bufSize, pixels);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Return a compressed texture image. </summary>
         /// <param name="texture">Specifies the texture object name for glGetCompressedTextureImage function.</param>
@@ -4448,7 +4448,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="bufSize">Specifies the size of the buffer pixels for glGetCompressedTextureImage and glGetnCompressedTexImage functions.</param>
         /// <param name="pixels">Returns the compressed texture image.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetCompressedTexImage.xhtml" /></remarks>
-        public static void GetCompressedTextureImage(TextureHandle texture, int level, int bufSize, void* pixels) => GLPointers._GetCompressedTextureImage_fnptr((int)texture, level, bufSize, pixels);
+        public static void GetCompressedTextureImage(int texture, int level, int bufSize, void* pixels) => GLPointers._GetCompressedTextureImage_fnptr(texture, level, bufSize, pixels);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Return texture parameter values for a specific level of    detail. </summary>
         /// <param name="texture">Specifies the texture object name for glGetTextureLevelParameterfv and glGetTextureLevelParameteriv functions.</param>
@@ -4456,7 +4456,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="pname">Specifies the symbolic name of a texture parameter. GL_TEXTURE_WIDTH, GL_TEXTURE_HEIGHT, GL_TEXTURE_DEPTH, GL_TEXTURE_INTERNAL_FORMAT, GL_TEXTURE_RED_SIZE, GL_TEXTURE_GREEN_SIZE, GL_TEXTURE_BLUE_SIZE, GL_TEXTURE_ALPHA_SIZE, GL_TEXTURE_DEPTH_SIZE, GL_TEXTURE_COMPRESSED, GL_TEXTURE_COMPRESSED_IMAGE_SIZE, and GL_TEXTURE_BUFFER_OFFSET are accepted.</param>
         /// <param name="parameters">Returns the requested data.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetTexLevelParameter.xhtml" /></remarks>
-        public static void GetTextureLevelParameterfv(TextureHandle texture, int level, GetTextureParameter pname, float* parameters) => GLPointers._GetTextureLevelParameterfv_fnptr((int)texture, level, (uint)pname, parameters);
+        public static void GetTextureLevelParameterfv(int texture, int level, GetTextureParameter pname, float* parameters) => GLPointers._GetTextureLevelParameterfv_fnptr(texture, level, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Return texture parameter values for a specific level of    detail. </summary>
         /// <param name="texture">Specifies the texture object name for glGetTextureLevelParameterfv and glGetTextureLevelParameteriv functions.</param>
@@ -4464,59 +4464,59 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="pname">Specifies the symbolic name of a texture parameter. GL_TEXTURE_WIDTH, GL_TEXTURE_HEIGHT, GL_TEXTURE_DEPTH, GL_TEXTURE_INTERNAL_FORMAT, GL_TEXTURE_RED_SIZE, GL_TEXTURE_GREEN_SIZE, GL_TEXTURE_BLUE_SIZE, GL_TEXTURE_ALPHA_SIZE, GL_TEXTURE_DEPTH_SIZE, GL_TEXTURE_COMPRESSED, GL_TEXTURE_COMPRESSED_IMAGE_SIZE, and GL_TEXTURE_BUFFER_OFFSET are accepted.</param>
         /// <param name="parameters">Returns the requested data.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetTexLevelParameter.xhtml" /></remarks>
-        public static void GetTextureLevelParameteriv(TextureHandle texture, int level, GetTextureParameter pname, int* parameters) => GLPointers._GetTextureLevelParameteriv_fnptr((int)texture, level, (uint)pname, parameters);
+        public static void GetTextureLevelParameteriv(int texture, int level, GetTextureParameter pname, int* parameters) => GLPointers._GetTextureLevelParameteriv_fnptr(texture, level, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Return texture parameter values. </summary>
         /// <param name="texture">Specifies the texture object name for glGetTextureParameterfv, glGetTextureParameteriv, glGetTextureParameterIiv, and glGetTextureParameterIuiv functions.</param>
         /// <param name="pname">Specifies the symbolic name of a texture parameter. GL_DEPTH_STENCIL_TEXTURE_MODE, GL_IMAGE_FORMAT_COMPATIBILITY_TYPE, GL_TEXTURE_BASE_LEVEL, GL_TEXTURE_BORDER_COLOR, GL_TEXTURE_COMPARE_MODE, GL_TEXTURE_COMPARE_FUNC, GL_TEXTURE_IMMUTABLE_FORMAT, GL_TEXTURE_IMMUTABLE_LEVELS, GL_TEXTURE_LOD_BIAS, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MAX_LEVEL, GL_TEXTURE_MAX_LOD, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_SWIZZLE_R, GL_TEXTURE_SWIZZLE_G, GL_TEXTURE_SWIZZLE_B, GL_TEXTURE_SWIZZLE_A, GL_TEXTURE_SWIZZLE_RGBA, GL_TEXTURE_TARGET, GL_TEXTURE_VIEW_MIN_LAYER, GL_TEXTURE_VIEW_MIN_LEVEL, GL_TEXTURE_VIEW_NUM_LAYERS, GL_TEXTURE_VIEW_NUM_LEVELS, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, and GL_TEXTURE_WRAP_R are accepted.</param>
         /// <param name="parameters">Returns the texture parameters.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetTexParameter.xhtml" /></remarks>
-        public static void GetTextureParameterfv(TextureHandle texture, GetTextureParameter pname, float* parameters) => GLPointers._GetTextureParameterfv_fnptr((int)texture, (uint)pname, parameters);
+        public static void GetTextureParameterfv(int texture, GetTextureParameter pname, float* parameters) => GLPointers._GetTextureParameterfv_fnptr(texture, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Return texture parameter values. </summary>
         /// <param name="texture">Specifies the texture object name for glGetTextureParameterfv, glGetTextureParameteriv, glGetTextureParameterIiv, and glGetTextureParameterIuiv functions.</param>
         /// <param name="pname">Specifies the symbolic name of a texture parameter. GL_DEPTH_STENCIL_TEXTURE_MODE, GL_IMAGE_FORMAT_COMPATIBILITY_TYPE, GL_TEXTURE_BASE_LEVEL, GL_TEXTURE_BORDER_COLOR, GL_TEXTURE_COMPARE_MODE, GL_TEXTURE_COMPARE_FUNC, GL_TEXTURE_IMMUTABLE_FORMAT, GL_TEXTURE_IMMUTABLE_LEVELS, GL_TEXTURE_LOD_BIAS, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MAX_LEVEL, GL_TEXTURE_MAX_LOD, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_SWIZZLE_R, GL_TEXTURE_SWIZZLE_G, GL_TEXTURE_SWIZZLE_B, GL_TEXTURE_SWIZZLE_A, GL_TEXTURE_SWIZZLE_RGBA, GL_TEXTURE_TARGET, GL_TEXTURE_VIEW_MIN_LAYER, GL_TEXTURE_VIEW_MIN_LEVEL, GL_TEXTURE_VIEW_NUM_LAYERS, GL_TEXTURE_VIEW_NUM_LEVELS, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, and GL_TEXTURE_WRAP_R are accepted.</param>
         /// <param name="parameters">Returns the texture parameters.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetTexParameter.xhtml" /></remarks>
-        public static void GetTextureParameterIiv(TextureHandle texture, GetTextureParameter pname, int* parameters) => GLPointers._GetTextureParameterIiv_fnptr((int)texture, (uint)pname, parameters);
+        public static void GetTextureParameterIiv(int texture, GetTextureParameter pname, int* parameters) => GLPointers._GetTextureParameterIiv_fnptr(texture, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Return texture parameter values. </summary>
         /// <param name="texture">Specifies the texture object name for glGetTextureParameterfv, glGetTextureParameteriv, glGetTextureParameterIiv, and glGetTextureParameterIuiv functions.</param>
         /// <param name="pname">Specifies the symbolic name of a texture parameter. GL_DEPTH_STENCIL_TEXTURE_MODE, GL_IMAGE_FORMAT_COMPATIBILITY_TYPE, GL_TEXTURE_BASE_LEVEL, GL_TEXTURE_BORDER_COLOR, GL_TEXTURE_COMPARE_MODE, GL_TEXTURE_COMPARE_FUNC, GL_TEXTURE_IMMUTABLE_FORMAT, GL_TEXTURE_IMMUTABLE_LEVELS, GL_TEXTURE_LOD_BIAS, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MAX_LEVEL, GL_TEXTURE_MAX_LOD, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_SWIZZLE_R, GL_TEXTURE_SWIZZLE_G, GL_TEXTURE_SWIZZLE_B, GL_TEXTURE_SWIZZLE_A, GL_TEXTURE_SWIZZLE_RGBA, GL_TEXTURE_TARGET, GL_TEXTURE_VIEW_MIN_LAYER, GL_TEXTURE_VIEW_MIN_LEVEL, GL_TEXTURE_VIEW_NUM_LAYERS, GL_TEXTURE_VIEW_NUM_LEVELS, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, and GL_TEXTURE_WRAP_R are accepted.</param>
         /// <param name="parameters">Returns the texture parameters.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetTexParameter.xhtml" /></remarks>
-        public static void GetTextureParameterIuiv(TextureHandle texture, GetTextureParameter pname, uint* parameters) => GLPointers._GetTextureParameterIuiv_fnptr((int)texture, (uint)pname, parameters);
+        public static void GetTextureParameterIuiv(int texture, GetTextureParameter pname, uint* parameters) => GLPointers._GetTextureParameterIuiv_fnptr(texture, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Return texture parameter values. </summary>
         /// <param name="texture">Specifies the texture object name for glGetTextureParameterfv, glGetTextureParameteriv, glGetTextureParameterIiv, and glGetTextureParameterIuiv functions.</param>
         /// <param name="pname">Specifies the symbolic name of a texture parameter. GL_DEPTH_STENCIL_TEXTURE_MODE, GL_IMAGE_FORMAT_COMPATIBILITY_TYPE, GL_TEXTURE_BASE_LEVEL, GL_TEXTURE_BORDER_COLOR, GL_TEXTURE_COMPARE_MODE, GL_TEXTURE_COMPARE_FUNC, GL_TEXTURE_IMMUTABLE_FORMAT, GL_TEXTURE_IMMUTABLE_LEVELS, GL_TEXTURE_LOD_BIAS, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MAX_LEVEL, GL_TEXTURE_MAX_LOD, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_SWIZZLE_R, GL_TEXTURE_SWIZZLE_G, GL_TEXTURE_SWIZZLE_B, GL_TEXTURE_SWIZZLE_A, GL_TEXTURE_SWIZZLE_RGBA, GL_TEXTURE_TARGET, GL_TEXTURE_VIEW_MIN_LAYER, GL_TEXTURE_VIEW_MIN_LEVEL, GL_TEXTURE_VIEW_NUM_LAYERS, GL_TEXTURE_VIEW_NUM_LEVELS, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, and GL_TEXTURE_WRAP_R are accepted.</param>
         /// <param name="parameters">Returns the texture parameters.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetTexParameter.xhtml" /></remarks>
-        public static void GetTextureParameteriv(TextureHandle texture, GetTextureParameter pname, int* parameters) => GLPointers._GetTextureParameteriv_fnptr((int)texture, (uint)pname, parameters);
+        public static void GetTextureParameteriv(int texture, GetTextureParameter pname, int* parameters) => GLPointers._GetTextureParameteriv_fnptr(texture, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Create vertex array objects. </summary>
         /// <param name="n"> Number of vertex array objects to create. </param>
         /// <param name="arrays"> Specifies an array in which names of the new vertex array objects are stored. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCreateVertexArrays.xhtml" /></remarks>
-        public static void CreateVertexArrays(int n, VertexArrayHandle* arrays) => GLPointers._CreateVertexArrays_fnptr(n, (int*)arrays);
+        public static void CreateVertexArrays(int n, int* arrays) => GLPointers._CreateVertexArrays_fnptr(n, arrays);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Enable or disable a generic vertex attribute    array. </summary>
         /// <param name="vaobj">Specifies the name of the vertex array object for glDisableVertexArrayAttrib and glEnableVertexArrayAttrib functions.</param>
         /// <param name="index">Specifies the index of the generic vertex attribute to be enabled or disabled.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glEnableVertexAttribArray.xhtml" /></remarks>
-        public static void DisableVertexArrayAttrib(VertexArrayHandle vaobj, uint index) => GLPointers._DisableVertexArrayAttrib_fnptr((int)vaobj, index);
+        public static void DisableVertexArrayAttrib(int vaobj, uint index) => GLPointers._DisableVertexArrayAttrib_fnptr(vaobj, index);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Enable or disable a generic vertex attribute    array. </summary>
         /// <param name="vaobj">Specifies the name of the vertex array object for glDisableVertexArrayAttrib and glEnableVertexArrayAttrib functions.</param>
         /// <param name="index">Specifies the index of the generic vertex attribute to be enabled or disabled.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glEnableVertexAttribArray.xhtml" /></remarks>
-        public static void EnableVertexArrayAttrib(VertexArrayHandle vaobj, uint index) => GLPointers._EnableVertexArrayAttrib_fnptr((int)vaobj, index);
+        public static void EnableVertexArrayAttrib(int vaobj, uint index) => GLPointers._EnableVertexArrayAttrib_fnptr(vaobj, index);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Configures element array buffer binding of a vertex array object. </summary>
         /// <param name="vaobj"> Specifies the name of the vertex array object. </param>
         /// <param name="buffer"> Specifies the name of the buffer object to use for the element array buffer binding. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glVertexArrayElementBuffer.xhtml" /></remarks>
-        public static void VertexArrayElementBuffer(VertexArrayHandle vaobj, BufferHandle buffer) => GLPointers._VertexArrayElementBuffer_fnptr((int)vaobj, (int)buffer);
+        public static void VertexArrayElementBuffer(int vaobj, int buffer) => GLPointers._VertexArrayElementBuffer_fnptr(vaobj, buffer);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Bind a buffer to a vertex buffer bind point. </summary>
         /// <param name="vaobj">Specifies the name of the vertex array object to be used by glVertexArrayVertexBuffer function.</param>
@@ -4525,7 +4525,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="offset">The offset of the first element of the buffer.</param>
         /// <param name="stride">The distance between elements within the buffer.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindVertexBuffer.xhtml" /></remarks>
-        public static void VertexArrayVertexBuffer(VertexArrayHandle vaobj, uint bindingindex, BufferHandle buffer, IntPtr offset, int stride) => GLPointers._VertexArrayVertexBuffer_fnptr((int)vaobj, bindingindex, (int)buffer, offset, stride);
+        public static void VertexArrayVertexBuffer(int vaobj, uint bindingindex, int buffer, IntPtr offset, int stride) => GLPointers._VertexArrayVertexBuffer_fnptr(vaobj, bindingindex, buffer, offset, stride);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Attach multiple buffer objects to a vertex array object. </summary>
         /// <param name="vaobj"> Specifies the name of the vertex array object for glVertexArrayVertexBuffers. </param>
@@ -4535,14 +4535,14 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="offsets"> Specifies the address of an array of offsets to associate with the binding points. </param>
         /// <param name="strides">!!missing documentation!!</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindVertexBuffers.xhtml" /></remarks>
-        public static void VertexArrayVertexBuffers(VertexArrayHandle vaobj, uint first, int count, BufferHandle* buffers, IntPtr* offsets, int* strides) => GLPointers._VertexArrayVertexBuffers_fnptr((int)vaobj, first, count, (int*)buffers, offsets, strides);
+        public static void VertexArrayVertexBuffers(int vaobj, uint first, int count, int* buffers, IntPtr* offsets, int* strides) => GLPointers._VertexArrayVertexBuffers_fnptr(vaobj, first, count, buffers, offsets, strides);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Associate a vertex attribute and a vertex buffer binding for a vertex array object. </summary>
         /// <param name="vaobj"> Specifies the name of the vertex array object for glVertexArrayAttribBinding. </param>
         /// <param name="attribindex"> The index of the attribute to associate with a vertex buffer binding. </param>
         /// <param name="bindingindex"> The index of the vertex buffer binding with which to associate the generic vertex attribute. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glVertexAttribBinding.xhtml" /></remarks>
-        public static void VertexArrayAttribBinding(VertexArrayHandle vaobj, uint attribindex, uint bindingindex) => GLPointers._VertexArrayAttribBinding_fnptr((int)vaobj, attribindex, bindingindex);
+        public static void VertexArrayAttribBinding(int vaobj, uint attribindex, uint bindingindex) => GLPointers._VertexArrayAttribBinding_fnptr(vaobj, attribindex, bindingindex);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specify the organization of vertex arrays. </summary>
         /// <param name="vaobj">Specifies the name of the vertex array object for glVertexArrayAttrib{I, L}Format functions.</param>
@@ -4552,7 +4552,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="normalized"> Specifies whether fixed-point data values should be normalized (GL_TRUE) or converted directly as fixed-point values (GL_FALSE) when they are accessed. This parameter is ignored if type is GL_FIXED. </param>
         /// <param name="relativeoffset">The distance between elements within the buffer.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glVertexAttribFormat.xhtml" /></remarks>
-        public static void VertexArrayAttribFormat(VertexArrayHandle vaobj, uint attribindex, int size, VertexAttribType type, bool normalized, uint relativeoffset) => GLPointers._VertexArrayAttribFormat_fnptr((int)vaobj, attribindex, size, (uint)type, (byte)(normalized ? 1 : 0), relativeoffset);
+        public static void VertexArrayAttribFormat(int vaobj, uint attribindex, int size, VertexAttribType type, bool normalized, uint relativeoffset) => GLPointers._VertexArrayAttribFormat_fnptr(vaobj, attribindex, size, (uint)type, (byte)(normalized ? 1 : 0), relativeoffset);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specify the organization of vertex arrays. </summary>
         /// <param name="vaobj">Specifies the name of the vertex array object for glVertexArrayAttrib{I, L}Format functions.</param>
@@ -4561,7 +4561,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="type">The type of the data stored in the array.</param>
         /// <param name="relativeoffset">The distance between elements within the buffer.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glVertexAttribFormat.xhtml" /></remarks>
-        public static void VertexArrayAttribIFormat(VertexArrayHandle vaobj, uint attribindex, int size, VertexAttribIType type, uint relativeoffset) => GLPointers._VertexArrayAttribIFormat_fnptr((int)vaobj, attribindex, size, (uint)type, relativeoffset);
+        public static void VertexArrayAttribIFormat(int vaobj, uint attribindex, int size, VertexAttribIType type, uint relativeoffset) => GLPointers._VertexArrayAttribIFormat_fnptr(vaobj, attribindex, size, (uint)type, relativeoffset);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specify the organization of vertex arrays. </summary>
         /// <param name="vaobj">Specifies the name of the vertex array object for glVertexArrayAttrib{I, L}Format functions.</param>
@@ -4570,21 +4570,21 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="type">The type of the data stored in the array.</param>
         /// <param name="relativeoffset">The distance between elements within the buffer.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glVertexAttribFormat.xhtml" /></remarks>
-        public static void VertexArrayAttribLFormat(VertexArrayHandle vaobj, uint attribindex, int size, VertexAttribLType type, uint relativeoffset) => GLPointers._VertexArrayAttribLFormat_fnptr((int)vaobj, attribindex, size, (uint)type, relativeoffset);
+        public static void VertexArrayAttribLFormat(int vaobj, uint attribindex, int size, VertexAttribLType type, uint relativeoffset) => GLPointers._VertexArrayAttribLFormat_fnptr(vaobj, attribindex, size, (uint)type, relativeoffset);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Modify the rate at which generic vertex attributes    advance. </summary>
         /// <param name="vaobj">Specifies the name of the vertex array object for glVertexArrayBindingDivisor function.</param>
         /// <param name="bindingindex">The index of the binding whose divisor to modify.</param>
         /// <param name="divisor">The new value for the instance step rate to apply.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glVertexBindingDivisor.xhtml" /></remarks>
-        public static void VertexArrayBindingDivisor(VertexArrayHandle vaobj, uint bindingindex, uint divisor) => GLPointers._VertexArrayBindingDivisor_fnptr((int)vaobj, bindingindex, divisor);
+        public static void VertexArrayBindingDivisor(int vaobj, uint bindingindex, uint divisor) => GLPointers._VertexArrayBindingDivisor_fnptr(vaobj, bindingindex, divisor);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Retrieve parameters of a vertex array object. </summary>
         /// <param name="vaobj">specifies the name of the vertex array object to use for the query.</param>
         /// <param name="pname">Name of the property to use for the query. Must be GL_ELEMENT_ARRAY_BUFFER_BINDING.</param>
         /// <param name="param">Returns the requested value.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetVertexArrayiv.xhtml" /></remarks>
-        public static void GetVertexArrayiv(VertexArrayHandle vaobj, VertexArrayPName pname, int* param) => GLPointers._GetVertexArrayiv_fnptr((int)vaobj, (uint)pname, param);
+        public static void GetVertexArrayiv(int vaobj, VertexArrayPName pname, int* param) => GLPointers._GetVertexArrayiv_fnptr(vaobj, (uint)pname, param);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Retrieve parameters of an attribute of a vertex array    object. </summary>
         /// <param name="vaobj">Specifies the name of a vertex array object.</param>
@@ -4592,7 +4592,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="pname">Specifies the property to be used for the query. For glGetVertexArrayIndexediv, it must be one of the following values: GL_VERTEX_ATTRIB_ARRAY_ENABLED, GL_VERTEX_ATTRIB_ARRAY_SIZE, GL_VERTEX_ATTRIB_ARRAY_STRIDE, GL_VERTEX_ATTRIB_ARRAY_TYPE, GL_VERTEX_ATTRIB_ARRAY_NORMALIZED, GL_VERTEX_ATTRIB_ARRAY_INTEGER, GL_VERTEX_ATTRIB_ARRAY_LONG, GL_VERTEX_ATTRIB_ARRAY_DIVISOR, or GL_VERTEX_ATTRIB_RELATIVE_OFFSET. For glGetVertexArrayIndexed64v, it must be equal to GL_VERTEX_BINDING_OFFSET.</param>
         /// <param name="param">Returns the requested value.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetVertexArrayIndexed.xhtml" /></remarks>
-        public static void GetVertexArrayIndexediv(VertexArrayHandle vaobj, uint index, VertexArrayPName pname, int* param) => GLPointers._GetVertexArrayIndexediv_fnptr((int)vaobj, index, (uint)pname, param);
+        public static void GetVertexArrayIndexediv(int vaobj, uint index, VertexArrayPName pname, int* param) => GLPointers._GetVertexArrayIndexediv_fnptr(vaobj, index, (uint)pname, param);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Retrieve parameters of an attribute of a vertex array    object. </summary>
         /// <param name="vaobj">Specifies the name of a vertex array object.</param>
@@ -4600,26 +4600,26 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="pname">Specifies the property to be used for the query. For glGetVertexArrayIndexediv, it must be one of the following values: GL_VERTEX_ATTRIB_ARRAY_ENABLED, GL_VERTEX_ATTRIB_ARRAY_SIZE, GL_VERTEX_ATTRIB_ARRAY_STRIDE, GL_VERTEX_ATTRIB_ARRAY_TYPE, GL_VERTEX_ATTRIB_ARRAY_NORMALIZED, GL_VERTEX_ATTRIB_ARRAY_INTEGER, GL_VERTEX_ATTRIB_ARRAY_LONG, GL_VERTEX_ATTRIB_ARRAY_DIVISOR, or GL_VERTEX_ATTRIB_RELATIVE_OFFSET. For glGetVertexArrayIndexed64v, it must be equal to GL_VERTEX_BINDING_OFFSET.</param>
         /// <param name="param">Returns the requested value.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetVertexArrayIndexed.xhtml" /></remarks>
-        public static void GetVertexArrayIndexed64iv(VertexArrayHandle vaobj, uint index, VertexArrayPName pname, long* param) => GLPointers._GetVertexArrayIndexed64iv_fnptr((int)vaobj, index, (uint)pname, param);
+        public static void GetVertexArrayIndexed64iv(int vaobj, uint index, VertexArrayPName pname, long* param) => GLPointers._GetVertexArrayIndexed64iv_fnptr(vaobj, index, (uint)pname, param);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Create sampler objects. </summary>
         /// <param name="n"> Number of sampler objects to create. </param>
         /// <param name="samplers"> Specifies an array in which names of the new sampler objects are stored. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCreateSamplers.xhtml" /></remarks>
-        public static void CreateSamplers(int n, SamplerHandle* samplers) => GLPointers._CreateSamplers_fnptr(n, (int*)samplers);
+        public static void CreateSamplers(int n, int* samplers) => GLPointers._CreateSamplers_fnptr(n, samplers);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Create program pipeline objects. </summary>
         /// <param name="n"> Number of program pipeline objects to create. </param>
         /// <param name="pipelines"> Specifies an array in which names of the new program pipeline objects are stored. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCreateProgramPipelines.xhtml" /></remarks>
-        public static void CreateProgramPipelines(int n, ProgramPipelineHandle* pipelines) => GLPointers._CreateProgramPipelines_fnptr(n, (int*)pipelines);
+        public static void CreateProgramPipelines(int n, int* pipelines) => GLPointers._CreateProgramPipelines_fnptr(n, pipelines);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Create query objects. </summary>
         /// <param name="target"> Specifies the target of each created query object. </param>
         /// <param name="n"> Number of query objects to create. </param>
         /// <param name="ids"> Specifies an array in which names of the new query objects are stored. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCreateQueries.xhtml" /></remarks>
-        public static void CreateQueries(QueryTarget target, int n, QueryHandle* ids) => GLPointers._CreateQueries_fnptr((uint)target, n, (int*)ids);
+        public static void CreateQueries(QueryTarget target, int n, int* ids) => GLPointers._CreateQueries_fnptr((uint)target, n, ids);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Return parameters of a query object. </summary>
         /// <param name="id"> Specifies the name of a query object. </param>
@@ -4627,7 +4627,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="pname"> Specifies the symbolic name of a query object parameter. Accepted values are GL_QUERY_RESULT or GL_QUERY_RESULT_AVAILABLE. </param>
         /// <param name="offset"> Specifies the byte offset into buffer's data store where the queried result will be written. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetQueryObject.xhtml" /></remarks>
-        public static void GetQueryBufferObjecti64v(QueryHandle id, BufferHandle buffer, QueryObjectParameterName pname, IntPtr offset) => GLPointers._GetQueryBufferObjecti64v_fnptr((int)id, (int)buffer, (uint)pname, offset);
+        public static void GetQueryBufferObjecti64v(int id, int buffer, QueryObjectParameterName pname, IntPtr offset) => GLPointers._GetQueryBufferObjecti64v_fnptr(id, buffer, (uint)pname, offset);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Return parameters of a query object. </summary>
         /// <param name="id"> Specifies the name of a query object. </param>
@@ -4635,7 +4635,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="pname"> Specifies the symbolic name of a query object parameter. Accepted values are GL_QUERY_RESULT or GL_QUERY_RESULT_AVAILABLE. </param>
         /// <param name="offset"> Specifies the byte offset into buffer's data store where the queried result will be written. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetQueryObject.xhtml" /></remarks>
-        public static void GetQueryBufferObjectiv(QueryHandle id, BufferHandle buffer, QueryObjectParameterName pname, IntPtr offset) => GLPointers._GetQueryBufferObjectiv_fnptr((int)id, (int)buffer, (uint)pname, offset);
+        public static void GetQueryBufferObjectiv(int id, int buffer, QueryObjectParameterName pname, IntPtr offset) => GLPointers._GetQueryBufferObjectiv_fnptr(id, buffer, (uint)pname, offset);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Return parameters of a query object. </summary>
         /// <param name="id"> Specifies the name of a query object. </param>
@@ -4643,7 +4643,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="pname"> Specifies the symbolic name of a query object parameter. Accepted values are GL_QUERY_RESULT or GL_QUERY_RESULT_AVAILABLE. </param>
         /// <param name="offset"> Specifies the byte offset into buffer's data store where the queried result will be written. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetQueryObject.xhtml" /></remarks>
-        public static void GetQueryBufferObjectui64v(QueryHandle id, BufferHandle buffer, QueryObjectParameterName pname, IntPtr offset) => GLPointers._GetQueryBufferObjectui64v_fnptr((int)id, (int)buffer, (uint)pname, offset);
+        public static void GetQueryBufferObjectui64v(int id, int buffer, QueryObjectParameterName pname, IntPtr offset) => GLPointers._GetQueryBufferObjectui64v_fnptr(id, buffer, (uint)pname, offset);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Return parameters of a query object. </summary>
         /// <param name="id"> Specifies the name of a query object. </param>
@@ -4651,7 +4651,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="pname"> Specifies the symbolic name of a query object parameter. Accepted values are GL_QUERY_RESULT or GL_QUERY_RESULT_AVAILABLE. </param>
         /// <param name="offset"> Specifies the byte offset into buffer's data store where the queried result will be written. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetQueryObject.xhtml" /></remarks>
-        public static void GetQueryBufferObjectuiv(QueryHandle id, BufferHandle buffer, QueryObjectParameterName pname, IntPtr offset) => GLPointers._GetQueryBufferObjectuiv_fnptr((int)id, (int)buffer, (uint)pname, offset);
+        public static void GetQueryBufferObjectuiv(int id, int buffer, QueryObjectParameterName pname, IntPtr offset) => GLPointers._GetQueryBufferObjectuiv_fnptr(id, buffer, (uint)pname, offset);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_ES3_1_compatibility]</b> Defines a barrier ordering memory transactions. </summary>
         /// <param name="barriers"> Specifies the barriers to insert. </param>
@@ -4672,7 +4672,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="bufSize">Specifies the size of the buffer to receive the retrieved pixel data.</param>
         /// <param name="pixels">Returns the texture subimage. Should be a pointer to an array of the type specified by type.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetTextureSubImage.xhtml" /></remarks>
-        public static void GetTextureSubImage(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, int bufSize, void* pixels) => GLPointers._GetTextureSubImage_fnptr((int)texture, level, xoffset, yoffset, zoffset, width, height, depth, (uint)format, (uint)type, bufSize, pixels);
+        public static void GetTextureSubImage(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, int bufSize, void* pixels) => GLPointers._GetTextureSubImage_fnptr(texture, level, xoffset, yoffset, zoffset, width, height, depth, (uint)format, (uint)type, bufSize, pixels);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_get_texture_sub_image]</b> Retrieve a sub-region of a compressed texture image from a    compressed texture object. </summary>
         /// <param name="texture">Specifies the name of the source texture object. Must be GL_TEXTURE_1D, GL_TEXTURE_1D_ARRAY, GL_TEXTURE_2D, GL_TEXTURE_2D_ARRAY, GL_TEXTURE_3D, GL_TEXTURE_CUBE_MAP, GL_TEXTURE_CUBE_MAP_ARRAY or GL_TEXTURE_RECTANGLE. In specific, buffer and multisample textures are not permitted.</param>
@@ -4686,7 +4686,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="bufSize">Specifies the size of the buffer to receive the retrieved pixel data.</param>
         /// <param name="pixels">Returns the texture subimage. Should be a pointer to an array of the type specified by type.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetCompressedTextureSubImage.xhtml" /></remarks>
-        public static void GetCompressedTextureSubImage(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, int bufSize, void* pixels) => GLPointers._GetCompressedTextureSubImage_fnptr((int)texture, level, xoffset, yoffset, zoffset, width, height, depth, bufSize, pixels);
+        public static void GetCompressedTextureSubImage(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, int bufSize, void* pixels) => GLPointers._GetCompressedTextureSubImage_fnptr(texture, level, xoffset, yoffset, zoffset, width, height, depth, bufSize, pixels);
         
         /// <summary> <b>[requires: v4.5 | GL_KHR_robustness]</b> Check if the rendering context has not been lost due to software or hardware issues. </summary>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetGraphicsResetStatus.xhtml" /></remarks>
@@ -4716,7 +4716,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="bufSize">Specifies the size of the buffer params.</param>
         /// <param name="parameters">Returns the value of the specified uniform variable.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetUniform.xhtml" /></remarks>
-        public static void GetnUniformdv(ProgramHandle program, int location, int bufSize, double* parameters) => GLPointers._GetnUniformdv_fnptr((int)program, location, bufSize, parameters);
+        public static void GetnUniformdv(int program, int location, int bufSize, double* parameters) => GLPointers._GetnUniformdv_fnptr(program, location, bufSize, parameters);
         
         /// <summary> <b>[requires: v4.5 | GL_KHR_robustness]</b> Returns the value of a uniform variable. </summary>
         /// <param name="program">Specifies the program object to be queried.</param>
@@ -4724,7 +4724,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="bufSize">Specifies the size of the buffer params.</param>
         /// <param name="parameters">Returns the value of the specified uniform variable.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetUniform.xhtml" /></remarks>
-        public static void GetnUniformfv(ProgramHandle program, int location, int bufSize, float* parameters) => GLPointers._GetnUniformfv_fnptr((int)program, location, bufSize, parameters);
+        public static void GetnUniformfv(int program, int location, int bufSize, float* parameters) => GLPointers._GetnUniformfv_fnptr(program, location, bufSize, parameters);
         
         /// <summary> <b>[requires: v4.5 | GL_KHR_robustness]</b> Returns the value of a uniform variable. </summary>
         /// <param name="program">Specifies the program object to be queried.</param>
@@ -4732,7 +4732,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="bufSize">Specifies the size of the buffer params.</param>
         /// <param name="parameters">Returns the value of the specified uniform variable.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetUniform.xhtml" /></remarks>
-        public static void GetnUniformiv(ProgramHandle program, int location, int bufSize, int* parameters) => GLPointers._GetnUniformiv_fnptr((int)program, location, bufSize, parameters);
+        public static void GetnUniformiv(int program, int location, int bufSize, int* parameters) => GLPointers._GetnUniformiv_fnptr(program, location, bufSize, parameters);
         
         /// <summary> <b>[requires: v4.5 | GL_KHR_robustness]</b> Returns the value of a uniform variable. </summary>
         /// <param name="program">Specifies the program object to be queried.</param>
@@ -4740,7 +4740,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="bufSize">Specifies the size of the buffer params.</param>
         /// <param name="parameters">Returns the value of the specified uniform variable.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetUniform.xhtml" /></remarks>
-        public static void GetnUniformuiv(ProgramHandle program, int location, int bufSize, uint* parameters) => GLPointers._GetnUniformuiv_fnptr((int)program, location, bufSize, parameters);
+        public static void GetnUniformuiv(int program, int location, int bufSize, uint* parameters) => GLPointers._GetnUniformuiv_fnptr(program, location, bufSize, parameters);
         
         /// <summary> <b>[requires: v4.5 | GL_KHR_robustness]</b> Read a block of pixels from the frame buffer. </summary>
         /// <param name="x">Specify the window coordinates of the first pixel that is read from the frame buffer. This location is the lower left corner of a rectangular block of pixels.</param>
@@ -4758,7 +4758,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTextureBarrier.xhtml" /></remarks>
         public static void TextureBarrier() => GLPointers._TextureBarrier_fnptr();
         
-        public static void SpecializeShader(ShaderHandle shader, byte* pEntryPoint, uint numSpecializationConstants, uint* pConstantIndex, uint* pConstantValue) => GLPointers._SpecializeShader_fnptr((int)shader, pEntryPoint, numSpecializationConstants, pConstantIndex, pConstantValue);
+        public static void SpecializeShader(int shader, byte* pEntryPoint, uint numSpecializationConstants, uint* pConstantIndex, uint* pConstantValue) => GLPointers._SpecializeShader_fnptr(shader, pEntryPoint, numSpecializationConstants, pConstantIndex, pConstantValue);
         
         public static void MultiDrawArraysIndirectCount(PrimitiveType mode, void* indirect, IntPtr drawcount, int maxdrawcount, int stride) => GLPointers._MultiDrawArraysIndirectCount_fnptr((uint)mode, indirect, drawcount, maxdrawcount, stride);
         
@@ -4815,7 +4815,7 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_AMD_framebuffer_multisample_advanced]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedRenderbufferStorageMultisampleAdvancedAMD(RenderbufferHandle renderbuffer, int samples, int storageSamples, InternalFormat internalformat, int width, int height) => GLPointers._NamedRenderbufferStorageMultisampleAdvancedAMD_fnptr((int)renderbuffer, samples, storageSamples, (uint)internalformat, width, height);
+            public static void NamedRenderbufferStorageMultisampleAdvancedAMD(int renderbuffer, int samples, int storageSamples, InternalFormat internalformat, int width, int height) => GLPointers._NamedRenderbufferStorageMultisampleAdvancedAMD_fnptr(renderbuffer, samples, storageSamples, (uint)internalformat, width, height);
             
             /// <summary> <b>[requires: GL_AMD_framebuffer_sample_positions]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -4823,7 +4823,7 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_AMD_framebuffer_sample_positions]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedFramebufferSamplePositionsfvAMD(FramebufferHandle framebuffer, uint numsamples, uint pixelindex, float* values) => GLPointers._NamedFramebufferSamplePositionsfvAMD_fnptr((int)framebuffer, numsamples, pixelindex, values);
+            public static void NamedFramebufferSamplePositionsfvAMD(int framebuffer, uint numsamples, uint pixelindex, float* values) => GLPointers._NamedFramebufferSamplePositionsfvAMD_fnptr(framebuffer, numsamples, pixelindex, values);
             
             /// <summary> <b>[requires: GL_AMD_framebuffer_sample_positions]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -4831,7 +4831,7 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_AMD_framebuffer_sample_positions]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetNamedFramebufferParameterfvAMD(FramebufferHandle framebuffer, All pname, uint numsamples, uint pixelindex, int size, float* values) => GLPointers._GetNamedFramebufferParameterfvAMD_fnptr((int)framebuffer, (uint)pname, numsamples, pixelindex, size, values);
+            public static void GetNamedFramebufferParameterfvAMD(int framebuffer, All pname, uint numsamples, uint pixelindex, int size, float* values) => GLPointers._GetNamedFramebufferParameterfvAMD_fnptr(framebuffer, (uint)pname, numsamples, pixelindex, size, values);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -4899,75 +4899,75 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetUniformi64vNV(ProgramHandle program, int location, long* parameters) => GLPointers._GetUniformi64vNV_fnptr((int)program, location, parameters);
+            public static void GetUniformi64vNV(int program, int location, long* parameters) => GLPointers._GetUniformi64vNV_fnptr(program, location, parameters);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_shader_buffer_load]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetUniformui64vNV(ProgramHandle program, int location, ulong* parameters) => GLPointers._GetUniformui64vNV_fnptr((int)program, location, parameters);
+            public static void GetUniformui64vNV(int program, int location, ulong* parameters) => GLPointers._GetUniformui64vNV_fnptr(program, location, parameters);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform1i64NV(ProgramHandle program, int location, long x) => GLPointers._ProgramUniform1i64NV_fnptr((int)program, location, x);
+            public static void ProgramUniform1i64NV(int program, int location, long x) => GLPointers._ProgramUniform1i64NV_fnptr(program, location, x);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform2i64NV(ProgramHandle program, int location, long x, long y) => GLPointers._ProgramUniform2i64NV_fnptr((int)program, location, x, y);
+            public static void ProgramUniform2i64NV(int program, int location, long x, long y) => GLPointers._ProgramUniform2i64NV_fnptr(program, location, x, y);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform3i64NV(ProgramHandle program, int location, long x, long y, long z) => GLPointers._ProgramUniform3i64NV_fnptr((int)program, location, x, y, z);
+            public static void ProgramUniform3i64NV(int program, int location, long x, long y, long z) => GLPointers._ProgramUniform3i64NV_fnptr(program, location, x, y, z);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform4i64NV(ProgramHandle program, int location, long x, long y, long z, long w) => GLPointers._ProgramUniform4i64NV_fnptr((int)program, location, x, y, z, w);
+            public static void ProgramUniform4i64NV(int program, int location, long x, long y, long z, long w) => GLPointers._ProgramUniform4i64NV_fnptr(program, location, x, y, z, w);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform1i64vNV(ProgramHandle program, int location, int count, long* value) => GLPointers._ProgramUniform1i64vNV_fnptr((int)program, location, count, value);
+            public static void ProgramUniform1i64vNV(int program, int location, int count, long* value) => GLPointers._ProgramUniform1i64vNV_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform2i64vNV(ProgramHandle program, int location, int count, long* value) => GLPointers._ProgramUniform2i64vNV_fnptr((int)program, location, count, value);
+            public static void ProgramUniform2i64vNV(int program, int location, int count, long* value) => GLPointers._ProgramUniform2i64vNV_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform3i64vNV(ProgramHandle program, int location, int count, long* value) => GLPointers._ProgramUniform3i64vNV_fnptr((int)program, location, count, value);
+            public static void ProgramUniform3i64vNV(int program, int location, int count, long* value) => GLPointers._ProgramUniform3i64vNV_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform4i64vNV(ProgramHandle program, int location, int count, long* value) => GLPointers._ProgramUniform4i64vNV_fnptr((int)program, location, count, value);
+            public static void ProgramUniform4i64vNV(int program, int location, int count, long* value) => GLPointers._ProgramUniform4i64vNV_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform1ui64NV(ProgramHandle program, int location, ulong x) => GLPointers._ProgramUniform1ui64NV_fnptr((int)program, location, x);
+            public static void ProgramUniform1ui64NV(int program, int location, ulong x) => GLPointers._ProgramUniform1ui64NV_fnptr(program, location, x);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform2ui64NV(ProgramHandle program, int location, ulong x, ulong y) => GLPointers._ProgramUniform2ui64NV_fnptr((int)program, location, x, y);
+            public static void ProgramUniform2ui64NV(int program, int location, ulong x, ulong y) => GLPointers._ProgramUniform2ui64NV_fnptr(program, location, x, y);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform3ui64NV(ProgramHandle program, int location, ulong x, ulong y, ulong z) => GLPointers._ProgramUniform3ui64NV_fnptr((int)program, location, x, y, z);
+            public static void ProgramUniform3ui64NV(int program, int location, ulong x, ulong y, ulong z) => GLPointers._ProgramUniform3ui64NV_fnptr(program, location, x, y, z);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform4ui64NV(ProgramHandle program, int location, ulong x, ulong y, ulong z, ulong w) => GLPointers._ProgramUniform4ui64NV_fnptr((int)program, location, x, y, z, w);
+            public static void ProgramUniform4ui64NV(int program, int location, ulong x, ulong y, ulong z, ulong w) => GLPointers._ProgramUniform4ui64NV_fnptr(program, location, x, y, z, w);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform1ui64vNV(ProgramHandle program, int location, int count, ulong* value) => GLPointers._ProgramUniform1ui64vNV_fnptr((int)program, location, count, value);
+            public static void ProgramUniform1ui64vNV(int program, int location, int count, ulong* value) => GLPointers._ProgramUniform1ui64vNV_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform2ui64vNV(ProgramHandle program, int location, int count, ulong* value) => GLPointers._ProgramUniform2ui64vNV_fnptr((int)program, location, count, value);
+            public static void ProgramUniform2ui64vNV(int program, int location, int count, ulong* value) => GLPointers._ProgramUniform2ui64vNV_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform3ui64vNV(ProgramHandle program, int location, int count, ulong* value) => GLPointers._ProgramUniform3ui64vNV_fnptr((int)program, location, count, value);
+            public static void ProgramUniform3ui64vNV(int program, int location, int count, ulong* value) => GLPointers._ProgramUniform3ui64vNV_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform4ui64vNV(ProgramHandle program, int location, int count, ulong* value) => GLPointers._ProgramUniform4ui64vNV_fnptr((int)program, location, count, value);
+            public static void ProgramUniform4ui64vNV(int program, int location, int count, ulong* value) => GLPointers._ProgramUniform4ui64vNV_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_AMD_interleaved_elements]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -4995,7 +4995,7 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_AMD_occlusion_query_event]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void QueryObjectParameteruiAMD(QueryTarget target, QueryHandle id, All pname, OcclusionQueryEventMaskAMD param) => GLPointers._QueryObjectParameteruiAMD_fnptr((uint)target, (int)id, (uint)pname, (uint)param);
+            public static void QueryObjectParameteruiAMD(QueryTarget target, int id, All pname, OcclusionQueryEventMaskAMD param) => GLPointers._QueryObjectParameteruiAMD_fnptr((uint)target, id, (uint)pname, (uint)param);
             
             /// <summary> <b>[requires: GL_AMD_performance_monitor]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -5051,7 +5051,7 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_AMD_sparse_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureStorageSparseAMD(TextureHandle texture, All target, SizedInternalFormat internalFormat, int width, int height, int depth, int layers, TextureStorageMaskAMD flags) => GLPointers._TextureStorageSparseAMD_fnptr((int)texture, (uint)target, (uint)internalFormat, width, height, depth, layers, (uint)flags);
+            public static void TextureStorageSparseAMD(int texture, All target, SizedInternalFormat internalFormat, int width, int height, int depth, int layers, TextureStorageMaskAMD flags) => GLPointers._TextureStorageSparseAMD_fnptr(texture, (uint)target, (uint)internalFormat, width, height, depth, layers, (uint)flags);
             
             /// <summary> <b>[requires: GL_AMD_stencil_operation_extended]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -5150,19 +5150,19 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_APPLE_vertex_array_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void BindVertexArrayAPPLE(VertexArrayHandle array) => GLPointers._BindVertexArrayAPPLE_fnptr((int)array);
+            public static void BindVertexArrayAPPLE(int array) => GLPointers._BindVertexArrayAPPLE_fnptr(array);
             
             /// <summary> <b>[requires: GL_APPLE_vertex_array_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void DeleteVertexArraysAPPLE(int n, VertexArrayHandle* arrays) => GLPointers._DeleteVertexArraysAPPLE_fnptr(n, (int*)arrays);
+            public static void DeleteVertexArraysAPPLE(int n, int* arrays) => GLPointers._DeleteVertexArraysAPPLE_fnptr(n, arrays);
             
             /// <summary> <b>[requires: GL_APPLE_vertex_array_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GenVertexArraysAPPLE(int n, VertexArrayHandle* arrays) => GLPointers._GenVertexArraysAPPLE_fnptr(n, (int*)arrays);
+            public static void GenVertexArraysAPPLE(int n, int* arrays) => GLPointers._GenVertexArraysAPPLE_fnptr(n, arrays);
             
             /// <summary> <b>[requires: GL_APPLE_vertex_array_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static bool IsVertexArrayAPPLE(VertexArrayHandle array) => GLPointers._IsVertexArrayAPPLE_fnptr((int)array) != 0;
+            public static bool IsVertexArrayAPPLE(int array) => GLPointers._IsVertexArrayAPPLE_fnptr(array) != 0;
             
             /// <summary> <b>[requires: GL_APPLE_vertex_array_range]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -5218,7 +5218,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="binary"> Specifies the address of an array of bytes containing pre-compiled binary shader code. </param>
             /// <param name="length"> Specifies the length of the array whose address is given in binary. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glShaderBinary.xhtml" /></remarks>
-            public static void ShaderBinary(int count, ShaderHandle* shaders, ShaderBinaryFormat binaryFormat, void* binary, int length) => GLPointers._ShaderBinary_fnptr(count, (int*)shaders, (uint)binaryFormat, binary, length);
+            public static void ShaderBinary(int count, int* shaders, ShaderBinaryFormat binaryFormat, void* binary, int length) => GLPointers._ShaderBinary_fnptr(count, shaders, (uint)binaryFormat, binary, length);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_ES2_compatibility]</b> Retrieve the range and precision for numeric formats supported by the shader compiler. </summary>
             /// <param name="shaderType"> Specifies the type of shader whose precision to query. shaderType must be GL_VERTEX_SHADER or GL_FRAGMENT_SHADER. </param>
@@ -5280,11 +5280,11 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_ARB_bindless_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static ulong GetTextureHandleARB(TextureHandle texture) => GLPointers._GetTextureHandleARB_fnptr((int)texture);
+            public static ulong GetTextureHandleARB(int texture) => GLPointers._GetTextureHandleARB_fnptr(texture);
             
             /// <summary> <b>[requires: GL_ARB_bindless_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static ulong GetTextureSamplerHandleARB(TextureHandle texture, SamplerHandle sampler) => GLPointers._GetTextureSamplerHandleARB_fnptr((int)texture, (int)sampler);
+            public static ulong GetTextureSamplerHandleARB(int texture, int sampler) => GLPointers._GetTextureSamplerHandleARB_fnptr(texture, sampler);
             
             /// <summary> <b>[requires: GL_ARB_bindless_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -5296,7 +5296,7 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_ARB_bindless_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static ulong GetImageHandleARB(TextureHandle texture, int level, bool layered, int layer, PixelFormat format) => GLPointers._GetImageHandleARB_fnptr((int)texture, level, (byte)(layered ? 1 : 0), layer, (uint)format);
+            public static ulong GetImageHandleARB(int texture, int level, bool layered, int layer, PixelFormat format) => GLPointers._GetImageHandleARB_fnptr(texture, level, (byte)(layered ? 1 : 0), layer, (uint)format);
             
             /// <summary> <b>[requires: GL_ARB_bindless_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -5316,11 +5316,11 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_ARB_bindless_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformHandleui64ARB(ProgramHandle program, int location, ulong value) => GLPointers._ProgramUniformHandleui64ARB_fnptr((int)program, location, value);
+            public static void ProgramUniformHandleui64ARB(int program, int location, ulong value) => GLPointers._ProgramUniformHandleui64ARB_fnptr(program, location, value);
             
             /// <summary> <b>[requires: GL_ARB_bindless_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformHandleui64vARB(ProgramHandle program, int location, int count, ulong* values) => GLPointers._ProgramUniformHandleui64vARB_fnptr((int)program, location, count, values);
+            public static void ProgramUniformHandleui64vARB(int program, int location, int count, ulong* values) => GLPointers._ProgramUniformHandleui64vARB_fnptr(program, location, count, values);
             
             /// <summary> <b>[requires: GL_ARB_bindless_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -5348,13 +5348,13 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="index"> The index of the color input to bind the user-defined varying out variable to </param>
             /// <param name="name"> The name of the user-defined varying out variable whose binding to modify </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindFragDataLocationIndexed.xhtml" /></remarks>
-            public static void BindFragDataLocationIndexed(ProgramHandle program, uint colorNumber, uint index, byte* name) => GLPointers._BindFragDataLocationIndexed_fnptr((int)program, colorNumber, index, name);
+            public static void BindFragDataLocationIndexed(int program, uint colorNumber, uint index, byte* name) => GLPointers._BindFragDataLocationIndexed_fnptr(program, colorNumber, index, name);
             
             /// <summary> <b>[requires: v3.3 | GL_ARB_blend_func_extended]</b> Query the bindings of color indices to user-defined varying out variables. </summary>
             /// <param name="program"> The name of the program containing varying out variable whose binding to query </param>
             /// <param name="name"> The name of the user-defined varying out variable whose index to query </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetFragDataIndex.xhtml" /></remarks>
-            public static int GetFragDataIndex(ProgramHandle program, byte* name) => GLPointers._GetFragDataIndex_fnptr((int)program, name);
+            public static int GetFragDataIndex(int program, byte* name) => GLPointers._GetFragDataIndex_fnptr(program, name);
             
             /// <summary> <b>[requires: v4.4 | GL_ARB_buffer_storage]</b> Creates and initializes a buffer object's immutable data    store. </summary>
             /// <param name="target"> Specifies the target to which the buffer object is bound for glBufferStorage, which must be one of the buffer binding targets in the following table: </param>
@@ -5395,7 +5395,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="type"> The type of the data whose address in memory is given by data. </param>
             /// <param name="data"> The address in memory of the data to be used to clear the specified region. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glClearTexImage.xhtml" /></remarks>
-            public static void ClearTexImage(TextureHandle texture, int level, PixelFormat format, PixelType type, void* data) => GLPointers._ClearTexImage_fnptr((int)texture, level, (uint)format, (uint)type, data);
+            public static void ClearTexImage(int texture, int level, PixelFormat format, PixelType type, void* data) => GLPointers._ClearTexImage_fnptr(texture, level, (uint)format, (uint)type, data);
             
             /// <summary> <b>[requires: v4.4 | GL_ARB_clear_texture]</b> Fills all or part of a texture image with a constant value. </summary>
             /// <param name="texture"> The name of an existing texture object containing the image to be cleared. </param>
@@ -5410,7 +5410,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="type"> The type of the data whose address in memory is given by data. </param>
             /// <param name="data"> The address in memory of the data to be used to clear the specified region. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glClearTexSubImage.xhtml" /></remarks>
-            public static void ClearTexSubImage(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, void* data) => GLPointers._ClearTexSubImage_fnptr((int)texture, level, xoffset, yoffset, zoffset, width, height, depth, (uint)format, (uint)type, data);
+            public static void ClearTexSubImage(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, void* data) => GLPointers._ClearTexSubImage_fnptr(texture, level, xoffset, yoffset, zoffset, width, height, depth, (uint)format, (uint)type, data);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_clip_control]</b> Control clip coordinate to window coordinate behavior. </summary>
             /// <param name="origin"> Specifies the clip control origin. Must be one of GL_LOWER_LEFT or GL_UPPER_LEFT. </param>
@@ -5486,14 +5486,14 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="n"> Number of transform feedback objects to create. </param>
             /// <param name="ids"> Specifies an array in which names of the new transform feedback objects are stored. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCreateTransformFeedbacks.xhtml" /></remarks>
-            public static void CreateTransformFeedbacks(int n, TransformFeedbackHandle* ids) => GLPointers._CreateTransformFeedbacks_fnptr(n, (int*)ids);
+            public static void CreateTransformFeedbacks(int n, int* ids) => GLPointers._CreateTransformFeedbacks_fnptr(n, ids);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Bind a buffer object to a transform feedback buffer object. </summary>
             /// <param name="xfb"> Name of the transform feedback buffer object. </param>
             /// <param name="index"> Index of the binding point within xfb. </param>
             /// <param name="buffer"> Name of the buffer object to bind to the specified binding point. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTransformFeedbackBufferBase.xhtml" /></remarks>
-            public static void TransformFeedbackBufferBase(TransformFeedbackHandle xfb, uint index, BufferHandle buffer) => GLPointers._TransformFeedbackBufferBase_fnptr((int)xfb, index, (int)buffer);
+            public static void TransformFeedbackBufferBase(int xfb, uint index, int buffer) => GLPointers._TransformFeedbackBufferBase_fnptr(xfb, index, buffer);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Bind a range within a buffer object to a transform feedback buffer object. </summary>
             /// <param name="xfb"> Name of the transform feedback buffer object. </param>
@@ -5502,22 +5502,14 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="offset"> The starting offset in basic machine units into the buffer object. </param>
             /// <param name="size"> The amount of data in basic machine units that can be read from or written to the buffer object while used as an indexed target. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTransformFeedbackBufferRange.xhtml" /></remarks>
-            public static void TransformFeedbackBufferRange(TransformFeedbackHandle xfb, uint index, BufferHandle buffer, IntPtr offset, nint size) => GLPointers._TransformFeedbackBufferRange_fnptr((int)xfb, index, (int)buffer, offset, size);
+            public static void TransformFeedbackBufferRange(int xfb, uint index, int buffer, IntPtr offset, nint size) => GLPointers._TransformFeedbackBufferRange_fnptr(xfb, index, buffer, offset, size);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Query the state of a transform feedback object.. </summary>
             /// <param name="xfb">The name of an existing transform feedback object, or zero for the default transform feedback object.</param>
             /// <param name="pname">Property to use for the query. Must be one of the values: GL_TRANSFORM_FEEDBACK_BUFFER_BINDING, GL_TRANSFORM_FEEDBACK_BUFFER_START, GL_TRANSFORM_FEEDBACK_BUFFER_SIZE, GL_TRANSFORM_FEEDBACK_PAUSED, GL_TRANSFORM_FEEDBACK_ACTIVE.</param>
             /// <param name="param">The address of a buffer into which will be written the requested state information.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetTransformFeedback.xhtml" /></remarks>
-            public static void GetTransformFeedbackiv(TransformFeedbackHandle xfb, TransformFeedbackPName pname, int* param) => GLPointers._GetTransformFeedbackiv_fnptr((int)xfb, (uint)pname, param);
-            
-            /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Query the state of a transform feedback object.. </summary>
-            /// <param name="xfb">The name of an existing transform feedback object, or zero for the default transform feedback object.</param>
-            /// <param name="pname">Property to use for the query. Must be one of the values: GL_TRANSFORM_FEEDBACK_BUFFER_BINDING, GL_TRANSFORM_FEEDBACK_BUFFER_START, GL_TRANSFORM_FEEDBACK_BUFFER_SIZE, GL_TRANSFORM_FEEDBACK_PAUSED, GL_TRANSFORM_FEEDBACK_ACTIVE.</param>
-            /// <param name="index">Index of the transform feedback stream (for indexed state).</param>
-            /// <param name="param">The address of a buffer into which will be written the requested state information.</param>
-            /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetTransformFeedback.xhtml" /></remarks>
-            public static void GetTransformFeedbacki_v(TransformFeedbackHandle xfb, TransformFeedbackPName pname, uint index, int* param) => GLPointers._GetTransformFeedbacki_v_fnptr((int)xfb, (uint)pname, index, param);
+            public static void GetTransformFeedbackiv(int xfb, TransformFeedbackPName pname, int* param) => GLPointers._GetTransformFeedbackiv_fnptr(xfb, (uint)pname, param);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Query the state of a transform feedback object.. </summary>
             /// <param name="xfb">The name of an existing transform feedback object, or zero for the default transform feedback object.</param>
@@ -5525,13 +5517,21 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="index">Index of the transform feedback stream (for indexed state).</param>
             /// <param name="param">The address of a buffer into which will be written the requested state information.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetTransformFeedback.xhtml" /></remarks>
-            public static void GetTransformFeedbacki64_v(TransformFeedbackHandle xfb, TransformFeedbackPName pname, uint index, long* param) => GLPointers._GetTransformFeedbacki64_v_fnptr((int)xfb, (uint)pname, index, param);
+            public static void GetTransformFeedbacki_v(int xfb, TransformFeedbackPName pname, uint index, int* param) => GLPointers._GetTransformFeedbacki_v_fnptr(xfb, (uint)pname, index, param);
+            
+            /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Query the state of a transform feedback object.. </summary>
+            /// <param name="xfb">The name of an existing transform feedback object, or zero for the default transform feedback object.</param>
+            /// <param name="pname">Property to use for the query. Must be one of the values: GL_TRANSFORM_FEEDBACK_BUFFER_BINDING, GL_TRANSFORM_FEEDBACK_BUFFER_START, GL_TRANSFORM_FEEDBACK_BUFFER_SIZE, GL_TRANSFORM_FEEDBACK_PAUSED, GL_TRANSFORM_FEEDBACK_ACTIVE.</param>
+            /// <param name="index">Index of the transform feedback stream (for indexed state).</param>
+            /// <param name="param">The address of a buffer into which will be written the requested state information.</param>
+            /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetTransformFeedback.xhtml" /></remarks>
+            public static void GetTransformFeedbacki64_v(int xfb, TransformFeedbackPName pname, uint index, long* param) => GLPointers._GetTransformFeedbacki64_v_fnptr(xfb, (uint)pname, index, param);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Create buffer objects. </summary>
             /// <param name="n"> Specifies the number of buffer objects to create. </param>
             /// <param name="buffers"> Specifies an array in which names of the new buffer objects are stored. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCreateBuffers.xhtml" /></remarks>
-            public static void CreateBuffers(int n, BufferHandle* buffers) => GLPointers._CreateBuffers_fnptr(n, (int*)buffers);
+            public static void CreateBuffers(int n, int* buffers) => GLPointers._CreateBuffers_fnptr(n, buffers);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Creates and initializes a buffer object's immutable data    store. </summary>
             /// <param name="buffer">Specifies the name of the buffer object for glNamedBufferStorage function.</param>
@@ -5539,7 +5539,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="data">Specifies a pointer to data that will be copied into the data store for initialization, or NULL if no data is to be copied.</param>
             /// <param name="flags">Specifies the intended usage of the buffer's data store. Must be a bitwise combination of the following flags. GL_DYNAMIC_STORAGE_BIT, GL_MAP_READ_BIT GL_MAP_WRITE_BIT, GL_MAP_PERSISTENT_BIT, GL_MAP_COHERENT_BIT, and GL_CLIENT_STORAGE_BIT.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBufferStorage.xhtml" /></remarks>
-            public static void NamedBufferStorage(BufferHandle buffer, nint size, void* data, BufferStorageMask flags) => GLPointers._NamedBufferStorage_fnptr((int)buffer, size, data, (uint)flags);
+            public static void NamedBufferStorage(int buffer, nint size, void* data, BufferStorageMask flags) => GLPointers._NamedBufferStorage_fnptr(buffer, size, data, (uint)flags);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Creates and initializes a buffer object's data    store. </summary>
             /// <param name="buffer">Specifies the name of the buffer object for glNamedBufferData function.</param>
@@ -5547,7 +5547,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="data">Specifies a pointer to data that will be copied into the data store for initialization, or NULL if no data is to be copied.</param>
             /// <param name="usage">Specifies the expected usage pattern of the data store. The symbolic constant must be GL_STREAM_DRAW, GL_STREAM_READ, GL_STREAM_COPY, GL_STATIC_DRAW, GL_STATIC_READ, GL_STATIC_COPY, GL_DYNAMIC_DRAW, GL_DYNAMIC_READ, or GL_DYNAMIC_COPY.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBufferData.xhtml" /></remarks>
-            public static void NamedBufferData(BufferHandle buffer, nint size, void* data, VertexBufferObjectUsage usage) => GLPointers._NamedBufferData_fnptr((int)buffer, size, data, (uint)usage);
+            public static void NamedBufferData(int buffer, nint size, void* data, VertexBufferObjectUsage usage) => GLPointers._NamedBufferData_fnptr(buffer, size, data, (uint)usage);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Updates a subset of a buffer object's data store. </summary>
             /// <param name="buffer"> Specifies the name of the buffer object for glNamedBufferSubData. </param>
@@ -5555,7 +5555,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="size"> Specifies the size in bytes of the data store region being replaced. </param>
             /// <param name="data"> Specifies a pointer to the new data that will be copied into the data store. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBufferSubData.xhtml" /></remarks>
-            public static void NamedBufferSubData(BufferHandle buffer, IntPtr offset, nint size, void* data) => GLPointers._NamedBufferSubData_fnptr((int)buffer, offset, size, data);
+            public static void NamedBufferSubData(int buffer, IntPtr offset, nint size, void* data) => GLPointers._NamedBufferSubData_fnptr(buffer, offset, size, data);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Copy all or part of the data store of a buffer object to the data store of another buffer object. </summary>
             /// <param name="readBuffer"> Specifies the name of the source buffer object for glCopyNamedBufferSubData. </param>
@@ -5564,7 +5564,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="writeOffset"> Specifies the offset, in basic machine units, within the data store of the destination buffer object at which data will be written. </param>
             /// <param name="size"> Specifies the size, in basic machine units, of the data to be copied from the source buffer object to the destination buffer object. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCopyBufferSubData.xhtml" /></remarks>
-            public static void CopyNamedBufferSubData(BufferHandle readBuffer, BufferHandle writeBuffer, IntPtr readOffset, IntPtr writeOffset, nint size) => GLPointers._CopyNamedBufferSubData_fnptr((int)readBuffer, (int)writeBuffer, readOffset, writeOffset, size);
+            public static void CopyNamedBufferSubData(int readBuffer, int writeBuffer, IntPtr readOffset, IntPtr writeOffset, nint size) => GLPointers._CopyNamedBufferSubData_fnptr(readBuffer, writeBuffer, readOffset, writeOffset, size);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Fill a buffer object's data store with a fixed value. </summary>
             /// <param name="buffer"> Specifies the name of the buffer object for glClearNamedBufferData. </param>
@@ -5573,7 +5573,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="type"> The type of the data in memory addressed by data. </param>
             /// <param name="data"> The address of a memory location storing the data to be replicated into the buffer's data store. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glClearBufferData.xhtml" /></remarks>
-            public static void ClearNamedBufferData(BufferHandle buffer, SizedInternalFormat internalformat, PixelFormat format, PixelType type, void* data) => GLPointers._ClearNamedBufferData_fnptr((int)buffer, (uint)internalformat, (uint)format, (uint)type, data);
+            public static void ClearNamedBufferData(int buffer, SizedInternalFormat internalformat, PixelFormat format, PixelType type, void* data) => GLPointers._ClearNamedBufferData_fnptr(buffer, (uint)internalformat, (uint)format, (uint)type, data);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Fill all or part of buffer object's data store with a fixed value. </summary>
             /// <param name="buffer"> Specifies the name of the buffer object for glClearNamedBufferSubData. </param>
@@ -5584,13 +5584,13 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="type"> The type of the data in memory addressed by data. </param>
             /// <param name="data"> The address of a memory location storing the data to be replicated into the buffer's data store. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glClearBufferSubData.xhtml" /></remarks>
-            public static void ClearNamedBufferSubData(BufferHandle buffer, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, void* data) => GLPointers._ClearNamedBufferSubData_fnptr((int)buffer, (uint)internalformat, offset, size, (uint)format, (uint)type, data);
+            public static void ClearNamedBufferSubData(int buffer, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, void* data) => GLPointers._ClearNamedBufferSubData_fnptr(buffer, (uint)internalformat, offset, size, (uint)format, (uint)type, data);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Map all of a buffer object's data store into the client's address space. </summary>
             /// <param name="buffer"> Specifies the name of the buffer object for glMapNamedBuffer. </param>
             /// <param name="access"> Specifies the access policy for glMapBuffer and glMapNamedBuffer, indicating whether it will be possible to read from, write to, or both read from and write to the buffer object's mapped data store. The symbolic constant must be GL_READ_ONLY, GL_WRITE_ONLY, or GL_READ_WRITE. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glMapBuffer.xhtml" /></remarks>
-            public static void* MapNamedBuffer(BufferHandle buffer, BufferAccessARB access) => GLPointers._MapNamedBuffer_fnptr((int)buffer, (uint)access);
+            public static void* MapNamedBuffer(int buffer, BufferAccessARB access) => GLPointers._MapNamedBuffer_fnptr(buffer, (uint)access);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Map all or part of a buffer object's data store into the client's address space. </summary>
             /// <param name="buffer"> Specifies the name of the buffer object for glMapNamedBufferRange. </param>
@@ -5598,40 +5598,40 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="length"> Specifies the length of the range to be mapped. </param>
             /// <param name="access"> Specifies a combination of access flags indicating the desired access to the mapped range. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glMapBufferRange.xhtml" /></remarks>
-            public static void* MapNamedBufferRange(BufferHandle buffer, IntPtr offset, nint length, MapBufferAccessMask access) => GLPointers._MapNamedBufferRange_fnptr((int)buffer, offset, length, (uint)access);
+            public static void* MapNamedBufferRange(int buffer, IntPtr offset, nint length, MapBufferAccessMask access) => GLPointers._MapNamedBufferRange_fnptr(buffer, offset, length, (uint)access);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Release the mapping of a buffer object's data store into the client's address space. </summary>
             /// <param name="buffer"> Specifies the name of the buffer object for glUnmapNamedBuffer. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glUnmapBuffer.xhtml" /></remarks>
-            public static bool UnmapNamedBuffer(BufferHandle buffer) => GLPointers._UnmapNamedBuffer_fnptr((int)buffer) != 0;
+            public static bool UnmapNamedBuffer(int buffer) => GLPointers._UnmapNamedBuffer_fnptr(buffer) != 0;
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Indicate modifications to a range of a mapped buffer. </summary>
             /// <param name="buffer"> Specifies the name of the buffer object for glFlushMappedNamedBufferRange. </param>
             /// <param name="offset"> Specifies the start of the buffer subrange, in basic machine units. </param>
             /// <param name="length"> Specifies the length of the buffer subrange, in basic machine units. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glFlushMappedBufferRange.xhtml" /></remarks>
-            public static void FlushMappedNamedBufferRange(BufferHandle buffer, IntPtr offset, nint length) => GLPointers._FlushMappedNamedBufferRange_fnptr((int)buffer, offset, length);
+            public static void FlushMappedNamedBufferRange(int buffer, IntPtr offset, nint length) => GLPointers._FlushMappedNamedBufferRange_fnptr(buffer, offset, length);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Return parameters of a buffer object. </summary>
             /// <param name="buffer"> Specifies the name of the buffer object for glGetNamedBufferParameteriv and glGetNamedBufferParameteri64v. </param>
             /// <param name="pname">!!missing documentation!!</param>
             /// <param name="parameters">!!missing documentation!!</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetBufferParameter.xhtml" /></remarks>
-            public static void GetNamedBufferParameteriv(BufferHandle buffer, BufferPNameARB pname, int* parameters) => GLPointers._GetNamedBufferParameteriv_fnptr((int)buffer, (uint)pname, parameters);
+            public static void GetNamedBufferParameteriv(int buffer, BufferPNameARB pname, int* parameters) => GLPointers._GetNamedBufferParameteriv_fnptr(buffer, (uint)pname, parameters);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Return parameters of a buffer object. </summary>
             /// <param name="buffer"> Specifies the name of the buffer object for glGetNamedBufferParameteriv and glGetNamedBufferParameteri64v. </param>
             /// <param name="pname">!!missing documentation!!</param>
             /// <param name="parameters">!!missing documentation!!</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetBufferParameter.xhtml" /></remarks>
-            public static void GetNamedBufferParameteri64v(BufferHandle buffer, BufferPNameARB pname, long* parameters) => GLPointers._GetNamedBufferParameteri64v_fnptr((int)buffer, (uint)pname, parameters);
+            public static void GetNamedBufferParameteri64v(int buffer, BufferPNameARB pname, long* parameters) => GLPointers._GetNamedBufferParameteri64v_fnptr(buffer, (uint)pname, parameters);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Return the pointer to a mapped buffer object's data store. </summary>
             /// <param name="buffer"> Specifies the name of the buffer object for glGetNamedBufferPointerv. </param>
             /// <param name="pname"> Specifies the name of the pointer to be returned. Must be GL_BUFFER_MAP_POINTER. </param>
             /// <param name="parameters"> Returns the pointer value specified by pname. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetBufferPointerv.xhtml" /></remarks>
-            public static void GetNamedBufferPointerv(BufferHandle buffer, BufferPointerNameARB pname, void** parameters) => GLPointers._GetNamedBufferPointerv_fnptr((int)buffer, (uint)pname, parameters);
+            public static void GetNamedBufferPointerv(int buffer, BufferPointerNameARB pname, void** parameters) => GLPointers._GetNamedBufferPointerv_fnptr(buffer, (uint)pname, parameters);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Returns a subset of a buffer object's data store. </summary>
             /// <param name="buffer"> Specifies the name of the buffer object for glGetNamedBufferSubData. </param>
@@ -5639,13 +5639,13 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="size"> Specifies the size in bytes of the data store region being returned. </param>
             /// <param name="data"> Specifies a pointer to the location where buffer object data is returned. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetBufferSubData.xhtml" /></remarks>
-            public static void GetNamedBufferSubData(BufferHandle buffer, IntPtr offset, nint size, void* data) => GLPointers._GetNamedBufferSubData_fnptr((int)buffer, offset, size, data);
+            public static void GetNamedBufferSubData(int buffer, IntPtr offset, nint size, void* data) => GLPointers._GetNamedBufferSubData_fnptr(buffer, offset, size, data);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Create framebuffer objects. </summary>
             /// <param name="n"> Number of framebuffer objects to create. </param>
             /// <param name="framebuffers"> Specifies an array in which names of the new framebuffer objects are stored. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCreateFramebuffers.xhtml" /></remarks>
-            public static void CreateFramebuffers(int n, FramebufferHandle* framebuffers) => GLPointers._CreateFramebuffers_fnptr(n, (int*)framebuffers);
+            public static void CreateFramebuffers(int n, int* framebuffers) => GLPointers._CreateFramebuffers_fnptr(n, framebuffers);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Attach a renderbuffer as a logical buffer of a framebuffer object. </summary>
             /// <param name="framebuffer"> Specifies the name of the framebuffer object for glNamedFramebufferRenderbuffer. </param>
@@ -5653,14 +5653,14 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="renderbuffertarget"> Specifies the renderbuffer target. Must be GL_RENDERBUFFER. </param>
             /// <param name="renderbuffer"> Specifies the name of an existing renderbuffer object of type renderbuffertarget to attach. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glFramebufferRenderbuffer.xhtml" /></remarks>
-            public static void NamedFramebufferRenderbuffer(FramebufferHandle framebuffer, FramebufferAttachment attachment, RenderbufferTarget renderbuffertarget, RenderbufferHandle renderbuffer) => GLPointers._NamedFramebufferRenderbuffer_fnptr((int)framebuffer, (uint)attachment, (uint)renderbuffertarget, (int)renderbuffer);
+            public static void NamedFramebufferRenderbuffer(int framebuffer, FramebufferAttachment attachment, RenderbufferTarget renderbuffertarget, int renderbuffer) => GLPointers._NamedFramebufferRenderbuffer_fnptr(framebuffer, (uint)attachment, (uint)renderbuffertarget, renderbuffer);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Set a named parameter of a framebuffer object. </summary>
             /// <param name="framebuffer"> Specifies the name of the framebuffer object for glNamedFramebufferParameteri. </param>
             /// <param name="pname"> Specifies the framebuffer parameter to be modified. </param>
             /// <param name="param"> The new value for the parameter named pname. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glFramebufferParameteri.xhtml" /></remarks>
-            public static void NamedFramebufferParameteri(FramebufferHandle framebuffer, FramebufferParameterName pname, int param) => GLPointers._NamedFramebufferParameteri_fnptr((int)framebuffer, (uint)pname, param);
+            public static void NamedFramebufferParameteri(int framebuffer, FramebufferParameterName pname, int param) => GLPointers._NamedFramebufferParameteri_fnptr(framebuffer, (uint)pname, param);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Attach a level of a texture object as a logical buffer of a framebuffer object. </summary>
             /// <param name="framebuffer"> Specifies the name of the framebuffer object for glNamedFramebufferTexture. </param>
@@ -5668,7 +5668,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="texture"> Specifies the name of an existing texture object to attach. </param>
             /// <param name="level"> Specifies the mipmap level of the texture object to attach. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glFramebufferTexture.xhtml" /></remarks>
-            public static void NamedFramebufferTexture(FramebufferHandle framebuffer, FramebufferAttachment attachment, TextureHandle texture, int level) => GLPointers._NamedFramebufferTexture_fnptr((int)framebuffer, (uint)attachment, (int)texture, level);
+            public static void NamedFramebufferTexture(int framebuffer, FramebufferAttachment attachment, int texture, int level) => GLPointers._NamedFramebufferTexture_fnptr(framebuffer, (uint)attachment, texture, level);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Attach a single layer of a texture object as a logical buffer of a framebuffer object. </summary>
             /// <param name="framebuffer"> Specifies the name of the framebuffer object for glNamedFramebufferTextureLayer. </param>
@@ -5677,33 +5677,33 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="level"> Specifies the mipmap level of the texture object to attach. </param>
             /// <param name="layer"> Specifies the layer of the texture object to attach. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glFramebufferTextureLayer.xhtml" /></remarks>
-            public static void NamedFramebufferTextureLayer(FramebufferHandle framebuffer, FramebufferAttachment attachment, TextureHandle texture, int level, int layer) => GLPointers._NamedFramebufferTextureLayer_fnptr((int)framebuffer, (uint)attachment, (int)texture, level, layer);
+            public static void NamedFramebufferTextureLayer(int framebuffer, FramebufferAttachment attachment, int texture, int level, int layer) => GLPointers._NamedFramebufferTextureLayer_fnptr(framebuffer, (uint)attachment, texture, level, layer);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specify which color buffers are to be drawn into. </summary>
             /// <param name="framebuffer">Specifies the name of the framebuffer object for glNamedFramebufferDrawBuffer function. Must be zero or the name of a framebuffer object.</param>
             /// <param name="buf">For default framebuffer, the argument specifies up to four color buffers to be drawn into. Symbolic constants GL_NONE, GL_FRONT_LEFT, GL_FRONT_RIGHT, GL_BACK_LEFT, GL_BACK_RIGHT, GL_FRONT, GL_BACK, GL_LEFT, GL_RIGHT, and GL_FRONT_AND_BACK are accepted. The initial value is GL_FRONT for single-buffered contexts, and GL_BACK for double-buffered contexts. For framebuffer objects, GL_COLOR_ATTACHMENT$m$ and GL_NONE enums are accepted, where $m$ is a value between 0 and GL_MAX_COLOR_ATTACHMENTS.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDrawBuffer.xhtml" /></remarks>
-            public static void NamedFramebufferDrawBuffer(FramebufferHandle framebuffer, ColorBuffer buf) => GLPointers._NamedFramebufferDrawBuffer_fnptr((int)framebuffer, (uint)buf);
+            public static void NamedFramebufferDrawBuffer(int framebuffer, ColorBuffer buf) => GLPointers._NamedFramebufferDrawBuffer_fnptr(framebuffer, (uint)buf);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specifies a list of color buffers to be drawn    into. </summary>
             /// <param name="framebuffer">Specifies the name of the framebuffer object for glNamedFramebufferDrawBuffers.</param>
             /// <param name="n">Specifies the number of buffers in bufs.</param>
             /// <param name="bufs">Points to an array of symbolic constants specifying the buffers into which fragment colors or data values will be written.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDrawBuffers.xhtml" /></remarks>
-            public static void NamedFramebufferDrawBuffers(FramebufferHandle framebuffer, int n, ColorBuffer* bufs) => GLPointers._NamedFramebufferDrawBuffers_fnptr((int)framebuffer, n, (uint*)bufs);
+            public static void NamedFramebufferDrawBuffers(int framebuffer, int n, ColorBuffer* bufs) => GLPointers._NamedFramebufferDrawBuffers_fnptr(framebuffer, n, (uint*)bufs);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Select a color buffer source for pixels. </summary>
             /// <param name="framebuffer">Specifies the name of the framebuffer object for glNamedFramebufferReadBuffer function.</param>
             /// <param name="mode">Specifies a color buffer. Accepted values are GL_FRONT_LEFT, GL_FRONT_RIGHT, GL_BACK_LEFT, GL_BACK_RIGHT, GL_FRONT, GL_BACK, GL_LEFT, GL_RIGHT, and the constants GL_COLOR_ATTACHMENTi.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glReadBuffer.xhtml" /></remarks>
-            public static void NamedFramebufferReadBuffer(FramebufferHandle framebuffer, ColorBuffer src) => GLPointers._NamedFramebufferReadBuffer_fnptr((int)framebuffer, (uint)src);
+            public static void NamedFramebufferReadBuffer(int framebuffer, ColorBuffer src) => GLPointers._NamedFramebufferReadBuffer_fnptr(framebuffer, (uint)src);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Invalidate the content of some or all of a framebuffer's attachments. </summary>
             /// <param name="framebuffer"> Specifies the name of the framebuffer object for glInvalidateNamedFramebufferData. </param>
             /// <param name="numAttachments"> Specifies the number of entries in the attachments array. </param>
             /// <param name="attachments"> Specifies a pointer to an array identifying the attachments to be invalidated. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glInvalidateFramebuffer.xhtml" /></remarks>
-            public static void InvalidateNamedFramebufferData(FramebufferHandle framebuffer, int numAttachments, FramebufferAttachment* attachments) => GLPointers._InvalidateNamedFramebufferData_fnptr((int)framebuffer, numAttachments, (uint*)attachments);
+            public static void InvalidateNamedFramebufferData(int framebuffer, int numAttachments, FramebufferAttachment* attachments) => GLPointers._InvalidateNamedFramebufferData_fnptr(framebuffer, numAttachments, (uint*)attachments);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Invalidate the content of a region of some or all of a framebuffer's attachments. </summary>
             /// <param name="framebuffer"> Specifies the name of the framebuffer object for glInvalidateNamedFramebufferSubData. </param>
@@ -5714,7 +5714,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="width"> Specifies the width of the region to be invalidated. </param>
             /// <param name="height"> Specifies the height of the region to be invalidated. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glInvalidateSubFramebuffer.xhtml" /></remarks>
-            public static void InvalidateNamedFramebufferSubData(FramebufferHandle framebuffer, int numAttachments, FramebufferAttachment* attachments, int x, int y, int width, int height) => GLPointers._InvalidateNamedFramebufferSubData_fnptr((int)framebuffer, numAttachments, (uint*)attachments, x, y, width, height);
+            public static void InvalidateNamedFramebufferSubData(int framebuffer, int numAttachments, FramebufferAttachment* attachments, int x, int y, int width, int height) => GLPointers._InvalidateNamedFramebufferSubData_fnptr(framebuffer, numAttachments, (uint*)attachments, x, y, width, height);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Clear individual buffers of a framebuffer. </summary>
             /// <param name="framebuffer"> Specifies the name of the framebuffer object for glClearNamedFramebuffer*. </param>
@@ -5722,7 +5722,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="drawbuffer"> Specify a particular draw buffer to clear. </param>
             /// <param name="value"> A pointer to the value or values to clear the buffer to. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glClearBuffer.xhtml" /></remarks>
-            public static void ClearNamedFramebufferiv(FramebufferHandle framebuffer, Buffer buffer, int drawbuffer, int* value) => GLPointers._ClearNamedFramebufferiv_fnptr((int)framebuffer, (uint)buffer, drawbuffer, value);
+            public static void ClearNamedFramebufferiv(int framebuffer, Buffer buffer, int drawbuffer, int* value) => GLPointers._ClearNamedFramebufferiv_fnptr(framebuffer, (uint)buffer, drawbuffer, value);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Clear individual buffers of a framebuffer. </summary>
             /// <param name="framebuffer"> Specifies the name of the framebuffer object for glClearNamedFramebuffer*. </param>
@@ -5730,7 +5730,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="drawbuffer"> Specify a particular draw buffer to clear. </param>
             /// <param name="value"> A pointer to the value or values to clear the buffer to. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glClearBuffer.xhtml" /></remarks>
-            public static void ClearNamedFramebufferuiv(FramebufferHandle framebuffer, Buffer buffer, int drawbuffer, uint* value) => GLPointers._ClearNamedFramebufferuiv_fnptr((int)framebuffer, (uint)buffer, drawbuffer, value);
+            public static void ClearNamedFramebufferuiv(int framebuffer, Buffer buffer, int drawbuffer, uint* value) => GLPointers._ClearNamedFramebufferuiv_fnptr(framebuffer, (uint)buffer, drawbuffer, value);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Clear individual buffers of a framebuffer. </summary>
             /// <param name="framebuffer"> Specifies the name of the framebuffer object for glClearNamedFramebuffer*. </param>
@@ -5738,7 +5738,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="drawbuffer"> Specify a particular draw buffer to clear. </param>
             /// <param name="value"> A pointer to the value or values to clear the buffer to. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glClearBuffer.xhtml" /></remarks>
-            public static void ClearNamedFramebufferfv(FramebufferHandle framebuffer, Buffer buffer, int drawbuffer, float* value) => GLPointers._ClearNamedFramebufferfv_fnptr((int)framebuffer, (uint)buffer, drawbuffer, value);
+            public static void ClearNamedFramebufferfv(int framebuffer, Buffer buffer, int drawbuffer, float* value) => GLPointers._ClearNamedFramebufferfv_fnptr(framebuffer, (uint)buffer, drawbuffer, value);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Clear individual buffers of a framebuffer. </summary>
             /// <param name="framebuffer"> Specifies the name of the framebuffer object for glClearNamedFramebuffer*. </param>
@@ -5747,7 +5747,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="depth"> The value to clear the depth buffer to. </param>
             /// <param name="stencil"> The value to clear the stencil buffer to. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glClearBuffer.xhtml" /></remarks>
-            public static void ClearNamedFramebufferfi(FramebufferHandle framebuffer, Buffer buffer, int drawbuffer, float depth, int stencil) => GLPointers._ClearNamedFramebufferfi_fnptr((int)framebuffer, (uint)buffer, drawbuffer, depth, stencil);
+            public static void ClearNamedFramebufferfi(int framebuffer, Buffer buffer, int drawbuffer, float depth, int stencil) => GLPointers._ClearNamedFramebufferfi_fnptr(framebuffer, (uint)buffer, drawbuffer, depth, stencil);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Copy a block of pixels from one framebuffer object to another. </summary>
             /// <param name="readFramebuffer"> Specifies the name of the source framebuffer object for glBlitNamedFramebuffer. </param>
@@ -5763,20 +5763,20 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="mask"> The bitwise OR of the flags indicating which buffers are to be copied. The allowed flags are GL_COLOR_BUFFER_BIT, GL_DEPTH_BUFFER_BIT and GL_STENCIL_BUFFER_BIT. </param>
             /// <param name="filter"> Specifies the interpolation to be applied if the image is stretched. Must be GL_NEAREST or GL_LINEAR. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBlitFramebuffer.xhtml" /></remarks>
-            public static void BlitNamedFramebuffer(FramebufferHandle readFramebuffer, FramebufferHandle drawFramebuffer, int srcX0, int srcY0, int srcX1, int srcY1, int dstX0, int dstY0, int dstX1, int dstY1, ClearBufferMask mask, BlitFramebufferFilter filter) => GLPointers._BlitNamedFramebuffer_fnptr((int)readFramebuffer, (int)drawFramebuffer, srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, (uint)mask, (uint)filter);
+            public static void BlitNamedFramebuffer(int readFramebuffer, int drawFramebuffer, int srcX0, int srcY0, int srcX1, int srcY1, int dstX0, int dstY0, int dstX1, int dstY1, ClearBufferMask mask, BlitFramebufferFilter filter) => GLPointers._BlitNamedFramebuffer_fnptr(readFramebuffer, drawFramebuffer, srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, (uint)mask, (uint)filter);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Check the completeness status of a framebuffer. </summary>
             /// <param name="framebuffer"> Specifies the name of the framebuffer object for glCheckNamedFramebufferStatus </param>
             /// <param name="target"> Specify the target to which the framebuffer is bound for glCheckFramebufferStatus, and the target against which framebuffer completeness of framebuffer is checked for glCheckNamedFramebufferStatus. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCheckFramebufferStatus.xhtml" /></remarks>
-            public static FramebufferStatus CheckNamedFramebufferStatus(FramebufferHandle framebuffer, FramebufferTarget target) => (FramebufferStatus) GLPointers._CheckNamedFramebufferStatus_fnptr((int)framebuffer, (uint)target);
+            public static FramebufferStatus CheckNamedFramebufferStatus(int framebuffer, FramebufferTarget target) => (FramebufferStatus) GLPointers._CheckNamedFramebufferStatus_fnptr(framebuffer, (uint)target);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Query a named parameter of a framebuffer object. </summary>
             /// <param name="framebuffer"> Specifies the name of the framebuffer object for glGetNamedFramebufferParameteriv. </param>
             /// <param name="pname"> Specifies the parameter of the framebuffer object to query. </param>
             /// <param name="param">!!missing documentation!!</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetFramebufferParameter.xhtml" /></remarks>
-            public static void GetNamedFramebufferParameteriv(FramebufferHandle framebuffer, GetFramebufferParameter pname, int* param) => GLPointers._GetNamedFramebufferParameteriv_fnptr((int)framebuffer, (uint)pname, param);
+            public static void GetNamedFramebufferParameteriv(int framebuffer, GetFramebufferParameter pname, int* param) => GLPointers._GetNamedFramebufferParameteriv_fnptr(framebuffer, (uint)pname, param);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Retrieve information about attachments of a framebuffer object. </summary>
             /// <param name="framebuffer"> Specifies the name of the framebuffer object for glGetNamedFramebufferAttachmentParameteriv. </param>
@@ -5784,13 +5784,13 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="pname"> Specifies the parameter of attachment to query. </param>
             /// <param name="parameters"> Returns the value of parameter pname for attachment. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetFramebufferAttachmentParameter.xhtml" /></remarks>
-            public static void GetNamedFramebufferAttachmentParameteriv(FramebufferHandle framebuffer, FramebufferAttachment attachment, FramebufferAttachmentParameterName pname, int* parameters) => GLPointers._GetNamedFramebufferAttachmentParameteriv_fnptr((int)framebuffer, (uint)attachment, (uint)pname, parameters);
+            public static void GetNamedFramebufferAttachmentParameteriv(int framebuffer, FramebufferAttachment attachment, FramebufferAttachmentParameterName pname, int* parameters) => GLPointers._GetNamedFramebufferAttachmentParameteriv_fnptr(framebuffer, (uint)attachment, (uint)pname, parameters);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Create renderbuffer objects. </summary>
             /// <param name="n"> Number of renderbuffer objects to create. </param>
             /// <param name="renderbuffers"> Specifies an array in which names of the new renderbuffer objects are stored. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCreateRenderbuffers.xhtml" /></remarks>
-            public static void CreateRenderbuffers(int n, RenderbufferHandle* renderbuffers) => GLPointers._CreateRenderbuffers_fnptr(n, (int*)renderbuffers);
+            public static void CreateRenderbuffers(int n, int* renderbuffers) => GLPointers._CreateRenderbuffers_fnptr(n, renderbuffers);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Establish data storage, format and dimensions of a    renderbuffer object's image. </summary>
             /// <param name="renderbuffer">Specifies the name of the renderbuffer object for glNamedRenderbufferStorage function.</param>
@@ -5798,7 +5798,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="width">Specifies the width of the renderbuffer, in pixels.</param>
             /// <param name="height">Specifies the height of the renderbuffer, in pixels.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glRenderbufferStorage.xhtml" /></remarks>
-            public static void NamedRenderbufferStorage(RenderbufferHandle renderbuffer, InternalFormat internalformat, int width, int height) => GLPointers._NamedRenderbufferStorage_fnptr((int)renderbuffer, (uint)internalformat, width, height);
+            public static void NamedRenderbufferStorage(int renderbuffer, InternalFormat internalformat, int width, int height) => GLPointers._NamedRenderbufferStorage_fnptr(renderbuffer, (uint)internalformat, width, height);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Establish data storage, format, dimensions and sample count of    a renderbuffer object's image. </summary>
             /// <param name="renderbuffer">Specifies the name of the renderbuffer object for glNamedRenderbufferStorageMultisample function.</param>
@@ -5807,28 +5807,28 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="width">Specifies the width of the renderbuffer, in pixels.</param>
             /// <param name="height">Specifies the height of the renderbuffer, in pixels.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glRenderbufferStorageMultisample.xhtml" /></remarks>
-            public static void NamedRenderbufferStorageMultisample(RenderbufferHandle renderbuffer, int samples, InternalFormat internalformat, int width, int height) => GLPointers._NamedRenderbufferStorageMultisample_fnptr((int)renderbuffer, samples, (uint)internalformat, width, height);
+            public static void NamedRenderbufferStorageMultisample(int renderbuffer, int samples, InternalFormat internalformat, int width, int height) => GLPointers._NamedRenderbufferStorageMultisample_fnptr(renderbuffer, samples, (uint)internalformat, width, height);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Query a named parameter of a renderbuffer object. </summary>
             /// <param name="renderbuffer"> Specifies the name of the renderbuffer object for glGetNamedRenderbufferParameteriv. </param>
             /// <param name="pname"> Specifies the parameter of the renderbuffer object to query. </param>
             /// <param name="parameters"> Returns the value of parameter pname for the renderbuffer object. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetRenderbufferParameter.xhtml" /></remarks>
-            public static void GetNamedRenderbufferParameteriv(RenderbufferHandle renderbuffer, RenderbufferParameterName pname, int* parameters) => GLPointers._GetNamedRenderbufferParameteriv_fnptr((int)renderbuffer, (uint)pname, parameters);
+            public static void GetNamedRenderbufferParameteriv(int renderbuffer, RenderbufferParameterName pname, int* parameters) => GLPointers._GetNamedRenderbufferParameteriv_fnptr(renderbuffer, (uint)pname, parameters);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Create texture objects. </summary>
             /// <param name="target"> Specifies the effective texture target of each created texture. </param>
             /// <param name="n"> Number of texture objects to create. </param>
             /// <param name="textures"> Specifies an array in which names of the new texture objects are stored. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCreateTextures.xhtml" /></remarks>
-            public static void CreateTextures(TextureTarget target, int n, TextureHandle* textures) => GLPointers._CreateTextures_fnptr((uint)target, n, (int*)textures);
+            public static void CreateTextures(TextureTarget target, int n, int* textures) => GLPointers._CreateTextures_fnptr((uint)target, n, textures);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Attach a buffer object's data store to a buffer texture object. </summary>
             /// <param name="texture"> Specifies the texture object name for glTextureBuffer. </param>
             /// <param name="internalformat"> Specifies the internal format of the data in the store belonging to buffer. </param>
             /// <param name="buffer"> Specifies the name of the buffer object whose storage to attach to the active buffer texture. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexBuffer.xhtml" /></remarks>
-            public static void TextureBuffer(TextureHandle texture, SizedInternalFormat internalformat, BufferHandle buffer) => GLPointers._TextureBuffer_fnptr((int)texture, (uint)internalformat, (int)buffer);
+            public static void TextureBuffer(int texture, SizedInternalFormat internalformat, int buffer) => GLPointers._TextureBuffer_fnptr(texture, (uint)internalformat, buffer);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Attach a range of a buffer object's data store to a buffer texture object. </summary>
             /// <param name="texture"> Specifies the texture object name for glTextureBufferRange. </param>
@@ -5837,7 +5837,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="offset"> Specifies the offset of the start of the range of the buffer's data store to attach. </param>
             /// <param name="size"> Specifies the size of the range of the buffer's data store to attach. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexBufferRange.xhtml" /></remarks>
-            public static void TextureBufferRange(TextureHandle texture, SizedInternalFormat internalformat, BufferHandle buffer, IntPtr offset, nint size) => GLPointers._TextureBufferRange_fnptr((int)texture, (uint)internalformat, (int)buffer, offset, size);
+            public static void TextureBufferRange(int texture, SizedInternalFormat internalformat, int buffer, IntPtr offset, nint size) => GLPointers._TextureBufferRange_fnptr(texture, (uint)internalformat, buffer, offset, size);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Simultaneously specify storage for all levels of a one-dimensional texture. </summary>
             /// <param name="texture"> Specifies the texture object name for glTextureStorage1D. The effective target of texture must be one of the valid non-proxy target values above. </param>
@@ -5845,7 +5845,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="internalformat"> Specifies the sized internal format to be used to store texture image data. </param>
             /// <param name="width"> Specifies the width of the texture, in texels. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexStorage1D.xhtml" /></remarks>
-            public static void TextureStorage1D(TextureHandle texture, int levels, SizedInternalFormat internalformat, int width) => GLPointers._TextureStorage1D_fnptr((int)texture, levels, (uint)internalformat, width);
+            public static void TextureStorage1D(int texture, int levels, SizedInternalFormat internalformat, int width) => GLPointers._TextureStorage1D_fnptr(texture, levels, (uint)internalformat, width);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Simultaneously specify storage for all levels of a two-dimensional or one-dimensional array texture. </summary>
             /// <param name="texture"> Specifies the texture object name for glTextureStorage2D. The effective target of texture must be one of the valid non-proxy target values above. </param>
@@ -5854,7 +5854,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="width"> Specifies the width of the texture, in texels. </param>
             /// <param name="height"> Specifies the height of the texture, in texels. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexStorage2D.xhtml" /></remarks>
-            public static void TextureStorage2D(TextureHandle texture, int levels, SizedInternalFormat internalformat, int width, int height) => GLPointers._TextureStorage2D_fnptr((int)texture, levels, (uint)internalformat, width, height);
+            public static void TextureStorage2D(int texture, int levels, SizedInternalFormat internalformat, int width, int height) => GLPointers._TextureStorage2D_fnptr(texture, levels, (uint)internalformat, width, height);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Simultaneously specify storage for all levels of a three-dimensional, two-dimensional array or cube-map array texture. </summary>
             /// <param name="texture"> Specifies the texture object name for glTextureStorage3D. The effective target of texture must be one of the valid non-proxy target values above. </param>
@@ -5864,7 +5864,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="height"> Specifies the height of the texture, in texels. </param>
             /// <param name="depth"> Specifies the depth of the texture, in texels. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexStorage3D.xhtml" /></remarks>
-            public static void TextureStorage3D(TextureHandle texture, int levels, SizedInternalFormat internalformat, int width, int height, int depth) => GLPointers._TextureStorage3D_fnptr((int)texture, levels, (uint)internalformat, width, height, depth);
+            public static void TextureStorage3D(int texture, int levels, SizedInternalFormat internalformat, int width, int height, int depth) => GLPointers._TextureStorage3D_fnptr(texture, levels, (uint)internalformat, width, height, depth);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specify storage for a two-dimensional multisample texture. </summary>
             /// <param name="texture"> Specifies the texture object name for glTextureStorage2DMultisample. The effective target of texture must be one of the valid non-proxy target values above. </param>
@@ -5874,7 +5874,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="height"> Specifies the height of the texture, in texels. </param>
             /// <param name="fixedsamplelocations"> Specifies whether the image will use identical sample locations and the same number of samples for all texels in the image, and the sample locations will not depend on the internal format or size of the image. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexStorage2DMultisample.xhtml" /></remarks>
-            public static void TextureStorage2DMultisample(TextureHandle texture, int samples, SizedInternalFormat internalformat, int width, int height, bool fixedsamplelocations) => GLPointers._TextureStorage2DMultisample_fnptr((int)texture, samples, (uint)internalformat, width, height, (byte)(fixedsamplelocations ? 1 : 0));
+            public static void TextureStorage2DMultisample(int texture, int samples, SizedInternalFormat internalformat, int width, int height, bool fixedsamplelocations) => GLPointers._TextureStorage2DMultisample_fnptr(texture, samples, (uint)internalformat, width, height, (byte)(fixedsamplelocations ? 1 : 0));
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specify storage for a two-dimensional multisample array texture. </summary>
             /// <param name="texture"> Specifies the texture object name for glTextureStorage3DMultisample. The effective target of texture must be one of the valid non-proxy target values above. </param>
@@ -5885,7 +5885,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="depth"> Specifies the depth of the texture, in layers. </param>
             /// <param name="fixedsamplelocations"> Specifies whether the image will use identical sample locations and the same number of samples for all texels in the image, and the sample locations will not depend on the internal format or size of the image. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexStorage3DMultisample.xhtml" /></remarks>
-            public static void TextureStorage3DMultisample(TextureHandle texture, int samples, SizedInternalFormat internalformat, int width, int height, int depth, bool fixedsamplelocations) => GLPointers._TextureStorage3DMultisample_fnptr((int)texture, samples, (uint)internalformat, width, height, depth, (byte)(fixedsamplelocations ? 1 : 0));
+            public static void TextureStorage3DMultisample(int texture, int samples, SizedInternalFormat internalformat, int width, int height, int depth, bool fixedsamplelocations) => GLPointers._TextureStorage3DMultisample_fnptr(texture, samples, (uint)internalformat, width, height, depth, (byte)(fixedsamplelocations ? 1 : 0));
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specify a one-dimensional texture subimage. </summary>
             /// <param name="texture"> Specifies the texture object name for glTextureSubImage1D. The effective target of texture must be one of the valid target values above. </param>
@@ -5896,7 +5896,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="type"> Specifies the data type of the pixel data. The following symbolic values are accepted: GL_UNSIGNED_BYTE, GL_BYTE, GL_UNSIGNED_SHORT, GL_SHORT, GL_UNSIGNED_INT, GL_INT, GL_FLOAT, GL_UNSIGNED_BYTE_3_3_2, GL_UNSIGNED_BYTE_2_3_3_REV, GL_UNSIGNED_SHORT_5_6_5, GL_UNSIGNED_SHORT_5_6_5_REV, GL_UNSIGNED_SHORT_4_4_4_4, GL_UNSIGNED_SHORT_4_4_4_4_REV, GL_UNSIGNED_SHORT_5_5_5_1, GL_UNSIGNED_SHORT_1_5_5_5_REV, GL_UNSIGNED_INT_8_8_8_8, GL_UNSIGNED_INT_8_8_8_8_REV, GL_UNSIGNED_INT_10_10_10_2, and GL_UNSIGNED_INT_2_10_10_10_REV. </param>
             /// <param name="pixels"> Specifies a pointer to the image data in memory. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexSubImage1D.xhtml" /></remarks>
-            public static void TextureSubImage1D(TextureHandle texture, int level, int xoffset, int width, PixelFormat format, PixelType type, void* pixels) => GLPointers._TextureSubImage1D_fnptr((int)texture, level, xoffset, width, (uint)format, (uint)type, pixels);
+            public static void TextureSubImage1D(int texture, int level, int xoffset, int width, PixelFormat format, PixelType type, void* pixels) => GLPointers._TextureSubImage1D_fnptr(texture, level, xoffset, width, (uint)format, (uint)type, pixels);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specify a two-dimensional texture subimage. </summary>
             /// <param name="texture"> Specifies the texture object name for glTextureSubImage2D. The effective target of texture must be one of the valid target values above. </param>
@@ -5909,7 +5909,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="type"> Specifies the data type of the pixel data. The following symbolic values are accepted: GL_UNSIGNED_BYTE, GL_BYTE, GL_UNSIGNED_SHORT, GL_SHORT, GL_UNSIGNED_INT, GL_INT, GL_FLOAT, GL_UNSIGNED_BYTE_3_3_2, GL_UNSIGNED_BYTE_2_3_3_REV, GL_UNSIGNED_SHORT_5_6_5, GL_UNSIGNED_SHORT_5_6_5_REV, GL_UNSIGNED_SHORT_4_4_4_4, GL_UNSIGNED_SHORT_4_4_4_4_REV, GL_UNSIGNED_SHORT_5_5_5_1, GL_UNSIGNED_SHORT_1_5_5_5_REV, GL_UNSIGNED_INT_8_8_8_8, GL_UNSIGNED_INT_8_8_8_8_REV, GL_UNSIGNED_INT_10_10_10_2, and GL_UNSIGNED_INT_2_10_10_10_REV. </param>
             /// <param name="pixels"> Specifies a pointer to the image data in memory. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexSubImage2D.xhtml" /></remarks>
-            public static void TextureSubImage2D(TextureHandle texture, int level, int xoffset, int yoffset, int width, int height, PixelFormat format, PixelType type, void* pixels) => GLPointers._TextureSubImage2D_fnptr((int)texture, level, xoffset, yoffset, width, height, (uint)format, (uint)type, pixels);
+            public static void TextureSubImage2D(int texture, int level, int xoffset, int yoffset, int width, int height, PixelFormat format, PixelType type, void* pixels) => GLPointers._TextureSubImage2D_fnptr(texture, level, xoffset, yoffset, width, height, (uint)format, (uint)type, pixels);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specify a three-dimensional texture subimage. </summary>
             /// <param name="texture"> Specifies the texture object name for glTextureSubImage3D. The effective target of texture must be one of the valid target values above. </param>
@@ -5924,7 +5924,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="type"> Specifies the data type of the pixel data. The following symbolic values are accepted: GL_UNSIGNED_BYTE, GL_BYTE, GL_UNSIGNED_SHORT, GL_SHORT, GL_UNSIGNED_INT, GL_INT, GL_FLOAT, GL_UNSIGNED_BYTE_3_3_2, GL_UNSIGNED_BYTE_2_3_3_REV, GL_UNSIGNED_SHORT_5_6_5, GL_UNSIGNED_SHORT_5_6_5_REV, GL_UNSIGNED_SHORT_4_4_4_4, GL_UNSIGNED_SHORT_4_4_4_4_REV, GL_UNSIGNED_SHORT_5_5_5_1, GL_UNSIGNED_SHORT_1_5_5_5_REV, GL_UNSIGNED_INT_8_8_8_8, GL_UNSIGNED_INT_8_8_8_8_REV, GL_UNSIGNED_INT_10_10_10_2, and GL_UNSIGNED_INT_2_10_10_10_REV. </param>
             /// <param name="pixels"> Specifies a pointer to the image data in memory. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexSubImage3D.xhtml" /></remarks>
-            public static void TextureSubImage3D(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, void* pixels) => GLPointers._TextureSubImage3D_fnptr((int)texture, level, xoffset, yoffset, zoffset, width, height, depth, (uint)format, (uint)type, pixels);
+            public static void TextureSubImage3D(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, void* pixels) => GLPointers._TextureSubImage3D_fnptr(texture, level, xoffset, yoffset, zoffset, width, height, depth, (uint)format, (uint)type, pixels);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specify a one-dimensional texture subimage in a compressed    format. </summary>
             /// <param name="texture">Specifies the texture object name for glCompressedTextureSubImage1D function.</param>
@@ -5935,7 +5935,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="imageSize">Specifies the number of unsigned bytes of image data starting at the address specified by data.</param>
             /// <param name="data">Specifies a pointer to the compressed image data in memory.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCompressedTexSubImage1D.xhtml" /></remarks>
-            public static void CompressedTextureSubImage1D(TextureHandle texture, int level, int xoffset, int width, InternalFormat format, int imageSize, void* data) => GLPointers._CompressedTextureSubImage1D_fnptr((int)texture, level, xoffset, width, (uint)format, imageSize, data);
+            public static void CompressedTextureSubImage1D(int texture, int level, int xoffset, int width, InternalFormat format, int imageSize, void* data) => GLPointers._CompressedTextureSubImage1D_fnptr(texture, level, xoffset, width, (uint)format, imageSize, data);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specify a two-dimensional texture subimage in a compressed format. </summary>
             /// <param name="texture">Specifies the texture object name for glCompressedTextureSubImage2D function.</param>
@@ -5948,7 +5948,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="imageSize">Specifies the number of unsigned bytes of image data starting at the address specified by data.</param>
             /// <param name="data">Specifies a pointer to the compressed image data in memory.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCompressedTexSubImage2D.xhtml" /></remarks>
-            public static void CompressedTextureSubImage2D(TextureHandle texture, int level, int xoffset, int yoffset, int width, int height, InternalFormat format, int imageSize, void* data) => GLPointers._CompressedTextureSubImage2D_fnptr((int)texture, level, xoffset, yoffset, width, height, (uint)format, imageSize, data);
+            public static void CompressedTextureSubImage2D(int texture, int level, int xoffset, int yoffset, int width, int height, InternalFormat format, int imageSize, void* data) => GLPointers._CompressedTextureSubImage2D_fnptr(texture, level, xoffset, yoffset, width, height, (uint)format, imageSize, data);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specify a three-dimensional texture subimage in a compressed format. </summary>
             /// <param name="texture">Specifies the texture object name for glCompressedTextureSubImage3D function.</param>
@@ -5963,7 +5963,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="imageSize">Specifies the number of unsigned bytes of image data starting at the address specified by data.</param>
             /// <param name="data">Specifies a pointer to the compressed image data in memory.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCompressedTexSubImage3D.xhtml" /></remarks>
-            public static void CompressedTextureSubImage3D(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, InternalFormat format, int imageSize, void* data) => GLPointers._CompressedTextureSubImage3D_fnptr((int)texture, level, xoffset, yoffset, zoffset, width, height, depth, (uint)format, imageSize, data);
+            public static void CompressedTextureSubImage3D(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, InternalFormat format, int imageSize, void* data) => GLPointers._CompressedTextureSubImage3D_fnptr(texture, level, xoffset, yoffset, zoffset, width, height, depth, (uint)format, imageSize, data);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Copy a one-dimensional texture subimage. </summary>
             /// <param name="texture">Specifies the texture object name for glCopyTextureSubImage1D function.</param>
@@ -5973,7 +5973,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="y">Specify the window coordinates of the left corner of the row of pixels to be copied.</param>
             /// <param name="width">Specifies the width of the texture subimage.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCopyTexSubImage1D.xhtml" /></remarks>
-            public static void CopyTextureSubImage1D(TextureHandle texture, int level, int xoffset, int x, int y, int width) => GLPointers._CopyTextureSubImage1D_fnptr((int)texture, level, xoffset, x, y, width);
+            public static void CopyTextureSubImage1D(int texture, int level, int xoffset, int x, int y, int width) => GLPointers._CopyTextureSubImage1D_fnptr(texture, level, xoffset, x, y, width);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Copy a two-dimensional texture subimage. </summary>
             /// <param name="texture">Specifies the texture object name for glCopyTextureSubImage2D function.</param>
@@ -5985,7 +5985,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="width">Specifies the width of the texture subimage.</param>
             /// <param name="height">Specifies the height of the texture subimage.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCopyTexSubImage2D.xhtml" /></remarks>
-            public static void CopyTextureSubImage2D(TextureHandle texture, int level, int xoffset, int yoffset, int x, int y, int width, int height) => GLPointers._CopyTextureSubImage2D_fnptr((int)texture, level, xoffset, yoffset, x, y, width, height);
+            public static void CopyTextureSubImage2D(int texture, int level, int xoffset, int yoffset, int x, int y, int width, int height) => GLPointers._CopyTextureSubImage2D_fnptr(texture, level, xoffset, yoffset, x, y, width, height);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Copy a three-dimensional texture subimage. </summary>
             /// <param name="texture">Specifies the texture object name for glCopyTextureSubImage3D function.</param>
@@ -5998,60 +5998,60 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="width">Specifies the width of the texture subimage.</param>
             /// <param name="height">Specifies the height of the texture subimage.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCopyTexSubImage3D.xhtml" /></remarks>
-            public static void CopyTextureSubImage3D(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int x, int y, int width, int height) => GLPointers._CopyTextureSubImage3D_fnptr((int)texture, level, xoffset, yoffset, zoffset, x, y, width, height);
+            public static void CopyTextureSubImage3D(int texture, int level, int xoffset, int yoffset, int zoffset, int x, int y, int width, int height) => GLPointers._CopyTextureSubImage3D_fnptr(texture, level, xoffset, yoffset, zoffset, x, y, width, height);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Set texture parameters. </summary>
             /// <param name="texture">Specifies the texture object name for glTextureParameter functions.</param>
             /// <param name="pname">Specifies the symbolic name of a single-valued texture parameter. pname can be one of the following: GL_DEPTH_STENCIL_TEXTURE_MODE, GL_TEXTURE_BASE_LEVEL, GL_TEXTURE_COMPARE_FUNC, GL_TEXTURE_COMPARE_MODE, GL_TEXTURE_LOD_BIAS, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_MAX_LEVEL, GL_TEXTURE_SWIZZLE_R, GL_TEXTURE_SWIZZLE_G, GL_TEXTURE_SWIZZLE_B, GL_TEXTURE_SWIZZLE_A, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, or GL_TEXTURE_WRAP_R.</param>
             /// <param name="param">For the scalar commands, specifies the value of pname.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexParameter.xhtml" /></remarks>
-            public static void TextureParameterf(TextureHandle texture, TextureParameterName pname, float param) => GLPointers._TextureParameterf_fnptr((int)texture, (uint)pname, param);
+            public static void TextureParameterf(int texture, TextureParameterName pname, float param) => GLPointers._TextureParameterf_fnptr(texture, (uint)pname, param);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Set texture parameters. </summary>
             /// <param name="texture">Specifies the texture object name for glTextureParameter functions.</param>
             /// <param name="pname">Specifies the symbolic name of a single-valued texture parameter. pname can be one of the following: GL_DEPTH_STENCIL_TEXTURE_MODE, GL_TEXTURE_BASE_LEVEL, GL_TEXTURE_COMPARE_FUNC, GL_TEXTURE_COMPARE_MODE, GL_TEXTURE_LOD_BIAS, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_MAX_LEVEL, GL_TEXTURE_SWIZZLE_R, GL_TEXTURE_SWIZZLE_G, GL_TEXTURE_SWIZZLE_B, GL_TEXTURE_SWIZZLE_A, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, or GL_TEXTURE_WRAP_R.</param>
             /// <param name="parameters">For the vector commands, specifies a pointer to an array where the value or values of pname are stored.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexParameter.xhtml" /></remarks>
-            public static void TextureParameterfv(TextureHandle texture, TextureParameterName pname, float* param) => GLPointers._TextureParameterfv_fnptr((int)texture, (uint)pname, param);
+            public static void TextureParameterfv(int texture, TextureParameterName pname, float* param) => GLPointers._TextureParameterfv_fnptr(texture, (uint)pname, param);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Set texture parameters. </summary>
             /// <param name="texture">Specifies the texture object name for glTextureParameter functions.</param>
             /// <param name="pname">Specifies the symbolic name of a single-valued texture parameter. pname can be one of the following: GL_DEPTH_STENCIL_TEXTURE_MODE, GL_TEXTURE_BASE_LEVEL, GL_TEXTURE_COMPARE_FUNC, GL_TEXTURE_COMPARE_MODE, GL_TEXTURE_LOD_BIAS, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_MAX_LEVEL, GL_TEXTURE_SWIZZLE_R, GL_TEXTURE_SWIZZLE_G, GL_TEXTURE_SWIZZLE_B, GL_TEXTURE_SWIZZLE_A, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, or GL_TEXTURE_WRAP_R.</param>
             /// <param name="param">For the scalar commands, specifies the value of pname.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexParameter.xhtml" /></remarks>
-            public static void TextureParameteri(TextureHandle texture, TextureParameterName pname, int param) => GLPointers._TextureParameteri_fnptr((int)texture, (uint)pname, param);
+            public static void TextureParameteri(int texture, TextureParameterName pname, int param) => GLPointers._TextureParameteri_fnptr(texture, (uint)pname, param);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Set texture parameters. </summary>
             /// <param name="texture">Specifies the texture object name for glTextureParameter functions.</param>
             /// <param name="pname">Specifies the symbolic name of a single-valued texture parameter. pname can be one of the following: GL_DEPTH_STENCIL_TEXTURE_MODE, GL_TEXTURE_BASE_LEVEL, GL_TEXTURE_COMPARE_FUNC, GL_TEXTURE_COMPARE_MODE, GL_TEXTURE_LOD_BIAS, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_MAX_LEVEL, GL_TEXTURE_SWIZZLE_R, GL_TEXTURE_SWIZZLE_G, GL_TEXTURE_SWIZZLE_B, GL_TEXTURE_SWIZZLE_A, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, or GL_TEXTURE_WRAP_R.</param>
             /// <param name="parameters">For the vector commands, specifies a pointer to an array where the value or values of pname are stored.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexParameter.xhtml" /></remarks>
-            public static void TextureParameterIiv(TextureHandle texture, TextureParameterName pname, int* parameters) => GLPointers._TextureParameterIiv_fnptr((int)texture, (uint)pname, parameters);
+            public static void TextureParameterIiv(int texture, TextureParameterName pname, int* parameters) => GLPointers._TextureParameterIiv_fnptr(texture, (uint)pname, parameters);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Set texture parameters. </summary>
             /// <param name="texture">Specifies the texture object name for glTextureParameter functions.</param>
             /// <param name="pname">Specifies the symbolic name of a single-valued texture parameter. pname can be one of the following: GL_DEPTH_STENCIL_TEXTURE_MODE, GL_TEXTURE_BASE_LEVEL, GL_TEXTURE_COMPARE_FUNC, GL_TEXTURE_COMPARE_MODE, GL_TEXTURE_LOD_BIAS, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_MAX_LEVEL, GL_TEXTURE_SWIZZLE_R, GL_TEXTURE_SWIZZLE_G, GL_TEXTURE_SWIZZLE_B, GL_TEXTURE_SWIZZLE_A, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, or GL_TEXTURE_WRAP_R.</param>
             /// <param name="parameters">For the vector commands, specifies a pointer to an array where the value or values of pname are stored.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexParameter.xhtml" /></remarks>
-            public static void TextureParameterIuiv(TextureHandle texture, TextureParameterName pname, uint* parameters) => GLPointers._TextureParameterIuiv_fnptr((int)texture, (uint)pname, parameters);
+            public static void TextureParameterIuiv(int texture, TextureParameterName pname, uint* parameters) => GLPointers._TextureParameterIuiv_fnptr(texture, (uint)pname, parameters);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Set texture parameters. </summary>
             /// <param name="texture">Specifies the texture object name for glTextureParameter functions.</param>
             /// <param name="pname">Specifies the symbolic name of a single-valued texture parameter. pname can be one of the following: GL_DEPTH_STENCIL_TEXTURE_MODE, GL_TEXTURE_BASE_LEVEL, GL_TEXTURE_COMPARE_FUNC, GL_TEXTURE_COMPARE_MODE, GL_TEXTURE_LOD_BIAS, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_MAX_LEVEL, GL_TEXTURE_SWIZZLE_R, GL_TEXTURE_SWIZZLE_G, GL_TEXTURE_SWIZZLE_B, GL_TEXTURE_SWIZZLE_A, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, or GL_TEXTURE_WRAP_R.</param>
             /// <param name="parameters">For the vector commands, specifies a pointer to an array where the value or values of pname are stored.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexParameter.xhtml" /></remarks>
-            public static void TextureParameteriv(TextureHandle texture, TextureParameterName pname, int* param) => GLPointers._TextureParameteriv_fnptr((int)texture, (uint)pname, param);
+            public static void TextureParameteriv(int texture, TextureParameterName pname, int* param) => GLPointers._TextureParameteriv_fnptr(texture, (uint)pname, param);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Generate mipmaps for a specified texture object. </summary>
             /// <param name="texture"> Specifies the texture object name for glGenerateTextureMipmap. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGenerateMipmap.xhtml" /></remarks>
-            public static void GenerateTextureMipmap(TextureHandle texture) => GLPointers._GenerateTextureMipmap_fnptr((int)texture);
+            public static void GenerateTextureMipmap(int texture) => GLPointers._GenerateTextureMipmap_fnptr(texture);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Bind an existing texture object to the specified texture unit . </summary>
             /// <param name="unit">Specifies the texture unit, to which the texture object should be bound to. </param>
             /// <param name="texture">Specifies the name of a texture. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindTextureUnit.xhtml" /></remarks>
-            public static void BindTextureUnit(uint unit, TextureHandle texture) => GLPointers._BindTextureUnit_fnptr(unit, (int)texture);
+            public static void BindTextureUnit(uint unit, int texture) => GLPointers._BindTextureUnit_fnptr(unit, texture);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Return a texture image. </summary>
             /// <param name="texture"> Specifies the texture object name. </param>
@@ -6061,7 +6061,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="bufSize">Specifies the size of the buffer pixels for glGetnTexImage and glGetTextureImage functions.</param>
             /// <param name="pixels">Returns the texture image. Should be a pointer to an array of the type specified by type.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetTexImage.xhtml" /></remarks>
-            public static void GetTextureImage(TextureHandle texture, int level, PixelFormat format, PixelType type, int bufSize, void* pixels) => GLPointers._GetTextureImage_fnptr((int)texture, level, (uint)format, (uint)type, bufSize, pixels);
+            public static void GetTextureImage(int texture, int level, PixelFormat format, PixelType type, int bufSize, void* pixels) => GLPointers._GetTextureImage_fnptr(texture, level, (uint)format, (uint)type, bufSize, pixels);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Return a compressed texture image. </summary>
             /// <param name="texture">Specifies the texture object name for glGetCompressedTextureImage function.</param>
@@ -6069,7 +6069,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="bufSize">Specifies the size of the buffer pixels for glGetCompressedTextureImage and glGetnCompressedTexImage functions.</param>
             /// <param name="pixels">Returns the compressed texture image.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetCompressedTexImage.xhtml" /></remarks>
-            public static void GetCompressedTextureImage(TextureHandle texture, int level, int bufSize, void* pixels) => GLPointers._GetCompressedTextureImage_fnptr((int)texture, level, bufSize, pixels);
+            public static void GetCompressedTextureImage(int texture, int level, int bufSize, void* pixels) => GLPointers._GetCompressedTextureImage_fnptr(texture, level, bufSize, pixels);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Return texture parameter values for a specific level of    detail. </summary>
             /// <param name="texture">Specifies the texture object name for glGetTextureLevelParameterfv and glGetTextureLevelParameteriv functions.</param>
@@ -6077,7 +6077,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="pname">Specifies the symbolic name of a texture parameter. GL_TEXTURE_WIDTH, GL_TEXTURE_HEIGHT, GL_TEXTURE_DEPTH, GL_TEXTURE_INTERNAL_FORMAT, GL_TEXTURE_RED_SIZE, GL_TEXTURE_GREEN_SIZE, GL_TEXTURE_BLUE_SIZE, GL_TEXTURE_ALPHA_SIZE, GL_TEXTURE_DEPTH_SIZE, GL_TEXTURE_COMPRESSED, GL_TEXTURE_COMPRESSED_IMAGE_SIZE, and GL_TEXTURE_BUFFER_OFFSET are accepted.</param>
             /// <param name="parameters">Returns the requested data.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetTexLevelParameter.xhtml" /></remarks>
-            public static void GetTextureLevelParameterfv(TextureHandle texture, int level, GetTextureParameter pname, float* parameters) => GLPointers._GetTextureLevelParameterfv_fnptr((int)texture, level, (uint)pname, parameters);
+            public static void GetTextureLevelParameterfv(int texture, int level, GetTextureParameter pname, float* parameters) => GLPointers._GetTextureLevelParameterfv_fnptr(texture, level, (uint)pname, parameters);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Return texture parameter values for a specific level of    detail. </summary>
             /// <param name="texture">Specifies the texture object name for glGetTextureLevelParameterfv and glGetTextureLevelParameteriv functions.</param>
@@ -6085,59 +6085,59 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="pname">Specifies the symbolic name of a texture parameter. GL_TEXTURE_WIDTH, GL_TEXTURE_HEIGHT, GL_TEXTURE_DEPTH, GL_TEXTURE_INTERNAL_FORMAT, GL_TEXTURE_RED_SIZE, GL_TEXTURE_GREEN_SIZE, GL_TEXTURE_BLUE_SIZE, GL_TEXTURE_ALPHA_SIZE, GL_TEXTURE_DEPTH_SIZE, GL_TEXTURE_COMPRESSED, GL_TEXTURE_COMPRESSED_IMAGE_SIZE, and GL_TEXTURE_BUFFER_OFFSET are accepted.</param>
             /// <param name="parameters">Returns the requested data.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetTexLevelParameter.xhtml" /></remarks>
-            public static void GetTextureLevelParameteriv(TextureHandle texture, int level, GetTextureParameter pname, int* parameters) => GLPointers._GetTextureLevelParameteriv_fnptr((int)texture, level, (uint)pname, parameters);
+            public static void GetTextureLevelParameteriv(int texture, int level, GetTextureParameter pname, int* parameters) => GLPointers._GetTextureLevelParameteriv_fnptr(texture, level, (uint)pname, parameters);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Return texture parameter values. </summary>
             /// <param name="texture">Specifies the texture object name for glGetTextureParameterfv, glGetTextureParameteriv, glGetTextureParameterIiv, and glGetTextureParameterIuiv functions.</param>
             /// <param name="pname">Specifies the symbolic name of a texture parameter. GL_DEPTH_STENCIL_TEXTURE_MODE, GL_IMAGE_FORMAT_COMPATIBILITY_TYPE, GL_TEXTURE_BASE_LEVEL, GL_TEXTURE_BORDER_COLOR, GL_TEXTURE_COMPARE_MODE, GL_TEXTURE_COMPARE_FUNC, GL_TEXTURE_IMMUTABLE_FORMAT, GL_TEXTURE_IMMUTABLE_LEVELS, GL_TEXTURE_LOD_BIAS, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MAX_LEVEL, GL_TEXTURE_MAX_LOD, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_SWIZZLE_R, GL_TEXTURE_SWIZZLE_G, GL_TEXTURE_SWIZZLE_B, GL_TEXTURE_SWIZZLE_A, GL_TEXTURE_SWIZZLE_RGBA, GL_TEXTURE_TARGET, GL_TEXTURE_VIEW_MIN_LAYER, GL_TEXTURE_VIEW_MIN_LEVEL, GL_TEXTURE_VIEW_NUM_LAYERS, GL_TEXTURE_VIEW_NUM_LEVELS, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, and GL_TEXTURE_WRAP_R are accepted.</param>
             /// <param name="parameters">Returns the texture parameters.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetTexParameter.xhtml" /></remarks>
-            public static void GetTextureParameterfv(TextureHandle texture, GetTextureParameter pname, float* parameters) => GLPointers._GetTextureParameterfv_fnptr((int)texture, (uint)pname, parameters);
+            public static void GetTextureParameterfv(int texture, GetTextureParameter pname, float* parameters) => GLPointers._GetTextureParameterfv_fnptr(texture, (uint)pname, parameters);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Return texture parameter values. </summary>
             /// <param name="texture">Specifies the texture object name for glGetTextureParameterfv, glGetTextureParameteriv, glGetTextureParameterIiv, and glGetTextureParameterIuiv functions.</param>
             /// <param name="pname">Specifies the symbolic name of a texture parameter. GL_DEPTH_STENCIL_TEXTURE_MODE, GL_IMAGE_FORMAT_COMPATIBILITY_TYPE, GL_TEXTURE_BASE_LEVEL, GL_TEXTURE_BORDER_COLOR, GL_TEXTURE_COMPARE_MODE, GL_TEXTURE_COMPARE_FUNC, GL_TEXTURE_IMMUTABLE_FORMAT, GL_TEXTURE_IMMUTABLE_LEVELS, GL_TEXTURE_LOD_BIAS, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MAX_LEVEL, GL_TEXTURE_MAX_LOD, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_SWIZZLE_R, GL_TEXTURE_SWIZZLE_G, GL_TEXTURE_SWIZZLE_B, GL_TEXTURE_SWIZZLE_A, GL_TEXTURE_SWIZZLE_RGBA, GL_TEXTURE_TARGET, GL_TEXTURE_VIEW_MIN_LAYER, GL_TEXTURE_VIEW_MIN_LEVEL, GL_TEXTURE_VIEW_NUM_LAYERS, GL_TEXTURE_VIEW_NUM_LEVELS, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, and GL_TEXTURE_WRAP_R are accepted.</param>
             /// <param name="parameters">Returns the texture parameters.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetTexParameter.xhtml" /></remarks>
-            public static void GetTextureParameterIiv(TextureHandle texture, GetTextureParameter pname, int* parameters) => GLPointers._GetTextureParameterIiv_fnptr((int)texture, (uint)pname, parameters);
+            public static void GetTextureParameterIiv(int texture, GetTextureParameter pname, int* parameters) => GLPointers._GetTextureParameterIiv_fnptr(texture, (uint)pname, parameters);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Return texture parameter values. </summary>
             /// <param name="texture">Specifies the texture object name for glGetTextureParameterfv, glGetTextureParameteriv, glGetTextureParameterIiv, and glGetTextureParameterIuiv functions.</param>
             /// <param name="pname">Specifies the symbolic name of a texture parameter. GL_DEPTH_STENCIL_TEXTURE_MODE, GL_IMAGE_FORMAT_COMPATIBILITY_TYPE, GL_TEXTURE_BASE_LEVEL, GL_TEXTURE_BORDER_COLOR, GL_TEXTURE_COMPARE_MODE, GL_TEXTURE_COMPARE_FUNC, GL_TEXTURE_IMMUTABLE_FORMAT, GL_TEXTURE_IMMUTABLE_LEVELS, GL_TEXTURE_LOD_BIAS, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MAX_LEVEL, GL_TEXTURE_MAX_LOD, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_SWIZZLE_R, GL_TEXTURE_SWIZZLE_G, GL_TEXTURE_SWIZZLE_B, GL_TEXTURE_SWIZZLE_A, GL_TEXTURE_SWIZZLE_RGBA, GL_TEXTURE_TARGET, GL_TEXTURE_VIEW_MIN_LAYER, GL_TEXTURE_VIEW_MIN_LEVEL, GL_TEXTURE_VIEW_NUM_LAYERS, GL_TEXTURE_VIEW_NUM_LEVELS, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, and GL_TEXTURE_WRAP_R are accepted.</param>
             /// <param name="parameters">Returns the texture parameters.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetTexParameter.xhtml" /></remarks>
-            public static void GetTextureParameterIuiv(TextureHandle texture, GetTextureParameter pname, uint* parameters) => GLPointers._GetTextureParameterIuiv_fnptr((int)texture, (uint)pname, parameters);
+            public static void GetTextureParameterIuiv(int texture, GetTextureParameter pname, uint* parameters) => GLPointers._GetTextureParameterIuiv_fnptr(texture, (uint)pname, parameters);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Return texture parameter values. </summary>
             /// <param name="texture">Specifies the texture object name for glGetTextureParameterfv, glGetTextureParameteriv, glGetTextureParameterIiv, and glGetTextureParameterIuiv functions.</param>
             /// <param name="pname">Specifies the symbolic name of a texture parameter. GL_DEPTH_STENCIL_TEXTURE_MODE, GL_IMAGE_FORMAT_COMPATIBILITY_TYPE, GL_TEXTURE_BASE_LEVEL, GL_TEXTURE_BORDER_COLOR, GL_TEXTURE_COMPARE_MODE, GL_TEXTURE_COMPARE_FUNC, GL_TEXTURE_IMMUTABLE_FORMAT, GL_TEXTURE_IMMUTABLE_LEVELS, GL_TEXTURE_LOD_BIAS, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MAX_LEVEL, GL_TEXTURE_MAX_LOD, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_SWIZZLE_R, GL_TEXTURE_SWIZZLE_G, GL_TEXTURE_SWIZZLE_B, GL_TEXTURE_SWIZZLE_A, GL_TEXTURE_SWIZZLE_RGBA, GL_TEXTURE_TARGET, GL_TEXTURE_VIEW_MIN_LAYER, GL_TEXTURE_VIEW_MIN_LEVEL, GL_TEXTURE_VIEW_NUM_LAYERS, GL_TEXTURE_VIEW_NUM_LEVELS, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, and GL_TEXTURE_WRAP_R are accepted.</param>
             /// <param name="parameters">Returns the texture parameters.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetTexParameter.xhtml" /></remarks>
-            public static void GetTextureParameteriv(TextureHandle texture, GetTextureParameter pname, int* parameters) => GLPointers._GetTextureParameteriv_fnptr((int)texture, (uint)pname, parameters);
+            public static void GetTextureParameteriv(int texture, GetTextureParameter pname, int* parameters) => GLPointers._GetTextureParameteriv_fnptr(texture, (uint)pname, parameters);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Create vertex array objects. </summary>
             /// <param name="n"> Number of vertex array objects to create. </param>
             /// <param name="arrays"> Specifies an array in which names of the new vertex array objects are stored. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCreateVertexArrays.xhtml" /></remarks>
-            public static void CreateVertexArrays(int n, VertexArrayHandle* arrays) => GLPointers._CreateVertexArrays_fnptr(n, (int*)arrays);
+            public static void CreateVertexArrays(int n, int* arrays) => GLPointers._CreateVertexArrays_fnptr(n, arrays);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Enable or disable a generic vertex attribute    array. </summary>
             /// <param name="vaobj">Specifies the name of the vertex array object for glDisableVertexArrayAttrib and glEnableVertexArrayAttrib functions.</param>
             /// <param name="index">Specifies the index of the generic vertex attribute to be enabled or disabled.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glEnableVertexAttribArray.xhtml" /></remarks>
-            public static void DisableVertexArrayAttrib(VertexArrayHandle vaobj, uint index) => GLPointers._DisableVertexArrayAttrib_fnptr((int)vaobj, index);
+            public static void DisableVertexArrayAttrib(int vaobj, uint index) => GLPointers._DisableVertexArrayAttrib_fnptr(vaobj, index);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Enable or disable a generic vertex attribute    array. </summary>
             /// <param name="vaobj">Specifies the name of the vertex array object for glDisableVertexArrayAttrib and glEnableVertexArrayAttrib functions.</param>
             /// <param name="index">Specifies the index of the generic vertex attribute to be enabled or disabled.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glEnableVertexAttribArray.xhtml" /></remarks>
-            public static void EnableVertexArrayAttrib(VertexArrayHandle vaobj, uint index) => GLPointers._EnableVertexArrayAttrib_fnptr((int)vaobj, index);
+            public static void EnableVertexArrayAttrib(int vaobj, uint index) => GLPointers._EnableVertexArrayAttrib_fnptr(vaobj, index);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Configures element array buffer binding of a vertex array object. </summary>
             /// <param name="vaobj"> Specifies the name of the vertex array object. </param>
             /// <param name="buffer"> Specifies the name of the buffer object to use for the element array buffer binding. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glVertexArrayElementBuffer.xhtml" /></remarks>
-            public static void VertexArrayElementBuffer(VertexArrayHandle vaobj, BufferHandle buffer) => GLPointers._VertexArrayElementBuffer_fnptr((int)vaobj, (int)buffer);
+            public static void VertexArrayElementBuffer(int vaobj, int buffer) => GLPointers._VertexArrayElementBuffer_fnptr(vaobj, buffer);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Bind a buffer to a vertex buffer bind point. </summary>
             /// <param name="vaobj">Specifies the name of the vertex array object to be used by glVertexArrayVertexBuffer function.</param>
@@ -6146,7 +6146,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="offset">The offset of the first element of the buffer.</param>
             /// <param name="stride">The distance between elements within the buffer.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindVertexBuffer.xhtml" /></remarks>
-            public static void VertexArrayVertexBuffer(VertexArrayHandle vaobj, uint bindingindex, BufferHandle buffer, IntPtr offset, int stride) => GLPointers._VertexArrayVertexBuffer_fnptr((int)vaobj, bindingindex, (int)buffer, offset, stride);
+            public static void VertexArrayVertexBuffer(int vaobj, uint bindingindex, int buffer, IntPtr offset, int stride) => GLPointers._VertexArrayVertexBuffer_fnptr(vaobj, bindingindex, buffer, offset, stride);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Attach multiple buffer objects to a vertex array object. </summary>
             /// <param name="vaobj"> Specifies the name of the vertex array object for glVertexArrayVertexBuffers. </param>
@@ -6156,14 +6156,14 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="offsets"> Specifies the address of an array of offsets to associate with the binding points. </param>
             /// <param name="strides">!!missing documentation!!</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindVertexBuffers.xhtml" /></remarks>
-            public static void VertexArrayVertexBuffers(VertexArrayHandle vaobj, uint first, int count, BufferHandle* buffers, IntPtr* offsets, int* strides) => GLPointers._VertexArrayVertexBuffers_fnptr((int)vaobj, first, count, (int*)buffers, offsets, strides);
+            public static void VertexArrayVertexBuffers(int vaobj, uint first, int count, int* buffers, IntPtr* offsets, int* strides) => GLPointers._VertexArrayVertexBuffers_fnptr(vaobj, first, count, buffers, offsets, strides);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Associate a vertex attribute and a vertex buffer binding for a vertex array object. </summary>
             /// <param name="vaobj"> Specifies the name of the vertex array object for glVertexArrayAttribBinding. </param>
             /// <param name="attribindex"> The index of the attribute to associate with a vertex buffer binding. </param>
             /// <param name="bindingindex"> The index of the vertex buffer binding with which to associate the generic vertex attribute. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glVertexAttribBinding.xhtml" /></remarks>
-            public static void VertexArrayAttribBinding(VertexArrayHandle vaobj, uint attribindex, uint bindingindex) => GLPointers._VertexArrayAttribBinding_fnptr((int)vaobj, attribindex, bindingindex);
+            public static void VertexArrayAttribBinding(int vaobj, uint attribindex, uint bindingindex) => GLPointers._VertexArrayAttribBinding_fnptr(vaobj, attribindex, bindingindex);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specify the organization of vertex arrays. </summary>
             /// <param name="vaobj">Specifies the name of the vertex array object for glVertexArrayAttrib{I, L}Format functions.</param>
@@ -6173,7 +6173,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="normalized"> Specifies whether fixed-point data values should be normalized (GL_TRUE) or converted directly as fixed-point values (GL_FALSE) when they are accessed. This parameter is ignored if type is GL_FIXED. </param>
             /// <param name="relativeoffset">The distance between elements within the buffer.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glVertexAttribFormat.xhtml" /></remarks>
-            public static void VertexArrayAttribFormat(VertexArrayHandle vaobj, uint attribindex, int size, VertexAttribType type, bool normalized, uint relativeoffset) => GLPointers._VertexArrayAttribFormat_fnptr((int)vaobj, attribindex, size, (uint)type, (byte)(normalized ? 1 : 0), relativeoffset);
+            public static void VertexArrayAttribFormat(int vaobj, uint attribindex, int size, VertexAttribType type, bool normalized, uint relativeoffset) => GLPointers._VertexArrayAttribFormat_fnptr(vaobj, attribindex, size, (uint)type, (byte)(normalized ? 1 : 0), relativeoffset);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specify the organization of vertex arrays. </summary>
             /// <param name="vaobj">Specifies the name of the vertex array object for glVertexArrayAttrib{I, L}Format functions.</param>
@@ -6182,7 +6182,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="type">The type of the data stored in the array.</param>
             /// <param name="relativeoffset">The distance between elements within the buffer.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glVertexAttribFormat.xhtml" /></remarks>
-            public static void VertexArrayAttribIFormat(VertexArrayHandle vaobj, uint attribindex, int size, VertexAttribIType type, uint relativeoffset) => GLPointers._VertexArrayAttribIFormat_fnptr((int)vaobj, attribindex, size, (uint)type, relativeoffset);
+            public static void VertexArrayAttribIFormat(int vaobj, uint attribindex, int size, VertexAttribIType type, uint relativeoffset) => GLPointers._VertexArrayAttribIFormat_fnptr(vaobj, attribindex, size, (uint)type, relativeoffset);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Specify the organization of vertex arrays. </summary>
             /// <param name="vaobj">Specifies the name of the vertex array object for glVertexArrayAttrib{I, L}Format functions.</param>
@@ -6191,21 +6191,21 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="type">The type of the data stored in the array.</param>
             /// <param name="relativeoffset">The distance between elements within the buffer.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glVertexAttribFormat.xhtml" /></remarks>
-            public static void VertexArrayAttribLFormat(VertexArrayHandle vaobj, uint attribindex, int size, VertexAttribLType type, uint relativeoffset) => GLPointers._VertexArrayAttribLFormat_fnptr((int)vaobj, attribindex, size, (uint)type, relativeoffset);
+            public static void VertexArrayAttribLFormat(int vaobj, uint attribindex, int size, VertexAttribLType type, uint relativeoffset) => GLPointers._VertexArrayAttribLFormat_fnptr(vaobj, attribindex, size, (uint)type, relativeoffset);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Modify the rate at which generic vertex attributes    advance. </summary>
             /// <param name="vaobj">Specifies the name of the vertex array object for glVertexArrayBindingDivisor function.</param>
             /// <param name="bindingindex">The index of the binding whose divisor to modify.</param>
             /// <param name="divisor">The new value for the instance step rate to apply.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glVertexBindingDivisor.xhtml" /></remarks>
-            public static void VertexArrayBindingDivisor(VertexArrayHandle vaobj, uint bindingindex, uint divisor) => GLPointers._VertexArrayBindingDivisor_fnptr((int)vaobj, bindingindex, divisor);
+            public static void VertexArrayBindingDivisor(int vaobj, uint bindingindex, uint divisor) => GLPointers._VertexArrayBindingDivisor_fnptr(vaobj, bindingindex, divisor);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Retrieve parameters of a vertex array object. </summary>
             /// <param name="vaobj">specifies the name of the vertex array object to use for the query.</param>
             /// <param name="pname">Name of the property to use for the query. Must be GL_ELEMENT_ARRAY_BUFFER_BINDING.</param>
             /// <param name="param">Returns the requested value.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetVertexArrayiv.xhtml" /></remarks>
-            public static void GetVertexArrayiv(VertexArrayHandle vaobj, VertexArrayPName pname, int* param) => GLPointers._GetVertexArrayiv_fnptr((int)vaobj, (uint)pname, param);
+            public static void GetVertexArrayiv(int vaobj, VertexArrayPName pname, int* param) => GLPointers._GetVertexArrayiv_fnptr(vaobj, (uint)pname, param);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Retrieve parameters of an attribute of a vertex array    object. </summary>
             /// <param name="vaobj">Specifies the name of a vertex array object.</param>
@@ -6213,7 +6213,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="pname">Specifies the property to be used for the query. For glGetVertexArrayIndexediv, it must be one of the following values: GL_VERTEX_ATTRIB_ARRAY_ENABLED, GL_VERTEX_ATTRIB_ARRAY_SIZE, GL_VERTEX_ATTRIB_ARRAY_STRIDE, GL_VERTEX_ATTRIB_ARRAY_TYPE, GL_VERTEX_ATTRIB_ARRAY_NORMALIZED, GL_VERTEX_ATTRIB_ARRAY_INTEGER, GL_VERTEX_ATTRIB_ARRAY_LONG, GL_VERTEX_ATTRIB_ARRAY_DIVISOR, or GL_VERTEX_ATTRIB_RELATIVE_OFFSET. For glGetVertexArrayIndexed64v, it must be equal to GL_VERTEX_BINDING_OFFSET.</param>
             /// <param name="param">Returns the requested value.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetVertexArrayIndexed.xhtml" /></remarks>
-            public static void GetVertexArrayIndexediv(VertexArrayHandle vaobj, uint index, VertexArrayPName pname, int* param) => GLPointers._GetVertexArrayIndexediv_fnptr((int)vaobj, index, (uint)pname, param);
+            public static void GetVertexArrayIndexediv(int vaobj, uint index, VertexArrayPName pname, int* param) => GLPointers._GetVertexArrayIndexediv_fnptr(vaobj, index, (uint)pname, param);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Retrieve parameters of an attribute of a vertex array    object. </summary>
             /// <param name="vaobj">Specifies the name of a vertex array object.</param>
@@ -6221,26 +6221,26 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="pname">Specifies the property to be used for the query. For glGetVertexArrayIndexediv, it must be one of the following values: GL_VERTEX_ATTRIB_ARRAY_ENABLED, GL_VERTEX_ATTRIB_ARRAY_SIZE, GL_VERTEX_ATTRIB_ARRAY_STRIDE, GL_VERTEX_ATTRIB_ARRAY_TYPE, GL_VERTEX_ATTRIB_ARRAY_NORMALIZED, GL_VERTEX_ATTRIB_ARRAY_INTEGER, GL_VERTEX_ATTRIB_ARRAY_LONG, GL_VERTEX_ATTRIB_ARRAY_DIVISOR, or GL_VERTEX_ATTRIB_RELATIVE_OFFSET. For glGetVertexArrayIndexed64v, it must be equal to GL_VERTEX_BINDING_OFFSET.</param>
             /// <param name="param">Returns the requested value.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetVertexArrayIndexed.xhtml" /></remarks>
-            public static void GetVertexArrayIndexed64iv(VertexArrayHandle vaobj, uint index, VertexArrayPName pname, long* param) => GLPointers._GetVertexArrayIndexed64iv_fnptr((int)vaobj, index, (uint)pname, param);
+            public static void GetVertexArrayIndexed64iv(int vaobj, uint index, VertexArrayPName pname, long* param) => GLPointers._GetVertexArrayIndexed64iv_fnptr(vaobj, index, (uint)pname, param);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Create sampler objects. </summary>
             /// <param name="n"> Number of sampler objects to create. </param>
             /// <param name="samplers"> Specifies an array in which names of the new sampler objects are stored. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCreateSamplers.xhtml" /></remarks>
-            public static void CreateSamplers(int n, SamplerHandle* samplers) => GLPointers._CreateSamplers_fnptr(n, (int*)samplers);
+            public static void CreateSamplers(int n, int* samplers) => GLPointers._CreateSamplers_fnptr(n, samplers);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Create program pipeline objects. </summary>
             /// <param name="n"> Number of program pipeline objects to create. </param>
             /// <param name="pipelines"> Specifies an array in which names of the new program pipeline objects are stored. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCreateProgramPipelines.xhtml" /></remarks>
-            public static void CreateProgramPipelines(int n, ProgramPipelineHandle* pipelines) => GLPointers._CreateProgramPipelines_fnptr(n, (int*)pipelines);
+            public static void CreateProgramPipelines(int n, int* pipelines) => GLPointers._CreateProgramPipelines_fnptr(n, pipelines);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Create query objects. </summary>
             /// <param name="target"> Specifies the target of each created query object. </param>
             /// <param name="n"> Number of query objects to create. </param>
             /// <param name="ids"> Specifies an array in which names of the new query objects are stored. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCreateQueries.xhtml" /></remarks>
-            public static void CreateQueries(QueryTarget target, int n, QueryHandle* ids) => GLPointers._CreateQueries_fnptr((uint)target, n, (int*)ids);
+            public static void CreateQueries(QueryTarget target, int n, int* ids) => GLPointers._CreateQueries_fnptr((uint)target, n, ids);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Return parameters of a query object. </summary>
             /// <param name="id"> Specifies the name of a query object. </param>
@@ -6248,7 +6248,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="pname"> Specifies the symbolic name of a query object parameter. Accepted values are GL_QUERY_RESULT or GL_QUERY_RESULT_AVAILABLE. </param>
             /// <param name="offset"> Specifies the byte offset into buffer's data store where the queried result will be written. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetQueryObject.xhtml" /></remarks>
-            public static void GetQueryBufferObjecti64v(QueryHandle id, BufferHandle buffer, QueryObjectParameterName pname, IntPtr offset) => GLPointers._GetQueryBufferObjecti64v_fnptr((int)id, (int)buffer, (uint)pname, offset);
+            public static void GetQueryBufferObjecti64v(int id, int buffer, QueryObjectParameterName pname, IntPtr offset) => GLPointers._GetQueryBufferObjecti64v_fnptr(id, buffer, (uint)pname, offset);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Return parameters of a query object. </summary>
             /// <param name="id"> Specifies the name of a query object. </param>
@@ -6256,7 +6256,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="pname"> Specifies the symbolic name of a query object parameter. Accepted values are GL_QUERY_RESULT or GL_QUERY_RESULT_AVAILABLE. </param>
             /// <param name="offset"> Specifies the byte offset into buffer's data store where the queried result will be written. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetQueryObject.xhtml" /></remarks>
-            public static void GetQueryBufferObjectiv(QueryHandle id, BufferHandle buffer, QueryObjectParameterName pname, IntPtr offset) => GLPointers._GetQueryBufferObjectiv_fnptr((int)id, (int)buffer, (uint)pname, offset);
+            public static void GetQueryBufferObjectiv(int id, int buffer, QueryObjectParameterName pname, IntPtr offset) => GLPointers._GetQueryBufferObjectiv_fnptr(id, buffer, (uint)pname, offset);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Return parameters of a query object. </summary>
             /// <param name="id"> Specifies the name of a query object. </param>
@@ -6264,7 +6264,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="pname"> Specifies the symbolic name of a query object parameter. Accepted values are GL_QUERY_RESULT or GL_QUERY_RESULT_AVAILABLE. </param>
             /// <param name="offset"> Specifies the byte offset into buffer's data store where the queried result will be written. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetQueryObject.xhtml" /></remarks>
-            public static void GetQueryBufferObjectui64v(QueryHandle id, BufferHandle buffer, QueryObjectParameterName pname, IntPtr offset) => GLPointers._GetQueryBufferObjectui64v_fnptr((int)id, (int)buffer, (uint)pname, offset);
+            public static void GetQueryBufferObjectui64v(int id, int buffer, QueryObjectParameterName pname, IntPtr offset) => GLPointers._GetQueryBufferObjectui64v_fnptr(id, buffer, (uint)pname, offset);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> Return parameters of a query object. </summary>
             /// <param name="id"> Specifies the name of a query object. </param>
@@ -6272,7 +6272,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="pname"> Specifies the symbolic name of a query object parameter. Accepted values are GL_QUERY_RESULT or GL_QUERY_RESULT_AVAILABLE. </param>
             /// <param name="offset"> Specifies the byte offset into buffer's data store where the queried result will be written. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetQueryObject.xhtml" /></remarks>
-            public static void GetQueryBufferObjectuiv(QueryHandle id, BufferHandle buffer, QueryObjectParameterName pname, IntPtr offset) => GLPointers._GetQueryBufferObjectuiv_fnptr((int)id, (int)buffer, (uint)pname, offset);
+            public static void GetQueryBufferObjectuiv(int id, int buffer, QueryObjectParameterName pname, IntPtr offset) => GLPointers._GetQueryBufferObjectuiv_fnptr(id, buffer, (uint)pname, offset);
             
             /// <summary> <b>[requires: GL_ARB_draw_buffers]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -6361,15 +6361,15 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_ARB_fragment_program | GL_ARB_vertex_program]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void BindProgramARB(ProgramTarget target, ProgramHandle program) => GLPointers._BindProgramARB_fnptr((uint)target, (int)program);
+            public static void BindProgramARB(ProgramTarget target, int program) => GLPointers._BindProgramARB_fnptr((uint)target, program);
             
             /// <summary> <b>[requires: GL_ARB_fragment_program | GL_ARB_vertex_program]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void DeleteProgramsARB(int n, ProgramHandle* programs) => GLPointers._DeleteProgramsARB_fnptr(n, (int*)programs);
+            public static void DeleteProgramsARB(int n, int* programs) => GLPointers._DeleteProgramsARB_fnptr(n, programs);
             
             /// <summary> <b>[requires: GL_ARB_fragment_program | GL_ARB_vertex_program]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GenProgramsARB(int n, ProgramHandle* programs) => GLPointers._GenProgramsARB_fnptr(n, (int*)programs);
+            public static void GenProgramsARB(int n, int* programs) => GLPointers._GenProgramsARB_fnptr(n, programs);
             
             /// <summary> <b>[requires: GL_ARB_fragment_program | GL_ARB_vertex_program]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -6429,7 +6429,7 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_ARB_fragment_program | GL_ARB_vertex_program]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static bool IsProgramARB(ProgramHandle program) => GLPointers._IsProgramARB_fnptr((int)program) != 0;
+            public static bool IsProgramARB(int program) => GLPointers._IsProgramARB_fnptr(program) != 0;
             
             /// <summary> <b>[requires: v4.3 | GL_ARB_framebuffer_no_attachments]</b> Set a named parameter of a framebuffer object. </summary>
             /// <param name="target"> Specifies the target to which the framebuffer is bound for glFramebufferParameteri. </param>
@@ -6448,25 +6448,25 @@ namespace OpenTK.Graphics.OpenGL
             /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Determine if a name corresponds to a renderbuffer object. </summary>
             /// <param name="renderbuffer"> Specifies a value that may be the name of a renderbuffer object. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsRenderbuffer.xhtml" /></remarks>
-            public static bool IsRenderbuffer(RenderbufferHandle renderbuffer) => GLPointers._IsRenderbuffer_fnptr((int)renderbuffer) != 0;
+            public static bool IsRenderbuffer(int renderbuffer) => GLPointers._IsRenderbuffer_fnptr(renderbuffer) != 0;
             
             /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Bind a renderbuffer to a renderbuffer target. </summary>
             /// <param name="target"> Specifies the renderbuffer target of the binding operation. target must be GL_RENDERBUFFER. </param>
             /// <param name="renderbuffer"> Specifies the name of the renderbuffer object to bind. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindRenderbuffer.xhtml" /></remarks>
-            public static void BindRenderbuffer(RenderbufferTarget target, RenderbufferHandle renderbuffer) => GLPointers._BindRenderbuffer_fnptr((uint)target, (int)renderbuffer);
+            public static void BindRenderbuffer(RenderbufferTarget target, int renderbuffer) => GLPointers._BindRenderbuffer_fnptr((uint)target, renderbuffer);
             
             /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Delete renderbuffer objects. </summary>
             /// <param name="n"> Specifies the number of renderbuffer objects to be deleted. </param>
             /// <param name="renderbuffers"> A pointer to an array containing n renderbuffer objects to be deleted. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDeleteRenderbuffers.xhtml" /></remarks>
-            public static void DeleteRenderbuffers(int n, RenderbufferHandle* renderbuffers) => GLPointers._DeleteRenderbuffers_fnptr(n, (int*)renderbuffers);
+            public static void DeleteRenderbuffers(int n, int* renderbuffers) => GLPointers._DeleteRenderbuffers_fnptr(n, renderbuffers);
             
             /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Generate renderbuffer object names. </summary>
             /// <param name="n"> Specifies the number of renderbuffer object names to generate. </param>
             /// <param name="renderbuffers"> Specifies an array in which the generated renderbuffer object names are stored. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGenRenderbuffers.xhtml" /></remarks>
-            public static void GenRenderbuffers(int n, RenderbufferHandle* renderbuffers) => GLPointers._GenRenderbuffers_fnptr(n, (int*)renderbuffers);
+            public static void GenRenderbuffers(int n, int* renderbuffers) => GLPointers._GenRenderbuffers_fnptr(n, renderbuffers);
             
             /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Establish data storage, format and dimensions of a    renderbuffer object's image. </summary>
             /// <param name="target">Specifies a binding target of the allocation for glRenderbufferStorage function. Must be GL_RENDERBUFFER.</param>
@@ -6486,25 +6486,25 @@ namespace OpenTK.Graphics.OpenGL
             /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Determine if a name corresponds to a framebuffer object. </summary>
             /// <param name="framebuffer"> Specifies a value that may be the name of a framebuffer object. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsFramebuffer.xhtml" /></remarks>
-            public static bool IsFramebuffer(FramebufferHandle framebuffer) => GLPointers._IsFramebuffer_fnptr((int)framebuffer) != 0;
+            public static bool IsFramebuffer(int framebuffer) => GLPointers._IsFramebuffer_fnptr(framebuffer) != 0;
             
             /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Bind a framebuffer to a framebuffer target. </summary>
             /// <param name="target"> Specifies the framebuffer target of the binding operation. </param>
             /// <param name="framebuffer"> Specifies the name of the framebuffer object to bind. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindFramebuffer.xhtml" /></remarks>
-            public static void BindFramebuffer(FramebufferTarget target, FramebufferHandle framebuffer) => GLPointers._BindFramebuffer_fnptr((uint)target, (int)framebuffer);
+            public static void BindFramebuffer(FramebufferTarget target, int framebuffer) => GLPointers._BindFramebuffer_fnptr((uint)target, framebuffer);
             
             /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Delete framebuffer objects. </summary>
             /// <param name="n"> Specifies the number of framebuffer objects to be deleted. </param>
             /// <param name="framebuffers"> A pointer to an array containing n framebuffer objects to be deleted. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDeleteFramebuffers.xhtml" /></remarks>
-            public static void DeleteFramebuffers(int n, FramebufferHandle* framebuffers) => GLPointers._DeleteFramebuffers_fnptr(n, (int*)framebuffers);
+            public static void DeleteFramebuffers(int n, int* framebuffers) => GLPointers._DeleteFramebuffers_fnptr(n, framebuffers);
             
             /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Generate framebuffer object names. </summary>
             /// <param name="n"> Specifies the number of framebuffer object names to generate. </param>
             /// <param name="ids"> Specifies an array in which the generated framebuffer object names are stored. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGenFramebuffers.xhtml" /></remarks>
-            public static void GenFramebuffers(int n, FramebufferHandle* framebuffers) => GLPointers._GenFramebuffers_fnptr(n, (int*)framebuffers);
+            public static void GenFramebuffers(int n, int* framebuffers) => GLPointers._GenFramebuffers_fnptr(n, framebuffers);
             
             /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Check the completeness status of a framebuffer. </summary>
             /// <param name="target"> Specify the target to which the framebuffer is bound for glCheckFramebufferStatus, and the target against which framebuffer completeness of framebuffer is checked for glCheckNamedFramebufferStatus. </param>
@@ -6518,7 +6518,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="texture"> Specifies the name of an existing texture object to attach. </param>
             /// <param name="level"> Specifies the mipmap level of the texture object to attach. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glFramebufferTexture.xhtml" /></remarks>
-            public static void FramebufferTexture1D(FramebufferTarget target, FramebufferAttachment attachment, TextureTarget textarget, TextureHandle texture, int level) => GLPointers._FramebufferTexture1D_fnptr((uint)target, (uint)attachment, (uint)textarget, (int)texture, level);
+            public static void FramebufferTexture1D(FramebufferTarget target, FramebufferAttachment attachment, TextureTarget textarget, int texture, int level) => GLPointers._FramebufferTexture1D_fnptr((uint)target, (uint)attachment, (uint)textarget, texture, level);
             
             /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Attach a level of a texture object as a logical buffer of a framebuffer object. </summary>
             /// <param name="target"> Specifies the target to which the framebuffer is bound for all commands except glNamedFramebufferTexture. </param>
@@ -6527,7 +6527,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="texture"> Specifies the name of an existing texture object to attach. </param>
             /// <param name="level"> Specifies the mipmap level of the texture object to attach. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glFramebufferTexture.xhtml" /></remarks>
-            public static void FramebufferTexture2D(FramebufferTarget target, FramebufferAttachment attachment, TextureTarget textarget, TextureHandle texture, int level) => GLPointers._FramebufferTexture2D_fnptr((uint)target, (uint)attachment, (uint)textarget, (int)texture, level);
+            public static void FramebufferTexture2D(FramebufferTarget target, FramebufferAttachment attachment, TextureTarget textarget, int texture, int level) => GLPointers._FramebufferTexture2D_fnptr((uint)target, (uint)attachment, (uint)textarget, texture, level);
             
             /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Attach a level of a texture object as a logical buffer of a framebuffer object. </summary>
             /// <param name="target"> Specifies the target to which the framebuffer is bound for all commands except glNamedFramebufferTexture. </param>
@@ -6537,7 +6537,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="level"> Specifies the mipmap level of the texture object to attach. </param>
             /// <param name="layer">!!missing documentation!!</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glFramebufferTexture.xhtml" /></remarks>
-            public static void FramebufferTexture3D(FramebufferTarget target, FramebufferAttachment attachment, TextureTarget textarget, TextureHandle texture, int level, int zoffset) => GLPointers._FramebufferTexture3D_fnptr((uint)target, (uint)attachment, (uint)textarget, (int)texture, level, zoffset);
+            public static void FramebufferTexture3D(FramebufferTarget target, FramebufferAttachment attachment, TextureTarget textarget, int texture, int level, int zoffset) => GLPointers._FramebufferTexture3D_fnptr((uint)target, (uint)attachment, (uint)textarget, texture, level, zoffset);
             
             /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Attach a renderbuffer as a logical buffer of a framebuffer object. </summary>
             /// <param name="target"> Specifies the target to which the framebuffer is bound for glFramebufferRenderbuffer. </param>
@@ -6545,7 +6545,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="renderbuffertarget"> Specifies the renderbuffer target. Must be GL_RENDERBUFFER. </param>
             /// <param name="renderbuffer"> Specifies the name of an existing renderbuffer object of type renderbuffertarget to attach. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glFramebufferRenderbuffer.xhtml" /></remarks>
-            public static void FramebufferRenderbuffer(FramebufferTarget target, FramebufferAttachment attachment, RenderbufferTarget renderbuffertarget, RenderbufferHandle renderbuffer) => GLPointers._FramebufferRenderbuffer_fnptr((uint)target, (uint)attachment, (uint)renderbuffertarget, (int)renderbuffer);
+            public static void FramebufferRenderbuffer(FramebufferTarget target, FramebufferAttachment attachment, RenderbufferTarget renderbuffertarget, int renderbuffer) => GLPointers._FramebufferRenderbuffer_fnptr((uint)target, (uint)attachment, (uint)renderbuffertarget, renderbuffer);
             
             /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> Retrieve information about attachments of a framebuffer object. </summary>
             /// <param name="target"> Specifies the target to which the framebuffer object is bound for glGetFramebufferAttachmentParameteriv. </param>
@@ -6590,23 +6590,23 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="level"> Specifies the mipmap level of the texture object to attach. </param>
             /// <param name="layer"> Specifies the layer of the texture object to attach. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glFramebufferTextureLayer.xhtml" /></remarks>
-            public static void FramebufferTextureLayer(FramebufferTarget target, FramebufferAttachment attachment, TextureHandle texture, int level, int layer) => GLPointers._FramebufferTextureLayer_fnptr((uint)target, (uint)attachment, (int)texture, level, layer);
+            public static void FramebufferTextureLayer(FramebufferTarget target, FramebufferAttachment attachment, int texture, int level, int layer) => GLPointers._FramebufferTextureLayer_fnptr((uint)target, (uint)attachment, texture, level, layer);
             
             /// <summary> <b>[requires: GL_ARB_geometry_shader4]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramParameteriARB(ProgramHandle program, ProgramParameterPName pname, int value) => GLPointers._ProgramParameteriARB_fnptr((int)program, (uint)pname, value);
+            public static void ProgramParameteriARB(int program, ProgramParameterPName pname, int value) => GLPointers._ProgramParameteriARB_fnptr(program, (uint)pname, value);
             
             /// <summary> <b>[requires: GL_ARB_geometry_shader4]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void FramebufferTextureARB(FramebufferTarget target, FramebufferAttachment attachment, TextureHandle texture, int level) => GLPointers._FramebufferTextureARB_fnptr((uint)target, (uint)attachment, (int)texture, level);
+            public static void FramebufferTextureARB(FramebufferTarget target, FramebufferAttachment attachment, int texture, int level) => GLPointers._FramebufferTextureARB_fnptr((uint)target, (uint)attachment, texture, level);
             
             /// <summary> <b>[requires: GL_ARB_geometry_shader4]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void FramebufferTextureLayerARB(FramebufferTarget target, FramebufferAttachment attachment, TextureHandle texture, int level, int layer) => GLPointers._FramebufferTextureLayerARB_fnptr((uint)target, (uint)attachment, (int)texture, level, layer);
+            public static void FramebufferTextureLayerARB(FramebufferTarget target, FramebufferAttachment attachment, int texture, int level, int layer) => GLPointers._FramebufferTextureLayerARB_fnptr((uint)target, (uint)attachment, texture, level, layer);
             
             /// <summary> <b>[requires: GL_ARB_geometry_shader4]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void FramebufferTextureFaceARB(FramebufferTarget target, FramebufferAttachment attachment, TextureHandle texture, int level, TextureTarget face) => GLPointers._FramebufferTextureFaceARB_fnptr((uint)target, (uint)attachment, (int)texture, level, (uint)face);
+            public static void FramebufferTextureFaceARB(FramebufferTarget target, FramebufferAttachment attachment, int texture, int level, TextureTarget face) => GLPointers._FramebufferTextureFaceARB_fnptr((uint)target, (uint)attachment, texture, level, (uint)face);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_get_program_binary]</b> Return a binary representation of a program object's compiled and linked executable source. </summary>
             /// <param name="program"> Specifies the name of a program object whose binary representation to retrieve. </param>
@@ -6615,7 +6615,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="binaryFormat"> Specifies the address of a variable to receive a token indicating the format of the binary data returned by the GL. </param>
             /// <param name="binary"> Specifies the address an array into which the GL will return program's binary representation. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetProgramBinary.xhtml" /></remarks>
-            public static void GetProgramBinary(ProgramHandle program, int bufSize, int* length, All* binaryFormat, void* binary) => GLPointers._GetProgramBinary_fnptr((int)program, bufSize, length, (uint*)binaryFormat, binary);
+            public static void GetProgramBinary(int program, int bufSize, int* length, All* binaryFormat, void* binary) => GLPointers._GetProgramBinary_fnptr(program, bufSize, length, (uint*)binaryFormat, binary);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_get_program_binary]</b> Load a program object with a program binary. </summary>
             /// <param name="program"> Specifies the name of a program object into which to load a program binary. </param>
@@ -6623,14 +6623,14 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="binary"> Specifies the address an array containing the binary to be loaded into program. </param>
             /// <param name="length"> Specifies the number of bytes contained in binary. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramBinary.xhtml" /></remarks>
-            public static void ProgramBinary(ProgramHandle program, All binaryFormat, void* binary, int length) => GLPointers._ProgramBinary_fnptr((int)program, (uint)binaryFormat, binary, length);
+            public static void ProgramBinary(int program, All binaryFormat, void* binary, int length) => GLPointers._ProgramBinary_fnptr(program, (uint)binaryFormat, binary, length);
             
             /// <summary> <b>[requires: v4.1 | v4.1 | GL_ARB_get_program_binary | GL_ARB_separate_shader_objects]</b> Specify a parameter for a program object. </summary>
             /// <param name="program"> Specifies the name of a program object whose parameter to modify. </param>
             /// <param name="pname"> Specifies the name of the parameter to modify. </param>
             /// <param name="value"> Specifies the new value of the parameter specified by pname for program. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramParameter.xhtml" /></remarks>
-            public static void ProgramParameteri(ProgramHandle program, ProgramParameterPName pname, int value) => GLPointers._ProgramParameteri_fnptr((int)program, (uint)pname, value);
+            public static void ProgramParameteri(int program, ProgramParameterPName pname, int value) => GLPointers._ProgramParameteri_fnptr(program, (uint)pname, value);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_get_texture_sub_image]</b> Retrieve a sub-region of a texture image from a texture    object. </summary>
             /// <param name="texture">Specifies the name of the source texture object. Must be GL_TEXTURE_1D, GL_TEXTURE_1D_ARRAY, GL_TEXTURE_2D, GL_TEXTURE_2D_ARRAY, GL_TEXTURE_3D, GL_TEXTURE_CUBE_MAP, GL_TEXTURE_CUBE_MAP_ARRAY or GL_TEXTURE_RECTANGLE. In specific, buffer and multisample textures are not permitted.</param>
@@ -6646,7 +6646,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="bufSize">Specifies the size of the buffer to receive the retrieved pixel data.</param>
             /// <param name="pixels">Returns the texture subimage. Should be a pointer to an array of the type specified by type.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetTextureSubImage.xhtml" /></remarks>
-            public static void GetTextureSubImage(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, int bufSize, void* pixels) => GLPointers._GetTextureSubImage_fnptr((int)texture, level, xoffset, yoffset, zoffset, width, height, depth, (uint)format, (uint)type, bufSize, pixels);
+            public static void GetTextureSubImage(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, int bufSize, void* pixels) => GLPointers._GetTextureSubImage_fnptr(texture, level, xoffset, yoffset, zoffset, width, height, depth, (uint)format, (uint)type, bufSize, pixels);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_get_texture_sub_image]</b> Retrieve a sub-region of a compressed texture image from a    compressed texture object. </summary>
             /// <param name="texture">Specifies the name of the source texture object. Must be GL_TEXTURE_1D, GL_TEXTURE_1D_ARRAY, GL_TEXTURE_2D, GL_TEXTURE_2D_ARRAY, GL_TEXTURE_3D, GL_TEXTURE_CUBE_MAP, GL_TEXTURE_CUBE_MAP_ARRAY or GL_TEXTURE_RECTANGLE. In specific, buffer and multisample textures are not permitted.</param>
@@ -6660,11 +6660,11 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="bufSize">Specifies the size of the buffer to receive the retrieved pixel data.</param>
             /// <param name="pixels">Returns the texture subimage. Should be a pointer to an array of the type specified by type.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetCompressedTextureSubImage.xhtml" /></remarks>
-            public static void GetCompressedTextureSubImage(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, int bufSize, void* pixels) => GLPointers._GetCompressedTextureSubImage_fnptr((int)texture, level, xoffset, yoffset, zoffset, width, height, depth, bufSize, pixels);
+            public static void GetCompressedTextureSubImage(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, int bufSize, void* pixels) => GLPointers._GetCompressedTextureSubImage_fnptr(texture, level, xoffset, yoffset, zoffset, width, height, depth, bufSize, pixels);
             
             /// <summary> <b>[requires: GL_ARB_gl_spirv]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void SpecializeShaderARB(ShaderHandle shader, byte* pEntryPoint, uint numSpecializationConstants, uint* pConstantIndex, uint* pConstantValue) => GLPointers._SpecializeShaderARB_fnptr((int)shader, pEntryPoint, numSpecializationConstants, pConstantIndex, pConstantValue);
+            public static void SpecializeShaderARB(int shader, byte* pEntryPoint, uint numSpecializationConstants, uint* pConstantIndex, uint* pConstantValue) => GLPointers._SpecializeShaderARB_fnptr(shader, pEntryPoint, numSpecializationConstants, pConstantIndex, pConstantValue);
             
             /// <summary> <b>[requires: v4.0 | GL_ARB_gpu_shader_fp64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -6739,7 +6739,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="location">Specifies the location of the uniform variable to be queried.</param>
             /// <param name="parameters">Returns the value of the specified uniform variable.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetUniform.xhtml" /></remarks>
-            public static void GetUniformdv(ProgramHandle program, int location, double* parameters) => GLPointers._GetUniformdv_fnptr((int)program, location, parameters);
+            public static void GetUniformdv(int program, int location, double* parameters) => GLPointers._GetUniformdv_fnptr(program, location, parameters);
             
             /// <summary> <b>[requires: GL_ARB_gpu_shader_int64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -6807,83 +6807,83 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_ARB_gpu_shader_int64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetUniformi64vARB(ProgramHandle program, int location, long* parameters) => GLPointers._GetUniformi64vARB_fnptr((int)program, location, parameters);
+            public static void GetUniformi64vARB(int program, int location, long* parameters) => GLPointers._GetUniformi64vARB_fnptr(program, location, parameters);
             
             /// <summary> <b>[requires: GL_ARB_gpu_shader_int64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetUniformui64vARB(ProgramHandle program, int location, ulong* parameters) => GLPointers._GetUniformui64vARB_fnptr((int)program, location, parameters);
+            public static void GetUniformui64vARB(int program, int location, ulong* parameters) => GLPointers._GetUniformui64vARB_fnptr(program, location, parameters);
             
             /// <summary> <b>[requires: GL_ARB_gpu_shader_int64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetnUniformi64vARB(ProgramHandle program, int location, int bufSize, long* parameters) => GLPointers._GetnUniformi64vARB_fnptr((int)program, location, bufSize, parameters);
+            public static void GetnUniformi64vARB(int program, int location, int bufSize, long* parameters) => GLPointers._GetnUniformi64vARB_fnptr(program, location, bufSize, parameters);
             
             /// <summary> <b>[requires: GL_ARB_gpu_shader_int64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetnUniformui64vARB(ProgramHandle program, int location, int bufSize, ulong* parameters) => GLPointers._GetnUniformui64vARB_fnptr((int)program, location, bufSize, parameters);
+            public static void GetnUniformui64vARB(int program, int location, int bufSize, ulong* parameters) => GLPointers._GetnUniformui64vARB_fnptr(program, location, bufSize, parameters);
             
             /// <summary> <b>[requires: GL_ARB_gpu_shader_int64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform1i64ARB(ProgramHandle program, int location, long x) => GLPointers._ProgramUniform1i64ARB_fnptr((int)program, location, x);
+            public static void ProgramUniform1i64ARB(int program, int location, long x) => GLPointers._ProgramUniform1i64ARB_fnptr(program, location, x);
             
             /// <summary> <b>[requires: GL_ARB_gpu_shader_int64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform2i64ARB(ProgramHandle program, int location, long x, long y) => GLPointers._ProgramUniform2i64ARB_fnptr((int)program, location, x, y);
+            public static void ProgramUniform2i64ARB(int program, int location, long x, long y) => GLPointers._ProgramUniform2i64ARB_fnptr(program, location, x, y);
             
             /// <summary> <b>[requires: GL_ARB_gpu_shader_int64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform3i64ARB(ProgramHandle program, int location, long x, long y, long z) => GLPointers._ProgramUniform3i64ARB_fnptr((int)program, location, x, y, z);
+            public static void ProgramUniform3i64ARB(int program, int location, long x, long y, long z) => GLPointers._ProgramUniform3i64ARB_fnptr(program, location, x, y, z);
             
             /// <summary> <b>[requires: GL_ARB_gpu_shader_int64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform4i64ARB(ProgramHandle program, int location, long x, long y, long z, long w) => GLPointers._ProgramUniform4i64ARB_fnptr((int)program, location, x, y, z, w);
+            public static void ProgramUniform4i64ARB(int program, int location, long x, long y, long z, long w) => GLPointers._ProgramUniform4i64ARB_fnptr(program, location, x, y, z, w);
             
             /// <summary> <b>[requires: GL_ARB_gpu_shader_int64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform1i64vARB(ProgramHandle program, int location, int count, long* value) => GLPointers._ProgramUniform1i64vARB_fnptr((int)program, location, count, value);
+            public static void ProgramUniform1i64vARB(int program, int location, int count, long* value) => GLPointers._ProgramUniform1i64vARB_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_ARB_gpu_shader_int64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform2i64vARB(ProgramHandle program, int location, int count, long* value) => GLPointers._ProgramUniform2i64vARB_fnptr((int)program, location, count, value);
+            public static void ProgramUniform2i64vARB(int program, int location, int count, long* value) => GLPointers._ProgramUniform2i64vARB_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_ARB_gpu_shader_int64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform3i64vARB(ProgramHandle program, int location, int count, long* value) => GLPointers._ProgramUniform3i64vARB_fnptr((int)program, location, count, value);
+            public static void ProgramUniform3i64vARB(int program, int location, int count, long* value) => GLPointers._ProgramUniform3i64vARB_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_ARB_gpu_shader_int64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform4i64vARB(ProgramHandle program, int location, int count, long* value) => GLPointers._ProgramUniform4i64vARB_fnptr((int)program, location, count, value);
+            public static void ProgramUniform4i64vARB(int program, int location, int count, long* value) => GLPointers._ProgramUniform4i64vARB_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_ARB_gpu_shader_int64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform1ui64ARB(ProgramHandle program, int location, ulong x) => GLPointers._ProgramUniform1ui64ARB_fnptr((int)program, location, x);
+            public static void ProgramUniform1ui64ARB(int program, int location, ulong x) => GLPointers._ProgramUniform1ui64ARB_fnptr(program, location, x);
             
             /// <summary> <b>[requires: GL_ARB_gpu_shader_int64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform2ui64ARB(ProgramHandle program, int location, ulong x, ulong y) => GLPointers._ProgramUniform2ui64ARB_fnptr((int)program, location, x, y);
+            public static void ProgramUniform2ui64ARB(int program, int location, ulong x, ulong y) => GLPointers._ProgramUniform2ui64ARB_fnptr(program, location, x, y);
             
             /// <summary> <b>[requires: GL_ARB_gpu_shader_int64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform3ui64ARB(ProgramHandle program, int location, ulong x, ulong y, ulong z) => GLPointers._ProgramUniform3ui64ARB_fnptr((int)program, location, x, y, z);
+            public static void ProgramUniform3ui64ARB(int program, int location, ulong x, ulong y, ulong z) => GLPointers._ProgramUniform3ui64ARB_fnptr(program, location, x, y, z);
             
             /// <summary> <b>[requires: GL_ARB_gpu_shader_int64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform4ui64ARB(ProgramHandle program, int location, ulong x, ulong y, ulong z, ulong w) => GLPointers._ProgramUniform4ui64ARB_fnptr((int)program, location, x, y, z, w);
+            public static void ProgramUniform4ui64ARB(int program, int location, ulong x, ulong y, ulong z, ulong w) => GLPointers._ProgramUniform4ui64ARB_fnptr(program, location, x, y, z, w);
             
             /// <summary> <b>[requires: GL_ARB_gpu_shader_int64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform1ui64vARB(ProgramHandle program, int location, int count, ulong* value) => GLPointers._ProgramUniform1ui64vARB_fnptr((int)program, location, count, value);
+            public static void ProgramUniform1ui64vARB(int program, int location, int count, ulong* value) => GLPointers._ProgramUniform1ui64vARB_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_ARB_gpu_shader_int64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform2ui64vARB(ProgramHandle program, int location, int count, ulong* value) => GLPointers._ProgramUniform2ui64vARB_fnptr((int)program, location, count, value);
+            public static void ProgramUniform2ui64vARB(int program, int location, int count, ulong* value) => GLPointers._ProgramUniform2ui64vARB_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_ARB_gpu_shader_int64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform3ui64vARB(ProgramHandle program, int location, int count, ulong* value) => GLPointers._ProgramUniform3ui64vARB_fnptr((int)program, location, count, value);
+            public static void ProgramUniform3ui64vARB(int program, int location, int count, ulong* value) => GLPointers._ProgramUniform3ui64vARB_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_ARB_gpu_shader_int64]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform4ui64vARB(ProgramHandle program, int location, int count, ulong* value) => GLPointers._ProgramUniform4ui64vARB_fnptr((int)program, location, count, value);
+            public static void ProgramUniform4ui64vARB(int program, int location, int count, ulong* value) => GLPointers._ProgramUniform4ui64vARB_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: v1.4 | GL_ARB_imaging]</b> Set the blend color. </summary>
             /// <param name="red"> specify the components of GL_BLEND_COLOR </param>
@@ -6938,25 +6938,25 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="height"> The height of the region to be invalidated. </param>
             /// <param name="depth"> The depth of the region to be invalidated. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glInvalidateTexSubImage.xhtml" /></remarks>
-            public static void InvalidateTexSubImage(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth) => GLPointers._InvalidateTexSubImage_fnptr((int)texture, level, xoffset, yoffset, zoffset, width, height, depth);
+            public static void InvalidateTexSubImage(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth) => GLPointers._InvalidateTexSubImage_fnptr(texture, level, xoffset, yoffset, zoffset, width, height, depth);
             
             /// <summary> <b>[requires: v4.3 | GL_ARB_invalidate_subdata]</b> Invalidate the entirety a texture image. </summary>
             /// <param name="texture"> The name of a texture object to invalidate. </param>
             /// <param name="level"> The level of detail of the texture object to invalidate. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glInvalidateTexImage.xhtml" /></remarks>
-            public static void InvalidateTexImage(TextureHandle texture, int level) => GLPointers._InvalidateTexImage_fnptr((int)texture, level);
+            public static void InvalidateTexImage(int texture, int level) => GLPointers._InvalidateTexImage_fnptr(texture, level);
             
             /// <summary> <b>[requires: v4.3 | GL_ARB_invalidate_subdata]</b> Invalidate a region of a buffer object's data store. </summary>
             /// <param name="buffer"> The name of a buffer object, a subrange of whose data store to invalidate. </param>
             /// <param name="offset"> The offset within the buffer's data store of the start of the range to be invalidated. </param>
             /// <param name="length"> The length of the range within the buffer's data store to be invalidated. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glInvalidateBufferSubData.xhtml" /></remarks>
-            public static void InvalidateBufferSubData(BufferHandle buffer, IntPtr offset, nint length) => GLPointers._InvalidateBufferSubData_fnptr((int)buffer, offset, length);
+            public static void InvalidateBufferSubData(int buffer, IntPtr offset, nint length) => GLPointers._InvalidateBufferSubData_fnptr(buffer, offset, length);
             
             /// <summary> <b>[requires: v4.3 | GL_ARB_invalidate_subdata]</b> Invalidate the content of a buffer object's data store. </summary>
             /// <param name="buffer"> The name of a buffer object whose data store to invalidate. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glInvalidateBufferData.xhtml" /></remarks>
-            public static void InvalidateBufferData(BufferHandle buffer) => GLPointers._InvalidateBufferData_fnptr((int)buffer);
+            public static void InvalidateBufferData(int buffer) => GLPointers._InvalidateBufferData_fnptr(buffer);
             
             /// <summary> <b>[requires: v4.3 | GL_ARB_invalidate_subdata]</b> Invalidate the content of some or all of a framebuffer's attachments. </summary>
             /// <param name="target"> Specifies the target to which the framebuffer object is attached for glInvalidateFramebuffer. </param>
@@ -7017,7 +7017,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="count"> Specify the number of contiguous binding points to which to bind buffers. </param>
             /// <param name="buffers"> A pointer to an array of names of buffer objects to bind to the targets on the specified binding point, or NULL. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindBuffersBase.xhtml" /></remarks>
-            public static void BindBuffersBase(BufferTargetARB target, uint first, int count, BufferHandle* buffers) => GLPointers._BindBuffersBase_fnptr((uint)target, first, count, (int*)buffers);
+            public static void BindBuffersBase(BufferTargetARB target, uint first, int count, int* buffers) => GLPointers._BindBuffersBase_fnptr((uint)target, first, count, buffers);
             
             /// <summary> <b>[requires: v4.4 | GL_ARB_multi_bind]</b> Bind ranges of one or more buffer objects to a sequence of indexed buffer targets. </summary>
             /// <param name="target"> Specify the target of the bind operation. target must be one of GL_ATOMIC_COUNTER_BUFFER, GL_TRANSFORM_FEEDBACK_BUFFER, GL_UNIFORM_BUFFER or GL_SHADER_STORAGE_BUFFER. </param>
@@ -7027,28 +7027,28 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="offsets"> A pointer to an array of offsets into the corresponding buffer in buffers to bind, or NULL if buffers is NULL. </param>
             /// <param name="sizes"> A pointer to an array of sizes of the corresponding buffer in buffers to bind, or NULL if buffers is NULL. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindBuffersRange.xhtml" /></remarks>
-            public static void BindBuffersRange(BufferTargetARB target, uint first, int count, BufferHandle* buffers, IntPtr* offsets, nint* sizes) => GLPointers._BindBuffersRange_fnptr((uint)target, first, count, (int*)buffers, offsets, sizes);
+            public static void BindBuffersRange(BufferTargetARB target, uint first, int count, int* buffers, IntPtr* offsets, nint* sizes) => GLPointers._BindBuffersRange_fnptr((uint)target, first, count, buffers, offsets, sizes);
             
             /// <summary> <b>[requires: v4.4 | GL_ARB_multi_bind]</b> Bind one or more named textures to a sequence of consecutive texture units. </summary>
             /// <param name="first"> Specifies the first texture unit to which a texture is to be bound. </param>
             /// <param name="count"> Specifies the number of textures to bind. </param>
             /// <param name="textures"> Specifies the address of an array of names of existing texture objects. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindTextures.xhtml" /></remarks>
-            public static void BindTextures(uint first, int count, TextureHandle* textures) => GLPointers._BindTextures_fnptr(first, count, (int*)textures);
+            public static void BindTextures(uint first, int count, int* textures) => GLPointers._BindTextures_fnptr(first, count, textures);
             
             /// <summary> <b>[requires: v4.4 | GL_ARB_multi_bind]</b> Bind one or more named sampler objects to a sequence of consecutive sampler units. </summary>
             /// <param name="first"> Specifies the first sampler unit to which a sampler object is to be bound. </param>
             /// <param name="count"> Specifies the number of samplers to bind. </param>
             /// <param name="samplers"> Specifies the address of an array of names of existing sampler objects. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindSamplers.xhtml" /></remarks>
-            public static void BindSamplers(uint first, int count, SamplerHandle* samplers) => GLPointers._BindSamplers_fnptr(first, count, (int*)samplers);
+            public static void BindSamplers(uint first, int count, int* samplers) => GLPointers._BindSamplers_fnptr(first, count, samplers);
             
             /// <summary> <b>[requires: v4.4 | GL_ARB_multi_bind]</b> Bind one or more named texture images to a sequence of consecutive image units. </summary>
             /// <param name="first"> Specifies the first image unit to which a texture is to be bound. </param>
             /// <param name="count"> Specifies the number of textures to bind. </param>
             /// <param name="textures"> Specifies the address of an array of names of existing texture objects. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindImageTextures.xhtml" /></remarks>
-            public static void BindImageTextures(uint first, int count, TextureHandle* textures) => GLPointers._BindImageTextures_fnptr(first, count, (int*)textures);
+            public static void BindImageTextures(uint first, int count, int* textures) => GLPointers._BindImageTextures_fnptr(first, count, textures);
             
             /// <summary> <b>[requires: v4.4 | GL_ARB_multi_bind]</b> Attach multiple buffer objects to a vertex array object. </summary>
             /// <param name="first"> Specifies the first vertex buffer binding point to which a buffer object is to be bound. </param>
@@ -7057,7 +7057,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="offsets"> Specifies the address of an array of offsets to associate with the binding points. </param>
             /// <param name="strides">!!missing documentation!!</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindVertexBuffers.xhtml" /></remarks>
-            public static void BindVertexBuffers(uint first, int count, BufferHandle* buffers, IntPtr* offsets, int* strides) => GLPointers._BindVertexBuffers_fnptr(first, count, (int*)buffers, offsets, strides);
+            public static void BindVertexBuffers(uint first, int count, int* buffers, IntPtr* offsets, int* strides) => GLPointers._BindVertexBuffers_fnptr(first, count, buffers, offsets, strides);
             
             /// <summary> <b>[requires: v4.3 | GL_ARB_multi_draw_indirect]</b> Render multiple sets of primitives from array data, taking parameters from memory. </summary>
             /// <param name="mode"> Specifies what kind of primitives to render. Symbolic constants GL_POINTS, GL_LINE_STRIP, GL_LINE_LOOP, GL_LINES, GL_LINE_STRIP_ADJACENCY, GL_LINES_ADJACENCY, GL_TRIANGLE_STRIP, GL_TRIANGLE_FAN, GL_TRIANGLES, GL_TRIANGLE_STRIP_ADJACENCY, GL_TRIANGLES_ADJACENCY, and GL_PATCHES are accepted. </param>
@@ -7218,19 +7218,19 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_ARB_occlusion_query]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GenQueriesARB(int n, QueryHandle* ids) => GLPointers._GenQueriesARB_fnptr(n, (int*)ids);
+            public static void GenQueriesARB(int n, int* ids) => GLPointers._GenQueriesARB_fnptr(n, ids);
             
             /// <summary> <b>[requires: GL_ARB_occlusion_query]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void DeleteQueriesARB(int n, QueryHandle* ids) => GLPointers._DeleteQueriesARB_fnptr(n, (int*)ids);
+            public static void DeleteQueriesARB(int n, int* ids) => GLPointers._DeleteQueriesARB_fnptr(n, ids);
             
             /// <summary> <b>[requires: GL_ARB_occlusion_query]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static bool IsQueryARB(QueryHandle id) => GLPointers._IsQueryARB_fnptr((int)id) != 0;
+            public static bool IsQueryARB(int id) => GLPointers._IsQueryARB_fnptr(id) != 0;
             
             /// <summary> <b>[requires: GL_ARB_occlusion_query]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void BeginQueryARB(QueryTarget target, QueryHandle id) => GLPointers._BeginQueryARB_fnptr((uint)target, (int)id);
+            public static void BeginQueryARB(QueryTarget target, int id) => GLPointers._BeginQueryARB_fnptr((uint)target, id);
             
             /// <summary> <b>[requires: GL_ARB_occlusion_query]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -7242,11 +7242,11 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_ARB_occlusion_query]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetQueryObjectivARB(QueryHandle id, QueryObjectParameterName pname, int* parameters) => GLPointers._GetQueryObjectivARB_fnptr((int)id, (uint)pname, parameters);
+            public static void GetQueryObjectivARB(int id, QueryObjectParameterName pname, int* parameters) => GLPointers._GetQueryObjectivARB_fnptr(id, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_ARB_occlusion_query]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetQueryObjectuivARB(QueryHandle id, QueryObjectParameterName pname, uint* parameters) => GLPointers._GetQueryObjectuivARB_fnptr((int)id, (uint)pname, parameters);
+            public static void GetQueryObjectuivARB(int id, QueryObjectParameterName pname, uint* parameters) => GLPointers._GetQueryObjectuivARB_fnptr(id, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_ARB_parallel_shader_compile]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -7270,14 +7270,14 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="pname"> The name of the parameter within programInterface to query. </param>
             /// <param name="parameters"> The address of a variable to retrieve the value of pname for the program interface. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetProgramInterface.xhtml" /></remarks>
-            public static void GetProgramInterfaceiv(ProgramHandle program, ProgramInterface programInterface, ProgramInterfacePName pname, int* parameters) => GLPointers._GetProgramInterfaceiv_fnptr((int)program, (uint)programInterface, (uint)pname, parameters);
+            public static void GetProgramInterfaceiv(int program, ProgramInterface programInterface, ProgramInterfacePName pname, int* parameters) => GLPointers._GetProgramInterfaceiv_fnptr(program, (uint)programInterface, (uint)pname, parameters);
             
             /// <summary> <b>[requires: v4.3 | GL_ARB_program_interface_query]</b> Query the index of a named resource within a program. </summary>
             /// <param name="program"> The name of a program object whose resources to query. </param>
             /// <param name="programInterface"> A token identifying the interface within program containing the resource named name. </param>
             /// <param name="name"> The name of the resource to query the index of. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetProgramResourceIndex.xhtml" /></remarks>
-            public static uint GetProgramResourceIndex(ProgramHandle program, ProgramInterface programInterface, byte* name) => GLPointers._GetProgramResourceIndex_fnptr((int)program, (uint)programInterface, name);
+            public static uint GetProgramResourceIndex(int program, ProgramInterface programInterface, byte* name) => GLPointers._GetProgramResourceIndex_fnptr(program, (uint)programInterface, name);
             
             /// <summary> <b>[requires: v4.3 | GL_ARB_program_interface_query]</b> Query the name of an indexed resource within a program. </summary>
             /// <param name="program"> The name of a program object whose resources to query. </param>
@@ -7287,7 +7287,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="length"> The address of a variable which will receive the length of the resource name. </param>
             /// <param name="name"> The address of a character array into which will be written the name of the resource. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetProgramResourceName.xhtml" /></remarks>
-            public static void GetProgramResourceName(ProgramHandle program, ProgramInterface programInterface, uint index, int bufSize, int* length, byte* name) => GLPointers._GetProgramResourceName_fnptr((int)program, (uint)programInterface, index, bufSize, length, name);
+            public static void GetProgramResourceName(int program, ProgramInterface programInterface, uint index, int bufSize, int* length, byte* name) => GLPointers._GetProgramResourceName_fnptr(program, (uint)programInterface, index, bufSize, length, name);
             
             /// <summary> <b>[requires: v4.3 | GL_ARB_program_interface_query]</b> Retrieve values for multiple properties of a single active resource within a program object. </summary>
             /// <param name="program"> The name of a program object whose resources to query. </param>
@@ -7299,21 +7299,21 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="length">!!missing documentation!!</param>
             /// <param name="parameters">!!missing documentation!!</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetProgramResource.xhtml" /></remarks>
-            public static void GetProgramResourceiv(ProgramHandle program, ProgramInterface programInterface, uint index, int propCount, ProgramResourceProperty* props, int count, int* length, int* parameters) => GLPointers._GetProgramResourceiv_fnptr((int)program, (uint)programInterface, index, propCount, (uint*)props, count, length, parameters);
+            public static void GetProgramResourceiv(int program, ProgramInterface programInterface, uint index, int propCount, ProgramResourceProperty* props, int count, int* length, int* parameters) => GLPointers._GetProgramResourceiv_fnptr(program, (uint)programInterface, index, propCount, (uint*)props, count, length, parameters);
             
             /// <summary> <b>[requires: v4.3 | GL_ARB_program_interface_query]</b> Query the location of a named resource within a program. </summary>
             /// <param name="program"> The name of a program object whose resources to query. </param>
             /// <param name="programInterface"> A token identifying the interface within program containing the resource named name. </param>
             /// <param name="name"> The name of the resource to query the location of. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetProgramResourceLocation.xhtml" /></remarks>
-            public static int GetProgramResourceLocation(ProgramHandle program, ProgramInterface programInterface, byte* name) => GLPointers._GetProgramResourceLocation_fnptr((int)program, (uint)programInterface, name);
+            public static int GetProgramResourceLocation(int program, ProgramInterface programInterface, byte* name) => GLPointers._GetProgramResourceLocation_fnptr(program, (uint)programInterface, name);
             
             /// <summary> <b>[requires: v4.3 | GL_ARB_program_interface_query]</b> Query the fragment color index of a named variable within a program. </summary>
             /// <param name="program"> The name of a program object whose resources to query. </param>
             /// <param name="programInterface"> A token identifying the interface within program containing the resource named name. </param>
             /// <param name="name"> The name of the resource to query the location of. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetProgramResourceLocationIndex.xhtml" /></remarks>
-            public static int GetProgramResourceLocationIndex(ProgramHandle program, ProgramInterface programInterface, byte* name) => GLPointers._GetProgramResourceLocationIndex_fnptr((int)program, (uint)programInterface, name);
+            public static int GetProgramResourceLocationIndex(int program, ProgramInterface programInterface, byte* name) => GLPointers._GetProgramResourceLocationIndex_fnptr(program, (uint)programInterface, name);
             
             /// <summary> <b>[requires: v3.2 | GL_ARB_provoking_vertex]</b> Specifiy the vertex to be used as the source of data for flat shaded varyings. </summary>
             /// <param name="provokeMode"> Specifies the vertex to be used as the source of data for flat shaded varyings. </param>
@@ -7338,19 +7338,19 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_ARB_robustness]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetnUniformfvARB(ProgramHandle program, int location, int bufSize, float* parameters) => GLPointers._GetnUniformfvARB_fnptr((int)program, location, bufSize, parameters);
+            public static void GetnUniformfvARB(int program, int location, int bufSize, float* parameters) => GLPointers._GetnUniformfvARB_fnptr(program, location, bufSize, parameters);
             
             /// <summary> <b>[requires: GL_ARB_robustness]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetnUniformivARB(ProgramHandle program, int location, int bufSize, int* parameters) => GLPointers._GetnUniformivARB_fnptr((int)program, location, bufSize, parameters);
+            public static void GetnUniformivARB(int program, int location, int bufSize, int* parameters) => GLPointers._GetnUniformivARB_fnptr(program, location, bufSize, parameters);
             
             /// <summary> <b>[requires: GL_ARB_robustness]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetnUniformuivARB(ProgramHandle program, int location, int bufSize, uint* parameters) => GLPointers._GetnUniformuivARB_fnptr((int)program, location, bufSize, parameters);
+            public static void GetnUniformuivARB(int program, int location, int bufSize, uint* parameters) => GLPointers._GetnUniformuivARB_fnptr(program, location, bufSize, parameters);
             
             /// <summary> <b>[requires: GL_ARB_robustness]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetnUniformdvARB(ProgramHandle program, int location, int bufSize, double* parameters) => GLPointers._GetnUniformdvARB_fnptr((int)program, location, bufSize, parameters);
+            public static void GetnUniformdvARB(int program, int location, int bufSize, double* parameters) => GLPointers._GetnUniformdvARB_fnptr(program, location, bufSize, parameters);
             
             /// <summary> <b>[requires: GL_ARB_sample_locations]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -7358,7 +7358,7 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_ARB_sample_locations]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedFramebufferSampleLocationsfvARB(FramebufferHandle framebuffer, uint start, int count, float* v) => GLPointers._NamedFramebufferSampleLocationsfvARB_fnptr((int)framebuffer, start, count, v);
+            public static void NamedFramebufferSampleLocationsfvARB(int framebuffer, uint start, int count, float* v) => GLPointers._NamedFramebufferSampleLocationsfvARB_fnptr(framebuffer, start, count, v);
             
             /// <summary> <b>[requires: GL_ARB_sample_locations]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -7372,150 +7372,150 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="n"> Specifies the number of sampler object names to generate. </param>
             /// <param name="samplers"> Specifies an array in which the generated sampler object names are stored. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGenSamplers.xhtml" /></remarks>
-            public static void GenSamplers(int count, SamplerHandle* samplers) => GLPointers._GenSamplers_fnptr(count, (int*)samplers);
+            public static void GenSamplers(int count, int* samplers) => GLPointers._GenSamplers_fnptr(count, samplers);
             
             /// <summary> <b>[requires: v3.3 | GL_ARB_sampler_objects]</b> Delete named sampler objects. </summary>
             /// <param name="n"> Specifies the number of sampler objects to be deleted. </param>
             /// <param name="samplers"> Specifies an array of sampler objects to be deleted. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDeleteSamplers.xhtml" /></remarks>
-            public static void DeleteSamplers(int count, SamplerHandle* samplers) => GLPointers._DeleteSamplers_fnptr(count, (int*)samplers);
+            public static void DeleteSamplers(int count, int* samplers) => GLPointers._DeleteSamplers_fnptr(count, samplers);
             
             /// <summary> <b>[requires: v3.3 | GL_ARB_sampler_objects]</b> Determine if a name corresponds to a sampler object. </summary>
             /// <param name="id"> Specifies a value that may be the name of a sampler object. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsSampler.xhtml" /></remarks>
-            public static bool IsSampler(SamplerHandle sampler) => GLPointers._IsSampler_fnptr((int)sampler) != 0;
+            public static bool IsSampler(int sampler) => GLPointers._IsSampler_fnptr(sampler) != 0;
             
             /// <summary> <b>[requires: v3.3 | GL_ARB_sampler_objects]</b> Bind a named sampler to a texturing target. </summary>
             /// <param name="unit"> Specifies the index of the texture unit to which the sampler is bound. </param>
             /// <param name="sampler"> Specifies the name of a sampler. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindSampler.xhtml" /></remarks>
-            public static void BindSampler(uint unit, SamplerHandle sampler) => GLPointers._BindSampler_fnptr(unit, (int)sampler);
+            public static void BindSampler(uint unit, int sampler) => GLPointers._BindSampler_fnptr(unit, sampler);
             
             /// <summary> <b>[requires: v3.3 | GL_ARB_sampler_objects]</b> Set sampler parameters. </summary>
             /// <param name="sampler"> Specifies the sampler object whose parameter to modify. </param>
             /// <param name="pname"> Specifies the symbolic name of a sampler parameter. pname can be one of the following: GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, GL_TEXTURE_WRAP_R, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_BORDER_COLOR, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_LOD_BIAS GL_TEXTURE_COMPARE_MODE, or GL_TEXTURE_COMPARE_FUNC. </param>
             /// <param name="param"> For the scalar commands, specifies the value of pname. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glSamplerParameter.xhtml" /></remarks>
-            public static void SamplerParameteri(SamplerHandle sampler, SamplerParameterI pname, int param) => GLPointers._SamplerParameteri_fnptr((int)sampler, (uint)pname, param);
+            public static void SamplerParameteri(int sampler, SamplerParameterI pname, int param) => GLPointers._SamplerParameteri_fnptr(sampler, (uint)pname, param);
             
             /// <summary> <b>[requires: v3.3 | GL_ARB_sampler_objects]</b> Set sampler parameters. </summary>
             /// <param name="sampler"> Specifies the sampler object whose parameter to modify. </param>
             /// <param name="pname"> Specifies the symbolic name of a sampler parameter. pname can be one of the following: GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, GL_TEXTURE_WRAP_R, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_BORDER_COLOR, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_LOD_BIAS GL_TEXTURE_COMPARE_MODE, or GL_TEXTURE_COMPARE_FUNC. </param>
             /// <param name="parameters"> For the vector commands (glSamplerParameter*v), specifies a pointer to an array where the value or values of pname are stored. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glSamplerParameter.xhtml" /></remarks>
-            public static void SamplerParameteriv(SamplerHandle sampler, SamplerParameterI pname, int* param) => GLPointers._SamplerParameteriv_fnptr((int)sampler, (uint)pname, param);
+            public static void SamplerParameteriv(int sampler, SamplerParameterI pname, int* param) => GLPointers._SamplerParameteriv_fnptr(sampler, (uint)pname, param);
             
             /// <summary> <b>[requires: v3.3 | GL_ARB_sampler_objects]</b> Set sampler parameters. </summary>
             /// <param name="sampler"> Specifies the sampler object whose parameter to modify. </param>
             /// <param name="pname"> Specifies the symbolic name of a sampler parameter. pname can be one of the following: GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, GL_TEXTURE_WRAP_R, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_BORDER_COLOR, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_LOD_BIAS GL_TEXTURE_COMPARE_MODE, or GL_TEXTURE_COMPARE_FUNC. </param>
             /// <param name="param"> For the scalar commands, specifies the value of pname. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glSamplerParameter.xhtml" /></remarks>
-            public static void SamplerParameterf(SamplerHandle sampler, SamplerParameterF pname, float param) => GLPointers._SamplerParameterf_fnptr((int)sampler, (uint)pname, param);
+            public static void SamplerParameterf(int sampler, SamplerParameterF pname, float param) => GLPointers._SamplerParameterf_fnptr(sampler, (uint)pname, param);
             
             /// <summary> <b>[requires: v3.3 | GL_ARB_sampler_objects]</b> Set sampler parameters. </summary>
             /// <param name="sampler"> Specifies the sampler object whose parameter to modify. </param>
             /// <param name="pname"> Specifies the symbolic name of a sampler parameter. pname can be one of the following: GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, GL_TEXTURE_WRAP_R, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_BORDER_COLOR, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_LOD_BIAS GL_TEXTURE_COMPARE_MODE, or GL_TEXTURE_COMPARE_FUNC. </param>
             /// <param name="parameters"> For the vector commands (glSamplerParameter*v), specifies a pointer to an array where the value or values of pname are stored. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glSamplerParameter.xhtml" /></remarks>
-            public static void SamplerParameterfv(SamplerHandle sampler, SamplerParameterF pname, float* param) => GLPointers._SamplerParameterfv_fnptr((int)sampler, (uint)pname, param);
+            public static void SamplerParameterfv(int sampler, SamplerParameterF pname, float* param) => GLPointers._SamplerParameterfv_fnptr(sampler, (uint)pname, param);
             
             /// <summary> <b>[requires: v3.3 | GL_ARB_sampler_objects]</b> Set sampler parameters. </summary>
             /// <param name="sampler"> Specifies the sampler object whose parameter to modify. </param>
             /// <param name="pname"> Specifies the symbolic name of a sampler parameter. pname can be one of the following: GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, GL_TEXTURE_WRAP_R, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_BORDER_COLOR, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_LOD_BIAS GL_TEXTURE_COMPARE_MODE, or GL_TEXTURE_COMPARE_FUNC. </param>
             /// <param name="parameters"> For the vector commands (glSamplerParameter*v), specifies a pointer to an array where the value or values of pname are stored. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glSamplerParameter.xhtml" /></remarks>
-            public static void SamplerParameterIiv(SamplerHandle sampler, SamplerParameterI pname, int* param) => GLPointers._SamplerParameterIiv_fnptr((int)sampler, (uint)pname, param);
+            public static void SamplerParameterIiv(int sampler, SamplerParameterI pname, int* param) => GLPointers._SamplerParameterIiv_fnptr(sampler, (uint)pname, param);
             
             /// <summary> <b>[requires: v3.3 | GL_ARB_sampler_objects]</b> Set sampler parameters. </summary>
             /// <param name="sampler"> Specifies the sampler object whose parameter to modify. </param>
             /// <param name="pname"> Specifies the symbolic name of a sampler parameter. pname can be one of the following: GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, GL_TEXTURE_WRAP_R, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_BORDER_COLOR, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_LOD_BIAS GL_TEXTURE_COMPARE_MODE, or GL_TEXTURE_COMPARE_FUNC. </param>
             /// <param name="parameters"> For the vector commands (glSamplerParameter*v), specifies a pointer to an array where the value or values of pname are stored. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glSamplerParameter.xhtml" /></remarks>
-            public static void SamplerParameterIuiv(SamplerHandle sampler, SamplerParameterI pname, uint* param) => GLPointers._SamplerParameterIuiv_fnptr((int)sampler, (uint)pname, param);
+            public static void SamplerParameterIuiv(int sampler, SamplerParameterI pname, uint* param) => GLPointers._SamplerParameterIuiv_fnptr(sampler, (uint)pname, param);
             
             /// <summary> <b>[requires: v3.3 | GL_ARB_sampler_objects]</b> Return sampler parameter values. </summary>
             /// <param name="sampler"> Specifies name of the sampler object from which to retrieve parameters. </param>
             /// <param name="pname"> Specifies the symbolic name of a sampler parameter. GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_LOD_BIAS, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, GL_TEXTURE_WRAP_R, GL_TEXTURE_BORDER_COLOR, GL_TEXTURE_COMPARE_MODE, and GL_TEXTURE_COMPARE_FUNC are accepted. </param>
             /// <param name="parameters"> Returns the sampler parameters. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetSamplerParameter.xhtml" /></remarks>
-            public static void GetSamplerParameteriv(SamplerHandle sampler, SamplerParameterI pname, int* parameters) => GLPointers._GetSamplerParameteriv_fnptr((int)sampler, (uint)pname, parameters);
+            public static void GetSamplerParameteriv(int sampler, SamplerParameterI pname, int* parameters) => GLPointers._GetSamplerParameteriv_fnptr(sampler, (uint)pname, parameters);
             
             /// <summary> <b>[requires: v3.3 | GL_ARB_sampler_objects]</b> Return sampler parameter values. </summary>
             /// <param name="sampler"> Specifies name of the sampler object from which to retrieve parameters. </param>
             /// <param name="pname"> Specifies the symbolic name of a sampler parameter. GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_LOD_BIAS, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, GL_TEXTURE_WRAP_R, GL_TEXTURE_BORDER_COLOR, GL_TEXTURE_COMPARE_MODE, and GL_TEXTURE_COMPARE_FUNC are accepted. </param>
             /// <param name="parameters"> Returns the sampler parameters. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetSamplerParameter.xhtml" /></remarks>
-            public static void GetSamplerParameterIiv(SamplerHandle sampler, SamplerParameterI pname, int* parameters) => GLPointers._GetSamplerParameterIiv_fnptr((int)sampler, (uint)pname, parameters);
+            public static void GetSamplerParameterIiv(int sampler, SamplerParameterI pname, int* parameters) => GLPointers._GetSamplerParameterIiv_fnptr(sampler, (uint)pname, parameters);
             
             /// <summary> <b>[requires: v3.3 | GL_ARB_sampler_objects]</b> Return sampler parameter values. </summary>
             /// <param name="sampler"> Specifies name of the sampler object from which to retrieve parameters. </param>
             /// <param name="pname"> Specifies the symbolic name of a sampler parameter. GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_LOD_BIAS, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, GL_TEXTURE_WRAP_R, GL_TEXTURE_BORDER_COLOR, GL_TEXTURE_COMPARE_MODE, and GL_TEXTURE_COMPARE_FUNC are accepted. </param>
             /// <param name="parameters"> Returns the sampler parameters. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetSamplerParameter.xhtml" /></remarks>
-            public static void GetSamplerParameterfv(SamplerHandle sampler, SamplerParameterF pname, float* parameters) => GLPointers._GetSamplerParameterfv_fnptr((int)sampler, (uint)pname, parameters);
+            public static void GetSamplerParameterfv(int sampler, SamplerParameterF pname, float* parameters) => GLPointers._GetSamplerParameterfv_fnptr(sampler, (uint)pname, parameters);
             
             /// <summary> <b>[requires: v3.3 | GL_ARB_sampler_objects]</b> Return sampler parameter values. </summary>
             /// <param name="sampler"> Specifies name of the sampler object from which to retrieve parameters. </param>
             /// <param name="pname"> Specifies the symbolic name of a sampler parameter. GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_LOD_BIAS, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, GL_TEXTURE_WRAP_R, GL_TEXTURE_BORDER_COLOR, GL_TEXTURE_COMPARE_MODE, and GL_TEXTURE_COMPARE_FUNC are accepted. </param>
             /// <param name="parameters"> Returns the sampler parameters. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetSamplerParameter.xhtml" /></remarks>
-            public static void GetSamplerParameterIuiv(SamplerHandle sampler, SamplerParameterI pname, uint* parameters) => GLPointers._GetSamplerParameterIuiv_fnptr((int)sampler, (uint)pname, parameters);
+            public static void GetSamplerParameterIuiv(int sampler, SamplerParameterI pname, uint* parameters) => GLPointers._GetSamplerParameterIuiv_fnptr(sampler, (uint)pname, parameters);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Bind stages of a program object to a program pipeline. </summary>
             /// <param name="pipeline"> Specifies the program pipeline object to which to bind stages from program. </param>
             /// <param name="stages"> Specifies a set of program stages to bind to the program pipeline object. </param>
             /// <param name="program"> Specifies the program object containing the shader executables to use in pipeline. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glUseProgramStages.xhtml" /></remarks>
-            public static void UseProgramStages(ProgramPipelineHandle pipeline, UseProgramStageMask stages, ProgramHandle program) => GLPointers._UseProgramStages_fnptr((int)pipeline, (uint)stages, (int)program);
+            public static void UseProgramStages(int pipeline, UseProgramStageMask stages, int program) => GLPointers._UseProgramStages_fnptr(pipeline, (uint)stages, program);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Set the active program object for a program pipeline object. </summary>
             /// <param name="pipeline"> Specifies the program pipeline object to set the active program object for. </param>
             /// <param name="program"> Specifies the program object to set as the active program pipeline object pipeline. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glActiveShaderProgram.xhtml" /></remarks>
-            public static void ActiveShaderProgram(ProgramPipelineHandle pipeline, ProgramHandle program) => GLPointers._ActiveShaderProgram_fnptr((int)pipeline, (int)program);
+            public static void ActiveShaderProgram(int pipeline, int program) => GLPointers._ActiveShaderProgram_fnptr(pipeline, program);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Create a stand-alone program from an array of null-terminated source code strings. </summary>
             /// <param name="type"> Specifies the type of shader to create. </param>
             /// <param name="count"> Specifies the number of source code strings in the array strings. </param>
             /// <param name="strings"> Specifies the address of an array of pointers to source code strings from which to create the program object. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glCreateShaderProgram.xhtml" /></remarks>
-            public static ProgramHandle CreateShaderProgramv(ShaderType type, int count, byte** strings) => (ProgramHandle) GLPointers._CreateShaderProgramv_fnptr((uint)type, count, strings);
+            public static int CreateShaderProgramv(ShaderType type, int count, byte** strings) => GLPointers._CreateShaderProgramv_fnptr((uint)type, count, strings);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Bind a program pipeline to the current context. </summary>
             /// <param name="pipeline"> Specifies the name of the pipeline object to bind to the context. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindProgramPipeline.xhtml" /></remarks>
-            public static void BindProgramPipeline(ProgramPipelineHandle pipeline) => GLPointers._BindProgramPipeline_fnptr((int)pipeline);
+            public static void BindProgramPipeline(int pipeline) => GLPointers._BindProgramPipeline_fnptr(pipeline);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Delete program pipeline objects. </summary>
             /// <param name="n"> Specifies the number of program pipeline objects to delete. </param>
             /// <param name="pipelines"> Specifies an array of names of program pipeline objects to delete. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDeleteProgramPipelines.xhtml" /></remarks>
-            public static void DeleteProgramPipelines(int n, ProgramPipelineHandle* pipelines) => GLPointers._DeleteProgramPipelines_fnptr(n, (int*)pipelines);
+            public static void DeleteProgramPipelines(int n, int* pipelines) => GLPointers._DeleteProgramPipelines_fnptr(n, pipelines);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Reserve program pipeline object names. </summary>
             /// <param name="n"> Specifies the number of program pipeline object names to reserve. </param>
             /// <param name="pipelines"> Specifies an array of into which the reserved names will be written. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGenProgramPipelines.xhtml" /></remarks>
-            public static void GenProgramPipelines(int n, ProgramPipelineHandle* pipelines) => GLPointers._GenProgramPipelines_fnptr(n, (int*)pipelines);
+            public static void GenProgramPipelines(int n, int* pipelines) => GLPointers._GenProgramPipelines_fnptr(n, pipelines);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Determine if a name corresponds to a program pipeline object. </summary>
             /// <param name="pipeline"> Specifies a value that may be the name of a program pipeline object. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsProgramPipeline.xhtml" /></remarks>
-            public static bool IsProgramPipeline(ProgramPipelineHandle pipeline) => GLPointers._IsProgramPipeline_fnptr((int)pipeline) != 0;
+            public static bool IsProgramPipeline(int pipeline) => GLPointers._IsProgramPipeline_fnptr(pipeline) != 0;
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Retrieve properties of a program pipeline object. </summary>
             /// <param name="pipeline"> Specifies the name of a program pipeline object whose parameter retrieve. </param>
             /// <param name="pname"> Specifies the name of the parameter to retrieve. </param>
             /// <param name="parameters"> Specifies the address of a variable into which will be written the value or values of pname for pipeline. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetProgramPipeline.xhtml" /></remarks>
-            public static void GetProgramPipelineiv(ProgramPipelineHandle pipeline, PipelineParameterName pname, int* parameters) => GLPointers._GetProgramPipelineiv_fnptr((int)pipeline, (uint)pname, parameters);
+            public static void GetProgramPipelineiv(int pipeline, PipelineParameterName pname, int* parameters) => GLPointers._GetProgramPipelineiv_fnptr(pipeline, (uint)pname, parameters);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
             /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
             /// <param name="v0"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniform1i(ProgramHandle program, int location, int v0) => GLPointers._ProgramUniform1i_fnptr((int)program, location, v0);
+            public static void ProgramUniform1i(int program, int location, int v0) => GLPointers._ProgramUniform1i_fnptr(program, location, v0);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -7523,14 +7523,14 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
             /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniform1iv(ProgramHandle program, int location, int count, int* value) => GLPointers._ProgramUniform1iv_fnptr((int)program, location, count, value);
+            public static void ProgramUniform1iv(int program, int location, int count, int* value) => GLPointers._ProgramUniform1iv_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
             /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
             /// <param name="v0"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniform1f(ProgramHandle program, int location, float v0) => GLPointers._ProgramUniform1f_fnptr((int)program, location, v0);
+            public static void ProgramUniform1f(int program, int location, float v0) => GLPointers._ProgramUniform1f_fnptr(program, location, v0);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -7538,22 +7538,22 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
             /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniform1fv(ProgramHandle program, int location, int count, float* value) => GLPointers._ProgramUniform1fv_fnptr((int)program, location, count, value);
+            public static void ProgramUniform1fv(int program, int location, int count, float* value) => GLPointers._ProgramUniform1fv_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform1d(ProgramHandle program, int location, double v0) => GLPointers._ProgramUniform1d_fnptr((int)program, location, v0);
+            public static void ProgramUniform1d(int program, int location, double v0) => GLPointers._ProgramUniform1d_fnptr(program, location, v0);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform1dv(ProgramHandle program, int location, int count, double* value) => GLPointers._ProgramUniform1dv_fnptr((int)program, location, count, value);
+            public static void ProgramUniform1dv(int program, int location, int count, double* value) => GLPointers._ProgramUniform1dv_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
             /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
             /// <param name="v0"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniform1ui(ProgramHandle program, int location, uint v0) => GLPointers._ProgramUniform1ui_fnptr((int)program, location, v0);
+            public static void ProgramUniform1ui(int program, int location, uint v0) => GLPointers._ProgramUniform1ui_fnptr(program, location, v0);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -7561,7 +7561,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
             /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniform1uiv(ProgramHandle program, int location, int count, uint* value) => GLPointers._ProgramUniform1uiv_fnptr((int)program, location, count, value);
+            public static void ProgramUniform1uiv(int program, int location, int count, uint* value) => GLPointers._ProgramUniform1uiv_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -7569,7 +7569,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="v0"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
             /// <param name="v1"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniform2i(ProgramHandle program, int location, int v0, int v1) => GLPointers._ProgramUniform2i_fnptr((int)program, location, v0, v1);
+            public static void ProgramUniform2i(int program, int location, int v0, int v1) => GLPointers._ProgramUniform2i_fnptr(program, location, v0, v1);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -7577,7 +7577,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
             /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniform2iv(ProgramHandle program, int location, int count, int* value) => GLPointers._ProgramUniform2iv_fnptr((int)program, location, count, value);
+            public static void ProgramUniform2iv(int program, int location, int count, int* value) => GLPointers._ProgramUniform2iv_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -7585,7 +7585,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="v0"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
             /// <param name="v1"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniform2f(ProgramHandle program, int location, float v0, float v1) => GLPointers._ProgramUniform2f_fnptr((int)program, location, v0, v1);
+            public static void ProgramUniform2f(int program, int location, float v0, float v1) => GLPointers._ProgramUniform2f_fnptr(program, location, v0, v1);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -7593,15 +7593,15 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
             /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniform2fv(ProgramHandle program, int location, int count, float* value) => GLPointers._ProgramUniform2fv_fnptr((int)program, location, count, value);
+            public static void ProgramUniform2fv(int program, int location, int count, float* value) => GLPointers._ProgramUniform2fv_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform2d(ProgramHandle program, int location, double v0, double v1) => GLPointers._ProgramUniform2d_fnptr((int)program, location, v0, v1);
+            public static void ProgramUniform2d(int program, int location, double v0, double v1) => GLPointers._ProgramUniform2d_fnptr(program, location, v0, v1);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform2dv(ProgramHandle program, int location, int count, double* value) => GLPointers._ProgramUniform2dv_fnptr((int)program, location, count, value);
+            public static void ProgramUniform2dv(int program, int location, int count, double* value) => GLPointers._ProgramUniform2dv_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -7609,7 +7609,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="v0"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
             /// <param name="v1"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniform2ui(ProgramHandle program, int location, uint v0, uint v1) => GLPointers._ProgramUniform2ui_fnptr((int)program, location, v0, v1);
+            public static void ProgramUniform2ui(int program, int location, uint v0, uint v1) => GLPointers._ProgramUniform2ui_fnptr(program, location, v0, v1);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -7617,7 +7617,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
             /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniform2uiv(ProgramHandle program, int location, int count, uint* value) => GLPointers._ProgramUniform2uiv_fnptr((int)program, location, count, value);
+            public static void ProgramUniform2uiv(int program, int location, int count, uint* value) => GLPointers._ProgramUniform2uiv_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -7626,7 +7626,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="v1"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
             /// <param name="v2"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniform3i(ProgramHandle program, int location, int v0, int v1, int v2) => GLPointers._ProgramUniform3i_fnptr((int)program, location, v0, v1, v2);
+            public static void ProgramUniform3i(int program, int location, int v0, int v1, int v2) => GLPointers._ProgramUniform3i_fnptr(program, location, v0, v1, v2);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -7634,7 +7634,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
             /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniform3iv(ProgramHandle program, int location, int count, int* value) => GLPointers._ProgramUniform3iv_fnptr((int)program, location, count, value);
+            public static void ProgramUniform3iv(int program, int location, int count, int* value) => GLPointers._ProgramUniform3iv_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -7643,7 +7643,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="v1"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
             /// <param name="v2"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniform3f(ProgramHandle program, int location, float v0, float v1, float v2) => GLPointers._ProgramUniform3f_fnptr((int)program, location, v0, v1, v2);
+            public static void ProgramUniform3f(int program, int location, float v0, float v1, float v2) => GLPointers._ProgramUniform3f_fnptr(program, location, v0, v1, v2);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -7651,15 +7651,15 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
             /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniform3fv(ProgramHandle program, int location, int count, float* value) => GLPointers._ProgramUniform3fv_fnptr((int)program, location, count, value);
+            public static void ProgramUniform3fv(int program, int location, int count, float* value) => GLPointers._ProgramUniform3fv_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform3d(ProgramHandle program, int location, double v0, double v1, double v2) => GLPointers._ProgramUniform3d_fnptr((int)program, location, v0, v1, v2);
+            public static void ProgramUniform3d(int program, int location, double v0, double v1, double v2) => GLPointers._ProgramUniform3d_fnptr(program, location, v0, v1, v2);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform3dv(ProgramHandle program, int location, int count, double* value) => GLPointers._ProgramUniform3dv_fnptr((int)program, location, count, value);
+            public static void ProgramUniform3dv(int program, int location, int count, double* value) => GLPointers._ProgramUniform3dv_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -7668,7 +7668,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="v1"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
             /// <param name="v2"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniform3ui(ProgramHandle program, int location, uint v0, uint v1, uint v2) => GLPointers._ProgramUniform3ui_fnptr((int)program, location, v0, v1, v2);
+            public static void ProgramUniform3ui(int program, int location, uint v0, uint v1, uint v2) => GLPointers._ProgramUniform3ui_fnptr(program, location, v0, v1, v2);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -7676,25 +7676,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
             /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniform3uiv(ProgramHandle program, int location, int count, uint* value) => GLPointers._ProgramUniform3uiv_fnptr((int)program, location, count, value);
-            
-            /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
-            /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
-            /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
-            /// <param name="v0"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
-            /// <param name="v1"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
-            /// <param name="v2"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
-            /// <param name="v3"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
-            /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniform4i(ProgramHandle program, int location, int v0, int v1, int v2, int v3) => GLPointers._ProgramUniform4i_fnptr((int)program, location, v0, v1, v2, v3);
-            
-            /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
-            /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
-            /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
-            /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
-            /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
-            /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniform4iv(ProgramHandle program, int location, int count, int* value) => GLPointers._ProgramUniform4iv_fnptr((int)program, location, count, value);
+            public static void ProgramUniform3uiv(int program, int location, int count, uint* value) => GLPointers._ProgramUniform3uiv_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -7704,7 +7686,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="v2"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
             /// <param name="v3"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniform4f(ProgramHandle program, int location, float v0, float v1, float v2, float v3) => GLPointers._ProgramUniform4f_fnptr((int)program, location, v0, v1, v2, v3);
+            public static void ProgramUniform4i(int program, int location, int v0, int v1, int v2, int v3) => GLPointers._ProgramUniform4i_fnptr(program, location, v0, v1, v2, v3);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -7712,15 +7694,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
             /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniform4fv(ProgramHandle program, int location, int count, float* value) => GLPointers._ProgramUniform4fv_fnptr((int)program, location, count, value);
-            
-            /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
-            /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform4d(ProgramHandle program, int location, double v0, double v1, double v2, double v3) => GLPointers._ProgramUniform4d_fnptr((int)program, location, v0, v1, v2, v3);
-            
-            /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
-            /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform4dv(ProgramHandle program, int location, int count, double* value) => GLPointers._ProgramUniform4dv_fnptr((int)program, location, count, value);
+            public static void ProgramUniform4iv(int program, int location, int count, int* value) => GLPointers._ProgramUniform4iv_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -7730,7 +7704,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="v2"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
             /// <param name="v3"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniform4ui(ProgramHandle program, int location, uint v0, uint v1, uint v2, uint v3) => GLPointers._ProgramUniform4ui_fnptr((int)program, location, v0, v1, v2, v3);
+            public static void ProgramUniform4f(int program, int location, float v0, float v1, float v2, float v3) => GLPointers._ProgramUniform4f_fnptr(program, location, v0, v1, v2, v3);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -7738,7 +7712,33 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
             /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniform4uiv(ProgramHandle program, int location, int count, uint* value) => GLPointers._ProgramUniform4uiv_fnptr((int)program, location, count, value);
+            public static void ProgramUniform4fv(int program, int location, int count, float* value) => GLPointers._ProgramUniform4fv_fnptr(program, location, count, value);
+            
+            /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
+            /// <remarks><see href="" /></remarks>
+            public static void ProgramUniform4d(int program, int location, double v0, double v1, double v2, double v3) => GLPointers._ProgramUniform4d_fnptr(program, location, v0, v1, v2, v3);
+            
+            /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
+            /// <remarks><see href="" /></remarks>
+            public static void ProgramUniform4dv(int program, int location, int count, double* value) => GLPointers._ProgramUniform4dv_fnptr(program, location, count, value);
+            
+            /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
+            /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
+            /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
+            /// <param name="v0"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
+            /// <param name="v1"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
+            /// <param name="v2"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
+            /// <param name="v3"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
+            /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
+            public static void ProgramUniform4ui(int program, int location, uint v0, uint v1, uint v2, uint v3) => GLPointers._ProgramUniform4ui_fnptr(program, location, v0, v1, v2, v3);
+            
+            /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
+            /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
+            /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
+            /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
+            /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
+            /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
+            public static void ProgramUniform4uiv(int program, int location, int count, uint* value) => GLPointers._ProgramUniform4uiv_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -7747,7 +7747,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
             /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniformMatrix2fv(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix2fv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix2fv(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix2fv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -7756,7 +7756,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
             /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniformMatrix3fv(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix3fv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix3fv(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix3fv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -7765,19 +7765,19 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
             /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniformMatrix4fv(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix4fv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix4fv(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix4fv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix2dv(ProgramHandle program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix2dv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix2dv(int program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix2dv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix3dv(ProgramHandle program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix3dv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix3dv(int program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix3dv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix4dv(ProgramHandle program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix4dv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix4dv(int program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix4dv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -7786,7 +7786,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
             /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniformMatrix2x3fv(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix2x3fv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix2x3fv(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix2x3fv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -7795,7 +7795,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
             /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniformMatrix3x2fv(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix3x2fv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix3x2fv(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix3x2fv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -7804,7 +7804,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
             /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniformMatrix2x4fv(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix2x4fv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix2x4fv(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix2x4fv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -7813,7 +7813,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
             /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniformMatrix4x2fv(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix4x2fv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix4x2fv(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix4x2fv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -7822,7 +7822,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
             /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniformMatrix3x4fv(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix3x4fv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix3x4fv(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix3x4fv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Specify the value of a uniform variable for a specified program object. </summary>
             /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -7831,36 +7831,36 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
             /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml" /></remarks>
-            public static void ProgramUniformMatrix4x3fv(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix4x3fv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix4x3fv(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix4x3fv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix2x3dv(ProgramHandle program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix2x3dv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix2x3dv(int program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix2x3dv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix3x2dv(ProgramHandle program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix3x2dv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix3x2dv(int program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix3x2dv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix2x4dv(ProgramHandle program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix2x4dv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix2x4dv(int program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix2x4dv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix4x2dv(ProgramHandle program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix4x2dv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix4x2dv(int program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix4x2dv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix3x4dv(ProgramHandle program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix3x4dv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix3x4dv(int program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix3x4dv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix4x3dv(ProgramHandle program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix4x3dv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix4x3dv(int program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix4x3dv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Validate a program pipeline object against current GL state. </summary>
             /// <param name="pipeline"> Specifies the name of a program pipeline object to validate. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glValidateProgramPipeline.xhtml" /></remarks>
-            public static void ValidateProgramPipeline(ProgramPipelineHandle pipeline) => GLPointers._ValidateProgramPipeline_fnptr((int)pipeline);
+            public static void ValidateProgramPipeline(int pipeline) => GLPointers._ValidateProgramPipeline_fnptr(pipeline);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> Retrieve the info log string from a program pipeline object. </summary>
             /// <param name="pipeline"> Specifies the name of a program pipeline object from which to retrieve the info log. </param>
@@ -7868,7 +7868,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="length"> Specifies the address of a variable into which will be written the number of characters written into infoLog. </param>
             /// <param name="infoLog"> Specifies the address of an array of characters into which will be written the info log for pipeline. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetProgramPipelineInfoLog.xhtml" /></remarks>
-            public static void GetProgramPipelineInfoLog(ProgramPipelineHandle pipeline, int bufSize, int* length, byte* infoLog) => GLPointers._GetProgramPipelineInfoLog_fnptr((int)pipeline, bufSize, length, infoLog);
+            public static void GetProgramPipelineInfoLog(int pipeline, int bufSize, int* length, byte* infoLog) => GLPointers._GetProgramPipelineInfoLog_fnptr(pipeline, bufSize, length, infoLog);
             
             /// <summary> <b>[requires: v4.2 | GL_ARB_shader_atomic_counters]</b> Retrieve information about the set of active atomic counter buffers for a program. </summary>
             /// <param name="program"> The name of a program object from which to retrieve information. </param>
@@ -7876,7 +7876,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="pname"> Specifies which parameter of the atomic counter buffer to retrieve. </param>
             /// <param name="parameters"> Specifies the address of a variable into which to write the retrieved information. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetActiveAtomicCounterBufferiv.xhtml" /></remarks>
-            public static void GetActiveAtomicCounterBufferiv(ProgramHandle program, uint bufferIndex, AtomicCounterBufferPName pname, int* parameters) => GLPointers._GetActiveAtomicCounterBufferiv_fnptr((int)program, bufferIndex, (uint)pname, parameters);
+            public static void GetActiveAtomicCounterBufferiv(int program, uint bufferIndex, AtomicCounterBufferPName pname, int* parameters) => GLPointers._GetActiveAtomicCounterBufferiv_fnptr(program, bufferIndex, (uint)pname, parameters);
             
             /// <summary> <b>[requires: v4.2 | GL_ARB_shader_image_load_store]</b> Bind a level of a texture to an image unit. </summary>
             /// <param name="unit"> Specifies the index of the image unit to which to bind the texture </param>
@@ -7887,7 +7887,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="access"> Specifies a token indicating the type of access that will be performed on the image. </param>
             /// <param name="format"> Specifies the format that the elements of the image will be treated as for the purposes of formatted stores. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindImageTexture.xhtml" /></remarks>
-            public static void BindImageTexture(uint unit, TextureHandle texture, int level, bool layered, int layer, BufferAccessARB access, InternalFormat format) => GLPointers._BindImageTexture_fnptr(unit, (int)texture, level, (byte)(layered ? 1 : 0), layer, (uint)access, (uint)format);
+            public static void BindImageTexture(uint unit, int texture, int level, bool layered, int layer, BufferAccessARB access, InternalFormat format) => GLPointers._BindImageTexture_fnptr(unit, texture, level, (byte)(layered ? 1 : 0), layer, (uint)access, (uint)format);
             
             /// <summary> <b>[requires: v4.2 | GL_ARB_shader_image_load_store]</b> Defines a barrier ordering memory transactions. </summary>
             /// <param name="barriers"> Specifies the barriers to insert. </param>
@@ -8055,21 +8055,21 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="storageBlockIndex"> The index storage block within the program. </param>
             /// <param name="storageBlockBinding"> The index storage block binding to associate with the specified storage block. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glShaderStorageBlockBinding.xhtml" /></remarks>
-            public static void ShaderStorageBlockBinding(ProgramHandle program, uint storageBlockIndex, uint storageBlockBinding) => GLPointers._ShaderStorageBlockBinding_fnptr((int)program, storageBlockIndex, storageBlockBinding);
+            public static void ShaderStorageBlockBinding(int program, uint storageBlockIndex, uint storageBlockBinding) => GLPointers._ShaderStorageBlockBinding_fnptr(program, storageBlockIndex, storageBlockBinding);
             
             /// <summary> <b>[requires: v4.0 | GL_ARB_shader_subroutine]</b> Retrieve the location of a subroutine uniform of a given shader stage within a program. </summary>
             /// <param name="program"> Specifies the name of the program containing shader stage. </param>
             /// <param name="shadertype"> Specifies the shader stage from which to query for subroutine uniform index. shadertype must be one of GL_VERTEX_SHADER, GL_TESS_CONTROL_SHADER, GL_TESS_EVALUATION_SHADER, GL_GEOMETRY_SHADER or GL_FRAGMENT_SHADER. </param>
             /// <param name="name"> Specifies the name of the subroutine uniform whose index to query. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetSubroutineUniformLocation.xhtml" /></remarks>
-            public static int GetSubroutineUniformLocation(ProgramHandle program, ShaderType shadertype, byte* name) => GLPointers._GetSubroutineUniformLocation_fnptr((int)program, (uint)shadertype, name);
+            public static int GetSubroutineUniformLocation(int program, ShaderType shadertype, byte* name) => GLPointers._GetSubroutineUniformLocation_fnptr(program, (uint)shadertype, name);
             
             /// <summary> <b>[requires: v4.0 | GL_ARB_shader_subroutine]</b> Retrieve the index of a subroutine uniform of a given shader stage within a program. </summary>
             /// <param name="program"> Specifies the name of the program containing shader stage. </param>
             /// <param name="shadertype"> Specifies the shader stage from which to query for subroutine uniform index. shadertype must be one of GL_VERTEX_SHADER, GL_TESS_CONTROL_SHADER, GL_TESS_EVALUATION_SHADER, GL_GEOMETRY_SHADER or GL_FRAGMENT_SHADER. </param>
             /// <param name="name"> Specifies the name of the subroutine uniform whose index to query. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetSubroutineIndex.xhtml" /></remarks>
-            public static uint GetSubroutineIndex(ProgramHandle program, ShaderType shadertype, byte* name) => GLPointers._GetSubroutineIndex_fnptr((int)program, (uint)shadertype, name);
+            public static uint GetSubroutineIndex(int program, ShaderType shadertype, byte* name) => GLPointers._GetSubroutineIndex_fnptr(program, (uint)shadertype, name);
             
             /// <summary> <b>[requires: v4.0 | GL_ARB_shader_subroutine]</b> Query a property of an active shader subroutine uniform. </summary>
             /// <param name="program"> Specifies the name of the program containing the subroutine. </param>
@@ -8078,7 +8078,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="pname"> Specifies the parameter of the shader subroutine uniform to query. pname must be GL_NUM_COMPATIBLE_SUBROUTINES, GL_COMPATIBLE_SUBROUTINES, GL_UNIFORM_SIZE or GL_UNIFORM_NAME_LENGTH. </param>
             /// <param name="values"> Specifies the address of a into which the queried value or values will be placed. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetActiveSubroutineUniform.xhtml" /></remarks>
-            public static void GetActiveSubroutineUniformiv(ProgramHandle program, ShaderType shadertype, uint index, SubroutineParameterName pname, int* values) => GLPointers._GetActiveSubroutineUniformiv_fnptr((int)program, (uint)shadertype, index, (uint)pname, values);
+            public static void GetActiveSubroutineUniformiv(int program, ShaderType shadertype, uint index, SubroutineParameterName pname, int* values) => GLPointers._GetActiveSubroutineUniformiv_fnptr(program, (uint)shadertype, index, (uint)pname, values);
             
             /// <summary> <b>[requires: v4.0 | GL_ARB_shader_subroutine]</b> Query the name of an active shader subroutine uniform. </summary>
             /// <param name="program"> Specifies the name of the program containing the subroutine. </param>
@@ -8088,7 +8088,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="length"> Specifies the address of a variable into which is written the number of characters copied into name. </param>
             /// <param name="name"> Specifies the address of a buffer that will receive the name of the specified shader subroutine uniform. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetActiveSubroutineUniformName.xhtml" /></remarks>
-            public static void GetActiveSubroutineUniformName(ProgramHandle program, ShaderType shadertype, uint index, int bufSize, int* length, byte* name) => GLPointers._GetActiveSubroutineUniformName_fnptr((int)program, (uint)shadertype, index, bufSize, length, name);
+            public static void GetActiveSubroutineUniformName(int program, ShaderType shadertype, uint index, int bufSize, int* length, byte* name) => GLPointers._GetActiveSubroutineUniformName_fnptr(program, (uint)shadertype, index, bufSize, length, name);
             
             /// <summary> <b>[requires: v4.0 | GL_ARB_shader_subroutine]</b> Query the name of an active shader subroutine. </summary>
             /// <param name="program"> Specifies the name of the program containing the subroutine. </param>
@@ -8098,7 +8098,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="length"> Specifies the address of a variable which is to receive the length of the shader subroutine uniform name. </param>
             /// <param name="name"> Specifies the address of an array into which the name of the shader subroutine uniform will be written. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetActiveSubroutineName.xhtml" /></remarks>
-            public static void GetActiveSubroutineName(ProgramHandle program, ShaderType shadertype, uint index, int bufSize, int* length, byte* name) => GLPointers._GetActiveSubroutineName_fnptr((int)program, (uint)shadertype, index, bufSize, length, name);
+            public static void GetActiveSubroutineName(int program, ShaderType shadertype, uint index, int bufSize, int* length, byte* name) => GLPointers._GetActiveSubroutineName_fnptr(program, (uint)shadertype, index, bufSize, length, name);
             
             /// <summary> <b>[requires: v4.0 | GL_ARB_shader_subroutine]</b> Load active subroutine uniforms. </summary>
             /// <param name="shadertype"> Specifies the shader stage from which to query for subroutine uniform index. shadertype must be one of GL_VERTEX_SHADER, GL_TESS_CONTROL_SHADER, GL_TESS_EVALUATION_SHADER, GL_GEOMETRY_SHADER or GL_FRAGMENT_SHADER. </param>
@@ -8120,7 +8120,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="pname"> Specifies the parameter of the shader to query. pname must be GL_ACTIVE_SUBROUTINE_UNIFORMS, GL_ACTIVE_SUBROUTINE_UNIFORM_LOCATIONS, GL_ACTIVE_SUBROUTINES, GL_ACTIVE_SUBROUTINE_UNIFORM_MAX_LENGTH, or GL_ACTIVE_SUBROUTINE_MAX_LENGTH. </param>
             /// <param name="values"> Specifies the address of a variable into which the queried value or values will be placed. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetProgramStage.xhtml" /></remarks>
-            public static void GetProgramStageiv(ProgramHandle program, ShaderType shadertype, ProgramStagePName pname, int* values) => GLPointers._GetProgramStageiv_fnptr((int)program, (uint)shadertype, (uint)pname, values);
+            public static void GetProgramStageiv(int program, ShaderType shadertype, ProgramStagePName pname, int* values) => GLPointers._GetProgramStageiv_fnptr(program, (uint)shadertype, (uint)pname, values);
             
             /// <summary> <b>[requires: GL_ARB_shading_language_include]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -8132,7 +8132,7 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_ARB_shading_language_include]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void CompileShaderIncludeARB(ShaderHandle shader, int count, byte** path, int* length) => GLPointers._CompileShaderIncludeARB_fnptr((int)shader, count, path, length);
+            public static void CompileShaderIncludeARB(int shader, int count, byte** path, int* length) => GLPointers._CompileShaderIncludeARB_fnptr(shader, count, path, length);
             
             /// <summary> <b>[requires: GL_ARB_shading_language_include]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -8152,11 +8152,11 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_ARB_sparse_buffer]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedBufferPageCommitmentEXT(BufferHandle buffer, IntPtr offset, nint size, bool commit) => GLPointers._NamedBufferPageCommitmentEXT_fnptr((int)buffer, offset, size, (byte)(commit ? 1 : 0));
+            public static void NamedBufferPageCommitmentEXT(int buffer, IntPtr offset, nint size, bool commit) => GLPointers._NamedBufferPageCommitmentEXT_fnptr(buffer, offset, size, (byte)(commit ? 1 : 0));
             
             /// <summary> <b>[requires: GL_ARB_sparse_buffer]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedBufferPageCommitmentARB(BufferHandle buffer, IntPtr offset, nint size, bool commit) => GLPointers._NamedBufferPageCommitmentARB_fnptr((int)buffer, offset, size, (byte)(commit ? 1 : 0));
+            public static void NamedBufferPageCommitmentARB(int buffer, IntPtr offset, nint size, bool commit) => GLPointers._NamedBufferPageCommitmentARB_fnptr(buffer, offset, size, (byte)(commit ? 1 : 0));
             
             /// <summary> <b>[requires: GL_ARB_sparse_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -8225,7 +8225,7 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_ARB_texture_buffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TexBufferARB(TextureTarget target, SizedInternalFormat internalformat, BufferHandle buffer) => GLPointers._TexBufferARB_fnptr((uint)target, (uint)internalformat, (int)buffer);
+            public static void TexBufferARB(TextureTarget target, SizedInternalFormat internalformat, int buffer) => GLPointers._TexBufferARB_fnptr((uint)target, (uint)internalformat, buffer);
             
             /// <summary> <b>[requires: v4.3 | GL_ARB_texture_buffer_range]</b> Attach a range of a buffer object's data store to a buffer texture object. </summary>
             /// <param name="target"> Specifies the target to which the texture object is bound for glTexBufferRange. Must be GL_TEXTURE_BUFFER. </param>
@@ -8234,7 +8234,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="offset"> Specifies the offset of the start of the range of the buffer's data store to attach. </param>
             /// <param name="size"> Specifies the size of the range of the buffer's data store to attach. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexBufferRange.xhtml" /></remarks>
-            public static void TexBufferRange(TextureTarget target, SizedInternalFormat internalformat, BufferHandle buffer, IntPtr offset, nint size) => GLPointers._TexBufferRange_fnptr((uint)target, (uint)internalformat, (int)buffer, offset, size);
+            public static void TexBufferRange(TextureTarget target, SizedInternalFormat internalformat, int buffer, IntPtr offset, nint size) => GLPointers._TexBufferRange_fnptr((uint)target, (uint)internalformat, buffer, offset, size);
             
             /// <summary> <b>[requires: GL_ARB_texture_compression]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -8356,50 +8356,50 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="minlayer"> Specifies the index of the first layer to include in the view. </param>
             /// <param name="numlayers"> Specifies the number of layers to include in the view. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTextureView.xhtml" /></remarks>
-            public static void TextureView(TextureHandle texture, TextureTarget target, TextureHandle origtexture, SizedInternalFormat internalformat, uint minlevel, uint numlevels, uint minlayer, uint numlayers) => GLPointers._TextureView_fnptr((int)texture, (uint)target, (int)origtexture, (uint)internalformat, minlevel, numlevels, minlayer, numlayers);
+            public static void TextureView(int texture, TextureTarget target, int origtexture, SizedInternalFormat internalformat, uint minlevel, uint numlevels, uint minlayer, uint numlayers) => GLPointers._TextureView_fnptr(texture, (uint)target, origtexture, (uint)internalformat, minlevel, numlevels, minlayer, numlayers);
             
             /// <summary> <b>[requires: v3.3 | GL_ARB_timer_query]</b> Record the GL time into a query object after all previous commands have reached the GL server but have not yet necessarily executed.. </summary>
             /// <param name="id"> Specify the name of a query object into which to record the GL time. </param>
             /// <param name="target"> Specify the counter to query. target must be GL_TIMESTAMP. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glQueryCounter.xhtml" /></remarks>
-            public static void QueryCounter(QueryHandle id, QueryCounterTarget target) => GLPointers._QueryCounter_fnptr((int)id, (uint)target);
+            public static void QueryCounter(int id, QueryCounterTarget target) => GLPointers._QueryCounter_fnptr(id, (uint)target);
             
             /// <summary> <b>[requires: v3.3 | GL_ARB_timer_query]</b> Return parameters of a query object. </summary>
             /// <param name="id"> Specifies the name of a query object. </param>
             /// <param name="pname"> Specifies the symbolic name of a query object parameter. Accepted values are GL_QUERY_RESULT or GL_QUERY_RESULT_AVAILABLE. </param>
             /// <param name="parameters"> If a buffer is bound to the GL_QUERY_RESULT_BUFFER target, then params is treated as an offset to a location within that buffer's data store to receive the result of the query. If no buffer is bound to GL_QUERY_RESULT_BUFFER, then params is treated as an address in client memory of a variable to receive the resulting data. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetQueryObject.xhtml" /></remarks>
-            public static void GetQueryObjecti64v(QueryHandle id, QueryObjectParameterName pname, long* parameters) => GLPointers._GetQueryObjecti64v_fnptr((int)id, (uint)pname, parameters);
+            public static void GetQueryObjecti64v(int id, QueryObjectParameterName pname, long* parameters) => GLPointers._GetQueryObjecti64v_fnptr(id, (uint)pname, parameters);
             
             /// <summary> <b>[requires: v3.3 | GL_ARB_timer_query]</b> Return parameters of a query object. </summary>
             /// <param name="id"> Specifies the name of a query object. </param>
             /// <param name="pname"> Specifies the symbolic name of a query object parameter. Accepted values are GL_QUERY_RESULT or GL_QUERY_RESULT_AVAILABLE. </param>
             /// <param name="parameters"> If a buffer is bound to the GL_QUERY_RESULT_BUFFER target, then params is treated as an offset to a location within that buffer's data store to receive the result of the query. If no buffer is bound to GL_QUERY_RESULT_BUFFER, then params is treated as an address in client memory of a variable to receive the resulting data. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetQueryObject.xhtml" /></remarks>
-            public static void GetQueryObjectui64v(QueryHandle id, QueryObjectParameterName pname, ulong* parameters) => GLPointers._GetQueryObjectui64v_fnptr((int)id, (uint)pname, parameters);
+            public static void GetQueryObjectui64v(int id, QueryObjectParameterName pname, ulong* parameters) => GLPointers._GetQueryObjectui64v_fnptr(id, (uint)pname, parameters);
             
             /// <summary> <b>[requires: v4.0 | GL_ARB_transform_feedback2]</b> Bind a transform feedback object. </summary>
             /// <param name="target"> Specifies the target to which to bind the transform feedback object id. target must be GL_TRANSFORM_FEEDBACK. </param>
             /// <param name="id"> Specifies the name of a transform feedback object reserved by glGenTransformFeedbacks. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindTransformFeedback.xhtml" /></remarks>
-            public static void BindTransformFeedback(BindTransformFeedbackTarget target, TransformFeedbackHandle id) => GLPointers._BindTransformFeedback_fnptr((uint)target, (int)id);
+            public static void BindTransformFeedback(BindTransformFeedbackTarget target, int id) => GLPointers._BindTransformFeedback_fnptr((uint)target, id);
             
             /// <summary> <b>[requires: v4.0 | GL_ARB_transform_feedback2]</b> Delete transform feedback objects. </summary>
             /// <param name="n"> Specifies the number of transform feedback objects to delete. </param>
             /// <param name="ids"> Specifies an array of names of transform feedback objects to delete. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDeleteTransformFeedbacks.xhtml" /></remarks>
-            public static void DeleteTransformFeedbacks(int n, TransformFeedbackHandle* ids) => GLPointers._DeleteTransformFeedbacks_fnptr(n, (int*)ids);
+            public static void DeleteTransformFeedbacks(int n, int* ids) => GLPointers._DeleteTransformFeedbacks_fnptr(n, ids);
             
             /// <summary> <b>[requires: v4.0 | GL_ARB_transform_feedback2]</b> Reserve transform feedback object names. </summary>
             /// <param name="n"> Specifies the number of transform feedback object names to reserve. </param>
             /// <param name="ids"> Specifies an array of into which the reserved names will be written. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGenTransformFeedbacks.xhtml" /></remarks>
-            public static void GenTransformFeedbacks(int n, TransformFeedbackHandle* ids) => GLPointers._GenTransformFeedbacks_fnptr(n, (int*)ids);
+            public static void GenTransformFeedbacks(int n, int* ids) => GLPointers._GenTransformFeedbacks_fnptr(n, ids);
             
             /// <summary> <b>[requires: v4.0 | GL_ARB_transform_feedback2]</b> Determine if a name corresponds to a transform feedback object. </summary>
             /// <param name="id"> Specifies a value that may be the name of a transform feedback object. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsTransformFeedback.xhtml" /></remarks>
-            public static bool IsTransformFeedback(TransformFeedbackHandle id) => GLPointers._IsTransformFeedback_fnptr((int)id) != 0;
+            public static bool IsTransformFeedback(int id) => GLPointers._IsTransformFeedback_fnptr(id) != 0;
             
             /// <summary> <b>[requires: v4.0 | GL_ARB_transform_feedback2]</b> Pause transform feedback operations. </summary>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glPauseTransformFeedback.xhtml" /></remarks>
@@ -8413,21 +8413,21 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="mode"> Specifies what kind of primitives to render. Symbolic constants GL_POINTS, GL_LINE_STRIP, GL_LINE_LOOP, GL_LINES, GL_LINE_STRIP_ADJACENCY, GL_LINES_ADJACENCY, GL_TRIANGLE_STRIP, GL_TRIANGLE_FAN, GL_TRIANGLES, GL_TRIANGLE_STRIP_ADJACENCY, GL_TRIANGLES_ADJACENCY, and GL_PATCHES are accepted. </param>
             /// <param name="id"> Specifies the name of a transform feedback object from which to retrieve a primitive count. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDrawTransformFeedback.xhtml" /></remarks>
-            public static void DrawTransformFeedback(PrimitiveType mode, TransformFeedbackHandle id) => GLPointers._DrawTransformFeedback_fnptr((uint)mode, (int)id);
+            public static void DrawTransformFeedback(PrimitiveType mode, int id) => GLPointers._DrawTransformFeedback_fnptr((uint)mode, id);
             
             /// <summary> <b>[requires: v4.0 | GL_ARB_transform_feedback3]</b> Render primitives using a count derived from a specifed stream of a transform feedback object. </summary>
             /// <param name="mode"> Specifies what kind of primitives to render. Symbolic constants GL_POINTS, GL_LINE_STRIP, GL_LINE_LOOP, GL_LINES, GL_LINE_STRIP_ADJACENCY, GL_LINES_ADJACENCY, GL_TRIANGLE_STRIP, GL_TRIANGLE_FAN, GL_TRIANGLES, GL_TRIANGLE_STRIP_ADJACENCY, GL_TRIANGLES_ADJACENCY, and GL_PATCHES are accepted. </param>
             /// <param name="id"> Specifies the name of a transform feedback object from which to retrieve a primitive count. </param>
             /// <param name="stream"> Specifies the index of the transform feedback stream from which to retrieve a primitive count. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDrawTransformFeedbackStream.xhtml" /></remarks>
-            public static void DrawTransformFeedbackStream(PrimitiveType mode, TransformFeedbackHandle id, uint stream) => GLPointers._DrawTransformFeedbackStream_fnptr((uint)mode, (int)id, stream);
+            public static void DrawTransformFeedbackStream(PrimitiveType mode, int id, uint stream) => GLPointers._DrawTransformFeedbackStream_fnptr((uint)mode, id, stream);
             
             /// <summary> <b>[requires: v4.0 | GL_ARB_transform_feedback3]</b> Delimit the boundaries of a query object on an indexed target. </summary>
             /// <param name="target"> Specifies the target type of query object established between glBeginQueryIndexed and the subsequent glEndQueryIndexed. The symbolic constant must be one of GL_SAMPLES_PASSED, GL_ANY_SAMPLES_PASSED, GL_PRIMITIVES_GENERATED, GL_TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN, or GL_TIME_ELAPSED. </param>
             /// <param name="index"> Specifies the index of the query target upon which to begin the query. </param>
             /// <param name="id"> Specifies the name of a query object. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBeginQueryIndexed.xhtml" /></remarks>
-            public static void BeginQueryIndexed(QueryTarget target, uint index, QueryHandle id) => GLPointers._BeginQueryIndexed_fnptr((uint)target, index, (int)id);
+            public static void BeginQueryIndexed(QueryTarget target, uint index, int id) => GLPointers._BeginQueryIndexed_fnptr((uint)target, index, id);
             
             /// <summary> <b>[requires: v4.0 | GL_ARB_transform_feedback3]</b> Delimit the boundaries of a query object on an indexed target. </summary>
             /// <param name="target"> Specifies the target type of query object established between glBeginQueryIndexed and the subsequent glEndQueryIndexed. The symbolic constant must be one of GL_SAMPLES_PASSED, GL_ANY_SAMPLES_PASSED, GL_PRIMITIVES_GENERATED, GL_TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN, or GL_TIME_ELAPSED. </param>
@@ -8448,7 +8448,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="id"> Specifies the name of a transform feedback object from which to retrieve a primitive count. </param>
             /// <param name="instancecount"> Specifies the number of instances of the geometry to render. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDrawTransformFeedbackInstanced.xhtml" /></remarks>
-            public static void DrawTransformFeedbackInstanced(PrimitiveType mode, TransformFeedbackHandle id, int instancecount) => GLPointers._DrawTransformFeedbackInstanced_fnptr((uint)mode, (int)id, instancecount);
+            public static void DrawTransformFeedbackInstanced(PrimitiveType mode, int id, int instancecount) => GLPointers._DrawTransformFeedbackInstanced_fnptr((uint)mode, id, instancecount);
             
             /// <summary> <b>[requires: v4.2 | GL_ARB_transform_feedback_instanced]</b> Render multiple instances of primitives using a count derived from a specifed stream of a transform feedback object. </summary>
             /// <param name="mode"> Specifies what kind of primitives to render. Symbolic constants GL_POINTS, GL_LINE_STRIP, GL_LINE_LOOP, GL_LINES, GL_LINE_STRIP_ADJACENCY, GL_LINES_ADJACENCY, GL_TRIANGLE_STRIP, GL_TRIANGLE_FAN, GL_TRIANGLES, GL_TRIANGLE_STRIP_ADJACENCY, GL_TRIANGLES_ADJACENCY, and GL_PATCHES are accepted. </param>
@@ -8456,7 +8456,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="stream"> Specifies the index of the transform feedback stream from which to retrieve a primitive count. </param>
             /// <param name="instancecount"> Specifies the number of instances of the geometry to render. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDrawTransformFeedbackStreamInstanced.xhtml" /></remarks>
-            public static void DrawTransformFeedbackStreamInstanced(PrimitiveType mode, TransformFeedbackHandle id, uint stream, int instancecount) => GLPointers._DrawTransformFeedbackStreamInstanced_fnptr((uint)mode, (int)id, stream, instancecount);
+            public static void DrawTransformFeedbackStreamInstanced(PrimitiveType mode, int id, uint stream, int instancecount) => GLPointers._DrawTransformFeedbackStreamInstanced_fnptr((uint)mode, id, stream, instancecount);
             
             /// <summary> <b>[requires: GL_ARB_transpose_matrix]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -8480,7 +8480,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="uniformNames"> Specifies the address of an array of pointers to buffers containing the names of the queried uniforms. </param>
             /// <param name="uniformIndices"> Specifies the address of an array that will receive the indices of the uniforms. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetUniformIndices.xhtml" /></remarks>
-            public static void GetUniformIndices(ProgramHandle program, int uniformCount, byte** uniformNames, uint* uniformIndices) => GLPointers._GetUniformIndices_fnptr((int)program, uniformCount, uniformNames, uniformIndices);
+            public static void GetUniformIndices(int program, int uniformCount, byte** uniformNames, uint* uniformIndices) => GLPointers._GetUniformIndices_fnptr(program, uniformCount, uniformNames, uniformIndices);
             
             /// <summary> <b>[requires: v3.1 | GL_ARB_uniform_buffer_object]</b> Returns information about several active uniform variables for the specified program object. </summary>
             /// <param name="program">Specifies the program object to be queried.</param>
@@ -8489,7 +8489,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="pname">Specifies the property of each uniform in uniformIndices that should be written into the corresponding element of params.</param>
             /// <param name="parameters">Specifies the address of an array of uniformCount integers which are to receive the value of pname for each uniform in uniformIndices.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetActiveUniformsiv.xhtml" /></remarks>
-            public static void GetActiveUniformsiv(ProgramHandle program, int uniformCount, uint* uniformIndices, UniformPName pname, int* parameters) => GLPointers._GetActiveUniformsiv_fnptr((int)program, uniformCount, uniformIndices, (uint)pname, parameters);
+            public static void GetActiveUniformsiv(int program, int uniformCount, uint* uniformIndices, UniformPName pname, int* parameters) => GLPointers._GetActiveUniformsiv_fnptr(program, uniformCount, uniformIndices, (uint)pname, parameters);
             
             /// <summary> <b>[requires: v3.1 | GL_ARB_uniform_buffer_object]</b> Query the name of an active uniform. </summary>
             /// <param name="program"> Specifies the program containing the active uniform index uniformIndex. </param>
@@ -8498,13 +8498,13 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="length"> Specifies the address of a variable that will receive the number of characters that were or would have been written to the buffer addressed by uniformName. </param>
             /// <param name="uniformName"> Specifies the address of a buffer into which the GL will place the name of the active uniform at uniformIndex within program. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetActiveUniformName.xhtml" /></remarks>
-            public static void GetActiveUniformName(ProgramHandle program, uint uniformIndex, int bufSize, int* length, byte* uniformName) => GLPointers._GetActiveUniformName_fnptr((int)program, uniformIndex, bufSize, length, uniformName);
+            public static void GetActiveUniformName(int program, uint uniformIndex, int bufSize, int* length, byte* uniformName) => GLPointers._GetActiveUniformName_fnptr(program, uniformIndex, bufSize, length, uniformName);
             
             /// <summary> <b>[requires: v3.1 | GL_ARB_uniform_buffer_object]</b> Retrieve the index of a named uniform block. </summary>
             /// <param name="program"> Specifies the name of a program containing the uniform block. </param>
             /// <param name="uniformBlockName"> Specifies the address an array of characters to containing the name of the uniform block whose index to retrieve. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetUniformBlockIndex.xhtml" /></remarks>
-            public static uint GetUniformBlockIndex(ProgramHandle program, byte* uniformBlockName) => GLPointers._GetUniformBlockIndex_fnptr((int)program, uniformBlockName);
+            public static uint GetUniformBlockIndex(int program, byte* uniformBlockName) => GLPointers._GetUniformBlockIndex_fnptr(program, uniformBlockName);
             
             /// <summary> <b>[requires: v3.1 | GL_ARB_uniform_buffer_object]</b> Query information about an active uniform block. </summary>
             /// <param name="program"> Specifies the name of a program containing the uniform block. </param>
@@ -8512,7 +8512,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="pname"> Specifies the name of the parameter to query. </param>
             /// <param name="parameters"> Specifies the address of a variable to receive the result of the query. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetActiveUniformBlock.xhtml" /></remarks>
-            public static void GetActiveUniformBlockiv(ProgramHandle program, uint uniformBlockIndex, UniformBlockPName pname, int* parameters) => GLPointers._GetActiveUniformBlockiv_fnptr((int)program, uniformBlockIndex, (uint)pname, parameters);
+            public static void GetActiveUniformBlockiv(int program, uint uniformBlockIndex, UniformBlockPName pname, int* parameters) => GLPointers._GetActiveUniformBlockiv_fnptr(program, uniformBlockIndex, (uint)pname, parameters);
             
             /// <summary> <b>[requires: v3.1 | GL_ARB_uniform_buffer_object]</b> Retrieve the name of an active uniform block. </summary>
             /// <param name="program"> Specifies the name of a program containing the uniform block. </param>
@@ -8521,14 +8521,14 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="length"> Specifies the address of a variable to receive the number of characters that were written to uniformBlockName. </param>
             /// <param name="uniformBlockName"> Specifies the address an array of characters to receive the name of the uniform block at uniformBlockIndex. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetActiveUniformBlockName.xhtml" /></remarks>
-            public static void GetActiveUniformBlockName(ProgramHandle program, uint uniformBlockIndex, int bufSize, int* length, byte* uniformBlockName) => GLPointers._GetActiveUniformBlockName_fnptr((int)program, uniformBlockIndex, bufSize, length, uniformBlockName);
+            public static void GetActiveUniformBlockName(int program, uint uniformBlockIndex, int bufSize, int* length, byte* uniformBlockName) => GLPointers._GetActiveUniformBlockName_fnptr(program, uniformBlockIndex, bufSize, length, uniformBlockName);
             
             /// <summary> <b>[requires: v3.1 | GL_ARB_uniform_buffer_object]</b> Assign a binding point to an active uniform block. </summary>
             /// <param name="program"> The name of a program object containing the active uniform block whose binding to assign. </param>
             /// <param name="uniformBlockIndex"> The index of the active uniform block within program whose binding to assign. </param>
             /// <param name="uniformBlockBinding"> Specifies the binding point to which to bind the uniform block with index uniformBlockIndex within program. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glUniformBlockBinding.xhtml" /></remarks>
-            public static void UniformBlockBinding(ProgramHandle program, uint uniformBlockIndex, uint uniformBlockBinding) => GLPointers._UniformBlockBinding_fnptr((int)program, uniformBlockIndex, uniformBlockBinding);
+            public static void UniformBlockBinding(int program, uint uniformBlockIndex, uint uniformBlockBinding) => GLPointers._UniformBlockBinding_fnptr(program, uniformBlockIndex, uniformBlockBinding);
             
             /// <summary> <b>[requires: v3.0 | v3.1 | GL_ARB_uniform_buffer_object]</b> Bind a range within a buffer object to an indexed buffer target. </summary>
             /// <param name="target"> Specify the target of the bind operation. target must be one of GL_ATOMIC_COUNTER_BUFFER, GL_TRANSFORM_FEEDBACK_BUFFER, GL_UNIFORM_BUFFER, or GL_SHADER_STORAGE_BUFFER. </param>
@@ -8537,14 +8537,14 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="offset"> The starting offset in basic machine units into the buffer object buffer. </param>
             /// <param name="size"> The amount of data in machine units that can be read from the buffer object while used as an indexed target. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindBufferRange.xhtml" /></remarks>
-            public static void BindBufferRange(BufferTargetARB target, uint index, BufferHandle buffer, IntPtr offset, nint size) => GLPointers._BindBufferRange_fnptr((uint)target, index, (int)buffer, offset, size);
+            public static void BindBufferRange(BufferTargetARB target, uint index, int buffer, IntPtr offset, nint size) => GLPointers._BindBufferRange_fnptr((uint)target, index, buffer, offset, size);
             
             /// <summary> <b>[requires: v3.0 | v3.1 | GL_ARB_uniform_buffer_object]</b> Bind a buffer object to an indexed buffer target. </summary>
             /// <param name="target"> Specify the target of the bind operation. target must be one of GL_ATOMIC_COUNTER_BUFFER, GL_TRANSFORM_FEEDBACK_BUFFER, GL_UNIFORM_BUFFER or GL_SHADER_STORAGE_BUFFER. </param>
             /// <param name="index"> Specify the index of the binding point within the array specified by target. </param>
             /// <param name="buffer"> The name of a buffer object to bind to the specified binding point. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindBufferBase.xhtml" /></remarks>
-            public static void BindBufferBase(BufferTargetARB target, uint index, BufferHandle buffer) => GLPointers._BindBufferBase_fnptr((uint)target, index, (int)buffer);
+            public static void BindBufferBase(BufferTargetARB target, uint index, int buffer) => GLPointers._BindBufferBase_fnptr((uint)target, index, buffer);
             
             /// <summary> <b>[requires: v3.0 | v3.1 | GL_ARB_uniform_buffer_object]</b> Return the value or values of a selected parameter. </summary>
             /// <param name="target"> Specifies the parameter value to be returned for indexed versions of glGet. The symbolic constants in the list below are accepted. </param>
@@ -8556,24 +8556,24 @@ namespace OpenTK.Graphics.OpenGL
             /// <summary> <b>[requires: v3.0 | GL_ARB_vertex_array_object]</b> Bind a vertex array object. </summary>
             /// <param name="array"> Specifies the name of the vertex array to bind. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindVertexArray.xhtml" /></remarks>
-            public static void BindVertexArray(VertexArrayHandle array) => GLPointers._BindVertexArray_fnptr((int)array);
+            public static void BindVertexArray(int array) => GLPointers._BindVertexArray_fnptr(array);
             
             /// <summary> <b>[requires: v3.0 | GL_ARB_vertex_array_object]</b> Delete vertex array objects. </summary>
             /// <param name="n"> Specifies the number of vertex array objects to be deleted. </param>
             /// <param name="arrays"> Specifies the address of an array containing the n names of the objects to be deleted. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDeleteVertexArrays.xhtml" /></remarks>
-            public static void DeleteVertexArrays(int n, VertexArrayHandle* arrays) => GLPointers._DeleteVertexArrays_fnptr(n, (int*)arrays);
+            public static void DeleteVertexArrays(int n, int* arrays) => GLPointers._DeleteVertexArrays_fnptr(n, arrays);
             
             /// <summary> <b>[requires: v3.0 | GL_ARB_vertex_array_object]</b> Generate vertex array object names. </summary>
             /// <param name="n"> Specifies the number of vertex array object names to generate. </param>
             /// <param name="arrays"> Specifies an array in which the generated vertex array object names are stored. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGenVertexArrays.xhtml" /></remarks>
-            public static void GenVertexArrays(int n, VertexArrayHandle* arrays) => GLPointers._GenVertexArrays_fnptr(n, (int*)arrays);
+            public static void GenVertexArrays(int n, int* arrays) => GLPointers._GenVertexArrays_fnptr(n, arrays);
             
             /// <summary> <b>[requires: v3.0 | GL_ARB_vertex_array_object]</b> Determine if a name corresponds to a vertex array object. </summary>
             /// <param name="array"> Specifies a value that may be the name of a vertex array object. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsVertexArray.xhtml" /></remarks>
-            public static bool IsVertexArray(VertexArrayHandle array) => GLPointers._IsVertexArray_fnptr((int)array) != 0;
+            public static bool IsVertexArray(int array) => GLPointers._IsVertexArray_fnptr(array) != 0;
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_vertex_attrib_64bit]</b> Specifies the value of a generic vertex attribute. </summary>
             /// <param name="index">Specifies the index of the generic vertex attribute to be modified.</param>
@@ -8651,7 +8651,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="offset">The offset of the first element of the buffer.</param>
             /// <param name="stride">The distance between elements within the buffer.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindVertexBuffer.xhtml" /></remarks>
-            public static void BindVertexBuffer(uint bindingindex, BufferHandle buffer, IntPtr offset, int stride) => GLPointers._BindVertexBuffer_fnptr(bindingindex, (int)buffer, offset, stride);
+            public static void BindVertexBuffer(uint bindingindex, int buffer, IntPtr offset, int stride) => GLPointers._BindVertexBuffer_fnptr(bindingindex, buffer, offset, stride);
             
             /// <summary> <b>[requires: v4.3 | GL_ARB_vertex_attrib_binding]</b> Specify the organization of vertex arrays. </summary>
             /// <param name="attribindex">The generic vertex attribute array being described.</param>
@@ -8732,19 +8732,19 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_ARB_vertex_buffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void BindBufferARB(BufferTargetARB target, BufferHandle buffer) => GLPointers._BindBufferARB_fnptr((uint)target, (int)buffer);
+            public static void BindBufferARB(BufferTargetARB target, int buffer) => GLPointers._BindBufferARB_fnptr((uint)target, buffer);
             
             /// <summary> <b>[requires: GL_ARB_vertex_buffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void DeleteBuffersARB(int n, BufferHandle* buffers) => GLPointers._DeleteBuffersARB_fnptr(n, (int*)buffers);
+            public static void DeleteBuffersARB(int n, int* buffers) => GLPointers._DeleteBuffersARB_fnptr(n, buffers);
             
             /// <summary> <b>[requires: GL_ARB_vertex_buffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GenBuffersARB(int n, BufferHandle* buffers) => GLPointers._GenBuffersARB_fnptr(n, (int*)buffers);
+            public static void GenBuffersARB(int n, int* buffers) => GLPointers._GenBuffersARB_fnptr(n, buffers);
             
             /// <summary> <b>[requires: GL_ARB_vertex_buffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static bool IsBufferARB(BufferHandle buffer) => GLPointers._IsBufferARB_fnptr((int)buffer) != 0;
+            public static bool IsBufferARB(int buffer) => GLPointers._IsBufferARB_fnptr(buffer) != 0;
             
             /// <summary> <b>[requires: GL_ARB_vertex_buffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -9243,11 +9243,11 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_ATI_map_object_buffer]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void* MapObjectBufferATI(BufferHandle buffer) => GLPointers._MapObjectBufferATI_fnptr((int)buffer);
+            public static void* MapObjectBufferATI(int buffer) => GLPointers._MapObjectBufferATI_fnptr(buffer);
             
             /// <summary> <b>[requires: GL_ATI_map_object_buffer]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void UnmapObjectBufferATI(BufferHandle buffer) => GLPointers._UnmapObjectBufferATI_fnptr((int)buffer);
+            public static void UnmapObjectBufferATI(int buffer) => GLPointers._UnmapObjectBufferATI_fnptr(buffer);
             
             /// <summary> <b>[requires: GL_ATI_pn_triangles]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -9271,27 +9271,27 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_ATI_vertex_array_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static bool IsObjectBufferATI(BufferHandle buffer) => GLPointers._IsObjectBufferATI_fnptr((int)buffer) != 0;
+            public static bool IsObjectBufferATI(int buffer) => GLPointers._IsObjectBufferATI_fnptr(buffer) != 0;
             
             /// <summary> <b>[requires: GL_ATI_vertex_array_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void UpdateObjectBufferATI(BufferHandle buffer, uint offset, int size, void* pointer, PreserveModeATI preserve) => GLPointers._UpdateObjectBufferATI_fnptr((int)buffer, offset, size, pointer, (uint)preserve);
+            public static void UpdateObjectBufferATI(int buffer, uint offset, int size, void* pointer, PreserveModeATI preserve) => GLPointers._UpdateObjectBufferATI_fnptr(buffer, offset, size, pointer, (uint)preserve);
             
             /// <summary> <b>[requires: GL_ATI_vertex_array_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetObjectBufferfvATI(BufferHandle buffer, ArrayObjectPNameATI pname, float* parameters) => GLPointers._GetObjectBufferfvATI_fnptr((int)buffer, (uint)pname, parameters);
+            public static void GetObjectBufferfvATI(int buffer, ArrayObjectPNameATI pname, float* parameters) => GLPointers._GetObjectBufferfvATI_fnptr(buffer, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_ATI_vertex_array_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetObjectBufferivATI(BufferHandle buffer, ArrayObjectPNameATI pname, int* parameters) => GLPointers._GetObjectBufferivATI_fnptr((int)buffer, (uint)pname, parameters);
+            public static void GetObjectBufferivATI(int buffer, ArrayObjectPNameATI pname, int* parameters) => GLPointers._GetObjectBufferivATI_fnptr(buffer, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_ATI_vertex_array_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void FreeObjectBufferATI(BufferHandle buffer) => GLPointers._FreeObjectBufferATI_fnptr((int)buffer);
+            public static void FreeObjectBufferATI(int buffer) => GLPointers._FreeObjectBufferATI_fnptr(buffer);
             
             /// <summary> <b>[requires: GL_ATI_vertex_array_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ArrayObjectATI(EnableCap array, int size, ScalarType type, int stride, BufferHandle buffer, uint offset) => GLPointers._ArrayObjectATI_fnptr((uint)array, size, (uint)type, stride, (int)buffer, offset);
+            public static void ArrayObjectATI(EnableCap array, int size, ScalarType type, int stride, int buffer, uint offset) => GLPointers._ArrayObjectATI_fnptr((uint)array, size, (uint)type, stride, buffer, offset);
             
             /// <summary> <b>[requires: GL_ATI_vertex_array_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -9303,7 +9303,7 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_ATI_vertex_array_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void VariantArrayObjectATI(uint id, ScalarType type, int stride, BufferHandle buffer, uint offset) => GLPointers._VariantArrayObjectATI_fnptr(id, (uint)type, stride, (int)buffer, offset);
+            public static void VariantArrayObjectATI(uint id, ScalarType type, int stride, int buffer, uint offset) => GLPointers._VariantArrayObjectATI_fnptr(id, (uint)type, stride, buffer, offset);
             
             /// <summary> <b>[requires: GL_ATI_vertex_array_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -9315,7 +9315,7 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_ATI_vertex_attrib_array_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void VertexAttribArrayObjectATI(uint index, int size, VertexAttribPointerType type, bool normalized, int stride, BufferHandle buffer, uint offset) => GLPointers._VertexAttribArrayObjectATI_fnptr(index, size, (uint)type, (byte)(normalized ? 1 : 0), stride, (int)buffer, offset);
+            public static void VertexAttribArrayObjectATI(uint index, int size, VertexAttribPointerType type, bool normalized, int stride, int buffer, uint offset) => GLPointers._VertexAttribArrayObjectATI_fnptr(index, size, (uint)type, (byte)(normalized ? 1 : 0), stride, buffer, offset);
             
             /// <summary> <b>[requires: GL_ATI_vertex_attrib_array_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -9514,19 +9514,19 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_EXT_EGL_image_storage]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void EGLImageTargetTextureStorageEXT(TextureHandle texture, void* image, int* attrib_list) => GLPointers._EGLImageTargetTextureStorageEXT_fnptr((int)texture, image, attrib_list);
+            public static void EGLImageTargetTextureStorageEXT(int texture, void* image, int* attrib_list) => GLPointers._EGLImageTargetTextureStorageEXT_fnptr(texture, image, attrib_list);
             
             /// <summary> <b>[requires: GL_EXT_bindable_uniform]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void UniformBufferEXT(ProgramHandle program, int location, BufferHandle buffer) => GLPointers._UniformBufferEXT_fnptr((int)program, location, (int)buffer);
+            public static void UniformBufferEXT(int program, int location, int buffer) => GLPointers._UniformBufferEXT_fnptr(program, location, buffer);
             
             /// <summary> <b>[requires: GL_EXT_bindable_uniform]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static int GetUniformBufferSizeEXT(ProgramHandle program, int location) => GLPointers._GetUniformBufferSizeEXT_fnptr((int)program, location);
+            public static int GetUniformBufferSizeEXT(int program, int location) => GLPointers._GetUniformBufferSizeEXT_fnptr(program, location);
             
             /// <summary> <b>[requires: GL_EXT_bindable_uniform]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static IntPtr GetUniformOffsetEXT(ProgramHandle program, int location) => GLPointers._GetUniformOffsetEXT_fnptr((int)program, location);
+            public static IntPtr GetUniformOffsetEXT(int program, int location) => GLPointers._GetUniformOffsetEXT_fnptr(program, location);
             
             /// <summary> <b>[requires: GL_EXT_blend_color]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -9822,87 +9822,87 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureParameterfEXT(TextureHandle texture, TextureTarget target, TextureParameterName pname, float param) => GLPointers._TextureParameterfEXT_fnptr((int)texture, (uint)target, (uint)pname, param);
+            public static void TextureParameterfEXT(int texture, TextureTarget target, TextureParameterName pname, float param) => GLPointers._TextureParameterfEXT_fnptr(texture, (uint)target, (uint)pname, param);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureParameterfvEXT(TextureHandle texture, TextureTarget target, TextureParameterName pname, float* parameters) => GLPointers._TextureParameterfvEXT_fnptr((int)texture, (uint)target, (uint)pname, parameters);
+            public static void TextureParameterfvEXT(int texture, TextureTarget target, TextureParameterName pname, float* parameters) => GLPointers._TextureParameterfvEXT_fnptr(texture, (uint)target, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureParameteriEXT(TextureHandle texture, TextureTarget target, TextureParameterName pname, int param) => GLPointers._TextureParameteriEXT_fnptr((int)texture, (uint)target, (uint)pname, param);
+            public static void TextureParameteriEXT(int texture, TextureTarget target, TextureParameterName pname, int param) => GLPointers._TextureParameteriEXT_fnptr(texture, (uint)target, (uint)pname, param);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureParameterivEXT(TextureHandle texture, TextureTarget target, TextureParameterName pname, int* parameters) => GLPointers._TextureParameterivEXT_fnptr((int)texture, (uint)target, (uint)pname, parameters);
+            public static void TextureParameterivEXT(int texture, TextureTarget target, TextureParameterName pname, int* parameters) => GLPointers._TextureParameterivEXT_fnptr(texture, (uint)target, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureImage1DEXT(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int width, int border, PixelFormat format, PixelType type, void* pixels) => GLPointers._TextureImage1DEXT_fnptr((int)texture, (uint)target, level, (int)internalformat, width, border, (uint)format, (uint)type, pixels);
+            public static void TextureImage1DEXT(int texture, TextureTarget target, int level, InternalFormat internalformat, int width, int border, PixelFormat format, PixelType type, void* pixels) => GLPointers._TextureImage1DEXT_fnptr(texture, (uint)target, level, (int)internalformat, width, border, (uint)format, (uint)type, pixels);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureImage2DEXT(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int border, PixelFormat format, PixelType type, void* pixels) => GLPointers._TextureImage2DEXT_fnptr((int)texture, (uint)target, level, (int)internalformat, width, height, border, (uint)format, (uint)type, pixels);
+            public static void TextureImage2DEXT(int texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int border, PixelFormat format, PixelType type, void* pixels) => GLPointers._TextureImage2DEXT_fnptr(texture, (uint)target, level, (int)internalformat, width, height, border, (uint)format, (uint)type, pixels);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureSubImage1DEXT(TextureHandle texture, TextureTarget target, int level, int xoffset, int width, PixelFormat format, PixelType type, void* pixels) => GLPointers._TextureSubImage1DEXT_fnptr((int)texture, (uint)target, level, xoffset, width, (uint)format, (uint)type, pixels);
+            public static void TextureSubImage1DEXT(int texture, TextureTarget target, int level, int xoffset, int width, PixelFormat format, PixelType type, void* pixels) => GLPointers._TextureSubImage1DEXT_fnptr(texture, (uint)target, level, xoffset, width, (uint)format, (uint)type, pixels);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureSubImage2DEXT(TextureHandle texture, TextureTarget target, int level, int xoffset, int yoffset, int width, int height, PixelFormat format, PixelType type, void* pixels) => GLPointers._TextureSubImage2DEXT_fnptr((int)texture, (uint)target, level, xoffset, yoffset, width, height, (uint)format, (uint)type, pixels);
+            public static void TextureSubImage2DEXT(int texture, TextureTarget target, int level, int xoffset, int yoffset, int width, int height, PixelFormat format, PixelType type, void* pixels) => GLPointers._TextureSubImage2DEXT_fnptr(texture, (uint)target, level, xoffset, yoffset, width, height, (uint)format, (uint)type, pixels);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void CopyTextureImage1DEXT(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int x, int y, int width, int border) => GLPointers._CopyTextureImage1DEXT_fnptr((int)texture, (uint)target, level, (uint)internalformat, x, y, width, border);
+            public static void CopyTextureImage1DEXT(int texture, TextureTarget target, int level, InternalFormat internalformat, int x, int y, int width, int border) => GLPointers._CopyTextureImage1DEXT_fnptr(texture, (uint)target, level, (uint)internalformat, x, y, width, border);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void CopyTextureImage2DEXT(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int x, int y, int width, int height, int border) => GLPointers._CopyTextureImage2DEXT_fnptr((int)texture, (uint)target, level, (uint)internalformat, x, y, width, height, border);
+            public static void CopyTextureImage2DEXT(int texture, TextureTarget target, int level, InternalFormat internalformat, int x, int y, int width, int height, int border) => GLPointers._CopyTextureImage2DEXT_fnptr(texture, (uint)target, level, (uint)internalformat, x, y, width, height, border);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void CopyTextureSubImage1DEXT(TextureHandle texture, TextureTarget target, int level, int xoffset, int x, int y, int width) => GLPointers._CopyTextureSubImage1DEXT_fnptr((int)texture, (uint)target, level, xoffset, x, y, width);
+            public static void CopyTextureSubImage1DEXT(int texture, TextureTarget target, int level, int xoffset, int x, int y, int width) => GLPointers._CopyTextureSubImage1DEXT_fnptr(texture, (uint)target, level, xoffset, x, y, width);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void CopyTextureSubImage2DEXT(TextureHandle texture, TextureTarget target, int level, int xoffset, int yoffset, int x, int y, int width, int height) => GLPointers._CopyTextureSubImage2DEXT_fnptr((int)texture, (uint)target, level, xoffset, yoffset, x, y, width, height);
+            public static void CopyTextureSubImage2DEXT(int texture, TextureTarget target, int level, int xoffset, int yoffset, int x, int y, int width, int height) => GLPointers._CopyTextureSubImage2DEXT_fnptr(texture, (uint)target, level, xoffset, yoffset, x, y, width, height);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetTextureImageEXT(TextureHandle texture, TextureTarget target, int level, PixelFormat format, PixelType type, void* pixels) => GLPointers._GetTextureImageEXT_fnptr((int)texture, (uint)target, level, (uint)format, (uint)type, pixels);
+            public static void GetTextureImageEXT(int texture, TextureTarget target, int level, PixelFormat format, PixelType type, void* pixels) => GLPointers._GetTextureImageEXT_fnptr(texture, (uint)target, level, (uint)format, (uint)type, pixels);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetTextureParameterfvEXT(TextureHandle texture, TextureTarget target, GetTextureParameter pname, float* parameters) => GLPointers._GetTextureParameterfvEXT_fnptr((int)texture, (uint)target, (uint)pname, parameters);
+            public static void GetTextureParameterfvEXT(int texture, TextureTarget target, GetTextureParameter pname, float* parameters) => GLPointers._GetTextureParameterfvEXT_fnptr(texture, (uint)target, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetTextureParameterivEXT(TextureHandle texture, TextureTarget target, GetTextureParameter pname, int* parameters) => GLPointers._GetTextureParameterivEXT_fnptr((int)texture, (uint)target, (uint)pname, parameters);
+            public static void GetTextureParameterivEXT(int texture, TextureTarget target, GetTextureParameter pname, int* parameters) => GLPointers._GetTextureParameterivEXT_fnptr(texture, (uint)target, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetTextureLevelParameterfvEXT(TextureHandle texture, TextureTarget target, int level, GetTextureParameter pname, float* parameters) => GLPointers._GetTextureLevelParameterfvEXT_fnptr((int)texture, (uint)target, level, (uint)pname, parameters);
+            public static void GetTextureLevelParameterfvEXT(int texture, TextureTarget target, int level, GetTextureParameter pname, float* parameters) => GLPointers._GetTextureLevelParameterfvEXT_fnptr(texture, (uint)target, level, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetTextureLevelParameterivEXT(TextureHandle texture, TextureTarget target, int level, GetTextureParameter pname, int* parameters) => GLPointers._GetTextureLevelParameterivEXT_fnptr((int)texture, (uint)target, level, (uint)pname, parameters);
+            public static void GetTextureLevelParameterivEXT(int texture, TextureTarget target, int level, GetTextureParameter pname, int* parameters) => GLPointers._GetTextureLevelParameterivEXT_fnptr(texture, (uint)target, level, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureImage3DEXT(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int depth, int border, PixelFormat format, PixelType type, void* pixels) => GLPointers._TextureImage3DEXT_fnptr((int)texture, (uint)target, level, (int)internalformat, width, height, depth, border, (uint)format, (uint)type, pixels);
+            public static void TextureImage3DEXT(int texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int depth, int border, PixelFormat format, PixelType type, void* pixels) => GLPointers._TextureImage3DEXT_fnptr(texture, (uint)target, level, (int)internalformat, width, height, depth, border, (uint)format, (uint)type, pixels);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureSubImage3DEXT(TextureHandle texture, TextureTarget target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, void* pixels) => GLPointers._TextureSubImage3DEXT_fnptr((int)texture, (uint)target, level, xoffset, yoffset, zoffset, width, height, depth, (uint)format, (uint)type, pixels);
+            public static void TextureSubImage3DEXT(int texture, TextureTarget target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, void* pixels) => GLPointers._TextureSubImage3DEXT_fnptr(texture, (uint)target, level, xoffset, yoffset, zoffset, width, height, depth, (uint)format, (uint)type, pixels);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void CopyTextureSubImage3DEXT(TextureHandle texture, TextureTarget target, int level, int xoffset, int yoffset, int zoffset, int x, int y, int width, int height) => GLPointers._CopyTextureSubImage3DEXT_fnptr((int)texture, (uint)target, level, xoffset, yoffset, zoffset, x, y, width, height);
+            public static void CopyTextureSubImage3DEXT(int texture, TextureTarget target, int level, int xoffset, int yoffset, int zoffset, int x, int y, int width, int height) => GLPointers._CopyTextureSubImage3DEXT_fnptr(texture, (uint)target, level, xoffset, yoffset, zoffset, x, y, width, height);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void BindMultiTextureEXT(TextureUnit texunit, TextureTarget target, TextureHandle texture) => GLPointers._BindMultiTextureEXT_fnptr((uint)texunit, (uint)target, (int)texture);
+            public static void BindMultiTextureEXT(TextureUnit texunit, TextureTarget target, int texture) => GLPointers._BindMultiTextureEXT_fnptr((uint)texunit, (uint)target, texture);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -10090,31 +10090,31 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void CompressedTextureImage3DEXT(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int depth, int border, int imageSize, void* bits) => GLPointers._CompressedTextureImage3DEXT_fnptr((int)texture, (uint)target, level, (uint)internalformat, width, height, depth, border, imageSize, bits);
+            public static void CompressedTextureImage3DEXT(int texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int depth, int border, int imageSize, void* bits) => GLPointers._CompressedTextureImage3DEXT_fnptr(texture, (uint)target, level, (uint)internalformat, width, height, depth, border, imageSize, bits);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void CompressedTextureImage2DEXT(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int border, int imageSize, void* bits) => GLPointers._CompressedTextureImage2DEXT_fnptr((int)texture, (uint)target, level, (uint)internalformat, width, height, border, imageSize, bits);
+            public static void CompressedTextureImage2DEXT(int texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int border, int imageSize, void* bits) => GLPointers._CompressedTextureImage2DEXT_fnptr(texture, (uint)target, level, (uint)internalformat, width, height, border, imageSize, bits);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void CompressedTextureImage1DEXT(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int width, int border, int imageSize, void* bits) => GLPointers._CompressedTextureImage1DEXT_fnptr((int)texture, (uint)target, level, (uint)internalformat, width, border, imageSize, bits);
+            public static void CompressedTextureImage1DEXT(int texture, TextureTarget target, int level, InternalFormat internalformat, int width, int border, int imageSize, void* bits) => GLPointers._CompressedTextureImage1DEXT_fnptr(texture, (uint)target, level, (uint)internalformat, width, border, imageSize, bits);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void CompressedTextureSubImage3DEXT(TextureHandle texture, TextureTarget target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, InternalFormat format, int imageSize, void* bits) => GLPointers._CompressedTextureSubImage3DEXT_fnptr((int)texture, (uint)target, level, xoffset, yoffset, zoffset, width, height, depth, (uint)format, imageSize, bits);
+            public static void CompressedTextureSubImage3DEXT(int texture, TextureTarget target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, InternalFormat format, int imageSize, void* bits) => GLPointers._CompressedTextureSubImage3DEXT_fnptr(texture, (uint)target, level, xoffset, yoffset, zoffset, width, height, depth, (uint)format, imageSize, bits);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void CompressedTextureSubImage2DEXT(TextureHandle texture, TextureTarget target, int level, int xoffset, int yoffset, int width, int height, InternalFormat format, int imageSize, void* bits) => GLPointers._CompressedTextureSubImage2DEXT_fnptr((int)texture, (uint)target, level, xoffset, yoffset, width, height, (uint)format, imageSize, bits);
+            public static void CompressedTextureSubImage2DEXT(int texture, TextureTarget target, int level, int xoffset, int yoffset, int width, int height, InternalFormat format, int imageSize, void* bits) => GLPointers._CompressedTextureSubImage2DEXT_fnptr(texture, (uint)target, level, xoffset, yoffset, width, height, (uint)format, imageSize, bits);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void CompressedTextureSubImage1DEXT(TextureHandle texture, TextureTarget target, int level, int xoffset, int width, InternalFormat format, int imageSize, void* bits) => GLPointers._CompressedTextureSubImage1DEXT_fnptr((int)texture, (uint)target, level, xoffset, width, (uint)format, imageSize, bits);
+            public static void CompressedTextureSubImage1DEXT(int texture, TextureTarget target, int level, int xoffset, int width, InternalFormat format, int imageSize, void* bits) => GLPointers._CompressedTextureSubImage1DEXT_fnptr(texture, (uint)target, level, xoffset, width, (uint)format, imageSize, bits);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetCompressedTextureImageEXT(TextureHandle texture, TextureTarget target, int lod, void* img) => GLPointers._GetCompressedTextureImageEXT_fnptr((int)texture, (uint)target, lod, img);
+            public static void GetCompressedTextureImageEXT(int texture, TextureTarget target, int lod, void* img) => GLPointers._GetCompressedTextureImageEXT_fnptr(texture, (uint)target, lod, img);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -10162,155 +10162,155 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedBufferDataEXT(BufferHandle buffer, nint size, void* data, VertexBufferObjectUsage usage) => GLPointers._NamedBufferDataEXT_fnptr((int)buffer, size, data, (uint)usage);
+            public static void NamedBufferDataEXT(int buffer, nint size, void* data, VertexBufferObjectUsage usage) => GLPointers._NamedBufferDataEXT_fnptr(buffer, size, data, (uint)usage);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedBufferSubDataEXT(BufferHandle buffer, IntPtr offset, nint size, void* data) => GLPointers._NamedBufferSubDataEXT_fnptr((int)buffer, offset, size, data);
+            public static void NamedBufferSubDataEXT(int buffer, IntPtr offset, nint size, void* data) => GLPointers._NamedBufferSubDataEXT_fnptr(buffer, offset, size, data);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void* MapNamedBufferEXT(BufferHandle buffer, BufferAccessARB access) => GLPointers._MapNamedBufferEXT_fnptr((int)buffer, (uint)access);
+            public static void* MapNamedBufferEXT(int buffer, BufferAccessARB access) => GLPointers._MapNamedBufferEXT_fnptr(buffer, (uint)access);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static bool UnmapNamedBufferEXT(BufferHandle buffer) => GLPointers._UnmapNamedBufferEXT_fnptr((int)buffer) != 0;
+            public static bool UnmapNamedBufferEXT(int buffer) => GLPointers._UnmapNamedBufferEXT_fnptr(buffer) != 0;
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetNamedBufferParameterivEXT(BufferHandle buffer, BufferPNameARB pname, int* parameters) => GLPointers._GetNamedBufferParameterivEXT_fnptr((int)buffer, (uint)pname, parameters);
+            public static void GetNamedBufferParameterivEXT(int buffer, BufferPNameARB pname, int* parameters) => GLPointers._GetNamedBufferParameterivEXT_fnptr(buffer, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetNamedBufferPointervEXT(BufferHandle buffer, BufferPointerNameARB pname, void** parameters) => GLPointers._GetNamedBufferPointervEXT_fnptr((int)buffer, (uint)pname, parameters);
+            public static void GetNamedBufferPointervEXT(int buffer, BufferPointerNameARB pname, void** parameters) => GLPointers._GetNamedBufferPointervEXT_fnptr(buffer, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetNamedBufferSubDataEXT(BufferHandle buffer, IntPtr offset, nint size, void* data) => GLPointers._GetNamedBufferSubDataEXT_fnptr((int)buffer, offset, size, data);
+            public static void GetNamedBufferSubDataEXT(int buffer, IntPtr offset, nint size, void* data) => GLPointers._GetNamedBufferSubDataEXT_fnptr(buffer, offset, size, data);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform1fEXT(ProgramHandle program, int location, float v0) => GLPointers._ProgramUniform1fEXT_fnptr((int)program, location, v0);
+            public static void ProgramUniform1fEXT(int program, int location, float v0) => GLPointers._ProgramUniform1fEXT_fnptr(program, location, v0);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform2fEXT(ProgramHandle program, int location, float v0, float v1) => GLPointers._ProgramUniform2fEXT_fnptr((int)program, location, v0, v1);
+            public static void ProgramUniform2fEXT(int program, int location, float v0, float v1) => GLPointers._ProgramUniform2fEXT_fnptr(program, location, v0, v1);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform3fEXT(ProgramHandle program, int location, float v0, float v1, float v2) => GLPointers._ProgramUniform3fEXT_fnptr((int)program, location, v0, v1, v2);
+            public static void ProgramUniform3fEXT(int program, int location, float v0, float v1, float v2) => GLPointers._ProgramUniform3fEXT_fnptr(program, location, v0, v1, v2);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform4fEXT(ProgramHandle program, int location, float v0, float v1, float v2, float v3) => GLPointers._ProgramUniform4fEXT_fnptr((int)program, location, v0, v1, v2, v3);
+            public static void ProgramUniform4fEXT(int program, int location, float v0, float v1, float v2, float v3) => GLPointers._ProgramUniform4fEXT_fnptr(program, location, v0, v1, v2, v3);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform1iEXT(ProgramHandle program, int location, int v0) => GLPointers._ProgramUniform1iEXT_fnptr((int)program, location, v0);
+            public static void ProgramUniform1iEXT(int program, int location, int v0) => GLPointers._ProgramUniform1iEXT_fnptr(program, location, v0);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform2iEXT(ProgramHandle program, int location, int v0, int v1) => GLPointers._ProgramUniform2iEXT_fnptr((int)program, location, v0, v1);
+            public static void ProgramUniform2iEXT(int program, int location, int v0, int v1) => GLPointers._ProgramUniform2iEXT_fnptr(program, location, v0, v1);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform3iEXT(ProgramHandle program, int location, int v0, int v1, int v2) => GLPointers._ProgramUniform3iEXT_fnptr((int)program, location, v0, v1, v2);
+            public static void ProgramUniform3iEXT(int program, int location, int v0, int v1, int v2) => GLPointers._ProgramUniform3iEXT_fnptr(program, location, v0, v1, v2);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform4iEXT(ProgramHandle program, int location, int v0, int v1, int v2, int v3) => GLPointers._ProgramUniform4iEXT_fnptr((int)program, location, v0, v1, v2, v3);
+            public static void ProgramUniform4iEXT(int program, int location, int v0, int v1, int v2, int v3) => GLPointers._ProgramUniform4iEXT_fnptr(program, location, v0, v1, v2, v3);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform1fvEXT(ProgramHandle program, int location, int count, float* value) => GLPointers._ProgramUniform1fvEXT_fnptr((int)program, location, count, value);
+            public static void ProgramUniform1fvEXT(int program, int location, int count, float* value) => GLPointers._ProgramUniform1fvEXT_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform2fvEXT(ProgramHandle program, int location, int count, float* value) => GLPointers._ProgramUniform2fvEXT_fnptr((int)program, location, count, value);
+            public static void ProgramUniform2fvEXT(int program, int location, int count, float* value) => GLPointers._ProgramUniform2fvEXT_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform3fvEXT(ProgramHandle program, int location, int count, float* value) => GLPointers._ProgramUniform3fvEXT_fnptr((int)program, location, count, value);
+            public static void ProgramUniform3fvEXT(int program, int location, int count, float* value) => GLPointers._ProgramUniform3fvEXT_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform4fvEXT(ProgramHandle program, int location, int count, float* value) => GLPointers._ProgramUniform4fvEXT_fnptr((int)program, location, count, value);
+            public static void ProgramUniform4fvEXT(int program, int location, int count, float* value) => GLPointers._ProgramUniform4fvEXT_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform1ivEXT(ProgramHandle program, int location, int count, int* value) => GLPointers._ProgramUniform1ivEXT_fnptr((int)program, location, count, value);
+            public static void ProgramUniform1ivEXT(int program, int location, int count, int* value) => GLPointers._ProgramUniform1ivEXT_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform2ivEXT(ProgramHandle program, int location, int count, int* value) => GLPointers._ProgramUniform2ivEXT_fnptr((int)program, location, count, value);
+            public static void ProgramUniform2ivEXT(int program, int location, int count, int* value) => GLPointers._ProgramUniform2ivEXT_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform3ivEXT(ProgramHandle program, int location, int count, int* value) => GLPointers._ProgramUniform3ivEXT_fnptr((int)program, location, count, value);
+            public static void ProgramUniform3ivEXT(int program, int location, int count, int* value) => GLPointers._ProgramUniform3ivEXT_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform4ivEXT(ProgramHandle program, int location, int count, int* value) => GLPointers._ProgramUniform4ivEXT_fnptr((int)program, location, count, value);
+            public static void ProgramUniform4ivEXT(int program, int location, int count, int* value) => GLPointers._ProgramUniform4ivEXT_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix2fvEXT(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix2fvEXT_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix2fvEXT(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix2fvEXT_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix3fvEXT(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix3fvEXT_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix3fvEXT(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix3fvEXT_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix4fvEXT(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix4fvEXT_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix4fvEXT(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix4fvEXT_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix2x3fvEXT(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix2x3fvEXT_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix2x3fvEXT(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix2x3fvEXT_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix3x2fvEXT(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix3x2fvEXT_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix3x2fvEXT(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix3x2fvEXT_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix2x4fvEXT(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix2x4fvEXT_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix2x4fvEXT(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix2x4fvEXT_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix4x2fvEXT(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix4x2fvEXT_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix4x2fvEXT(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix4x2fvEXT_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix3x4fvEXT(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix3x4fvEXT_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix3x4fvEXT(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix3x4fvEXT_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix4x3fvEXT(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix4x3fvEXT_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix4x3fvEXT(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix4x3fvEXT_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureBufferEXT(TextureHandle texture, TextureTarget target, SizedInternalFormat internalformat, BufferHandle buffer) => GLPointers._TextureBufferEXT_fnptr((int)texture, (uint)target, (uint)internalformat, (int)buffer);
+            public static void TextureBufferEXT(int texture, TextureTarget target, SizedInternalFormat internalformat, int buffer) => GLPointers._TextureBufferEXT_fnptr(texture, (uint)target, (uint)internalformat, buffer);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void MultiTexBufferEXT(TextureUnit texunit, TextureTarget target, InternalFormat internalformat, BufferHandle buffer) => GLPointers._MultiTexBufferEXT_fnptr((uint)texunit, (uint)target, (uint)internalformat, (int)buffer);
+            public static void MultiTexBufferEXT(TextureUnit texunit, TextureTarget target, InternalFormat internalformat, int buffer) => GLPointers._MultiTexBufferEXT_fnptr((uint)texunit, (uint)target, (uint)internalformat, buffer);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureParameterIivEXT(TextureHandle texture, TextureTarget target, TextureParameterName pname, int* parameters) => GLPointers._TextureParameterIivEXT_fnptr((int)texture, (uint)target, (uint)pname, parameters);
+            public static void TextureParameterIivEXT(int texture, TextureTarget target, TextureParameterName pname, int* parameters) => GLPointers._TextureParameterIivEXT_fnptr(texture, (uint)target, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureParameterIuivEXT(TextureHandle texture, TextureTarget target, TextureParameterName pname, uint* parameters) => GLPointers._TextureParameterIuivEXT_fnptr((int)texture, (uint)target, (uint)pname, parameters);
+            public static void TextureParameterIuivEXT(int texture, TextureTarget target, TextureParameterName pname, uint* parameters) => GLPointers._TextureParameterIuivEXT_fnptr(texture, (uint)target, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetTextureParameterIivEXT(TextureHandle texture, TextureTarget target, GetTextureParameter pname, int* parameters) => GLPointers._GetTextureParameterIivEXT_fnptr((int)texture, (uint)target, (uint)pname, parameters);
+            public static void GetTextureParameterIivEXT(int texture, TextureTarget target, GetTextureParameter pname, int* parameters) => GLPointers._GetTextureParameterIivEXT_fnptr(texture, (uint)target, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetTextureParameterIuivEXT(TextureHandle texture, TextureTarget target, GetTextureParameter pname, uint* parameters) => GLPointers._GetTextureParameterIuivEXT_fnptr((int)texture, (uint)target, (uint)pname, parameters);
+            public static void GetTextureParameterIuivEXT(int texture, TextureTarget target, GetTextureParameter pname, uint* parameters) => GLPointers._GetTextureParameterIuivEXT_fnptr(texture, (uint)target, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -10330,71 +10330,71 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform1uiEXT(ProgramHandle program, int location, uint v0) => GLPointers._ProgramUniform1uiEXT_fnptr((int)program, location, v0);
+            public static void ProgramUniform1uiEXT(int program, int location, uint v0) => GLPointers._ProgramUniform1uiEXT_fnptr(program, location, v0);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform2uiEXT(ProgramHandle program, int location, uint v0, uint v1) => GLPointers._ProgramUniform2uiEXT_fnptr((int)program, location, v0, v1);
+            public static void ProgramUniform2uiEXT(int program, int location, uint v0, uint v1) => GLPointers._ProgramUniform2uiEXT_fnptr(program, location, v0, v1);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform3uiEXT(ProgramHandle program, int location, uint v0, uint v1, uint v2) => GLPointers._ProgramUniform3uiEXT_fnptr((int)program, location, v0, v1, v2);
+            public static void ProgramUniform3uiEXT(int program, int location, uint v0, uint v1, uint v2) => GLPointers._ProgramUniform3uiEXT_fnptr(program, location, v0, v1, v2);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform4uiEXT(ProgramHandle program, int location, uint v0, uint v1, uint v2, uint v3) => GLPointers._ProgramUniform4uiEXT_fnptr((int)program, location, v0, v1, v2, v3);
+            public static void ProgramUniform4uiEXT(int program, int location, uint v0, uint v1, uint v2, uint v3) => GLPointers._ProgramUniform4uiEXT_fnptr(program, location, v0, v1, v2, v3);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform1uivEXT(ProgramHandle program, int location, int count, uint* value) => GLPointers._ProgramUniform1uivEXT_fnptr((int)program, location, count, value);
+            public static void ProgramUniform1uivEXT(int program, int location, int count, uint* value) => GLPointers._ProgramUniform1uivEXT_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform2uivEXT(ProgramHandle program, int location, int count, uint* value) => GLPointers._ProgramUniform2uivEXT_fnptr((int)program, location, count, value);
+            public static void ProgramUniform2uivEXT(int program, int location, int count, uint* value) => GLPointers._ProgramUniform2uivEXT_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform3uivEXT(ProgramHandle program, int location, int count, uint* value) => GLPointers._ProgramUniform3uivEXT_fnptr((int)program, location, count, value);
+            public static void ProgramUniform3uivEXT(int program, int location, int count, uint* value) => GLPointers._ProgramUniform3uivEXT_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform4uivEXT(ProgramHandle program, int location, int count, uint* value) => GLPointers._ProgramUniform4uivEXT_fnptr((int)program, location, count, value);
+            public static void ProgramUniform4uivEXT(int program, int location, int count, uint* value) => GLPointers._ProgramUniform4uivEXT_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedProgramLocalParameters4fvEXT(ProgramHandle program, ProgramTarget target, uint index, int count, float* parameters) => GLPointers._NamedProgramLocalParameters4fvEXT_fnptr((int)program, (uint)target, index, count, parameters);
+            public static void NamedProgramLocalParameters4fvEXT(int program, ProgramTarget target, uint index, int count, float* parameters) => GLPointers._NamedProgramLocalParameters4fvEXT_fnptr(program, (uint)target, index, count, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedProgramLocalParameterI4iEXT(ProgramHandle program, ProgramTarget target, uint index, int x, int y, int z, int w) => GLPointers._NamedProgramLocalParameterI4iEXT_fnptr((int)program, (uint)target, index, x, y, z, w);
+            public static void NamedProgramLocalParameterI4iEXT(int program, ProgramTarget target, uint index, int x, int y, int z, int w) => GLPointers._NamedProgramLocalParameterI4iEXT_fnptr(program, (uint)target, index, x, y, z, w);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedProgramLocalParameterI4ivEXT(ProgramHandle program, ProgramTarget target, uint index, int* parameters) => GLPointers._NamedProgramLocalParameterI4ivEXT_fnptr((int)program, (uint)target, index, parameters);
+            public static void NamedProgramLocalParameterI4ivEXT(int program, ProgramTarget target, uint index, int* parameters) => GLPointers._NamedProgramLocalParameterI4ivEXT_fnptr(program, (uint)target, index, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedProgramLocalParametersI4ivEXT(ProgramHandle program, ProgramTarget target, uint index, int count, int* parameters) => GLPointers._NamedProgramLocalParametersI4ivEXT_fnptr((int)program, (uint)target, index, count, parameters);
+            public static void NamedProgramLocalParametersI4ivEXT(int program, ProgramTarget target, uint index, int count, int* parameters) => GLPointers._NamedProgramLocalParametersI4ivEXT_fnptr(program, (uint)target, index, count, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedProgramLocalParameterI4uiEXT(ProgramHandle program, ProgramTarget target, uint index, uint x, uint y, uint z, uint w) => GLPointers._NamedProgramLocalParameterI4uiEXT_fnptr((int)program, (uint)target, index, x, y, z, w);
+            public static void NamedProgramLocalParameterI4uiEXT(int program, ProgramTarget target, uint index, uint x, uint y, uint z, uint w) => GLPointers._NamedProgramLocalParameterI4uiEXT_fnptr(program, (uint)target, index, x, y, z, w);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedProgramLocalParameterI4uivEXT(ProgramHandle program, ProgramTarget target, uint index, uint* parameters) => GLPointers._NamedProgramLocalParameterI4uivEXT_fnptr((int)program, (uint)target, index, parameters);
+            public static void NamedProgramLocalParameterI4uivEXT(int program, ProgramTarget target, uint index, uint* parameters) => GLPointers._NamedProgramLocalParameterI4uivEXT_fnptr(program, (uint)target, index, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedProgramLocalParametersI4uivEXT(ProgramHandle program, ProgramTarget target, uint index, int count, uint* parameters) => GLPointers._NamedProgramLocalParametersI4uivEXT_fnptr((int)program, (uint)target, index, count, parameters);
+            public static void NamedProgramLocalParametersI4uivEXT(int program, ProgramTarget target, uint index, int count, uint* parameters) => GLPointers._NamedProgramLocalParametersI4uivEXT_fnptr(program, (uint)target, index, count, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetNamedProgramLocalParameterIivEXT(ProgramHandle program, ProgramTarget target, uint index, int* parameters) => GLPointers._GetNamedProgramLocalParameterIivEXT_fnptr((int)program, (uint)target, index, parameters);
+            public static void GetNamedProgramLocalParameterIivEXT(int program, ProgramTarget target, uint index, int* parameters) => GLPointers._GetNamedProgramLocalParameterIivEXT_fnptr(program, (uint)target, index, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetNamedProgramLocalParameterIuivEXT(ProgramHandle program, ProgramTarget target, uint index, uint* parameters) => GLPointers._GetNamedProgramLocalParameterIuivEXT_fnptr((int)program, (uint)target, index, parameters);
+            public static void GetNamedProgramLocalParameterIuivEXT(int program, ProgramTarget target, uint index, uint* parameters) => GLPointers._GetNamedProgramLocalParameterIuivEXT_fnptr(program, (uint)target, index, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -10418,83 +10418,83 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedProgramStringEXT(ProgramHandle program, ProgramTarget target, ProgramFormat format, int len, void* str) => GLPointers._NamedProgramStringEXT_fnptr((int)program, (uint)target, (uint)format, len, str);
+            public static void NamedProgramStringEXT(int program, ProgramTarget target, ProgramFormat format, int len, void* str) => GLPointers._NamedProgramStringEXT_fnptr(program, (uint)target, (uint)format, len, str);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedProgramLocalParameter4dEXT(ProgramHandle program, ProgramTarget target, uint index, double x, double y, double z, double w) => GLPointers._NamedProgramLocalParameter4dEXT_fnptr((int)program, (uint)target, index, x, y, z, w);
+            public static void NamedProgramLocalParameter4dEXT(int program, ProgramTarget target, uint index, double x, double y, double z, double w) => GLPointers._NamedProgramLocalParameter4dEXT_fnptr(program, (uint)target, index, x, y, z, w);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedProgramLocalParameter4dvEXT(ProgramHandle program, ProgramTarget target, uint index, double* parameters) => GLPointers._NamedProgramLocalParameter4dvEXT_fnptr((int)program, (uint)target, index, parameters);
+            public static void NamedProgramLocalParameter4dvEXT(int program, ProgramTarget target, uint index, double* parameters) => GLPointers._NamedProgramLocalParameter4dvEXT_fnptr(program, (uint)target, index, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedProgramLocalParameter4fEXT(ProgramHandle program, ProgramTarget target, uint index, float x, float y, float z, float w) => GLPointers._NamedProgramLocalParameter4fEXT_fnptr((int)program, (uint)target, index, x, y, z, w);
+            public static void NamedProgramLocalParameter4fEXT(int program, ProgramTarget target, uint index, float x, float y, float z, float w) => GLPointers._NamedProgramLocalParameter4fEXT_fnptr(program, (uint)target, index, x, y, z, w);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedProgramLocalParameter4fvEXT(ProgramHandle program, ProgramTarget target, uint index, float* parameters) => GLPointers._NamedProgramLocalParameter4fvEXT_fnptr((int)program, (uint)target, index, parameters);
+            public static void NamedProgramLocalParameter4fvEXT(int program, ProgramTarget target, uint index, float* parameters) => GLPointers._NamedProgramLocalParameter4fvEXT_fnptr(program, (uint)target, index, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetNamedProgramLocalParameterdvEXT(ProgramHandle program, ProgramTarget target, uint index, double* parameters) => GLPointers._GetNamedProgramLocalParameterdvEXT_fnptr((int)program, (uint)target, index, parameters);
+            public static void GetNamedProgramLocalParameterdvEXT(int program, ProgramTarget target, uint index, double* parameters) => GLPointers._GetNamedProgramLocalParameterdvEXT_fnptr(program, (uint)target, index, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetNamedProgramLocalParameterfvEXT(ProgramHandle program, ProgramTarget target, uint index, float* parameters) => GLPointers._GetNamedProgramLocalParameterfvEXT_fnptr((int)program, (uint)target, index, parameters);
+            public static void GetNamedProgramLocalParameterfvEXT(int program, ProgramTarget target, uint index, float* parameters) => GLPointers._GetNamedProgramLocalParameterfvEXT_fnptr(program, (uint)target, index, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetNamedProgramivEXT(ProgramHandle program, ProgramTarget target, ProgramPropertyARB pname, int* parameters) => GLPointers._GetNamedProgramivEXT_fnptr((int)program, (uint)target, (uint)pname, parameters);
+            public static void GetNamedProgramivEXT(int program, ProgramTarget target, ProgramPropertyARB pname, int* parameters) => GLPointers._GetNamedProgramivEXT_fnptr(program, (uint)target, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetNamedProgramStringEXT(ProgramHandle program, ProgramTarget target, ProgramStringProperty pname, void* str) => GLPointers._GetNamedProgramStringEXT_fnptr((int)program, (uint)target, (uint)pname, str);
+            public static void GetNamedProgramStringEXT(int program, ProgramTarget target, ProgramStringProperty pname, void* str) => GLPointers._GetNamedProgramStringEXT_fnptr(program, (uint)target, (uint)pname, str);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedRenderbufferStorageEXT(RenderbufferHandle renderbuffer, InternalFormat internalformat, int width, int height) => GLPointers._NamedRenderbufferStorageEXT_fnptr((int)renderbuffer, (uint)internalformat, width, height);
+            public static void NamedRenderbufferStorageEXT(int renderbuffer, InternalFormat internalformat, int width, int height) => GLPointers._NamedRenderbufferStorageEXT_fnptr(renderbuffer, (uint)internalformat, width, height);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetNamedRenderbufferParameterivEXT(RenderbufferHandle renderbuffer, RenderbufferParameterName pname, int* parameters) => GLPointers._GetNamedRenderbufferParameterivEXT_fnptr((int)renderbuffer, (uint)pname, parameters);
+            public static void GetNamedRenderbufferParameterivEXT(int renderbuffer, RenderbufferParameterName pname, int* parameters) => GLPointers._GetNamedRenderbufferParameterivEXT_fnptr(renderbuffer, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedRenderbufferStorageMultisampleEXT(RenderbufferHandle renderbuffer, int samples, InternalFormat internalformat, int width, int height) => GLPointers._NamedRenderbufferStorageMultisampleEXT_fnptr((int)renderbuffer, samples, (uint)internalformat, width, height);
+            public static void NamedRenderbufferStorageMultisampleEXT(int renderbuffer, int samples, InternalFormat internalformat, int width, int height) => GLPointers._NamedRenderbufferStorageMultisampleEXT_fnptr(renderbuffer, samples, (uint)internalformat, width, height);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedRenderbufferStorageMultisampleCoverageEXT(RenderbufferHandle renderbuffer, int coverageSamples, int colorSamples, InternalFormat internalformat, int width, int height) => GLPointers._NamedRenderbufferStorageMultisampleCoverageEXT_fnptr((int)renderbuffer, coverageSamples, colorSamples, (uint)internalformat, width, height);
+            public static void NamedRenderbufferStorageMultisampleCoverageEXT(int renderbuffer, int coverageSamples, int colorSamples, InternalFormat internalformat, int width, int height) => GLPointers._NamedRenderbufferStorageMultisampleCoverageEXT_fnptr(renderbuffer, coverageSamples, colorSamples, (uint)internalformat, width, height);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static FramebufferStatus CheckNamedFramebufferStatusEXT(FramebufferHandle framebuffer, FramebufferTarget target) => (FramebufferStatus) GLPointers._CheckNamedFramebufferStatusEXT_fnptr((int)framebuffer, (uint)target);
+            public static FramebufferStatus CheckNamedFramebufferStatusEXT(int framebuffer, FramebufferTarget target) => (FramebufferStatus) GLPointers._CheckNamedFramebufferStatusEXT_fnptr(framebuffer, (uint)target);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedFramebufferTexture1DEXT(FramebufferHandle framebuffer, FramebufferAttachment attachment, TextureTarget textarget, TextureHandle texture, int level) => GLPointers._NamedFramebufferTexture1DEXT_fnptr((int)framebuffer, (uint)attachment, (uint)textarget, (int)texture, level);
+            public static void NamedFramebufferTexture1DEXT(int framebuffer, FramebufferAttachment attachment, TextureTarget textarget, int texture, int level) => GLPointers._NamedFramebufferTexture1DEXT_fnptr(framebuffer, (uint)attachment, (uint)textarget, texture, level);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedFramebufferTexture2DEXT(FramebufferHandle framebuffer, FramebufferAttachment attachment, TextureTarget textarget, TextureHandle texture, int level) => GLPointers._NamedFramebufferTexture2DEXT_fnptr((int)framebuffer, (uint)attachment, (uint)textarget, (int)texture, level);
+            public static void NamedFramebufferTexture2DEXT(int framebuffer, FramebufferAttachment attachment, TextureTarget textarget, int texture, int level) => GLPointers._NamedFramebufferTexture2DEXT_fnptr(framebuffer, (uint)attachment, (uint)textarget, texture, level);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedFramebufferTexture3DEXT(FramebufferHandle framebuffer, FramebufferAttachment attachment, TextureTarget textarget, TextureHandle texture, int level, int zoffset) => GLPointers._NamedFramebufferTexture3DEXT_fnptr((int)framebuffer, (uint)attachment, (uint)textarget, (int)texture, level, zoffset);
+            public static void NamedFramebufferTexture3DEXT(int framebuffer, FramebufferAttachment attachment, TextureTarget textarget, int texture, int level, int zoffset) => GLPointers._NamedFramebufferTexture3DEXT_fnptr(framebuffer, (uint)attachment, (uint)textarget, texture, level, zoffset);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedFramebufferRenderbufferEXT(FramebufferHandle framebuffer, FramebufferAttachment attachment, RenderbufferTarget renderbuffertarget, RenderbufferHandle renderbuffer) => GLPointers._NamedFramebufferRenderbufferEXT_fnptr((int)framebuffer, (uint)attachment, (uint)renderbuffertarget, (int)renderbuffer);
+            public static void NamedFramebufferRenderbufferEXT(int framebuffer, FramebufferAttachment attachment, RenderbufferTarget renderbuffertarget, int renderbuffer) => GLPointers._NamedFramebufferRenderbufferEXT_fnptr(framebuffer, (uint)attachment, (uint)renderbuffertarget, renderbuffer);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetNamedFramebufferAttachmentParameterivEXT(FramebufferHandle framebuffer, FramebufferAttachment attachment, FramebufferAttachmentParameterName pname, int* parameters) => GLPointers._GetNamedFramebufferAttachmentParameterivEXT_fnptr((int)framebuffer, (uint)attachment, (uint)pname, parameters);
+            public static void GetNamedFramebufferAttachmentParameterivEXT(int framebuffer, FramebufferAttachment attachment, FramebufferAttachmentParameterName pname, int* parameters) => GLPointers._GetNamedFramebufferAttachmentParameterivEXT_fnptr(framebuffer, (uint)attachment, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GenerateTextureMipmapEXT(TextureHandle texture, TextureTarget target) => GLPointers._GenerateTextureMipmapEXT_fnptr((int)texture, (uint)target);
+            public static void GenerateTextureMipmapEXT(int texture, TextureTarget target) => GLPointers._GenerateTextureMipmapEXT_fnptr(texture, (uint)target);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -10502,275 +10502,275 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void FramebufferDrawBufferEXT(FramebufferHandle framebuffer, DrawBufferMode mode) => GLPointers._FramebufferDrawBufferEXT_fnptr((int)framebuffer, (uint)mode);
+            public static void FramebufferDrawBufferEXT(int framebuffer, DrawBufferMode mode) => GLPointers._FramebufferDrawBufferEXT_fnptr(framebuffer, (uint)mode);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void FramebufferDrawBuffersEXT(FramebufferHandle framebuffer, int n, DrawBufferMode* bufs) => GLPointers._FramebufferDrawBuffersEXT_fnptr((int)framebuffer, n, (uint*)bufs);
+            public static void FramebufferDrawBuffersEXT(int framebuffer, int n, DrawBufferMode* bufs) => GLPointers._FramebufferDrawBuffersEXT_fnptr(framebuffer, n, (uint*)bufs);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void FramebufferReadBufferEXT(FramebufferHandle framebuffer, ReadBufferMode mode) => GLPointers._FramebufferReadBufferEXT_fnptr((int)framebuffer, (uint)mode);
+            public static void FramebufferReadBufferEXT(int framebuffer, ReadBufferMode mode) => GLPointers._FramebufferReadBufferEXT_fnptr(framebuffer, (uint)mode);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetFramebufferParameterivEXT(FramebufferHandle framebuffer, GetFramebufferParameter pname, int* parameters) => GLPointers._GetFramebufferParameterivEXT_fnptr((int)framebuffer, (uint)pname, parameters);
+            public static void GetFramebufferParameterivEXT(int framebuffer, GetFramebufferParameter pname, int* parameters) => GLPointers._GetFramebufferParameterivEXT_fnptr(framebuffer, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedCopyBufferSubDataEXT(BufferHandle readBuffer, BufferHandle writeBuffer, IntPtr readOffset, IntPtr writeOffset, nint size) => GLPointers._NamedCopyBufferSubDataEXT_fnptr((int)readBuffer, (int)writeBuffer, readOffset, writeOffset, size);
+            public static void NamedCopyBufferSubDataEXT(int readBuffer, int writeBuffer, IntPtr readOffset, IntPtr writeOffset, nint size) => GLPointers._NamedCopyBufferSubDataEXT_fnptr(readBuffer, writeBuffer, readOffset, writeOffset, size);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedFramebufferTextureEXT(FramebufferHandle framebuffer, FramebufferAttachment attachment, TextureHandle texture, int level) => GLPointers._NamedFramebufferTextureEXT_fnptr((int)framebuffer, (uint)attachment, (int)texture, level);
+            public static void NamedFramebufferTextureEXT(int framebuffer, FramebufferAttachment attachment, int texture, int level) => GLPointers._NamedFramebufferTextureEXT_fnptr(framebuffer, (uint)attachment, texture, level);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedFramebufferTextureLayerEXT(FramebufferHandle framebuffer, FramebufferAttachment attachment, TextureHandle texture, int level, int layer) => GLPointers._NamedFramebufferTextureLayerEXT_fnptr((int)framebuffer, (uint)attachment, (int)texture, level, layer);
+            public static void NamedFramebufferTextureLayerEXT(int framebuffer, FramebufferAttachment attachment, int texture, int level, int layer) => GLPointers._NamedFramebufferTextureLayerEXT_fnptr(framebuffer, (uint)attachment, texture, level, layer);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedFramebufferTextureFaceEXT(FramebufferHandle framebuffer, FramebufferAttachment attachment, TextureHandle texture, int level, TextureTarget face) => GLPointers._NamedFramebufferTextureFaceEXT_fnptr((int)framebuffer, (uint)attachment, (int)texture, level, (uint)face);
+            public static void NamedFramebufferTextureFaceEXT(int framebuffer, FramebufferAttachment attachment, int texture, int level, TextureTarget face) => GLPointers._NamedFramebufferTextureFaceEXT_fnptr(framebuffer, (uint)attachment, texture, level, (uint)face);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureRenderbufferEXT(TextureHandle texture, TextureTarget target, RenderbufferHandle renderbuffer) => GLPointers._TextureRenderbufferEXT_fnptr((int)texture, (uint)target, (int)renderbuffer);
+            public static void TextureRenderbufferEXT(int texture, TextureTarget target, int renderbuffer) => GLPointers._TextureRenderbufferEXT_fnptr(texture, (uint)target, renderbuffer);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void MultiTexRenderbufferEXT(TextureUnit texunit, TextureTarget target, RenderbufferHandle renderbuffer) => GLPointers._MultiTexRenderbufferEXT_fnptr((uint)texunit, (uint)target, (int)renderbuffer);
+            public static void MultiTexRenderbufferEXT(TextureUnit texunit, TextureTarget target, int renderbuffer) => GLPointers._MultiTexRenderbufferEXT_fnptr((uint)texunit, (uint)target, renderbuffer);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void VertexArrayVertexOffsetEXT(VertexArrayHandle vaobj, BufferHandle buffer, int size, VertexPointerType type, int stride, IntPtr offset) => GLPointers._VertexArrayVertexOffsetEXT_fnptr((int)vaobj, (int)buffer, size, (uint)type, stride, offset);
+            public static void VertexArrayVertexOffsetEXT(int vaobj, int buffer, int size, VertexPointerType type, int stride, IntPtr offset) => GLPointers._VertexArrayVertexOffsetEXT_fnptr(vaobj, buffer, size, (uint)type, stride, offset);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void VertexArrayColorOffsetEXT(VertexArrayHandle vaobj, BufferHandle buffer, int size, ColorPointerType type, int stride, IntPtr offset) => GLPointers._VertexArrayColorOffsetEXT_fnptr((int)vaobj, (int)buffer, size, (uint)type, stride, offset);
+            public static void VertexArrayColorOffsetEXT(int vaobj, int buffer, int size, ColorPointerType type, int stride, IntPtr offset) => GLPointers._VertexArrayColorOffsetEXT_fnptr(vaobj, buffer, size, (uint)type, stride, offset);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void VertexArrayEdgeFlagOffsetEXT(VertexArrayHandle vaobj, BufferHandle buffer, int stride, IntPtr offset) => GLPointers._VertexArrayEdgeFlagOffsetEXT_fnptr((int)vaobj, (int)buffer, stride, offset);
+            public static void VertexArrayEdgeFlagOffsetEXT(int vaobj, int buffer, int stride, IntPtr offset) => GLPointers._VertexArrayEdgeFlagOffsetEXT_fnptr(vaobj, buffer, stride, offset);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void VertexArrayIndexOffsetEXT(VertexArrayHandle vaobj, BufferHandle buffer, IndexPointerType type, int stride, IntPtr offset) => GLPointers._VertexArrayIndexOffsetEXT_fnptr((int)vaobj, (int)buffer, (uint)type, stride, offset);
+            public static void VertexArrayIndexOffsetEXT(int vaobj, int buffer, IndexPointerType type, int stride, IntPtr offset) => GLPointers._VertexArrayIndexOffsetEXT_fnptr(vaobj, buffer, (uint)type, stride, offset);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void VertexArrayNormalOffsetEXT(VertexArrayHandle vaobj, BufferHandle buffer, NormalPointerType type, int stride, IntPtr offset) => GLPointers._VertexArrayNormalOffsetEXT_fnptr((int)vaobj, (int)buffer, (uint)type, stride, offset);
+            public static void VertexArrayNormalOffsetEXT(int vaobj, int buffer, NormalPointerType type, int stride, IntPtr offset) => GLPointers._VertexArrayNormalOffsetEXT_fnptr(vaobj, buffer, (uint)type, stride, offset);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void VertexArrayTexCoordOffsetEXT(VertexArrayHandle vaobj, BufferHandle buffer, int size, TexCoordPointerType type, int stride, IntPtr offset) => GLPointers._VertexArrayTexCoordOffsetEXT_fnptr((int)vaobj, (int)buffer, size, (uint)type, stride, offset);
+            public static void VertexArrayTexCoordOffsetEXT(int vaobj, int buffer, int size, TexCoordPointerType type, int stride, IntPtr offset) => GLPointers._VertexArrayTexCoordOffsetEXT_fnptr(vaobj, buffer, size, (uint)type, stride, offset);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void VertexArrayMultiTexCoordOffsetEXT(VertexArrayHandle vaobj, BufferHandle buffer, All texunit, int size, TexCoordPointerType type, int stride, IntPtr offset) => GLPointers._VertexArrayMultiTexCoordOffsetEXT_fnptr((int)vaobj, (int)buffer, (uint)texunit, size, (uint)type, stride, offset);
+            public static void VertexArrayMultiTexCoordOffsetEXT(int vaobj, int buffer, All texunit, int size, TexCoordPointerType type, int stride, IntPtr offset) => GLPointers._VertexArrayMultiTexCoordOffsetEXT_fnptr(vaobj, buffer, (uint)texunit, size, (uint)type, stride, offset);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void VertexArrayFogCoordOffsetEXT(VertexArrayHandle vaobj, BufferHandle buffer, FogCoordinatePointerType type, int stride, IntPtr offset) => GLPointers._VertexArrayFogCoordOffsetEXT_fnptr((int)vaobj, (int)buffer, (uint)type, stride, offset);
+            public static void VertexArrayFogCoordOffsetEXT(int vaobj, int buffer, FogCoordinatePointerType type, int stride, IntPtr offset) => GLPointers._VertexArrayFogCoordOffsetEXT_fnptr(vaobj, buffer, (uint)type, stride, offset);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void VertexArraySecondaryColorOffsetEXT(VertexArrayHandle vaobj, BufferHandle buffer, int size, ColorPointerType type, int stride, IntPtr offset) => GLPointers._VertexArraySecondaryColorOffsetEXT_fnptr((int)vaobj, (int)buffer, size, (uint)type, stride, offset);
+            public static void VertexArraySecondaryColorOffsetEXT(int vaobj, int buffer, int size, ColorPointerType type, int stride, IntPtr offset) => GLPointers._VertexArraySecondaryColorOffsetEXT_fnptr(vaobj, buffer, size, (uint)type, stride, offset);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void VertexArrayVertexAttribOffsetEXT(VertexArrayHandle vaobj, BufferHandle buffer, uint index, int size, VertexAttribPointerType type, bool normalized, int stride, IntPtr offset) => GLPointers._VertexArrayVertexAttribOffsetEXT_fnptr((int)vaobj, (int)buffer, index, size, (uint)type, (byte)(normalized ? 1 : 0), stride, offset);
+            public static void VertexArrayVertexAttribOffsetEXT(int vaobj, int buffer, uint index, int size, VertexAttribPointerType type, bool normalized, int stride, IntPtr offset) => GLPointers._VertexArrayVertexAttribOffsetEXT_fnptr(vaobj, buffer, index, size, (uint)type, (byte)(normalized ? 1 : 0), stride, offset);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void VertexArrayVertexAttribIOffsetEXT(VertexArrayHandle vaobj, BufferHandle buffer, uint index, int size, VertexAttribType type, int stride, IntPtr offset) => GLPointers._VertexArrayVertexAttribIOffsetEXT_fnptr((int)vaobj, (int)buffer, index, size, (uint)type, stride, offset);
+            public static void VertexArrayVertexAttribIOffsetEXT(int vaobj, int buffer, uint index, int size, VertexAttribType type, int stride, IntPtr offset) => GLPointers._VertexArrayVertexAttribIOffsetEXT_fnptr(vaobj, buffer, index, size, (uint)type, stride, offset);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void EnableVertexArrayEXT(VertexArrayHandle vaobj, EnableCap array) => GLPointers._EnableVertexArrayEXT_fnptr((int)vaobj, (uint)array);
+            public static void EnableVertexArrayEXT(int vaobj, EnableCap array) => GLPointers._EnableVertexArrayEXT_fnptr(vaobj, (uint)array);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void DisableVertexArrayEXT(VertexArrayHandle vaobj, EnableCap array) => GLPointers._DisableVertexArrayEXT_fnptr((int)vaobj, (uint)array);
+            public static void DisableVertexArrayEXT(int vaobj, EnableCap array) => GLPointers._DisableVertexArrayEXT_fnptr(vaobj, (uint)array);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void EnableVertexArrayAttribEXT(VertexArrayHandle vaobj, uint index) => GLPointers._EnableVertexArrayAttribEXT_fnptr((int)vaobj, index);
+            public static void EnableVertexArrayAttribEXT(int vaobj, uint index) => GLPointers._EnableVertexArrayAttribEXT_fnptr(vaobj, index);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void DisableVertexArrayAttribEXT(VertexArrayHandle vaobj, uint index) => GLPointers._DisableVertexArrayAttribEXT_fnptr((int)vaobj, index);
+            public static void DisableVertexArrayAttribEXT(int vaobj, uint index) => GLPointers._DisableVertexArrayAttribEXT_fnptr(vaobj, index);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetVertexArrayIntegervEXT(VertexArrayHandle vaobj, VertexArrayPName pname, int* param) => GLPointers._GetVertexArrayIntegervEXT_fnptr((int)vaobj, (uint)pname, param);
+            public static void GetVertexArrayIntegervEXT(int vaobj, VertexArrayPName pname, int* param) => GLPointers._GetVertexArrayIntegervEXT_fnptr(vaobj, (uint)pname, param);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetVertexArrayPointervEXT(VertexArrayHandle vaobj, VertexArrayPName pname, void** param) => GLPointers._GetVertexArrayPointervEXT_fnptr((int)vaobj, (uint)pname, param);
+            public static void GetVertexArrayPointervEXT(int vaobj, VertexArrayPName pname, void** param) => GLPointers._GetVertexArrayPointervEXT_fnptr(vaobj, (uint)pname, param);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetVertexArrayIntegeri_vEXT(VertexArrayHandle vaobj, uint index, VertexArrayPName pname, int* param) => GLPointers._GetVertexArrayIntegeri_vEXT_fnptr((int)vaobj, index, (uint)pname, param);
+            public static void GetVertexArrayIntegeri_vEXT(int vaobj, uint index, VertexArrayPName pname, int* param) => GLPointers._GetVertexArrayIntegeri_vEXT_fnptr(vaobj, index, (uint)pname, param);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetVertexArrayPointeri_vEXT(VertexArrayHandle vaobj, uint index, VertexArrayPName pname, void** param) => GLPointers._GetVertexArrayPointeri_vEXT_fnptr((int)vaobj, index, (uint)pname, param);
+            public static void GetVertexArrayPointeri_vEXT(int vaobj, uint index, VertexArrayPName pname, void** param) => GLPointers._GetVertexArrayPointeri_vEXT_fnptr(vaobj, index, (uint)pname, param);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void* MapNamedBufferRangeEXT(BufferHandle buffer, IntPtr offset, nint length, MapBufferAccessMask access) => GLPointers._MapNamedBufferRangeEXT_fnptr((int)buffer, offset, length, (uint)access);
+            public static void* MapNamedBufferRangeEXT(int buffer, IntPtr offset, nint length, MapBufferAccessMask access) => GLPointers._MapNamedBufferRangeEXT_fnptr(buffer, offset, length, (uint)access);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void FlushMappedNamedBufferRangeEXT(BufferHandle buffer, IntPtr offset, nint length) => GLPointers._FlushMappedNamedBufferRangeEXT_fnptr((int)buffer, offset, length);
+            public static void FlushMappedNamedBufferRangeEXT(int buffer, IntPtr offset, nint length) => GLPointers._FlushMappedNamedBufferRangeEXT_fnptr(buffer, offset, length);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedBufferStorageEXT(BufferHandle buffer, nint size, void* data, BufferStorageMask flags) => GLPointers._NamedBufferStorageEXT_fnptr((int)buffer, size, data, (uint)flags);
+            public static void NamedBufferStorageEXT(int buffer, nint size, void* data, BufferStorageMask flags) => GLPointers._NamedBufferStorageEXT_fnptr(buffer, size, data, (uint)flags);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ClearNamedBufferDataEXT(BufferHandle buffer, SizedInternalFormat internalformat, PixelFormat format, PixelType type, void* data) => GLPointers._ClearNamedBufferDataEXT_fnptr((int)buffer, (uint)internalformat, (uint)format, (uint)type, data);
+            public static void ClearNamedBufferDataEXT(int buffer, SizedInternalFormat internalformat, PixelFormat format, PixelType type, void* data) => GLPointers._ClearNamedBufferDataEXT_fnptr(buffer, (uint)internalformat, (uint)format, (uint)type, data);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ClearNamedBufferSubDataEXT(BufferHandle buffer, SizedInternalFormat internalformat, nint offset, nint size, PixelFormat format, PixelType type, void* data) => GLPointers._ClearNamedBufferSubDataEXT_fnptr((int)buffer, (uint)internalformat, offset, size, (uint)format, (uint)type, data);
+            public static void ClearNamedBufferSubDataEXT(int buffer, SizedInternalFormat internalformat, nint offset, nint size, PixelFormat format, PixelType type, void* data) => GLPointers._ClearNamedBufferSubDataEXT_fnptr(buffer, (uint)internalformat, offset, size, (uint)format, (uint)type, data);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedFramebufferParameteriEXT(FramebufferHandle framebuffer, FramebufferParameterName pname, int param) => GLPointers._NamedFramebufferParameteriEXT_fnptr((int)framebuffer, (uint)pname, param);
+            public static void NamedFramebufferParameteriEXT(int framebuffer, FramebufferParameterName pname, int param) => GLPointers._NamedFramebufferParameteriEXT_fnptr(framebuffer, (uint)pname, param);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetNamedFramebufferParameterivEXT(FramebufferHandle framebuffer, GetFramebufferParameter pname, int* parameters) => GLPointers._GetNamedFramebufferParameterivEXT_fnptr((int)framebuffer, (uint)pname, parameters);
+            public static void GetNamedFramebufferParameterivEXT(int framebuffer, GetFramebufferParameter pname, int* parameters) => GLPointers._GetNamedFramebufferParameterivEXT_fnptr(framebuffer, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform1dEXT(ProgramHandle program, int location, double x) => GLPointers._ProgramUniform1dEXT_fnptr((int)program, location, x);
+            public static void ProgramUniform1dEXT(int program, int location, double x) => GLPointers._ProgramUniform1dEXT_fnptr(program, location, x);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform2dEXT(ProgramHandle program, int location, double x, double y) => GLPointers._ProgramUniform2dEXT_fnptr((int)program, location, x, y);
+            public static void ProgramUniform2dEXT(int program, int location, double x, double y) => GLPointers._ProgramUniform2dEXT_fnptr(program, location, x, y);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform3dEXT(ProgramHandle program, int location, double x, double y, double z) => GLPointers._ProgramUniform3dEXT_fnptr((int)program, location, x, y, z);
+            public static void ProgramUniform3dEXT(int program, int location, double x, double y, double z) => GLPointers._ProgramUniform3dEXT_fnptr(program, location, x, y, z);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform4dEXT(ProgramHandle program, int location, double x, double y, double z, double w) => GLPointers._ProgramUniform4dEXT_fnptr((int)program, location, x, y, z, w);
+            public static void ProgramUniform4dEXT(int program, int location, double x, double y, double z, double w) => GLPointers._ProgramUniform4dEXT_fnptr(program, location, x, y, z, w);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform1dvEXT(ProgramHandle program, int location, int count, double* value) => GLPointers._ProgramUniform1dvEXT_fnptr((int)program, location, count, value);
+            public static void ProgramUniform1dvEXT(int program, int location, int count, double* value) => GLPointers._ProgramUniform1dvEXT_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform2dvEXT(ProgramHandle program, int location, int count, double* value) => GLPointers._ProgramUniform2dvEXT_fnptr((int)program, location, count, value);
+            public static void ProgramUniform2dvEXT(int program, int location, int count, double* value) => GLPointers._ProgramUniform2dvEXT_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform3dvEXT(ProgramHandle program, int location, int count, double* value) => GLPointers._ProgramUniform3dvEXT_fnptr((int)program, location, count, value);
+            public static void ProgramUniform3dvEXT(int program, int location, int count, double* value) => GLPointers._ProgramUniform3dvEXT_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform4dvEXT(ProgramHandle program, int location, int count, double* value) => GLPointers._ProgramUniform4dvEXT_fnptr((int)program, location, count, value);
+            public static void ProgramUniform4dvEXT(int program, int location, int count, double* value) => GLPointers._ProgramUniform4dvEXT_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix2dvEXT(ProgramHandle program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix2dvEXT_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix2dvEXT(int program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix2dvEXT_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix3dvEXT(ProgramHandle program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix3dvEXT_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix3dvEXT(int program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix3dvEXT_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix4dvEXT(ProgramHandle program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix4dvEXT_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix4dvEXT(int program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix4dvEXT_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix2x3dvEXT(ProgramHandle program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix2x3dvEXT_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix2x3dvEXT(int program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix2x3dvEXT_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix2x4dvEXT(ProgramHandle program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix2x4dvEXT_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix2x4dvEXT(int program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix2x4dvEXT_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix3x2dvEXT(ProgramHandle program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix3x2dvEXT_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix3x2dvEXT(int program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix3x2dvEXT_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix3x4dvEXT(ProgramHandle program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix3x4dvEXT_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix3x4dvEXT(int program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix3x4dvEXT_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix4x2dvEXT(ProgramHandle program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix4x2dvEXT_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix4x2dvEXT(int program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix4x2dvEXT_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix4x3dvEXT(ProgramHandle program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix4x3dvEXT_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix4x3dvEXT(int program, int location, int count, bool transpose, double* value) => GLPointers._ProgramUniformMatrix4x3dvEXT_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureBufferRangeEXT(TextureHandle texture, TextureTarget target, SizedInternalFormat internalformat, BufferHandle buffer, IntPtr offset, nint size) => GLPointers._TextureBufferRangeEXT_fnptr((int)texture, (uint)target, (uint)internalformat, (int)buffer, offset, size);
-            
-            /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_texture_storage]</b>  </summary>
-            /// <remarks><see href="" /></remarks>
-            public static void TextureStorage1DEXT(TextureHandle texture, All target, int levels, SizedInternalFormat internalformat, int width) => GLPointers._TextureStorage1DEXT_fnptr((int)texture, (uint)target, levels, (uint)internalformat, width);
+            public static void TextureBufferRangeEXT(int texture, TextureTarget target, SizedInternalFormat internalformat, int buffer, IntPtr offset, nint size) => GLPointers._TextureBufferRangeEXT_fnptr(texture, (uint)target, (uint)internalformat, buffer, offset, size);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_texture_storage]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureStorage2DEXT(TextureHandle texture, All target, int levels, SizedInternalFormat internalformat, int width, int height) => GLPointers._TextureStorage2DEXT_fnptr((int)texture, (uint)target, levels, (uint)internalformat, width, height);
+            public static void TextureStorage1DEXT(int texture, All target, int levels, SizedInternalFormat internalformat, int width) => GLPointers._TextureStorage1DEXT_fnptr(texture, (uint)target, levels, (uint)internalformat, width);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_texture_storage]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureStorage3DEXT(TextureHandle texture, All target, int levels, SizedInternalFormat internalformat, int width, int height, int depth) => GLPointers._TextureStorage3DEXT_fnptr((int)texture, (uint)target, levels, (uint)internalformat, width, height, depth);
+            public static void TextureStorage2DEXT(int texture, All target, int levels, SizedInternalFormat internalformat, int width, int height) => GLPointers._TextureStorage2DEXT_fnptr(texture, (uint)target, levels, (uint)internalformat, width, height);
+            
+            /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_texture_storage]</b>  </summary>
+            /// <remarks><see href="" /></remarks>
+            public static void TextureStorage3DEXT(int texture, All target, int levels, SizedInternalFormat internalformat, int width, int height, int depth) => GLPointers._TextureStorage3DEXT_fnptr(texture, (uint)target, levels, (uint)internalformat, width, height, depth);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureStorage2DMultisampleEXT(TextureHandle texture, TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, bool fixedsamplelocations) => GLPointers._TextureStorage2DMultisampleEXT_fnptr((int)texture, (uint)target, samples, (uint)internalformat, width, height, (byte)(fixedsamplelocations ? 1 : 0));
+            public static void TextureStorage2DMultisampleEXT(int texture, TextureTarget target, int samples, SizedInternalFormat internalformat, int width, int height, bool fixedsamplelocations) => GLPointers._TextureStorage2DMultisampleEXT_fnptr(texture, (uint)target, samples, (uint)internalformat, width, height, (byte)(fixedsamplelocations ? 1 : 0));
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureStorage3DMultisampleEXT(TextureHandle texture, All target, int samples, SizedInternalFormat internalformat, int width, int height, int depth, bool fixedsamplelocations) => GLPointers._TextureStorage3DMultisampleEXT_fnptr((int)texture, (uint)target, samples, (uint)internalformat, width, height, depth, (byte)(fixedsamplelocations ? 1 : 0));
+            public static void TextureStorage3DMultisampleEXT(int texture, All target, int samples, SizedInternalFormat internalformat, int width, int height, int depth, bool fixedsamplelocations) => GLPointers._TextureStorage3DMultisampleEXT_fnptr(texture, (uint)target, samples, (uint)internalformat, width, height, depth, (byte)(fixedsamplelocations ? 1 : 0));
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void VertexArrayBindVertexBufferEXT(VertexArrayHandle vaobj, uint bindingindex, BufferHandle buffer, IntPtr offset, int stride) => GLPointers._VertexArrayBindVertexBufferEXT_fnptr((int)vaobj, bindingindex, (int)buffer, offset, stride);
+            public static void VertexArrayBindVertexBufferEXT(int vaobj, uint bindingindex, int buffer, IntPtr offset, int stride) => GLPointers._VertexArrayBindVertexBufferEXT_fnptr(vaobj, bindingindex, buffer, offset, stride);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void VertexArrayVertexAttribFormatEXT(VertexArrayHandle vaobj, uint attribindex, int size, VertexAttribType type, bool normalized, uint relativeoffset) => GLPointers._VertexArrayVertexAttribFormatEXT_fnptr((int)vaobj, attribindex, size, (uint)type, (byte)(normalized ? 1 : 0), relativeoffset);
+            public static void VertexArrayVertexAttribFormatEXT(int vaobj, uint attribindex, int size, VertexAttribType type, bool normalized, uint relativeoffset) => GLPointers._VertexArrayVertexAttribFormatEXT_fnptr(vaobj, attribindex, size, (uint)type, (byte)(normalized ? 1 : 0), relativeoffset);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void VertexArrayVertexAttribIFormatEXT(VertexArrayHandle vaobj, uint attribindex, int size, VertexAttribIType type, uint relativeoffset) => GLPointers._VertexArrayVertexAttribIFormatEXT_fnptr((int)vaobj, attribindex, size, (uint)type, relativeoffset);
+            public static void VertexArrayVertexAttribIFormatEXT(int vaobj, uint attribindex, int size, VertexAttribIType type, uint relativeoffset) => GLPointers._VertexArrayVertexAttribIFormatEXT_fnptr(vaobj, attribindex, size, (uint)type, relativeoffset);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void VertexArrayVertexAttribLFormatEXT(VertexArrayHandle vaobj, uint attribindex, int size, VertexAttribLType type, uint relativeoffset) => GLPointers._VertexArrayVertexAttribLFormatEXT_fnptr((int)vaobj, attribindex, size, (uint)type, relativeoffset);
+            public static void VertexArrayVertexAttribLFormatEXT(int vaobj, uint attribindex, int size, VertexAttribLType type, uint relativeoffset) => GLPointers._VertexArrayVertexAttribLFormatEXT_fnptr(vaobj, attribindex, size, (uint)type, relativeoffset);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void VertexArrayVertexAttribBindingEXT(VertexArrayHandle vaobj, uint attribindex, uint bindingindex) => GLPointers._VertexArrayVertexAttribBindingEXT_fnptr((int)vaobj, attribindex, bindingindex);
+            public static void VertexArrayVertexAttribBindingEXT(int vaobj, uint attribindex, uint bindingindex) => GLPointers._VertexArrayVertexAttribBindingEXT_fnptr(vaobj, attribindex, bindingindex);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void VertexArrayVertexBindingDivisorEXT(VertexArrayHandle vaobj, uint bindingindex, uint divisor) => GLPointers._VertexArrayVertexBindingDivisorEXT_fnptr((int)vaobj, bindingindex, divisor);
+            public static void VertexArrayVertexBindingDivisorEXT(int vaobj, uint bindingindex, uint divisor) => GLPointers._VertexArrayVertexBindingDivisorEXT_fnptr(vaobj, bindingindex, divisor);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void VertexArrayVertexAttribLOffsetEXT(VertexArrayHandle vaobj, BufferHandle buffer, uint index, int size, VertexAttribLType type, int stride, IntPtr offset) => GLPointers._VertexArrayVertexAttribLOffsetEXT_fnptr((int)vaobj, (int)buffer, index, size, (uint)type, stride, offset);
+            public static void VertexArrayVertexAttribLOffsetEXT(int vaobj, int buffer, uint index, int size, VertexAttribLType type, int stride, IntPtr offset) => GLPointers._VertexArrayVertexAttribLOffsetEXT_fnptr(vaobj, buffer, index, size, (uint)type, stride, offset);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TexturePageCommitmentEXT(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, bool commit) => GLPointers._TexturePageCommitmentEXT_fnptr((int)texture, level, xoffset, yoffset, zoffset, width, height, depth, (byte)(commit ? 1 : 0));
+            public static void TexturePageCommitmentEXT(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, bool commit) => GLPointers._TexturePageCommitmentEXT_fnptr(texture, level, xoffset, yoffset, zoffset, width, height, depth, (byte)(commit ? 1 : 0));
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void VertexArrayVertexAttribDivisorEXT(VertexArrayHandle vaobj, uint index, uint divisor) => GLPointers._VertexArrayVertexAttribDivisorEXT_fnptr((int)vaobj, index, divisor);
+            public static void VertexArrayVertexAttribDivisorEXT(int vaobj, uint index, uint divisor) => GLPointers._VertexArrayVertexAttribDivisorEXT_fnptr(vaobj, index, divisor);
             
             /// <summary> <b>[requires: GL_EXT_draw_buffers2]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -10794,7 +10794,7 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_EXT_external_buffer]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedBufferStorageExternalEXT(BufferHandle buffer, IntPtr offset, nint size, void* clientBuffer, BufferStorageMask flags) => GLPointers._NamedBufferStorageExternalEXT_fnptr((int)buffer, offset, size, clientBuffer, (uint)flags);
+            public static void NamedBufferStorageExternalEXT(int buffer, IntPtr offset, nint size, void* clientBuffer, BufferStorageMask flags) => GLPointers._NamedBufferStorageExternalEXT_fnptr(buffer, offset, size, clientBuffer, (uint)flags);
             
             /// <summary> <b>[requires: GL_EXT_fog_coord]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -10826,19 +10826,19 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_EXT_framebuffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static bool IsRenderbufferEXT(RenderbufferHandle renderbuffer) => GLPointers._IsRenderbufferEXT_fnptr((int)renderbuffer) != 0;
+            public static bool IsRenderbufferEXT(int renderbuffer) => GLPointers._IsRenderbufferEXT_fnptr(renderbuffer) != 0;
             
             /// <summary> <b>[requires: GL_EXT_framebuffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void BindRenderbufferEXT(RenderbufferTarget target, RenderbufferHandle renderbuffer) => GLPointers._BindRenderbufferEXT_fnptr((uint)target, (int)renderbuffer);
+            public static void BindRenderbufferEXT(RenderbufferTarget target, int renderbuffer) => GLPointers._BindRenderbufferEXT_fnptr((uint)target, renderbuffer);
             
             /// <summary> <b>[requires: GL_EXT_framebuffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void DeleteRenderbuffersEXT(int n, RenderbufferHandle* renderbuffers) => GLPointers._DeleteRenderbuffersEXT_fnptr(n, (int*)renderbuffers);
+            public static void DeleteRenderbuffersEXT(int n, int* renderbuffers) => GLPointers._DeleteRenderbuffersEXT_fnptr(n, renderbuffers);
             
             /// <summary> <b>[requires: GL_EXT_framebuffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GenRenderbuffersEXT(int n, RenderbufferHandle* renderbuffers) => GLPointers._GenRenderbuffersEXT_fnptr(n, (int*)renderbuffers);
+            public static void GenRenderbuffersEXT(int n, int* renderbuffers) => GLPointers._GenRenderbuffersEXT_fnptr(n, renderbuffers);
             
             /// <summary> <b>[requires: GL_EXT_framebuffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -10850,19 +10850,19 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_EXT_framebuffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static bool IsFramebufferEXT(FramebufferHandle framebuffer) => GLPointers._IsFramebufferEXT_fnptr((int)framebuffer) != 0;
+            public static bool IsFramebufferEXT(int framebuffer) => GLPointers._IsFramebufferEXT_fnptr(framebuffer) != 0;
             
             /// <summary> <b>[requires: GL_EXT_framebuffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void BindFramebufferEXT(FramebufferTarget target, FramebufferHandle framebuffer) => GLPointers._BindFramebufferEXT_fnptr((uint)target, (int)framebuffer);
+            public static void BindFramebufferEXT(FramebufferTarget target, int framebuffer) => GLPointers._BindFramebufferEXT_fnptr((uint)target, framebuffer);
             
             /// <summary> <b>[requires: GL_EXT_framebuffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void DeleteFramebuffersEXT(int n, FramebufferHandle* framebuffers) => GLPointers._DeleteFramebuffersEXT_fnptr(n, (int*)framebuffers);
+            public static void DeleteFramebuffersEXT(int n, int* framebuffers) => GLPointers._DeleteFramebuffersEXT_fnptr(n, framebuffers);
             
             /// <summary> <b>[requires: GL_EXT_framebuffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GenFramebuffersEXT(int n, FramebufferHandle* framebuffers) => GLPointers._GenFramebuffersEXT_fnptr(n, (int*)framebuffers);
+            public static void GenFramebuffersEXT(int n, int* framebuffers) => GLPointers._GenFramebuffersEXT_fnptr(n, framebuffers);
             
             /// <summary> <b>[requires: GL_EXT_framebuffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -10870,19 +10870,19 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_EXT_framebuffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void FramebufferTexture1DEXT(FramebufferTarget target, FramebufferAttachment attachment, TextureTarget textarget, TextureHandle texture, int level) => GLPointers._FramebufferTexture1DEXT_fnptr((uint)target, (uint)attachment, (uint)textarget, (int)texture, level);
+            public static void FramebufferTexture1DEXT(FramebufferTarget target, FramebufferAttachment attachment, TextureTarget textarget, int texture, int level) => GLPointers._FramebufferTexture1DEXT_fnptr((uint)target, (uint)attachment, (uint)textarget, texture, level);
             
             /// <summary> <b>[requires: GL_EXT_framebuffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void FramebufferTexture2DEXT(FramebufferTarget target, FramebufferAttachment attachment, TextureTarget textarget, TextureHandle texture, int level) => GLPointers._FramebufferTexture2DEXT_fnptr((uint)target, (uint)attachment, (uint)textarget, (int)texture, level);
+            public static void FramebufferTexture2DEXT(FramebufferTarget target, FramebufferAttachment attachment, TextureTarget textarget, int texture, int level) => GLPointers._FramebufferTexture2DEXT_fnptr((uint)target, (uint)attachment, (uint)textarget, texture, level);
             
             /// <summary> <b>[requires: GL_EXT_framebuffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void FramebufferTexture3DEXT(FramebufferTarget target, FramebufferAttachment attachment, TextureTarget textarget, TextureHandle texture, int level, int zoffset) => GLPointers._FramebufferTexture3DEXT_fnptr((uint)target, (uint)attachment, (uint)textarget, (int)texture, level, zoffset);
+            public static void FramebufferTexture3DEXT(FramebufferTarget target, FramebufferAttachment attachment, TextureTarget textarget, int texture, int level, int zoffset) => GLPointers._FramebufferTexture3DEXT_fnptr((uint)target, (uint)attachment, (uint)textarget, texture, level, zoffset);
             
             /// <summary> <b>[requires: GL_EXT_framebuffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void FramebufferRenderbufferEXT(FramebufferTarget target, FramebufferAttachment attachment, RenderbufferTarget renderbuffertarget, RenderbufferHandle renderbuffer) => GLPointers._FramebufferRenderbufferEXT_fnptr((uint)target, (uint)attachment, (uint)renderbuffertarget, (int)renderbuffer);
+            public static void FramebufferRenderbufferEXT(FramebufferTarget target, FramebufferAttachment attachment, RenderbufferTarget renderbuffertarget, int renderbuffer) => GLPointers._FramebufferRenderbufferEXT_fnptr((uint)target, (uint)attachment, (uint)renderbuffertarget, renderbuffer);
             
             /// <summary> <b>[requires: GL_EXT_framebuffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -10894,7 +10894,7 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_EXT_geometry_shader4 | GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramParameteriEXT(ProgramHandle program, ProgramParameterPName pname, int value) => GLPointers._ProgramParameteriEXT_fnptr((int)program, (uint)pname, value);
+            public static void ProgramParameteriEXT(int program, ProgramParameterPName pname, int value) => GLPointers._ProgramParameteriEXT_fnptr(program, (uint)pname, value);
             
             /// <summary> <b>[requires: GL_EXT_gpu_program_parameters]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -10906,15 +10906,15 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_EXT_gpu_shader4]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetUniformuivEXT(ProgramHandle program, int location, uint* parameters) => GLPointers._GetUniformuivEXT_fnptr((int)program, location, parameters);
+            public static void GetUniformuivEXT(int program, int location, uint* parameters) => GLPointers._GetUniformuivEXT_fnptr(program, location, parameters);
             
             /// <summary> <b>[requires: GL_EXT_gpu_shader4]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void BindFragDataLocationEXT(ProgramHandle program, uint color, byte* name) => GLPointers._BindFragDataLocationEXT_fnptr((int)program, color, name);
+            public static void BindFragDataLocationEXT(int program, uint color, byte* name) => GLPointers._BindFragDataLocationEXT_fnptr(program, color, name);
             
             /// <summary> <b>[requires: GL_EXT_gpu_shader4]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static int GetFragDataLocationEXT(ProgramHandle program, byte* name) => GLPointers._GetFragDataLocationEXT_fnptr((int)program, name);
+            public static int GetFragDataLocationEXT(int program, byte* name) => GLPointers._GetFragDataLocationEXT_fnptr(program, name);
             
             /// <summary> <b>[requires: GL_EXT_gpu_shader4]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -11150,23 +11150,23 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_EXT_memory_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureStorageMem2DEXT(TextureHandle texture, int levels, SizedInternalFormat internalFormat, int width, int height, uint memory, ulong offset) => GLPointers._TextureStorageMem2DEXT_fnptr((int)texture, levels, (uint)internalFormat, width, height, memory, offset);
+            public static void TextureStorageMem2DEXT(int texture, int levels, SizedInternalFormat internalFormat, int width, int height, uint memory, ulong offset) => GLPointers._TextureStorageMem2DEXT_fnptr(texture, levels, (uint)internalFormat, width, height, memory, offset);
             
             /// <summary> <b>[requires: GL_EXT_memory_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureStorageMem2DMultisampleEXT(TextureHandle texture, int samples, SizedInternalFormat internalFormat, int width, int height, bool fixedSampleLocations, uint memory, ulong offset) => GLPointers._TextureStorageMem2DMultisampleEXT_fnptr((int)texture, samples, (uint)internalFormat, width, height, (byte)(fixedSampleLocations ? 1 : 0), memory, offset);
+            public static void TextureStorageMem2DMultisampleEXT(int texture, int samples, SizedInternalFormat internalFormat, int width, int height, bool fixedSampleLocations, uint memory, ulong offset) => GLPointers._TextureStorageMem2DMultisampleEXT_fnptr(texture, samples, (uint)internalFormat, width, height, (byte)(fixedSampleLocations ? 1 : 0), memory, offset);
             
             /// <summary> <b>[requires: GL_EXT_memory_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureStorageMem3DEXT(TextureHandle texture, int levels, SizedInternalFormat internalFormat, int width, int height, int depth, uint memory, ulong offset) => GLPointers._TextureStorageMem3DEXT_fnptr((int)texture, levels, (uint)internalFormat, width, height, depth, memory, offset);
+            public static void TextureStorageMem3DEXT(int texture, int levels, SizedInternalFormat internalFormat, int width, int height, int depth, uint memory, ulong offset) => GLPointers._TextureStorageMem3DEXT_fnptr(texture, levels, (uint)internalFormat, width, height, depth, memory, offset);
             
             /// <summary> <b>[requires: GL_EXT_memory_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureStorageMem3DMultisampleEXT(TextureHandle texture, int samples, SizedInternalFormat internalFormat, int width, int height, int depth, bool fixedSampleLocations, uint memory, ulong offset) => GLPointers._TextureStorageMem3DMultisampleEXT_fnptr((int)texture, samples, (uint)internalFormat, width, height, depth, (byte)(fixedSampleLocations ? 1 : 0), memory, offset);
+            public static void TextureStorageMem3DMultisampleEXT(int texture, int samples, SizedInternalFormat internalFormat, int width, int height, int depth, bool fixedSampleLocations, uint memory, ulong offset) => GLPointers._TextureStorageMem3DMultisampleEXT_fnptr(texture, samples, (uint)internalFormat, width, height, depth, (byte)(fixedSampleLocations ? 1 : 0), memory, offset);
             
             /// <summary> <b>[requires: GL_EXT_memory_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedBufferStorageMemEXT(BufferHandle buffer, nint size, uint memory, ulong offset) => GLPointers._NamedBufferStorageMemEXT_fnptr((int)buffer, size, memory, offset);
+            public static void NamedBufferStorageMemEXT(int buffer, nint size, uint memory, ulong offset) => GLPointers._NamedBufferStorageMemEXT_fnptr(buffer, size, memory, offset);
             
             /// <summary> <b>[requires: GL_EXT_memory_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -11174,7 +11174,7 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_EXT_memory_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureStorageMem1DEXT(TextureHandle texture, int levels, SizedInternalFormat internalFormat, int width, uint memory, ulong offset) => GLPointers._TextureStorageMem1DEXT_fnptr((int)texture, levels, (uint)internalFormat, width, memory, offset);
+            public static void TextureStorageMem1DEXT(int texture, int levels, SizedInternalFormat internalFormat, int width, uint memory, ulong offset) => GLPointers._TextureStorageMem1DEXT_fnptr(texture, levels, (uint)internalFormat, width, memory, offset);
             
             /// <summary> <b>[requires: GL_EXT_memory_object_fd]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -11290,11 +11290,11 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_EXT_semaphore]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void WaitSemaphoreEXT(uint semaphore, uint numBufferBarriers, BufferHandle* buffers, uint numTextureBarriers, TextureHandle* textures, TextureLayout* srcLayouts) => GLPointers._WaitSemaphoreEXT_fnptr(semaphore, numBufferBarriers, (int*)buffers, numTextureBarriers, (int*)textures, (uint*)srcLayouts);
+            public static void WaitSemaphoreEXT(uint semaphore, uint numBufferBarriers, int* buffers, uint numTextureBarriers, int* textures, TextureLayout* srcLayouts) => GLPointers._WaitSemaphoreEXT_fnptr(semaphore, numBufferBarriers, buffers, numTextureBarriers, textures, (uint*)srcLayouts);
             
             /// <summary> <b>[requires: GL_EXT_semaphore]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void SignalSemaphoreEXT(uint semaphore, uint numBufferBarriers, BufferHandle* buffers, uint numTextureBarriers, TextureHandle* textures, TextureLayout* dstLayouts) => GLPointers._SignalSemaphoreEXT_fnptr(semaphore, numBufferBarriers, (int*)buffers, numTextureBarriers, (int*)textures, (uint*)dstLayouts);
+            public static void SignalSemaphoreEXT(uint semaphore, uint numBufferBarriers, int* buffers, uint numTextureBarriers, int* textures, TextureLayout* dstLayouts) => GLPointers._SignalSemaphoreEXT_fnptr(semaphore, numBufferBarriers, buffers, numTextureBarriers, textures, (uint*)dstLayouts);
             
             /// <summary> <b>[requires: GL_EXT_semaphore_fd]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -11378,55 +11378,55 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void UseShaderProgramEXT(All type, ProgramHandle program) => GLPointers._UseShaderProgramEXT_fnptr((uint)type, (int)program);
+            public static void UseShaderProgramEXT(All type, int program) => GLPointers._UseShaderProgramEXT_fnptr((uint)type, program);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ActiveProgramEXT(ProgramHandle program) => GLPointers._ActiveProgramEXT_fnptr((int)program);
+            public static void ActiveProgramEXT(int program) => GLPointers._ActiveProgramEXT_fnptr(program);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static ProgramHandle CreateShaderProgramEXT(ShaderType type, byte* str) => (ProgramHandle) GLPointers._CreateShaderProgramEXT_fnptr((uint)type, str);
+            public static int CreateShaderProgramEXT(ShaderType type, byte* str) => GLPointers._CreateShaderProgramEXT_fnptr((uint)type, str);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ActiveShaderProgramEXT(ProgramPipelineHandle pipeline, ProgramHandle program) => GLPointers._ActiveShaderProgramEXT_fnptr((int)pipeline, (int)program);
+            public static void ActiveShaderProgramEXT(int pipeline, int program) => GLPointers._ActiveShaderProgramEXT_fnptr(pipeline, program);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void BindProgramPipelineEXT(ProgramPipelineHandle pipeline) => GLPointers._BindProgramPipelineEXT_fnptr((int)pipeline);
+            public static void BindProgramPipelineEXT(int pipeline) => GLPointers._BindProgramPipelineEXT_fnptr(pipeline);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static ProgramHandle CreateShaderProgramvEXT(ShaderType type, int count, byte** strings) => (ProgramHandle) GLPointers._CreateShaderProgramvEXT_fnptr((uint)type, count, strings);
+            public static int CreateShaderProgramvEXT(ShaderType type, int count, byte** strings) => GLPointers._CreateShaderProgramvEXT_fnptr((uint)type, count, strings);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void DeleteProgramPipelinesEXT(int n, ProgramPipelineHandle* pipelines) => GLPointers._DeleteProgramPipelinesEXT_fnptr(n, (int*)pipelines);
+            public static void DeleteProgramPipelinesEXT(int n, int* pipelines) => GLPointers._DeleteProgramPipelinesEXT_fnptr(n, pipelines);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GenProgramPipelinesEXT(int n, ProgramPipelineHandle* pipelines) => GLPointers._GenProgramPipelinesEXT_fnptr(n, (int*)pipelines);
+            public static void GenProgramPipelinesEXT(int n, int* pipelines) => GLPointers._GenProgramPipelinesEXT_fnptr(n, pipelines);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetProgramPipelineInfoLogEXT(ProgramPipelineHandle pipeline, int bufSize, int* length, byte* infoLog) => GLPointers._GetProgramPipelineInfoLogEXT_fnptr((int)pipeline, bufSize, length, infoLog);
+            public static void GetProgramPipelineInfoLogEXT(int pipeline, int bufSize, int* length, byte* infoLog) => GLPointers._GetProgramPipelineInfoLogEXT_fnptr(pipeline, bufSize, length, infoLog);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetProgramPipelineivEXT(ProgramPipelineHandle pipeline, PipelineParameterName pname, int* parameters) => GLPointers._GetProgramPipelineivEXT_fnptr((int)pipeline, (uint)pname, parameters);
+            public static void GetProgramPipelineivEXT(int pipeline, PipelineParameterName pname, int* parameters) => GLPointers._GetProgramPipelineivEXT_fnptr(pipeline, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static bool IsProgramPipelineEXT(ProgramPipelineHandle pipeline) => GLPointers._IsProgramPipelineEXT_fnptr((int)pipeline) != 0;
+            public static bool IsProgramPipelineEXT(int pipeline) => GLPointers._IsProgramPipelineEXT_fnptr(pipeline) != 0;
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void UseProgramStagesEXT(ProgramPipelineHandle pipeline, UseProgramStageMask stages, ProgramHandle program) => GLPointers._UseProgramStagesEXT_fnptr((int)pipeline, (uint)stages, (int)program);
+            public static void UseProgramStagesEXT(int pipeline, UseProgramStageMask stages, int program) => GLPointers._UseProgramStagesEXT_fnptr(pipeline, (uint)stages, program);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ValidateProgramPipelineEXT(ProgramPipelineHandle pipeline) => GLPointers._ValidateProgramPipelineEXT_fnptr((int)pipeline);
+            public static void ValidateProgramPipelineEXT(int pipeline) => GLPointers._ValidateProgramPipelineEXT_fnptr(pipeline);
             
             /// <summary> <b>[requires: GL_EXT_shader_framebuffer_fetch_non_coherent]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -11434,7 +11434,7 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_EXT_shader_image_load_store]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void BindImageTextureEXT(uint index, TextureHandle texture, int level, bool layered, int layer, BufferAccessARB access, int format) => GLPointers._BindImageTextureEXT_fnptr(index, (int)texture, level, (byte)(layered ? 1 : 0), layer, (uint)access, format);
+            public static void BindImageTextureEXT(uint index, int texture, int level, bool layered, int layer, BufferAccessARB access, int format) => GLPointers._BindImageTextureEXT_fnptr(index, texture, level, (byte)(layered ? 1 : 0), layer, (uint)access, format);
             
             /// <summary> <b>[requires: GL_EXT_shader_image_load_store]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -11466,11 +11466,11 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_EXT_texture_array | GL_NV_geometry_program4]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void FramebufferTextureLayerEXT(FramebufferTarget target, FramebufferAttachment attachment, TextureHandle texture, int level, int layer) => GLPointers._FramebufferTextureLayerEXT_fnptr((uint)target, (uint)attachment, (int)texture, level, layer);
+            public static void FramebufferTextureLayerEXT(FramebufferTarget target, FramebufferAttachment attachment, int texture, int level, int layer) => GLPointers._FramebufferTextureLayerEXT_fnptr((uint)target, (uint)attachment, texture, level, layer);
             
             /// <summary> <b>[requires: GL_EXT_texture_buffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TexBufferEXT(TextureTarget target, SizedInternalFormat internalformat, BufferHandle buffer) => GLPointers._TexBufferEXT_fnptr((uint)target, (uint)internalformat, (int)buffer);
+            public static void TexBufferEXT(TextureTarget target, SizedInternalFormat internalformat, int buffer) => GLPointers._TexBufferEXT_fnptr((uint)target, (uint)internalformat, buffer);
             
             /// <summary> <b>[requires: GL_EXT_texture_integer]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -11498,27 +11498,27 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_EXT_texture_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static bool AreTexturesResidentEXT(int n, TextureHandle* textures, bool* residences) => GLPointers._AreTexturesResidentEXT_fnptr(n, (int*)textures, (byte*)residences) != 0;
+            public static bool AreTexturesResidentEXT(int n, int* textures, bool* residences) => GLPointers._AreTexturesResidentEXT_fnptr(n, textures, (byte*)residences) != 0;
             
             /// <summary> <b>[requires: GL_EXT_texture_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void BindTextureEXT(TextureTarget target, TextureHandle texture) => GLPointers._BindTextureEXT_fnptr((uint)target, (int)texture);
+            public static void BindTextureEXT(TextureTarget target, int texture) => GLPointers._BindTextureEXT_fnptr((uint)target, texture);
             
             /// <summary> <b>[requires: GL_EXT_texture_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void DeleteTexturesEXT(int n, TextureHandle* textures) => GLPointers._DeleteTexturesEXT_fnptr(n, (int*)textures);
+            public static void DeleteTexturesEXT(int n, int* textures) => GLPointers._DeleteTexturesEXT_fnptr(n, textures);
             
             /// <summary> <b>[requires: GL_EXT_texture_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GenTexturesEXT(int n, TextureHandle* textures) => GLPointers._GenTexturesEXT_fnptr(n, (int*)textures);
+            public static void GenTexturesEXT(int n, int* textures) => GLPointers._GenTexturesEXT_fnptr(n, textures);
             
             /// <summary> <b>[requires: GL_EXT_texture_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static bool IsTextureEXT(TextureHandle texture) => GLPointers._IsTextureEXT_fnptr((int)texture) != 0;
+            public static bool IsTextureEXT(int texture) => GLPointers._IsTextureEXT_fnptr(texture) != 0;
             
             /// <summary> <b>[requires: GL_EXT_texture_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void PrioritizeTexturesEXT(int n, TextureHandle* textures, float* priorities) => GLPointers._PrioritizeTexturesEXT_fnptr(n, (int*)textures, priorities);
+            public static void PrioritizeTexturesEXT(int n, int* textures, float* priorities) => GLPointers._PrioritizeTexturesEXT_fnptr(n, textures, priorities);
             
             /// <summary> <b>[requires: GL_EXT_texture_perturb_normal]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -11538,11 +11538,11 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_EXT_timer_query]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetQueryObjecti64vEXT(QueryHandle id, QueryObjectParameterName pname, long* parameters) => GLPointers._GetQueryObjecti64vEXT_fnptr((int)id, (uint)pname, parameters);
+            public static void GetQueryObjecti64vEXT(int id, QueryObjectParameterName pname, long* parameters) => GLPointers._GetQueryObjecti64vEXT_fnptr(id, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_EXT_timer_query]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetQueryObjectui64vEXT(QueryHandle id, QueryObjectParameterName pname, ulong* parameters) => GLPointers._GetQueryObjectui64vEXT_fnptr((int)id, (uint)pname, parameters);
+            public static void GetQueryObjectui64vEXT(int id, QueryObjectParameterName pname, ulong* parameters) => GLPointers._GetQueryObjectui64vEXT_fnptr(id, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_EXT_transform_feedback]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -11554,23 +11554,23 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_EXT_transform_feedback]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void BindBufferRangeEXT(BufferTargetARB target, uint index, BufferHandle buffer, IntPtr offset, nint size) => GLPointers._BindBufferRangeEXT_fnptr((uint)target, index, (int)buffer, offset, size);
+            public static void BindBufferRangeEXT(BufferTargetARB target, uint index, int buffer, IntPtr offset, nint size) => GLPointers._BindBufferRangeEXT_fnptr((uint)target, index, buffer, offset, size);
             
             /// <summary> <b>[requires: GL_EXT_transform_feedback]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void BindBufferOffsetEXT(BufferTargetARB target, uint index, BufferHandle buffer, IntPtr offset) => GLPointers._BindBufferOffsetEXT_fnptr((uint)target, index, (int)buffer, offset);
+            public static void BindBufferOffsetEXT(BufferTargetARB target, uint index, int buffer, IntPtr offset) => GLPointers._BindBufferOffsetEXT_fnptr((uint)target, index, buffer, offset);
             
             /// <summary> <b>[requires: GL_EXT_transform_feedback]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void BindBufferBaseEXT(BufferTargetARB target, uint index, BufferHandle buffer) => GLPointers._BindBufferBaseEXT_fnptr((uint)target, index, (int)buffer);
+            public static void BindBufferBaseEXT(BufferTargetARB target, uint index, int buffer) => GLPointers._BindBufferBaseEXT_fnptr((uint)target, index, buffer);
             
             /// <summary> <b>[requires: GL_EXT_transform_feedback]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TransformFeedbackVaryingsEXT(ProgramHandle program, int count, byte** varyings, TransformFeedbackBufferMode bufferMode) => GLPointers._TransformFeedbackVaryingsEXT_fnptr((int)program, count, varyings, (uint)bufferMode);
+            public static void TransformFeedbackVaryingsEXT(int program, int count, byte** varyings, TransformFeedbackBufferMode bufferMode) => GLPointers._TransformFeedbackVaryingsEXT_fnptr(program, count, varyings, (uint)bufferMode);
             
             /// <summary> <b>[requires: GL_EXT_transform_feedback]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetTransformFeedbackVaryingEXT(ProgramHandle program, uint index, int bufSize, int* length, int* size, AttributeType* type, byte* name) => GLPointers._GetTransformFeedbackVaryingEXT_fnptr((int)program, index, bufSize, length, size, (uint*)type, name);
+            public static void GetTransformFeedbackVaryingEXT(int program, uint index, int bufSize, int* length, int* size, AttributeType* type, byte* name) => GLPointers._GetTransformFeedbackVaryingEXT_fnptr(program, index, bufSize, length, size, (uint*)type, name);
             
             /// <summary> <b>[requires: GL_EXT_vertex_array]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -11881,11 +11881,11 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_NV_bindless_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static ulong GetTextureHandleNV(TextureHandle texture) => GLPointers._GetTextureHandleNV_fnptr((int)texture);
+            public static ulong GetTextureHandleNV(int texture) => GLPointers._GetTextureHandleNV_fnptr(texture);
             
             /// <summary> <b>[requires: GL_NV_bindless_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static ulong GetTextureSamplerHandleNV(TextureHandle texture, SamplerHandle sampler) => GLPointers._GetTextureSamplerHandleNV_fnptr((int)texture, (int)sampler);
+            public static ulong GetTextureSamplerHandleNV(int texture, int sampler) => GLPointers._GetTextureSamplerHandleNV_fnptr(texture, sampler);
             
             /// <summary> <b>[requires: GL_NV_bindless_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -11897,7 +11897,7 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_NV_bindless_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static ulong GetImageHandleNV(TextureHandle texture, int level, bool layered, int layer, PixelFormat format) => GLPointers._GetImageHandleNV_fnptr((int)texture, level, (byte)(layered ? 1 : 0), layer, (uint)format);
+            public static ulong GetImageHandleNV(int texture, int level, bool layered, int layer, PixelFormat format) => GLPointers._GetImageHandleNV_fnptr(texture, level, (byte)(layered ? 1 : 0), layer, (uint)format);
             
             /// <summary> <b>[requires: GL_NV_bindless_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -11917,11 +11917,11 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_NV_bindless_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformHandleui64NV(ProgramHandle program, int location, ulong value) => GLPointers._ProgramUniformHandleui64NV_fnptr((int)program, location, value);
+            public static void ProgramUniformHandleui64NV(int program, int location, ulong value) => GLPointers._ProgramUniformHandleui64NV_fnptr(program, location, value);
             
             /// <summary> <b>[requires: GL_NV_bindless_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformHandleui64vNV(ProgramHandle program, int location, int count, ulong* values) => GLPointers._ProgramUniformHandleui64vNV_fnptr((int)program, location, count, values);
+            public static void ProgramUniformHandleui64vNV(int program, int location, int count, ulong* values) => GLPointers._ProgramUniformHandleui64vNV_fnptr(program, location, count, values);
             
             /// <summary> <b>[requires: GL_NV_bindless_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -11977,7 +11977,7 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_NV_command_list]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void DrawCommandsStatesNV(BufferHandle buffer, IntPtr* indirects, int* sizes, uint* states, uint* fbos, uint count) => GLPointers._DrawCommandsStatesNV_fnptr((int)buffer, indirects, sizes, states, fbos, count);
+            public static void DrawCommandsStatesNV(int buffer, IntPtr* indirects, int* sizes, uint* states, uint* fbos, uint count) => GLPointers._DrawCommandsStatesNV_fnptr(buffer, indirects, sizes, states, fbos, count);
             
             /// <summary> <b>[requires: GL_NV_command_list]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -12049,11 +12049,11 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_NV_draw_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void DrawTextureNV(TextureHandle texture, SamplerHandle sampler, float x0, float y0, float x1, float y1, float z, float s0, float t0, float s1, float t1) => GLPointers._DrawTextureNV_fnptr((int)texture, (int)sampler, x0, y0, x1, y1, z, s0, t0, s1, t1);
+            public static void DrawTextureNV(int texture, int sampler, float x0, float y0, float x1, float y1, float z, float s0, float t0, float s1, float t1) => GLPointers._DrawTextureNV_fnptr(texture, sampler, x0, y0, x1, y1, z, s0, t0, s1, t1);
             
             /// <summary> <b>[requires: GL_NV_draw_vulkan_image]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void DrawVkImageNV(ulong vkImage, SamplerHandle sampler, float x0, float y0, float x1, float y1, float z, float s0, float t0, float s1, float t1) => GLPointers._DrawVkImageNV_fnptr(vkImage, (int)sampler, x0, y0, x1, y1, z, s0, t0, s1, t1);
+            public static void DrawVkImageNV(ulong vkImage, int sampler, float x0, float y0, float x1, float y1, float z, float s0, float t0, float s1, float t1) => GLPointers._DrawVkImageNV_fnptr(vkImage, sampler, x0, y0, x1, y1, z, s0, t0, s1, t1);
             
             /// <summary> <b>[requires: GL_NV_draw_vulkan_image]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -12117,7 +12117,7 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_NV_explicit_multisample]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TexRenderbufferNV(TextureTarget target, RenderbufferHandle renderbuffer) => GLPointers._TexRenderbufferNV_fnptr((uint)target, (int)renderbuffer);
+            public static void TexRenderbufferNV(TextureTarget target, int renderbuffer) => GLPointers._TexRenderbufferNV_fnptr((uint)target, renderbuffer);
             
             /// <summary> <b>[requires: GL_NV_fence]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -12153,27 +12153,27 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_NV_fragment_program]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramNamedParameter4fNV(ProgramHandle id, int len, byte* name, float x, float y, float z, float w) => GLPointers._ProgramNamedParameter4fNV_fnptr((int)id, len, name, x, y, z, w);
+            public static void ProgramNamedParameter4fNV(int id, int len, byte* name, float x, float y, float z, float w) => GLPointers._ProgramNamedParameter4fNV_fnptr(id, len, name, x, y, z, w);
             
             /// <summary> <b>[requires: GL_NV_fragment_program]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramNamedParameter4fvNV(ProgramHandle id, int len, byte* name, float* v) => GLPointers._ProgramNamedParameter4fvNV_fnptr((int)id, len, name, v);
+            public static void ProgramNamedParameter4fvNV(int id, int len, byte* name, float* v) => GLPointers._ProgramNamedParameter4fvNV_fnptr(id, len, name, v);
             
             /// <summary> <b>[requires: GL_NV_fragment_program]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramNamedParameter4dNV(ProgramHandle id, int len, byte* name, double x, double y, double z, double w) => GLPointers._ProgramNamedParameter4dNV_fnptr((int)id, len, name, x, y, z, w);
+            public static void ProgramNamedParameter4dNV(int id, int len, byte* name, double x, double y, double z, double w) => GLPointers._ProgramNamedParameter4dNV_fnptr(id, len, name, x, y, z, w);
             
             /// <summary> <b>[requires: GL_NV_fragment_program]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramNamedParameter4dvNV(ProgramHandle id, int len, byte* name, double* v) => GLPointers._ProgramNamedParameter4dvNV_fnptr((int)id, len, name, v);
+            public static void ProgramNamedParameter4dvNV(int id, int len, byte* name, double* v) => GLPointers._ProgramNamedParameter4dvNV_fnptr(id, len, name, v);
             
             /// <summary> <b>[requires: GL_NV_fragment_program]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetProgramNamedParameterfvNV(ProgramHandle id, int len, byte* name, float* parameters) => GLPointers._GetProgramNamedParameterfvNV_fnptr((int)id, len, name, parameters);
+            public static void GetProgramNamedParameterfvNV(int id, int len, byte* name, float* parameters) => GLPointers._GetProgramNamedParameterfvNV_fnptr(id, len, name, parameters);
             
             /// <summary> <b>[requires: GL_NV_fragment_program]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetProgramNamedParameterdvNV(ProgramHandle id, int len, byte* name, double* parameters) => GLPointers._GetProgramNamedParameterdvNV_fnptr((int)id, len, name, parameters);
+            public static void GetProgramNamedParameterdvNV(int id, int len, byte* name, double* parameters) => GLPointers._GetProgramNamedParameterdvNV_fnptr(id, len, name, parameters);
             
             /// <summary> <b>[requires: GL_EXT_raster_multisample | GL_NV_framebuffer_mixed_samples]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -12201,15 +12201,15 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_NV_geometry_program4]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void FramebufferTextureEXT(FramebufferTarget target, FramebufferAttachment attachment, TextureHandle texture, int level) => GLPointers._FramebufferTextureEXT_fnptr((uint)target, (uint)attachment, (int)texture, level);
+            public static void FramebufferTextureEXT(FramebufferTarget target, FramebufferAttachment attachment, int texture, int level) => GLPointers._FramebufferTextureEXT_fnptr((uint)target, (uint)attachment, texture, level);
             
             /// <summary> <b>[requires: GL_EXT_texture_array | GL_NV_geometry_program4]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void FramebufferTextureLayerEXT(FramebufferTarget target, FramebufferAttachment attachment, TextureHandle texture, int level, int layer) => GLPointers._FramebufferTextureLayerEXT_fnptr((uint)target, (uint)attachment, (int)texture, level, layer);
+            public static void FramebufferTextureLayerEXT(FramebufferTarget target, FramebufferAttachment attachment, int texture, int level, int layer) => GLPointers._FramebufferTextureLayerEXT_fnptr((uint)target, (uint)attachment, texture, level, layer);
             
             /// <summary> <b>[requires: GL_NV_geometry_program4]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void FramebufferTextureFaceEXT(FramebufferTarget target, FramebufferAttachment attachment, TextureHandle texture, int level, TextureTarget face) => GLPointers._FramebufferTextureFaceEXT_fnptr((uint)target, (uint)attachment, (int)texture, level, (uint)face);
+            public static void FramebufferTextureFaceEXT(FramebufferTarget target, FramebufferAttachment attachment, int texture, int level, TextureTarget face) => GLPointers._FramebufferTextureFaceEXT_fnptr((uint)target, (uint)attachment, texture, level, (uint)face);
             
             /// <summary> <b>[requires: GL_NV_gpu_program4]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -12349,71 +12349,71 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetUniformi64vNV(ProgramHandle program, int location, long* parameters) => GLPointers._GetUniformi64vNV_fnptr((int)program, location, parameters);
+            public static void GetUniformi64vNV(int program, int location, long* parameters) => GLPointers._GetUniformi64vNV_fnptr(program, location, parameters);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform1i64NV(ProgramHandle program, int location, long x) => GLPointers._ProgramUniform1i64NV_fnptr((int)program, location, x);
+            public static void ProgramUniform1i64NV(int program, int location, long x) => GLPointers._ProgramUniform1i64NV_fnptr(program, location, x);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform2i64NV(ProgramHandle program, int location, long x, long y) => GLPointers._ProgramUniform2i64NV_fnptr((int)program, location, x, y);
+            public static void ProgramUniform2i64NV(int program, int location, long x, long y) => GLPointers._ProgramUniform2i64NV_fnptr(program, location, x, y);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform3i64NV(ProgramHandle program, int location, long x, long y, long z) => GLPointers._ProgramUniform3i64NV_fnptr((int)program, location, x, y, z);
+            public static void ProgramUniform3i64NV(int program, int location, long x, long y, long z) => GLPointers._ProgramUniform3i64NV_fnptr(program, location, x, y, z);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform4i64NV(ProgramHandle program, int location, long x, long y, long z, long w) => GLPointers._ProgramUniform4i64NV_fnptr((int)program, location, x, y, z, w);
+            public static void ProgramUniform4i64NV(int program, int location, long x, long y, long z, long w) => GLPointers._ProgramUniform4i64NV_fnptr(program, location, x, y, z, w);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform1i64vNV(ProgramHandle program, int location, int count, long* value) => GLPointers._ProgramUniform1i64vNV_fnptr((int)program, location, count, value);
+            public static void ProgramUniform1i64vNV(int program, int location, int count, long* value) => GLPointers._ProgramUniform1i64vNV_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform2i64vNV(ProgramHandle program, int location, int count, long* value) => GLPointers._ProgramUniform2i64vNV_fnptr((int)program, location, count, value);
+            public static void ProgramUniform2i64vNV(int program, int location, int count, long* value) => GLPointers._ProgramUniform2i64vNV_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform3i64vNV(ProgramHandle program, int location, int count, long* value) => GLPointers._ProgramUniform3i64vNV_fnptr((int)program, location, count, value);
+            public static void ProgramUniform3i64vNV(int program, int location, int count, long* value) => GLPointers._ProgramUniform3i64vNV_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform4i64vNV(ProgramHandle program, int location, int count, long* value) => GLPointers._ProgramUniform4i64vNV_fnptr((int)program, location, count, value);
+            public static void ProgramUniform4i64vNV(int program, int location, int count, long* value) => GLPointers._ProgramUniform4i64vNV_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform1ui64NV(ProgramHandle program, int location, ulong x) => GLPointers._ProgramUniform1ui64NV_fnptr((int)program, location, x);
+            public static void ProgramUniform1ui64NV(int program, int location, ulong x) => GLPointers._ProgramUniform1ui64NV_fnptr(program, location, x);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform2ui64NV(ProgramHandle program, int location, ulong x, ulong y) => GLPointers._ProgramUniform2ui64NV_fnptr((int)program, location, x, y);
+            public static void ProgramUniform2ui64NV(int program, int location, ulong x, ulong y) => GLPointers._ProgramUniform2ui64NV_fnptr(program, location, x, y);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform3ui64NV(ProgramHandle program, int location, ulong x, ulong y, ulong z) => GLPointers._ProgramUniform3ui64NV_fnptr((int)program, location, x, y, z);
+            public static void ProgramUniform3ui64NV(int program, int location, ulong x, ulong y, ulong z) => GLPointers._ProgramUniform3ui64NV_fnptr(program, location, x, y, z);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform4ui64NV(ProgramHandle program, int location, ulong x, ulong y, ulong z, ulong w) => GLPointers._ProgramUniform4ui64NV_fnptr((int)program, location, x, y, z, w);
+            public static void ProgramUniform4ui64NV(int program, int location, ulong x, ulong y, ulong z, ulong w) => GLPointers._ProgramUniform4ui64NV_fnptr(program, location, x, y, z, w);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform1ui64vNV(ProgramHandle program, int location, int count, ulong* value) => GLPointers._ProgramUniform1ui64vNV_fnptr((int)program, location, count, value);
+            public static void ProgramUniform1ui64vNV(int program, int location, int count, ulong* value) => GLPointers._ProgramUniform1ui64vNV_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform2ui64vNV(ProgramHandle program, int location, int count, ulong* value) => GLPointers._ProgramUniform2ui64vNV_fnptr((int)program, location, count, value);
+            public static void ProgramUniform2ui64vNV(int program, int location, int count, ulong* value) => GLPointers._ProgramUniform2ui64vNV_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform3ui64vNV(ProgramHandle program, int location, int count, ulong* value) => GLPointers._ProgramUniform3ui64vNV_fnptr((int)program, location, count, value);
+            public static void ProgramUniform3ui64vNV(int program, int location, int count, ulong* value) => GLPointers._ProgramUniform3ui64vNV_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform4ui64vNV(ProgramHandle program, int location, int count, ulong* value) => GLPointers._ProgramUniform4ui64vNV_fnptr((int)program, location, count, value);
+            public static void ProgramUniform4ui64vNV(int program, int location, int count, ulong* value) => GLPointers._ProgramUniform4ui64vNV_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_NV_half_float]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -12609,11 +12609,11 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_NV_gpu_multicast]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void MulticastBufferSubDataNV(All gpuMask, BufferHandle buffer, IntPtr offset, nint size, void* data) => GLPointers._MulticastBufferSubDataNV_fnptr((uint)gpuMask, (int)buffer, offset, size, data);
+            public static void MulticastBufferSubDataNV(All gpuMask, int buffer, IntPtr offset, nint size, void* data) => GLPointers._MulticastBufferSubDataNV_fnptr((uint)gpuMask, buffer, offset, size, data);
             
             /// <summary> <b>[requires: GL_NV_gpu_multicast]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void MulticastCopyBufferSubDataNV(uint readGpu, All writeGpuMask, BufferHandle readBuffer, BufferHandle writeBuffer, IntPtr readOffset, IntPtr writeOffset, nint size) => GLPointers._MulticastCopyBufferSubDataNV_fnptr(readGpu, (uint)writeGpuMask, (int)readBuffer, (int)writeBuffer, readOffset, writeOffset, size);
+            public static void MulticastCopyBufferSubDataNV(uint readGpu, All writeGpuMask, int readBuffer, int writeBuffer, IntPtr readOffset, IntPtr writeOffset, nint size) => GLPointers._MulticastCopyBufferSubDataNV_fnptr(readGpu, (uint)writeGpuMask, readBuffer, writeBuffer, readOffset, writeOffset, size);
             
             /// <summary> <b>[requires: GL_NV_gpu_multicast]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -12625,7 +12625,7 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_NV_gpu_multicast]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void MulticastFramebufferSampleLocationsfvNV(uint gpu, FramebufferHandle framebuffer, uint start, int count, float* v) => GLPointers._MulticastFramebufferSampleLocationsfvNV_fnptr(gpu, (int)framebuffer, start, count, v);
+            public static void MulticastFramebufferSampleLocationsfvNV(uint gpu, int framebuffer, uint start, int count, float* v) => GLPointers._MulticastFramebufferSampleLocationsfvNV_fnptr(gpu, framebuffer, start, count, v);
             
             /// <summary> <b>[requires: GL_NV_gpu_multicast]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -12669,11 +12669,11 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_NV_memory_attachment]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureAttachMemoryNV(TextureHandle texture, uint memory, ulong offset) => GLPointers._TextureAttachMemoryNV_fnptr((int)texture, memory, offset);
+            public static void TextureAttachMemoryNV(int texture, uint memory, ulong offset) => GLPointers._TextureAttachMemoryNV_fnptr(texture, memory, offset);
             
             /// <summary> <b>[requires: GL_NV_memory_attachment]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedBufferAttachMemoryNV(BufferHandle buffer, uint memory, ulong offset) => GLPointers._NamedBufferAttachMemoryNV_fnptr((int)buffer, memory, offset);
+            public static void NamedBufferAttachMemoryNV(int buffer, uint memory, ulong offset) => GLPointers._NamedBufferAttachMemoryNV_fnptr(buffer, memory, offset);
             
             /// <summary> <b>[requires: GL_NV_memory_object_sparse]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -12685,11 +12685,11 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_NV_memory_object_sparse]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedBufferPageCommitmentMemNV(BufferHandle buffer, IntPtr offset, nint size, uint memory, ulong memOffset, bool commit) => GLPointers._NamedBufferPageCommitmentMemNV_fnptr((int)buffer, offset, size, memory, memOffset, (byte)(commit ? 1 : 0));
+            public static void NamedBufferPageCommitmentMemNV(int buffer, IntPtr offset, nint size, uint memory, ulong memOffset, bool commit) => GLPointers._NamedBufferPageCommitmentMemNV_fnptr(buffer, offset, size, memory, memOffset, (byte)(commit ? 1 : 0));
             
             /// <summary> <b>[requires: GL_NV_memory_object_sparse]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TexturePageCommitmentMemNV(TextureHandle texture, int layer, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, uint memory, ulong offset, bool commit) => GLPointers._TexturePageCommitmentMemNV_fnptr((int)texture, layer, level, xoffset, yoffset, zoffset, width, height, depth, memory, offset, (byte)(commit ? 1 : 0));
+            public static void TexturePageCommitmentMemNV(int texture, int layer, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, uint memory, ulong offset, bool commit) => GLPointers._TexturePageCommitmentMemNV_fnptr(texture, layer, level, xoffset, yoffset, zoffset, width, height, depth, memory, offset, (byte)(commit ? 1 : 0));
             
             /// <summary> <b>[requires: GL_NV_mesh_shader]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -12969,11 +12969,11 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_NV_path_rendering]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramPathFragmentInputGenNV(ProgramHandle program, int location, All genMode, int components, float* coeffs) => GLPointers._ProgramPathFragmentInputGenNV_fnptr((int)program, location, (uint)genMode, components, coeffs);
+            public static void ProgramPathFragmentInputGenNV(int program, int location, All genMode, int components, float* coeffs) => GLPointers._ProgramPathFragmentInputGenNV_fnptr(program, location, (uint)genMode, components, coeffs);
             
             /// <summary> <b>[requires: GL_NV_path_rendering]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetProgramResourcefvNV(ProgramHandle program, ProgramInterface programInterface, uint index, int propCount, All* props, int count, int* length, float* parameters) => GLPointers._GetProgramResourcefvNV_fnptr((int)program, (uint)programInterface, index, propCount, (uint*)props, count, length, parameters);
+            public static void GetProgramResourcefvNV(int program, ProgramInterface programInterface, uint index, int propCount, All* props, int count, int* length, float* parameters) => GLPointers._GetProgramResourcefvNV_fnptr(program, (uint)programInterface, index, propCount, (uint*)props, count, length, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_NV_path_rendering]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -13181,7 +13181,7 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_NV_sample_locations]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedFramebufferSampleLocationsfvNV(FramebufferHandle framebuffer, uint start, int count, float* v) => GLPointers._NamedFramebufferSampleLocationsfvNV_fnptr((int)framebuffer, start, count, v);
+            public static void NamedFramebufferSampleLocationsfvNV(int framebuffer, uint start, int count, float* v) => GLPointers._NamedFramebufferSampleLocationsfvNV_fnptr(framebuffer, start, count, v);
             
             /// <summary> <b>[requires: GL_NV_sample_locations]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -13209,15 +13209,15 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_NV_shader_buffer_load]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void MakeNamedBufferResidentNV(BufferHandle buffer, All access) => GLPointers._MakeNamedBufferResidentNV_fnptr((int)buffer, (uint)access);
+            public static void MakeNamedBufferResidentNV(int buffer, All access) => GLPointers._MakeNamedBufferResidentNV_fnptr(buffer, (uint)access);
             
             /// <summary> <b>[requires: GL_NV_shader_buffer_load]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void MakeNamedBufferNonResidentNV(BufferHandle buffer) => GLPointers._MakeNamedBufferNonResidentNV_fnptr((int)buffer);
+            public static void MakeNamedBufferNonResidentNV(int buffer) => GLPointers._MakeNamedBufferNonResidentNV_fnptr(buffer);
             
             /// <summary> <b>[requires: GL_NV_shader_buffer_load]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static bool IsNamedBufferResidentNV(BufferHandle buffer) => GLPointers._IsNamedBufferResidentNV_fnptr((int)buffer) != 0;
+            public static bool IsNamedBufferResidentNV(int buffer) => GLPointers._IsNamedBufferResidentNV_fnptr(buffer) != 0;
             
             /// <summary> <b>[requires: GL_NV_shader_buffer_load]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -13225,7 +13225,7 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_NV_shader_buffer_load]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetNamedBufferParameterui64vNV(BufferHandle buffer, BufferPNameARB pname, ulong* parameters) => GLPointers._GetNamedBufferParameterui64vNV_fnptr((int)buffer, (uint)pname, parameters);
+            public static void GetNamedBufferParameterui64vNV(int buffer, BufferPNameARB pname, ulong* parameters) => GLPointers._GetNamedBufferParameterui64vNV_fnptr(buffer, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_NV_shader_buffer_load]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -13241,19 +13241,19 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_AMD_gpu_shader_int64 | GL_NV_shader_buffer_load]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetUniformui64vNV(ProgramHandle program, int location, ulong* parameters) => GLPointers._GetUniformui64vNV_fnptr((int)program, location, parameters);
+            public static void GetUniformui64vNV(int program, int location, ulong* parameters) => GLPointers._GetUniformui64vNV_fnptr(program, location, parameters);
             
             /// <summary> <b>[requires: GL_NV_shader_buffer_load]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformui64NV(ProgramHandle program, int location, ulong value) => GLPointers._ProgramUniformui64NV_fnptr((int)program, location, value);
+            public static void ProgramUniformui64NV(int program, int location, ulong value) => GLPointers._ProgramUniformui64NV_fnptr(program, location, value);
             
             /// <summary> <b>[requires: GL_NV_shader_buffer_load]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformui64vNV(ProgramHandle program, int location, int count, ulong* value) => GLPointers._ProgramUniformui64vNV_fnptr((int)program, location, count, value);
+            public static void ProgramUniformui64vNV(int program, int location, int count, ulong* value) => GLPointers._ProgramUniformui64vNV_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_NV_shading_rate_image]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void BindShadingRateImageNV(TextureHandle texture) => GLPointers._BindShadingRateImageNV_fnptr((int)texture);
+            public static void BindShadingRateImageNV(int texture) => GLPointers._BindShadingRateImageNV_fnptr(texture);
             
             /// <summary> <b>[requires: GL_NV_shading_rate_image]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -13293,19 +13293,19 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_NV_texture_multisample]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureImage2DMultisampleNV(TextureHandle texture, TextureTarget target, int samples, InternalFormat internalFormat, int width, int height, bool fixedSampleLocations) => GLPointers._TextureImage2DMultisampleNV_fnptr((int)texture, (uint)target, samples, (int)internalFormat, width, height, (byte)(fixedSampleLocations ? 1 : 0));
+            public static void TextureImage2DMultisampleNV(int texture, TextureTarget target, int samples, InternalFormat internalFormat, int width, int height, bool fixedSampleLocations) => GLPointers._TextureImage2DMultisampleNV_fnptr(texture, (uint)target, samples, (int)internalFormat, width, height, (byte)(fixedSampleLocations ? 1 : 0));
             
             /// <summary> <b>[requires: GL_NV_texture_multisample]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureImage3DMultisampleNV(TextureHandle texture, TextureTarget target, int samples, InternalFormat internalFormat, int width, int height, int depth, bool fixedSampleLocations) => GLPointers._TextureImage3DMultisampleNV_fnptr((int)texture, (uint)target, samples, (int)internalFormat, width, height, depth, (byte)(fixedSampleLocations ? 1 : 0));
+            public static void TextureImage3DMultisampleNV(int texture, TextureTarget target, int samples, InternalFormat internalFormat, int width, int height, int depth, bool fixedSampleLocations) => GLPointers._TextureImage3DMultisampleNV_fnptr(texture, (uint)target, samples, (int)internalFormat, width, height, depth, (byte)(fixedSampleLocations ? 1 : 0));
             
             /// <summary> <b>[requires: GL_NV_texture_multisample]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureImage2DMultisampleCoverageNV(TextureHandle texture, TextureTarget target, int coverageSamples, int colorSamples, InternalFormat internalFormat, int width, int height, bool fixedSampleLocations) => GLPointers._TextureImage2DMultisampleCoverageNV_fnptr((int)texture, (uint)target, coverageSamples, colorSamples, (int)internalFormat, width, height, (byte)(fixedSampleLocations ? 1 : 0));
+            public static void TextureImage2DMultisampleCoverageNV(int texture, TextureTarget target, int coverageSamples, int colorSamples, InternalFormat internalFormat, int width, int height, bool fixedSampleLocations) => GLPointers._TextureImage2DMultisampleCoverageNV_fnptr(texture, (uint)target, coverageSamples, colorSamples, (int)internalFormat, width, height, (byte)(fixedSampleLocations ? 1 : 0));
             
             /// <summary> <b>[requires: GL_NV_texture_multisample]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureImage3DMultisampleCoverageNV(TextureHandle texture, TextureTarget target, int coverageSamples, int colorSamples, InternalFormat internalFormat, int width, int height, int depth, bool fixedSampleLocations) => GLPointers._TextureImage3DMultisampleCoverageNV_fnptr((int)texture, (uint)target, coverageSamples, colorSamples, (int)internalFormat, width, height, depth, (byte)(fixedSampleLocations ? 1 : 0));
+            public static void TextureImage3DMultisampleCoverageNV(int texture, TextureTarget target, int coverageSamples, int colorSamples, InternalFormat internalFormat, int width, int height, int depth, bool fixedSampleLocations) => GLPointers._TextureImage3DMultisampleCoverageNV_fnptr(texture, (uint)target, coverageSamples, colorSamples, (int)internalFormat, width, height, depth, (byte)(fixedSampleLocations ? 1 : 0));
             
             /// <summary> <b>[requires: GL_NV_transform_feedback]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -13321,35 +13321,35 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_NV_transform_feedback]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void BindBufferRangeNV(BufferTargetARB target, uint index, BufferHandle buffer, IntPtr offset, nint size) => GLPointers._BindBufferRangeNV_fnptr((uint)target, index, (int)buffer, offset, size);
+            public static void BindBufferRangeNV(BufferTargetARB target, uint index, int buffer, IntPtr offset, nint size) => GLPointers._BindBufferRangeNV_fnptr((uint)target, index, buffer, offset, size);
             
             /// <summary> <b>[requires: GL_NV_transform_feedback]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void BindBufferOffsetNV(BufferTargetARB target, uint index, BufferHandle buffer, IntPtr offset) => GLPointers._BindBufferOffsetNV_fnptr((uint)target, index, (int)buffer, offset);
+            public static void BindBufferOffsetNV(BufferTargetARB target, uint index, int buffer, IntPtr offset) => GLPointers._BindBufferOffsetNV_fnptr((uint)target, index, buffer, offset);
             
             /// <summary> <b>[requires: GL_NV_transform_feedback]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void BindBufferBaseNV(BufferTargetARB target, uint index, BufferHandle buffer) => GLPointers._BindBufferBaseNV_fnptr((uint)target, index, (int)buffer);
+            public static void BindBufferBaseNV(BufferTargetARB target, uint index, int buffer) => GLPointers._BindBufferBaseNV_fnptr((uint)target, index, buffer);
             
             /// <summary> <b>[requires: GL_NV_transform_feedback]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TransformFeedbackVaryingsNV(ProgramHandle program, int count, TransformFeedbackTokenNV* locations, TransformFeedbackBufferMode bufferMode) => GLPointers._TransformFeedbackVaryingsNV_fnptr((int)program, count, (int*)locations, (uint)bufferMode);
+            public static void TransformFeedbackVaryingsNV(int program, int count, TransformFeedbackTokenNV* locations, TransformFeedbackBufferMode bufferMode) => GLPointers._TransformFeedbackVaryingsNV_fnptr(program, count, (int*)locations, (uint)bufferMode);
             
             /// <summary> <b>[requires: GL_NV_transform_feedback]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ActiveVaryingNV(ProgramHandle program, byte* name) => GLPointers._ActiveVaryingNV_fnptr((int)program, name);
+            public static void ActiveVaryingNV(int program, byte* name) => GLPointers._ActiveVaryingNV_fnptr(program, name);
             
             /// <summary> <b>[requires: GL_NV_transform_feedback]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static int GetVaryingLocationNV(ProgramHandle program, byte* name) => GLPointers._GetVaryingLocationNV_fnptr((int)program, name);
+            public static int GetVaryingLocationNV(int program, byte* name) => GLPointers._GetVaryingLocationNV_fnptr(program, name);
             
             /// <summary> <b>[requires: GL_NV_transform_feedback]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetActiveVaryingNV(ProgramHandle program, uint index, int bufSize, int* length, int* size, All* type, byte* name) => GLPointers._GetActiveVaryingNV_fnptr((int)program, index, bufSize, length, size, (uint*)type, name);
+            public static void GetActiveVaryingNV(int program, uint index, int bufSize, int* length, int* size, All* type, byte* name) => GLPointers._GetActiveVaryingNV_fnptr(program, index, bufSize, length, size, (uint*)type, name);
             
             /// <summary> <b>[requires: GL_NV_transform_feedback]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetTransformFeedbackVaryingNV(ProgramHandle program, uint index, int* location) => GLPointers._GetTransformFeedbackVaryingNV_fnptr((int)program, index, location);
+            public static void GetTransformFeedbackVaryingNV(int program, uint index, int* location) => GLPointers._GetTransformFeedbackVaryingNV_fnptr(program, index, location);
             
             /// <summary> <b>[requires: GL_NV_transform_feedback]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -13357,19 +13357,19 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_NV_transform_feedback2]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void BindTransformFeedbackNV(BufferTargetARB target, TransformFeedbackHandle id) => GLPointers._BindTransformFeedbackNV_fnptr((uint)target, (int)id);
+            public static void BindTransformFeedbackNV(BufferTargetARB target, int id) => GLPointers._BindTransformFeedbackNV_fnptr((uint)target, id);
             
             /// <summary> <b>[requires: GL_NV_transform_feedback2]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void DeleteTransformFeedbacksNV(int n, TransformFeedbackHandle* ids) => GLPointers._DeleteTransformFeedbacksNV_fnptr(n, (int*)ids);
+            public static void DeleteTransformFeedbacksNV(int n, int* ids) => GLPointers._DeleteTransformFeedbacksNV_fnptr(n, ids);
             
             /// <summary> <b>[requires: GL_NV_transform_feedback2]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GenTransformFeedbacksNV(int n, TransformFeedbackHandle* ids) => GLPointers._GenTransformFeedbacksNV_fnptr(n, (int*)ids);
+            public static void GenTransformFeedbacksNV(int n, int* ids) => GLPointers._GenTransformFeedbacksNV_fnptr(n, ids);
             
             /// <summary> <b>[requires: GL_NV_transform_feedback2]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static bool IsTransformFeedbackNV(TransformFeedbackHandle id) => GLPointers._IsTransformFeedbackNV_fnptr((int)id) != 0;
+            public static bool IsTransformFeedbackNV(int id) => GLPointers._IsTransformFeedbackNV_fnptr(id) != 0;
             
             /// <summary> <b>[requires: GL_NV_transform_feedback2]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -13381,7 +13381,7 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_NV_transform_feedback2]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void DrawTransformFeedbackNV(PrimitiveType mode, TransformFeedbackHandle id) => GLPointers._DrawTransformFeedbackNV_fnptr((uint)mode, (int)id);
+            public static void DrawTransformFeedbackNV(PrimitiveType mode, int id) => GLPointers._DrawTransformFeedbackNV_fnptr((uint)mode, id);
             
             /// <summary> <b>[requires: GL_NV_vdpau_interop]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -13561,15 +13561,15 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_NV_vertex_program]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static bool AreProgramsResidentNV(int n, ProgramHandle* programs, bool* residences) => GLPointers._AreProgramsResidentNV_fnptr(n, (int*)programs, (byte*)residences) != 0;
+            public static bool AreProgramsResidentNV(int n, int* programs, bool* residences) => GLPointers._AreProgramsResidentNV_fnptr(n, programs, (byte*)residences) != 0;
             
             /// <summary> <b>[requires: GL_NV_vertex_program]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void BindProgramNV(VertexAttribEnumNV target, ProgramHandle id) => GLPointers._BindProgramNV_fnptr((uint)target, (int)id);
+            public static void BindProgramNV(VertexAttribEnumNV target, int id) => GLPointers._BindProgramNV_fnptr((uint)target, id);
             
             /// <summary> <b>[requires: GL_NV_vertex_program]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void DeleteProgramsNV(int n, ProgramHandle* programs) => GLPointers._DeleteProgramsNV_fnptr(n, (int*)programs);
+            public static void DeleteProgramsNV(int n, int* programs) => GLPointers._DeleteProgramsNV_fnptr(n, programs);
             
             /// <summary> <b>[requires: GL_NV_vertex_program]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -13577,7 +13577,7 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_NV_vertex_program]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GenProgramsNV(int n, ProgramHandle* programs) => GLPointers._GenProgramsNV_fnptr(n, (int*)programs);
+            public static void GenProgramsNV(int n, int* programs) => GLPointers._GenProgramsNV_fnptr(n, programs);
             
             /// <summary> <b>[requires: GL_NV_vertex_program]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -13589,11 +13589,11 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_NV_vertex_program]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetProgramivNV(ProgramHandle id, VertexAttribEnumNV pname, int* parameters) => GLPointers._GetProgramivNV_fnptr((int)id, (uint)pname, parameters);
+            public static void GetProgramivNV(int id, VertexAttribEnumNV pname, int* parameters) => GLPointers._GetProgramivNV_fnptr(id, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_NV_vertex_program]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetProgramStringNV(ProgramHandle id, VertexAttribEnumNV pname, byte* program) => GLPointers._GetProgramStringNV_fnptr((int)id, (uint)pname, program);
+            public static void GetProgramStringNV(int id, VertexAttribEnumNV pname, byte* program) => GLPointers._GetProgramStringNV_fnptr(id, (uint)pname, program);
             
             /// <summary> <b>[requires: GL_NV_vertex_program]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -13617,7 +13617,7 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_NV_vertex_program]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static bool IsProgramNV(ProgramHandle id) => GLPointers._IsProgramNV_fnptr((int)id) != 0;
+            public static bool IsProgramNV(int id) => GLPointers._IsProgramNV_fnptr(id) != 0;
             
             /// <summary> <b>[requires: GL_NV_vertex_program]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -13649,7 +13649,7 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_NV_vertex_program]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void RequestResidentProgramsNV(int n, ProgramHandle* programs) => GLPointers._RequestResidentProgramsNV_fnptr(n, (int*)programs);
+            public static void RequestResidentProgramsNV(int n, int* programs) => GLPointers._RequestResidentProgramsNV_fnptr(n, programs);
             
             /// <summary> <b>[requires: GL_NV_vertex_program]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -13917,7 +13917,7 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_NV_video_capture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void BindVideoCaptureStreamTextureNV(uint video_capture_slot, uint stream, All frame_region, All target, TextureHandle texture) => GLPointers._BindVideoCaptureStreamTextureNV_fnptr(video_capture_slot, stream, (uint)frame_region, (uint)target, (int)texture);
+            public static void BindVideoCaptureStreamTextureNV(uint video_capture_slot, uint stream, All frame_region, All target, int texture) => GLPointers._BindVideoCaptureStreamTextureNV_fnptr(video_capture_slot, stream, (uint)frame_region, (uint)target, texture);
             
             /// <summary> <b>[requires: GL_NV_video_capture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -14060,15 +14060,15 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_INTEL_map_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void SyncTextureINTEL(TextureHandle texture) => GLPointers._SyncTextureINTEL_fnptr((int)texture);
+            public static void SyncTextureINTEL(int texture) => GLPointers._SyncTextureINTEL_fnptr(texture);
             
             /// <summary> <b>[requires: GL_INTEL_map_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void UnmapTexture2DINTEL(TextureHandle texture, int level) => GLPointers._UnmapTexture2DINTEL_fnptr((int)texture, level);
+            public static void UnmapTexture2DINTEL(int texture, int level) => GLPointers._UnmapTexture2DINTEL_fnptr(texture, level);
             
             /// <summary> <b>[requires: GL_INTEL_map_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void* MapTexture2DINTEL(TextureHandle texture, int level, All access, int* stride, All* layout) => GLPointers._MapTexture2DINTEL_fnptr((int)texture, level, (uint)access, stride, (uint*)layout);
+            public static void* MapTexture2DINTEL(int texture, int level, All access, int* stride, All* layout) => GLPointers._MapTexture2DINTEL_fnptr(texture, level, (uint)access, stride, (uint*)layout);
             
             /// <summary> <b>[requires: GL_INTEL_parallel_arrays]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -14281,7 +14281,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="bufSize">Specifies the size of the buffer params.</param>
             /// <param name="parameters">Returns the value of the specified uniform variable.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetUniform.xhtml" /></remarks>
-            public static void GetnUniformfv(ProgramHandle program, int location, int bufSize, float* parameters) => GLPointers._GetnUniformfv_fnptr((int)program, location, bufSize, parameters);
+            public static void GetnUniformfv(int program, int location, int bufSize, float* parameters) => GLPointers._GetnUniformfv_fnptr(program, location, bufSize, parameters);
             
             /// <summary> <b>[requires: v4.5 | GL_KHR_robustness]</b> Returns the value of a uniform variable. </summary>
             /// <param name="program">Specifies the program object to be queried.</param>
@@ -14289,7 +14289,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="bufSize">Specifies the size of the buffer params.</param>
             /// <param name="parameters">Returns the value of the specified uniform variable.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetUniform.xhtml" /></remarks>
-            public static void GetnUniformiv(ProgramHandle program, int location, int bufSize, int* parameters) => GLPointers._GetnUniformiv_fnptr((int)program, location, bufSize, parameters);
+            public static void GetnUniformiv(int program, int location, int bufSize, int* parameters) => GLPointers._GetnUniformiv_fnptr(program, location, bufSize, parameters);
             
             /// <summary> <b>[requires: v4.5 | GL_KHR_robustness]</b> Returns the value of a uniform variable. </summary>
             /// <param name="program">Specifies the program object to be queried.</param>
@@ -14297,7 +14297,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="bufSize">Specifies the size of the buffer params.</param>
             /// <param name="parameters">Returns the value of the specified uniform variable.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetUniform.xhtml" /></remarks>
-            public static void GetnUniformuiv(ProgramHandle program, int location, int bufSize, uint* parameters) => GLPointers._GetnUniformuiv_fnptr((int)program, location, bufSize, parameters);
+            public static void GetnUniformuiv(int program, int location, int bufSize, uint* parameters) => GLPointers._GetnUniformuiv_fnptr(program, location, bufSize, parameters);
             
             /// <summary> <b>[requires: GL_KHR_robustness]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -14309,15 +14309,15 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_KHR_robustness]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetnUniformfvKHR(ProgramHandle program, int location, int bufSize, float* parameters) => GLPointers._GetnUniformfvKHR_fnptr((int)program, location, bufSize, parameters);
+            public static void GetnUniformfvKHR(int program, int location, int bufSize, float* parameters) => GLPointers._GetnUniformfvKHR_fnptr(program, location, bufSize, parameters);
             
             /// <summary> <b>[requires: GL_KHR_robustness]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetnUniformivKHR(ProgramHandle program, int location, int bufSize, int* parameters) => GLPointers._GetnUniformivKHR_fnptr((int)program, location, bufSize, parameters);
+            public static void GetnUniformivKHR(int program, int location, int bufSize, int* parameters) => GLPointers._GetnUniformivKHR_fnptr(program, location, bufSize, parameters);
             
             /// <summary> <b>[requires: GL_KHR_robustness]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetnUniformuivKHR(ProgramHandle program, int location, int bufSize, uint* parameters) => GLPointers._GetnUniformuivKHR_fnptr((int)program, location, bufSize, parameters);
+            public static void GetnUniformuivKHR(int program, int location, int bufSize, uint* parameters) => GLPointers._GetnUniformuivKHR_fnptr(program, location, bufSize, parameters);
             
             /// <summary> <b>[requires: GL_KHR_parallel_shader_compile]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -14447,7 +14447,7 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_NVX_linked_gpu_multicast]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void LGPUNamedBufferSubDataNVX(All gpuMask, BufferHandle buffer, IntPtr offset, nint size, void* data) => GLPointers._LGPUNamedBufferSubDataNVX_fnptr((uint)gpuMask, (int)buffer, offset, size, data);
+            public static void LGPUNamedBufferSubDataNVX(All gpuMask, int buffer, IntPtr offset, nint size, void* data) => GLPointers._LGPUNamedBufferSubDataNVX_fnptr((uint)gpuMask, buffer, offset, size, data);
             
             /// <summary> <b>[requires: GL_NVX_linked_gpu_multicast]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -14475,7 +14475,7 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_NVX_gpu_multicast2]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static uint AsyncCopyBufferSubDataNVX(int waitSemaphoreCount, uint* waitSemaphoreArray, ulong* fenceValueArray, uint readGpu, All writeGpuMask, BufferHandle readBuffer, BufferHandle writeBuffer, IntPtr readOffset, IntPtr writeOffset, nint size, int signalSemaphoreCount, uint* signalSemaphoreArray, ulong* signalValueArray) => GLPointers._AsyncCopyBufferSubDataNVX_fnptr(waitSemaphoreCount, waitSemaphoreArray, fenceValueArray, readGpu, (uint)writeGpuMask, (int)readBuffer, (int)writeBuffer, readOffset, writeOffset, size, signalSemaphoreCount, signalSemaphoreArray, signalValueArray);
+            public static uint AsyncCopyBufferSubDataNVX(int waitSemaphoreCount, uint* waitSemaphoreArray, ulong* fenceValueArray, uint readGpu, All writeGpuMask, int readBuffer, int writeBuffer, IntPtr readOffset, IntPtr writeOffset, nint size, int signalSemaphoreCount, uint* signalSemaphoreArray, ulong* signalValueArray) => GLPointers._AsyncCopyBufferSubDataNVX_fnptr(waitSemaphoreCount, waitSemaphoreArray, fenceValueArray, readGpu, (uint)writeGpuMask, readBuffer, writeBuffer, readOffset, writeOffset, size, signalSemaphoreCount, signalSemaphoreArray, signalValueArray);
             
             /// <summary> <b>[requires: GL_NVX_gpu_multicast2]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -14918,7 +14918,7 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_OES_fixed_point]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void PrioritizeTexturesxOES(int n, TextureHandle* textures, int* priorities) => GLPointers._PrioritizeTexturesxOES_fnptr(n, (int*)textures, priorities);
+            public static void PrioritizeTexturesxOES(int n, int* textures, int* priorities) => GLPointers._PrioritizeTexturesxOES_fnptr(n, textures, priorities);
             
             /// <summary> <b>[requires: GL_OES_fixed_point]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -15049,7 +15049,7 @@ namespace OpenTK.Graphics.OpenGL
         {
             /// <summary> <b>[requires: GL_OVR_multiview]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void FramebufferTextureMultiviewOVR(FramebufferTarget target, FramebufferAttachment attachment, TextureHandle texture, int level, int baseViewIndex, int numViews) => GLPointers._FramebufferTextureMultiviewOVR_fnptr((uint)target, (uint)attachment, (int)texture, level, baseViewIndex, numViews);
+            public static void FramebufferTextureMultiviewOVR(FramebufferTarget target, FramebufferAttachment attachment, int texture, int level, int baseViewIndex, int numViews) => GLPointers._FramebufferTextureMultiviewOVR_fnptr((uint)target, (uint)attachment, texture, level, baseViewIndex, numViews);
             
         }
         public static unsafe partial class PGI
@@ -15282,27 +15282,27 @@ namespace OpenTK.Graphics.OpenGL
             
             /// <summary> <b>[requires: GL_SGIX_list_priority]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetListParameterfvSGIX(DisplayListHandle list, ListParameterName pname, float* parameters) => GLPointers._GetListParameterfvSGIX_fnptr((int)list, (uint)pname, parameters);
+            public static void GetListParameterfvSGIX(int list, ListParameterName pname, float* parameters) => GLPointers._GetListParameterfvSGIX_fnptr(list, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_SGIX_list_priority]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetListParameterivSGIX(DisplayListHandle list, ListParameterName pname, int* parameters) => GLPointers._GetListParameterivSGIX_fnptr((int)list, (uint)pname, parameters);
+            public static void GetListParameterivSGIX(int list, ListParameterName pname, int* parameters) => GLPointers._GetListParameterivSGIX_fnptr(list, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_SGIX_list_priority]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ListParameterfSGIX(DisplayListHandle list, ListParameterName pname, float param) => GLPointers._ListParameterfSGIX_fnptr((int)list, (uint)pname, param);
+            public static void ListParameterfSGIX(int list, ListParameterName pname, float param) => GLPointers._ListParameterfSGIX_fnptr(list, (uint)pname, param);
             
             /// <summary> <b>[requires: GL_SGIX_list_priority]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ListParameterfvSGIX(DisplayListHandle list, ListParameterName pname, float* parameters) => GLPointers._ListParameterfvSGIX_fnptr((int)list, (uint)pname, parameters);
+            public static void ListParameterfvSGIX(int list, ListParameterName pname, float* parameters) => GLPointers._ListParameterfvSGIX_fnptr(list, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_SGIX_list_priority]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ListParameteriSGIX(DisplayListHandle list, ListParameterName pname, int param) => GLPointers._ListParameteriSGIX_fnptr((int)list, (uint)pname, param);
+            public static void ListParameteriSGIX(int list, ListParameterName pname, int param) => GLPointers._ListParameteriSGIX_fnptr(list, (uint)pname, param);
             
             /// <summary> <b>[requires: GL_SGIX_list_priority]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ListParameterivSGIX(DisplayListHandle list, ListParameterName pname, int* parameters) => GLPointers._ListParameterivSGIX_fnptr((int)list, (uint)pname, parameters);
+            public static void ListParameterivSGIX(int list, ListParameterName pname, int* parameters) => GLPointers._ListParameterivSGIX_fnptr(list, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_SGIX_pixel_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>

--- a/src/OpenTK.Graphics/OpenGL/GL.Overloads.cs
+++ b/src/OpenTK.Graphics/OpenGL/GL.Overloads.cs
@@ -464,44 +464,44 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="DeleteTextures"/>
-        public static unsafe void DeleteTexture(in TextureHandle texture)
+        public static unsafe void DeleteTexture(in int texture)
         {
             int n = 1;
-            fixed(TextureHandle* textures_handle = &texture)
+            fixed(int* textures_handle = &texture)
             {
                 DeleteTextures(n, textures_handle);
             }
         }
         /// <inheritdoc cref="DeleteTextures"/>
-        public static unsafe void DeleteTextures(ReadOnlySpan<TextureHandle> textures)
+        public static unsafe void DeleteTextures(ReadOnlySpan<int> textures)
         {
             int n = (int)(textures.Length);
-            fixed (TextureHandle* textures_ptr = textures)
+            fixed (int* textures_ptr = textures)
             {
                 DeleteTextures(n, textures_ptr);
             }
         }
         /// <inheritdoc cref="DeleteTextures"/>
-        public static unsafe void DeleteTextures(TextureHandle[] textures)
+        public static unsafe void DeleteTextures(int[] textures)
         {
             int n = (int)(textures.Length);
-            fixed (TextureHandle* textures_ptr = textures)
+            fixed (int* textures_ptr = textures)
             {
                 DeleteTextures(n, textures_ptr);
             }
         }
         /// <inheritdoc cref="DeleteTextures"/>
-        public static unsafe void DeleteTextures(int n, in TextureHandle textures)
+        public static unsafe void DeleteTextures(int n, in int textures)
         {
-            fixed (TextureHandle* textures_ptr = &textures)
+            fixed (int* textures_ptr = &textures)
             {
                 DeleteTextures(n, textures_ptr);
             }
         }
         /// <inheritdoc cref="GenTextures"/>
-        public static unsafe TextureHandle GenTexture()
+        public static unsafe int GenTexture()
         {
-            TextureHandle texture;
+            int texture;
             int n = 1;
             Unsafe.SkipInit(out texture);
             // FIXME: This could be a problem for the overloads that take an out parameter
@@ -512,12 +512,12 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            TextureHandle* textures_handle = (TextureHandle*)Unsafe.AsPointer(ref texture);
+            int* textures_handle = (int*)Unsafe.AsPointer(ref texture);
             GenTextures(n, textures_handle);
             return texture;
         }
         /// <inheritdoc cref="GenTextures"/>
-        public static unsafe void GenTexture(out TextureHandle texture)
+        public static unsafe void GenTexture(out int texture)
         {
             int n = 1;
             Unsafe.SkipInit(out texture);
@@ -529,31 +529,31 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            TextureHandle* textures_handle = (TextureHandle*)Unsafe.AsPointer(ref texture);
+            int* textures_handle = (int*)Unsafe.AsPointer(ref texture);
             GenTextures(n, textures_handle);
         }
         /// <inheritdoc cref="GenTextures"/>
-        public static unsafe void GenTextures(Span<TextureHandle> textures)
+        public static unsafe void GenTextures(Span<int> textures)
         {
             int n = (int)(textures.Length);
-            fixed (TextureHandle* textures_ptr = textures)
+            fixed (int* textures_ptr = textures)
             {
                 GenTextures(n, textures_ptr);
             }
         }
         /// <inheritdoc cref="GenTextures"/>
-        public static unsafe void GenTextures(TextureHandle[] textures)
+        public static unsafe void GenTextures(int[] textures)
         {
             int n = (int)(textures.Length);
-            fixed (TextureHandle* textures_ptr = textures)
+            fixed (int* textures_ptr = textures)
             {
                 GenTextures(n, textures_ptr);
             }
         }
         /// <inheritdoc cref="GenTextures"/>
-        public static unsafe void GenTextures(int n, ref TextureHandle textures)
+        public static unsafe void GenTextures(int n, ref int textures)
         {
-            fixed (TextureHandle* textures_ptr = &textures)
+            fixed (int* textures_ptr = &textures)
             {
                 GenTextures(n, textures_ptr);
             }
@@ -977,9 +977,9 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GenQueries"/>
-        public static unsafe QueryHandle GenQuery()
+        public static unsafe int GenQuery()
         {
-            QueryHandle id;
+            int id;
             int n = 1;
             Unsafe.SkipInit(out id);
             // FIXME: This could be a problem for the overloads that take an out parameter
@@ -990,12 +990,12 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            QueryHandle* ids_handle = (QueryHandle*)Unsafe.AsPointer(ref id);
+            int* ids_handle = (int*)Unsafe.AsPointer(ref id);
             GenQueries(n, ids_handle);
             return id;
         }
         /// <inheritdoc cref="GenQueries"/>
-        public static unsafe void GenQuery(out QueryHandle id)
+        public static unsafe void GenQuery(out int id)
         {
             int n = 1;
             Unsafe.SkipInit(out id);
@@ -1007,66 +1007,66 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            QueryHandle* ids_handle = (QueryHandle*)Unsafe.AsPointer(ref id);
+            int* ids_handle = (int*)Unsafe.AsPointer(ref id);
             GenQueries(n, ids_handle);
         }
         /// <inheritdoc cref="GenQueries"/>
-        public static unsafe void GenQueries(Span<QueryHandle> ids)
+        public static unsafe void GenQueries(Span<int> ids)
         {
             int n = (int)(ids.Length);
-            fixed (QueryHandle* ids_ptr = ids)
+            fixed (int* ids_ptr = ids)
             {
                 GenQueries(n, ids_ptr);
             }
         }
         /// <inheritdoc cref="GenQueries"/>
-        public static unsafe void GenQueries(QueryHandle[] ids)
+        public static unsafe void GenQueries(int[] ids)
         {
             int n = (int)(ids.Length);
-            fixed (QueryHandle* ids_ptr = ids)
+            fixed (int* ids_ptr = ids)
             {
                 GenQueries(n, ids_ptr);
             }
         }
         /// <inheritdoc cref="GenQueries"/>
-        public static unsafe void GenQueries(int n, ref QueryHandle ids)
+        public static unsafe void GenQueries(int n, ref int ids)
         {
-            fixed (QueryHandle* ids_ptr = &ids)
+            fixed (int* ids_ptr = &ids)
             {
                 GenQueries(n, ids_ptr);
             }
         }
         /// <inheritdoc cref="DeleteQueries"/>
-        public static unsafe void DeleteQuery(in QueryHandle id)
+        public static unsafe void DeleteQuery(in int id)
         {
             int n = 1;
-            fixed(QueryHandle* ids_handle = &id)
+            fixed(int* ids_handle = &id)
             {
                 DeleteQueries(n, ids_handle);
             }
         }
         /// <inheritdoc cref="DeleteQueries"/>
-        public static unsafe void DeleteQueries(ReadOnlySpan<QueryHandle> ids)
+        public static unsafe void DeleteQueries(ReadOnlySpan<int> ids)
         {
             int n = (int)(ids.Length);
-            fixed (QueryHandle* ids_ptr = ids)
+            fixed (int* ids_ptr = ids)
             {
                 DeleteQueries(n, ids_ptr);
             }
         }
         /// <inheritdoc cref="DeleteQueries"/>
-        public static unsafe void DeleteQueries(QueryHandle[] ids)
+        public static unsafe void DeleteQueries(int[] ids)
         {
             int n = (int)(ids.Length);
-            fixed (QueryHandle* ids_ptr = ids)
+            fixed (int* ids_ptr = ids)
             {
                 DeleteQueries(n, ids_ptr);
             }
         }
         /// <inheritdoc cref="DeleteQueries"/>
-        public static unsafe void DeleteQueries(int n, in QueryHandle ids)
+        public static unsafe void DeleteQueries(int n, in int ids)
         {
-            fixed (QueryHandle* ids_ptr = &ids)
+            fixed (int* ids_ptr = &ids)
             {
                 DeleteQueries(n, ids_ptr);
             }
@@ -1096,7 +1096,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetQueryObjectiv"/>
-        public static unsafe void GetQueryObjecti(QueryHandle id, QueryObjectParameterName pname, Span<int> parameters)
+        public static unsafe void GetQueryObjecti(int id, QueryObjectParameterName pname, Span<int> parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
@@ -1104,7 +1104,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetQueryObjectiv"/>
-        public static unsafe void GetQueryObjecti(QueryHandle id, QueryObjectParameterName pname, int[] parameters)
+        public static unsafe void GetQueryObjecti(int id, QueryObjectParameterName pname, int[] parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
@@ -1112,7 +1112,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetQueryObjectiv"/>
-        public static unsafe void GetQueryObjecti(QueryHandle id, QueryObjectParameterName pname, ref int parameters)
+        public static unsafe void GetQueryObjecti(int id, QueryObjectParameterName pname, ref int parameters)
         {
             fixed (int* parameters_ptr = &parameters)
             {
@@ -1120,7 +1120,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetQueryObjectuiv"/>
-        public static unsafe void GetQueryObjectui(QueryHandle id, QueryObjectParameterName pname, Span<uint> parameters)
+        public static unsafe void GetQueryObjectui(int id, QueryObjectParameterName pname, Span<uint> parameters)
         {
             fixed (uint* parameters_ptr = parameters)
             {
@@ -1128,7 +1128,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetQueryObjectuiv"/>
-        public static unsafe void GetQueryObjectui(QueryHandle id, QueryObjectParameterName pname, uint[] parameters)
+        public static unsafe void GetQueryObjectui(int id, QueryObjectParameterName pname, uint[] parameters)
         {
             fixed (uint* parameters_ptr = parameters)
             {
@@ -1136,7 +1136,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetQueryObjectuiv"/>
-        public static unsafe void GetQueryObjectui(QueryHandle id, QueryObjectParameterName pname, ref uint parameters)
+        public static unsafe void GetQueryObjectui(int id, QueryObjectParameterName pname, ref uint parameters)
         {
             fixed (uint* parameters_ptr = &parameters)
             {
@@ -1144,44 +1144,44 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="DeleteBuffers"/>
-        public static unsafe void DeleteBuffer(in BufferHandle buffer)
+        public static unsafe void DeleteBuffer(in int buffer)
         {
             int n = 1;
-            fixed(BufferHandle* buffers_handle = &buffer)
+            fixed(int* buffers_handle = &buffer)
             {
                 DeleteBuffers(n, buffers_handle);
             }
         }
         /// <inheritdoc cref="DeleteBuffers"/>
-        public static unsafe void DeleteBuffers(ReadOnlySpan<BufferHandle> buffers)
+        public static unsafe void DeleteBuffers(ReadOnlySpan<int> buffers)
         {
             int n = (int)(buffers.Length);
-            fixed (BufferHandle* buffers_ptr = buffers)
+            fixed (int* buffers_ptr = buffers)
             {
                 DeleteBuffers(n, buffers_ptr);
             }
         }
         /// <inheritdoc cref="DeleteBuffers"/>
-        public static unsafe void DeleteBuffers(BufferHandle[] buffers)
+        public static unsafe void DeleteBuffers(int[] buffers)
         {
             int n = (int)(buffers.Length);
-            fixed (BufferHandle* buffers_ptr = buffers)
+            fixed (int* buffers_ptr = buffers)
             {
                 DeleteBuffers(n, buffers_ptr);
             }
         }
         /// <inheritdoc cref="DeleteBuffers"/>
-        public static unsafe void DeleteBuffers(int n, in BufferHandle buffers)
+        public static unsafe void DeleteBuffers(int n, in int buffers)
         {
-            fixed (BufferHandle* buffers_ptr = &buffers)
+            fixed (int* buffers_ptr = &buffers)
             {
                 DeleteBuffers(n, buffers_ptr);
             }
         }
         /// <inheritdoc cref="GenBuffers"/>
-        public static unsafe BufferHandle GenBuffer()
+        public static unsafe int GenBuffer()
         {
-            BufferHandle buffer;
+            int buffer;
             int n = 1;
             Unsafe.SkipInit(out buffer);
             // FIXME: This could be a problem for the overloads that take an out parameter
@@ -1192,12 +1192,12 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            BufferHandle* buffers_handle = (BufferHandle*)Unsafe.AsPointer(ref buffer);
+            int* buffers_handle = (int*)Unsafe.AsPointer(ref buffer);
             GenBuffers(n, buffers_handle);
             return buffer;
         }
         /// <inheritdoc cref="GenBuffers"/>
-        public static unsafe void GenBuffer(out BufferHandle buffer)
+        public static unsafe void GenBuffer(out int buffer)
         {
             int n = 1;
             Unsafe.SkipInit(out buffer);
@@ -1209,31 +1209,31 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            BufferHandle* buffers_handle = (BufferHandle*)Unsafe.AsPointer(ref buffer);
+            int* buffers_handle = (int*)Unsafe.AsPointer(ref buffer);
             GenBuffers(n, buffers_handle);
         }
         /// <inheritdoc cref="GenBuffers"/>
-        public static unsafe void GenBuffers(Span<BufferHandle> buffers)
+        public static unsafe void GenBuffers(Span<int> buffers)
         {
             int n = (int)(buffers.Length);
-            fixed (BufferHandle* buffers_ptr = buffers)
+            fixed (int* buffers_ptr = buffers)
             {
                 GenBuffers(n, buffers_ptr);
             }
         }
         /// <inheritdoc cref="GenBuffers"/>
-        public static unsafe void GenBuffers(BufferHandle[] buffers)
+        public static unsafe void GenBuffers(int[] buffers)
         {
             int n = (int)(buffers.Length);
-            fixed (BufferHandle* buffers_ptr = buffers)
+            fixed (int* buffers_ptr = buffers)
             {
                 GenBuffers(n, buffers_ptr);
             }
         }
         /// <inheritdoc cref="GenBuffers"/>
-        public static unsafe void GenBuffers(int n, ref BufferHandle buffers)
+        public static unsafe void GenBuffers(int n, ref int buffers)
         {
-            fixed (BufferHandle* buffers_ptr = &buffers)
+            fixed (int* buffers_ptr = &buffers)
             {
                 GenBuffers(n, buffers_ptr);
             }
@@ -1399,14 +1399,14 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="BindAttribLocation"/>
-        public static unsafe void BindAttribLocation(ProgramHandle program, uint index, string name)
+        public static unsafe void BindAttribLocation(int program, uint index, string name)
         {
             byte* name_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(name);
             BindAttribLocation(program, index, name_ptr);
             Marshal.FreeCoTaskMem((IntPtr)name_ptr);
         }
         /// <inheritdoc cref="GetActiveAttrib"/>
-        public static unsafe string GetActiveAttrib(ProgramHandle program, uint index, int bufSize, Span<int> length, Span<int> size, Span<AttributeType> type)
+        public static unsafe string GetActiveAttrib(int program, uint index, int bufSize, Span<int> length, Span<int> size, Span<AttributeType> type)
         {
             string name;
             fixed (int* length_ptr = length)
@@ -1425,7 +1425,7 @@ namespace OpenTK.Graphics.OpenGL
             return name;
         }
         /// <inheritdoc cref="GetActiveAttrib"/>
-        public static unsafe void GetActiveAttrib(ProgramHandle program, uint index, int bufSize, Span<int> length, Span<int> size, Span<AttributeType> type, out string name)
+        public static unsafe void GetActiveAttrib(int program, uint index, int bufSize, Span<int> length, Span<int> size, Span<AttributeType> type, out string name)
         {
             fixed (int* length_ptr = length)
             {
@@ -1442,7 +1442,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetActiveAttrib"/>
-        public static unsafe string GetActiveAttrib(ProgramHandle program, uint index, int bufSize, int[] length, int[] size, AttributeType[] type)
+        public static unsafe string GetActiveAttrib(int program, uint index, int bufSize, int[] length, int[] size, AttributeType[] type)
         {
             string name;
             fixed (int* length_ptr = length)
@@ -1461,7 +1461,7 @@ namespace OpenTK.Graphics.OpenGL
             return name;
         }
         /// <inheritdoc cref="GetActiveAttrib"/>
-        public static unsafe void GetActiveAttrib(ProgramHandle program, uint index, int bufSize, int[] length, int[] size, AttributeType[] type, out string name)
+        public static unsafe void GetActiveAttrib(int program, uint index, int bufSize, int[] length, int[] size, AttributeType[] type, out string name)
         {
             fixed (int* length_ptr = length)
             {
@@ -1478,7 +1478,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetActiveAttrib"/>
-        public static unsafe string GetActiveAttrib(ProgramHandle program, uint index, int bufSize, ref int length, ref int size, ref AttributeType type)
+        public static unsafe string GetActiveAttrib(int program, uint index, int bufSize, ref int length, ref int size, ref AttributeType type)
         {
             string name;
             fixed (int* length_ptr = &length)
@@ -1493,7 +1493,7 @@ namespace OpenTK.Graphics.OpenGL
             return name;
         }
         /// <inheritdoc cref="GetActiveAttrib"/>
-        public static unsafe void GetActiveAttrib(ProgramHandle program, uint index, int bufSize, ref int length, ref int size, ref AttributeType type, out string name)
+        public static unsafe void GetActiveAttrib(int program, uint index, int bufSize, ref int length, ref int size, ref AttributeType type, out string name)
         {
             fixed (int* length_ptr = &length)
             fixed (int* size_ptr = &size)
@@ -1506,7 +1506,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetActiveUniform"/>
-        public static unsafe string GetActiveUniform(ProgramHandle program, uint index, int bufSize, Span<int> length, Span<int> size, Span<UniformType> type)
+        public static unsafe string GetActiveUniform(int program, uint index, int bufSize, Span<int> length, Span<int> size, Span<UniformType> type)
         {
             string name;
             fixed (int* length_ptr = length)
@@ -1525,7 +1525,7 @@ namespace OpenTK.Graphics.OpenGL
             return name;
         }
         /// <inheritdoc cref="GetActiveUniform"/>
-        public static unsafe void GetActiveUniform(ProgramHandle program, uint index, int bufSize, Span<int> length, Span<int> size, Span<UniformType> type, out string name)
+        public static unsafe void GetActiveUniform(int program, uint index, int bufSize, Span<int> length, Span<int> size, Span<UniformType> type, out string name)
         {
             fixed (int* length_ptr = length)
             {
@@ -1542,7 +1542,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetActiveUniform"/>
-        public static unsafe string GetActiveUniform(ProgramHandle program, uint index, int bufSize, int[] length, int[] size, UniformType[] type)
+        public static unsafe string GetActiveUniform(int program, uint index, int bufSize, int[] length, int[] size, UniformType[] type)
         {
             string name;
             fixed (int* length_ptr = length)
@@ -1561,7 +1561,7 @@ namespace OpenTK.Graphics.OpenGL
             return name;
         }
         /// <inheritdoc cref="GetActiveUniform"/>
-        public static unsafe void GetActiveUniform(ProgramHandle program, uint index, int bufSize, int[] length, int[] size, UniformType[] type, out string name)
+        public static unsafe void GetActiveUniform(int program, uint index, int bufSize, int[] length, int[] size, UniformType[] type, out string name)
         {
             fixed (int* length_ptr = length)
             {
@@ -1578,7 +1578,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetActiveUniform"/>
-        public static unsafe string GetActiveUniform(ProgramHandle program, uint index, int bufSize, ref int length, ref int size, ref UniformType type)
+        public static unsafe string GetActiveUniform(int program, uint index, int bufSize, ref int length, ref int size, ref UniformType type)
         {
             string name;
             fixed (int* length_ptr = &length)
@@ -1593,7 +1593,7 @@ namespace OpenTK.Graphics.OpenGL
             return name;
         }
         /// <inheritdoc cref="GetActiveUniform"/>
-        public static unsafe void GetActiveUniform(ProgramHandle program, uint index, int bufSize, ref int length, ref int size, ref UniformType type, out string name)
+        public static unsafe void GetActiveUniform(int program, uint index, int bufSize, ref int length, ref int size, ref UniformType type, out string name)
         {
             fixed (int* length_ptr = &length)
             fixed (int* size_ptr = &size)
@@ -1606,40 +1606,40 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetAttachedShaders"/>
-        public static unsafe void GetAttachedShaders(ProgramHandle program, Span<int> count, Span<ShaderHandle> shaders)
+        public static unsafe void GetAttachedShaders(int program, Span<int> count, Span<int> shaders)
         {
             fixed (int* count_ptr = count)
             {
                 int maxCount = (int)(shaders.Length);
-                fixed (ShaderHandle* shaders_ptr = shaders)
+                fixed (int* shaders_ptr = shaders)
                 {
                     GetAttachedShaders(program, maxCount, count_ptr, shaders_ptr);
                 }
             }
         }
         /// <inheritdoc cref="GetAttachedShaders"/>
-        public static unsafe void GetAttachedShaders(ProgramHandle program, int[] count, ShaderHandle[] shaders)
+        public static unsafe void GetAttachedShaders(int program, int[] count, int[] shaders)
         {
             fixed (int* count_ptr = count)
             {
                 int maxCount = (int)(shaders.Length);
-                fixed (ShaderHandle* shaders_ptr = shaders)
+                fixed (int* shaders_ptr = shaders)
                 {
                     GetAttachedShaders(program, maxCount, count_ptr, shaders_ptr);
                 }
             }
         }
         /// <inheritdoc cref="GetAttachedShaders"/>
-        public static unsafe void GetAttachedShaders(ProgramHandle program, int maxCount, ref int count, ref ShaderHandle shaders)
+        public static unsafe void GetAttachedShaders(int program, int maxCount, ref int count, ref int shaders)
         {
             fixed (int* count_ptr = &count)
-            fixed (ShaderHandle* shaders_ptr = &shaders)
+            fixed (int* shaders_ptr = &shaders)
             {
                 GetAttachedShaders(program, maxCount, count_ptr, shaders_ptr);
             }
         }
         /// <inheritdoc cref="GetAttribLocation"/>
-        public static unsafe int GetAttribLocation(ProgramHandle program, string name)
+        public static unsafe int GetAttribLocation(int program, string name)
         {
             int returnValue;
             byte* name_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(name);
@@ -1648,7 +1648,7 @@ namespace OpenTK.Graphics.OpenGL
             return returnValue;
         }
         /// <inheritdoc cref="GetProgramiv"/>
-        public static unsafe void GetProgrami(ProgramHandle program, ProgramPropertyARB pname, Span<int> parameters)
+        public static unsafe void GetProgrami(int program, ProgramPropertyARB pname, Span<int> parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
@@ -1656,7 +1656,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetProgramiv"/>
-        public static unsafe void GetProgrami(ProgramHandle program, ProgramPropertyARB pname, int[] parameters)
+        public static unsafe void GetProgrami(int program, ProgramPropertyARB pname, int[] parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
@@ -1664,7 +1664,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetProgramiv"/>
-        public static unsafe void GetProgrami(ProgramHandle program, ProgramPropertyARB pname, ref int parameters)
+        public static unsafe void GetProgrami(int program, ProgramPropertyARB pname, ref int parameters)
         {
             fixed (int* parameters_ptr = &parameters)
             {
@@ -1672,7 +1672,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetProgramInfoLog"/>
-        public static unsafe string GetProgramInfoLog(ProgramHandle program, int bufSize, Span<int> length)
+        public static unsafe string GetProgramInfoLog(int program, int bufSize, Span<int> length)
         {
             string infoLog;
             fixed (int* length_ptr = length)
@@ -1685,7 +1685,7 @@ namespace OpenTK.Graphics.OpenGL
             return infoLog;
         }
         /// <inheritdoc cref="GetProgramInfoLog"/>
-        public static unsafe void GetProgramInfoLog(ProgramHandle program, int bufSize, Span<int> length, out string infoLog)
+        public static unsafe void GetProgramInfoLog(int program, int bufSize, Span<int> length, out string infoLog)
         {
             fixed (int* length_ptr = length)
             {
@@ -1696,7 +1696,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetProgramInfoLog"/>
-        public static unsafe string GetProgramInfoLog(ProgramHandle program, int bufSize, int[] length)
+        public static unsafe string GetProgramInfoLog(int program, int bufSize, int[] length)
         {
             string infoLog;
             fixed (int* length_ptr = length)
@@ -1709,7 +1709,7 @@ namespace OpenTK.Graphics.OpenGL
             return infoLog;
         }
         /// <inheritdoc cref="GetProgramInfoLog"/>
-        public static unsafe void GetProgramInfoLog(ProgramHandle program, int bufSize, int[] length, out string infoLog)
+        public static unsafe void GetProgramInfoLog(int program, int bufSize, int[] length, out string infoLog)
         {
             fixed (int* length_ptr = length)
             {
@@ -1720,7 +1720,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetProgramInfoLog"/>
-        public static unsafe string GetProgramInfoLog(ProgramHandle program, int bufSize, ref int length)
+        public static unsafe string GetProgramInfoLog(int program, int bufSize, ref int length)
         {
             string infoLog;
             fixed (int* length_ptr = &length)
@@ -1733,7 +1733,7 @@ namespace OpenTK.Graphics.OpenGL
             return infoLog;
         }
         /// <inheritdoc cref="GetProgramInfoLog"/>
-        public static unsafe void GetProgramInfoLog(ProgramHandle program, int bufSize, ref int length, out string infoLog)
+        public static unsafe void GetProgramInfoLog(int program, int bufSize, ref int length, out string infoLog)
         {
             fixed (int* length_ptr = &length)
             {
@@ -1744,7 +1744,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetShaderiv"/>
-        public static unsafe void GetShaderi(ShaderHandle shader, ShaderParameterName pname, Span<int> parameters)
+        public static unsafe void GetShaderi(int shader, ShaderParameterName pname, Span<int> parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
@@ -1752,7 +1752,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetShaderiv"/>
-        public static unsafe void GetShaderi(ShaderHandle shader, ShaderParameterName pname, int[] parameters)
+        public static unsafe void GetShaderi(int shader, ShaderParameterName pname, int[] parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
@@ -1760,7 +1760,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetShaderiv"/>
-        public static unsafe void GetShaderi(ShaderHandle shader, ShaderParameterName pname, ref int parameters)
+        public static unsafe void GetShaderi(int shader, ShaderParameterName pname, ref int parameters)
         {
             fixed (int* parameters_ptr = &parameters)
             {
@@ -1768,7 +1768,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetShaderInfoLog"/>
-        public static unsafe string GetShaderInfoLog(ShaderHandle shader, int bufSize, Span<int> length)
+        public static unsafe string GetShaderInfoLog(int shader, int bufSize, Span<int> length)
         {
             string infoLog;
             fixed (int* length_ptr = length)
@@ -1781,7 +1781,7 @@ namespace OpenTK.Graphics.OpenGL
             return infoLog;
         }
         /// <inheritdoc cref="GetShaderInfoLog"/>
-        public static unsafe void GetShaderInfoLog(ShaderHandle shader, int bufSize, Span<int> length, out string infoLog)
+        public static unsafe void GetShaderInfoLog(int shader, int bufSize, Span<int> length, out string infoLog)
         {
             fixed (int* length_ptr = length)
             {
@@ -1792,7 +1792,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetShaderInfoLog"/>
-        public static unsafe string GetShaderInfoLog(ShaderHandle shader, int bufSize, int[] length)
+        public static unsafe string GetShaderInfoLog(int shader, int bufSize, int[] length)
         {
             string infoLog;
             fixed (int* length_ptr = length)
@@ -1805,7 +1805,7 @@ namespace OpenTK.Graphics.OpenGL
             return infoLog;
         }
         /// <inheritdoc cref="GetShaderInfoLog"/>
-        public static unsafe void GetShaderInfoLog(ShaderHandle shader, int bufSize, int[] length, out string infoLog)
+        public static unsafe void GetShaderInfoLog(int shader, int bufSize, int[] length, out string infoLog)
         {
             fixed (int* length_ptr = length)
             {
@@ -1816,7 +1816,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetShaderInfoLog"/>
-        public static unsafe string GetShaderInfoLog(ShaderHandle shader, int bufSize, ref int length)
+        public static unsafe string GetShaderInfoLog(int shader, int bufSize, ref int length)
         {
             string infoLog;
             fixed (int* length_ptr = &length)
@@ -1829,7 +1829,7 @@ namespace OpenTK.Graphics.OpenGL
             return infoLog;
         }
         /// <inheritdoc cref="GetShaderInfoLog"/>
-        public static unsafe void GetShaderInfoLog(ShaderHandle shader, int bufSize, ref int length, out string infoLog)
+        public static unsafe void GetShaderInfoLog(int shader, int bufSize, ref int length, out string infoLog)
         {
             fixed (int* length_ptr = &length)
             {
@@ -1840,7 +1840,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetShaderSource"/>
-        public static unsafe string GetShaderSource(ShaderHandle shader, int bufSize, Span<int> length)
+        public static unsafe string GetShaderSource(int shader, int bufSize, Span<int> length)
         {
             string source;
             fixed (int* length_ptr = length)
@@ -1853,7 +1853,7 @@ namespace OpenTK.Graphics.OpenGL
             return source;
         }
         /// <inheritdoc cref="GetShaderSource"/>
-        public static unsafe void GetShaderSource(ShaderHandle shader, int bufSize, Span<int> length, out string source)
+        public static unsafe void GetShaderSource(int shader, int bufSize, Span<int> length, out string source)
         {
             fixed (int* length_ptr = length)
             {
@@ -1864,7 +1864,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetShaderSource"/>
-        public static unsafe string GetShaderSource(ShaderHandle shader, int bufSize, int[] length)
+        public static unsafe string GetShaderSource(int shader, int bufSize, int[] length)
         {
             string source;
             fixed (int* length_ptr = length)
@@ -1877,7 +1877,7 @@ namespace OpenTK.Graphics.OpenGL
             return source;
         }
         /// <inheritdoc cref="GetShaderSource"/>
-        public static unsafe void GetShaderSource(ShaderHandle shader, int bufSize, int[] length, out string source)
+        public static unsafe void GetShaderSource(int shader, int bufSize, int[] length, out string source)
         {
             fixed (int* length_ptr = length)
             {
@@ -1888,7 +1888,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetShaderSource"/>
-        public static unsafe string GetShaderSource(ShaderHandle shader, int bufSize, ref int length)
+        public static unsafe string GetShaderSource(int shader, int bufSize, ref int length)
         {
             string source;
             fixed (int* length_ptr = &length)
@@ -1901,7 +1901,7 @@ namespace OpenTK.Graphics.OpenGL
             return source;
         }
         /// <inheritdoc cref="GetShaderSource"/>
-        public static unsafe void GetShaderSource(ShaderHandle shader, int bufSize, ref int length, out string source)
+        public static unsafe void GetShaderSource(int shader, int bufSize, ref int length, out string source)
         {
             fixed (int* length_ptr = &length)
             {
@@ -1912,7 +1912,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetUniformLocation"/>
-        public static unsafe int GetUniformLocation(ProgramHandle program, string name)
+        public static unsafe int GetUniformLocation(int program, string name)
         {
             int returnValue;
             byte* name_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(name);
@@ -1921,7 +1921,7 @@ namespace OpenTK.Graphics.OpenGL
             return returnValue;
         }
         /// <inheritdoc cref="GetUniformfv"/>
-        public static unsafe void GetUniformf(ProgramHandle program, int location, Span<float> parameters)
+        public static unsafe void GetUniformf(int program, int location, Span<float> parameters)
         {
             fixed (float* parameters_ptr = parameters)
             {
@@ -1929,7 +1929,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetUniformfv"/>
-        public static unsafe void GetUniformf(ProgramHandle program, int location, float[] parameters)
+        public static unsafe void GetUniformf(int program, int location, float[] parameters)
         {
             fixed (float* parameters_ptr = parameters)
             {
@@ -1937,7 +1937,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetUniformfv"/>
-        public static unsafe void GetUniformf(ProgramHandle program, int location, ref float parameters)
+        public static unsafe void GetUniformf(int program, int location, ref float parameters)
         {
             fixed (float* parameters_ptr = &parameters)
             {
@@ -1945,7 +1945,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetUniformiv"/>
-        public static unsafe void GetUniformi(ProgramHandle program, int location, Span<int> parameters)
+        public static unsafe void GetUniformi(int program, int location, Span<int> parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
@@ -1953,7 +1953,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetUniformiv"/>
-        public static unsafe void GetUniformi(ProgramHandle program, int location, int[] parameters)
+        public static unsafe void GetUniformi(int program, int location, int[] parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
@@ -1961,7 +1961,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetUniformiv"/>
-        public static unsafe void GetUniformi(ProgramHandle program, int location, ref int parameters)
+        public static unsafe void GetUniformi(int program, int location, ref int parameters)
         {
             fixed (int* parameters_ptr = &parameters)
             {
@@ -2046,7 +2046,7 @@ namespace OpenTK.Graphics.OpenGL
             GetVertexAttribPointerv(index, pname, pointer);
         }
         /// <inheritdoc cref="ShaderSource"/>
-        public static unsafe void ShaderSource(ShaderHandle shader, int count, byte** str, ReadOnlySpan<int> length)
+        public static unsafe void ShaderSource(int shader, int count, byte** str, ReadOnlySpan<int> length)
         {
             fixed (int* length_ptr = length)
             {
@@ -2054,7 +2054,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ShaderSource"/>
-        public static unsafe void ShaderSource(ShaderHandle shader, int count, byte** str, int[] length)
+        public static unsafe void ShaderSource(int shader, int count, byte** str, int[] length)
         {
             fixed (int* length_ptr = length)
             {
@@ -2062,7 +2062,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ShaderSource"/>
-        public static unsafe void ShaderSource(ShaderHandle shader, int count, byte** str, in int length)
+        public static unsafe void ShaderSource(int shader, int count, byte** str, in int length)
         {
             fixed (int* length_ptr = &length)
             {
@@ -3187,7 +3187,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetTransformFeedbackVarying"/>
-        public static unsafe string GetTransformFeedbackVarying(ProgramHandle program, uint index, int bufSize, Span<int> length, Span<int> size, Span<AttributeType> type)
+        public static unsafe string GetTransformFeedbackVarying(int program, uint index, int bufSize, Span<int> length, Span<int> size, Span<AttributeType> type)
         {
             string name;
             fixed (int* length_ptr = length)
@@ -3206,7 +3206,7 @@ namespace OpenTK.Graphics.OpenGL
             return name;
         }
         /// <inheritdoc cref="GetTransformFeedbackVarying"/>
-        public static unsafe void GetTransformFeedbackVarying(ProgramHandle program, uint index, int bufSize, Span<int> length, Span<int> size, Span<AttributeType> type, out string name)
+        public static unsafe void GetTransformFeedbackVarying(int program, uint index, int bufSize, Span<int> length, Span<int> size, Span<AttributeType> type, out string name)
         {
             fixed (int* length_ptr = length)
             {
@@ -3223,7 +3223,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetTransformFeedbackVarying"/>
-        public static unsafe string GetTransformFeedbackVarying(ProgramHandle program, uint index, int bufSize, int[] length, int[] size, AttributeType[] type)
+        public static unsafe string GetTransformFeedbackVarying(int program, uint index, int bufSize, int[] length, int[] size, AttributeType[] type)
         {
             string name;
             fixed (int* length_ptr = length)
@@ -3242,7 +3242,7 @@ namespace OpenTK.Graphics.OpenGL
             return name;
         }
         /// <inheritdoc cref="GetTransformFeedbackVarying"/>
-        public static unsafe void GetTransformFeedbackVarying(ProgramHandle program, uint index, int bufSize, int[] length, int[] size, AttributeType[] type, out string name)
+        public static unsafe void GetTransformFeedbackVarying(int program, uint index, int bufSize, int[] length, int[] size, AttributeType[] type, out string name)
         {
             fixed (int* length_ptr = length)
             {
@@ -3259,7 +3259,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetTransformFeedbackVarying"/>
-        public static unsafe string GetTransformFeedbackVarying(ProgramHandle program, uint index, int bufSize, ref int length, ref int size, ref AttributeType type)
+        public static unsafe string GetTransformFeedbackVarying(int program, uint index, int bufSize, ref int length, ref int size, ref AttributeType type)
         {
             string name;
             fixed (int* length_ptr = &length)
@@ -3274,7 +3274,7 @@ namespace OpenTK.Graphics.OpenGL
             return name;
         }
         /// <inheritdoc cref="GetTransformFeedbackVarying"/>
-        public static unsafe void GetTransformFeedbackVarying(ProgramHandle program, uint index, int bufSize, ref int length, ref int size, ref AttributeType type, out string name)
+        public static unsafe void GetTransformFeedbackVarying(int program, uint index, int bufSize, ref int length, ref int size, ref AttributeType type, out string name)
         {
             fixed (int* length_ptr = &length)
             fixed (int* size_ptr = &size)
@@ -3569,7 +3569,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetUniformuiv"/>
-        public static unsafe void GetUniformui(ProgramHandle program, int location, Span<uint> parameters)
+        public static unsafe void GetUniformui(int program, int location, Span<uint> parameters)
         {
             fixed (uint* parameters_ptr = parameters)
             {
@@ -3577,7 +3577,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetUniformuiv"/>
-        public static unsafe void GetUniformui(ProgramHandle program, int location, uint[] parameters)
+        public static unsafe void GetUniformui(int program, int location, uint[] parameters)
         {
             fixed (uint* parameters_ptr = parameters)
             {
@@ -3585,7 +3585,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetUniformuiv"/>
-        public static unsafe void GetUniformui(ProgramHandle program, int location, ref uint parameters)
+        public static unsafe void GetUniformui(int program, int location, ref uint parameters)
         {
             fixed (uint* parameters_ptr = &parameters)
             {
@@ -3593,14 +3593,14 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="BindFragDataLocation"/>
-        public static unsafe void BindFragDataLocation(ProgramHandle program, uint color, string name)
+        public static unsafe void BindFragDataLocation(int program, uint color, string name)
         {
             byte* name_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(name);
             BindFragDataLocation(program, color, name_ptr);
             Marshal.FreeCoTaskMem((IntPtr)name_ptr);
         }
         /// <inheritdoc cref="GetFragDataLocation"/>
-        public static unsafe int GetFragDataLocation(ProgramHandle program, string name)
+        public static unsafe int GetFragDataLocation(int program, string name)
         {
             int returnValue;
             byte* name_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(name);
@@ -3895,44 +3895,44 @@ namespace OpenTK.Graphics.OpenGL
             return returnValue_str;
         }
         /// <inheritdoc cref="DeleteRenderbuffers"/>
-        public static unsafe void DeleteRenderbuffer(in RenderbufferHandle renderbuffer)
+        public static unsafe void DeleteRenderbuffer(in int renderbuffer)
         {
             int n = 1;
-            fixed(RenderbufferHandle* renderbuffers_handle = &renderbuffer)
+            fixed(int* renderbuffers_handle = &renderbuffer)
             {
                 DeleteRenderbuffers(n, renderbuffers_handle);
             }
         }
         /// <inheritdoc cref="DeleteRenderbuffers"/>
-        public static unsafe void DeleteRenderbuffers(ReadOnlySpan<RenderbufferHandle> renderbuffers)
+        public static unsafe void DeleteRenderbuffers(ReadOnlySpan<int> renderbuffers)
         {
             int n = (int)(renderbuffers.Length);
-            fixed (RenderbufferHandle* renderbuffers_ptr = renderbuffers)
+            fixed (int* renderbuffers_ptr = renderbuffers)
             {
                 DeleteRenderbuffers(n, renderbuffers_ptr);
             }
         }
         /// <inheritdoc cref="DeleteRenderbuffers"/>
-        public static unsafe void DeleteRenderbuffers(RenderbufferHandle[] renderbuffers)
+        public static unsafe void DeleteRenderbuffers(int[] renderbuffers)
         {
             int n = (int)(renderbuffers.Length);
-            fixed (RenderbufferHandle* renderbuffers_ptr = renderbuffers)
+            fixed (int* renderbuffers_ptr = renderbuffers)
             {
                 DeleteRenderbuffers(n, renderbuffers_ptr);
             }
         }
         /// <inheritdoc cref="DeleteRenderbuffers"/>
-        public static unsafe void DeleteRenderbuffers(int n, in RenderbufferHandle renderbuffers)
+        public static unsafe void DeleteRenderbuffers(int n, in int renderbuffers)
         {
-            fixed (RenderbufferHandle* renderbuffers_ptr = &renderbuffers)
+            fixed (int* renderbuffers_ptr = &renderbuffers)
             {
                 DeleteRenderbuffers(n, renderbuffers_ptr);
             }
         }
         /// <inheritdoc cref="GenRenderbuffers"/>
-        public static unsafe RenderbufferHandle GenRenderbuffer()
+        public static unsafe int GenRenderbuffer()
         {
-            RenderbufferHandle renderbuffer;
+            int renderbuffer;
             int n = 1;
             Unsafe.SkipInit(out renderbuffer);
             // FIXME: This could be a problem for the overloads that take an out parameter
@@ -3943,12 +3943,12 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            RenderbufferHandle* renderbuffers_handle = (RenderbufferHandle*)Unsafe.AsPointer(ref renderbuffer);
+            int* renderbuffers_handle = (int*)Unsafe.AsPointer(ref renderbuffer);
             GenRenderbuffers(n, renderbuffers_handle);
             return renderbuffer;
         }
         /// <inheritdoc cref="GenRenderbuffers"/>
-        public static unsafe void GenRenderbuffer(out RenderbufferHandle renderbuffer)
+        public static unsafe void GenRenderbuffer(out int renderbuffer)
         {
             int n = 1;
             Unsafe.SkipInit(out renderbuffer);
@@ -3960,31 +3960,31 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            RenderbufferHandle* renderbuffers_handle = (RenderbufferHandle*)Unsafe.AsPointer(ref renderbuffer);
+            int* renderbuffers_handle = (int*)Unsafe.AsPointer(ref renderbuffer);
             GenRenderbuffers(n, renderbuffers_handle);
         }
         /// <inheritdoc cref="GenRenderbuffers"/>
-        public static unsafe void GenRenderbuffers(Span<RenderbufferHandle> renderbuffers)
+        public static unsafe void GenRenderbuffers(Span<int> renderbuffers)
         {
             int n = (int)(renderbuffers.Length);
-            fixed (RenderbufferHandle* renderbuffers_ptr = renderbuffers)
+            fixed (int* renderbuffers_ptr = renderbuffers)
             {
                 GenRenderbuffers(n, renderbuffers_ptr);
             }
         }
         /// <inheritdoc cref="GenRenderbuffers"/>
-        public static unsafe void GenRenderbuffers(RenderbufferHandle[] renderbuffers)
+        public static unsafe void GenRenderbuffers(int[] renderbuffers)
         {
             int n = (int)(renderbuffers.Length);
-            fixed (RenderbufferHandle* renderbuffers_ptr = renderbuffers)
+            fixed (int* renderbuffers_ptr = renderbuffers)
             {
                 GenRenderbuffers(n, renderbuffers_ptr);
             }
         }
         /// <inheritdoc cref="GenRenderbuffers"/>
-        public static unsafe void GenRenderbuffers(int n, ref RenderbufferHandle renderbuffers)
+        public static unsafe void GenRenderbuffers(int n, ref int renderbuffers)
         {
-            fixed (RenderbufferHandle* renderbuffers_ptr = &renderbuffers)
+            fixed (int* renderbuffers_ptr = &renderbuffers)
             {
                 GenRenderbuffers(n, renderbuffers_ptr);
             }
@@ -4014,44 +4014,44 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="DeleteFramebuffers"/>
-        public static unsafe void DeleteFramebuffer(in FramebufferHandle framebuffer)
+        public static unsafe void DeleteFramebuffer(in int framebuffer)
         {
             int n = 1;
-            fixed(FramebufferHandle* framebuffers_handle = &framebuffer)
+            fixed(int* framebuffers_handle = &framebuffer)
             {
                 DeleteFramebuffers(n, framebuffers_handle);
             }
         }
         /// <inheritdoc cref="DeleteFramebuffers"/>
-        public static unsafe void DeleteFramebuffers(ReadOnlySpan<FramebufferHandle> framebuffers)
+        public static unsafe void DeleteFramebuffers(ReadOnlySpan<int> framebuffers)
         {
             int n = (int)(framebuffers.Length);
-            fixed (FramebufferHandle* framebuffers_ptr = framebuffers)
+            fixed (int* framebuffers_ptr = framebuffers)
             {
                 DeleteFramebuffers(n, framebuffers_ptr);
             }
         }
         /// <inheritdoc cref="DeleteFramebuffers"/>
-        public static unsafe void DeleteFramebuffers(FramebufferHandle[] framebuffers)
+        public static unsafe void DeleteFramebuffers(int[] framebuffers)
         {
             int n = (int)(framebuffers.Length);
-            fixed (FramebufferHandle* framebuffers_ptr = framebuffers)
+            fixed (int* framebuffers_ptr = framebuffers)
             {
                 DeleteFramebuffers(n, framebuffers_ptr);
             }
         }
         /// <inheritdoc cref="DeleteFramebuffers"/>
-        public static unsafe void DeleteFramebuffers(int n, in FramebufferHandle framebuffers)
+        public static unsafe void DeleteFramebuffers(int n, in int framebuffers)
         {
-            fixed (FramebufferHandle* framebuffers_ptr = &framebuffers)
+            fixed (int* framebuffers_ptr = &framebuffers)
             {
                 DeleteFramebuffers(n, framebuffers_ptr);
             }
         }
         /// <inheritdoc cref="GenFramebuffers"/>
-        public static unsafe FramebufferHandle GenFramebuffer()
+        public static unsafe int GenFramebuffer()
         {
-            FramebufferHandle framebuffer;
+            int framebuffer;
             int n = 1;
             Unsafe.SkipInit(out framebuffer);
             // FIXME: This could be a problem for the overloads that take an out parameter
@@ -4062,12 +4062,12 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            FramebufferHandle* framebuffers_handle = (FramebufferHandle*)Unsafe.AsPointer(ref framebuffer);
+            int* framebuffers_handle = (int*)Unsafe.AsPointer(ref framebuffer);
             GenFramebuffers(n, framebuffers_handle);
             return framebuffer;
         }
         /// <inheritdoc cref="GenFramebuffers"/>
-        public static unsafe void GenFramebuffer(out FramebufferHandle framebuffer)
+        public static unsafe void GenFramebuffer(out int framebuffer)
         {
             int n = 1;
             Unsafe.SkipInit(out framebuffer);
@@ -4079,31 +4079,31 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            FramebufferHandle* framebuffers_handle = (FramebufferHandle*)Unsafe.AsPointer(ref framebuffer);
+            int* framebuffers_handle = (int*)Unsafe.AsPointer(ref framebuffer);
             GenFramebuffers(n, framebuffers_handle);
         }
         /// <inheritdoc cref="GenFramebuffers"/>
-        public static unsafe void GenFramebuffers(Span<FramebufferHandle> framebuffers)
+        public static unsafe void GenFramebuffers(Span<int> framebuffers)
         {
             int n = (int)(framebuffers.Length);
-            fixed (FramebufferHandle* framebuffers_ptr = framebuffers)
+            fixed (int* framebuffers_ptr = framebuffers)
             {
                 GenFramebuffers(n, framebuffers_ptr);
             }
         }
         /// <inheritdoc cref="GenFramebuffers"/>
-        public static unsafe void GenFramebuffers(FramebufferHandle[] framebuffers)
+        public static unsafe void GenFramebuffers(int[] framebuffers)
         {
             int n = (int)(framebuffers.Length);
-            fixed (FramebufferHandle* framebuffers_ptr = framebuffers)
+            fixed (int* framebuffers_ptr = framebuffers)
             {
                 GenFramebuffers(n, framebuffers_ptr);
             }
         }
         /// <inheritdoc cref="GenFramebuffers"/>
-        public static unsafe void GenFramebuffers(int n, ref FramebufferHandle framebuffers)
+        public static unsafe void GenFramebuffers(int n, ref int framebuffers)
         {
-            fixed (FramebufferHandle* framebuffers_ptr = &framebuffers)
+            fixed (int* framebuffers_ptr = &framebuffers)
             {
                 GenFramebuffers(n, framebuffers_ptr);
             }
@@ -4133,44 +4133,44 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="DeleteVertexArrays"/>
-        public static unsafe void DeleteVertexArray(in VertexArrayHandle array)
+        public static unsafe void DeleteVertexArray(in int array)
         {
             int n = 1;
-            fixed(VertexArrayHandle* arrays_handle = &array)
+            fixed(int* arrays_handle = &array)
             {
                 DeleteVertexArrays(n, arrays_handle);
             }
         }
         /// <inheritdoc cref="DeleteVertexArrays"/>
-        public static unsafe void DeleteVertexArrays(ReadOnlySpan<VertexArrayHandle> arrays)
+        public static unsafe void DeleteVertexArrays(ReadOnlySpan<int> arrays)
         {
             int n = (int)(arrays.Length);
-            fixed (VertexArrayHandle* arrays_ptr = arrays)
+            fixed (int* arrays_ptr = arrays)
             {
                 DeleteVertexArrays(n, arrays_ptr);
             }
         }
         /// <inheritdoc cref="DeleteVertexArrays"/>
-        public static unsafe void DeleteVertexArrays(VertexArrayHandle[] arrays)
+        public static unsafe void DeleteVertexArrays(int[] arrays)
         {
             int n = (int)(arrays.Length);
-            fixed (VertexArrayHandle* arrays_ptr = arrays)
+            fixed (int* arrays_ptr = arrays)
             {
                 DeleteVertexArrays(n, arrays_ptr);
             }
         }
         /// <inheritdoc cref="DeleteVertexArrays"/>
-        public static unsafe void DeleteVertexArrays(int n, in VertexArrayHandle arrays)
+        public static unsafe void DeleteVertexArrays(int n, in int arrays)
         {
-            fixed (VertexArrayHandle* arrays_ptr = &arrays)
+            fixed (int* arrays_ptr = &arrays)
             {
                 DeleteVertexArrays(n, arrays_ptr);
             }
         }
         /// <inheritdoc cref="GenVertexArrays"/>
-        public static unsafe VertexArrayHandle GenVertexArray()
+        public static unsafe int GenVertexArray()
         {
-            VertexArrayHandle array;
+            int array;
             int n = 1;
             Unsafe.SkipInit(out array);
             // FIXME: This could be a problem for the overloads that take an out parameter
@@ -4181,12 +4181,12 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            VertexArrayHandle* arrays_handle = (VertexArrayHandle*)Unsafe.AsPointer(ref array);
+            int* arrays_handle = (int*)Unsafe.AsPointer(ref array);
             GenVertexArrays(n, arrays_handle);
             return array;
         }
         /// <inheritdoc cref="GenVertexArrays"/>
-        public static unsafe void GenVertexArray(out VertexArrayHandle array)
+        public static unsafe void GenVertexArray(out int array)
         {
             int n = 1;
             Unsafe.SkipInit(out array);
@@ -4198,31 +4198,31 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            VertexArrayHandle* arrays_handle = (VertexArrayHandle*)Unsafe.AsPointer(ref array);
+            int* arrays_handle = (int*)Unsafe.AsPointer(ref array);
             GenVertexArrays(n, arrays_handle);
         }
         /// <inheritdoc cref="GenVertexArrays"/>
-        public static unsafe void GenVertexArrays(Span<VertexArrayHandle> arrays)
+        public static unsafe void GenVertexArrays(Span<int> arrays)
         {
             int n = (int)(arrays.Length);
-            fixed (VertexArrayHandle* arrays_ptr = arrays)
+            fixed (int* arrays_ptr = arrays)
             {
                 GenVertexArrays(n, arrays_ptr);
             }
         }
         /// <inheritdoc cref="GenVertexArrays"/>
-        public static unsafe void GenVertexArrays(VertexArrayHandle[] arrays)
+        public static unsafe void GenVertexArrays(int[] arrays)
         {
             int n = (int)(arrays.Length);
-            fixed (VertexArrayHandle* arrays_ptr = arrays)
+            fixed (int* arrays_ptr = arrays)
             {
                 GenVertexArrays(n, arrays_ptr);
             }
         }
         /// <inheritdoc cref="GenVertexArrays"/>
-        public static unsafe void GenVertexArrays(int n, ref VertexArrayHandle arrays)
+        public static unsafe void GenVertexArrays(int n, ref int arrays)
         {
-            fixed (VertexArrayHandle* arrays_ptr = &arrays)
+            fixed (int* arrays_ptr = &arrays)
             {
                 GenVertexArrays(n, arrays_ptr);
             }
@@ -4234,7 +4234,7 @@ namespace OpenTK.Graphics.OpenGL
             DrawElementsInstanced(mode, count, type, indices, instancecount);
         }
         /// <inheritdoc cref="GetUniformIndices"/>
-        public static unsafe void GetUniformIndices(ProgramHandle program, int uniformCount, byte** uniformNames, Span<uint> uniformIndices)
+        public static unsafe void GetUniformIndices(int program, int uniformCount, byte** uniformNames, Span<uint> uniformIndices)
         {
             fixed (uint* uniformIndices_ptr = uniformIndices)
             {
@@ -4242,7 +4242,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetUniformIndices"/>
-        public static unsafe void GetUniformIndices(ProgramHandle program, int uniformCount, byte** uniformNames, uint[] uniformIndices)
+        public static unsafe void GetUniformIndices(int program, int uniformCount, byte** uniformNames, uint[] uniformIndices)
         {
             fixed (uint* uniformIndices_ptr = uniformIndices)
             {
@@ -4250,7 +4250,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetUniformIndices"/>
-        public static unsafe void GetUniformIndices(ProgramHandle program, int uniformCount, byte** uniformNames, ref uint uniformIndices)
+        public static unsafe void GetUniformIndices(int program, int uniformCount, byte** uniformNames, ref uint uniformIndices)
         {
             fixed (uint* uniformIndices_ptr = &uniformIndices)
             {
@@ -4258,7 +4258,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetActiveUniformsiv"/>
-        public static unsafe void GetActiveUniformsi(ProgramHandle program, ReadOnlySpan<uint> uniformIndices, UniformPName pname, Span<int> parameters)
+        public static unsafe void GetActiveUniformsi(int program, ReadOnlySpan<uint> uniformIndices, UniformPName pname, Span<int> parameters)
         {
             int uniformCount = (int)(uniformIndices.Length);
             fixed (uint* uniformIndices_ptr = uniformIndices)
@@ -4270,7 +4270,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetActiveUniformsiv"/>
-        public static unsafe void GetActiveUniformsi(ProgramHandle program, uint[] uniformIndices, UniformPName pname, int[] parameters)
+        public static unsafe void GetActiveUniformsi(int program, uint[] uniformIndices, UniformPName pname, int[] parameters)
         {
             int uniformCount = (int)(uniformIndices.Length);
             fixed (uint* uniformIndices_ptr = uniformIndices)
@@ -4282,7 +4282,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetActiveUniformsiv"/>
-        public static unsafe void GetActiveUniformsi(ProgramHandle program, int uniformCount, in uint uniformIndices, UniformPName pname, ref int parameters)
+        public static unsafe void GetActiveUniformsi(int program, int uniformCount, in uint uniformIndices, UniformPName pname, ref int parameters)
         {
             fixed (uint* uniformIndices_ptr = &uniformIndices)
             fixed (int* parameters_ptr = &parameters)
@@ -4291,7 +4291,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetActiveUniformName"/>
-        public static unsafe string GetActiveUniformName(ProgramHandle program, uint uniformIndex, int bufSize, Span<int> length)
+        public static unsafe string GetActiveUniformName(int program, uint uniformIndex, int bufSize, Span<int> length)
         {
             string uniformName;
             fixed (int* length_ptr = length)
@@ -4304,7 +4304,7 @@ namespace OpenTK.Graphics.OpenGL
             return uniformName;
         }
         /// <inheritdoc cref="GetActiveUniformName"/>
-        public static unsafe void GetActiveUniformName(ProgramHandle program, uint uniformIndex, int bufSize, Span<int> length, out string uniformName)
+        public static unsafe void GetActiveUniformName(int program, uint uniformIndex, int bufSize, Span<int> length, out string uniformName)
         {
             fixed (int* length_ptr = length)
             {
@@ -4315,7 +4315,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetActiveUniformName"/>
-        public static unsafe string GetActiveUniformName(ProgramHandle program, uint uniformIndex, int bufSize, int[] length)
+        public static unsafe string GetActiveUniformName(int program, uint uniformIndex, int bufSize, int[] length)
         {
             string uniformName;
             fixed (int* length_ptr = length)
@@ -4328,7 +4328,7 @@ namespace OpenTK.Graphics.OpenGL
             return uniformName;
         }
         /// <inheritdoc cref="GetActiveUniformName"/>
-        public static unsafe void GetActiveUniformName(ProgramHandle program, uint uniformIndex, int bufSize, int[] length, out string uniformName)
+        public static unsafe void GetActiveUniformName(int program, uint uniformIndex, int bufSize, int[] length, out string uniformName)
         {
             fixed (int* length_ptr = length)
             {
@@ -4339,7 +4339,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetActiveUniformName"/>
-        public static unsafe string GetActiveUniformName(ProgramHandle program, uint uniformIndex, int bufSize, ref int length)
+        public static unsafe string GetActiveUniformName(int program, uint uniformIndex, int bufSize, ref int length)
         {
             string uniformName;
             fixed (int* length_ptr = &length)
@@ -4352,7 +4352,7 @@ namespace OpenTK.Graphics.OpenGL
             return uniformName;
         }
         /// <inheritdoc cref="GetActiveUniformName"/>
-        public static unsafe void GetActiveUniformName(ProgramHandle program, uint uniformIndex, int bufSize, ref int length, out string uniformName)
+        public static unsafe void GetActiveUniformName(int program, uint uniformIndex, int bufSize, ref int length, out string uniformName)
         {
             fixed (int* length_ptr = &length)
             {
@@ -4363,7 +4363,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetUniformBlockIndex"/>
-        public static unsafe uint GetUniformBlockIndex(ProgramHandle program, string uniformBlockName)
+        public static unsafe uint GetUniformBlockIndex(int program, string uniformBlockName)
         {
             uint returnValue;
             byte* uniformBlockName_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(uniformBlockName);
@@ -4372,7 +4372,7 @@ namespace OpenTK.Graphics.OpenGL
             return returnValue;
         }
         /// <inheritdoc cref="GetActiveUniformBlockiv"/>
-        public static unsafe void GetActiveUniformBlocki(ProgramHandle program, uint uniformBlockIndex, UniformBlockPName pname, Span<int> parameters)
+        public static unsafe void GetActiveUniformBlocki(int program, uint uniformBlockIndex, UniformBlockPName pname, Span<int> parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
@@ -4380,7 +4380,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetActiveUniformBlockiv"/>
-        public static unsafe void GetActiveUniformBlocki(ProgramHandle program, uint uniformBlockIndex, UniformBlockPName pname, int[] parameters)
+        public static unsafe void GetActiveUniformBlocki(int program, uint uniformBlockIndex, UniformBlockPName pname, int[] parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
@@ -4388,7 +4388,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetActiveUniformBlockiv"/>
-        public static unsafe void GetActiveUniformBlocki(ProgramHandle program, uint uniformBlockIndex, UniformBlockPName pname, ref int parameters)
+        public static unsafe void GetActiveUniformBlocki(int program, uint uniformBlockIndex, UniformBlockPName pname, ref int parameters)
         {
             fixed (int* parameters_ptr = &parameters)
             {
@@ -4396,7 +4396,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetActiveUniformBlockName"/>
-        public static unsafe string GetActiveUniformBlockName(ProgramHandle program, uint uniformBlockIndex, int bufSize, Span<int> length)
+        public static unsafe string GetActiveUniformBlockName(int program, uint uniformBlockIndex, int bufSize, Span<int> length)
         {
             string uniformBlockName;
             fixed (int* length_ptr = length)
@@ -4409,7 +4409,7 @@ namespace OpenTK.Graphics.OpenGL
             return uniformBlockName;
         }
         /// <inheritdoc cref="GetActiveUniformBlockName"/>
-        public static unsafe void GetActiveUniformBlockName(ProgramHandle program, uint uniformBlockIndex, int bufSize, Span<int> length, out string uniformBlockName)
+        public static unsafe void GetActiveUniformBlockName(int program, uint uniformBlockIndex, int bufSize, Span<int> length, out string uniformBlockName)
         {
             fixed (int* length_ptr = length)
             {
@@ -4420,7 +4420,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetActiveUniformBlockName"/>
-        public static unsafe string GetActiveUniformBlockName(ProgramHandle program, uint uniformBlockIndex, int bufSize, int[] length)
+        public static unsafe string GetActiveUniformBlockName(int program, uint uniformBlockIndex, int bufSize, int[] length)
         {
             string uniformBlockName;
             fixed (int* length_ptr = length)
@@ -4433,7 +4433,7 @@ namespace OpenTK.Graphics.OpenGL
             return uniformBlockName;
         }
         /// <inheritdoc cref="GetActiveUniformBlockName"/>
-        public static unsafe void GetActiveUniformBlockName(ProgramHandle program, uint uniformBlockIndex, int bufSize, int[] length, out string uniformBlockName)
+        public static unsafe void GetActiveUniformBlockName(int program, uint uniformBlockIndex, int bufSize, int[] length, out string uniformBlockName)
         {
             fixed (int* length_ptr = length)
             {
@@ -4444,7 +4444,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetActiveUniformBlockName"/>
-        public static unsafe string GetActiveUniformBlockName(ProgramHandle program, uint uniformBlockIndex, int bufSize, ref int length)
+        public static unsafe string GetActiveUniformBlockName(int program, uint uniformBlockIndex, int bufSize, ref int length)
         {
             string uniformBlockName;
             fixed (int* length_ptr = &length)
@@ -4457,7 +4457,7 @@ namespace OpenTK.Graphics.OpenGL
             return uniformBlockName;
         }
         /// <inheritdoc cref="GetActiveUniformBlockName"/>
-        public static unsafe void GetActiveUniformBlockName(ProgramHandle program, uint uniformBlockIndex, int bufSize, ref int length, out string uniformBlockName)
+        public static unsafe void GetActiveUniformBlockName(int program, uint uniformBlockIndex, int bufSize, ref int length, out string uniformBlockName)
         {
             fixed (int* length_ptr = &length)
             {
@@ -4646,14 +4646,14 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="BindFragDataLocationIndexed"/>
-        public static unsafe void BindFragDataLocationIndexed(ProgramHandle program, uint colorNumber, uint index, string name)
+        public static unsafe void BindFragDataLocationIndexed(int program, uint colorNumber, uint index, string name)
         {
             byte* name_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(name);
             BindFragDataLocationIndexed(program, colorNumber, index, name_ptr);
             Marshal.FreeCoTaskMem((IntPtr)name_ptr);
         }
         /// <inheritdoc cref="GetFragDataIndex"/>
-        public static unsafe int GetFragDataIndex(ProgramHandle program, string name)
+        public static unsafe int GetFragDataIndex(int program, string name)
         {
             int returnValue;
             byte* name_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(name);
@@ -4662,9 +4662,9 @@ namespace OpenTK.Graphics.OpenGL
             return returnValue;
         }
         /// <inheritdoc cref="GenSamplers"/>
-        public static unsafe SamplerHandle GenSampler()
+        public static unsafe int GenSampler()
         {
-            SamplerHandle sampler;
+            int sampler;
             int count = 1;
             Unsafe.SkipInit(out sampler);
             // FIXME: This could be a problem for the overloads that take an out parameter
@@ -4675,12 +4675,12 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            SamplerHandle* samplers_handle = (SamplerHandle*)Unsafe.AsPointer(ref sampler);
+            int* samplers_handle = (int*)Unsafe.AsPointer(ref sampler);
             GenSamplers(count, samplers_handle);
             return sampler;
         }
         /// <inheritdoc cref="GenSamplers"/>
-        public static unsafe void GenSampler(out SamplerHandle sampler)
+        public static unsafe void GenSampler(out int sampler)
         {
             int count = 1;
             Unsafe.SkipInit(out sampler);
@@ -4692,72 +4692,72 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            SamplerHandle* samplers_handle = (SamplerHandle*)Unsafe.AsPointer(ref sampler);
+            int* samplers_handle = (int*)Unsafe.AsPointer(ref sampler);
             GenSamplers(count, samplers_handle);
         }
         /// <inheritdoc cref="GenSamplers"/>
-        public static unsafe void GenSamplers(Span<SamplerHandle> samplers)
+        public static unsafe void GenSamplers(Span<int> samplers)
         {
             int count = (int)(samplers.Length);
-            fixed (SamplerHandle* samplers_ptr = samplers)
+            fixed (int* samplers_ptr = samplers)
             {
                 GenSamplers(count, samplers_ptr);
             }
         }
         /// <inheritdoc cref="GenSamplers"/>
-        public static unsafe void GenSamplers(SamplerHandle[] samplers)
+        public static unsafe void GenSamplers(int[] samplers)
         {
             int count = (int)(samplers.Length);
-            fixed (SamplerHandle* samplers_ptr = samplers)
+            fixed (int* samplers_ptr = samplers)
             {
                 GenSamplers(count, samplers_ptr);
             }
         }
         /// <inheritdoc cref="GenSamplers"/>
-        public static unsafe void GenSamplers(int count, ref SamplerHandle samplers)
+        public static unsafe void GenSamplers(int count, ref int samplers)
         {
-            fixed (SamplerHandle* samplers_ptr = &samplers)
+            fixed (int* samplers_ptr = &samplers)
             {
                 GenSamplers(count, samplers_ptr);
             }
         }
         /// <inheritdoc cref="DeleteSamplers"/>
-        public static unsafe void DeleteSampler(in SamplerHandle sampler)
+        public static unsafe void DeleteSampler(in int sampler)
         {
             int count = 1;
-            fixed(SamplerHandle* samplers_handle = &sampler)
+            fixed(int* samplers_handle = &sampler)
             {
                 DeleteSamplers(count, samplers_handle);
             }
         }
         /// <inheritdoc cref="DeleteSamplers"/>
-        public static unsafe void DeleteSamplers(ReadOnlySpan<SamplerHandle> samplers)
+        public static unsafe void DeleteSamplers(ReadOnlySpan<int> samplers)
         {
             int count = (int)(samplers.Length);
-            fixed (SamplerHandle* samplers_ptr = samplers)
+            fixed (int* samplers_ptr = samplers)
             {
                 DeleteSamplers(count, samplers_ptr);
             }
         }
         /// <inheritdoc cref="DeleteSamplers"/>
-        public static unsafe void DeleteSamplers(SamplerHandle[] samplers)
+        public static unsafe void DeleteSamplers(int[] samplers)
         {
             int count = (int)(samplers.Length);
-            fixed (SamplerHandle* samplers_ptr = samplers)
+            fixed (int* samplers_ptr = samplers)
             {
                 DeleteSamplers(count, samplers_ptr);
             }
         }
         /// <inheritdoc cref="DeleteSamplers"/>
-        public static unsafe void DeleteSamplers(int count, in SamplerHandle samplers)
+        public static unsafe void DeleteSamplers(int count, in int samplers)
         {
-            fixed (SamplerHandle* samplers_ptr = &samplers)
+            fixed (int* samplers_ptr = &samplers)
             {
                 DeleteSamplers(count, samplers_ptr);
             }
         }
         /// <inheritdoc cref="SamplerParameteriv"/>
-        public static unsafe void SamplerParameteri(SamplerHandle sampler, SamplerParameterI pname, ReadOnlySpan<int> param)
+        public static unsafe void SamplerParameteri(int sampler, SamplerParameterI pname, ReadOnlySpan<int> param)
         {
             fixed (int* param_ptr = param)
             {
@@ -4765,7 +4765,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="SamplerParameteriv"/>
-        public static unsafe void SamplerParameteri(SamplerHandle sampler, SamplerParameterI pname, int[] param)
+        public static unsafe void SamplerParameteri(int sampler, SamplerParameterI pname, int[] param)
         {
             fixed (int* param_ptr = param)
             {
@@ -4773,7 +4773,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="SamplerParameteriv"/>
-        public static unsafe void SamplerParameteri(SamplerHandle sampler, SamplerParameterI pname, in int param)
+        public static unsafe void SamplerParameteri(int sampler, SamplerParameterI pname, in int param)
         {
             fixed (int* param_ptr = &param)
             {
@@ -4781,7 +4781,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="SamplerParameterfv"/>
-        public static unsafe void SamplerParameterf(SamplerHandle sampler, SamplerParameterF pname, ReadOnlySpan<float> param)
+        public static unsafe void SamplerParameterf(int sampler, SamplerParameterF pname, ReadOnlySpan<float> param)
         {
             fixed (float* param_ptr = param)
             {
@@ -4789,7 +4789,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="SamplerParameterfv"/>
-        public static unsafe void SamplerParameterf(SamplerHandle sampler, SamplerParameterF pname, float[] param)
+        public static unsafe void SamplerParameterf(int sampler, SamplerParameterF pname, float[] param)
         {
             fixed (float* param_ptr = param)
             {
@@ -4797,7 +4797,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="SamplerParameterfv"/>
-        public static unsafe void SamplerParameterf(SamplerHandle sampler, SamplerParameterF pname, in float param)
+        public static unsafe void SamplerParameterf(int sampler, SamplerParameterF pname, in float param)
         {
             fixed (float* param_ptr = &param)
             {
@@ -4805,7 +4805,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="SamplerParameterIiv"/>
-        public static unsafe void SamplerParameterIi(SamplerHandle sampler, SamplerParameterI pname, ReadOnlySpan<int> param)
+        public static unsafe void SamplerParameterIi(int sampler, SamplerParameterI pname, ReadOnlySpan<int> param)
         {
             fixed (int* param_ptr = param)
             {
@@ -4813,7 +4813,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="SamplerParameterIiv"/>
-        public static unsafe void SamplerParameterIi(SamplerHandle sampler, SamplerParameterI pname, int[] param)
+        public static unsafe void SamplerParameterIi(int sampler, SamplerParameterI pname, int[] param)
         {
             fixed (int* param_ptr = param)
             {
@@ -4821,7 +4821,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="SamplerParameterIiv"/>
-        public static unsafe void SamplerParameterIi(SamplerHandle sampler, SamplerParameterI pname, in int param)
+        public static unsafe void SamplerParameterIi(int sampler, SamplerParameterI pname, in int param)
         {
             fixed (int* param_ptr = &param)
             {
@@ -4829,7 +4829,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="SamplerParameterIuiv"/>
-        public static unsafe void SamplerParameterIui(SamplerHandle sampler, SamplerParameterI pname, ReadOnlySpan<uint> param)
+        public static unsafe void SamplerParameterIui(int sampler, SamplerParameterI pname, ReadOnlySpan<uint> param)
         {
             fixed (uint* param_ptr = param)
             {
@@ -4837,7 +4837,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="SamplerParameterIuiv"/>
-        public static unsafe void SamplerParameterIui(SamplerHandle sampler, SamplerParameterI pname, uint[] param)
+        public static unsafe void SamplerParameterIui(int sampler, SamplerParameterI pname, uint[] param)
         {
             fixed (uint* param_ptr = param)
             {
@@ -4845,7 +4845,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="SamplerParameterIuiv"/>
-        public static unsafe void SamplerParameterIui(SamplerHandle sampler, SamplerParameterI pname, in uint param)
+        public static unsafe void SamplerParameterIui(int sampler, SamplerParameterI pname, in uint param)
         {
             fixed (uint* param_ptr = &param)
             {
@@ -4853,7 +4853,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetSamplerParameteriv"/>
-        public static unsafe void GetSamplerParameteri(SamplerHandle sampler, SamplerParameterI pname, Span<int> parameters)
+        public static unsafe void GetSamplerParameteri(int sampler, SamplerParameterI pname, Span<int> parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
@@ -4861,7 +4861,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetSamplerParameteriv"/>
-        public static unsafe void GetSamplerParameteri(SamplerHandle sampler, SamplerParameterI pname, int[] parameters)
+        public static unsafe void GetSamplerParameteri(int sampler, SamplerParameterI pname, int[] parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
@@ -4869,7 +4869,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetSamplerParameteriv"/>
-        public static unsafe void GetSamplerParameteri(SamplerHandle sampler, SamplerParameterI pname, ref int parameters)
+        public static unsafe void GetSamplerParameteri(int sampler, SamplerParameterI pname, ref int parameters)
         {
             fixed (int* parameters_ptr = &parameters)
             {
@@ -4877,7 +4877,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetSamplerParameterIiv"/>
-        public static unsafe void GetSamplerParameterIi(SamplerHandle sampler, SamplerParameterI pname, Span<int> parameters)
+        public static unsafe void GetSamplerParameterIi(int sampler, SamplerParameterI pname, Span<int> parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
@@ -4885,7 +4885,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetSamplerParameterIiv"/>
-        public static unsafe void GetSamplerParameterIi(SamplerHandle sampler, SamplerParameterI pname, int[] parameters)
+        public static unsafe void GetSamplerParameterIi(int sampler, SamplerParameterI pname, int[] parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
@@ -4893,7 +4893,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetSamplerParameterIiv"/>
-        public static unsafe void GetSamplerParameterIi(SamplerHandle sampler, SamplerParameterI pname, ref int parameters)
+        public static unsafe void GetSamplerParameterIi(int sampler, SamplerParameterI pname, ref int parameters)
         {
             fixed (int* parameters_ptr = &parameters)
             {
@@ -4901,7 +4901,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetSamplerParameterfv"/>
-        public static unsafe void GetSamplerParameterf(SamplerHandle sampler, SamplerParameterF pname, Span<float> parameters)
+        public static unsafe void GetSamplerParameterf(int sampler, SamplerParameterF pname, Span<float> parameters)
         {
             fixed (float* parameters_ptr = parameters)
             {
@@ -4909,7 +4909,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetSamplerParameterfv"/>
-        public static unsafe void GetSamplerParameterf(SamplerHandle sampler, SamplerParameterF pname, float[] parameters)
+        public static unsafe void GetSamplerParameterf(int sampler, SamplerParameterF pname, float[] parameters)
         {
             fixed (float* parameters_ptr = parameters)
             {
@@ -4917,7 +4917,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetSamplerParameterfv"/>
-        public static unsafe void GetSamplerParameterf(SamplerHandle sampler, SamplerParameterF pname, ref float parameters)
+        public static unsafe void GetSamplerParameterf(int sampler, SamplerParameterF pname, ref float parameters)
         {
             fixed (float* parameters_ptr = &parameters)
             {
@@ -4925,7 +4925,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetSamplerParameterIuiv"/>
-        public static unsafe void GetSamplerParameterIui(SamplerHandle sampler, SamplerParameterI pname, Span<uint> parameters)
+        public static unsafe void GetSamplerParameterIui(int sampler, SamplerParameterI pname, Span<uint> parameters)
         {
             fixed (uint* parameters_ptr = parameters)
             {
@@ -4933,7 +4933,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetSamplerParameterIuiv"/>
-        public static unsafe void GetSamplerParameterIui(SamplerHandle sampler, SamplerParameterI pname, uint[] parameters)
+        public static unsafe void GetSamplerParameterIui(int sampler, SamplerParameterI pname, uint[] parameters)
         {
             fixed (uint* parameters_ptr = parameters)
             {
@@ -4941,7 +4941,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetSamplerParameterIuiv"/>
-        public static unsafe void GetSamplerParameterIui(SamplerHandle sampler, SamplerParameterI pname, ref uint parameters)
+        public static unsafe void GetSamplerParameterIui(int sampler, SamplerParameterI pname, ref uint parameters)
         {
             fixed (uint* parameters_ptr = &parameters)
             {
@@ -4949,7 +4949,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetQueryObjecti64v"/>
-        public static unsafe void GetQueryObjecti64(QueryHandle id, QueryObjectParameterName pname, Span<long> parameters)
+        public static unsafe void GetQueryObjecti64(int id, QueryObjectParameterName pname, Span<long> parameters)
         {
             fixed (long* parameters_ptr = parameters)
             {
@@ -4957,7 +4957,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetQueryObjecti64v"/>
-        public static unsafe void GetQueryObjecti64(QueryHandle id, QueryObjectParameterName pname, long[] parameters)
+        public static unsafe void GetQueryObjecti64(int id, QueryObjectParameterName pname, long[] parameters)
         {
             fixed (long* parameters_ptr = parameters)
             {
@@ -4965,7 +4965,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetQueryObjecti64v"/>
-        public static unsafe void GetQueryObjecti64(QueryHandle id, QueryObjectParameterName pname, ref long parameters)
+        public static unsafe void GetQueryObjecti64(int id, QueryObjectParameterName pname, ref long parameters)
         {
             fixed (long* parameters_ptr = &parameters)
             {
@@ -4973,7 +4973,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetQueryObjectui64v"/>
-        public static unsafe void GetQueryObjectui64(QueryHandle id, QueryObjectParameterName pname, Span<ulong> parameters)
+        public static unsafe void GetQueryObjectui64(int id, QueryObjectParameterName pname, Span<ulong> parameters)
         {
             fixed (ulong* parameters_ptr = parameters)
             {
@@ -4981,7 +4981,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetQueryObjectui64v"/>
-        public static unsafe void GetQueryObjectui64(QueryHandle id, QueryObjectParameterName pname, ulong[] parameters)
+        public static unsafe void GetQueryObjectui64(int id, QueryObjectParameterName pname, ulong[] parameters)
         {
             fixed (ulong* parameters_ptr = parameters)
             {
@@ -4989,7 +4989,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetQueryObjectui64v"/>
-        public static unsafe void GetQueryObjectui64(QueryHandle id, QueryObjectParameterName pname, ref ulong parameters)
+        public static unsafe void GetQueryObjectui64(int id, QueryObjectParameterName pname, ref ulong parameters)
         {
             fixed (ulong* parameters_ptr = &parameters)
             {
@@ -5474,7 +5474,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetUniformdv"/>
-        public static unsafe void GetUniformd(ProgramHandle program, int location, Span<double> parameters)
+        public static unsafe void GetUniformd(int program, int location, Span<double> parameters)
         {
             fixed (double* parameters_ptr = parameters)
             {
@@ -5482,7 +5482,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetUniformdv"/>
-        public static unsafe void GetUniformd(ProgramHandle program, int location, double[] parameters)
+        public static unsafe void GetUniformd(int program, int location, double[] parameters)
         {
             fixed (double* parameters_ptr = parameters)
             {
@@ -5490,7 +5490,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetUniformdv"/>
-        public static unsafe void GetUniformd(ProgramHandle program, int location, ref double parameters)
+        public static unsafe void GetUniformd(int program, int location, ref double parameters)
         {
             fixed (double* parameters_ptr = &parameters)
             {
@@ -5498,7 +5498,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetSubroutineUniformLocation"/>
-        public static unsafe int GetSubroutineUniformLocation(ProgramHandle program, ShaderType shadertype, string name)
+        public static unsafe int GetSubroutineUniformLocation(int program, ShaderType shadertype, string name)
         {
             int returnValue;
             byte* name_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(name);
@@ -5507,7 +5507,7 @@ namespace OpenTK.Graphics.OpenGL
             return returnValue;
         }
         /// <inheritdoc cref="GetSubroutineIndex"/>
-        public static unsafe uint GetSubroutineIndex(ProgramHandle program, ShaderType shadertype, string name)
+        public static unsafe uint GetSubroutineIndex(int program, ShaderType shadertype, string name)
         {
             uint returnValue;
             byte* name_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(name);
@@ -5516,7 +5516,7 @@ namespace OpenTK.Graphics.OpenGL
             return returnValue;
         }
         /// <inheritdoc cref="GetActiveSubroutineUniformiv"/>
-        public static unsafe void GetActiveSubroutineUniformi(ProgramHandle program, ShaderType shadertype, uint index, SubroutineParameterName pname, Span<int> values)
+        public static unsafe void GetActiveSubroutineUniformi(int program, ShaderType shadertype, uint index, SubroutineParameterName pname, Span<int> values)
         {
             fixed (int* values_ptr = values)
             {
@@ -5524,7 +5524,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetActiveSubroutineUniformiv"/>
-        public static unsafe void GetActiveSubroutineUniformi(ProgramHandle program, ShaderType shadertype, uint index, SubroutineParameterName pname, int[] values)
+        public static unsafe void GetActiveSubroutineUniformi(int program, ShaderType shadertype, uint index, SubroutineParameterName pname, int[] values)
         {
             fixed (int* values_ptr = values)
             {
@@ -5532,7 +5532,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetActiveSubroutineUniformiv"/>
-        public static unsafe void GetActiveSubroutineUniformi(ProgramHandle program, ShaderType shadertype, uint index, SubroutineParameterName pname, ref int values)
+        public static unsafe void GetActiveSubroutineUniformi(int program, ShaderType shadertype, uint index, SubroutineParameterName pname, ref int values)
         {
             fixed (int* values_ptr = &values)
             {
@@ -5540,7 +5540,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetActiveSubroutineUniformName"/>
-        public static unsafe string GetActiveSubroutineUniformName(ProgramHandle program, ShaderType shadertype, uint index, int bufSize, Span<int> length)
+        public static unsafe string GetActiveSubroutineUniformName(int program, ShaderType shadertype, uint index, int bufSize, Span<int> length)
         {
             string name;
             fixed (int* length_ptr = length)
@@ -5553,7 +5553,7 @@ namespace OpenTK.Graphics.OpenGL
             return name;
         }
         /// <inheritdoc cref="GetActiveSubroutineUniformName"/>
-        public static unsafe void GetActiveSubroutineUniformName(ProgramHandle program, ShaderType shadertype, uint index, int bufSize, Span<int> length, out string name)
+        public static unsafe void GetActiveSubroutineUniformName(int program, ShaderType shadertype, uint index, int bufSize, Span<int> length, out string name)
         {
             fixed (int* length_ptr = length)
             {
@@ -5564,7 +5564,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetActiveSubroutineUniformName"/>
-        public static unsafe string GetActiveSubroutineUniformName(ProgramHandle program, ShaderType shadertype, uint index, int bufSize, int[] length)
+        public static unsafe string GetActiveSubroutineUniformName(int program, ShaderType shadertype, uint index, int bufSize, int[] length)
         {
             string name;
             fixed (int* length_ptr = length)
@@ -5577,7 +5577,7 @@ namespace OpenTK.Graphics.OpenGL
             return name;
         }
         /// <inheritdoc cref="GetActiveSubroutineUniformName"/>
-        public static unsafe void GetActiveSubroutineUniformName(ProgramHandle program, ShaderType shadertype, uint index, int bufSize, int[] length, out string name)
+        public static unsafe void GetActiveSubroutineUniformName(int program, ShaderType shadertype, uint index, int bufSize, int[] length, out string name)
         {
             fixed (int* length_ptr = length)
             {
@@ -5588,7 +5588,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetActiveSubroutineUniformName"/>
-        public static unsafe string GetActiveSubroutineUniformName(ProgramHandle program, ShaderType shadertype, uint index, int bufSize, ref int length)
+        public static unsafe string GetActiveSubroutineUniformName(int program, ShaderType shadertype, uint index, int bufSize, ref int length)
         {
             string name;
             fixed (int* length_ptr = &length)
@@ -5601,7 +5601,7 @@ namespace OpenTK.Graphics.OpenGL
             return name;
         }
         /// <inheritdoc cref="GetActiveSubroutineUniformName"/>
-        public static unsafe void GetActiveSubroutineUniformName(ProgramHandle program, ShaderType shadertype, uint index, int bufSize, ref int length, out string name)
+        public static unsafe void GetActiveSubroutineUniformName(int program, ShaderType shadertype, uint index, int bufSize, ref int length, out string name)
         {
             fixed (int* length_ptr = &length)
             {
@@ -5612,7 +5612,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetActiveSubroutineName"/>
-        public static unsafe string GetActiveSubroutineName(ProgramHandle program, ShaderType shadertype, uint index, int bufSize, Span<int> length)
+        public static unsafe string GetActiveSubroutineName(int program, ShaderType shadertype, uint index, int bufSize, Span<int> length)
         {
             string name;
             fixed (int* length_ptr = length)
@@ -5625,7 +5625,7 @@ namespace OpenTK.Graphics.OpenGL
             return name;
         }
         /// <inheritdoc cref="GetActiveSubroutineName"/>
-        public static unsafe void GetActiveSubroutineName(ProgramHandle program, ShaderType shadertype, uint index, int bufSize, Span<int> length, out string name)
+        public static unsafe void GetActiveSubroutineName(int program, ShaderType shadertype, uint index, int bufSize, Span<int> length, out string name)
         {
             fixed (int* length_ptr = length)
             {
@@ -5636,7 +5636,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetActiveSubroutineName"/>
-        public static unsafe string GetActiveSubroutineName(ProgramHandle program, ShaderType shadertype, uint index, int bufSize, int[] length)
+        public static unsafe string GetActiveSubroutineName(int program, ShaderType shadertype, uint index, int bufSize, int[] length)
         {
             string name;
             fixed (int* length_ptr = length)
@@ -5649,7 +5649,7 @@ namespace OpenTK.Graphics.OpenGL
             return name;
         }
         /// <inheritdoc cref="GetActiveSubroutineName"/>
-        public static unsafe void GetActiveSubroutineName(ProgramHandle program, ShaderType shadertype, uint index, int bufSize, int[] length, out string name)
+        public static unsafe void GetActiveSubroutineName(int program, ShaderType shadertype, uint index, int bufSize, int[] length, out string name)
         {
             fixed (int* length_ptr = length)
             {
@@ -5660,7 +5660,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetActiveSubroutineName"/>
-        public static unsafe string GetActiveSubroutineName(ProgramHandle program, ShaderType shadertype, uint index, int bufSize, ref int length)
+        public static unsafe string GetActiveSubroutineName(int program, ShaderType shadertype, uint index, int bufSize, ref int length)
         {
             string name;
             fixed (int* length_ptr = &length)
@@ -5673,7 +5673,7 @@ namespace OpenTK.Graphics.OpenGL
             return name;
         }
         /// <inheritdoc cref="GetActiveSubroutineName"/>
-        public static unsafe void GetActiveSubroutineName(ProgramHandle program, ShaderType shadertype, uint index, int bufSize, ref int length, out string name)
+        public static unsafe void GetActiveSubroutineName(int program, ShaderType shadertype, uint index, int bufSize, ref int length, out string name)
         {
             fixed (int* length_ptr = &length)
             {
@@ -5734,7 +5734,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetProgramStageiv"/>
-        public static unsafe void GetProgramStagei(ProgramHandle program, ShaderType shadertype, ProgramStagePName pname, Span<int> values)
+        public static unsafe void GetProgramStagei(int program, ShaderType shadertype, ProgramStagePName pname, Span<int> values)
         {
             fixed (int* values_ptr = values)
             {
@@ -5742,7 +5742,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetProgramStageiv"/>
-        public static unsafe void GetProgramStagei(ProgramHandle program, ShaderType shadertype, ProgramStagePName pname, int[] values)
+        public static unsafe void GetProgramStagei(int program, ShaderType shadertype, ProgramStagePName pname, int[] values)
         {
             fixed (int* values_ptr = values)
             {
@@ -5750,7 +5750,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetProgramStageiv"/>
-        public static unsafe void GetProgramStagei(ProgramHandle program, ShaderType shadertype, ProgramStagePName pname, ref int values)
+        public static unsafe void GetProgramStagei(int program, ShaderType shadertype, ProgramStagePName pname, ref int values)
         {
             fixed (int* values_ptr = &values)
             {
@@ -5782,44 +5782,44 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="DeleteTransformFeedbacks"/>
-        public static unsafe void DeleteTransformFeedback(in TransformFeedbackHandle id)
+        public static unsafe void DeleteTransformFeedback(in int id)
         {
             int n = 1;
-            fixed(TransformFeedbackHandle* ids_handle = &id)
+            fixed(int* ids_handle = &id)
             {
                 DeleteTransformFeedbacks(n, ids_handle);
             }
         }
         /// <inheritdoc cref="DeleteTransformFeedbacks"/>
-        public static unsafe void DeleteTransformFeedbacks(ReadOnlySpan<TransformFeedbackHandle> ids)
+        public static unsafe void DeleteTransformFeedbacks(ReadOnlySpan<int> ids)
         {
             int n = (int)(ids.Length);
-            fixed (TransformFeedbackHandle* ids_ptr = ids)
+            fixed (int* ids_ptr = ids)
             {
                 DeleteTransformFeedbacks(n, ids_ptr);
             }
         }
         /// <inheritdoc cref="DeleteTransformFeedbacks"/>
-        public static unsafe void DeleteTransformFeedbacks(TransformFeedbackHandle[] ids)
+        public static unsafe void DeleteTransformFeedbacks(int[] ids)
         {
             int n = (int)(ids.Length);
-            fixed (TransformFeedbackHandle* ids_ptr = ids)
+            fixed (int* ids_ptr = ids)
             {
                 DeleteTransformFeedbacks(n, ids_ptr);
             }
         }
         /// <inheritdoc cref="DeleteTransformFeedbacks"/>
-        public static unsafe void DeleteTransformFeedbacks(int n, in TransformFeedbackHandle ids)
+        public static unsafe void DeleteTransformFeedbacks(int n, in int ids)
         {
-            fixed (TransformFeedbackHandle* ids_ptr = &ids)
+            fixed (int* ids_ptr = &ids)
             {
                 DeleteTransformFeedbacks(n, ids_ptr);
             }
         }
         /// <inheritdoc cref="GenTransformFeedbacks"/>
-        public static unsafe TransformFeedbackHandle GenTransformFeedback()
+        public static unsafe int GenTransformFeedback()
         {
-            TransformFeedbackHandle id;
+            int id;
             int n = 1;
             Unsafe.SkipInit(out id);
             // FIXME: This could be a problem for the overloads that take an out parameter
@@ -5830,12 +5830,12 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            TransformFeedbackHandle* ids_handle = (TransformFeedbackHandle*)Unsafe.AsPointer(ref id);
+            int* ids_handle = (int*)Unsafe.AsPointer(ref id);
             GenTransformFeedbacks(n, ids_handle);
             return id;
         }
         /// <inheritdoc cref="GenTransformFeedbacks"/>
-        public static unsafe void GenTransformFeedback(out TransformFeedbackHandle id)
+        public static unsafe void GenTransformFeedback(out int id)
         {
             int n = 1;
             Unsafe.SkipInit(out id);
@@ -5847,31 +5847,31 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            TransformFeedbackHandle* ids_handle = (TransformFeedbackHandle*)Unsafe.AsPointer(ref id);
+            int* ids_handle = (int*)Unsafe.AsPointer(ref id);
             GenTransformFeedbacks(n, ids_handle);
         }
         /// <inheritdoc cref="GenTransformFeedbacks"/>
-        public static unsafe void GenTransformFeedbacks(Span<TransformFeedbackHandle> ids)
+        public static unsafe void GenTransformFeedbacks(Span<int> ids)
         {
             int n = (int)(ids.Length);
-            fixed (TransformFeedbackHandle* ids_ptr = ids)
+            fixed (int* ids_ptr = ids)
             {
                 GenTransformFeedbacks(n, ids_ptr);
             }
         }
         /// <inheritdoc cref="GenTransformFeedbacks"/>
-        public static unsafe void GenTransformFeedbacks(TransformFeedbackHandle[] ids)
+        public static unsafe void GenTransformFeedbacks(int[] ids)
         {
             int n = (int)(ids.Length);
-            fixed (TransformFeedbackHandle* ids_ptr = ids)
+            fixed (int* ids_ptr = ids)
             {
                 GenTransformFeedbacks(n, ids_ptr);
             }
         }
         /// <inheritdoc cref="GenTransformFeedbacks"/>
-        public static unsafe void GenTransformFeedbacks(int n, ref TransformFeedbackHandle ids)
+        public static unsafe void GenTransformFeedbacks(int n, ref int ids)
         {
-            fixed (TransformFeedbackHandle* ids_ptr = &ids)
+            fixed (int* ids_ptr = &ids)
             {
                 GenTransformFeedbacks(n, ids_ptr);
             }
@@ -5901,40 +5901,40 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ShaderBinary"/>
-        public static unsafe void ShaderBinary(ReadOnlySpan<ShaderHandle> shaders, ShaderBinaryFormat binaryFormat, IntPtr binary, int length)
+        public static unsafe void ShaderBinary(ReadOnlySpan<int> shaders, ShaderBinaryFormat binaryFormat, IntPtr binary, int length)
         {
             int count = (int)(shaders.Length);
-            fixed (ShaderHandle* shaders_ptr = shaders)
+            fixed (int* shaders_ptr = shaders)
             {
                 void* binary_vptr = (void*)binary;
                 ShaderBinary(count, shaders_ptr, binaryFormat, binary_vptr, length);
             }
         }
         /// <inheritdoc cref="ShaderBinary"/>
-        public static unsafe void ShaderBinary(ShaderHandle[] shaders, ShaderBinaryFormat binaryFormat, IntPtr binary, int length)
+        public static unsafe void ShaderBinary(int[] shaders, ShaderBinaryFormat binaryFormat, IntPtr binary, int length)
         {
             int count = (int)(shaders.Length);
-            fixed (ShaderHandle* shaders_ptr = shaders)
+            fixed (int* shaders_ptr = shaders)
             {
                 void* binary_vptr = (void*)binary;
                 ShaderBinary(count, shaders_ptr, binaryFormat, binary_vptr, length);
             }
         }
         /// <inheritdoc cref="ShaderBinary"/>
-        public static unsafe void ShaderBinary(int count, in ShaderHandle shaders, ShaderBinaryFormat binaryFormat, IntPtr binary, int length)
+        public static unsafe void ShaderBinary(int count, in int shaders, ShaderBinaryFormat binaryFormat, IntPtr binary, int length)
         {
-            fixed (ShaderHandle* shaders_ptr = &shaders)
+            fixed (int* shaders_ptr = &shaders)
             {
                 void* binary_vptr = (void*)binary;
                 ShaderBinary(count, shaders_ptr, binaryFormat, binary_vptr, length);
             }
         }
         /// <inheritdoc cref="ShaderBinary"/>
-        public static unsafe void ShaderBinary<T1>(ReadOnlySpan<ShaderHandle> shaders, ShaderBinaryFormat binaryFormat, ReadOnlySpan<T1> binary)
+        public static unsafe void ShaderBinary<T1>(ReadOnlySpan<int> shaders, ShaderBinaryFormat binaryFormat, ReadOnlySpan<T1> binary)
             where T1 : unmanaged
         {
             int count = (int)(shaders.Length);
-            fixed (ShaderHandle* shaders_ptr = shaders)
+            fixed (int* shaders_ptr = shaders)
             {
                 int length = (int)(binary.Length * sizeof(T1));
                 fixed (void* binary_ptr = binary)
@@ -5944,11 +5944,11 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ShaderBinary"/>
-        public static unsafe void ShaderBinary<T1>(ShaderHandle[] shaders, ShaderBinaryFormat binaryFormat, T1[] binary)
+        public static unsafe void ShaderBinary<T1>(int[] shaders, ShaderBinaryFormat binaryFormat, T1[] binary)
             where T1 : unmanaged
         {
             int count = (int)(shaders.Length);
-            fixed (ShaderHandle* shaders_ptr = shaders)
+            fixed (int* shaders_ptr = shaders)
             {
                 int length = (int)(binary.Length * sizeof(T1));
                 fixed (void* binary_ptr = binary)
@@ -5958,10 +5958,10 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ShaderBinary"/>
-        public static unsafe void ShaderBinary<T1>(int count, in ShaderHandle shaders, ShaderBinaryFormat binaryFormat, in T1 binary, int length)
+        public static unsafe void ShaderBinary<T1>(int count, in int shaders, ShaderBinaryFormat binaryFormat, in T1 binary, int length)
             where T1 : unmanaged
         {
-            fixed (ShaderHandle* shaders_ptr = &shaders)
+            fixed (int* shaders_ptr = &shaders)
             fixed (void* binary_ptr = &binary)
             {
                 ShaderBinary(count, shaders_ptr, binaryFormat, binary_ptr, length);
@@ -5999,7 +5999,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetProgramBinary"/>
-        public static unsafe void GetProgramBinary(ProgramHandle program, int bufSize, Span<int> length, Span<All> binaryFormat, IntPtr binary)
+        public static unsafe void GetProgramBinary(int program, int bufSize, Span<int> length, Span<All> binaryFormat, IntPtr binary)
         {
             fixed (int* length_ptr = length)
             {
@@ -6011,7 +6011,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetProgramBinary"/>
-        public static unsafe void GetProgramBinary(ProgramHandle program, int bufSize, int[] length, All[] binaryFormat, IntPtr binary)
+        public static unsafe void GetProgramBinary(int program, int bufSize, int[] length, All[] binaryFormat, IntPtr binary)
         {
             fixed (int* length_ptr = length)
             {
@@ -6023,7 +6023,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetProgramBinary"/>
-        public static unsafe void GetProgramBinary(ProgramHandle program, int bufSize, ref int length, ref All binaryFormat, IntPtr binary)
+        public static unsafe void GetProgramBinary(int program, int bufSize, ref int length, ref All binaryFormat, IntPtr binary)
         {
             fixed (int* length_ptr = &length)
             fixed (All* binaryFormat_ptr = &binaryFormat)
@@ -6033,7 +6033,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetProgramBinary"/>
-        public static unsafe void GetProgramBinary<T1>(ProgramHandle program, Span<int> length, Span<All> binaryFormat, Span<T1> binary)
+        public static unsafe void GetProgramBinary<T1>(int program, Span<int> length, Span<All> binaryFormat, Span<T1> binary)
             where T1 : unmanaged
         {
             fixed (int* length_ptr = length)
@@ -6049,7 +6049,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetProgramBinary"/>
-        public static unsafe void GetProgramBinary<T1>(ProgramHandle program, int[] length, All[] binaryFormat, T1[] binary)
+        public static unsafe void GetProgramBinary<T1>(int program, int[] length, All[] binaryFormat, T1[] binary)
             where T1 : unmanaged
         {
             fixed (int* length_ptr = length)
@@ -6065,7 +6065,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetProgramBinary"/>
-        public static unsafe void GetProgramBinary<T1>(ProgramHandle program, int bufSize, ref int length, ref All binaryFormat, ref T1 binary)
+        public static unsafe void GetProgramBinary<T1>(int program, int bufSize, ref int length, ref All binaryFormat, ref T1 binary)
             where T1 : unmanaged
         {
             fixed (int* length_ptr = &length)
@@ -6076,13 +6076,13 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramBinary"/>
-        public static unsafe void ProgramBinary(ProgramHandle program, All binaryFormat, IntPtr binary, int length)
+        public static unsafe void ProgramBinary(int program, All binaryFormat, IntPtr binary, int length)
         {
             void* binary_vptr = (void*)binary;
             ProgramBinary(program, binaryFormat, binary_vptr, length);
         }
         /// <inheritdoc cref="ProgramBinary"/>
-        public static unsafe void ProgramBinary<T1>(ProgramHandle program, All binaryFormat, ReadOnlySpan<T1> binary)
+        public static unsafe void ProgramBinary<T1>(int program, All binaryFormat, ReadOnlySpan<T1> binary)
             where T1 : unmanaged
         {
             int length = (int)(binary.Length * sizeof(T1));
@@ -6092,7 +6092,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramBinary"/>
-        public static unsafe void ProgramBinary<T1>(ProgramHandle program, All binaryFormat, T1[] binary)
+        public static unsafe void ProgramBinary<T1>(int program, All binaryFormat, T1[] binary)
             where T1 : unmanaged
         {
             int length = (int)(binary.Length * sizeof(T1));
@@ -6102,7 +6102,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramBinary"/>
-        public static unsafe void ProgramBinary<T1>(ProgramHandle program, All binaryFormat, in T1 binary, int length)
+        public static unsafe void ProgramBinary<T1>(int program, All binaryFormat, in T1 binary, int length)
             where T1 : unmanaged
         {
             fixed (void* binary_ptr = &binary)
@@ -6111,51 +6111,51 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="CreateShaderProgramv"/>
-        public static unsafe ProgramHandle CreateShaderProgram(ShaderType type, int count, byte** strings)
+        public static unsafe int CreateShaderProgram(ShaderType type, int count, byte** strings)
         {
-            ProgramHandle returnValue;
+            int returnValue;
             returnValue = CreateShaderProgramv(type, count, strings);
             return returnValue;
         }
         /// <inheritdoc cref="DeleteProgramPipelines"/>
-        public static unsafe void DeleteProgramPipeline(in ProgramPipelineHandle pipeline)
+        public static unsafe void DeleteProgramPipeline(in int pipeline)
         {
             int n = 1;
-            fixed(ProgramPipelineHandle* pipelines_handle = &pipeline)
+            fixed(int* pipelines_handle = &pipeline)
             {
                 DeleteProgramPipelines(n, pipelines_handle);
             }
         }
         /// <inheritdoc cref="DeleteProgramPipelines"/>
-        public static unsafe void DeleteProgramPipelines(ReadOnlySpan<ProgramPipelineHandle> pipelines)
+        public static unsafe void DeleteProgramPipelines(ReadOnlySpan<int> pipelines)
         {
             int n = (int)(pipelines.Length);
-            fixed (ProgramPipelineHandle* pipelines_ptr = pipelines)
+            fixed (int* pipelines_ptr = pipelines)
             {
                 DeleteProgramPipelines(n, pipelines_ptr);
             }
         }
         /// <inheritdoc cref="DeleteProgramPipelines"/>
-        public static unsafe void DeleteProgramPipelines(ProgramPipelineHandle[] pipelines)
+        public static unsafe void DeleteProgramPipelines(int[] pipelines)
         {
             int n = (int)(pipelines.Length);
-            fixed (ProgramPipelineHandle* pipelines_ptr = pipelines)
+            fixed (int* pipelines_ptr = pipelines)
             {
                 DeleteProgramPipelines(n, pipelines_ptr);
             }
         }
         /// <inheritdoc cref="DeleteProgramPipelines"/>
-        public static unsafe void DeleteProgramPipelines(int n, in ProgramPipelineHandle pipelines)
+        public static unsafe void DeleteProgramPipelines(int n, in int pipelines)
         {
-            fixed (ProgramPipelineHandle* pipelines_ptr = &pipelines)
+            fixed (int* pipelines_ptr = &pipelines)
             {
                 DeleteProgramPipelines(n, pipelines_ptr);
             }
         }
         /// <inheritdoc cref="GenProgramPipelines"/>
-        public static unsafe ProgramPipelineHandle GenProgramPipeline()
+        public static unsafe int GenProgramPipeline()
         {
-            ProgramPipelineHandle pipeline;
+            int pipeline;
             int n = 1;
             Unsafe.SkipInit(out pipeline);
             // FIXME: This could be a problem for the overloads that take an out parameter
@@ -6166,12 +6166,12 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            ProgramPipelineHandle* pipelines_handle = (ProgramPipelineHandle*)Unsafe.AsPointer(ref pipeline);
+            int* pipelines_handle = (int*)Unsafe.AsPointer(ref pipeline);
             GenProgramPipelines(n, pipelines_handle);
             return pipeline;
         }
         /// <inheritdoc cref="GenProgramPipelines"/>
-        public static unsafe void GenProgramPipeline(out ProgramPipelineHandle pipeline)
+        public static unsafe void GenProgramPipeline(out int pipeline)
         {
             int n = 1;
             Unsafe.SkipInit(out pipeline);
@@ -6183,37 +6183,37 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            ProgramPipelineHandle* pipelines_handle = (ProgramPipelineHandle*)Unsafe.AsPointer(ref pipeline);
+            int* pipelines_handle = (int*)Unsafe.AsPointer(ref pipeline);
             GenProgramPipelines(n, pipelines_handle);
         }
         /// <inheritdoc cref="GenProgramPipelines"/>
-        public static unsafe void GenProgramPipelines(Span<ProgramPipelineHandle> pipelines)
+        public static unsafe void GenProgramPipelines(Span<int> pipelines)
         {
             int n = (int)(pipelines.Length);
-            fixed (ProgramPipelineHandle* pipelines_ptr = pipelines)
+            fixed (int* pipelines_ptr = pipelines)
             {
                 GenProgramPipelines(n, pipelines_ptr);
             }
         }
         /// <inheritdoc cref="GenProgramPipelines"/>
-        public static unsafe void GenProgramPipelines(ProgramPipelineHandle[] pipelines)
+        public static unsafe void GenProgramPipelines(int[] pipelines)
         {
             int n = (int)(pipelines.Length);
-            fixed (ProgramPipelineHandle* pipelines_ptr = pipelines)
+            fixed (int* pipelines_ptr = pipelines)
             {
                 GenProgramPipelines(n, pipelines_ptr);
             }
         }
         /// <inheritdoc cref="GenProgramPipelines"/>
-        public static unsafe void GenProgramPipelines(int n, ref ProgramPipelineHandle pipelines)
+        public static unsafe void GenProgramPipelines(int n, ref int pipelines)
         {
-            fixed (ProgramPipelineHandle* pipelines_ptr = &pipelines)
+            fixed (int* pipelines_ptr = &pipelines)
             {
                 GenProgramPipelines(n, pipelines_ptr);
             }
         }
         /// <inheritdoc cref="GetProgramPipelineiv"/>
-        public static unsafe void GetProgramPipelinei(ProgramPipelineHandle pipeline, PipelineParameterName pname, Span<int> parameters)
+        public static unsafe void GetProgramPipelinei(int pipeline, PipelineParameterName pname, Span<int> parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
@@ -6221,7 +6221,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetProgramPipelineiv"/>
-        public static unsafe void GetProgramPipelinei(ProgramPipelineHandle pipeline, PipelineParameterName pname, int[] parameters)
+        public static unsafe void GetProgramPipelinei(int pipeline, PipelineParameterName pname, int[] parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
@@ -6229,7 +6229,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetProgramPipelineiv"/>
-        public static unsafe void GetProgramPipelinei(ProgramPipelineHandle pipeline, PipelineParameterName pname, ref int parameters)
+        public static unsafe void GetProgramPipelinei(int pipeline, PipelineParameterName pname, ref int parameters)
         {
             fixed (int* parameters_ptr = &parameters)
             {
@@ -6237,7 +6237,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform1iv"/>
-        public static unsafe void ProgramUniform1iv(ProgramHandle program, int location, ReadOnlySpan<int> value)
+        public static unsafe void ProgramUniform1iv(int program, int location, ReadOnlySpan<int> value)
         {
             int count = (int)(value.Length);
             fixed (int* value_ptr = value)
@@ -6246,7 +6246,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform1iv"/>
-        public static unsafe void ProgramUniform1iv(ProgramHandle program, int location, int[] value)
+        public static unsafe void ProgramUniform1iv(int program, int location, int[] value)
         {
             int count = (int)(value.Length);
             fixed (int* value_ptr = value)
@@ -6255,7 +6255,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform1iv"/>
-        public static unsafe void ProgramUniform1iv(ProgramHandle program, int location, int count, in int value)
+        public static unsafe void ProgramUniform1iv(int program, int location, int count, in int value)
         {
             fixed (int* value_ptr = &value)
             {
@@ -6263,7 +6263,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform1fv"/>
-        public static unsafe void ProgramUniform1fv(ProgramHandle program, int location, ReadOnlySpan<float> value)
+        public static unsafe void ProgramUniform1fv(int program, int location, ReadOnlySpan<float> value)
         {
             int count = (int)(value.Length);
             fixed (float* value_ptr = value)
@@ -6272,7 +6272,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform1fv"/>
-        public static unsafe void ProgramUniform1fv(ProgramHandle program, int location, float[] value)
+        public static unsafe void ProgramUniform1fv(int program, int location, float[] value)
         {
             int count = (int)(value.Length);
             fixed (float* value_ptr = value)
@@ -6281,7 +6281,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform1fv"/>
-        public static unsafe void ProgramUniform1fv(ProgramHandle program, int location, int count, in float value)
+        public static unsafe void ProgramUniform1fv(int program, int location, int count, in float value)
         {
             fixed (float* value_ptr = &value)
             {
@@ -6289,7 +6289,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform1dv"/>
-        public static unsafe void ProgramUniform1dv(ProgramHandle program, int location, ReadOnlySpan<double> value)
+        public static unsafe void ProgramUniform1dv(int program, int location, ReadOnlySpan<double> value)
         {
             int count = (int)(value.Length);
             fixed (double* value_ptr = value)
@@ -6298,7 +6298,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform1dv"/>
-        public static unsafe void ProgramUniform1dv(ProgramHandle program, int location, double[] value)
+        public static unsafe void ProgramUniform1dv(int program, int location, double[] value)
         {
             int count = (int)(value.Length);
             fixed (double* value_ptr = value)
@@ -6307,7 +6307,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform1dv"/>
-        public static unsafe void ProgramUniform1dv(ProgramHandle program, int location, int count, in double value)
+        public static unsafe void ProgramUniform1dv(int program, int location, int count, in double value)
         {
             fixed (double* value_ptr = &value)
             {
@@ -6315,7 +6315,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform1uiv"/>
-        public static unsafe void ProgramUniform1ui(ProgramHandle program, int location, ReadOnlySpan<uint> value)
+        public static unsafe void ProgramUniform1ui(int program, int location, ReadOnlySpan<uint> value)
         {
             int count = (int)(value.Length);
             fixed (uint* value_ptr = value)
@@ -6324,7 +6324,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform1uiv"/>
-        public static unsafe void ProgramUniform1ui(ProgramHandle program, int location, uint[] value)
+        public static unsafe void ProgramUniform1ui(int program, int location, uint[] value)
         {
             int count = (int)(value.Length);
             fixed (uint* value_ptr = value)
@@ -6333,7 +6333,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform1uiv"/>
-        public static unsafe void ProgramUniform1ui(ProgramHandle program, int location, int count, in uint value)
+        public static unsafe void ProgramUniform1ui(int program, int location, int count, in uint value)
         {
             fixed (uint* value_ptr = &value)
             {
@@ -6341,7 +6341,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform2iv"/>
-        public static unsafe void ProgramUniform2i(ProgramHandle program, int location, int count, in Vector2i value)
+        public static unsafe void ProgramUniform2i(int program, int location, int count, in Vector2i value)
         {
             fixed (Vector2i* tmp_vecPtr = &value)
             {
@@ -6350,7 +6350,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform2iv"/>
-        public static unsafe void ProgramUniform2i(ProgramHandle program, int location, int count, ReadOnlySpan<Vector2i> value)
+        public static unsafe void ProgramUniform2i(int program, int location, int count, ReadOnlySpan<Vector2i> value)
         {
             fixed (Vector2i* tmp_vecPtr = value)
             {
@@ -6359,7 +6359,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform2iv"/>
-        public static unsafe void ProgramUniform2i(ProgramHandle program, int location, int count, Vector2i[] value)
+        public static unsafe void ProgramUniform2i(int program, int location, int count, Vector2i[] value)
         {
             fixed (Vector2i* tmp_vecPtr = value)
             {
@@ -6368,7 +6368,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform2fv"/>
-        public static unsafe void ProgramUniform2f(ProgramHandle program, int location, int count, in Vector2 value)
+        public static unsafe void ProgramUniform2f(int program, int location, int count, in Vector2 value)
         {
             fixed (Vector2* tmp_vecPtr = &value)
             {
@@ -6377,7 +6377,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform2fv"/>
-        public static unsafe void ProgramUniform2f(ProgramHandle program, int location, int count, ReadOnlySpan<Vector2> value)
+        public static unsafe void ProgramUniform2f(int program, int location, int count, ReadOnlySpan<Vector2> value)
         {
             fixed (Vector2* tmp_vecPtr = value)
             {
@@ -6386,7 +6386,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform2fv"/>
-        public static unsafe void ProgramUniform2f(ProgramHandle program, int location, int count, Vector2[] value)
+        public static unsafe void ProgramUniform2f(int program, int location, int count, Vector2[] value)
         {
             fixed (Vector2* tmp_vecPtr = value)
             {
@@ -6395,7 +6395,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform2fv"/>
-        public static unsafe void ProgramUniform2f(ProgramHandle program, int location, int count, in System.Numerics.Vector2 value)
+        public static unsafe void ProgramUniform2f(int program, int location, int count, in System.Numerics.Vector2 value)
         {
             fixed (System.Numerics.Vector2* tmp_vecPtr = &value)
             {
@@ -6404,7 +6404,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform2fv"/>
-        public static unsafe void ProgramUniform2f(ProgramHandle program, int location, int count, ReadOnlySpan<System.Numerics.Vector2> value)
+        public static unsafe void ProgramUniform2f(int program, int location, int count, ReadOnlySpan<System.Numerics.Vector2> value)
         {
             fixed (System.Numerics.Vector2* tmp_vecPtr = value)
             {
@@ -6413,7 +6413,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform2fv"/>
-        public static unsafe void ProgramUniform2f(ProgramHandle program, int location, int count, System.Numerics.Vector2[] value)
+        public static unsafe void ProgramUniform2f(int program, int location, int count, System.Numerics.Vector2[] value)
         {
             fixed (System.Numerics.Vector2* tmp_vecPtr = value)
             {
@@ -6422,7 +6422,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform2dv"/>
-        public static unsafe void ProgramUniform2d(ProgramHandle program, int location, int count, in Vector2d value)
+        public static unsafe void ProgramUniform2d(int program, int location, int count, in Vector2d value)
         {
             fixed (Vector2d* tmp_vecPtr = &value)
             {
@@ -6431,7 +6431,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform2dv"/>
-        public static unsafe void ProgramUniform2d(ProgramHandle program, int location, int count, ReadOnlySpan<Vector2d> value)
+        public static unsafe void ProgramUniform2d(int program, int location, int count, ReadOnlySpan<Vector2d> value)
         {
             fixed (Vector2d* tmp_vecPtr = value)
             {
@@ -6440,7 +6440,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform2dv"/>
-        public static unsafe void ProgramUniform2d(ProgramHandle program, int location, int count, Vector2d[] value)
+        public static unsafe void ProgramUniform2d(int program, int location, int count, Vector2d[] value)
         {
             fixed (Vector2d* tmp_vecPtr = value)
             {
@@ -6449,7 +6449,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform2uiv"/>
-        public static unsafe void ProgramUniform2ui(ProgramHandle program, int location, ReadOnlySpan<uint> value)
+        public static unsafe void ProgramUniform2ui(int program, int location, ReadOnlySpan<uint> value)
         {
             int count = (int)(value.Length / 2);
             fixed (uint* value_ptr = value)
@@ -6458,7 +6458,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform2uiv"/>
-        public static unsafe void ProgramUniform2ui(ProgramHandle program, int location, uint[] value)
+        public static unsafe void ProgramUniform2ui(int program, int location, uint[] value)
         {
             int count = (int)(value.Length / 2);
             fixed (uint* value_ptr = value)
@@ -6467,7 +6467,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform2uiv"/>
-        public static unsafe void ProgramUniform2ui(ProgramHandle program, int location, int count, in uint value)
+        public static unsafe void ProgramUniform2ui(int program, int location, int count, in uint value)
         {
             fixed (uint* value_ptr = &value)
             {
@@ -6475,7 +6475,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform3iv"/>
-        public static unsafe void ProgramUniform3i(ProgramHandle program, int location, int count, in Vector3i value)
+        public static unsafe void ProgramUniform3i(int program, int location, int count, in Vector3i value)
         {
             fixed (Vector3i* tmp_vecPtr = &value)
             {
@@ -6484,7 +6484,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform3iv"/>
-        public static unsafe void ProgramUniform3i(ProgramHandle program, int location, int count, ReadOnlySpan<Vector3i> value)
+        public static unsafe void ProgramUniform3i(int program, int location, int count, ReadOnlySpan<Vector3i> value)
         {
             fixed (Vector3i* tmp_vecPtr = value)
             {
@@ -6493,7 +6493,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform3iv"/>
-        public static unsafe void ProgramUniform3i(ProgramHandle program, int location, int count, Vector3i[] value)
+        public static unsafe void ProgramUniform3i(int program, int location, int count, Vector3i[] value)
         {
             fixed (Vector3i* tmp_vecPtr = value)
             {
@@ -6502,7 +6502,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform3fv"/>
-        public static unsafe void ProgramUniform3f(ProgramHandle program, int location, int count, in Vector3 value)
+        public static unsafe void ProgramUniform3f(int program, int location, int count, in Vector3 value)
         {
             fixed (Vector3* tmp_vecPtr = &value)
             {
@@ -6511,7 +6511,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform3fv"/>
-        public static unsafe void ProgramUniform3f(ProgramHandle program, int location, int count, ReadOnlySpan<Vector3> value)
+        public static unsafe void ProgramUniform3f(int program, int location, int count, ReadOnlySpan<Vector3> value)
         {
             fixed (Vector3* tmp_vecPtr = value)
             {
@@ -6520,7 +6520,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform3fv"/>
-        public static unsafe void ProgramUniform3f(ProgramHandle program, int location, int count, Vector3[] value)
+        public static unsafe void ProgramUniform3f(int program, int location, int count, Vector3[] value)
         {
             fixed (Vector3* tmp_vecPtr = value)
             {
@@ -6529,7 +6529,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform3fv"/>
-        public static unsafe void ProgramUniform3f(ProgramHandle program, int location, int count, in System.Numerics.Vector3 value)
+        public static unsafe void ProgramUniform3f(int program, int location, int count, in System.Numerics.Vector3 value)
         {
             fixed (System.Numerics.Vector3* tmp_vecPtr = &value)
             {
@@ -6538,7 +6538,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform3fv"/>
-        public static unsafe void ProgramUniform3f(ProgramHandle program, int location, int count, ReadOnlySpan<System.Numerics.Vector3> value)
+        public static unsafe void ProgramUniform3f(int program, int location, int count, ReadOnlySpan<System.Numerics.Vector3> value)
         {
             fixed (System.Numerics.Vector3* tmp_vecPtr = value)
             {
@@ -6547,7 +6547,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform3fv"/>
-        public static unsafe void ProgramUniform3f(ProgramHandle program, int location, int count, System.Numerics.Vector3[] value)
+        public static unsafe void ProgramUniform3f(int program, int location, int count, System.Numerics.Vector3[] value)
         {
             fixed (System.Numerics.Vector3* tmp_vecPtr = value)
             {
@@ -6556,7 +6556,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform3dv"/>
-        public static unsafe void ProgramUniform3d(ProgramHandle program, int location, int count, in Vector3d value)
+        public static unsafe void ProgramUniform3d(int program, int location, int count, in Vector3d value)
         {
             fixed (Vector3d* tmp_vecPtr = &value)
             {
@@ -6565,7 +6565,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform3dv"/>
-        public static unsafe void ProgramUniform3d(ProgramHandle program, int location, int count, ReadOnlySpan<Vector3d> value)
+        public static unsafe void ProgramUniform3d(int program, int location, int count, ReadOnlySpan<Vector3d> value)
         {
             fixed (Vector3d* tmp_vecPtr = value)
             {
@@ -6574,7 +6574,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform3dv"/>
-        public static unsafe void ProgramUniform3d(ProgramHandle program, int location, int count, Vector3d[] value)
+        public static unsafe void ProgramUniform3d(int program, int location, int count, Vector3d[] value)
         {
             fixed (Vector3d* tmp_vecPtr = value)
             {
@@ -6583,7 +6583,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform3uiv"/>
-        public static unsafe void ProgramUniform3ui(ProgramHandle program, int location, ReadOnlySpan<uint> value)
+        public static unsafe void ProgramUniform3ui(int program, int location, ReadOnlySpan<uint> value)
         {
             int count = (int)(value.Length / 3);
             fixed (uint* value_ptr = value)
@@ -6592,7 +6592,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform3uiv"/>
-        public static unsafe void ProgramUniform3ui(ProgramHandle program, int location, uint[] value)
+        public static unsafe void ProgramUniform3ui(int program, int location, uint[] value)
         {
             int count = (int)(value.Length / 3);
             fixed (uint* value_ptr = value)
@@ -6601,7 +6601,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform3uiv"/>
-        public static unsafe void ProgramUniform3ui(ProgramHandle program, int location, int count, in uint value)
+        public static unsafe void ProgramUniform3ui(int program, int location, int count, in uint value)
         {
             fixed (uint* value_ptr = &value)
             {
@@ -6609,7 +6609,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform4iv"/>
-        public static unsafe void ProgramUniform4i(ProgramHandle program, int location, int count, in Vector4i value)
+        public static unsafe void ProgramUniform4i(int program, int location, int count, in Vector4i value)
         {
             fixed (Vector4i* tmp_vecPtr = &value)
             {
@@ -6618,7 +6618,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform4iv"/>
-        public static unsafe void ProgramUniform4i(ProgramHandle program, int location, int count, ReadOnlySpan<Vector4i> value)
+        public static unsafe void ProgramUniform4i(int program, int location, int count, ReadOnlySpan<Vector4i> value)
         {
             fixed (Vector4i* tmp_vecPtr = value)
             {
@@ -6627,7 +6627,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform4iv"/>
-        public static unsafe void ProgramUniform4i(ProgramHandle program, int location, int count, Vector4i[] value)
+        public static unsafe void ProgramUniform4i(int program, int location, int count, Vector4i[] value)
         {
             fixed (Vector4i* tmp_vecPtr = value)
             {
@@ -6636,7 +6636,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform4fv"/>
-        public static unsafe void ProgramUniform4f(ProgramHandle program, int location, int count, in Vector4 value)
+        public static unsafe void ProgramUniform4f(int program, int location, int count, in Vector4 value)
         {
             fixed (Vector4* tmp_vecPtr = &value)
             {
@@ -6645,7 +6645,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform4fv"/>
-        public static unsafe void ProgramUniform4f(ProgramHandle program, int location, int count, ReadOnlySpan<Vector4> value)
+        public static unsafe void ProgramUniform4f(int program, int location, int count, ReadOnlySpan<Vector4> value)
         {
             fixed (Vector4* tmp_vecPtr = value)
             {
@@ -6654,7 +6654,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform4fv"/>
-        public static unsafe void ProgramUniform4f(ProgramHandle program, int location, int count, Vector4[] value)
+        public static unsafe void ProgramUniform4f(int program, int location, int count, Vector4[] value)
         {
             fixed (Vector4* tmp_vecPtr = value)
             {
@@ -6663,7 +6663,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform4fv"/>
-        public static unsafe void ProgramUniform4f(ProgramHandle program, int location, int count, in System.Numerics.Vector4 value)
+        public static unsafe void ProgramUniform4f(int program, int location, int count, in System.Numerics.Vector4 value)
         {
             fixed (System.Numerics.Vector4* tmp_vecPtr = &value)
             {
@@ -6672,7 +6672,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform4fv"/>
-        public static unsafe void ProgramUniform4f(ProgramHandle program, int location, int count, ReadOnlySpan<System.Numerics.Vector4> value)
+        public static unsafe void ProgramUniform4f(int program, int location, int count, ReadOnlySpan<System.Numerics.Vector4> value)
         {
             fixed (System.Numerics.Vector4* tmp_vecPtr = value)
             {
@@ -6681,7 +6681,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform4fv"/>
-        public static unsafe void ProgramUniform4f(ProgramHandle program, int location, int count, System.Numerics.Vector4[] value)
+        public static unsafe void ProgramUniform4f(int program, int location, int count, System.Numerics.Vector4[] value)
         {
             fixed (System.Numerics.Vector4* tmp_vecPtr = value)
             {
@@ -6690,7 +6690,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform4dv"/>
-        public static unsafe void ProgramUniform4d(ProgramHandle program, int location, int count, in Vector4d value)
+        public static unsafe void ProgramUniform4d(int program, int location, int count, in Vector4d value)
         {
             fixed (Vector4d* tmp_vecPtr = &value)
             {
@@ -6699,7 +6699,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform4dv"/>
-        public static unsafe void ProgramUniform4d(ProgramHandle program, int location, int count, ReadOnlySpan<Vector4d> value)
+        public static unsafe void ProgramUniform4d(int program, int location, int count, ReadOnlySpan<Vector4d> value)
         {
             fixed (Vector4d* tmp_vecPtr = value)
             {
@@ -6708,7 +6708,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform4dv"/>
-        public static unsafe void ProgramUniform4d(ProgramHandle program, int location, int count, Vector4d[] value)
+        public static unsafe void ProgramUniform4d(int program, int location, int count, Vector4d[] value)
         {
             fixed (Vector4d* tmp_vecPtr = value)
             {
@@ -6717,7 +6717,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform4uiv"/>
-        public static unsafe void ProgramUniform4ui(ProgramHandle program, int location, ReadOnlySpan<uint> value)
+        public static unsafe void ProgramUniform4ui(int program, int location, ReadOnlySpan<uint> value)
         {
             int count = (int)(value.Length / 4);
             fixed (uint* value_ptr = value)
@@ -6726,7 +6726,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform4uiv"/>
-        public static unsafe void ProgramUniform4ui(ProgramHandle program, int location, uint[] value)
+        public static unsafe void ProgramUniform4ui(int program, int location, uint[] value)
         {
             int count = (int)(value.Length / 4);
             fixed (uint* value_ptr = value)
@@ -6735,7 +6735,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniform4uiv"/>
-        public static unsafe void ProgramUniform4ui(ProgramHandle program, int location, int count, in uint value)
+        public static unsafe void ProgramUniform4ui(int program, int location, int count, in uint value)
         {
             fixed (uint* value_ptr = &value)
             {
@@ -6743,7 +6743,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2fv"/>
-        public static unsafe void ProgramUniformMatrix2f(ProgramHandle program, int location, int count, bool transpose, in Matrix2 value)
+        public static unsafe void ProgramUniformMatrix2f(int program, int location, int count, bool transpose, in Matrix2 value)
         {
             fixed (Matrix2* tmp_vecPtr = &value)
             {
@@ -6752,7 +6752,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2fv"/>
-        public static unsafe void ProgramUniformMatrix2f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix2> value)
+        public static unsafe void ProgramUniformMatrix2f(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix2> value)
         {
             fixed (Matrix2* tmp_vecPtr = value)
             {
@@ -6761,7 +6761,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2fv"/>
-        public static unsafe void ProgramUniformMatrix2f(ProgramHandle program, int location, int count, bool transpose, Matrix2[] value)
+        public static unsafe void ProgramUniformMatrix2f(int program, int location, int count, bool transpose, Matrix2[] value)
         {
             fixed (Matrix2* tmp_vecPtr = value)
             {
@@ -6770,7 +6770,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3fv"/>
-        public static unsafe void ProgramUniformMatrix3f(ProgramHandle program, int location, int count, bool transpose, in Matrix3 value)
+        public static unsafe void ProgramUniformMatrix3f(int program, int location, int count, bool transpose, in Matrix3 value)
         {
             fixed (Matrix3* tmp_vecPtr = &value)
             {
@@ -6779,7 +6779,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3fv"/>
-        public static unsafe void ProgramUniformMatrix3f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix3> value)
+        public static unsafe void ProgramUniformMatrix3f(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix3> value)
         {
             fixed (Matrix3* tmp_vecPtr = value)
             {
@@ -6788,7 +6788,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3fv"/>
-        public static unsafe void ProgramUniformMatrix3f(ProgramHandle program, int location, int count, bool transpose, Matrix3[] value)
+        public static unsafe void ProgramUniformMatrix3f(int program, int location, int count, bool transpose, Matrix3[] value)
         {
             fixed (Matrix3* tmp_vecPtr = value)
             {
@@ -6797,7 +6797,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
-        public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, int count, bool transpose, in Matrix4 value)
+        public static unsafe void ProgramUniformMatrix4f(int program, int location, int count, bool transpose, in Matrix4 value)
         {
             fixed (Matrix4* tmp_vecPtr = &value)
             {
@@ -6806,7 +6806,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
-        public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix4> value)
+        public static unsafe void ProgramUniformMatrix4f(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix4> value)
         {
             fixed (Matrix4* tmp_vecPtr = value)
             {
@@ -6815,7 +6815,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
-        public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, int count, bool transpose, Matrix4[] value)
+        public static unsafe void ProgramUniformMatrix4f(int program, int location, int count, bool transpose, Matrix4[] value)
         {
             fixed (Matrix4* tmp_vecPtr = value)
             {
@@ -6824,7 +6824,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
-        public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, int count, bool transpose, in System.Numerics.Matrix4x4 value)
+        public static unsafe void ProgramUniformMatrix4f(int program, int location, int count, bool transpose, in System.Numerics.Matrix4x4 value)
         {
             fixed (System.Numerics.Matrix4x4* tmp_vecPtr = &value)
             {
@@ -6833,7 +6833,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
-        public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<System.Numerics.Matrix4x4> value)
+        public static unsafe void ProgramUniformMatrix4f(int program, int location, int count, bool transpose, ReadOnlySpan<System.Numerics.Matrix4x4> value)
         {
             fixed (System.Numerics.Matrix4x4* tmp_vecPtr = value)
             {
@@ -6842,7 +6842,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
-        public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, int count, bool transpose, System.Numerics.Matrix4x4[] value)
+        public static unsafe void ProgramUniformMatrix4f(int program, int location, int count, bool transpose, System.Numerics.Matrix4x4[] value)
         {
             fixed (System.Numerics.Matrix4x4* tmp_vecPtr = value)
             {
@@ -6851,7 +6851,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2dv"/>
-        public static unsafe void ProgramUniformMatrix2d(ProgramHandle program, int location, int count, bool transpose, in Matrix2d value)
+        public static unsafe void ProgramUniformMatrix2d(int program, int location, int count, bool transpose, in Matrix2d value)
         {
             fixed (Matrix2d* tmp_vecPtr = &value)
             {
@@ -6860,7 +6860,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2dv"/>
-        public static unsafe void ProgramUniformMatrix2d(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix2d> value)
+        public static unsafe void ProgramUniformMatrix2d(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix2d> value)
         {
             fixed (Matrix2d* tmp_vecPtr = value)
             {
@@ -6869,7 +6869,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2dv"/>
-        public static unsafe void ProgramUniformMatrix2d(ProgramHandle program, int location, int count, bool transpose, Matrix2d[] value)
+        public static unsafe void ProgramUniformMatrix2d(int program, int location, int count, bool transpose, Matrix2d[] value)
         {
             fixed (Matrix2d* tmp_vecPtr = value)
             {
@@ -6878,7 +6878,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3dv"/>
-        public static unsafe void ProgramUniformMatrix3d(ProgramHandle program, int location, int count, bool transpose, in Matrix3d value)
+        public static unsafe void ProgramUniformMatrix3d(int program, int location, int count, bool transpose, in Matrix3d value)
         {
             fixed (Matrix3d* tmp_vecPtr = &value)
             {
@@ -6887,7 +6887,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3dv"/>
-        public static unsafe void ProgramUniformMatrix3d(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix3d> value)
+        public static unsafe void ProgramUniformMatrix3d(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix3d> value)
         {
             fixed (Matrix3d* tmp_vecPtr = value)
             {
@@ -6896,7 +6896,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3dv"/>
-        public static unsafe void ProgramUniformMatrix3d(ProgramHandle program, int location, int count, bool transpose, Matrix3d[] value)
+        public static unsafe void ProgramUniformMatrix3d(int program, int location, int count, bool transpose, Matrix3d[] value)
         {
             fixed (Matrix3d* tmp_vecPtr = value)
             {
@@ -6905,7 +6905,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4dv"/>
-        public static unsafe void ProgramUniformMatrix4d(ProgramHandle program, int location, int count, bool transpose, in Matrix4d value)
+        public static unsafe void ProgramUniformMatrix4d(int program, int location, int count, bool transpose, in Matrix4d value)
         {
             fixed (Matrix4d* tmp_vecPtr = &value)
             {
@@ -6914,7 +6914,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4dv"/>
-        public static unsafe void ProgramUniformMatrix4d(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix4d> value)
+        public static unsafe void ProgramUniformMatrix4d(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix4d> value)
         {
             fixed (Matrix4d* tmp_vecPtr = value)
             {
@@ -6923,7 +6923,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4dv"/>
-        public static unsafe void ProgramUniformMatrix4d(ProgramHandle program, int location, int count, bool transpose, Matrix4d[] value)
+        public static unsafe void ProgramUniformMatrix4d(int program, int location, int count, bool transpose, Matrix4d[] value)
         {
             fixed (Matrix4d* tmp_vecPtr = value)
             {
@@ -6932,7 +6932,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x3fv"/>
-        public static unsafe void ProgramUniformMatrix2x3f(ProgramHandle program, int location, int count, bool transpose, in Matrix2x3 value)
+        public static unsafe void ProgramUniformMatrix2x3f(int program, int location, int count, bool transpose, in Matrix2x3 value)
         {
             fixed (Matrix2x3* tmp_vecPtr = &value)
             {
@@ -6941,7 +6941,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x3fv"/>
-        public static unsafe void ProgramUniformMatrix2x3f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix2x3> value)
+        public static unsafe void ProgramUniformMatrix2x3f(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix2x3> value)
         {
             fixed (Matrix2x3* tmp_vecPtr = value)
             {
@@ -6950,7 +6950,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x3fv"/>
-        public static unsafe void ProgramUniformMatrix2x3f(ProgramHandle program, int location, int count, bool transpose, Matrix2x3[] value)
+        public static unsafe void ProgramUniformMatrix2x3f(int program, int location, int count, bool transpose, Matrix2x3[] value)
         {
             fixed (Matrix2x3* tmp_vecPtr = value)
             {
@@ -6959,7 +6959,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
-        public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, int count, bool transpose, in Matrix3x2 value)
+        public static unsafe void ProgramUniformMatrix3x2f(int program, int location, int count, bool transpose, in Matrix3x2 value)
         {
             fixed (Matrix3x2* tmp_vecPtr = &value)
             {
@@ -6968,7 +6968,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
-        public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix3x2> value)
+        public static unsafe void ProgramUniformMatrix3x2f(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix3x2> value)
         {
             fixed (Matrix3x2* tmp_vecPtr = value)
             {
@@ -6977,7 +6977,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
-        public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, int count, bool transpose, Matrix3x2[] value)
+        public static unsafe void ProgramUniformMatrix3x2f(int program, int location, int count, bool transpose, Matrix3x2[] value)
         {
             fixed (Matrix3x2* tmp_vecPtr = value)
             {
@@ -6986,7 +6986,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
-        public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, int count, bool transpose, in System.Numerics.Matrix3x2 value)
+        public static unsafe void ProgramUniformMatrix3x2f(int program, int location, int count, bool transpose, in System.Numerics.Matrix3x2 value)
         {
             fixed (System.Numerics.Matrix3x2* tmp_vecPtr = &value)
             {
@@ -6995,7 +6995,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
-        public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<System.Numerics.Matrix3x2> value)
+        public static unsafe void ProgramUniformMatrix3x2f(int program, int location, int count, bool transpose, ReadOnlySpan<System.Numerics.Matrix3x2> value)
         {
             fixed (System.Numerics.Matrix3x2* tmp_vecPtr = value)
             {
@@ -7004,7 +7004,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
-        public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, int count, bool transpose, System.Numerics.Matrix3x2[] value)
+        public static unsafe void ProgramUniformMatrix3x2f(int program, int location, int count, bool transpose, System.Numerics.Matrix3x2[] value)
         {
             fixed (System.Numerics.Matrix3x2* tmp_vecPtr = value)
             {
@@ -7013,7 +7013,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x4fv"/>
-        public static unsafe void ProgramUniformMatrix2x4f(ProgramHandle program, int location, int count, bool transpose, in Matrix2x4 value)
+        public static unsafe void ProgramUniformMatrix2x4f(int program, int location, int count, bool transpose, in Matrix2x4 value)
         {
             fixed (Matrix2x4* tmp_vecPtr = &value)
             {
@@ -7022,7 +7022,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x4fv"/>
-        public static unsafe void ProgramUniformMatrix2x4f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix2x4> value)
+        public static unsafe void ProgramUniformMatrix2x4f(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix2x4> value)
         {
             fixed (Matrix2x4* tmp_vecPtr = value)
             {
@@ -7031,7 +7031,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x4fv"/>
-        public static unsafe void ProgramUniformMatrix2x4f(ProgramHandle program, int location, int count, bool transpose, Matrix2x4[] value)
+        public static unsafe void ProgramUniformMatrix2x4f(int program, int location, int count, bool transpose, Matrix2x4[] value)
         {
             fixed (Matrix2x4* tmp_vecPtr = value)
             {
@@ -7040,7 +7040,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x2fv"/>
-        public static unsafe void ProgramUniformMatrix4x2f(ProgramHandle program, int location, int count, bool transpose, in Matrix4x2 value)
+        public static unsafe void ProgramUniformMatrix4x2f(int program, int location, int count, bool transpose, in Matrix4x2 value)
         {
             fixed (Matrix4x2* tmp_vecPtr = &value)
             {
@@ -7049,7 +7049,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x2fv"/>
-        public static unsafe void ProgramUniformMatrix4x2f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix4x2> value)
+        public static unsafe void ProgramUniformMatrix4x2f(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix4x2> value)
         {
             fixed (Matrix4x2* tmp_vecPtr = value)
             {
@@ -7058,7 +7058,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x2fv"/>
-        public static unsafe void ProgramUniformMatrix4x2f(ProgramHandle program, int location, int count, bool transpose, Matrix4x2[] value)
+        public static unsafe void ProgramUniformMatrix4x2f(int program, int location, int count, bool transpose, Matrix4x2[] value)
         {
             fixed (Matrix4x2* tmp_vecPtr = value)
             {
@@ -7067,7 +7067,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x4fv"/>
-        public static unsafe void ProgramUniformMatrix3x4f(ProgramHandle program, int location, int count, bool transpose, in Matrix3x4 value)
+        public static unsafe void ProgramUniformMatrix3x4f(int program, int location, int count, bool transpose, in Matrix3x4 value)
         {
             fixed (Matrix3x4* tmp_vecPtr = &value)
             {
@@ -7076,7 +7076,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x4fv"/>
-        public static unsafe void ProgramUniformMatrix3x4f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix3x4> value)
+        public static unsafe void ProgramUniformMatrix3x4f(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix3x4> value)
         {
             fixed (Matrix3x4* tmp_vecPtr = value)
             {
@@ -7085,7 +7085,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x4fv"/>
-        public static unsafe void ProgramUniformMatrix3x4f(ProgramHandle program, int location, int count, bool transpose, Matrix3x4[] value)
+        public static unsafe void ProgramUniformMatrix3x4f(int program, int location, int count, bool transpose, Matrix3x4[] value)
         {
             fixed (Matrix3x4* tmp_vecPtr = value)
             {
@@ -7094,7 +7094,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x3fv"/>
-        public static unsafe void ProgramUniformMatrix4x3f(ProgramHandle program, int location, int count, bool transpose, in Matrix4x3 value)
+        public static unsafe void ProgramUniformMatrix4x3f(int program, int location, int count, bool transpose, in Matrix4x3 value)
         {
             fixed (Matrix4x3* tmp_vecPtr = &value)
             {
@@ -7103,7 +7103,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x3fv"/>
-        public static unsafe void ProgramUniformMatrix4x3f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix4x3> value)
+        public static unsafe void ProgramUniformMatrix4x3f(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix4x3> value)
         {
             fixed (Matrix4x3* tmp_vecPtr = value)
             {
@@ -7112,7 +7112,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x3fv"/>
-        public static unsafe void ProgramUniformMatrix4x3f(ProgramHandle program, int location, int count, bool transpose, Matrix4x3[] value)
+        public static unsafe void ProgramUniformMatrix4x3f(int program, int location, int count, bool transpose, Matrix4x3[] value)
         {
             fixed (Matrix4x3* tmp_vecPtr = value)
             {
@@ -7121,7 +7121,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x3dv"/>
-        public static unsafe void ProgramUniformMatrix2x3d(ProgramHandle program, int location, int count, bool transpose, in Matrix2x3d value)
+        public static unsafe void ProgramUniformMatrix2x3d(int program, int location, int count, bool transpose, in Matrix2x3d value)
         {
             fixed (Matrix2x3d* tmp_vecPtr = &value)
             {
@@ -7130,7 +7130,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x3dv"/>
-        public static unsafe void ProgramUniformMatrix2x3d(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix2x3d> value)
+        public static unsafe void ProgramUniformMatrix2x3d(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix2x3d> value)
         {
             fixed (Matrix2x3d* tmp_vecPtr = value)
             {
@@ -7139,7 +7139,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x3dv"/>
-        public static unsafe void ProgramUniformMatrix2x3d(ProgramHandle program, int location, int count, bool transpose, Matrix2x3d[] value)
+        public static unsafe void ProgramUniformMatrix2x3d(int program, int location, int count, bool transpose, Matrix2x3d[] value)
         {
             fixed (Matrix2x3d* tmp_vecPtr = value)
             {
@@ -7148,7 +7148,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x2dv"/>
-        public static unsafe void ProgramUniformMatrix3x2d(ProgramHandle program, int location, int count, bool transpose, in Matrix3x2d value)
+        public static unsafe void ProgramUniformMatrix3x2d(int program, int location, int count, bool transpose, in Matrix3x2d value)
         {
             fixed (Matrix3x2d* tmp_vecPtr = &value)
             {
@@ -7157,7 +7157,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x2dv"/>
-        public static unsafe void ProgramUniformMatrix3x2d(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix3x2d> value)
+        public static unsafe void ProgramUniformMatrix3x2d(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix3x2d> value)
         {
             fixed (Matrix3x2d* tmp_vecPtr = value)
             {
@@ -7166,7 +7166,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x2dv"/>
-        public static unsafe void ProgramUniformMatrix3x2d(ProgramHandle program, int location, int count, bool transpose, Matrix3x2d[] value)
+        public static unsafe void ProgramUniformMatrix3x2d(int program, int location, int count, bool transpose, Matrix3x2d[] value)
         {
             fixed (Matrix3x2d* tmp_vecPtr = value)
             {
@@ -7175,7 +7175,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x4dv"/>
-        public static unsafe void ProgramUniformMatrix2x4d(ProgramHandle program, int location, int count, bool transpose, in Matrix2x4d value)
+        public static unsafe void ProgramUniformMatrix2x4d(int program, int location, int count, bool transpose, in Matrix2x4d value)
         {
             fixed (Matrix2x4d* tmp_vecPtr = &value)
             {
@@ -7184,7 +7184,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x4dv"/>
-        public static unsafe void ProgramUniformMatrix2x4d(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix2x4d> value)
+        public static unsafe void ProgramUniformMatrix2x4d(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix2x4d> value)
         {
             fixed (Matrix2x4d* tmp_vecPtr = value)
             {
@@ -7193,7 +7193,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x4dv"/>
-        public static unsafe void ProgramUniformMatrix2x4d(ProgramHandle program, int location, int count, bool transpose, Matrix2x4d[] value)
+        public static unsafe void ProgramUniformMatrix2x4d(int program, int location, int count, bool transpose, Matrix2x4d[] value)
         {
             fixed (Matrix2x4d* tmp_vecPtr = value)
             {
@@ -7202,7 +7202,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x2dv"/>
-        public static unsafe void ProgramUniformMatrix4x2d(ProgramHandle program, int location, int count, bool transpose, in Matrix4x2d value)
+        public static unsafe void ProgramUniformMatrix4x2d(int program, int location, int count, bool transpose, in Matrix4x2d value)
         {
             fixed (Matrix4x2d* tmp_vecPtr = &value)
             {
@@ -7211,7 +7211,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x2dv"/>
-        public static unsafe void ProgramUniformMatrix4x2d(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix4x2d> value)
+        public static unsafe void ProgramUniformMatrix4x2d(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix4x2d> value)
         {
             fixed (Matrix4x2d* tmp_vecPtr = value)
             {
@@ -7220,7 +7220,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x2dv"/>
-        public static unsafe void ProgramUniformMatrix4x2d(ProgramHandle program, int location, int count, bool transpose, Matrix4x2d[] value)
+        public static unsafe void ProgramUniformMatrix4x2d(int program, int location, int count, bool transpose, Matrix4x2d[] value)
         {
             fixed (Matrix4x2d* tmp_vecPtr = value)
             {
@@ -7229,7 +7229,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x4dv"/>
-        public static unsafe void ProgramUniformMatrix3x4d(ProgramHandle program, int location, int count, bool transpose, in Matrix3x4d value)
+        public static unsafe void ProgramUniformMatrix3x4d(int program, int location, int count, bool transpose, in Matrix3x4d value)
         {
             fixed (Matrix3x4d* tmp_vecPtr = &value)
             {
@@ -7238,7 +7238,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x4dv"/>
-        public static unsafe void ProgramUniformMatrix3x4d(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix3x4d> value)
+        public static unsafe void ProgramUniformMatrix3x4d(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix3x4d> value)
         {
             fixed (Matrix3x4d* tmp_vecPtr = value)
             {
@@ -7247,7 +7247,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x4dv"/>
-        public static unsafe void ProgramUniformMatrix3x4d(ProgramHandle program, int location, int count, bool transpose, Matrix3x4d[] value)
+        public static unsafe void ProgramUniformMatrix3x4d(int program, int location, int count, bool transpose, Matrix3x4d[] value)
         {
             fixed (Matrix3x4d* tmp_vecPtr = value)
             {
@@ -7256,7 +7256,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x3dv"/>
-        public static unsafe void ProgramUniformMatrix4x3d(ProgramHandle program, int location, int count, bool transpose, in Matrix4x3d value)
+        public static unsafe void ProgramUniformMatrix4x3d(int program, int location, int count, bool transpose, in Matrix4x3d value)
         {
             fixed (Matrix4x3d* tmp_vecPtr = &value)
             {
@@ -7265,7 +7265,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x3dv"/>
-        public static unsafe void ProgramUniformMatrix4x3d(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix4x3d> value)
+        public static unsafe void ProgramUniformMatrix4x3d(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix4x3d> value)
         {
             fixed (Matrix4x3d* tmp_vecPtr = value)
             {
@@ -7274,7 +7274,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x3dv"/>
-        public static unsafe void ProgramUniformMatrix4x3d(ProgramHandle program, int location, int count, bool transpose, Matrix4x3d[] value)
+        public static unsafe void ProgramUniformMatrix4x3d(int program, int location, int count, bool transpose, Matrix4x3d[] value)
         {
             fixed (Matrix4x3d* tmp_vecPtr = value)
             {
@@ -7283,7 +7283,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetProgramPipelineInfoLog"/>
-        public static unsafe string GetProgramPipelineInfoLog(ProgramPipelineHandle pipeline, int bufSize, Span<int> length)
+        public static unsafe string GetProgramPipelineInfoLog(int pipeline, int bufSize, Span<int> length)
         {
             string infoLog;
             fixed (int* length_ptr = length)
@@ -7296,7 +7296,7 @@ namespace OpenTK.Graphics.OpenGL
             return infoLog;
         }
         /// <inheritdoc cref="GetProgramPipelineInfoLog"/>
-        public static unsafe void GetProgramPipelineInfoLog(ProgramPipelineHandle pipeline, int bufSize, Span<int> length, out string infoLog)
+        public static unsafe void GetProgramPipelineInfoLog(int pipeline, int bufSize, Span<int> length, out string infoLog)
         {
             fixed (int* length_ptr = length)
             {
@@ -7307,7 +7307,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetProgramPipelineInfoLog"/>
-        public static unsafe string GetProgramPipelineInfoLog(ProgramPipelineHandle pipeline, int bufSize, int[] length)
+        public static unsafe string GetProgramPipelineInfoLog(int pipeline, int bufSize, int[] length)
         {
             string infoLog;
             fixed (int* length_ptr = length)
@@ -7320,7 +7320,7 @@ namespace OpenTK.Graphics.OpenGL
             return infoLog;
         }
         /// <inheritdoc cref="GetProgramPipelineInfoLog"/>
-        public static unsafe void GetProgramPipelineInfoLog(ProgramPipelineHandle pipeline, int bufSize, int[] length, out string infoLog)
+        public static unsafe void GetProgramPipelineInfoLog(int pipeline, int bufSize, int[] length, out string infoLog)
         {
             fixed (int* length_ptr = length)
             {
@@ -7331,7 +7331,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetProgramPipelineInfoLog"/>
-        public static unsafe string GetProgramPipelineInfoLog(ProgramPipelineHandle pipeline, int bufSize, ref int length)
+        public static unsafe string GetProgramPipelineInfoLog(int pipeline, int bufSize, ref int length)
         {
             string infoLog;
             fixed (int* length_ptr = &length)
@@ -7344,7 +7344,7 @@ namespace OpenTK.Graphics.OpenGL
             return infoLog;
         }
         /// <inheritdoc cref="GetProgramPipelineInfoLog"/>
-        public static unsafe void GetProgramPipelineInfoLog(ProgramPipelineHandle pipeline, int bufSize, ref int length, out string infoLog)
+        public static unsafe void GetProgramPipelineInfoLog(int pipeline, int bufSize, ref int length, out string infoLog)
         {
             fixed (int* length_ptr = &length)
             {
@@ -7627,7 +7627,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetActiveAtomicCounterBufferiv"/>
-        public static unsafe void GetActiveAtomicCounterBufferi(ProgramHandle program, uint bufferIndex, AtomicCounterBufferPName pname, Span<int> parameters)
+        public static unsafe void GetActiveAtomicCounterBufferi(int program, uint bufferIndex, AtomicCounterBufferPName pname, Span<int> parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
@@ -7635,7 +7635,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetActiveAtomicCounterBufferiv"/>
-        public static unsafe void GetActiveAtomicCounterBufferi(ProgramHandle program, uint bufferIndex, AtomicCounterBufferPName pname, int[] parameters)
+        public static unsafe void GetActiveAtomicCounterBufferi(int program, uint bufferIndex, AtomicCounterBufferPName pname, int[] parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
@@ -7643,7 +7643,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetActiveAtomicCounterBufferiv"/>
-        public static unsafe void GetActiveAtomicCounterBufferi(ProgramHandle program, uint bufferIndex, AtomicCounterBufferPName pname, ref int parameters)
+        public static unsafe void GetActiveAtomicCounterBufferi(int program, uint bufferIndex, AtomicCounterBufferPName pname, ref int parameters)
         {
             fixed (int* parameters_ptr = &parameters)
             {
@@ -7885,7 +7885,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetProgramInterfaceiv"/>
-        public static unsafe void GetProgramInterfacei(ProgramHandle program, ProgramInterface programInterface, ProgramInterfacePName pname, Span<int> parameters)
+        public static unsafe void GetProgramInterfacei(int program, ProgramInterface programInterface, ProgramInterfacePName pname, Span<int> parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
@@ -7893,7 +7893,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetProgramInterfaceiv"/>
-        public static unsafe void GetProgramInterfacei(ProgramHandle program, ProgramInterface programInterface, ProgramInterfacePName pname, int[] parameters)
+        public static unsafe void GetProgramInterfacei(int program, ProgramInterface programInterface, ProgramInterfacePName pname, int[] parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
@@ -7901,7 +7901,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetProgramInterfaceiv"/>
-        public static unsafe void GetProgramInterfacei(ProgramHandle program, ProgramInterface programInterface, ProgramInterfacePName pname, ref int parameters)
+        public static unsafe void GetProgramInterfacei(int program, ProgramInterface programInterface, ProgramInterfacePName pname, ref int parameters)
         {
             fixed (int* parameters_ptr = &parameters)
             {
@@ -7909,7 +7909,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetProgramResourceIndex"/>
-        public static unsafe uint GetProgramResourceIndex(ProgramHandle program, ProgramInterface programInterface, string name)
+        public static unsafe uint GetProgramResourceIndex(int program, ProgramInterface programInterface, string name)
         {
             uint returnValue;
             byte* name_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(name);
@@ -7918,7 +7918,7 @@ namespace OpenTK.Graphics.OpenGL
             return returnValue;
         }
         /// <inheritdoc cref="GetProgramResourceName"/>
-        public static unsafe string GetProgramResourceName(ProgramHandle program, ProgramInterface programInterface, uint index, int bufSize, Span<int> length)
+        public static unsafe string GetProgramResourceName(int program, ProgramInterface programInterface, uint index, int bufSize, Span<int> length)
         {
             string name;
             fixed (int* length_ptr = length)
@@ -7931,7 +7931,7 @@ namespace OpenTK.Graphics.OpenGL
             return name;
         }
         /// <inheritdoc cref="GetProgramResourceName"/>
-        public static unsafe void GetProgramResourceName(ProgramHandle program, ProgramInterface programInterface, uint index, int bufSize, Span<int> length, out string name)
+        public static unsafe void GetProgramResourceName(int program, ProgramInterface programInterface, uint index, int bufSize, Span<int> length, out string name)
         {
             fixed (int* length_ptr = length)
             {
@@ -7942,7 +7942,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetProgramResourceName"/>
-        public static unsafe string GetProgramResourceName(ProgramHandle program, ProgramInterface programInterface, uint index, int bufSize, int[] length)
+        public static unsafe string GetProgramResourceName(int program, ProgramInterface programInterface, uint index, int bufSize, int[] length)
         {
             string name;
             fixed (int* length_ptr = length)
@@ -7955,7 +7955,7 @@ namespace OpenTK.Graphics.OpenGL
             return name;
         }
         /// <inheritdoc cref="GetProgramResourceName"/>
-        public static unsafe void GetProgramResourceName(ProgramHandle program, ProgramInterface programInterface, uint index, int bufSize, int[] length, out string name)
+        public static unsafe void GetProgramResourceName(int program, ProgramInterface programInterface, uint index, int bufSize, int[] length, out string name)
         {
             fixed (int* length_ptr = length)
             {
@@ -7966,7 +7966,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetProgramResourceName"/>
-        public static unsafe string GetProgramResourceName(ProgramHandle program, ProgramInterface programInterface, uint index, int bufSize, ref int length)
+        public static unsafe string GetProgramResourceName(int program, ProgramInterface programInterface, uint index, int bufSize, ref int length)
         {
             string name;
             fixed (int* length_ptr = &length)
@@ -7979,7 +7979,7 @@ namespace OpenTK.Graphics.OpenGL
             return name;
         }
         /// <inheritdoc cref="GetProgramResourceName"/>
-        public static unsafe void GetProgramResourceName(ProgramHandle program, ProgramInterface programInterface, uint index, int bufSize, ref int length, out string name)
+        public static unsafe void GetProgramResourceName(int program, ProgramInterface programInterface, uint index, int bufSize, ref int length, out string name)
         {
             fixed (int* length_ptr = &length)
             {
@@ -7990,7 +7990,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetProgramResourceiv"/>
-        public static unsafe void GetProgramResourcei(ProgramHandle program, ProgramInterface programInterface, uint index, ReadOnlySpan<ProgramResourceProperty> props, Span<int> length, Span<int> parameters)
+        public static unsafe void GetProgramResourcei(int program, ProgramInterface programInterface, uint index, ReadOnlySpan<ProgramResourceProperty> props, Span<int> length, Span<int> parameters)
         {
             int propCount = (int)(props.Length);
             fixed (ProgramResourceProperty* props_ptr = props)
@@ -8006,7 +8006,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetProgramResourceiv"/>
-        public static unsafe void GetProgramResourcei(ProgramHandle program, ProgramInterface programInterface, uint index, ProgramResourceProperty[] props, int[] length, int[] parameters)
+        public static unsafe void GetProgramResourcei(int program, ProgramInterface programInterface, uint index, ProgramResourceProperty[] props, int[] length, int[] parameters)
         {
             int propCount = (int)(props.Length);
             fixed (ProgramResourceProperty* props_ptr = props)
@@ -8022,7 +8022,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetProgramResourceiv"/>
-        public static unsafe void GetProgramResourcei(ProgramHandle program, ProgramInterface programInterface, uint index, int propCount, in ProgramResourceProperty props, int count, ref int length, ref int parameters)
+        public static unsafe void GetProgramResourcei(int program, ProgramInterface programInterface, uint index, int propCount, in ProgramResourceProperty props, int count, ref int length, ref int parameters)
         {
             fixed (ProgramResourceProperty* props_ptr = &props)
             fixed (int* length_ptr = &length)
@@ -8032,7 +8032,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetProgramResourceLocation"/>
-        public static unsafe int GetProgramResourceLocation(ProgramHandle program, ProgramInterface programInterface, string name)
+        public static unsafe int GetProgramResourceLocation(int program, ProgramInterface programInterface, string name)
         {
             int returnValue;
             byte* name_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(name);
@@ -8041,7 +8041,7 @@ namespace OpenTK.Graphics.OpenGL
             return returnValue;
         }
         /// <inheritdoc cref="GetProgramResourceLocationIndex"/>
-        public static unsafe int GetProgramResourceLocationIndex(ProgramHandle program, ProgramInterface programInterface, string name)
+        public static unsafe int GetProgramResourceLocationIndex(int program, ProgramInterface programInterface, string name)
         {
             int returnValue;
             byte* name_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(name);
@@ -8477,13 +8477,13 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ClearTexImage"/>
-        public static unsafe void ClearTexImage(TextureHandle texture, int level, PixelFormat format, PixelType type, IntPtr data)
+        public static unsafe void ClearTexImage(int texture, int level, PixelFormat format, PixelType type, IntPtr data)
         {
             void* data_vptr = (void*)data;
             ClearTexImage(texture, level, format, type, data_vptr);
         }
         /// <inheritdoc cref="ClearTexImage"/>
-        public static unsafe void ClearTexImage<T1>(TextureHandle texture, int level, PixelFormat format, PixelType type, ReadOnlySpan<T1> data)
+        public static unsafe void ClearTexImage<T1>(int texture, int level, PixelFormat format, PixelType type, ReadOnlySpan<T1> data)
             where T1 : unmanaged
         {
             fixed (void* data_ptr = data)
@@ -8492,7 +8492,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ClearTexImage"/>
-        public static unsafe void ClearTexImage<T1>(TextureHandle texture, int level, PixelFormat format, PixelType type, T1[] data)
+        public static unsafe void ClearTexImage<T1>(int texture, int level, PixelFormat format, PixelType type, T1[] data)
             where T1 : unmanaged
         {
             fixed (void* data_ptr = data)
@@ -8501,7 +8501,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ClearTexImage"/>
-        public static unsafe void ClearTexImage<T1>(TextureHandle texture, int level, PixelFormat format, PixelType type, in T1 data)
+        public static unsafe void ClearTexImage<T1>(int texture, int level, PixelFormat format, PixelType type, in T1 data)
             where T1 : unmanaged
         {
             fixed (void* data_ptr = &data)
@@ -8510,13 +8510,13 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ClearTexSubImage"/>
-        public static unsafe void ClearTexSubImage(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, IntPtr data)
+        public static unsafe void ClearTexSubImage(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, IntPtr data)
         {
             void* data_vptr = (void*)data;
             ClearTexSubImage(texture, level, xoffset, yoffset, zoffset, width, height, depth, format, type, data_vptr);
         }
         /// <inheritdoc cref="ClearTexSubImage"/>
-        public static unsafe void ClearTexSubImage<T1>(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, ReadOnlySpan<T1> data)
+        public static unsafe void ClearTexSubImage<T1>(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, ReadOnlySpan<T1> data)
             where T1 : unmanaged
         {
             fixed (void* data_ptr = data)
@@ -8525,7 +8525,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ClearTexSubImage"/>
-        public static unsafe void ClearTexSubImage<T1>(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, T1[] data)
+        public static unsafe void ClearTexSubImage<T1>(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, T1[] data)
             where T1 : unmanaged
         {
             fixed (void* data_ptr = data)
@@ -8534,7 +8534,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ClearTexSubImage"/>
-        public static unsafe void ClearTexSubImage<T1>(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, in T1 data)
+        public static unsafe void ClearTexSubImage<T1>(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, in T1 data)
             where T1 : unmanaged
         {
             fixed (void* data_ptr = &data)
@@ -8543,35 +8543,35 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="BindBuffersBase"/>
-        public static unsafe void BindBuffersBase(BufferTargetARB target, uint first, ReadOnlySpan<BufferHandle> buffers)
+        public static unsafe void BindBuffersBase(BufferTargetARB target, uint first, ReadOnlySpan<int> buffers)
         {
             int count = (int)(buffers.Length);
-            fixed (BufferHandle* buffers_ptr = buffers)
+            fixed (int* buffers_ptr = buffers)
             {
                 BindBuffersBase(target, first, count, buffers_ptr);
             }
         }
         /// <inheritdoc cref="BindBuffersBase"/>
-        public static unsafe void BindBuffersBase(BufferTargetARB target, uint first, BufferHandle[] buffers)
+        public static unsafe void BindBuffersBase(BufferTargetARB target, uint first, int[] buffers)
         {
             int count = (int)(buffers.Length);
-            fixed (BufferHandle* buffers_ptr = buffers)
+            fixed (int* buffers_ptr = buffers)
             {
                 BindBuffersBase(target, first, count, buffers_ptr);
             }
         }
         /// <inheritdoc cref="BindBuffersBase"/>
-        public static unsafe void BindBuffersBase(BufferTargetARB target, uint first, int count, in BufferHandle buffers)
+        public static unsafe void BindBuffersBase(BufferTargetARB target, uint first, int count, in int buffers)
         {
-            fixed (BufferHandle* buffers_ptr = &buffers)
+            fixed (int* buffers_ptr = &buffers)
             {
                 BindBuffersBase(target, first, count, buffers_ptr);
             }
         }
         /// <inheritdoc cref="BindBuffersRange"/>
-        public static unsafe void BindBuffersRange(BufferTargetARB target, uint first, int count, ReadOnlySpan<BufferHandle> buffers, ReadOnlySpan<IntPtr> offsets, ReadOnlySpan<nint> sizes)
+        public static unsafe void BindBuffersRange(BufferTargetARB target, uint first, int count, ReadOnlySpan<int> buffers, ReadOnlySpan<IntPtr> offsets, ReadOnlySpan<nint> sizes)
         {
-            fixed (BufferHandle* buffers_ptr = buffers)
+            fixed (int* buffers_ptr = buffers)
             {
                 fixed (IntPtr* offsets_ptr = offsets)
                 {
@@ -8583,9 +8583,9 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="BindBuffersRange"/>
-        public static unsafe void BindBuffersRange(BufferTargetARB target, uint first, int count, BufferHandle[] buffers, IntPtr[] offsets, nint[] sizes)
+        public static unsafe void BindBuffersRange(BufferTargetARB target, uint first, int count, int[] buffers, IntPtr[] offsets, nint[] sizes)
         {
-            fixed (BufferHandle* buffers_ptr = buffers)
+            fixed (int* buffers_ptr = buffers)
             {
                 fixed (IntPtr* offsets_ptr = offsets)
                 {
@@ -8597,9 +8597,9 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="BindBuffersRange"/>
-        public static unsafe void BindBuffersRange(BufferTargetARB target, uint first, int count, in BufferHandle buffers, in IntPtr offsets, in nint sizes)
+        public static unsafe void BindBuffersRange(BufferTargetARB target, uint first, int count, in int buffers, in IntPtr offsets, in nint sizes)
         {
-            fixed (BufferHandle* buffers_ptr = &buffers)
+            fixed (int* buffers_ptr = &buffers)
             fixed (IntPtr* offsets_ptr = &offsets)
             fixed (nint* sizes_ptr = &sizes)
             {
@@ -8607,87 +8607,87 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="BindTextures"/>
-        public static unsafe void BindTextures(uint first, ReadOnlySpan<TextureHandle> textures)
+        public static unsafe void BindTextures(uint first, ReadOnlySpan<int> textures)
         {
             int count = (int)(textures.Length);
-            fixed (TextureHandle* textures_ptr = textures)
+            fixed (int* textures_ptr = textures)
             {
                 BindTextures(first, count, textures_ptr);
             }
         }
         /// <inheritdoc cref="BindTextures"/>
-        public static unsafe void BindTextures(uint first, TextureHandle[] textures)
+        public static unsafe void BindTextures(uint first, int[] textures)
         {
             int count = (int)(textures.Length);
-            fixed (TextureHandle* textures_ptr = textures)
+            fixed (int* textures_ptr = textures)
             {
                 BindTextures(first, count, textures_ptr);
             }
         }
         /// <inheritdoc cref="BindTextures"/>
-        public static unsafe void BindTextures(uint first, int count, in TextureHandle textures)
+        public static unsafe void BindTextures(uint first, int count, in int textures)
         {
-            fixed (TextureHandle* textures_ptr = &textures)
+            fixed (int* textures_ptr = &textures)
             {
                 BindTextures(first, count, textures_ptr);
             }
         }
         /// <inheritdoc cref="BindSamplers"/>
-        public static unsafe void BindSamplers(uint first, ReadOnlySpan<SamplerHandle> samplers)
+        public static unsafe void BindSamplers(uint first, ReadOnlySpan<int> samplers)
         {
             int count = (int)(samplers.Length);
-            fixed (SamplerHandle* samplers_ptr = samplers)
+            fixed (int* samplers_ptr = samplers)
             {
                 BindSamplers(first, count, samplers_ptr);
             }
         }
         /// <inheritdoc cref="BindSamplers"/>
-        public static unsafe void BindSamplers(uint first, SamplerHandle[] samplers)
+        public static unsafe void BindSamplers(uint first, int[] samplers)
         {
             int count = (int)(samplers.Length);
-            fixed (SamplerHandle* samplers_ptr = samplers)
+            fixed (int* samplers_ptr = samplers)
             {
                 BindSamplers(first, count, samplers_ptr);
             }
         }
         /// <inheritdoc cref="BindSamplers"/>
-        public static unsafe void BindSamplers(uint first, int count, in SamplerHandle samplers)
+        public static unsafe void BindSamplers(uint first, int count, in int samplers)
         {
-            fixed (SamplerHandle* samplers_ptr = &samplers)
+            fixed (int* samplers_ptr = &samplers)
             {
                 BindSamplers(first, count, samplers_ptr);
             }
         }
         /// <inheritdoc cref="BindImageTextures"/>
-        public static unsafe void BindImageTextures(uint first, ReadOnlySpan<TextureHandle> textures)
+        public static unsafe void BindImageTextures(uint first, ReadOnlySpan<int> textures)
         {
             int count = (int)(textures.Length);
-            fixed (TextureHandle* textures_ptr = textures)
+            fixed (int* textures_ptr = textures)
             {
                 BindImageTextures(first, count, textures_ptr);
             }
         }
         /// <inheritdoc cref="BindImageTextures"/>
-        public static unsafe void BindImageTextures(uint first, TextureHandle[] textures)
+        public static unsafe void BindImageTextures(uint first, int[] textures)
         {
             int count = (int)(textures.Length);
-            fixed (TextureHandle* textures_ptr = textures)
+            fixed (int* textures_ptr = textures)
             {
                 BindImageTextures(first, count, textures_ptr);
             }
         }
         /// <inheritdoc cref="BindImageTextures"/>
-        public static unsafe void BindImageTextures(uint first, int count, in TextureHandle textures)
+        public static unsafe void BindImageTextures(uint first, int count, in int textures)
         {
-            fixed (TextureHandle* textures_ptr = &textures)
+            fixed (int* textures_ptr = &textures)
             {
                 BindImageTextures(first, count, textures_ptr);
             }
         }
         /// <inheritdoc cref="BindVertexBuffers"/>
-        public static unsafe void BindVertexBuffers(uint first, int count, ReadOnlySpan<BufferHandle> buffers, ReadOnlySpan<IntPtr> offsets, ReadOnlySpan<int> strides)
+        public static unsafe void BindVertexBuffers(uint first, int count, ReadOnlySpan<int> buffers, ReadOnlySpan<IntPtr> offsets, ReadOnlySpan<int> strides)
         {
-            fixed (BufferHandle* buffers_ptr = buffers)
+            fixed (int* buffers_ptr = buffers)
             {
                 fixed (IntPtr* offsets_ptr = offsets)
                 {
@@ -8699,9 +8699,9 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="BindVertexBuffers"/>
-        public static unsafe void BindVertexBuffers(uint first, int count, BufferHandle[] buffers, IntPtr[] offsets, int[] strides)
+        public static unsafe void BindVertexBuffers(uint first, int count, int[] buffers, IntPtr[] offsets, int[] strides)
         {
-            fixed (BufferHandle* buffers_ptr = buffers)
+            fixed (int* buffers_ptr = buffers)
             {
                 fixed (IntPtr* offsets_ptr = offsets)
                 {
@@ -8713,9 +8713,9 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="BindVertexBuffers"/>
-        public static unsafe void BindVertexBuffers(uint first, int count, in BufferHandle buffers, in IntPtr offsets, in int strides)
+        public static unsafe void BindVertexBuffers(uint first, int count, in int buffers, in IntPtr offsets, in int strides)
         {
-            fixed (BufferHandle* buffers_ptr = &buffers)
+            fixed (int* buffers_ptr = &buffers)
             fixed (IntPtr* offsets_ptr = &offsets)
             fixed (int* strides_ptr = &strides)
             {
@@ -8723,9 +8723,9 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="CreateTransformFeedbacks"/>
-        public static unsafe TransformFeedbackHandle CreateTransformFeedback()
+        public static unsafe int CreateTransformFeedback()
         {
-            TransformFeedbackHandle id;
+            int id;
             int n = 1;
             Unsafe.SkipInit(out id);
             // FIXME: This could be a problem for the overloads that take an out parameter
@@ -8736,12 +8736,12 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            TransformFeedbackHandle* ids_handle = (TransformFeedbackHandle*)Unsafe.AsPointer(ref id);
+            int* ids_handle = (int*)Unsafe.AsPointer(ref id);
             CreateTransformFeedbacks(n, ids_handle);
             return id;
         }
         /// <inheritdoc cref="CreateTransformFeedbacks"/>
-        public static unsafe void CreateTransformFeedback(out TransformFeedbackHandle id)
+        public static unsafe void CreateTransformFeedback(out int id)
         {
             int n = 1;
             Unsafe.SkipInit(out id);
@@ -8753,37 +8753,37 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            TransformFeedbackHandle* ids_handle = (TransformFeedbackHandle*)Unsafe.AsPointer(ref id);
+            int* ids_handle = (int*)Unsafe.AsPointer(ref id);
             CreateTransformFeedbacks(n, ids_handle);
         }
         /// <inheritdoc cref="CreateTransformFeedbacks"/>
-        public static unsafe void CreateTransformFeedbacks(Span<TransformFeedbackHandle> ids)
+        public static unsafe void CreateTransformFeedbacks(Span<int> ids)
         {
             int n = (int)(ids.Length);
-            fixed (TransformFeedbackHandle* ids_ptr = ids)
+            fixed (int* ids_ptr = ids)
             {
                 CreateTransformFeedbacks(n, ids_ptr);
             }
         }
         /// <inheritdoc cref="CreateTransformFeedbacks"/>
-        public static unsafe void CreateTransformFeedbacks(TransformFeedbackHandle[] ids)
+        public static unsafe void CreateTransformFeedbacks(int[] ids)
         {
             int n = (int)(ids.Length);
-            fixed (TransformFeedbackHandle* ids_ptr = ids)
+            fixed (int* ids_ptr = ids)
             {
                 CreateTransformFeedbacks(n, ids_ptr);
             }
         }
         /// <inheritdoc cref="CreateTransformFeedbacks"/>
-        public static unsafe void CreateTransformFeedbacks(int n, ref TransformFeedbackHandle ids)
+        public static unsafe void CreateTransformFeedbacks(int n, ref int ids)
         {
-            fixed (TransformFeedbackHandle* ids_ptr = &ids)
+            fixed (int* ids_ptr = &ids)
             {
                 CreateTransformFeedbacks(n, ids_ptr);
             }
         }
         /// <inheritdoc cref="GetTransformFeedbackiv"/>
-        public static unsafe void GetTransformFeedbacki(TransformFeedbackHandle xfb, TransformFeedbackPName pname, ref int param)
+        public static unsafe void GetTransformFeedbacki(int xfb, TransformFeedbackPName pname, ref int param)
         {
             fixed (int* param_ptr = &param)
             {
@@ -8791,7 +8791,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetTransformFeedbacki_v"/>
-        public static unsafe void GetTransformFeedback(TransformFeedbackHandle xfb, TransformFeedbackPName pname, uint index, ref int param)
+        public static unsafe void GetTransformFeedback(int xfb, TransformFeedbackPName pname, uint index, ref int param)
         {
             fixed (int* param_ptr = &param)
             {
@@ -8799,7 +8799,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetTransformFeedbacki64_v"/>
-        public static unsafe void GetTransformFeedbacki64_(TransformFeedbackHandle xfb, TransformFeedbackPName pname, uint index, ref long param)
+        public static unsafe void GetTransformFeedbacki64_(int xfb, TransformFeedbackPName pname, uint index, ref long param)
         {
             fixed (long* param_ptr = &param)
             {
@@ -8807,9 +8807,9 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="CreateBuffers"/>
-        public static unsafe BufferHandle CreateBuffer()
+        public static unsafe int CreateBuffer()
         {
-            BufferHandle buffer;
+            int buffer;
             int n = 1;
             Unsafe.SkipInit(out buffer);
             // FIXME: This could be a problem for the overloads that take an out parameter
@@ -8820,12 +8820,12 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            BufferHandle* buffers_handle = (BufferHandle*)Unsafe.AsPointer(ref buffer);
+            int* buffers_handle = (int*)Unsafe.AsPointer(ref buffer);
             CreateBuffers(n, buffers_handle);
             return buffer;
         }
         /// <inheritdoc cref="CreateBuffers"/>
-        public static unsafe void CreateBuffer(out BufferHandle buffer)
+        public static unsafe void CreateBuffer(out int buffer)
         {
             int n = 1;
             Unsafe.SkipInit(out buffer);
@@ -8837,43 +8837,43 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            BufferHandle* buffers_handle = (BufferHandle*)Unsafe.AsPointer(ref buffer);
+            int* buffers_handle = (int*)Unsafe.AsPointer(ref buffer);
             CreateBuffers(n, buffers_handle);
         }
         /// <inheritdoc cref="CreateBuffers"/>
-        public static unsafe void CreateBuffers(Span<BufferHandle> buffers)
+        public static unsafe void CreateBuffers(Span<int> buffers)
         {
             int n = (int)(buffers.Length);
-            fixed (BufferHandle* buffers_ptr = buffers)
+            fixed (int* buffers_ptr = buffers)
             {
                 CreateBuffers(n, buffers_ptr);
             }
         }
         /// <inheritdoc cref="CreateBuffers"/>
-        public static unsafe void CreateBuffers(BufferHandle[] buffers)
+        public static unsafe void CreateBuffers(int[] buffers)
         {
             int n = (int)(buffers.Length);
-            fixed (BufferHandle* buffers_ptr = buffers)
+            fixed (int* buffers_ptr = buffers)
             {
                 CreateBuffers(n, buffers_ptr);
             }
         }
         /// <inheritdoc cref="CreateBuffers"/>
-        public static unsafe void CreateBuffers(int n, ref BufferHandle buffers)
+        public static unsafe void CreateBuffers(int n, ref int buffers)
         {
-            fixed (BufferHandle* buffers_ptr = &buffers)
+            fixed (int* buffers_ptr = &buffers)
             {
                 CreateBuffers(n, buffers_ptr);
             }
         }
         /// <inheritdoc cref="NamedBufferStorage"/>
-        public static unsafe void NamedBufferStorage(BufferHandle buffer, nint size, IntPtr data, BufferStorageMask flags)
+        public static unsafe void NamedBufferStorage(int buffer, nint size, IntPtr data, BufferStorageMask flags)
         {
             void* data_vptr = (void*)data;
             NamedBufferStorage(buffer, size, data_vptr, flags);
         }
         /// <inheritdoc cref="NamedBufferStorage"/>
-        public static unsafe void NamedBufferStorage<T1>(BufferHandle buffer, ReadOnlySpan<T1> data, BufferStorageMask flags)
+        public static unsafe void NamedBufferStorage<T1>(int buffer, ReadOnlySpan<T1> data, BufferStorageMask flags)
             where T1 : unmanaged
         {
             nint size = (nint)(data.Length * sizeof(T1));
@@ -8883,7 +8883,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="NamedBufferStorage"/>
-        public static unsafe void NamedBufferStorage<T1>(BufferHandle buffer, T1[] data, BufferStorageMask flags)
+        public static unsafe void NamedBufferStorage<T1>(int buffer, T1[] data, BufferStorageMask flags)
             where T1 : unmanaged
         {
             nint size = (nint)(data.Length * sizeof(T1));
@@ -8893,7 +8893,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="NamedBufferStorage"/>
-        public static unsafe void NamedBufferStorage<T1>(BufferHandle buffer, nint size, in T1 data, BufferStorageMask flags)
+        public static unsafe void NamedBufferStorage<T1>(int buffer, nint size, in T1 data, BufferStorageMask flags)
             where T1 : unmanaged
         {
             fixed (void* data_ptr = &data)
@@ -8902,13 +8902,13 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="NamedBufferData"/>
-        public static unsafe void NamedBufferData(BufferHandle buffer, nint size, IntPtr data, VertexBufferObjectUsage usage)
+        public static unsafe void NamedBufferData(int buffer, nint size, IntPtr data, VertexBufferObjectUsage usage)
         {
             void* data_vptr = (void*)data;
             NamedBufferData(buffer, size, data_vptr, usage);
         }
         /// <inheritdoc cref="NamedBufferData"/>
-        public static unsafe void NamedBufferData<T1>(BufferHandle buffer, ReadOnlySpan<T1> data, VertexBufferObjectUsage usage)
+        public static unsafe void NamedBufferData<T1>(int buffer, ReadOnlySpan<T1> data, VertexBufferObjectUsage usage)
             where T1 : unmanaged
         {
             nint size = (nint)(data.Length * sizeof(T1));
@@ -8918,7 +8918,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="NamedBufferData"/>
-        public static unsafe void NamedBufferData<T1>(BufferHandle buffer, T1[] data, VertexBufferObjectUsage usage)
+        public static unsafe void NamedBufferData<T1>(int buffer, T1[] data, VertexBufferObjectUsage usage)
             where T1 : unmanaged
         {
             nint size = (nint)(data.Length * sizeof(T1));
@@ -8928,7 +8928,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="NamedBufferData"/>
-        public static unsafe void NamedBufferData<T1>(BufferHandle buffer, nint size, in T1 data, VertexBufferObjectUsage usage)
+        public static unsafe void NamedBufferData<T1>(int buffer, nint size, in T1 data, VertexBufferObjectUsage usage)
             where T1 : unmanaged
         {
             fixed (void* data_ptr = &data)
@@ -8937,13 +8937,13 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="NamedBufferSubData"/>
-        public static unsafe void NamedBufferSubData(BufferHandle buffer, IntPtr offset, nint size, IntPtr data)
+        public static unsafe void NamedBufferSubData(int buffer, IntPtr offset, nint size, IntPtr data)
         {
             void* data_vptr = (void*)data;
             NamedBufferSubData(buffer, offset, size, data_vptr);
         }
         /// <inheritdoc cref="NamedBufferSubData"/>
-        public static unsafe void NamedBufferSubData<T1>(BufferHandle buffer, IntPtr offset, ReadOnlySpan<T1> data)
+        public static unsafe void NamedBufferSubData<T1>(int buffer, IntPtr offset, ReadOnlySpan<T1> data)
             where T1 : unmanaged
         {
             nint size = (nint)(data.Length * sizeof(T1));
@@ -8953,7 +8953,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="NamedBufferSubData"/>
-        public static unsafe void NamedBufferSubData<T1>(BufferHandle buffer, IntPtr offset, T1[] data)
+        public static unsafe void NamedBufferSubData<T1>(int buffer, IntPtr offset, T1[] data)
             where T1 : unmanaged
         {
             nint size = (nint)(data.Length * sizeof(T1));
@@ -8963,7 +8963,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="NamedBufferSubData"/>
-        public static unsafe void NamedBufferSubData<T1>(BufferHandle buffer, IntPtr offset, nint size, in T1 data)
+        public static unsafe void NamedBufferSubData<T1>(int buffer, IntPtr offset, nint size, in T1 data)
             where T1 : unmanaged
         {
             fixed (void* data_ptr = &data)
@@ -8972,13 +8972,13 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ClearNamedBufferData"/>
-        public static unsafe void ClearNamedBufferData(BufferHandle buffer, SizedInternalFormat internalformat, PixelFormat format, PixelType type, IntPtr data)
+        public static unsafe void ClearNamedBufferData(int buffer, SizedInternalFormat internalformat, PixelFormat format, PixelType type, IntPtr data)
         {
             void* data_vptr = (void*)data;
             ClearNamedBufferData(buffer, internalformat, format, type, data_vptr);
         }
         /// <inheritdoc cref="ClearNamedBufferData"/>
-        public static unsafe void ClearNamedBufferData<T1>(BufferHandle buffer, SizedInternalFormat internalformat, PixelFormat format, PixelType type, in T1 data)
+        public static unsafe void ClearNamedBufferData<T1>(int buffer, SizedInternalFormat internalformat, PixelFormat format, PixelType type, in T1 data)
             where T1 : unmanaged
         {
             fixed (void* data_ptr = &data)
@@ -8987,13 +8987,13 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ClearNamedBufferSubData"/>
-        public static unsafe void ClearNamedBufferSubData(BufferHandle buffer, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, IntPtr data)
+        public static unsafe void ClearNamedBufferSubData(int buffer, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, IntPtr data)
         {
             void* data_vptr = (void*)data;
             ClearNamedBufferSubData(buffer, internalformat, offset, size, format, type, data_vptr);
         }
         /// <inheritdoc cref="ClearNamedBufferSubData"/>
-        public static unsafe void ClearNamedBufferSubData<T1>(BufferHandle buffer, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, ReadOnlySpan<T1> data)
+        public static unsafe void ClearNamedBufferSubData<T1>(int buffer, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, ReadOnlySpan<T1> data)
             where T1 : unmanaged
         {
             fixed (void* data_ptr = data)
@@ -9002,7 +9002,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ClearNamedBufferSubData"/>
-        public static unsafe void ClearNamedBufferSubData<T1>(BufferHandle buffer, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, T1[] data)
+        public static unsafe void ClearNamedBufferSubData<T1>(int buffer, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, T1[] data)
             where T1 : unmanaged
         {
             fixed (void* data_ptr = data)
@@ -9011,7 +9011,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ClearNamedBufferSubData"/>
-        public static unsafe void ClearNamedBufferSubData<T1>(BufferHandle buffer, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, in T1 data)
+        public static unsafe void ClearNamedBufferSubData<T1>(int buffer, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, in T1 data)
             where T1 : unmanaged
         {
             fixed (void* data_ptr = &data)
@@ -9020,7 +9020,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetNamedBufferParameteriv"/>
-        public static unsafe void GetNamedBufferParameteri(BufferHandle buffer, BufferPNameARB pname, ref int parameters)
+        public static unsafe void GetNamedBufferParameteri(int buffer, BufferPNameARB pname, ref int parameters)
         {
             fixed (int* parameters_ptr = &parameters)
             {
@@ -9028,7 +9028,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetNamedBufferParameteri64v"/>
-        public static unsafe void GetNamedBufferParameteri64(BufferHandle buffer, BufferPNameARB pname, ref long parameters)
+        public static unsafe void GetNamedBufferParameteri64(int buffer, BufferPNameARB pname, ref long parameters)
         {
             fixed (long* parameters_ptr = &parameters)
             {
@@ -9036,18 +9036,18 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetNamedBufferPointerv"/>
-        public static unsafe void GetNamedBufferPointer(BufferHandle buffer, BufferPointerNameARB pname, void** parameters)
+        public static unsafe void GetNamedBufferPointer(int buffer, BufferPointerNameARB pname, void** parameters)
         {
             GetNamedBufferPointerv(buffer, pname, parameters);
         }
         /// <inheritdoc cref="GetNamedBufferSubData"/>
-        public static unsafe void GetNamedBufferSubData(BufferHandle buffer, IntPtr offset, nint size, IntPtr data)
+        public static unsafe void GetNamedBufferSubData(int buffer, IntPtr offset, nint size, IntPtr data)
         {
             void* data_vptr = (void*)data;
             GetNamedBufferSubData(buffer, offset, size, data_vptr);
         }
         /// <inheritdoc cref="GetNamedBufferSubData"/>
-        public static unsafe void GetNamedBufferSubData<T1>(BufferHandle buffer, IntPtr offset, nint size, ref T1 data)
+        public static unsafe void GetNamedBufferSubData<T1>(int buffer, IntPtr offset, nint size, ref T1 data)
             where T1 : unmanaged
         {
             fixed (void* data_ptr = &data)
@@ -9056,9 +9056,9 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="CreateFramebuffers"/>
-        public static unsafe FramebufferHandle CreateFramebuffer()
+        public static unsafe int CreateFramebuffer()
         {
-            FramebufferHandle framebuffer;
+            int framebuffer;
             int n = 1;
             Unsafe.SkipInit(out framebuffer);
             // FIXME: This could be a problem for the overloads that take an out parameter
@@ -9069,12 +9069,12 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            FramebufferHandle* framebuffers_handle = (FramebufferHandle*)Unsafe.AsPointer(ref framebuffer);
+            int* framebuffers_handle = (int*)Unsafe.AsPointer(ref framebuffer);
             CreateFramebuffers(n, framebuffers_handle);
             return framebuffer;
         }
         /// <inheritdoc cref="CreateFramebuffers"/>
-        public static unsafe void CreateFramebuffer(out FramebufferHandle framebuffer)
+        public static unsafe void CreateFramebuffer(out int framebuffer)
         {
             int n = 1;
             Unsafe.SkipInit(out framebuffer);
@@ -9086,37 +9086,37 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            FramebufferHandle* framebuffers_handle = (FramebufferHandle*)Unsafe.AsPointer(ref framebuffer);
+            int* framebuffers_handle = (int*)Unsafe.AsPointer(ref framebuffer);
             CreateFramebuffers(n, framebuffers_handle);
         }
         /// <inheritdoc cref="CreateFramebuffers"/>
-        public static unsafe void CreateFramebuffers(Span<FramebufferHandle> framebuffers)
+        public static unsafe void CreateFramebuffers(Span<int> framebuffers)
         {
             int n = (int)(framebuffers.Length);
-            fixed (FramebufferHandle* framebuffers_ptr = framebuffers)
+            fixed (int* framebuffers_ptr = framebuffers)
             {
                 CreateFramebuffers(n, framebuffers_ptr);
             }
         }
         /// <inheritdoc cref="CreateFramebuffers"/>
-        public static unsafe void CreateFramebuffers(FramebufferHandle[] framebuffers)
+        public static unsafe void CreateFramebuffers(int[] framebuffers)
         {
             int n = (int)(framebuffers.Length);
-            fixed (FramebufferHandle* framebuffers_ptr = framebuffers)
+            fixed (int* framebuffers_ptr = framebuffers)
             {
                 CreateFramebuffers(n, framebuffers_ptr);
             }
         }
         /// <inheritdoc cref="CreateFramebuffers"/>
-        public static unsafe void CreateFramebuffers(int n, ref FramebufferHandle framebuffers)
+        public static unsafe void CreateFramebuffers(int n, ref int framebuffers)
         {
-            fixed (FramebufferHandle* framebuffers_ptr = &framebuffers)
+            fixed (int* framebuffers_ptr = &framebuffers)
             {
                 CreateFramebuffers(n, framebuffers_ptr);
             }
         }
         /// <inheritdoc cref="NamedFramebufferDrawBuffers"/>
-        public static unsafe void NamedFramebufferDrawBuffers(FramebufferHandle framebuffer, ReadOnlySpan<ColorBuffer> bufs)
+        public static unsafe void NamedFramebufferDrawBuffers(int framebuffer, ReadOnlySpan<ColorBuffer> bufs)
         {
             int n = (int)(bufs.Length);
             fixed (ColorBuffer* bufs_ptr = bufs)
@@ -9125,7 +9125,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="NamedFramebufferDrawBuffers"/>
-        public static unsafe void NamedFramebufferDrawBuffers(FramebufferHandle framebuffer, ColorBuffer[] bufs)
+        public static unsafe void NamedFramebufferDrawBuffers(int framebuffer, ColorBuffer[] bufs)
         {
             int n = (int)(bufs.Length);
             fixed (ColorBuffer* bufs_ptr = bufs)
@@ -9134,7 +9134,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="NamedFramebufferDrawBuffers"/>
-        public static unsafe void NamedFramebufferDrawBuffers(FramebufferHandle framebuffer, int n, in ColorBuffer bufs)
+        public static unsafe void NamedFramebufferDrawBuffers(int framebuffer, int n, in ColorBuffer bufs)
         {
             fixed (ColorBuffer* bufs_ptr = &bufs)
             {
@@ -9142,7 +9142,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="InvalidateNamedFramebufferData"/>
-        public static unsafe void InvalidateNamedFramebufferData(FramebufferHandle framebuffer, ReadOnlySpan<FramebufferAttachment> attachments)
+        public static unsafe void InvalidateNamedFramebufferData(int framebuffer, ReadOnlySpan<FramebufferAttachment> attachments)
         {
             int numAttachments = (int)(attachments.Length);
             fixed (FramebufferAttachment* attachments_ptr = attachments)
@@ -9151,7 +9151,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="InvalidateNamedFramebufferData"/>
-        public static unsafe void InvalidateNamedFramebufferData(FramebufferHandle framebuffer, FramebufferAttachment[] attachments)
+        public static unsafe void InvalidateNamedFramebufferData(int framebuffer, FramebufferAttachment[] attachments)
         {
             int numAttachments = (int)(attachments.Length);
             fixed (FramebufferAttachment* attachments_ptr = attachments)
@@ -9160,7 +9160,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="InvalidateNamedFramebufferData"/>
-        public static unsafe void InvalidateNamedFramebufferData(FramebufferHandle framebuffer, int numAttachments, in FramebufferAttachment attachments)
+        public static unsafe void InvalidateNamedFramebufferData(int framebuffer, int numAttachments, in FramebufferAttachment attachments)
         {
             fixed (FramebufferAttachment* attachments_ptr = &attachments)
             {
@@ -9168,7 +9168,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="InvalidateNamedFramebufferSubData"/>
-        public static unsafe void InvalidateNamedFramebufferSubData(FramebufferHandle framebuffer, ReadOnlySpan<FramebufferAttachment> attachments, int x, int y, int width, int height)
+        public static unsafe void InvalidateNamedFramebufferSubData(int framebuffer, ReadOnlySpan<FramebufferAttachment> attachments, int x, int y, int width, int height)
         {
             int numAttachments = (int)(attachments.Length);
             fixed (FramebufferAttachment* attachments_ptr = attachments)
@@ -9177,7 +9177,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="InvalidateNamedFramebufferSubData"/>
-        public static unsafe void InvalidateNamedFramebufferSubData(FramebufferHandle framebuffer, FramebufferAttachment[] attachments, int x, int y, int width, int height)
+        public static unsafe void InvalidateNamedFramebufferSubData(int framebuffer, FramebufferAttachment[] attachments, int x, int y, int width, int height)
         {
             int numAttachments = (int)(attachments.Length);
             fixed (FramebufferAttachment* attachments_ptr = attachments)
@@ -9186,7 +9186,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="InvalidateNamedFramebufferSubData"/>
-        public static unsafe void InvalidateNamedFramebufferSubData(FramebufferHandle framebuffer, int numAttachments, in FramebufferAttachment attachments, int x, int y, int width, int height)
+        public static unsafe void InvalidateNamedFramebufferSubData(int framebuffer, int numAttachments, in FramebufferAttachment attachments, int x, int y, int width, int height)
         {
             fixed (FramebufferAttachment* attachments_ptr = &attachments)
             {
@@ -9194,7 +9194,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ClearNamedFramebufferiv"/>
-        public static unsafe void ClearNamedFramebufferi(FramebufferHandle framebuffer, Buffer buffer, int drawbuffer, ReadOnlySpan<int> value)
+        public static unsafe void ClearNamedFramebufferi(int framebuffer, Buffer buffer, int drawbuffer, ReadOnlySpan<int> value)
         {
             fixed (int* value_ptr = value)
             {
@@ -9202,7 +9202,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ClearNamedFramebufferiv"/>
-        public static unsafe void ClearNamedFramebufferi(FramebufferHandle framebuffer, Buffer buffer, int drawbuffer, int[] value)
+        public static unsafe void ClearNamedFramebufferi(int framebuffer, Buffer buffer, int drawbuffer, int[] value)
         {
             fixed (int* value_ptr = value)
             {
@@ -9210,7 +9210,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ClearNamedFramebufferiv"/>
-        public static unsafe void ClearNamedFramebufferi(FramebufferHandle framebuffer, Buffer buffer, int drawbuffer, in int value)
+        public static unsafe void ClearNamedFramebufferi(int framebuffer, Buffer buffer, int drawbuffer, in int value)
         {
             fixed (int* value_ptr = &value)
             {
@@ -9218,7 +9218,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ClearNamedFramebufferuiv"/>
-        public static unsafe void ClearNamedFramebufferui(FramebufferHandle framebuffer, Buffer buffer, int drawbuffer, ReadOnlySpan<uint> value)
+        public static unsafe void ClearNamedFramebufferui(int framebuffer, Buffer buffer, int drawbuffer, ReadOnlySpan<uint> value)
         {
             fixed (uint* value_ptr = value)
             {
@@ -9226,7 +9226,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ClearNamedFramebufferuiv"/>
-        public static unsafe void ClearNamedFramebufferui(FramebufferHandle framebuffer, Buffer buffer, int drawbuffer, uint[] value)
+        public static unsafe void ClearNamedFramebufferui(int framebuffer, Buffer buffer, int drawbuffer, uint[] value)
         {
             fixed (uint* value_ptr = value)
             {
@@ -9234,7 +9234,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ClearNamedFramebufferuiv"/>
-        public static unsafe void ClearNamedFramebufferui(FramebufferHandle framebuffer, Buffer buffer, int drawbuffer, in uint value)
+        public static unsafe void ClearNamedFramebufferui(int framebuffer, Buffer buffer, int drawbuffer, in uint value)
         {
             fixed (uint* value_ptr = &value)
             {
@@ -9242,7 +9242,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ClearNamedFramebufferfv"/>
-        public static unsafe void ClearNamedFramebufferf(FramebufferHandle framebuffer, Buffer buffer, int drawbuffer, ReadOnlySpan<float> value)
+        public static unsafe void ClearNamedFramebufferf(int framebuffer, Buffer buffer, int drawbuffer, ReadOnlySpan<float> value)
         {
             fixed (float* value_ptr = value)
             {
@@ -9250,7 +9250,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ClearNamedFramebufferfv"/>
-        public static unsafe void ClearNamedFramebufferf(FramebufferHandle framebuffer, Buffer buffer, int drawbuffer, float[] value)
+        public static unsafe void ClearNamedFramebufferf(int framebuffer, Buffer buffer, int drawbuffer, float[] value)
         {
             fixed (float* value_ptr = value)
             {
@@ -9258,7 +9258,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ClearNamedFramebufferfv"/>
-        public static unsafe void ClearNamedFramebufferf(FramebufferHandle framebuffer, Buffer buffer, int drawbuffer, in float value)
+        public static unsafe void ClearNamedFramebufferf(int framebuffer, Buffer buffer, int drawbuffer, in float value)
         {
             fixed (float* value_ptr = &value)
             {
@@ -9266,12 +9266,12 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="ClearNamedFramebufferfi"/>
-        public static unsafe void ClearNamedFramebuffer(FramebufferHandle framebuffer, Buffer buffer, int drawbuffer, float depth, int stencil)
+        public static unsafe void ClearNamedFramebuffer(int framebuffer, Buffer buffer, int drawbuffer, float depth, int stencil)
         {
             ClearNamedFramebufferfi(framebuffer, buffer, drawbuffer, depth, stencil);
         }
         /// <inheritdoc cref="GetNamedFramebufferParameteriv"/>
-        public static unsafe void GetNamedFramebufferParameteri(FramebufferHandle framebuffer, GetFramebufferParameter pname, ref int param)
+        public static unsafe void GetNamedFramebufferParameteri(int framebuffer, GetFramebufferParameter pname, ref int param)
         {
             fixed (int* param_ptr = &param)
             {
@@ -9279,7 +9279,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetNamedFramebufferAttachmentParameteriv"/>
-        public static unsafe void GetNamedFramebufferAttachmentParameteri(FramebufferHandle framebuffer, FramebufferAttachment attachment, FramebufferAttachmentParameterName pname, ref int parameters)
+        public static unsafe void GetNamedFramebufferAttachmentParameteri(int framebuffer, FramebufferAttachment attachment, FramebufferAttachmentParameterName pname, ref int parameters)
         {
             fixed (int* parameters_ptr = &parameters)
             {
@@ -9287,9 +9287,9 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="CreateRenderbuffers"/>
-        public static unsafe RenderbufferHandle CreateRenderbuffer()
+        public static unsafe int CreateRenderbuffer()
         {
-            RenderbufferHandle renderbuffer;
+            int renderbuffer;
             int n = 1;
             Unsafe.SkipInit(out renderbuffer);
             // FIXME: This could be a problem for the overloads that take an out parameter
@@ -9300,12 +9300,12 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            RenderbufferHandle* renderbuffers_handle = (RenderbufferHandle*)Unsafe.AsPointer(ref renderbuffer);
+            int* renderbuffers_handle = (int*)Unsafe.AsPointer(ref renderbuffer);
             CreateRenderbuffers(n, renderbuffers_handle);
             return renderbuffer;
         }
         /// <inheritdoc cref="CreateRenderbuffers"/>
-        public static unsafe void CreateRenderbuffer(out RenderbufferHandle renderbuffer)
+        public static unsafe void CreateRenderbuffer(out int renderbuffer)
         {
             int n = 1;
             Unsafe.SkipInit(out renderbuffer);
@@ -9317,37 +9317,37 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            RenderbufferHandle* renderbuffers_handle = (RenderbufferHandle*)Unsafe.AsPointer(ref renderbuffer);
+            int* renderbuffers_handle = (int*)Unsafe.AsPointer(ref renderbuffer);
             CreateRenderbuffers(n, renderbuffers_handle);
         }
         /// <inheritdoc cref="CreateRenderbuffers"/>
-        public static unsafe void CreateRenderbuffers(Span<RenderbufferHandle> renderbuffers)
+        public static unsafe void CreateRenderbuffers(Span<int> renderbuffers)
         {
             int n = (int)(renderbuffers.Length);
-            fixed (RenderbufferHandle* renderbuffers_ptr = renderbuffers)
+            fixed (int* renderbuffers_ptr = renderbuffers)
             {
                 CreateRenderbuffers(n, renderbuffers_ptr);
             }
         }
         /// <inheritdoc cref="CreateRenderbuffers"/>
-        public static unsafe void CreateRenderbuffers(RenderbufferHandle[] renderbuffers)
+        public static unsafe void CreateRenderbuffers(int[] renderbuffers)
         {
             int n = (int)(renderbuffers.Length);
-            fixed (RenderbufferHandle* renderbuffers_ptr = renderbuffers)
+            fixed (int* renderbuffers_ptr = renderbuffers)
             {
                 CreateRenderbuffers(n, renderbuffers_ptr);
             }
         }
         /// <inheritdoc cref="CreateRenderbuffers"/>
-        public static unsafe void CreateRenderbuffers(int n, ref RenderbufferHandle renderbuffers)
+        public static unsafe void CreateRenderbuffers(int n, ref int renderbuffers)
         {
-            fixed (RenderbufferHandle* renderbuffers_ptr = &renderbuffers)
+            fixed (int* renderbuffers_ptr = &renderbuffers)
             {
                 CreateRenderbuffers(n, renderbuffers_ptr);
             }
         }
         /// <inheritdoc cref="GetNamedRenderbufferParameteriv"/>
-        public static unsafe void GetNamedRenderbufferParameteri(RenderbufferHandle renderbuffer, RenderbufferParameterName pname, ref int parameters)
+        public static unsafe void GetNamedRenderbufferParameteri(int renderbuffer, RenderbufferParameterName pname, ref int parameters)
         {
             fixed (int* parameters_ptr = &parameters)
             {
@@ -9355,9 +9355,9 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="CreateTextures"/>
-        public static unsafe TextureHandle CreateTexture(TextureTarget target)
+        public static unsafe int CreateTexture(TextureTarget target)
         {
-            TextureHandle texture;
+            int texture;
             int n = 1;
             Unsafe.SkipInit(out texture);
             // FIXME: This could be a problem for the overloads that take an out parameter
@@ -9368,12 +9368,12 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            TextureHandle* textures_handle = (TextureHandle*)Unsafe.AsPointer(ref texture);
+            int* textures_handle = (int*)Unsafe.AsPointer(ref texture);
             CreateTextures(target, n, textures_handle);
             return texture;
         }
         /// <inheritdoc cref="CreateTextures"/>
-        public static unsafe void CreateTexture(TextureTarget target, out TextureHandle texture)
+        public static unsafe void CreateTexture(TextureTarget target, out int texture)
         {
             int n = 1;
             Unsafe.SkipInit(out texture);
@@ -9385,43 +9385,43 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            TextureHandle* textures_handle = (TextureHandle*)Unsafe.AsPointer(ref texture);
+            int* textures_handle = (int*)Unsafe.AsPointer(ref texture);
             CreateTextures(target, n, textures_handle);
         }
         /// <inheritdoc cref="CreateTextures"/>
-        public static unsafe void CreateTextures(TextureTarget target, Span<TextureHandle> textures)
+        public static unsafe void CreateTextures(TextureTarget target, Span<int> textures)
         {
             int n = (int)(textures.Length);
-            fixed (TextureHandle* textures_ptr = textures)
+            fixed (int* textures_ptr = textures)
             {
                 CreateTextures(target, n, textures_ptr);
             }
         }
         /// <inheritdoc cref="CreateTextures"/>
-        public static unsafe void CreateTextures(TextureTarget target, TextureHandle[] textures)
+        public static unsafe void CreateTextures(TextureTarget target, int[] textures)
         {
             int n = (int)(textures.Length);
-            fixed (TextureHandle* textures_ptr = textures)
+            fixed (int* textures_ptr = textures)
             {
                 CreateTextures(target, n, textures_ptr);
             }
         }
         /// <inheritdoc cref="CreateTextures"/>
-        public static unsafe void CreateTextures(TextureTarget target, int n, ref TextureHandle textures)
+        public static unsafe void CreateTextures(TextureTarget target, int n, ref int textures)
         {
-            fixed (TextureHandle* textures_ptr = &textures)
+            fixed (int* textures_ptr = &textures)
             {
                 CreateTextures(target, n, textures_ptr);
             }
         }
         /// <inheritdoc cref="TextureSubImage1D"/>
-        public static unsafe void TextureSubImage1D(TextureHandle texture, int level, int xoffset, int width, PixelFormat format, PixelType type, IntPtr pixels)
+        public static unsafe void TextureSubImage1D(int texture, int level, int xoffset, int width, PixelFormat format, PixelType type, IntPtr pixels)
         {
             void* pixels_vptr = (void*)pixels;
             TextureSubImage1D(texture, level, xoffset, width, format, type, pixels_vptr);
         }
         /// <inheritdoc cref="TextureSubImage1D"/>
-        public static unsafe void TextureSubImage1D<T1>(TextureHandle texture, int level, int xoffset, int width, PixelFormat format, PixelType type, in T1 pixels)
+        public static unsafe void TextureSubImage1D<T1>(int texture, int level, int xoffset, int width, PixelFormat format, PixelType type, in T1 pixels)
             where T1 : unmanaged
         {
             fixed (void* pixels_ptr = &pixels)
@@ -9430,13 +9430,13 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="TextureSubImage2D"/>
-        public static unsafe void TextureSubImage2D(TextureHandle texture, int level, int xoffset, int yoffset, int width, int height, PixelFormat format, PixelType type, IntPtr pixels)
+        public static unsafe void TextureSubImage2D(int texture, int level, int xoffset, int yoffset, int width, int height, PixelFormat format, PixelType type, IntPtr pixels)
         {
             void* pixels_vptr = (void*)pixels;
             TextureSubImage2D(texture, level, xoffset, yoffset, width, height, format, type, pixels_vptr);
         }
         /// <inheritdoc cref="TextureSubImage2D"/>
-        public static unsafe void TextureSubImage2D<T1>(TextureHandle texture, int level, int xoffset, int yoffset, int width, int height, PixelFormat format, PixelType type, in T1 pixels)
+        public static unsafe void TextureSubImage2D<T1>(int texture, int level, int xoffset, int yoffset, int width, int height, PixelFormat format, PixelType type, in T1 pixels)
             where T1 : unmanaged
         {
             fixed (void* pixels_ptr = &pixels)
@@ -9445,13 +9445,13 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="TextureSubImage3D"/>
-        public static unsafe void TextureSubImage3D(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, IntPtr pixels)
+        public static unsafe void TextureSubImage3D(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, IntPtr pixels)
         {
             void* pixels_vptr = (void*)pixels;
             TextureSubImage3D(texture, level, xoffset, yoffset, zoffset, width, height, depth, format, type, pixels_vptr);
         }
         /// <inheritdoc cref="TextureSubImage3D"/>
-        public static unsafe void TextureSubImage3D<T1>(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, in T1 pixels)
+        public static unsafe void TextureSubImage3D<T1>(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, in T1 pixels)
             where T1 : unmanaged
         {
             fixed (void* pixels_ptr = &pixels)
@@ -9460,13 +9460,13 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="CompressedTextureSubImage1D"/>
-        public static unsafe void CompressedTextureSubImage1D(TextureHandle texture, int level, int xoffset, int width, InternalFormat format, int imageSize, IntPtr data)
+        public static unsafe void CompressedTextureSubImage1D(int texture, int level, int xoffset, int width, InternalFormat format, int imageSize, IntPtr data)
         {
             void* data_vptr = (void*)data;
             CompressedTextureSubImage1D(texture, level, xoffset, width, format, imageSize, data_vptr);
         }
         /// <inheritdoc cref="CompressedTextureSubImage1D"/>
-        public static unsafe void CompressedTextureSubImage1D<T1>(TextureHandle texture, int level, int xoffset, int width, InternalFormat format, int imageSize, in T1 data)
+        public static unsafe void CompressedTextureSubImage1D<T1>(int texture, int level, int xoffset, int width, InternalFormat format, int imageSize, in T1 data)
             where T1 : unmanaged
         {
             fixed (void* data_ptr = &data)
@@ -9475,13 +9475,13 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="CompressedTextureSubImage2D"/>
-        public static unsafe void CompressedTextureSubImage2D(TextureHandle texture, int level, int xoffset, int yoffset, int width, int height, InternalFormat format, int imageSize, IntPtr data)
+        public static unsafe void CompressedTextureSubImage2D(int texture, int level, int xoffset, int yoffset, int width, int height, InternalFormat format, int imageSize, IntPtr data)
         {
             void* data_vptr = (void*)data;
             CompressedTextureSubImage2D(texture, level, xoffset, yoffset, width, height, format, imageSize, data_vptr);
         }
         /// <inheritdoc cref="CompressedTextureSubImage2D"/>
-        public static unsafe void CompressedTextureSubImage2D<T1>(TextureHandle texture, int level, int xoffset, int yoffset, int width, int height, InternalFormat format, int imageSize, in T1 data)
+        public static unsafe void CompressedTextureSubImage2D<T1>(int texture, int level, int xoffset, int yoffset, int width, int height, InternalFormat format, int imageSize, in T1 data)
             where T1 : unmanaged
         {
             fixed (void* data_ptr = &data)
@@ -9490,13 +9490,13 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="CompressedTextureSubImage3D"/>
-        public static unsafe void CompressedTextureSubImage3D(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, InternalFormat format, int imageSize, IntPtr data)
+        public static unsafe void CompressedTextureSubImage3D(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, InternalFormat format, int imageSize, IntPtr data)
         {
             void* data_vptr = (void*)data;
             CompressedTextureSubImage3D(texture, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, data_vptr);
         }
         /// <inheritdoc cref="CompressedTextureSubImage3D"/>
-        public static unsafe void CompressedTextureSubImage3D<T1>(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, InternalFormat format, int imageSize, in T1 data)
+        public static unsafe void CompressedTextureSubImage3D<T1>(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, InternalFormat format, int imageSize, in T1 data)
             where T1 : unmanaged
         {
             fixed (void* data_ptr = &data)
@@ -9505,7 +9505,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="TextureParameterfv"/>
-        public static unsafe void TextureParameterf(TextureHandle texture, TextureParameterName pname, ReadOnlySpan<float> param)
+        public static unsafe void TextureParameterf(int texture, TextureParameterName pname, ReadOnlySpan<float> param)
         {
             fixed (float* param_ptr = param)
             {
@@ -9513,7 +9513,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="TextureParameterfv"/>
-        public static unsafe void TextureParameterf(TextureHandle texture, TextureParameterName pname, float[] param)
+        public static unsafe void TextureParameterf(int texture, TextureParameterName pname, float[] param)
         {
             fixed (float* param_ptr = param)
             {
@@ -9521,7 +9521,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="TextureParameterfv"/>
-        public static unsafe void TextureParameterf(TextureHandle texture, TextureParameterName pname, in float param)
+        public static unsafe void TextureParameterf(int texture, TextureParameterName pname, in float param)
         {
             fixed (float* param_ptr = &param)
             {
@@ -9529,7 +9529,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="TextureParameterIiv"/>
-        public static unsafe void TextureParameterIi(TextureHandle texture, TextureParameterName pname, ReadOnlySpan<int> parameters)
+        public static unsafe void TextureParameterIi(int texture, TextureParameterName pname, ReadOnlySpan<int> parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
@@ -9537,7 +9537,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="TextureParameterIiv"/>
-        public static unsafe void TextureParameterIi(TextureHandle texture, TextureParameterName pname, int[] parameters)
+        public static unsafe void TextureParameterIi(int texture, TextureParameterName pname, int[] parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
@@ -9545,7 +9545,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="TextureParameterIiv"/>
-        public static unsafe void TextureParameterIi(TextureHandle texture, TextureParameterName pname, in int parameters)
+        public static unsafe void TextureParameterIi(int texture, TextureParameterName pname, in int parameters)
         {
             fixed (int* parameters_ptr = &parameters)
             {
@@ -9553,7 +9553,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="TextureParameterIuiv"/>
-        public static unsafe void TextureParameterIui(TextureHandle texture, TextureParameterName pname, ReadOnlySpan<uint> parameters)
+        public static unsafe void TextureParameterIui(int texture, TextureParameterName pname, ReadOnlySpan<uint> parameters)
         {
             fixed (uint* parameters_ptr = parameters)
             {
@@ -9561,7 +9561,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="TextureParameterIuiv"/>
-        public static unsafe void TextureParameterIui(TextureHandle texture, TextureParameterName pname, uint[] parameters)
+        public static unsafe void TextureParameterIui(int texture, TextureParameterName pname, uint[] parameters)
         {
             fixed (uint* parameters_ptr = parameters)
             {
@@ -9569,7 +9569,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="TextureParameterIuiv"/>
-        public static unsafe void TextureParameterIui(TextureHandle texture, TextureParameterName pname, in uint parameters)
+        public static unsafe void TextureParameterIui(int texture, TextureParameterName pname, in uint parameters)
         {
             fixed (uint* parameters_ptr = &parameters)
             {
@@ -9577,7 +9577,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="TextureParameteriv"/>
-        public static unsafe void TextureParameteri(TextureHandle texture, TextureParameterName pname, ReadOnlySpan<int> param)
+        public static unsafe void TextureParameteri(int texture, TextureParameterName pname, ReadOnlySpan<int> param)
         {
             fixed (int* param_ptr = param)
             {
@@ -9585,7 +9585,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="TextureParameteriv"/>
-        public static unsafe void TextureParameteri(TextureHandle texture, TextureParameterName pname, int[] param)
+        public static unsafe void TextureParameteri(int texture, TextureParameterName pname, int[] param)
         {
             fixed (int* param_ptr = param)
             {
@@ -9593,7 +9593,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="TextureParameteriv"/>
-        public static unsafe void TextureParameteri(TextureHandle texture, TextureParameterName pname, in int param)
+        public static unsafe void TextureParameteri(int texture, TextureParameterName pname, in int param)
         {
             fixed (int* param_ptr = &param)
             {
@@ -9601,13 +9601,13 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetTextureImage"/>
-        public static unsafe void GetTextureImage(TextureHandle texture, int level, PixelFormat format, PixelType type, int bufSize, IntPtr pixels)
+        public static unsafe void GetTextureImage(int texture, int level, PixelFormat format, PixelType type, int bufSize, IntPtr pixels)
         {
             void* pixels_vptr = (void*)pixels;
             GetTextureImage(texture, level, format, type, bufSize, pixels_vptr);
         }
         /// <inheritdoc cref="GetTextureImage"/>
-        public static unsafe void GetTextureImage<T1>(TextureHandle texture, int level, PixelFormat format, PixelType type, Span<T1> pixels)
+        public static unsafe void GetTextureImage<T1>(int texture, int level, PixelFormat format, PixelType type, Span<T1> pixels)
             where T1 : unmanaged
         {
             int bufSize = (int)(pixels.Length * sizeof(T1));
@@ -9617,7 +9617,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetTextureImage"/>
-        public static unsafe void GetTextureImage<T1>(TextureHandle texture, int level, PixelFormat format, PixelType type, T1[] pixels)
+        public static unsafe void GetTextureImage<T1>(int texture, int level, PixelFormat format, PixelType type, T1[] pixels)
             where T1 : unmanaged
         {
             int bufSize = (int)(pixels.Length * sizeof(T1));
@@ -9627,7 +9627,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetTextureImage"/>
-        public static unsafe void GetTextureImage<T1>(TextureHandle texture, int level, PixelFormat format, PixelType type, int bufSize, ref T1 pixels)
+        public static unsafe void GetTextureImage<T1>(int texture, int level, PixelFormat format, PixelType type, int bufSize, ref T1 pixels)
             where T1 : unmanaged
         {
             fixed (void* pixels_ptr = &pixels)
@@ -9636,13 +9636,13 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetCompressedTextureImage"/>
-        public static unsafe void GetCompressedTextureImage(TextureHandle texture, int level, int bufSize, IntPtr pixels)
+        public static unsafe void GetCompressedTextureImage(int texture, int level, int bufSize, IntPtr pixels)
         {
             void* pixels_vptr = (void*)pixels;
             GetCompressedTextureImage(texture, level, bufSize, pixels_vptr);
         }
         /// <inheritdoc cref="GetCompressedTextureImage"/>
-        public static unsafe void GetCompressedTextureImage<T1>(TextureHandle texture, int level, Span<T1> pixels)
+        public static unsafe void GetCompressedTextureImage<T1>(int texture, int level, Span<T1> pixels)
             where T1 : unmanaged
         {
             int bufSize = (int)(pixels.Length * sizeof(T1));
@@ -9652,7 +9652,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetCompressedTextureImage"/>
-        public static unsafe void GetCompressedTextureImage<T1>(TextureHandle texture, int level, T1[] pixels)
+        public static unsafe void GetCompressedTextureImage<T1>(int texture, int level, T1[] pixels)
             where T1 : unmanaged
         {
             int bufSize = (int)(pixels.Length * sizeof(T1));
@@ -9662,7 +9662,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetCompressedTextureImage"/>
-        public static unsafe void GetCompressedTextureImage<T1>(TextureHandle texture, int level, int bufSize, ref T1 pixels)
+        public static unsafe void GetCompressedTextureImage<T1>(int texture, int level, int bufSize, ref T1 pixels)
             where T1 : unmanaged
         {
             fixed (void* pixels_ptr = &pixels)
@@ -9671,7 +9671,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetTextureLevelParameterfv"/>
-        public static unsafe void GetTextureLevelParameterf(TextureHandle texture, int level, GetTextureParameter pname, ref float parameters)
+        public static unsafe void GetTextureLevelParameterf(int texture, int level, GetTextureParameter pname, ref float parameters)
         {
             fixed (float* parameters_ptr = &parameters)
             {
@@ -9679,7 +9679,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetTextureLevelParameteriv"/>
-        public static unsafe void GetTextureLevelParameteri(TextureHandle texture, int level, GetTextureParameter pname, ref int parameters)
+        public static unsafe void GetTextureLevelParameteri(int texture, int level, GetTextureParameter pname, ref int parameters)
         {
             fixed (int* parameters_ptr = &parameters)
             {
@@ -9687,7 +9687,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetTextureParameterfv"/>
-        public static unsafe void GetTextureParameterf(TextureHandle texture, GetTextureParameter pname, ref float parameters)
+        public static unsafe void GetTextureParameterf(int texture, GetTextureParameter pname, ref float parameters)
         {
             fixed (float* parameters_ptr = &parameters)
             {
@@ -9695,7 +9695,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetTextureParameterIiv"/>
-        public static unsafe void GetTextureParameterIi(TextureHandle texture, GetTextureParameter pname, ref int parameters)
+        public static unsafe void GetTextureParameterIi(int texture, GetTextureParameter pname, ref int parameters)
         {
             fixed (int* parameters_ptr = &parameters)
             {
@@ -9703,7 +9703,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetTextureParameterIuiv"/>
-        public static unsafe void GetTextureParameterIui(TextureHandle texture, GetTextureParameter pname, ref uint parameters)
+        public static unsafe void GetTextureParameterIui(int texture, GetTextureParameter pname, ref uint parameters)
         {
             fixed (uint* parameters_ptr = &parameters)
             {
@@ -9711,7 +9711,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetTextureParameteriv"/>
-        public static unsafe void GetTextureParameteri(TextureHandle texture, GetTextureParameter pname, ref int parameters)
+        public static unsafe void GetTextureParameteri(int texture, GetTextureParameter pname, ref int parameters)
         {
             fixed (int* parameters_ptr = &parameters)
             {
@@ -9719,9 +9719,9 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="CreateVertexArrays"/>
-        public static unsafe VertexArrayHandle CreateVertexArray()
+        public static unsafe int CreateVertexArray()
         {
-            VertexArrayHandle array;
+            int array;
             int n = 1;
             Unsafe.SkipInit(out array);
             // FIXME: This could be a problem for the overloads that take an out parameter
@@ -9732,12 +9732,12 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            VertexArrayHandle* arrays_handle = (VertexArrayHandle*)Unsafe.AsPointer(ref array);
+            int* arrays_handle = (int*)Unsafe.AsPointer(ref array);
             CreateVertexArrays(n, arrays_handle);
             return array;
         }
         /// <inheritdoc cref="CreateVertexArrays"/>
-        public static unsafe void CreateVertexArray(out VertexArrayHandle array)
+        public static unsafe void CreateVertexArray(out int array)
         {
             int n = 1;
             Unsafe.SkipInit(out array);
@@ -9749,39 +9749,39 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            VertexArrayHandle* arrays_handle = (VertexArrayHandle*)Unsafe.AsPointer(ref array);
+            int* arrays_handle = (int*)Unsafe.AsPointer(ref array);
             CreateVertexArrays(n, arrays_handle);
         }
         /// <inheritdoc cref="CreateVertexArrays"/>
-        public static unsafe void CreateVertexArrays(Span<VertexArrayHandle> arrays)
+        public static unsafe void CreateVertexArrays(Span<int> arrays)
         {
             int n = (int)(arrays.Length);
-            fixed (VertexArrayHandle* arrays_ptr = arrays)
+            fixed (int* arrays_ptr = arrays)
             {
                 CreateVertexArrays(n, arrays_ptr);
             }
         }
         /// <inheritdoc cref="CreateVertexArrays"/>
-        public static unsafe void CreateVertexArrays(VertexArrayHandle[] arrays)
+        public static unsafe void CreateVertexArrays(int[] arrays)
         {
             int n = (int)(arrays.Length);
-            fixed (VertexArrayHandle* arrays_ptr = arrays)
+            fixed (int* arrays_ptr = arrays)
             {
                 CreateVertexArrays(n, arrays_ptr);
             }
         }
         /// <inheritdoc cref="CreateVertexArrays"/>
-        public static unsafe void CreateVertexArrays(int n, ref VertexArrayHandle arrays)
+        public static unsafe void CreateVertexArrays(int n, ref int arrays)
         {
-            fixed (VertexArrayHandle* arrays_ptr = &arrays)
+            fixed (int* arrays_ptr = &arrays)
             {
                 CreateVertexArrays(n, arrays_ptr);
             }
         }
         /// <inheritdoc cref="VertexArrayVertexBuffers"/>
-        public static unsafe void VertexArrayVertexBuffers(VertexArrayHandle vaobj, uint first, int count, ReadOnlySpan<BufferHandle> buffers, ReadOnlySpan<IntPtr> offsets, ReadOnlySpan<int> strides)
+        public static unsafe void VertexArrayVertexBuffers(int vaobj, uint first, int count, ReadOnlySpan<int> buffers, ReadOnlySpan<IntPtr> offsets, ReadOnlySpan<int> strides)
         {
-            fixed (BufferHandle* buffers_ptr = buffers)
+            fixed (int* buffers_ptr = buffers)
             {
                 fixed (IntPtr* offsets_ptr = offsets)
                 {
@@ -9793,9 +9793,9 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="VertexArrayVertexBuffers"/>
-        public static unsafe void VertexArrayVertexBuffers(VertexArrayHandle vaobj, uint first, int count, BufferHandle[] buffers, IntPtr[] offsets, int[] strides)
+        public static unsafe void VertexArrayVertexBuffers(int vaobj, uint first, int count, int[] buffers, IntPtr[] offsets, int[] strides)
         {
-            fixed (BufferHandle* buffers_ptr = buffers)
+            fixed (int* buffers_ptr = buffers)
             {
                 fixed (IntPtr* offsets_ptr = offsets)
                 {
@@ -9807,9 +9807,9 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="VertexArrayVertexBuffers"/>
-        public static unsafe void VertexArrayVertexBuffers(VertexArrayHandle vaobj, uint first, int count, in BufferHandle buffers, in IntPtr offsets, in int strides)
+        public static unsafe void VertexArrayVertexBuffers(int vaobj, uint first, int count, in int buffers, in IntPtr offsets, in int strides)
         {
-            fixed (BufferHandle* buffers_ptr = &buffers)
+            fixed (int* buffers_ptr = &buffers)
             fixed (IntPtr* offsets_ptr = &offsets)
             fixed (int* strides_ptr = &strides)
             {
@@ -9817,7 +9817,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetVertexArrayiv"/>
-        public static unsafe void GetVertexArrayi(VertexArrayHandle vaobj, VertexArrayPName pname, ref int param)
+        public static unsafe void GetVertexArrayi(int vaobj, VertexArrayPName pname, ref int param)
         {
             fixed (int* param_ptr = &param)
             {
@@ -9825,7 +9825,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetVertexArrayIndexediv"/>
-        public static unsafe void GetVertexArrayIndexedi(VertexArrayHandle vaobj, uint index, VertexArrayPName pname, ref int param)
+        public static unsafe void GetVertexArrayIndexedi(int vaobj, uint index, VertexArrayPName pname, ref int param)
         {
             fixed (int* param_ptr = &param)
             {
@@ -9833,7 +9833,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetVertexArrayIndexed64iv"/>
-        public static unsafe void GetVertexArrayIndexed64iv(VertexArrayHandle vaobj, uint index, VertexArrayPName pname, ref long param)
+        public static unsafe void GetVertexArrayIndexed64iv(int vaobj, uint index, VertexArrayPName pname, ref long param)
         {
             fixed (long* param_ptr = &param)
             {
@@ -9841,9 +9841,9 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="CreateSamplers"/>
-        public static unsafe SamplerHandle CreateSampler()
+        public static unsafe int CreateSampler()
         {
-            SamplerHandle sampler;
+            int sampler;
             int n = 1;
             Unsafe.SkipInit(out sampler);
             // FIXME: This could be a problem for the overloads that take an out parameter
@@ -9854,12 +9854,12 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            SamplerHandle* samplers_handle = (SamplerHandle*)Unsafe.AsPointer(ref sampler);
+            int* samplers_handle = (int*)Unsafe.AsPointer(ref sampler);
             CreateSamplers(n, samplers_handle);
             return sampler;
         }
         /// <inheritdoc cref="CreateSamplers"/>
-        public static unsafe void CreateSampler(out SamplerHandle sampler)
+        public static unsafe void CreateSampler(out int sampler)
         {
             int n = 1;
             Unsafe.SkipInit(out sampler);
@@ -9871,39 +9871,39 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            SamplerHandle* samplers_handle = (SamplerHandle*)Unsafe.AsPointer(ref sampler);
+            int* samplers_handle = (int*)Unsafe.AsPointer(ref sampler);
             CreateSamplers(n, samplers_handle);
         }
         /// <inheritdoc cref="CreateSamplers"/>
-        public static unsafe void CreateSamplers(Span<SamplerHandle> samplers)
+        public static unsafe void CreateSamplers(Span<int> samplers)
         {
             int n = (int)(samplers.Length);
-            fixed (SamplerHandle* samplers_ptr = samplers)
+            fixed (int* samplers_ptr = samplers)
             {
                 CreateSamplers(n, samplers_ptr);
             }
         }
         /// <inheritdoc cref="CreateSamplers"/>
-        public static unsafe void CreateSamplers(SamplerHandle[] samplers)
+        public static unsafe void CreateSamplers(int[] samplers)
         {
             int n = (int)(samplers.Length);
-            fixed (SamplerHandle* samplers_ptr = samplers)
+            fixed (int* samplers_ptr = samplers)
             {
                 CreateSamplers(n, samplers_ptr);
             }
         }
         /// <inheritdoc cref="CreateSamplers"/>
-        public static unsafe void CreateSamplers(int n, ref SamplerHandle samplers)
+        public static unsafe void CreateSamplers(int n, ref int samplers)
         {
-            fixed (SamplerHandle* samplers_ptr = &samplers)
+            fixed (int* samplers_ptr = &samplers)
             {
                 CreateSamplers(n, samplers_ptr);
             }
         }
         /// <inheritdoc cref="CreateProgramPipelines"/>
-        public static unsafe ProgramPipelineHandle CreateProgramPipeline()
+        public static unsafe int CreateProgramPipeline()
         {
-            ProgramPipelineHandle pipeline;
+            int pipeline;
             int n = 1;
             Unsafe.SkipInit(out pipeline);
             // FIXME: This could be a problem for the overloads that take an out parameter
@@ -9914,12 +9914,12 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            ProgramPipelineHandle* pipelines_handle = (ProgramPipelineHandle*)Unsafe.AsPointer(ref pipeline);
+            int* pipelines_handle = (int*)Unsafe.AsPointer(ref pipeline);
             CreateProgramPipelines(n, pipelines_handle);
             return pipeline;
         }
         /// <inheritdoc cref="CreateProgramPipelines"/>
-        public static unsafe void CreateProgramPipeline(out ProgramPipelineHandle pipeline)
+        public static unsafe void CreateProgramPipeline(out int pipeline)
         {
             int n = 1;
             Unsafe.SkipInit(out pipeline);
@@ -9931,39 +9931,39 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            ProgramPipelineHandle* pipelines_handle = (ProgramPipelineHandle*)Unsafe.AsPointer(ref pipeline);
+            int* pipelines_handle = (int*)Unsafe.AsPointer(ref pipeline);
             CreateProgramPipelines(n, pipelines_handle);
         }
         /// <inheritdoc cref="CreateProgramPipelines"/>
-        public static unsafe void CreateProgramPipelines(Span<ProgramPipelineHandle> pipelines)
+        public static unsafe void CreateProgramPipelines(Span<int> pipelines)
         {
             int n = (int)(pipelines.Length);
-            fixed (ProgramPipelineHandle* pipelines_ptr = pipelines)
+            fixed (int* pipelines_ptr = pipelines)
             {
                 CreateProgramPipelines(n, pipelines_ptr);
             }
         }
         /// <inheritdoc cref="CreateProgramPipelines"/>
-        public static unsafe void CreateProgramPipelines(ProgramPipelineHandle[] pipelines)
+        public static unsafe void CreateProgramPipelines(int[] pipelines)
         {
             int n = (int)(pipelines.Length);
-            fixed (ProgramPipelineHandle* pipelines_ptr = pipelines)
+            fixed (int* pipelines_ptr = pipelines)
             {
                 CreateProgramPipelines(n, pipelines_ptr);
             }
         }
         /// <inheritdoc cref="CreateProgramPipelines"/>
-        public static unsafe void CreateProgramPipelines(int n, ref ProgramPipelineHandle pipelines)
+        public static unsafe void CreateProgramPipelines(int n, ref int pipelines)
         {
-            fixed (ProgramPipelineHandle* pipelines_ptr = &pipelines)
+            fixed (int* pipelines_ptr = &pipelines)
             {
                 CreateProgramPipelines(n, pipelines_ptr);
             }
         }
         /// <inheritdoc cref="CreateQueries"/>
-        public static unsafe QueryHandle CreateQuery(QueryTarget target)
+        public static unsafe int CreateQuery(QueryTarget target)
         {
-            QueryHandle id;
+            int id;
             int n = 1;
             Unsafe.SkipInit(out id);
             // FIXME: This could be a problem for the overloads that take an out parameter
@@ -9974,12 +9974,12 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            QueryHandle* ids_handle = (QueryHandle*)Unsafe.AsPointer(ref id);
+            int* ids_handle = (int*)Unsafe.AsPointer(ref id);
             CreateQueries(target, n, ids_handle);
             return id;
         }
         /// <inheritdoc cref="CreateQueries"/>
-        public static unsafe void CreateQuery(QueryTarget target, out QueryHandle id)
+        public static unsafe void CreateQuery(QueryTarget target, out int id)
         {
             int n = 1;
             Unsafe.SkipInit(out id);
@@ -9991,63 +9991,63 @@ namespace OpenTK.Graphics.OpenGL
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            QueryHandle* ids_handle = (QueryHandle*)Unsafe.AsPointer(ref id);
+            int* ids_handle = (int*)Unsafe.AsPointer(ref id);
             CreateQueries(target, n, ids_handle);
         }
         /// <inheritdoc cref="CreateQueries"/>
-        public static unsafe void CreateQueries(QueryTarget target, Span<QueryHandle> ids)
+        public static unsafe void CreateQueries(QueryTarget target, Span<int> ids)
         {
             int n = (int)(ids.Length);
-            fixed (QueryHandle* ids_ptr = ids)
+            fixed (int* ids_ptr = ids)
             {
                 CreateQueries(target, n, ids_ptr);
             }
         }
         /// <inheritdoc cref="CreateQueries"/>
-        public static unsafe void CreateQueries(QueryTarget target, QueryHandle[] ids)
+        public static unsafe void CreateQueries(QueryTarget target, int[] ids)
         {
             int n = (int)(ids.Length);
-            fixed (QueryHandle* ids_ptr = ids)
+            fixed (int* ids_ptr = ids)
             {
                 CreateQueries(target, n, ids_ptr);
             }
         }
         /// <inheritdoc cref="CreateQueries"/>
-        public static unsafe void CreateQueries(QueryTarget target, int n, ref QueryHandle ids)
+        public static unsafe void CreateQueries(QueryTarget target, int n, ref int ids)
         {
-            fixed (QueryHandle* ids_ptr = &ids)
+            fixed (int* ids_ptr = &ids)
             {
                 CreateQueries(target, n, ids_ptr);
             }
         }
         /// <inheritdoc cref="GetQueryBufferObjecti64v"/>
-        public static unsafe void GetQueryBufferObjecti64(QueryHandle id, BufferHandle buffer, QueryObjectParameterName pname, IntPtr offset)
+        public static unsafe void GetQueryBufferObjecti64(int id, int buffer, QueryObjectParameterName pname, IntPtr offset)
         {
             GetQueryBufferObjecti64v(id, buffer, pname, offset);
         }
         /// <inheritdoc cref="GetQueryBufferObjectiv"/>
-        public static unsafe void GetQueryBufferObjecti(QueryHandle id, BufferHandle buffer, QueryObjectParameterName pname, IntPtr offset)
+        public static unsafe void GetQueryBufferObjecti(int id, int buffer, QueryObjectParameterName pname, IntPtr offset)
         {
             GetQueryBufferObjectiv(id, buffer, pname, offset);
         }
         /// <inheritdoc cref="GetQueryBufferObjectui64v"/>
-        public static unsafe void GetQueryBufferObjectui64(QueryHandle id, BufferHandle buffer, QueryObjectParameterName pname, IntPtr offset)
+        public static unsafe void GetQueryBufferObjectui64(int id, int buffer, QueryObjectParameterName pname, IntPtr offset)
         {
             GetQueryBufferObjectui64v(id, buffer, pname, offset);
         }
         /// <inheritdoc cref="GetQueryBufferObjectuiv"/>
-        public static unsafe void GetQueryBufferObjectui(QueryHandle id, BufferHandle buffer, QueryObjectParameterName pname, IntPtr offset)
+        public static unsafe void GetQueryBufferObjectui(int id, int buffer, QueryObjectParameterName pname, IntPtr offset)
         {
             GetQueryBufferObjectuiv(id, buffer, pname, offset);
         }
         /// <inheritdoc cref="GetTextureSubImage"/>
-        public static unsafe void GetTextureSubImage(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, int bufSize, IntPtr pixels)
+        public static unsafe void GetTextureSubImage(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, int bufSize, IntPtr pixels)
         {
             void* pixels_vptr = (void*)pixels;
             GetTextureSubImage(texture, level, xoffset, yoffset, zoffset, width, height, depth, format, type, bufSize, pixels_vptr);
         }
         /// <inheritdoc cref="GetTextureSubImage"/>
-        public static unsafe void GetTextureSubImage<T1>(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, Span<T1> pixels)
+        public static unsafe void GetTextureSubImage<T1>(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, Span<T1> pixels)
             where T1 : unmanaged
         {
             int bufSize = (int)(pixels.Length * sizeof(T1));
@@ -10057,7 +10057,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetTextureSubImage"/>
-        public static unsafe void GetTextureSubImage<T1>(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, T1[] pixels)
+        public static unsafe void GetTextureSubImage<T1>(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, T1[] pixels)
             where T1 : unmanaged
         {
             int bufSize = (int)(pixels.Length * sizeof(T1));
@@ -10067,7 +10067,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetTextureSubImage"/>
-        public static unsafe void GetTextureSubImage<T1>(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, int bufSize, ref T1 pixels)
+        public static unsafe void GetTextureSubImage<T1>(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, int bufSize, ref T1 pixels)
             where T1 : unmanaged
         {
             fixed (void* pixels_ptr = &pixels)
@@ -10076,13 +10076,13 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetCompressedTextureSubImage"/>
-        public static unsafe void GetCompressedTextureSubImage(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, int bufSize, IntPtr pixels)
+        public static unsafe void GetCompressedTextureSubImage(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, int bufSize, IntPtr pixels)
         {
             void* pixels_vptr = (void*)pixels;
             GetCompressedTextureSubImage(texture, level, xoffset, yoffset, zoffset, width, height, depth, bufSize, pixels_vptr);
         }
         /// <inheritdoc cref="GetCompressedTextureSubImage"/>
-        public static unsafe void GetCompressedTextureSubImage<T1>(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, Span<T1> pixels)
+        public static unsafe void GetCompressedTextureSubImage<T1>(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, Span<T1> pixels)
             where T1 : unmanaged
         {
             int bufSize = (int)(pixels.Length * sizeof(T1));
@@ -10092,7 +10092,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetCompressedTextureSubImage"/>
-        public static unsafe void GetCompressedTextureSubImage<T1>(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, T1[] pixels)
+        public static unsafe void GetCompressedTextureSubImage<T1>(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, T1[] pixels)
             where T1 : unmanaged
         {
             int bufSize = (int)(pixels.Length * sizeof(T1));
@@ -10102,7 +10102,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetCompressedTextureSubImage"/>
-        public static unsafe void GetCompressedTextureSubImage<T1>(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, int bufSize, ref T1 pixels)
+        public static unsafe void GetCompressedTextureSubImage<T1>(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, int bufSize, ref T1 pixels)
             where T1 : unmanaged
         {
             fixed (void* pixels_ptr = &pixels)
@@ -10181,7 +10181,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetnUniformdv"/>
-        public static unsafe void GetnUniformd(ProgramHandle program, int location, Span<double> parameters)
+        public static unsafe void GetnUniformd(int program, int location, Span<double> parameters)
         {
             int bufSize = (int)(parameters.Length * 8);
             fixed (double* parameters_ptr = parameters)
@@ -10190,7 +10190,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetnUniformdv"/>
-        public static unsafe void GetnUniformd(ProgramHandle program, int location, double[] parameters)
+        public static unsafe void GetnUniformd(int program, int location, double[] parameters)
         {
             int bufSize = (int)(parameters.Length * 8);
             fixed (double* parameters_ptr = parameters)
@@ -10199,7 +10199,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetnUniformdv"/>
-        public static unsafe void GetnUniformd(ProgramHandle program, int location, int bufSize, ref double parameters)
+        public static unsafe void GetnUniformd(int program, int location, int bufSize, ref double parameters)
         {
             fixed (double* parameters_ptr = &parameters)
             {
@@ -10207,7 +10207,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetnUniformfv"/>
-        public static unsafe void GetnUniformf(ProgramHandle program, int location, Span<float> parameters)
+        public static unsafe void GetnUniformf(int program, int location, Span<float> parameters)
         {
             int bufSize = (int)(parameters.Length * 4);
             fixed (float* parameters_ptr = parameters)
@@ -10216,7 +10216,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetnUniformfv"/>
-        public static unsafe void GetnUniformf(ProgramHandle program, int location, float[] parameters)
+        public static unsafe void GetnUniformf(int program, int location, float[] parameters)
         {
             int bufSize = (int)(parameters.Length * 4);
             fixed (float* parameters_ptr = parameters)
@@ -10225,7 +10225,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetnUniformfv"/>
-        public static unsafe void GetnUniformf(ProgramHandle program, int location, int bufSize, ref float parameters)
+        public static unsafe void GetnUniformf(int program, int location, int bufSize, ref float parameters)
         {
             fixed (float* parameters_ptr = &parameters)
             {
@@ -10233,7 +10233,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetnUniformiv"/>
-        public static unsafe void GetnUniformi(ProgramHandle program, int location, Span<int> parameters)
+        public static unsafe void GetnUniformi(int program, int location, Span<int> parameters)
         {
             int bufSize = (int)(parameters.Length * 4);
             fixed (int* parameters_ptr = parameters)
@@ -10242,7 +10242,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetnUniformiv"/>
-        public static unsafe void GetnUniformi(ProgramHandle program, int location, int[] parameters)
+        public static unsafe void GetnUniformi(int program, int location, int[] parameters)
         {
             int bufSize = (int)(parameters.Length * 4);
             fixed (int* parameters_ptr = parameters)
@@ -10251,7 +10251,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetnUniformiv"/>
-        public static unsafe void GetnUniformi(ProgramHandle program, int location, int bufSize, ref int parameters)
+        public static unsafe void GetnUniformi(int program, int location, int bufSize, ref int parameters)
         {
             fixed (int* parameters_ptr = &parameters)
             {
@@ -10259,7 +10259,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetnUniformuiv"/>
-        public static unsafe void GetnUniformui(ProgramHandle program, int location, Span<uint> parameters)
+        public static unsafe void GetnUniformui(int program, int location, Span<uint> parameters)
         {
             int bufSize = (int)(parameters.Length * 4);
             fixed (uint* parameters_ptr = parameters)
@@ -10268,7 +10268,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetnUniformuiv"/>
-        public static unsafe void GetnUniformui(ProgramHandle program, int location, uint[] parameters)
+        public static unsafe void GetnUniformui(int program, int location, uint[] parameters)
         {
             int bufSize = (int)(parameters.Length * 4);
             fixed (uint* parameters_ptr = parameters)
@@ -10277,7 +10277,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="GetnUniformuiv"/>
-        public static unsafe void GetnUniformui(ProgramHandle program, int location, int bufSize, ref uint parameters)
+        public static unsafe void GetnUniformui(int program, int location, int bufSize, ref uint parameters)
         {
             fixed (uint* parameters_ptr = &parameters)
             {
@@ -10320,7 +10320,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="SpecializeShader"/>
-        public static unsafe void SpecializeShader(ShaderHandle shader, string pEntryPoint, uint numSpecializationConstants, ReadOnlySpan<uint> pConstantIndex, ReadOnlySpan<uint> pConstantValue)
+        public static unsafe void SpecializeShader(int shader, string pEntryPoint, uint numSpecializationConstants, ReadOnlySpan<uint> pConstantIndex, ReadOnlySpan<uint> pConstantValue)
         {
             fixed (uint* pConstantIndex_ptr = pConstantIndex)
             {
@@ -10333,7 +10333,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="SpecializeShader"/>
-        public static unsafe void SpecializeShader(ShaderHandle shader, string pEntryPoint, uint numSpecializationConstants, uint[] pConstantIndex, uint[] pConstantValue)
+        public static unsafe void SpecializeShader(int shader, string pEntryPoint, uint numSpecializationConstants, uint[] pConstantIndex, uint[] pConstantValue)
         {
             fixed (uint* pConstantIndex_ptr = pConstantIndex)
             {
@@ -10346,7 +10346,7 @@ namespace OpenTK.Graphics.OpenGL
             }
         }
         /// <inheritdoc cref="SpecializeShader"/>
-        public static unsafe void SpecializeShader(ShaderHandle shader, string pEntryPoint, uint numSpecializationConstants, in uint pConstantIndex, in uint pConstantValue)
+        public static unsafe void SpecializeShader(int shader, string pEntryPoint, uint numSpecializationConstants, in uint pConstantIndex, in uint pConstantValue)
         {
             fixed (uint* pConstantIndex_ptr = &pConstantIndex)
             fixed (uint* pConstantValue_ptr = &pConstantValue)
@@ -10510,7 +10510,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="NamedFramebufferSamplePositionsfvAMD"/>
-            public static unsafe void NamedFramebufferSamplePositionsfvAMD(FramebufferHandle framebuffer, uint numsamples, uint pixelindex, in float values)
+            public static unsafe void NamedFramebufferSamplePositionsfvAMD(int framebuffer, uint numsamples, uint pixelindex, in float values)
             {
                 fixed (float* values_ptr = &values)
                 {
@@ -10526,7 +10526,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetNamedFramebufferParameterfvAMD"/>
-            public static unsafe void GetNamedFramebufferParameterfvAMD(FramebufferHandle framebuffer, All pname, uint numsamples, uint pixelindex, int size, ref float values)
+            public static unsafe void GetNamedFramebufferParameterfvAMD(int framebuffer, All pname, uint numsamples, uint pixelindex, int size, ref float values)
             {
                 fixed (float* values_ptr = &values)
                 {
@@ -10742,7 +10742,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetUniformi64vNV"/>
-            public static unsafe void GetUniformi64vNV(ProgramHandle program, int location, Span<long> parameters)
+            public static unsafe void GetUniformi64vNV(int program, int location, Span<long> parameters)
             {
                 fixed (long* parameters_ptr = parameters)
                 {
@@ -10750,7 +10750,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetUniformi64vNV"/>
-            public static unsafe void GetUniformi64vNV(ProgramHandle program, int location, long[] parameters)
+            public static unsafe void GetUniformi64vNV(int program, int location, long[] parameters)
             {
                 fixed (long* parameters_ptr = parameters)
                 {
@@ -10758,7 +10758,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetUniformi64vNV"/>
-            public static unsafe void GetUniformi64vNV(ProgramHandle program, int location, ref long parameters)
+            public static unsafe void GetUniformi64vNV(int program, int location, ref long parameters)
             {
                 fixed (long* parameters_ptr = &parameters)
                 {
@@ -10766,7 +10766,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetUniformui64vNV"/>
-            public static unsafe void GetUniformui64vNV(ProgramHandle program, int location, Span<ulong> parameters)
+            public static unsafe void GetUniformui64vNV(int program, int location, Span<ulong> parameters)
             {
                 fixed (ulong* parameters_ptr = parameters)
                 {
@@ -10774,7 +10774,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetUniformui64vNV"/>
-            public static unsafe void GetUniformui64vNV(ProgramHandle program, int location, ulong[] parameters)
+            public static unsafe void GetUniformui64vNV(int program, int location, ulong[] parameters)
             {
                 fixed (ulong* parameters_ptr = parameters)
                 {
@@ -10782,7 +10782,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetUniformui64vNV"/>
-            public static unsafe void GetUniformui64vNV(ProgramHandle program, int location, ref ulong parameters)
+            public static unsafe void GetUniformui64vNV(int program, int location, ref ulong parameters)
             {
                 fixed (ulong* parameters_ptr = &parameters)
                 {
@@ -10790,7 +10790,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform1i64vNV"/>
-            public static unsafe void ProgramUniform1i64vNV(ProgramHandle program, int location, ReadOnlySpan<long> value)
+            public static unsafe void ProgramUniform1i64vNV(int program, int location, ReadOnlySpan<long> value)
             {
                 int count = (int)(value.Length);
                 fixed (long* value_ptr = value)
@@ -10799,7 +10799,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform1i64vNV"/>
-            public static unsafe void ProgramUniform1i64vNV(ProgramHandle program, int location, long[] value)
+            public static unsafe void ProgramUniform1i64vNV(int program, int location, long[] value)
             {
                 int count = (int)(value.Length);
                 fixed (long* value_ptr = value)
@@ -10808,7 +10808,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform1i64vNV"/>
-            public static unsafe void ProgramUniform1i64vNV(ProgramHandle program, int location, int count, in long value)
+            public static unsafe void ProgramUniform1i64vNV(int program, int location, int count, in long value)
             {
                 fixed (long* value_ptr = &value)
                 {
@@ -10816,7 +10816,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform2i64vNV"/>
-            public static unsafe void ProgramUniform2i64vNV(ProgramHandle program, int location, ReadOnlySpan<long> value)
+            public static unsafe void ProgramUniform2i64vNV(int program, int location, ReadOnlySpan<long> value)
             {
                 int count = (int)(value.Length / 2);
                 fixed (long* value_ptr = value)
@@ -10825,7 +10825,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform2i64vNV"/>
-            public static unsafe void ProgramUniform2i64vNV(ProgramHandle program, int location, long[] value)
+            public static unsafe void ProgramUniform2i64vNV(int program, int location, long[] value)
             {
                 int count = (int)(value.Length / 2);
                 fixed (long* value_ptr = value)
@@ -10834,7 +10834,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform2i64vNV"/>
-            public static unsafe void ProgramUniform2i64vNV(ProgramHandle program, int location, int count, in long value)
+            public static unsafe void ProgramUniform2i64vNV(int program, int location, int count, in long value)
             {
                 fixed (long* value_ptr = &value)
                 {
@@ -10842,7 +10842,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform3i64vNV"/>
-            public static unsafe void ProgramUniform3i64vNV(ProgramHandle program, int location, ReadOnlySpan<long> value)
+            public static unsafe void ProgramUniform3i64vNV(int program, int location, ReadOnlySpan<long> value)
             {
                 int count = (int)(value.Length / 3);
                 fixed (long* value_ptr = value)
@@ -10851,7 +10851,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform3i64vNV"/>
-            public static unsafe void ProgramUniform3i64vNV(ProgramHandle program, int location, long[] value)
+            public static unsafe void ProgramUniform3i64vNV(int program, int location, long[] value)
             {
                 int count = (int)(value.Length / 3);
                 fixed (long* value_ptr = value)
@@ -10860,7 +10860,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform3i64vNV"/>
-            public static unsafe void ProgramUniform3i64vNV(ProgramHandle program, int location, int count, in long value)
+            public static unsafe void ProgramUniform3i64vNV(int program, int location, int count, in long value)
             {
                 fixed (long* value_ptr = &value)
                 {
@@ -10868,7 +10868,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform4i64vNV"/>
-            public static unsafe void ProgramUniform4i64vNV(ProgramHandle program, int location, ReadOnlySpan<long> value)
+            public static unsafe void ProgramUniform4i64vNV(int program, int location, ReadOnlySpan<long> value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (long* value_ptr = value)
@@ -10877,7 +10877,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform4i64vNV"/>
-            public static unsafe void ProgramUniform4i64vNV(ProgramHandle program, int location, long[] value)
+            public static unsafe void ProgramUniform4i64vNV(int program, int location, long[] value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (long* value_ptr = value)
@@ -10886,7 +10886,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform4i64vNV"/>
-            public static unsafe void ProgramUniform4i64vNV(ProgramHandle program, int location, int count, in long value)
+            public static unsafe void ProgramUniform4i64vNV(int program, int location, int count, in long value)
             {
                 fixed (long* value_ptr = &value)
                 {
@@ -10894,7 +10894,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform1ui64vNV"/>
-            public static unsafe void ProgramUniform1ui64vNV(ProgramHandle program, int location, ReadOnlySpan<ulong> value)
+            public static unsafe void ProgramUniform1ui64vNV(int program, int location, ReadOnlySpan<ulong> value)
             {
                 int count = (int)(value.Length);
                 fixed (ulong* value_ptr = value)
@@ -10903,7 +10903,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform1ui64vNV"/>
-            public static unsafe void ProgramUniform1ui64vNV(ProgramHandle program, int location, ulong[] value)
+            public static unsafe void ProgramUniform1ui64vNV(int program, int location, ulong[] value)
             {
                 int count = (int)(value.Length);
                 fixed (ulong* value_ptr = value)
@@ -10912,7 +10912,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform1ui64vNV"/>
-            public static unsafe void ProgramUniform1ui64vNV(ProgramHandle program, int location, int count, in ulong value)
+            public static unsafe void ProgramUniform1ui64vNV(int program, int location, int count, in ulong value)
             {
                 fixed (ulong* value_ptr = &value)
                 {
@@ -10920,7 +10920,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform2ui64vNV"/>
-            public static unsafe void ProgramUniform2ui64vNV(ProgramHandle program, int location, ReadOnlySpan<ulong> value)
+            public static unsafe void ProgramUniform2ui64vNV(int program, int location, ReadOnlySpan<ulong> value)
             {
                 int count = (int)(value.Length / 2);
                 fixed (ulong* value_ptr = value)
@@ -10929,7 +10929,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform2ui64vNV"/>
-            public static unsafe void ProgramUniform2ui64vNV(ProgramHandle program, int location, ulong[] value)
+            public static unsafe void ProgramUniform2ui64vNV(int program, int location, ulong[] value)
             {
                 int count = (int)(value.Length / 2);
                 fixed (ulong* value_ptr = value)
@@ -10938,7 +10938,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform2ui64vNV"/>
-            public static unsafe void ProgramUniform2ui64vNV(ProgramHandle program, int location, int count, in ulong value)
+            public static unsafe void ProgramUniform2ui64vNV(int program, int location, int count, in ulong value)
             {
                 fixed (ulong* value_ptr = &value)
                 {
@@ -10946,7 +10946,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform3ui64vNV"/>
-            public static unsafe void ProgramUniform3ui64vNV(ProgramHandle program, int location, ReadOnlySpan<ulong> value)
+            public static unsafe void ProgramUniform3ui64vNV(int program, int location, ReadOnlySpan<ulong> value)
             {
                 int count = (int)(value.Length / 3);
                 fixed (ulong* value_ptr = value)
@@ -10955,7 +10955,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform3ui64vNV"/>
-            public static unsafe void ProgramUniform3ui64vNV(ProgramHandle program, int location, ulong[] value)
+            public static unsafe void ProgramUniform3ui64vNV(int program, int location, ulong[] value)
             {
                 int count = (int)(value.Length / 3);
                 fixed (ulong* value_ptr = value)
@@ -10964,7 +10964,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform3ui64vNV"/>
-            public static unsafe void ProgramUniform3ui64vNV(ProgramHandle program, int location, int count, in ulong value)
+            public static unsafe void ProgramUniform3ui64vNV(int program, int location, int count, in ulong value)
             {
                 fixed (ulong* value_ptr = &value)
                 {
@@ -10972,7 +10972,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform4ui64vNV"/>
-            public static unsafe void ProgramUniform4ui64vNV(ProgramHandle program, int location, ReadOnlySpan<ulong> value)
+            public static unsafe void ProgramUniform4ui64vNV(int program, int location, ReadOnlySpan<ulong> value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (ulong* value_ptr = value)
@@ -10981,7 +10981,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform4ui64vNV"/>
-            public static unsafe void ProgramUniform4ui64vNV(ProgramHandle program, int location, ulong[] value)
+            public static unsafe void ProgramUniform4ui64vNV(int program, int location, ulong[] value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (ulong* value_ptr = value)
@@ -10990,7 +10990,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform4ui64vNV"/>
-            public static unsafe void ProgramUniform4ui64vNV(ProgramHandle program, int location, int count, in ulong value)
+            public static unsafe void ProgramUniform4ui64vNV(int program, int location, int count, in ulong value)
             {
                 fixed (ulong* value_ptr = &value)
                 {
@@ -11710,53 +11710,53 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="DeleteVertexArraysAPPLE"/>
-            public static unsafe void DeleteVertexArraysAPPLE(ReadOnlySpan<VertexArrayHandle> arrays)
+            public static unsafe void DeleteVertexArraysAPPLE(ReadOnlySpan<int> arrays)
             {
                 int n = (int)(arrays.Length);
-                fixed (VertexArrayHandle* arrays_ptr = arrays)
+                fixed (int* arrays_ptr = arrays)
                 {
                     DeleteVertexArraysAPPLE(n, arrays_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteVertexArraysAPPLE"/>
-            public static unsafe void DeleteVertexArraysAPPLE(VertexArrayHandle[] arrays)
+            public static unsafe void DeleteVertexArraysAPPLE(int[] arrays)
             {
                 int n = (int)(arrays.Length);
-                fixed (VertexArrayHandle* arrays_ptr = arrays)
+                fixed (int* arrays_ptr = arrays)
                 {
                     DeleteVertexArraysAPPLE(n, arrays_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteVertexArraysAPPLE"/>
-            public static unsafe void DeleteVertexArraysAPPLE(int n, in VertexArrayHandle arrays)
+            public static unsafe void DeleteVertexArraysAPPLE(int n, in int arrays)
             {
-                fixed (VertexArrayHandle* arrays_ptr = &arrays)
+                fixed (int* arrays_ptr = &arrays)
                 {
                     DeleteVertexArraysAPPLE(n, arrays_ptr);
                 }
             }
             /// <inheritdoc cref="GenVertexArraysAPPLE"/>
-            public static unsafe void GenVertexArraysAPPLE(Span<VertexArrayHandle> arrays)
+            public static unsafe void GenVertexArraysAPPLE(Span<int> arrays)
             {
                 int n = (int)(arrays.Length);
-                fixed (VertexArrayHandle* arrays_ptr = arrays)
+                fixed (int* arrays_ptr = arrays)
                 {
                     GenVertexArraysAPPLE(n, arrays_ptr);
                 }
             }
             /// <inheritdoc cref="GenVertexArraysAPPLE"/>
-            public static unsafe void GenVertexArraysAPPLE(VertexArrayHandle[] arrays)
+            public static unsafe void GenVertexArraysAPPLE(int[] arrays)
             {
                 int n = (int)(arrays.Length);
-                fixed (VertexArrayHandle* arrays_ptr = arrays)
+                fixed (int* arrays_ptr = arrays)
                 {
                     GenVertexArraysAPPLE(n, arrays_ptr);
                 }
             }
             /// <inheritdoc cref="GenVertexArraysAPPLE"/>
-            public static unsafe void GenVertexArraysAPPLE(int n, ref VertexArrayHandle arrays)
+            public static unsafe void GenVertexArraysAPPLE(int n, ref int arrays)
             {
-                fixed (VertexArrayHandle* arrays_ptr = &arrays)
+                fixed (int* arrays_ptr = &arrays)
                 {
                     GenVertexArraysAPPLE(n, arrays_ptr);
                 }
@@ -11931,40 +11931,40 @@ namespace OpenTK.Graphics.OpenGL
         public static unsafe partial class ARB
         {
             /// <inheritdoc cref="ShaderBinary"/>
-            public static unsafe void ShaderBinary(ReadOnlySpan<ShaderHandle> shaders, ShaderBinaryFormat binaryFormat, IntPtr binary, int length)
+            public static unsafe void ShaderBinary(ReadOnlySpan<int> shaders, ShaderBinaryFormat binaryFormat, IntPtr binary, int length)
             {
                 int count = (int)(shaders.Length);
-                fixed (ShaderHandle* shaders_ptr = shaders)
+                fixed (int* shaders_ptr = shaders)
                 {
                     void* binary_vptr = (void*)binary;
                     ShaderBinary(count, shaders_ptr, binaryFormat, binary_vptr, length);
                 }
             }
             /// <inheritdoc cref="ShaderBinary"/>
-            public static unsafe void ShaderBinary(ShaderHandle[] shaders, ShaderBinaryFormat binaryFormat, IntPtr binary, int length)
+            public static unsafe void ShaderBinary(int[] shaders, ShaderBinaryFormat binaryFormat, IntPtr binary, int length)
             {
                 int count = (int)(shaders.Length);
-                fixed (ShaderHandle* shaders_ptr = shaders)
+                fixed (int* shaders_ptr = shaders)
                 {
                     void* binary_vptr = (void*)binary;
                     ShaderBinary(count, shaders_ptr, binaryFormat, binary_vptr, length);
                 }
             }
             /// <inheritdoc cref="ShaderBinary"/>
-            public static unsafe void ShaderBinary(int count, in ShaderHandle shaders, ShaderBinaryFormat binaryFormat, IntPtr binary, int length)
+            public static unsafe void ShaderBinary(int count, in int shaders, ShaderBinaryFormat binaryFormat, IntPtr binary, int length)
             {
-                fixed (ShaderHandle* shaders_ptr = &shaders)
+                fixed (int* shaders_ptr = &shaders)
                 {
                     void* binary_vptr = (void*)binary;
                     ShaderBinary(count, shaders_ptr, binaryFormat, binary_vptr, length);
                 }
             }
             /// <inheritdoc cref="ShaderBinary"/>
-            public static unsafe void ShaderBinary<T1>(ReadOnlySpan<ShaderHandle> shaders, ShaderBinaryFormat binaryFormat, ReadOnlySpan<T1> binary)
+            public static unsafe void ShaderBinary<T1>(ReadOnlySpan<int> shaders, ShaderBinaryFormat binaryFormat, ReadOnlySpan<T1> binary)
                 where T1 : unmanaged
             {
                 int count = (int)(shaders.Length);
-                fixed (ShaderHandle* shaders_ptr = shaders)
+                fixed (int* shaders_ptr = shaders)
                 {
                     int length = (int)(binary.Length * sizeof(T1));
                     fixed (void* binary_ptr = binary)
@@ -11974,11 +11974,11 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ShaderBinary"/>
-            public static unsafe void ShaderBinary<T1>(ShaderHandle[] shaders, ShaderBinaryFormat binaryFormat, T1[] binary)
+            public static unsafe void ShaderBinary<T1>(int[] shaders, ShaderBinaryFormat binaryFormat, T1[] binary)
                 where T1 : unmanaged
             {
                 int count = (int)(shaders.Length);
-                fixed (ShaderHandle* shaders_ptr = shaders)
+                fixed (int* shaders_ptr = shaders)
                 {
                     int length = (int)(binary.Length * sizeof(T1));
                     fixed (void* binary_ptr = binary)
@@ -11988,10 +11988,10 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ShaderBinary"/>
-            public static unsafe void ShaderBinary<T1>(int count, in ShaderHandle shaders, ShaderBinaryFormat binaryFormat, in T1 binary, int length)
+            public static unsafe void ShaderBinary<T1>(int count, in int shaders, ShaderBinaryFormat binaryFormat, in T1 binary, int length)
                 where T1 : unmanaged
             {
-                fixed (ShaderHandle* shaders_ptr = &shaders)
+                fixed (int* shaders_ptr = &shaders)
                 fixed (void* binary_ptr = &binary)
                 {
                     ShaderBinary(count, shaders_ptr, binaryFormat, binary_ptr, length);
@@ -12067,7 +12067,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformHandleui64vARB"/>
-            public static unsafe void ProgramUniformHandleui64vARB(ProgramHandle program, int location, ReadOnlySpan<ulong> values)
+            public static unsafe void ProgramUniformHandleui64vARB(int program, int location, ReadOnlySpan<ulong> values)
             {
                 int count = (int)(values.Length);
                 fixed (ulong* values_ptr = values)
@@ -12076,7 +12076,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformHandleui64vARB"/>
-            public static unsafe void ProgramUniformHandleui64vARB(ProgramHandle program, int location, ulong[] values)
+            public static unsafe void ProgramUniformHandleui64vARB(int program, int location, ulong[] values)
             {
                 int count = (int)(values.Length);
                 fixed (ulong* values_ptr = values)
@@ -12085,7 +12085,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformHandleui64vARB"/>
-            public static unsafe void ProgramUniformHandleui64vARB(ProgramHandle program, int location, int count, in ulong values)
+            public static unsafe void ProgramUniformHandleui64vARB(int program, int location, int count, in ulong values)
             {
                 fixed (ulong* values_ptr = &values)
                 {
@@ -12109,14 +12109,14 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="BindFragDataLocationIndexed"/>
-            public static unsafe void BindFragDataLocationIndexed(ProgramHandle program, uint colorNumber, uint index, string name)
+            public static unsafe void BindFragDataLocationIndexed(int program, uint colorNumber, uint index, string name)
             {
                 byte* name_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(name);
                 BindFragDataLocationIndexed(program, colorNumber, index, name_ptr);
                 Marshal.FreeCoTaskMem((IntPtr)name_ptr);
             }
             /// <inheritdoc cref="GetFragDataIndex"/>
-            public static unsafe int GetFragDataIndex(ProgramHandle program, string name)
+            public static unsafe int GetFragDataIndex(int program, string name)
             {
                 int returnValue;
                 byte* name_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(name);
@@ -12237,13 +12237,13 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ClearTexImage"/>
-            public static unsafe void ClearTexImage(TextureHandle texture, int level, PixelFormat format, PixelType type, IntPtr data)
+            public static unsafe void ClearTexImage(int texture, int level, PixelFormat format, PixelType type, IntPtr data)
             {
                 void* data_vptr = (void*)data;
                 ClearTexImage(texture, level, format, type, data_vptr);
             }
             /// <inheritdoc cref="ClearTexImage"/>
-            public static unsafe void ClearTexImage<T1>(TextureHandle texture, int level, PixelFormat format, PixelType type, ReadOnlySpan<T1> data)
+            public static unsafe void ClearTexImage<T1>(int texture, int level, PixelFormat format, PixelType type, ReadOnlySpan<T1> data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = data)
@@ -12252,7 +12252,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ClearTexImage"/>
-            public static unsafe void ClearTexImage<T1>(TextureHandle texture, int level, PixelFormat format, PixelType type, T1[] data)
+            public static unsafe void ClearTexImage<T1>(int texture, int level, PixelFormat format, PixelType type, T1[] data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = data)
@@ -12261,7 +12261,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ClearTexImage"/>
-            public static unsafe void ClearTexImage<T1>(TextureHandle texture, int level, PixelFormat format, PixelType type, in T1 data)
+            public static unsafe void ClearTexImage<T1>(int texture, int level, PixelFormat format, PixelType type, in T1 data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = &data)
@@ -12270,13 +12270,13 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ClearTexSubImage"/>
-            public static unsafe void ClearTexSubImage(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, IntPtr data)
+            public static unsafe void ClearTexSubImage(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, IntPtr data)
             {
                 void* data_vptr = (void*)data;
                 ClearTexSubImage(texture, level, xoffset, yoffset, zoffset, width, height, depth, format, type, data_vptr);
             }
             /// <inheritdoc cref="ClearTexSubImage"/>
-            public static unsafe void ClearTexSubImage<T1>(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, ReadOnlySpan<T1> data)
+            public static unsafe void ClearTexSubImage<T1>(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, ReadOnlySpan<T1> data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = data)
@@ -12285,7 +12285,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ClearTexSubImage"/>
-            public static unsafe void ClearTexSubImage<T1>(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, T1[] data)
+            public static unsafe void ClearTexSubImage<T1>(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, T1[] data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = data)
@@ -12294,7 +12294,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ClearTexSubImage"/>
-            public static unsafe void ClearTexSubImage<T1>(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, in T1 data)
+            public static unsafe void ClearTexSubImage<T1>(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, in T1 data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = &data)
@@ -12440,9 +12440,9 @@ namespace OpenTK.Graphics.OpenGL
                 return returnValue;
             }
             /// <inheritdoc cref="CreateTransformFeedbacks"/>
-            public static unsafe TransformFeedbackHandle CreateTransformFeedback()
+            public static unsafe int CreateTransformFeedback()
             {
-                TransformFeedbackHandle id;
+                int id;
                 int n = 1;
                 Unsafe.SkipInit(out id);
                 // FIXME: This could be a problem for the overloads that take an out parameter
@@ -12453,12 +12453,12 @@ namespace OpenTK.Graphics.OpenGL
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                TransformFeedbackHandle* ids_handle = (TransformFeedbackHandle*)Unsafe.AsPointer(ref id);
+                int* ids_handle = (int*)Unsafe.AsPointer(ref id);
                 CreateTransformFeedbacks(n, ids_handle);
                 return id;
             }
             /// <inheritdoc cref="CreateTransformFeedbacks"/>
-            public static unsafe void CreateTransformFeedback(out TransformFeedbackHandle id)
+            public static unsafe void CreateTransformFeedback(out int id)
             {
                 int n = 1;
                 Unsafe.SkipInit(out id);
@@ -12470,37 +12470,37 @@ namespace OpenTK.Graphics.OpenGL
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                TransformFeedbackHandle* ids_handle = (TransformFeedbackHandle*)Unsafe.AsPointer(ref id);
+                int* ids_handle = (int*)Unsafe.AsPointer(ref id);
                 CreateTransformFeedbacks(n, ids_handle);
             }
             /// <inheritdoc cref="CreateTransformFeedbacks"/>
-            public static unsafe void CreateTransformFeedbacks(Span<TransformFeedbackHandle> ids)
+            public static unsafe void CreateTransformFeedbacks(Span<int> ids)
             {
                 int n = (int)(ids.Length);
-                fixed (TransformFeedbackHandle* ids_ptr = ids)
+                fixed (int* ids_ptr = ids)
                 {
                     CreateTransformFeedbacks(n, ids_ptr);
                 }
             }
             /// <inheritdoc cref="CreateTransformFeedbacks"/>
-            public static unsafe void CreateTransformFeedbacks(TransformFeedbackHandle[] ids)
+            public static unsafe void CreateTransformFeedbacks(int[] ids)
             {
                 int n = (int)(ids.Length);
-                fixed (TransformFeedbackHandle* ids_ptr = ids)
+                fixed (int* ids_ptr = ids)
                 {
                     CreateTransformFeedbacks(n, ids_ptr);
                 }
             }
             /// <inheritdoc cref="CreateTransformFeedbacks"/>
-            public static unsafe void CreateTransformFeedbacks(int n, ref TransformFeedbackHandle ids)
+            public static unsafe void CreateTransformFeedbacks(int n, ref int ids)
             {
-                fixed (TransformFeedbackHandle* ids_ptr = &ids)
+                fixed (int* ids_ptr = &ids)
                 {
                     CreateTransformFeedbacks(n, ids_ptr);
                 }
             }
             /// <inheritdoc cref="GetTransformFeedbackiv"/>
-            public static unsafe void GetTransformFeedbacki(TransformFeedbackHandle xfb, TransformFeedbackPName pname, ref int param)
+            public static unsafe void GetTransformFeedbacki(int xfb, TransformFeedbackPName pname, ref int param)
             {
                 fixed (int* param_ptr = &param)
                 {
@@ -12508,7 +12508,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetTransformFeedbacki_v"/>
-            public static unsafe void GetTransformFeedback(TransformFeedbackHandle xfb, TransformFeedbackPName pname, uint index, ref int param)
+            public static unsafe void GetTransformFeedback(int xfb, TransformFeedbackPName pname, uint index, ref int param)
             {
                 fixed (int* param_ptr = &param)
                 {
@@ -12516,7 +12516,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetTransformFeedbacki64_v"/>
-            public static unsafe void GetTransformFeedbacki64_(TransformFeedbackHandle xfb, TransformFeedbackPName pname, uint index, ref long param)
+            public static unsafe void GetTransformFeedbacki64_(int xfb, TransformFeedbackPName pname, uint index, ref long param)
             {
                 fixed (long* param_ptr = &param)
                 {
@@ -12524,9 +12524,9 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="CreateBuffers"/>
-            public static unsafe BufferHandle CreateBuffer()
+            public static unsafe int CreateBuffer()
             {
-                BufferHandle buffer;
+                int buffer;
                 int n = 1;
                 Unsafe.SkipInit(out buffer);
                 // FIXME: This could be a problem for the overloads that take an out parameter
@@ -12537,12 +12537,12 @@ namespace OpenTK.Graphics.OpenGL
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                BufferHandle* buffers_handle = (BufferHandle*)Unsafe.AsPointer(ref buffer);
+                int* buffers_handle = (int*)Unsafe.AsPointer(ref buffer);
                 CreateBuffers(n, buffers_handle);
                 return buffer;
             }
             /// <inheritdoc cref="CreateBuffers"/>
-            public static unsafe void CreateBuffer(out BufferHandle buffer)
+            public static unsafe void CreateBuffer(out int buffer)
             {
                 int n = 1;
                 Unsafe.SkipInit(out buffer);
@@ -12554,43 +12554,43 @@ namespace OpenTK.Graphics.OpenGL
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                BufferHandle* buffers_handle = (BufferHandle*)Unsafe.AsPointer(ref buffer);
+                int* buffers_handle = (int*)Unsafe.AsPointer(ref buffer);
                 CreateBuffers(n, buffers_handle);
             }
             /// <inheritdoc cref="CreateBuffers"/>
-            public static unsafe void CreateBuffers(Span<BufferHandle> buffers)
+            public static unsafe void CreateBuffers(Span<int> buffers)
             {
                 int n = (int)(buffers.Length);
-                fixed (BufferHandle* buffers_ptr = buffers)
+                fixed (int* buffers_ptr = buffers)
                 {
                     CreateBuffers(n, buffers_ptr);
                 }
             }
             /// <inheritdoc cref="CreateBuffers"/>
-            public static unsafe void CreateBuffers(BufferHandle[] buffers)
+            public static unsafe void CreateBuffers(int[] buffers)
             {
                 int n = (int)(buffers.Length);
-                fixed (BufferHandle* buffers_ptr = buffers)
+                fixed (int* buffers_ptr = buffers)
                 {
                     CreateBuffers(n, buffers_ptr);
                 }
             }
             /// <inheritdoc cref="CreateBuffers"/>
-            public static unsafe void CreateBuffers(int n, ref BufferHandle buffers)
+            public static unsafe void CreateBuffers(int n, ref int buffers)
             {
-                fixed (BufferHandle* buffers_ptr = &buffers)
+                fixed (int* buffers_ptr = &buffers)
                 {
                     CreateBuffers(n, buffers_ptr);
                 }
             }
             /// <inheritdoc cref="NamedBufferStorage"/>
-            public static unsafe void NamedBufferStorage(BufferHandle buffer, nint size, IntPtr data, BufferStorageMask flags)
+            public static unsafe void NamedBufferStorage(int buffer, nint size, IntPtr data, BufferStorageMask flags)
             {
                 void* data_vptr = (void*)data;
                 NamedBufferStorage(buffer, size, data_vptr, flags);
             }
             /// <inheritdoc cref="NamedBufferStorage"/>
-            public static unsafe void NamedBufferStorage<T1>(BufferHandle buffer, ReadOnlySpan<T1> data, BufferStorageMask flags)
+            public static unsafe void NamedBufferStorage<T1>(int buffer, ReadOnlySpan<T1> data, BufferStorageMask flags)
                 where T1 : unmanaged
             {
                 nint size = (nint)(data.Length * sizeof(T1));
@@ -12600,7 +12600,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="NamedBufferStorage"/>
-            public static unsafe void NamedBufferStorage<T1>(BufferHandle buffer, T1[] data, BufferStorageMask flags)
+            public static unsafe void NamedBufferStorage<T1>(int buffer, T1[] data, BufferStorageMask flags)
                 where T1 : unmanaged
             {
                 nint size = (nint)(data.Length * sizeof(T1));
@@ -12610,7 +12610,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="NamedBufferStorage"/>
-            public static unsafe void NamedBufferStorage<T1>(BufferHandle buffer, nint size, in T1 data, BufferStorageMask flags)
+            public static unsafe void NamedBufferStorage<T1>(int buffer, nint size, in T1 data, BufferStorageMask flags)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = &data)
@@ -12619,13 +12619,13 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="NamedBufferData"/>
-            public static unsafe void NamedBufferData(BufferHandle buffer, nint size, IntPtr data, VertexBufferObjectUsage usage)
+            public static unsafe void NamedBufferData(int buffer, nint size, IntPtr data, VertexBufferObjectUsage usage)
             {
                 void* data_vptr = (void*)data;
                 NamedBufferData(buffer, size, data_vptr, usage);
             }
             /// <inheritdoc cref="NamedBufferData"/>
-            public static unsafe void NamedBufferData<T1>(BufferHandle buffer, ReadOnlySpan<T1> data, VertexBufferObjectUsage usage)
+            public static unsafe void NamedBufferData<T1>(int buffer, ReadOnlySpan<T1> data, VertexBufferObjectUsage usage)
                 where T1 : unmanaged
             {
                 nint size = (nint)(data.Length * sizeof(T1));
@@ -12635,7 +12635,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="NamedBufferData"/>
-            public static unsafe void NamedBufferData<T1>(BufferHandle buffer, T1[] data, VertexBufferObjectUsage usage)
+            public static unsafe void NamedBufferData<T1>(int buffer, T1[] data, VertexBufferObjectUsage usage)
                 where T1 : unmanaged
             {
                 nint size = (nint)(data.Length * sizeof(T1));
@@ -12645,7 +12645,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="NamedBufferData"/>
-            public static unsafe void NamedBufferData<T1>(BufferHandle buffer, nint size, in T1 data, VertexBufferObjectUsage usage)
+            public static unsafe void NamedBufferData<T1>(int buffer, nint size, in T1 data, VertexBufferObjectUsage usage)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = &data)
@@ -12654,13 +12654,13 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="NamedBufferSubData"/>
-            public static unsafe void NamedBufferSubData(BufferHandle buffer, IntPtr offset, nint size, IntPtr data)
+            public static unsafe void NamedBufferSubData(int buffer, IntPtr offset, nint size, IntPtr data)
             {
                 void* data_vptr = (void*)data;
                 NamedBufferSubData(buffer, offset, size, data_vptr);
             }
             /// <inheritdoc cref="NamedBufferSubData"/>
-            public static unsafe void NamedBufferSubData<T1>(BufferHandle buffer, IntPtr offset, ReadOnlySpan<T1> data)
+            public static unsafe void NamedBufferSubData<T1>(int buffer, IntPtr offset, ReadOnlySpan<T1> data)
                 where T1 : unmanaged
             {
                 nint size = (nint)(data.Length * sizeof(T1));
@@ -12670,7 +12670,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="NamedBufferSubData"/>
-            public static unsafe void NamedBufferSubData<T1>(BufferHandle buffer, IntPtr offset, T1[] data)
+            public static unsafe void NamedBufferSubData<T1>(int buffer, IntPtr offset, T1[] data)
                 where T1 : unmanaged
             {
                 nint size = (nint)(data.Length * sizeof(T1));
@@ -12680,7 +12680,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="NamedBufferSubData"/>
-            public static unsafe void NamedBufferSubData<T1>(BufferHandle buffer, IntPtr offset, nint size, in T1 data)
+            public static unsafe void NamedBufferSubData<T1>(int buffer, IntPtr offset, nint size, in T1 data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = &data)
@@ -12689,13 +12689,13 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ClearNamedBufferData"/>
-            public static unsafe void ClearNamedBufferData(BufferHandle buffer, SizedInternalFormat internalformat, PixelFormat format, PixelType type, IntPtr data)
+            public static unsafe void ClearNamedBufferData(int buffer, SizedInternalFormat internalformat, PixelFormat format, PixelType type, IntPtr data)
             {
                 void* data_vptr = (void*)data;
                 ClearNamedBufferData(buffer, internalformat, format, type, data_vptr);
             }
             /// <inheritdoc cref="ClearNamedBufferData"/>
-            public static unsafe void ClearNamedBufferData<T1>(BufferHandle buffer, SizedInternalFormat internalformat, PixelFormat format, PixelType type, in T1 data)
+            public static unsafe void ClearNamedBufferData<T1>(int buffer, SizedInternalFormat internalformat, PixelFormat format, PixelType type, in T1 data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = &data)
@@ -12704,13 +12704,13 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ClearNamedBufferSubData"/>
-            public static unsafe void ClearNamedBufferSubData(BufferHandle buffer, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, IntPtr data)
+            public static unsafe void ClearNamedBufferSubData(int buffer, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, IntPtr data)
             {
                 void* data_vptr = (void*)data;
                 ClearNamedBufferSubData(buffer, internalformat, offset, size, format, type, data_vptr);
             }
             /// <inheritdoc cref="ClearNamedBufferSubData"/>
-            public static unsafe void ClearNamedBufferSubData<T1>(BufferHandle buffer, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, ReadOnlySpan<T1> data)
+            public static unsafe void ClearNamedBufferSubData<T1>(int buffer, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, ReadOnlySpan<T1> data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = data)
@@ -12719,7 +12719,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ClearNamedBufferSubData"/>
-            public static unsafe void ClearNamedBufferSubData<T1>(BufferHandle buffer, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, T1[] data)
+            public static unsafe void ClearNamedBufferSubData<T1>(int buffer, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, T1[] data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = data)
@@ -12728,7 +12728,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ClearNamedBufferSubData"/>
-            public static unsafe void ClearNamedBufferSubData<T1>(BufferHandle buffer, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, in T1 data)
+            public static unsafe void ClearNamedBufferSubData<T1>(int buffer, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, in T1 data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = &data)
@@ -12737,7 +12737,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetNamedBufferParameteriv"/>
-            public static unsafe void GetNamedBufferParameteri(BufferHandle buffer, BufferPNameARB pname, ref int parameters)
+            public static unsafe void GetNamedBufferParameteri(int buffer, BufferPNameARB pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -12745,7 +12745,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetNamedBufferParameteri64v"/>
-            public static unsafe void GetNamedBufferParameteri64(BufferHandle buffer, BufferPNameARB pname, ref long parameters)
+            public static unsafe void GetNamedBufferParameteri64(int buffer, BufferPNameARB pname, ref long parameters)
             {
                 fixed (long* parameters_ptr = &parameters)
                 {
@@ -12753,18 +12753,18 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetNamedBufferPointerv"/>
-            public static unsafe void GetNamedBufferPointer(BufferHandle buffer, BufferPointerNameARB pname, void** parameters)
+            public static unsafe void GetNamedBufferPointer(int buffer, BufferPointerNameARB pname, void** parameters)
             {
                 GetNamedBufferPointerv(buffer, pname, parameters);
             }
             /// <inheritdoc cref="GetNamedBufferSubData"/>
-            public static unsafe void GetNamedBufferSubData(BufferHandle buffer, IntPtr offset, nint size, IntPtr data)
+            public static unsafe void GetNamedBufferSubData(int buffer, IntPtr offset, nint size, IntPtr data)
             {
                 void* data_vptr = (void*)data;
                 GetNamedBufferSubData(buffer, offset, size, data_vptr);
             }
             /// <inheritdoc cref="GetNamedBufferSubData"/>
-            public static unsafe void GetNamedBufferSubData<T1>(BufferHandle buffer, IntPtr offset, nint size, ref T1 data)
+            public static unsafe void GetNamedBufferSubData<T1>(int buffer, IntPtr offset, nint size, ref T1 data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = &data)
@@ -12773,9 +12773,9 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="CreateFramebuffers"/>
-            public static unsafe FramebufferHandle CreateFramebuffer()
+            public static unsafe int CreateFramebuffer()
             {
-                FramebufferHandle framebuffer;
+                int framebuffer;
                 int n = 1;
                 Unsafe.SkipInit(out framebuffer);
                 // FIXME: This could be a problem for the overloads that take an out parameter
@@ -12786,12 +12786,12 @@ namespace OpenTK.Graphics.OpenGL
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                FramebufferHandle* framebuffers_handle = (FramebufferHandle*)Unsafe.AsPointer(ref framebuffer);
+                int* framebuffers_handle = (int*)Unsafe.AsPointer(ref framebuffer);
                 CreateFramebuffers(n, framebuffers_handle);
                 return framebuffer;
             }
             /// <inheritdoc cref="CreateFramebuffers"/>
-            public static unsafe void CreateFramebuffer(out FramebufferHandle framebuffer)
+            public static unsafe void CreateFramebuffer(out int framebuffer)
             {
                 int n = 1;
                 Unsafe.SkipInit(out framebuffer);
@@ -12803,37 +12803,37 @@ namespace OpenTK.Graphics.OpenGL
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                FramebufferHandle* framebuffers_handle = (FramebufferHandle*)Unsafe.AsPointer(ref framebuffer);
+                int* framebuffers_handle = (int*)Unsafe.AsPointer(ref framebuffer);
                 CreateFramebuffers(n, framebuffers_handle);
             }
             /// <inheritdoc cref="CreateFramebuffers"/>
-            public static unsafe void CreateFramebuffers(Span<FramebufferHandle> framebuffers)
+            public static unsafe void CreateFramebuffers(Span<int> framebuffers)
             {
                 int n = (int)(framebuffers.Length);
-                fixed (FramebufferHandle* framebuffers_ptr = framebuffers)
+                fixed (int* framebuffers_ptr = framebuffers)
                 {
                     CreateFramebuffers(n, framebuffers_ptr);
                 }
             }
             /// <inheritdoc cref="CreateFramebuffers"/>
-            public static unsafe void CreateFramebuffers(FramebufferHandle[] framebuffers)
+            public static unsafe void CreateFramebuffers(int[] framebuffers)
             {
                 int n = (int)(framebuffers.Length);
-                fixed (FramebufferHandle* framebuffers_ptr = framebuffers)
+                fixed (int* framebuffers_ptr = framebuffers)
                 {
                     CreateFramebuffers(n, framebuffers_ptr);
                 }
             }
             /// <inheritdoc cref="CreateFramebuffers"/>
-            public static unsafe void CreateFramebuffers(int n, ref FramebufferHandle framebuffers)
+            public static unsafe void CreateFramebuffers(int n, ref int framebuffers)
             {
-                fixed (FramebufferHandle* framebuffers_ptr = &framebuffers)
+                fixed (int* framebuffers_ptr = &framebuffers)
                 {
                     CreateFramebuffers(n, framebuffers_ptr);
                 }
             }
             /// <inheritdoc cref="NamedFramebufferDrawBuffers"/>
-            public static unsafe void NamedFramebufferDrawBuffers(FramebufferHandle framebuffer, ReadOnlySpan<ColorBuffer> bufs)
+            public static unsafe void NamedFramebufferDrawBuffers(int framebuffer, ReadOnlySpan<ColorBuffer> bufs)
             {
                 int n = (int)(bufs.Length);
                 fixed (ColorBuffer* bufs_ptr = bufs)
@@ -12842,7 +12842,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="NamedFramebufferDrawBuffers"/>
-            public static unsafe void NamedFramebufferDrawBuffers(FramebufferHandle framebuffer, ColorBuffer[] bufs)
+            public static unsafe void NamedFramebufferDrawBuffers(int framebuffer, ColorBuffer[] bufs)
             {
                 int n = (int)(bufs.Length);
                 fixed (ColorBuffer* bufs_ptr = bufs)
@@ -12851,7 +12851,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="NamedFramebufferDrawBuffers"/>
-            public static unsafe void NamedFramebufferDrawBuffers(FramebufferHandle framebuffer, int n, in ColorBuffer bufs)
+            public static unsafe void NamedFramebufferDrawBuffers(int framebuffer, int n, in ColorBuffer bufs)
             {
                 fixed (ColorBuffer* bufs_ptr = &bufs)
                 {
@@ -12859,7 +12859,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="InvalidateNamedFramebufferData"/>
-            public static unsafe void InvalidateNamedFramebufferData(FramebufferHandle framebuffer, ReadOnlySpan<FramebufferAttachment> attachments)
+            public static unsafe void InvalidateNamedFramebufferData(int framebuffer, ReadOnlySpan<FramebufferAttachment> attachments)
             {
                 int numAttachments = (int)(attachments.Length);
                 fixed (FramebufferAttachment* attachments_ptr = attachments)
@@ -12868,7 +12868,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="InvalidateNamedFramebufferData"/>
-            public static unsafe void InvalidateNamedFramebufferData(FramebufferHandle framebuffer, FramebufferAttachment[] attachments)
+            public static unsafe void InvalidateNamedFramebufferData(int framebuffer, FramebufferAttachment[] attachments)
             {
                 int numAttachments = (int)(attachments.Length);
                 fixed (FramebufferAttachment* attachments_ptr = attachments)
@@ -12877,7 +12877,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="InvalidateNamedFramebufferData"/>
-            public static unsafe void InvalidateNamedFramebufferData(FramebufferHandle framebuffer, int numAttachments, in FramebufferAttachment attachments)
+            public static unsafe void InvalidateNamedFramebufferData(int framebuffer, int numAttachments, in FramebufferAttachment attachments)
             {
                 fixed (FramebufferAttachment* attachments_ptr = &attachments)
                 {
@@ -12885,7 +12885,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="InvalidateNamedFramebufferSubData"/>
-            public static unsafe void InvalidateNamedFramebufferSubData(FramebufferHandle framebuffer, ReadOnlySpan<FramebufferAttachment> attachments, int x, int y, int width, int height)
+            public static unsafe void InvalidateNamedFramebufferSubData(int framebuffer, ReadOnlySpan<FramebufferAttachment> attachments, int x, int y, int width, int height)
             {
                 int numAttachments = (int)(attachments.Length);
                 fixed (FramebufferAttachment* attachments_ptr = attachments)
@@ -12894,7 +12894,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="InvalidateNamedFramebufferSubData"/>
-            public static unsafe void InvalidateNamedFramebufferSubData(FramebufferHandle framebuffer, FramebufferAttachment[] attachments, int x, int y, int width, int height)
+            public static unsafe void InvalidateNamedFramebufferSubData(int framebuffer, FramebufferAttachment[] attachments, int x, int y, int width, int height)
             {
                 int numAttachments = (int)(attachments.Length);
                 fixed (FramebufferAttachment* attachments_ptr = attachments)
@@ -12903,7 +12903,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="InvalidateNamedFramebufferSubData"/>
-            public static unsafe void InvalidateNamedFramebufferSubData(FramebufferHandle framebuffer, int numAttachments, in FramebufferAttachment attachments, int x, int y, int width, int height)
+            public static unsafe void InvalidateNamedFramebufferSubData(int framebuffer, int numAttachments, in FramebufferAttachment attachments, int x, int y, int width, int height)
             {
                 fixed (FramebufferAttachment* attachments_ptr = &attachments)
                 {
@@ -12911,7 +12911,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ClearNamedFramebufferiv"/>
-            public static unsafe void ClearNamedFramebufferi(FramebufferHandle framebuffer, Buffer buffer, int drawbuffer, ReadOnlySpan<int> value)
+            public static unsafe void ClearNamedFramebufferi(int framebuffer, Buffer buffer, int drawbuffer, ReadOnlySpan<int> value)
             {
                 fixed (int* value_ptr = value)
                 {
@@ -12919,7 +12919,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ClearNamedFramebufferiv"/>
-            public static unsafe void ClearNamedFramebufferi(FramebufferHandle framebuffer, Buffer buffer, int drawbuffer, int[] value)
+            public static unsafe void ClearNamedFramebufferi(int framebuffer, Buffer buffer, int drawbuffer, int[] value)
             {
                 fixed (int* value_ptr = value)
                 {
@@ -12927,7 +12927,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ClearNamedFramebufferiv"/>
-            public static unsafe void ClearNamedFramebufferi(FramebufferHandle framebuffer, Buffer buffer, int drawbuffer, in int value)
+            public static unsafe void ClearNamedFramebufferi(int framebuffer, Buffer buffer, int drawbuffer, in int value)
             {
                 fixed (int* value_ptr = &value)
                 {
@@ -12935,7 +12935,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ClearNamedFramebufferuiv"/>
-            public static unsafe void ClearNamedFramebufferui(FramebufferHandle framebuffer, Buffer buffer, int drawbuffer, ReadOnlySpan<uint> value)
+            public static unsafe void ClearNamedFramebufferui(int framebuffer, Buffer buffer, int drawbuffer, ReadOnlySpan<uint> value)
             {
                 fixed (uint* value_ptr = value)
                 {
@@ -12943,7 +12943,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ClearNamedFramebufferuiv"/>
-            public static unsafe void ClearNamedFramebufferui(FramebufferHandle framebuffer, Buffer buffer, int drawbuffer, uint[] value)
+            public static unsafe void ClearNamedFramebufferui(int framebuffer, Buffer buffer, int drawbuffer, uint[] value)
             {
                 fixed (uint* value_ptr = value)
                 {
@@ -12951,7 +12951,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ClearNamedFramebufferuiv"/>
-            public static unsafe void ClearNamedFramebufferui(FramebufferHandle framebuffer, Buffer buffer, int drawbuffer, in uint value)
+            public static unsafe void ClearNamedFramebufferui(int framebuffer, Buffer buffer, int drawbuffer, in uint value)
             {
                 fixed (uint* value_ptr = &value)
                 {
@@ -12959,7 +12959,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ClearNamedFramebufferfv"/>
-            public static unsafe void ClearNamedFramebufferf(FramebufferHandle framebuffer, Buffer buffer, int drawbuffer, ReadOnlySpan<float> value)
+            public static unsafe void ClearNamedFramebufferf(int framebuffer, Buffer buffer, int drawbuffer, ReadOnlySpan<float> value)
             {
                 fixed (float* value_ptr = value)
                 {
@@ -12967,7 +12967,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ClearNamedFramebufferfv"/>
-            public static unsafe void ClearNamedFramebufferf(FramebufferHandle framebuffer, Buffer buffer, int drawbuffer, float[] value)
+            public static unsafe void ClearNamedFramebufferf(int framebuffer, Buffer buffer, int drawbuffer, float[] value)
             {
                 fixed (float* value_ptr = value)
                 {
@@ -12975,7 +12975,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ClearNamedFramebufferfv"/>
-            public static unsafe void ClearNamedFramebufferf(FramebufferHandle framebuffer, Buffer buffer, int drawbuffer, in float value)
+            public static unsafe void ClearNamedFramebufferf(int framebuffer, Buffer buffer, int drawbuffer, in float value)
             {
                 fixed (float* value_ptr = &value)
                 {
@@ -12983,12 +12983,12 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ClearNamedFramebufferfi"/>
-            public static unsafe void ClearNamedFramebuffer(FramebufferHandle framebuffer, Buffer buffer, int drawbuffer, float depth, int stencil)
+            public static unsafe void ClearNamedFramebuffer(int framebuffer, Buffer buffer, int drawbuffer, float depth, int stencil)
             {
                 ClearNamedFramebufferfi(framebuffer, buffer, drawbuffer, depth, stencil);
             }
             /// <inheritdoc cref="GetNamedFramebufferParameteriv"/>
-            public static unsafe void GetNamedFramebufferParameteri(FramebufferHandle framebuffer, GetFramebufferParameter pname, ref int param)
+            public static unsafe void GetNamedFramebufferParameteri(int framebuffer, GetFramebufferParameter pname, ref int param)
             {
                 fixed (int* param_ptr = &param)
                 {
@@ -12996,7 +12996,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetNamedFramebufferAttachmentParameteriv"/>
-            public static unsafe void GetNamedFramebufferAttachmentParameteri(FramebufferHandle framebuffer, FramebufferAttachment attachment, FramebufferAttachmentParameterName pname, ref int parameters)
+            public static unsafe void GetNamedFramebufferAttachmentParameteri(int framebuffer, FramebufferAttachment attachment, FramebufferAttachmentParameterName pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -13004,9 +13004,9 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="CreateRenderbuffers"/>
-            public static unsafe RenderbufferHandle CreateRenderbuffer()
+            public static unsafe int CreateRenderbuffer()
             {
-                RenderbufferHandle renderbuffer;
+                int renderbuffer;
                 int n = 1;
                 Unsafe.SkipInit(out renderbuffer);
                 // FIXME: This could be a problem for the overloads that take an out parameter
@@ -13017,12 +13017,12 @@ namespace OpenTK.Graphics.OpenGL
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                RenderbufferHandle* renderbuffers_handle = (RenderbufferHandle*)Unsafe.AsPointer(ref renderbuffer);
+                int* renderbuffers_handle = (int*)Unsafe.AsPointer(ref renderbuffer);
                 CreateRenderbuffers(n, renderbuffers_handle);
                 return renderbuffer;
             }
             /// <inheritdoc cref="CreateRenderbuffers"/>
-            public static unsafe void CreateRenderbuffer(out RenderbufferHandle renderbuffer)
+            public static unsafe void CreateRenderbuffer(out int renderbuffer)
             {
                 int n = 1;
                 Unsafe.SkipInit(out renderbuffer);
@@ -13034,37 +13034,37 @@ namespace OpenTK.Graphics.OpenGL
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                RenderbufferHandle* renderbuffers_handle = (RenderbufferHandle*)Unsafe.AsPointer(ref renderbuffer);
+                int* renderbuffers_handle = (int*)Unsafe.AsPointer(ref renderbuffer);
                 CreateRenderbuffers(n, renderbuffers_handle);
             }
             /// <inheritdoc cref="CreateRenderbuffers"/>
-            public static unsafe void CreateRenderbuffers(Span<RenderbufferHandle> renderbuffers)
+            public static unsafe void CreateRenderbuffers(Span<int> renderbuffers)
             {
                 int n = (int)(renderbuffers.Length);
-                fixed (RenderbufferHandle* renderbuffers_ptr = renderbuffers)
+                fixed (int* renderbuffers_ptr = renderbuffers)
                 {
                     CreateRenderbuffers(n, renderbuffers_ptr);
                 }
             }
             /// <inheritdoc cref="CreateRenderbuffers"/>
-            public static unsafe void CreateRenderbuffers(RenderbufferHandle[] renderbuffers)
+            public static unsafe void CreateRenderbuffers(int[] renderbuffers)
             {
                 int n = (int)(renderbuffers.Length);
-                fixed (RenderbufferHandle* renderbuffers_ptr = renderbuffers)
+                fixed (int* renderbuffers_ptr = renderbuffers)
                 {
                     CreateRenderbuffers(n, renderbuffers_ptr);
                 }
             }
             /// <inheritdoc cref="CreateRenderbuffers"/>
-            public static unsafe void CreateRenderbuffers(int n, ref RenderbufferHandle renderbuffers)
+            public static unsafe void CreateRenderbuffers(int n, ref int renderbuffers)
             {
-                fixed (RenderbufferHandle* renderbuffers_ptr = &renderbuffers)
+                fixed (int* renderbuffers_ptr = &renderbuffers)
                 {
                     CreateRenderbuffers(n, renderbuffers_ptr);
                 }
             }
             /// <inheritdoc cref="GetNamedRenderbufferParameteriv"/>
-            public static unsafe void GetNamedRenderbufferParameteri(RenderbufferHandle renderbuffer, RenderbufferParameterName pname, ref int parameters)
+            public static unsafe void GetNamedRenderbufferParameteri(int renderbuffer, RenderbufferParameterName pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -13072,9 +13072,9 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="CreateTextures"/>
-            public static unsafe TextureHandle CreateTexture(TextureTarget target)
+            public static unsafe int CreateTexture(TextureTarget target)
             {
-                TextureHandle texture;
+                int texture;
                 int n = 1;
                 Unsafe.SkipInit(out texture);
                 // FIXME: This could be a problem for the overloads that take an out parameter
@@ -13085,12 +13085,12 @@ namespace OpenTK.Graphics.OpenGL
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                TextureHandle* textures_handle = (TextureHandle*)Unsafe.AsPointer(ref texture);
+                int* textures_handle = (int*)Unsafe.AsPointer(ref texture);
                 CreateTextures(target, n, textures_handle);
                 return texture;
             }
             /// <inheritdoc cref="CreateTextures"/>
-            public static unsafe void CreateTexture(TextureTarget target, out TextureHandle texture)
+            public static unsafe void CreateTexture(TextureTarget target, out int texture)
             {
                 int n = 1;
                 Unsafe.SkipInit(out texture);
@@ -13102,43 +13102,43 @@ namespace OpenTK.Graphics.OpenGL
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                TextureHandle* textures_handle = (TextureHandle*)Unsafe.AsPointer(ref texture);
+                int* textures_handle = (int*)Unsafe.AsPointer(ref texture);
                 CreateTextures(target, n, textures_handle);
             }
             /// <inheritdoc cref="CreateTextures"/>
-            public static unsafe void CreateTextures(TextureTarget target, Span<TextureHandle> textures)
+            public static unsafe void CreateTextures(TextureTarget target, Span<int> textures)
             {
                 int n = (int)(textures.Length);
-                fixed (TextureHandle* textures_ptr = textures)
+                fixed (int* textures_ptr = textures)
                 {
                     CreateTextures(target, n, textures_ptr);
                 }
             }
             /// <inheritdoc cref="CreateTextures"/>
-            public static unsafe void CreateTextures(TextureTarget target, TextureHandle[] textures)
+            public static unsafe void CreateTextures(TextureTarget target, int[] textures)
             {
                 int n = (int)(textures.Length);
-                fixed (TextureHandle* textures_ptr = textures)
+                fixed (int* textures_ptr = textures)
                 {
                     CreateTextures(target, n, textures_ptr);
                 }
             }
             /// <inheritdoc cref="CreateTextures"/>
-            public static unsafe void CreateTextures(TextureTarget target, int n, ref TextureHandle textures)
+            public static unsafe void CreateTextures(TextureTarget target, int n, ref int textures)
             {
-                fixed (TextureHandle* textures_ptr = &textures)
+                fixed (int* textures_ptr = &textures)
                 {
                     CreateTextures(target, n, textures_ptr);
                 }
             }
             /// <inheritdoc cref="TextureSubImage1D"/>
-            public static unsafe void TextureSubImage1D(TextureHandle texture, int level, int xoffset, int width, PixelFormat format, PixelType type, IntPtr pixels)
+            public static unsafe void TextureSubImage1D(int texture, int level, int xoffset, int width, PixelFormat format, PixelType type, IntPtr pixels)
             {
                 void* pixels_vptr = (void*)pixels;
                 TextureSubImage1D(texture, level, xoffset, width, format, type, pixels_vptr);
             }
             /// <inheritdoc cref="TextureSubImage1D"/>
-            public static unsafe void TextureSubImage1D<T1>(TextureHandle texture, int level, int xoffset, int width, PixelFormat format, PixelType type, in T1 pixels)
+            public static unsafe void TextureSubImage1D<T1>(int texture, int level, int xoffset, int width, PixelFormat format, PixelType type, in T1 pixels)
                 where T1 : unmanaged
             {
                 fixed (void* pixels_ptr = &pixels)
@@ -13147,13 +13147,13 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="TextureSubImage2D"/>
-            public static unsafe void TextureSubImage2D(TextureHandle texture, int level, int xoffset, int yoffset, int width, int height, PixelFormat format, PixelType type, IntPtr pixels)
+            public static unsafe void TextureSubImage2D(int texture, int level, int xoffset, int yoffset, int width, int height, PixelFormat format, PixelType type, IntPtr pixels)
             {
                 void* pixels_vptr = (void*)pixels;
                 TextureSubImage2D(texture, level, xoffset, yoffset, width, height, format, type, pixels_vptr);
             }
             /// <inheritdoc cref="TextureSubImage2D"/>
-            public static unsafe void TextureSubImage2D<T1>(TextureHandle texture, int level, int xoffset, int yoffset, int width, int height, PixelFormat format, PixelType type, in T1 pixels)
+            public static unsafe void TextureSubImage2D<T1>(int texture, int level, int xoffset, int yoffset, int width, int height, PixelFormat format, PixelType type, in T1 pixels)
                 where T1 : unmanaged
             {
                 fixed (void* pixels_ptr = &pixels)
@@ -13162,13 +13162,13 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="TextureSubImage3D"/>
-            public static unsafe void TextureSubImage3D(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, IntPtr pixels)
+            public static unsafe void TextureSubImage3D(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, IntPtr pixels)
             {
                 void* pixels_vptr = (void*)pixels;
                 TextureSubImage3D(texture, level, xoffset, yoffset, zoffset, width, height, depth, format, type, pixels_vptr);
             }
             /// <inheritdoc cref="TextureSubImage3D"/>
-            public static unsafe void TextureSubImage3D<T1>(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, in T1 pixels)
+            public static unsafe void TextureSubImage3D<T1>(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, in T1 pixels)
                 where T1 : unmanaged
             {
                 fixed (void* pixels_ptr = &pixels)
@@ -13177,13 +13177,13 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="CompressedTextureSubImage1D"/>
-            public static unsafe void CompressedTextureSubImage1D(TextureHandle texture, int level, int xoffset, int width, InternalFormat format, int imageSize, IntPtr data)
+            public static unsafe void CompressedTextureSubImage1D(int texture, int level, int xoffset, int width, InternalFormat format, int imageSize, IntPtr data)
             {
                 void* data_vptr = (void*)data;
                 CompressedTextureSubImage1D(texture, level, xoffset, width, format, imageSize, data_vptr);
             }
             /// <inheritdoc cref="CompressedTextureSubImage1D"/>
-            public static unsafe void CompressedTextureSubImage1D<T1>(TextureHandle texture, int level, int xoffset, int width, InternalFormat format, int imageSize, in T1 data)
+            public static unsafe void CompressedTextureSubImage1D<T1>(int texture, int level, int xoffset, int width, InternalFormat format, int imageSize, in T1 data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = &data)
@@ -13192,13 +13192,13 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="CompressedTextureSubImage2D"/>
-            public static unsafe void CompressedTextureSubImage2D(TextureHandle texture, int level, int xoffset, int yoffset, int width, int height, InternalFormat format, int imageSize, IntPtr data)
+            public static unsafe void CompressedTextureSubImage2D(int texture, int level, int xoffset, int yoffset, int width, int height, InternalFormat format, int imageSize, IntPtr data)
             {
                 void* data_vptr = (void*)data;
                 CompressedTextureSubImage2D(texture, level, xoffset, yoffset, width, height, format, imageSize, data_vptr);
             }
             /// <inheritdoc cref="CompressedTextureSubImage2D"/>
-            public static unsafe void CompressedTextureSubImage2D<T1>(TextureHandle texture, int level, int xoffset, int yoffset, int width, int height, InternalFormat format, int imageSize, in T1 data)
+            public static unsafe void CompressedTextureSubImage2D<T1>(int texture, int level, int xoffset, int yoffset, int width, int height, InternalFormat format, int imageSize, in T1 data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = &data)
@@ -13207,13 +13207,13 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="CompressedTextureSubImage3D"/>
-            public static unsafe void CompressedTextureSubImage3D(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, InternalFormat format, int imageSize, IntPtr data)
+            public static unsafe void CompressedTextureSubImage3D(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, InternalFormat format, int imageSize, IntPtr data)
             {
                 void* data_vptr = (void*)data;
                 CompressedTextureSubImage3D(texture, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, data_vptr);
             }
             /// <inheritdoc cref="CompressedTextureSubImage3D"/>
-            public static unsafe void CompressedTextureSubImage3D<T1>(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, InternalFormat format, int imageSize, in T1 data)
+            public static unsafe void CompressedTextureSubImage3D<T1>(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, InternalFormat format, int imageSize, in T1 data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = &data)
@@ -13222,7 +13222,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="TextureParameterfv"/>
-            public static unsafe void TextureParameterf(TextureHandle texture, TextureParameterName pname, ReadOnlySpan<float> param)
+            public static unsafe void TextureParameterf(int texture, TextureParameterName pname, ReadOnlySpan<float> param)
             {
                 fixed (float* param_ptr = param)
                 {
@@ -13230,7 +13230,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="TextureParameterfv"/>
-            public static unsafe void TextureParameterf(TextureHandle texture, TextureParameterName pname, float[] param)
+            public static unsafe void TextureParameterf(int texture, TextureParameterName pname, float[] param)
             {
                 fixed (float* param_ptr = param)
                 {
@@ -13238,7 +13238,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="TextureParameterfv"/>
-            public static unsafe void TextureParameterf(TextureHandle texture, TextureParameterName pname, in float param)
+            public static unsafe void TextureParameterf(int texture, TextureParameterName pname, in float param)
             {
                 fixed (float* param_ptr = &param)
                 {
@@ -13246,7 +13246,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="TextureParameterIiv"/>
-            public static unsafe void TextureParameterIi(TextureHandle texture, TextureParameterName pname, ReadOnlySpan<int> parameters)
+            public static unsafe void TextureParameterIi(int texture, TextureParameterName pname, ReadOnlySpan<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -13254,7 +13254,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="TextureParameterIiv"/>
-            public static unsafe void TextureParameterIi(TextureHandle texture, TextureParameterName pname, int[] parameters)
+            public static unsafe void TextureParameterIi(int texture, TextureParameterName pname, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -13262,7 +13262,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="TextureParameterIiv"/>
-            public static unsafe void TextureParameterIi(TextureHandle texture, TextureParameterName pname, in int parameters)
+            public static unsafe void TextureParameterIi(int texture, TextureParameterName pname, in int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -13270,7 +13270,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="TextureParameterIuiv"/>
-            public static unsafe void TextureParameterIui(TextureHandle texture, TextureParameterName pname, ReadOnlySpan<uint> parameters)
+            public static unsafe void TextureParameterIui(int texture, TextureParameterName pname, ReadOnlySpan<uint> parameters)
             {
                 fixed (uint* parameters_ptr = parameters)
                 {
@@ -13278,7 +13278,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="TextureParameterIuiv"/>
-            public static unsafe void TextureParameterIui(TextureHandle texture, TextureParameterName pname, uint[] parameters)
+            public static unsafe void TextureParameterIui(int texture, TextureParameterName pname, uint[] parameters)
             {
                 fixed (uint* parameters_ptr = parameters)
                 {
@@ -13286,7 +13286,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="TextureParameterIuiv"/>
-            public static unsafe void TextureParameterIui(TextureHandle texture, TextureParameterName pname, in uint parameters)
+            public static unsafe void TextureParameterIui(int texture, TextureParameterName pname, in uint parameters)
             {
                 fixed (uint* parameters_ptr = &parameters)
                 {
@@ -13294,7 +13294,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="TextureParameteriv"/>
-            public static unsafe void TextureParameteri(TextureHandle texture, TextureParameterName pname, ReadOnlySpan<int> param)
+            public static unsafe void TextureParameteri(int texture, TextureParameterName pname, ReadOnlySpan<int> param)
             {
                 fixed (int* param_ptr = param)
                 {
@@ -13302,7 +13302,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="TextureParameteriv"/>
-            public static unsafe void TextureParameteri(TextureHandle texture, TextureParameterName pname, int[] param)
+            public static unsafe void TextureParameteri(int texture, TextureParameterName pname, int[] param)
             {
                 fixed (int* param_ptr = param)
                 {
@@ -13310,7 +13310,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="TextureParameteriv"/>
-            public static unsafe void TextureParameteri(TextureHandle texture, TextureParameterName pname, in int param)
+            public static unsafe void TextureParameteri(int texture, TextureParameterName pname, in int param)
             {
                 fixed (int* param_ptr = &param)
                 {
@@ -13318,13 +13318,13 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetTextureImage"/>
-            public static unsafe void GetTextureImage(TextureHandle texture, int level, PixelFormat format, PixelType type, int bufSize, IntPtr pixels)
+            public static unsafe void GetTextureImage(int texture, int level, PixelFormat format, PixelType type, int bufSize, IntPtr pixels)
             {
                 void* pixels_vptr = (void*)pixels;
                 GetTextureImage(texture, level, format, type, bufSize, pixels_vptr);
             }
             /// <inheritdoc cref="GetTextureImage"/>
-            public static unsafe void GetTextureImage<T1>(TextureHandle texture, int level, PixelFormat format, PixelType type, Span<T1> pixels)
+            public static unsafe void GetTextureImage<T1>(int texture, int level, PixelFormat format, PixelType type, Span<T1> pixels)
                 where T1 : unmanaged
             {
                 int bufSize = (int)(pixels.Length * sizeof(T1));
@@ -13334,7 +13334,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetTextureImage"/>
-            public static unsafe void GetTextureImage<T1>(TextureHandle texture, int level, PixelFormat format, PixelType type, T1[] pixels)
+            public static unsafe void GetTextureImage<T1>(int texture, int level, PixelFormat format, PixelType type, T1[] pixels)
                 where T1 : unmanaged
             {
                 int bufSize = (int)(pixels.Length * sizeof(T1));
@@ -13344,7 +13344,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetTextureImage"/>
-            public static unsafe void GetTextureImage<T1>(TextureHandle texture, int level, PixelFormat format, PixelType type, int bufSize, ref T1 pixels)
+            public static unsafe void GetTextureImage<T1>(int texture, int level, PixelFormat format, PixelType type, int bufSize, ref T1 pixels)
                 where T1 : unmanaged
             {
                 fixed (void* pixels_ptr = &pixels)
@@ -13353,13 +13353,13 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetCompressedTextureImage"/>
-            public static unsafe void GetCompressedTextureImage(TextureHandle texture, int level, int bufSize, IntPtr pixels)
+            public static unsafe void GetCompressedTextureImage(int texture, int level, int bufSize, IntPtr pixels)
             {
                 void* pixels_vptr = (void*)pixels;
                 GetCompressedTextureImage(texture, level, bufSize, pixels_vptr);
             }
             /// <inheritdoc cref="GetCompressedTextureImage"/>
-            public static unsafe void GetCompressedTextureImage<T1>(TextureHandle texture, int level, Span<T1> pixels)
+            public static unsafe void GetCompressedTextureImage<T1>(int texture, int level, Span<T1> pixels)
                 where T1 : unmanaged
             {
                 int bufSize = (int)(pixels.Length * sizeof(T1));
@@ -13369,7 +13369,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetCompressedTextureImage"/>
-            public static unsafe void GetCompressedTextureImage<T1>(TextureHandle texture, int level, T1[] pixels)
+            public static unsafe void GetCompressedTextureImage<T1>(int texture, int level, T1[] pixels)
                 where T1 : unmanaged
             {
                 int bufSize = (int)(pixels.Length * sizeof(T1));
@@ -13379,7 +13379,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetCompressedTextureImage"/>
-            public static unsafe void GetCompressedTextureImage<T1>(TextureHandle texture, int level, int bufSize, ref T1 pixels)
+            public static unsafe void GetCompressedTextureImage<T1>(int texture, int level, int bufSize, ref T1 pixels)
                 where T1 : unmanaged
             {
                 fixed (void* pixels_ptr = &pixels)
@@ -13388,7 +13388,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetTextureLevelParameterfv"/>
-            public static unsafe void GetTextureLevelParameterf(TextureHandle texture, int level, GetTextureParameter pname, ref float parameters)
+            public static unsafe void GetTextureLevelParameterf(int texture, int level, GetTextureParameter pname, ref float parameters)
             {
                 fixed (float* parameters_ptr = &parameters)
                 {
@@ -13396,7 +13396,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetTextureLevelParameteriv"/>
-            public static unsafe void GetTextureLevelParameteri(TextureHandle texture, int level, GetTextureParameter pname, ref int parameters)
+            public static unsafe void GetTextureLevelParameteri(int texture, int level, GetTextureParameter pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -13404,7 +13404,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetTextureParameterfv"/>
-            public static unsafe void GetTextureParameterf(TextureHandle texture, GetTextureParameter pname, ref float parameters)
+            public static unsafe void GetTextureParameterf(int texture, GetTextureParameter pname, ref float parameters)
             {
                 fixed (float* parameters_ptr = &parameters)
                 {
@@ -13412,7 +13412,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetTextureParameterIiv"/>
-            public static unsafe void GetTextureParameterIi(TextureHandle texture, GetTextureParameter pname, ref int parameters)
+            public static unsafe void GetTextureParameterIi(int texture, GetTextureParameter pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -13420,7 +13420,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetTextureParameterIuiv"/>
-            public static unsafe void GetTextureParameterIui(TextureHandle texture, GetTextureParameter pname, ref uint parameters)
+            public static unsafe void GetTextureParameterIui(int texture, GetTextureParameter pname, ref uint parameters)
             {
                 fixed (uint* parameters_ptr = &parameters)
                 {
@@ -13428,7 +13428,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetTextureParameteriv"/>
-            public static unsafe void GetTextureParameteri(TextureHandle texture, GetTextureParameter pname, ref int parameters)
+            public static unsafe void GetTextureParameteri(int texture, GetTextureParameter pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -13436,9 +13436,9 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="CreateVertexArrays"/>
-            public static unsafe VertexArrayHandle CreateVertexArray()
+            public static unsafe int CreateVertexArray()
             {
-                VertexArrayHandle array;
+                int array;
                 int n = 1;
                 Unsafe.SkipInit(out array);
                 // FIXME: This could be a problem for the overloads that take an out parameter
@@ -13449,12 +13449,12 @@ namespace OpenTK.Graphics.OpenGL
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                VertexArrayHandle* arrays_handle = (VertexArrayHandle*)Unsafe.AsPointer(ref array);
+                int* arrays_handle = (int*)Unsafe.AsPointer(ref array);
                 CreateVertexArrays(n, arrays_handle);
                 return array;
             }
             /// <inheritdoc cref="CreateVertexArrays"/>
-            public static unsafe void CreateVertexArray(out VertexArrayHandle array)
+            public static unsafe void CreateVertexArray(out int array)
             {
                 int n = 1;
                 Unsafe.SkipInit(out array);
@@ -13466,39 +13466,39 @@ namespace OpenTK.Graphics.OpenGL
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                VertexArrayHandle* arrays_handle = (VertexArrayHandle*)Unsafe.AsPointer(ref array);
+                int* arrays_handle = (int*)Unsafe.AsPointer(ref array);
                 CreateVertexArrays(n, arrays_handle);
             }
             /// <inheritdoc cref="CreateVertexArrays"/>
-            public static unsafe void CreateVertexArrays(Span<VertexArrayHandle> arrays)
+            public static unsafe void CreateVertexArrays(Span<int> arrays)
             {
                 int n = (int)(arrays.Length);
-                fixed (VertexArrayHandle* arrays_ptr = arrays)
+                fixed (int* arrays_ptr = arrays)
                 {
                     CreateVertexArrays(n, arrays_ptr);
                 }
             }
             /// <inheritdoc cref="CreateVertexArrays"/>
-            public static unsafe void CreateVertexArrays(VertexArrayHandle[] arrays)
+            public static unsafe void CreateVertexArrays(int[] arrays)
             {
                 int n = (int)(arrays.Length);
-                fixed (VertexArrayHandle* arrays_ptr = arrays)
+                fixed (int* arrays_ptr = arrays)
                 {
                     CreateVertexArrays(n, arrays_ptr);
                 }
             }
             /// <inheritdoc cref="CreateVertexArrays"/>
-            public static unsafe void CreateVertexArrays(int n, ref VertexArrayHandle arrays)
+            public static unsafe void CreateVertexArrays(int n, ref int arrays)
             {
-                fixed (VertexArrayHandle* arrays_ptr = &arrays)
+                fixed (int* arrays_ptr = &arrays)
                 {
                     CreateVertexArrays(n, arrays_ptr);
                 }
             }
             /// <inheritdoc cref="VertexArrayVertexBuffers"/>
-            public static unsafe void VertexArrayVertexBuffers(VertexArrayHandle vaobj, uint first, int count, ReadOnlySpan<BufferHandle> buffers, ReadOnlySpan<IntPtr> offsets, ReadOnlySpan<int> strides)
+            public static unsafe void VertexArrayVertexBuffers(int vaobj, uint first, int count, ReadOnlySpan<int> buffers, ReadOnlySpan<IntPtr> offsets, ReadOnlySpan<int> strides)
             {
-                fixed (BufferHandle* buffers_ptr = buffers)
+                fixed (int* buffers_ptr = buffers)
                 {
                     fixed (IntPtr* offsets_ptr = offsets)
                     {
@@ -13510,9 +13510,9 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="VertexArrayVertexBuffers"/>
-            public static unsafe void VertexArrayVertexBuffers(VertexArrayHandle vaobj, uint first, int count, BufferHandle[] buffers, IntPtr[] offsets, int[] strides)
+            public static unsafe void VertexArrayVertexBuffers(int vaobj, uint first, int count, int[] buffers, IntPtr[] offsets, int[] strides)
             {
-                fixed (BufferHandle* buffers_ptr = buffers)
+                fixed (int* buffers_ptr = buffers)
                 {
                     fixed (IntPtr* offsets_ptr = offsets)
                     {
@@ -13524,9 +13524,9 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="VertexArrayVertexBuffers"/>
-            public static unsafe void VertexArrayVertexBuffers(VertexArrayHandle vaobj, uint first, int count, in BufferHandle buffers, in IntPtr offsets, in int strides)
+            public static unsafe void VertexArrayVertexBuffers(int vaobj, uint first, int count, in int buffers, in IntPtr offsets, in int strides)
             {
-                fixed (BufferHandle* buffers_ptr = &buffers)
+                fixed (int* buffers_ptr = &buffers)
                 fixed (IntPtr* offsets_ptr = &offsets)
                 fixed (int* strides_ptr = &strides)
                 {
@@ -13534,7 +13534,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetVertexArrayiv"/>
-            public static unsafe void GetVertexArrayi(VertexArrayHandle vaobj, VertexArrayPName pname, ref int param)
+            public static unsafe void GetVertexArrayi(int vaobj, VertexArrayPName pname, ref int param)
             {
                 fixed (int* param_ptr = &param)
                 {
@@ -13542,7 +13542,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetVertexArrayIndexediv"/>
-            public static unsafe void GetVertexArrayIndexedi(VertexArrayHandle vaobj, uint index, VertexArrayPName pname, ref int param)
+            public static unsafe void GetVertexArrayIndexedi(int vaobj, uint index, VertexArrayPName pname, ref int param)
             {
                 fixed (int* param_ptr = &param)
                 {
@@ -13550,7 +13550,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetVertexArrayIndexed64iv"/>
-            public static unsafe void GetVertexArrayIndexed64iv(VertexArrayHandle vaobj, uint index, VertexArrayPName pname, ref long param)
+            public static unsafe void GetVertexArrayIndexed64iv(int vaobj, uint index, VertexArrayPName pname, ref long param)
             {
                 fixed (long* param_ptr = &param)
                 {
@@ -13558,9 +13558,9 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="CreateSamplers"/>
-            public static unsafe SamplerHandle CreateSampler()
+            public static unsafe int CreateSampler()
             {
-                SamplerHandle sampler;
+                int sampler;
                 int n = 1;
                 Unsafe.SkipInit(out sampler);
                 // FIXME: This could be a problem for the overloads that take an out parameter
@@ -13571,12 +13571,12 @@ namespace OpenTK.Graphics.OpenGL
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                SamplerHandle* samplers_handle = (SamplerHandle*)Unsafe.AsPointer(ref sampler);
+                int* samplers_handle = (int*)Unsafe.AsPointer(ref sampler);
                 CreateSamplers(n, samplers_handle);
                 return sampler;
             }
             /// <inheritdoc cref="CreateSamplers"/>
-            public static unsafe void CreateSampler(out SamplerHandle sampler)
+            public static unsafe void CreateSampler(out int sampler)
             {
                 int n = 1;
                 Unsafe.SkipInit(out sampler);
@@ -13588,39 +13588,39 @@ namespace OpenTK.Graphics.OpenGL
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                SamplerHandle* samplers_handle = (SamplerHandle*)Unsafe.AsPointer(ref sampler);
+                int* samplers_handle = (int*)Unsafe.AsPointer(ref sampler);
                 CreateSamplers(n, samplers_handle);
             }
             /// <inheritdoc cref="CreateSamplers"/>
-            public static unsafe void CreateSamplers(Span<SamplerHandle> samplers)
+            public static unsafe void CreateSamplers(Span<int> samplers)
             {
                 int n = (int)(samplers.Length);
-                fixed (SamplerHandle* samplers_ptr = samplers)
+                fixed (int* samplers_ptr = samplers)
                 {
                     CreateSamplers(n, samplers_ptr);
                 }
             }
             /// <inheritdoc cref="CreateSamplers"/>
-            public static unsafe void CreateSamplers(SamplerHandle[] samplers)
+            public static unsafe void CreateSamplers(int[] samplers)
             {
                 int n = (int)(samplers.Length);
-                fixed (SamplerHandle* samplers_ptr = samplers)
+                fixed (int* samplers_ptr = samplers)
                 {
                     CreateSamplers(n, samplers_ptr);
                 }
             }
             /// <inheritdoc cref="CreateSamplers"/>
-            public static unsafe void CreateSamplers(int n, ref SamplerHandle samplers)
+            public static unsafe void CreateSamplers(int n, ref int samplers)
             {
-                fixed (SamplerHandle* samplers_ptr = &samplers)
+                fixed (int* samplers_ptr = &samplers)
                 {
                     CreateSamplers(n, samplers_ptr);
                 }
             }
             /// <inheritdoc cref="CreateProgramPipelines"/>
-            public static unsafe ProgramPipelineHandle CreateProgramPipeline()
+            public static unsafe int CreateProgramPipeline()
             {
-                ProgramPipelineHandle pipeline;
+                int pipeline;
                 int n = 1;
                 Unsafe.SkipInit(out pipeline);
                 // FIXME: This could be a problem for the overloads that take an out parameter
@@ -13631,12 +13631,12 @@ namespace OpenTK.Graphics.OpenGL
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                ProgramPipelineHandle* pipelines_handle = (ProgramPipelineHandle*)Unsafe.AsPointer(ref pipeline);
+                int* pipelines_handle = (int*)Unsafe.AsPointer(ref pipeline);
                 CreateProgramPipelines(n, pipelines_handle);
                 return pipeline;
             }
             /// <inheritdoc cref="CreateProgramPipelines"/>
-            public static unsafe void CreateProgramPipeline(out ProgramPipelineHandle pipeline)
+            public static unsafe void CreateProgramPipeline(out int pipeline)
             {
                 int n = 1;
                 Unsafe.SkipInit(out pipeline);
@@ -13648,39 +13648,39 @@ namespace OpenTK.Graphics.OpenGL
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                ProgramPipelineHandle* pipelines_handle = (ProgramPipelineHandle*)Unsafe.AsPointer(ref pipeline);
+                int* pipelines_handle = (int*)Unsafe.AsPointer(ref pipeline);
                 CreateProgramPipelines(n, pipelines_handle);
             }
             /// <inheritdoc cref="CreateProgramPipelines"/>
-            public static unsafe void CreateProgramPipelines(Span<ProgramPipelineHandle> pipelines)
+            public static unsafe void CreateProgramPipelines(Span<int> pipelines)
             {
                 int n = (int)(pipelines.Length);
-                fixed (ProgramPipelineHandle* pipelines_ptr = pipelines)
+                fixed (int* pipelines_ptr = pipelines)
                 {
                     CreateProgramPipelines(n, pipelines_ptr);
                 }
             }
             /// <inheritdoc cref="CreateProgramPipelines"/>
-            public static unsafe void CreateProgramPipelines(ProgramPipelineHandle[] pipelines)
+            public static unsafe void CreateProgramPipelines(int[] pipelines)
             {
                 int n = (int)(pipelines.Length);
-                fixed (ProgramPipelineHandle* pipelines_ptr = pipelines)
+                fixed (int* pipelines_ptr = pipelines)
                 {
                     CreateProgramPipelines(n, pipelines_ptr);
                 }
             }
             /// <inheritdoc cref="CreateProgramPipelines"/>
-            public static unsafe void CreateProgramPipelines(int n, ref ProgramPipelineHandle pipelines)
+            public static unsafe void CreateProgramPipelines(int n, ref int pipelines)
             {
-                fixed (ProgramPipelineHandle* pipelines_ptr = &pipelines)
+                fixed (int* pipelines_ptr = &pipelines)
                 {
                     CreateProgramPipelines(n, pipelines_ptr);
                 }
             }
             /// <inheritdoc cref="CreateQueries"/>
-            public static unsafe QueryHandle CreateQuery(QueryTarget target)
+            public static unsafe int CreateQuery(QueryTarget target)
             {
-                QueryHandle id;
+                int id;
                 int n = 1;
                 Unsafe.SkipInit(out id);
                 // FIXME: This could be a problem for the overloads that take an out parameter
@@ -13691,12 +13691,12 @@ namespace OpenTK.Graphics.OpenGL
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                QueryHandle* ids_handle = (QueryHandle*)Unsafe.AsPointer(ref id);
+                int* ids_handle = (int*)Unsafe.AsPointer(ref id);
                 CreateQueries(target, n, ids_handle);
                 return id;
             }
             /// <inheritdoc cref="CreateQueries"/>
-            public static unsafe void CreateQuery(QueryTarget target, out QueryHandle id)
+            public static unsafe void CreateQuery(QueryTarget target, out int id)
             {
                 int n = 1;
                 Unsafe.SkipInit(out id);
@@ -13708,52 +13708,52 @@ namespace OpenTK.Graphics.OpenGL
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                QueryHandle* ids_handle = (QueryHandle*)Unsafe.AsPointer(ref id);
+                int* ids_handle = (int*)Unsafe.AsPointer(ref id);
                 CreateQueries(target, n, ids_handle);
             }
             /// <inheritdoc cref="CreateQueries"/>
-            public static unsafe void CreateQueries(QueryTarget target, Span<QueryHandle> ids)
+            public static unsafe void CreateQueries(QueryTarget target, Span<int> ids)
             {
                 int n = (int)(ids.Length);
-                fixed (QueryHandle* ids_ptr = ids)
+                fixed (int* ids_ptr = ids)
                 {
                     CreateQueries(target, n, ids_ptr);
                 }
             }
             /// <inheritdoc cref="CreateQueries"/>
-            public static unsafe void CreateQueries(QueryTarget target, QueryHandle[] ids)
+            public static unsafe void CreateQueries(QueryTarget target, int[] ids)
             {
                 int n = (int)(ids.Length);
-                fixed (QueryHandle* ids_ptr = ids)
+                fixed (int* ids_ptr = ids)
                 {
                     CreateQueries(target, n, ids_ptr);
                 }
             }
             /// <inheritdoc cref="CreateQueries"/>
-            public static unsafe void CreateQueries(QueryTarget target, int n, ref QueryHandle ids)
+            public static unsafe void CreateQueries(QueryTarget target, int n, ref int ids)
             {
-                fixed (QueryHandle* ids_ptr = &ids)
+                fixed (int* ids_ptr = &ids)
                 {
                     CreateQueries(target, n, ids_ptr);
                 }
             }
             /// <inheritdoc cref="GetQueryBufferObjecti64v"/>
-            public static unsafe void GetQueryBufferObjecti64(QueryHandle id, BufferHandle buffer, QueryObjectParameterName pname, IntPtr offset)
+            public static unsafe void GetQueryBufferObjecti64(int id, int buffer, QueryObjectParameterName pname, IntPtr offset)
             {
                 GetQueryBufferObjecti64v(id, buffer, pname, offset);
             }
             /// <inheritdoc cref="GetQueryBufferObjectiv"/>
-            public static unsafe void GetQueryBufferObjecti(QueryHandle id, BufferHandle buffer, QueryObjectParameterName pname, IntPtr offset)
+            public static unsafe void GetQueryBufferObjecti(int id, int buffer, QueryObjectParameterName pname, IntPtr offset)
             {
                 GetQueryBufferObjectiv(id, buffer, pname, offset);
             }
             /// <inheritdoc cref="GetQueryBufferObjectui64v"/>
-            public static unsafe void GetQueryBufferObjectui64(QueryHandle id, BufferHandle buffer, QueryObjectParameterName pname, IntPtr offset)
+            public static unsafe void GetQueryBufferObjectui64(int id, int buffer, QueryObjectParameterName pname, IntPtr offset)
             {
                 GetQueryBufferObjectui64v(id, buffer, pname, offset);
             }
             /// <inheritdoc cref="GetQueryBufferObjectuiv"/>
-            public static unsafe void GetQueryBufferObjectui(QueryHandle id, BufferHandle buffer, QueryObjectParameterName pname, IntPtr offset)
+            public static unsafe void GetQueryBufferObjectui(int id, int buffer, QueryObjectParameterName pname, IntPtr offset)
             {
                 GetQueryBufferObjectuiv(id, buffer, pname, offset);
             }
@@ -13904,53 +13904,53 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="DeleteProgramsARB"/>
-            public static unsafe void DeleteProgramsARB(ReadOnlySpan<ProgramHandle> programs)
+            public static unsafe void DeleteProgramsARB(ReadOnlySpan<int> programs)
             {
                 int n = (int)(programs.Length);
-                fixed (ProgramHandle* programs_ptr = programs)
+                fixed (int* programs_ptr = programs)
                 {
                     DeleteProgramsARB(n, programs_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteProgramsARB"/>
-            public static unsafe void DeleteProgramsARB(ProgramHandle[] programs)
+            public static unsafe void DeleteProgramsARB(int[] programs)
             {
                 int n = (int)(programs.Length);
-                fixed (ProgramHandle* programs_ptr = programs)
+                fixed (int* programs_ptr = programs)
                 {
                     DeleteProgramsARB(n, programs_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteProgramsARB"/>
-            public static unsafe void DeleteProgramsARB(int n, in ProgramHandle programs)
+            public static unsafe void DeleteProgramsARB(int n, in int programs)
             {
-                fixed (ProgramHandle* programs_ptr = &programs)
+                fixed (int* programs_ptr = &programs)
                 {
                     DeleteProgramsARB(n, programs_ptr);
                 }
             }
             /// <inheritdoc cref="GenProgramsARB"/>
-            public static unsafe void GenProgramsARB(Span<ProgramHandle> programs)
+            public static unsafe void GenProgramsARB(Span<int> programs)
             {
                 int n = (int)(programs.Length);
-                fixed (ProgramHandle* programs_ptr = programs)
+                fixed (int* programs_ptr = programs)
                 {
                     GenProgramsARB(n, programs_ptr);
                 }
             }
             /// <inheritdoc cref="GenProgramsARB"/>
-            public static unsafe void GenProgramsARB(ProgramHandle[] programs)
+            public static unsafe void GenProgramsARB(int[] programs)
             {
                 int n = (int)(programs.Length);
-                fixed (ProgramHandle* programs_ptr = programs)
+                fixed (int* programs_ptr = programs)
                 {
                     GenProgramsARB(n, programs_ptr);
                 }
             }
             /// <inheritdoc cref="GenProgramsARB"/>
-            public static unsafe void GenProgramsARB(int n, ref ProgramHandle programs)
+            public static unsafe void GenProgramsARB(int n, ref int programs)
             {
-                fixed (ProgramHandle* programs_ptr = &programs)
+                fixed (int* programs_ptr = &programs)
                 {
                     GenProgramsARB(n, programs_ptr);
                 }
@@ -14229,44 +14229,44 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="DeleteRenderbuffers"/>
-            public static unsafe void DeleteRenderbuffer(in RenderbufferHandle renderbuffer)
+            public static unsafe void DeleteRenderbuffer(in int renderbuffer)
             {
                 int n = 1;
-                fixed(RenderbufferHandle* renderbuffers_handle = &renderbuffer)
+                fixed(int* renderbuffers_handle = &renderbuffer)
                 {
                     DeleteRenderbuffers(n, renderbuffers_handle);
                 }
             }
             /// <inheritdoc cref="DeleteRenderbuffers"/>
-            public static unsafe void DeleteRenderbuffers(ReadOnlySpan<RenderbufferHandle> renderbuffers)
+            public static unsafe void DeleteRenderbuffers(ReadOnlySpan<int> renderbuffers)
             {
                 int n = (int)(renderbuffers.Length);
-                fixed (RenderbufferHandle* renderbuffers_ptr = renderbuffers)
+                fixed (int* renderbuffers_ptr = renderbuffers)
                 {
                     DeleteRenderbuffers(n, renderbuffers_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteRenderbuffers"/>
-            public static unsafe void DeleteRenderbuffers(RenderbufferHandle[] renderbuffers)
+            public static unsafe void DeleteRenderbuffers(int[] renderbuffers)
             {
                 int n = (int)(renderbuffers.Length);
-                fixed (RenderbufferHandle* renderbuffers_ptr = renderbuffers)
+                fixed (int* renderbuffers_ptr = renderbuffers)
                 {
                     DeleteRenderbuffers(n, renderbuffers_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteRenderbuffers"/>
-            public static unsafe void DeleteRenderbuffers(int n, in RenderbufferHandle renderbuffers)
+            public static unsafe void DeleteRenderbuffers(int n, in int renderbuffers)
             {
-                fixed (RenderbufferHandle* renderbuffers_ptr = &renderbuffers)
+                fixed (int* renderbuffers_ptr = &renderbuffers)
                 {
                     DeleteRenderbuffers(n, renderbuffers_ptr);
                 }
             }
             /// <inheritdoc cref="GenRenderbuffers"/>
-            public static unsafe RenderbufferHandle GenRenderbuffer()
+            public static unsafe int GenRenderbuffer()
             {
-                RenderbufferHandle renderbuffer;
+                int renderbuffer;
                 int n = 1;
                 Unsafe.SkipInit(out renderbuffer);
                 // FIXME: This could be a problem for the overloads that take an out parameter
@@ -14277,12 +14277,12 @@ namespace OpenTK.Graphics.OpenGL
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                RenderbufferHandle* renderbuffers_handle = (RenderbufferHandle*)Unsafe.AsPointer(ref renderbuffer);
+                int* renderbuffers_handle = (int*)Unsafe.AsPointer(ref renderbuffer);
                 GenRenderbuffers(n, renderbuffers_handle);
                 return renderbuffer;
             }
             /// <inheritdoc cref="GenRenderbuffers"/>
-            public static unsafe void GenRenderbuffer(out RenderbufferHandle renderbuffer)
+            public static unsafe void GenRenderbuffer(out int renderbuffer)
             {
                 int n = 1;
                 Unsafe.SkipInit(out renderbuffer);
@@ -14294,31 +14294,31 @@ namespace OpenTK.Graphics.OpenGL
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                RenderbufferHandle* renderbuffers_handle = (RenderbufferHandle*)Unsafe.AsPointer(ref renderbuffer);
+                int* renderbuffers_handle = (int*)Unsafe.AsPointer(ref renderbuffer);
                 GenRenderbuffers(n, renderbuffers_handle);
             }
             /// <inheritdoc cref="GenRenderbuffers"/>
-            public static unsafe void GenRenderbuffers(Span<RenderbufferHandle> renderbuffers)
+            public static unsafe void GenRenderbuffers(Span<int> renderbuffers)
             {
                 int n = (int)(renderbuffers.Length);
-                fixed (RenderbufferHandle* renderbuffers_ptr = renderbuffers)
+                fixed (int* renderbuffers_ptr = renderbuffers)
                 {
                     GenRenderbuffers(n, renderbuffers_ptr);
                 }
             }
             /// <inheritdoc cref="GenRenderbuffers"/>
-            public static unsafe void GenRenderbuffers(RenderbufferHandle[] renderbuffers)
+            public static unsafe void GenRenderbuffers(int[] renderbuffers)
             {
                 int n = (int)(renderbuffers.Length);
-                fixed (RenderbufferHandle* renderbuffers_ptr = renderbuffers)
+                fixed (int* renderbuffers_ptr = renderbuffers)
                 {
                     GenRenderbuffers(n, renderbuffers_ptr);
                 }
             }
             /// <inheritdoc cref="GenRenderbuffers"/>
-            public static unsafe void GenRenderbuffers(int n, ref RenderbufferHandle renderbuffers)
+            public static unsafe void GenRenderbuffers(int n, ref int renderbuffers)
             {
-                fixed (RenderbufferHandle* renderbuffers_ptr = &renderbuffers)
+                fixed (int* renderbuffers_ptr = &renderbuffers)
                 {
                     GenRenderbuffers(n, renderbuffers_ptr);
                 }
@@ -14348,44 +14348,44 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="DeleteFramebuffers"/>
-            public static unsafe void DeleteFramebuffer(in FramebufferHandle framebuffer)
+            public static unsafe void DeleteFramebuffer(in int framebuffer)
             {
                 int n = 1;
-                fixed(FramebufferHandle* framebuffers_handle = &framebuffer)
+                fixed(int* framebuffers_handle = &framebuffer)
                 {
                     DeleteFramebuffers(n, framebuffers_handle);
                 }
             }
             /// <inheritdoc cref="DeleteFramebuffers"/>
-            public static unsafe void DeleteFramebuffers(ReadOnlySpan<FramebufferHandle> framebuffers)
+            public static unsafe void DeleteFramebuffers(ReadOnlySpan<int> framebuffers)
             {
                 int n = (int)(framebuffers.Length);
-                fixed (FramebufferHandle* framebuffers_ptr = framebuffers)
+                fixed (int* framebuffers_ptr = framebuffers)
                 {
                     DeleteFramebuffers(n, framebuffers_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteFramebuffers"/>
-            public static unsafe void DeleteFramebuffers(FramebufferHandle[] framebuffers)
+            public static unsafe void DeleteFramebuffers(int[] framebuffers)
             {
                 int n = (int)(framebuffers.Length);
-                fixed (FramebufferHandle* framebuffers_ptr = framebuffers)
+                fixed (int* framebuffers_ptr = framebuffers)
                 {
                     DeleteFramebuffers(n, framebuffers_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteFramebuffers"/>
-            public static unsafe void DeleteFramebuffers(int n, in FramebufferHandle framebuffers)
+            public static unsafe void DeleteFramebuffers(int n, in int framebuffers)
             {
-                fixed (FramebufferHandle* framebuffers_ptr = &framebuffers)
+                fixed (int* framebuffers_ptr = &framebuffers)
                 {
                     DeleteFramebuffers(n, framebuffers_ptr);
                 }
             }
             /// <inheritdoc cref="GenFramebuffers"/>
-            public static unsafe FramebufferHandle GenFramebuffer()
+            public static unsafe int GenFramebuffer()
             {
-                FramebufferHandle framebuffer;
+                int framebuffer;
                 int n = 1;
                 Unsafe.SkipInit(out framebuffer);
                 // FIXME: This could be a problem for the overloads that take an out parameter
@@ -14396,12 +14396,12 @@ namespace OpenTK.Graphics.OpenGL
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                FramebufferHandle* framebuffers_handle = (FramebufferHandle*)Unsafe.AsPointer(ref framebuffer);
+                int* framebuffers_handle = (int*)Unsafe.AsPointer(ref framebuffer);
                 GenFramebuffers(n, framebuffers_handle);
                 return framebuffer;
             }
             /// <inheritdoc cref="GenFramebuffers"/>
-            public static unsafe void GenFramebuffer(out FramebufferHandle framebuffer)
+            public static unsafe void GenFramebuffer(out int framebuffer)
             {
                 int n = 1;
                 Unsafe.SkipInit(out framebuffer);
@@ -14413,31 +14413,31 @@ namespace OpenTK.Graphics.OpenGL
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                FramebufferHandle* framebuffers_handle = (FramebufferHandle*)Unsafe.AsPointer(ref framebuffer);
+                int* framebuffers_handle = (int*)Unsafe.AsPointer(ref framebuffer);
                 GenFramebuffers(n, framebuffers_handle);
             }
             /// <inheritdoc cref="GenFramebuffers"/>
-            public static unsafe void GenFramebuffers(Span<FramebufferHandle> framebuffers)
+            public static unsafe void GenFramebuffers(Span<int> framebuffers)
             {
                 int n = (int)(framebuffers.Length);
-                fixed (FramebufferHandle* framebuffers_ptr = framebuffers)
+                fixed (int* framebuffers_ptr = framebuffers)
                 {
                     GenFramebuffers(n, framebuffers_ptr);
                 }
             }
             /// <inheritdoc cref="GenFramebuffers"/>
-            public static unsafe void GenFramebuffers(FramebufferHandle[] framebuffers)
+            public static unsafe void GenFramebuffers(int[] framebuffers)
             {
                 int n = (int)(framebuffers.Length);
-                fixed (FramebufferHandle* framebuffers_ptr = framebuffers)
+                fixed (int* framebuffers_ptr = framebuffers)
                 {
                     GenFramebuffers(n, framebuffers_ptr);
                 }
             }
             /// <inheritdoc cref="GenFramebuffers"/>
-            public static unsafe void GenFramebuffers(int n, ref FramebufferHandle framebuffers)
+            public static unsafe void GenFramebuffers(int n, ref int framebuffers)
             {
-                fixed (FramebufferHandle* framebuffers_ptr = &framebuffers)
+                fixed (int* framebuffers_ptr = &framebuffers)
                 {
                     GenFramebuffers(n, framebuffers_ptr);
                 }
@@ -14467,7 +14467,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetProgramBinary"/>
-            public static unsafe void GetProgramBinary(ProgramHandle program, int bufSize, Span<int> length, Span<All> binaryFormat, IntPtr binary)
+            public static unsafe void GetProgramBinary(int program, int bufSize, Span<int> length, Span<All> binaryFormat, IntPtr binary)
             {
                 fixed (int* length_ptr = length)
                 {
@@ -14479,7 +14479,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetProgramBinary"/>
-            public static unsafe void GetProgramBinary(ProgramHandle program, int bufSize, int[] length, All[] binaryFormat, IntPtr binary)
+            public static unsafe void GetProgramBinary(int program, int bufSize, int[] length, All[] binaryFormat, IntPtr binary)
             {
                 fixed (int* length_ptr = length)
                 {
@@ -14491,7 +14491,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetProgramBinary"/>
-            public static unsafe void GetProgramBinary(ProgramHandle program, int bufSize, ref int length, ref All binaryFormat, IntPtr binary)
+            public static unsafe void GetProgramBinary(int program, int bufSize, ref int length, ref All binaryFormat, IntPtr binary)
             {
                 fixed (int* length_ptr = &length)
                 fixed (All* binaryFormat_ptr = &binaryFormat)
@@ -14501,7 +14501,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetProgramBinary"/>
-            public static unsafe void GetProgramBinary<T1>(ProgramHandle program, Span<int> length, Span<All> binaryFormat, Span<T1> binary)
+            public static unsafe void GetProgramBinary<T1>(int program, Span<int> length, Span<All> binaryFormat, Span<T1> binary)
                 where T1 : unmanaged
             {
                 fixed (int* length_ptr = length)
@@ -14517,7 +14517,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetProgramBinary"/>
-            public static unsafe void GetProgramBinary<T1>(ProgramHandle program, int[] length, All[] binaryFormat, T1[] binary)
+            public static unsafe void GetProgramBinary<T1>(int program, int[] length, All[] binaryFormat, T1[] binary)
                 where T1 : unmanaged
             {
                 fixed (int* length_ptr = length)
@@ -14533,7 +14533,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetProgramBinary"/>
-            public static unsafe void GetProgramBinary<T1>(ProgramHandle program, int bufSize, ref int length, ref All binaryFormat, ref T1 binary)
+            public static unsafe void GetProgramBinary<T1>(int program, int bufSize, ref int length, ref All binaryFormat, ref T1 binary)
                 where T1 : unmanaged
             {
                 fixed (int* length_ptr = &length)
@@ -14544,13 +14544,13 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramBinary"/>
-            public static unsafe void ProgramBinary(ProgramHandle program, All binaryFormat, IntPtr binary, int length)
+            public static unsafe void ProgramBinary(int program, All binaryFormat, IntPtr binary, int length)
             {
                 void* binary_vptr = (void*)binary;
                 ProgramBinary(program, binaryFormat, binary_vptr, length);
             }
             /// <inheritdoc cref="ProgramBinary"/>
-            public static unsafe void ProgramBinary<T1>(ProgramHandle program, All binaryFormat, ReadOnlySpan<T1> binary)
+            public static unsafe void ProgramBinary<T1>(int program, All binaryFormat, ReadOnlySpan<T1> binary)
                 where T1 : unmanaged
             {
                 int length = (int)(binary.Length * sizeof(T1));
@@ -14560,7 +14560,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramBinary"/>
-            public static unsafe void ProgramBinary<T1>(ProgramHandle program, All binaryFormat, T1[] binary)
+            public static unsafe void ProgramBinary<T1>(int program, All binaryFormat, T1[] binary)
                 where T1 : unmanaged
             {
                 int length = (int)(binary.Length * sizeof(T1));
@@ -14570,7 +14570,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramBinary"/>
-            public static unsafe void ProgramBinary<T1>(ProgramHandle program, All binaryFormat, in T1 binary, int length)
+            public static unsafe void ProgramBinary<T1>(int program, All binaryFormat, in T1 binary, int length)
                 where T1 : unmanaged
             {
                 fixed (void* binary_ptr = &binary)
@@ -14579,13 +14579,13 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetTextureSubImage"/>
-            public static unsafe void GetTextureSubImage(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, int bufSize, IntPtr pixels)
+            public static unsafe void GetTextureSubImage(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, int bufSize, IntPtr pixels)
             {
                 void* pixels_vptr = (void*)pixels;
                 GetTextureSubImage(texture, level, xoffset, yoffset, zoffset, width, height, depth, format, type, bufSize, pixels_vptr);
             }
             /// <inheritdoc cref="GetTextureSubImage"/>
-            public static unsafe void GetTextureSubImage<T1>(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, Span<T1> pixels)
+            public static unsafe void GetTextureSubImage<T1>(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, Span<T1> pixels)
                 where T1 : unmanaged
             {
                 int bufSize = (int)(pixels.Length * sizeof(T1));
@@ -14595,7 +14595,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetTextureSubImage"/>
-            public static unsafe void GetTextureSubImage<T1>(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, T1[] pixels)
+            public static unsafe void GetTextureSubImage<T1>(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, T1[] pixels)
                 where T1 : unmanaged
             {
                 int bufSize = (int)(pixels.Length * sizeof(T1));
@@ -14605,7 +14605,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetTextureSubImage"/>
-            public static unsafe void GetTextureSubImage<T1>(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, int bufSize, ref T1 pixels)
+            public static unsafe void GetTextureSubImage<T1>(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, int bufSize, ref T1 pixels)
                 where T1 : unmanaged
             {
                 fixed (void* pixels_ptr = &pixels)
@@ -14614,13 +14614,13 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetCompressedTextureSubImage"/>
-            public static unsafe void GetCompressedTextureSubImage(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, int bufSize, IntPtr pixels)
+            public static unsafe void GetCompressedTextureSubImage(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, int bufSize, IntPtr pixels)
             {
                 void* pixels_vptr = (void*)pixels;
                 GetCompressedTextureSubImage(texture, level, xoffset, yoffset, zoffset, width, height, depth, bufSize, pixels_vptr);
             }
             /// <inheritdoc cref="GetCompressedTextureSubImage"/>
-            public static unsafe void GetCompressedTextureSubImage<T1>(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, Span<T1> pixels)
+            public static unsafe void GetCompressedTextureSubImage<T1>(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, Span<T1> pixels)
                 where T1 : unmanaged
             {
                 int bufSize = (int)(pixels.Length * sizeof(T1));
@@ -14630,7 +14630,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetCompressedTextureSubImage"/>
-            public static unsafe void GetCompressedTextureSubImage<T1>(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, T1[] pixels)
+            public static unsafe void GetCompressedTextureSubImage<T1>(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, T1[] pixels)
                 where T1 : unmanaged
             {
                 int bufSize = (int)(pixels.Length * sizeof(T1));
@@ -14640,7 +14640,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetCompressedTextureSubImage"/>
-            public static unsafe void GetCompressedTextureSubImage<T1>(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, int bufSize, ref T1 pixels)
+            public static unsafe void GetCompressedTextureSubImage<T1>(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, int bufSize, ref T1 pixels)
                 where T1 : unmanaged
             {
                 fixed (void* pixels_ptr = &pixels)
@@ -14649,7 +14649,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="SpecializeShaderARB"/>
-            public static unsafe void SpecializeShaderARB(ShaderHandle shader, string pEntryPoint, uint numSpecializationConstants, in uint pConstantIndex, in uint pConstantValue)
+            public static unsafe void SpecializeShaderARB(int shader, string pEntryPoint, uint numSpecializationConstants, in uint pConstantIndex, in uint pConstantValue)
             {
                 fixed (uint* pConstantIndex_ptr = &pConstantIndex)
                 fixed (uint* pConstantValue_ptr = &pConstantValue)
@@ -15011,7 +15011,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetUniformdv"/>
-            public static unsafe void GetUniformd(ProgramHandle program, int location, Span<double> parameters)
+            public static unsafe void GetUniformd(int program, int location, Span<double> parameters)
             {
                 fixed (double* parameters_ptr = parameters)
                 {
@@ -15019,7 +15019,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetUniformdv"/>
-            public static unsafe void GetUniformd(ProgramHandle program, int location, double[] parameters)
+            public static unsafe void GetUniformd(int program, int location, double[] parameters)
             {
                 fixed (double* parameters_ptr = parameters)
                 {
@@ -15027,7 +15027,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetUniformdv"/>
-            public static unsafe void GetUniformd(ProgramHandle program, int location, ref double parameters)
+            public static unsafe void GetUniformd(int program, int location, ref double parameters)
             {
                 fixed (double* parameters_ptr = &parameters)
                 {
@@ -15243,7 +15243,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetUniformi64vARB"/>
-            public static unsafe void GetUniformi64vARB(ProgramHandle program, int location, Span<long> parameters)
+            public static unsafe void GetUniformi64vARB(int program, int location, Span<long> parameters)
             {
                 fixed (long* parameters_ptr = parameters)
                 {
@@ -15251,7 +15251,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetUniformi64vARB"/>
-            public static unsafe void GetUniformi64vARB(ProgramHandle program, int location, long[] parameters)
+            public static unsafe void GetUniformi64vARB(int program, int location, long[] parameters)
             {
                 fixed (long* parameters_ptr = parameters)
                 {
@@ -15259,7 +15259,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetUniformi64vARB"/>
-            public static unsafe void GetUniformi64vARB(ProgramHandle program, int location, ref long parameters)
+            public static unsafe void GetUniformi64vARB(int program, int location, ref long parameters)
             {
                 fixed (long* parameters_ptr = &parameters)
                 {
@@ -15267,7 +15267,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetUniformui64vARB"/>
-            public static unsafe void GetUniformui64vARB(ProgramHandle program, int location, Span<ulong> parameters)
+            public static unsafe void GetUniformui64vARB(int program, int location, Span<ulong> parameters)
             {
                 fixed (ulong* parameters_ptr = parameters)
                 {
@@ -15275,7 +15275,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetUniformui64vARB"/>
-            public static unsafe void GetUniformui64vARB(ProgramHandle program, int location, ulong[] parameters)
+            public static unsafe void GetUniformui64vARB(int program, int location, ulong[] parameters)
             {
                 fixed (ulong* parameters_ptr = parameters)
                 {
@@ -15283,7 +15283,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetUniformui64vARB"/>
-            public static unsafe void GetUniformui64vARB(ProgramHandle program, int location, ref ulong parameters)
+            public static unsafe void GetUniformui64vARB(int program, int location, ref ulong parameters)
             {
                 fixed (ulong* parameters_ptr = &parameters)
                 {
@@ -15291,7 +15291,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetnUniformi64vARB"/>
-            public static unsafe void GetnUniformi64vARB(ProgramHandle program, int location, Span<long> parameters)
+            public static unsafe void GetnUniformi64vARB(int program, int location, Span<long> parameters)
             {
                 int bufSize = (int)(parameters.Length * 8);
                 fixed (long* parameters_ptr = parameters)
@@ -15300,7 +15300,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetnUniformi64vARB"/>
-            public static unsafe void GetnUniformi64vARB(ProgramHandle program, int location, long[] parameters)
+            public static unsafe void GetnUniformi64vARB(int program, int location, long[] parameters)
             {
                 int bufSize = (int)(parameters.Length * 8);
                 fixed (long* parameters_ptr = parameters)
@@ -15309,7 +15309,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetnUniformi64vARB"/>
-            public static unsafe void GetnUniformi64vARB(ProgramHandle program, int location, int bufSize, ref long parameters)
+            public static unsafe void GetnUniformi64vARB(int program, int location, int bufSize, ref long parameters)
             {
                 fixed (long* parameters_ptr = &parameters)
                 {
@@ -15317,7 +15317,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetnUniformui64vARB"/>
-            public static unsafe void GetnUniformui64vARB(ProgramHandle program, int location, Span<ulong> parameters)
+            public static unsafe void GetnUniformui64vARB(int program, int location, Span<ulong> parameters)
             {
                 int bufSize = (int)(parameters.Length * 8);
                 fixed (ulong* parameters_ptr = parameters)
@@ -15326,7 +15326,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetnUniformui64vARB"/>
-            public static unsafe void GetnUniformui64vARB(ProgramHandle program, int location, ulong[] parameters)
+            public static unsafe void GetnUniformui64vARB(int program, int location, ulong[] parameters)
             {
                 int bufSize = (int)(parameters.Length * 8);
                 fixed (ulong* parameters_ptr = parameters)
@@ -15335,7 +15335,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetnUniformui64vARB"/>
-            public static unsafe void GetnUniformui64vARB(ProgramHandle program, int location, int bufSize, ref ulong parameters)
+            public static unsafe void GetnUniformui64vARB(int program, int location, int bufSize, ref ulong parameters)
             {
                 fixed (ulong* parameters_ptr = &parameters)
                 {
@@ -15343,7 +15343,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform1i64vARB"/>
-            public static unsafe void ProgramUniform1i64vARB(ProgramHandle program, int location, ReadOnlySpan<long> value)
+            public static unsafe void ProgramUniform1i64vARB(int program, int location, ReadOnlySpan<long> value)
             {
                 int count = (int)(value.Length);
                 fixed (long* value_ptr = value)
@@ -15352,7 +15352,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform1i64vARB"/>
-            public static unsafe void ProgramUniform1i64vARB(ProgramHandle program, int location, long[] value)
+            public static unsafe void ProgramUniform1i64vARB(int program, int location, long[] value)
             {
                 int count = (int)(value.Length);
                 fixed (long* value_ptr = value)
@@ -15361,7 +15361,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform1i64vARB"/>
-            public static unsafe void ProgramUniform1i64vARB(ProgramHandle program, int location, int count, in long value)
+            public static unsafe void ProgramUniform1i64vARB(int program, int location, int count, in long value)
             {
                 fixed (long* value_ptr = &value)
                 {
@@ -15369,7 +15369,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform2i64vARB"/>
-            public static unsafe void ProgramUniform2i64vARB(ProgramHandle program, int location, ReadOnlySpan<long> value)
+            public static unsafe void ProgramUniform2i64vARB(int program, int location, ReadOnlySpan<long> value)
             {
                 int count = (int)(value.Length / 2);
                 fixed (long* value_ptr = value)
@@ -15378,7 +15378,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform2i64vARB"/>
-            public static unsafe void ProgramUniform2i64vARB(ProgramHandle program, int location, long[] value)
+            public static unsafe void ProgramUniform2i64vARB(int program, int location, long[] value)
             {
                 int count = (int)(value.Length / 2);
                 fixed (long* value_ptr = value)
@@ -15387,7 +15387,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform2i64vARB"/>
-            public static unsafe void ProgramUniform2i64vARB(ProgramHandle program, int location, int count, in long value)
+            public static unsafe void ProgramUniform2i64vARB(int program, int location, int count, in long value)
             {
                 fixed (long* value_ptr = &value)
                 {
@@ -15395,7 +15395,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform3i64vARB"/>
-            public static unsafe void ProgramUniform3i64vARB(ProgramHandle program, int location, ReadOnlySpan<long> value)
+            public static unsafe void ProgramUniform3i64vARB(int program, int location, ReadOnlySpan<long> value)
             {
                 int count = (int)(value.Length / 3);
                 fixed (long* value_ptr = value)
@@ -15404,7 +15404,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform3i64vARB"/>
-            public static unsafe void ProgramUniform3i64vARB(ProgramHandle program, int location, long[] value)
+            public static unsafe void ProgramUniform3i64vARB(int program, int location, long[] value)
             {
                 int count = (int)(value.Length / 3);
                 fixed (long* value_ptr = value)
@@ -15413,7 +15413,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform3i64vARB"/>
-            public static unsafe void ProgramUniform3i64vARB(ProgramHandle program, int location, int count, in long value)
+            public static unsafe void ProgramUniform3i64vARB(int program, int location, int count, in long value)
             {
                 fixed (long* value_ptr = &value)
                 {
@@ -15421,7 +15421,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform4i64vARB"/>
-            public static unsafe void ProgramUniform4i64vARB(ProgramHandle program, int location, ReadOnlySpan<long> value)
+            public static unsafe void ProgramUniform4i64vARB(int program, int location, ReadOnlySpan<long> value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (long* value_ptr = value)
@@ -15430,7 +15430,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform4i64vARB"/>
-            public static unsafe void ProgramUniform4i64vARB(ProgramHandle program, int location, long[] value)
+            public static unsafe void ProgramUniform4i64vARB(int program, int location, long[] value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (long* value_ptr = value)
@@ -15439,7 +15439,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform4i64vARB"/>
-            public static unsafe void ProgramUniform4i64vARB(ProgramHandle program, int location, int count, in long value)
+            public static unsafe void ProgramUniform4i64vARB(int program, int location, int count, in long value)
             {
                 fixed (long* value_ptr = &value)
                 {
@@ -15447,7 +15447,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform1ui64vARB"/>
-            public static unsafe void ProgramUniform1ui64vARB(ProgramHandle program, int location, ReadOnlySpan<ulong> value)
+            public static unsafe void ProgramUniform1ui64vARB(int program, int location, ReadOnlySpan<ulong> value)
             {
                 int count = (int)(value.Length);
                 fixed (ulong* value_ptr = value)
@@ -15456,7 +15456,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform1ui64vARB"/>
-            public static unsafe void ProgramUniform1ui64vARB(ProgramHandle program, int location, ulong[] value)
+            public static unsafe void ProgramUniform1ui64vARB(int program, int location, ulong[] value)
             {
                 int count = (int)(value.Length);
                 fixed (ulong* value_ptr = value)
@@ -15465,7 +15465,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform1ui64vARB"/>
-            public static unsafe void ProgramUniform1ui64vARB(ProgramHandle program, int location, int count, in ulong value)
+            public static unsafe void ProgramUniform1ui64vARB(int program, int location, int count, in ulong value)
             {
                 fixed (ulong* value_ptr = &value)
                 {
@@ -15473,7 +15473,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform2ui64vARB"/>
-            public static unsafe void ProgramUniform2ui64vARB(ProgramHandle program, int location, ReadOnlySpan<ulong> value)
+            public static unsafe void ProgramUniform2ui64vARB(int program, int location, ReadOnlySpan<ulong> value)
             {
                 int count = (int)(value.Length / 2);
                 fixed (ulong* value_ptr = value)
@@ -15482,7 +15482,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform2ui64vARB"/>
-            public static unsafe void ProgramUniform2ui64vARB(ProgramHandle program, int location, ulong[] value)
+            public static unsafe void ProgramUniform2ui64vARB(int program, int location, ulong[] value)
             {
                 int count = (int)(value.Length / 2);
                 fixed (ulong* value_ptr = value)
@@ -15491,7 +15491,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform2ui64vARB"/>
-            public static unsafe void ProgramUniform2ui64vARB(ProgramHandle program, int location, int count, in ulong value)
+            public static unsafe void ProgramUniform2ui64vARB(int program, int location, int count, in ulong value)
             {
                 fixed (ulong* value_ptr = &value)
                 {
@@ -15499,7 +15499,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform3ui64vARB"/>
-            public static unsafe void ProgramUniform3ui64vARB(ProgramHandle program, int location, ReadOnlySpan<ulong> value)
+            public static unsafe void ProgramUniform3ui64vARB(int program, int location, ReadOnlySpan<ulong> value)
             {
                 int count = (int)(value.Length / 3);
                 fixed (ulong* value_ptr = value)
@@ -15508,7 +15508,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform3ui64vARB"/>
-            public static unsafe void ProgramUniform3ui64vARB(ProgramHandle program, int location, ulong[] value)
+            public static unsafe void ProgramUniform3ui64vARB(int program, int location, ulong[] value)
             {
                 int count = (int)(value.Length / 3);
                 fixed (ulong* value_ptr = value)
@@ -15517,7 +15517,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform3ui64vARB"/>
-            public static unsafe void ProgramUniform3ui64vARB(ProgramHandle program, int location, int count, in ulong value)
+            public static unsafe void ProgramUniform3ui64vARB(int program, int location, int count, in ulong value)
             {
                 fixed (ulong* value_ptr = &value)
                 {
@@ -15525,7 +15525,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform4ui64vARB"/>
-            public static unsafe void ProgramUniform4ui64vARB(ProgramHandle program, int location, ReadOnlySpan<ulong> value)
+            public static unsafe void ProgramUniform4ui64vARB(int program, int location, ReadOnlySpan<ulong> value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (ulong* value_ptr = value)
@@ -15534,7 +15534,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform4ui64vARB"/>
-            public static unsafe void ProgramUniform4ui64vARB(ProgramHandle program, int location, ulong[] value)
+            public static unsafe void ProgramUniform4ui64vARB(int program, int location, ulong[] value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (ulong* value_ptr = value)
@@ -15543,7 +15543,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform4ui64vARB"/>
-            public static unsafe void ProgramUniform4ui64vARB(ProgramHandle program, int location, int count, in ulong value)
+            public static unsafe void ProgramUniform4ui64vARB(int program, int location, int count, in ulong value)
             {
                 fixed (ulong* value_ptr = &value)
                 {
@@ -15796,35 +15796,35 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="BindBuffersBase"/>
-            public static unsafe void BindBuffersBase(BufferTargetARB target, uint first, ReadOnlySpan<BufferHandle> buffers)
+            public static unsafe void BindBuffersBase(BufferTargetARB target, uint first, ReadOnlySpan<int> buffers)
             {
                 int count = (int)(buffers.Length);
-                fixed (BufferHandle* buffers_ptr = buffers)
+                fixed (int* buffers_ptr = buffers)
                 {
                     BindBuffersBase(target, first, count, buffers_ptr);
                 }
             }
             /// <inheritdoc cref="BindBuffersBase"/>
-            public static unsafe void BindBuffersBase(BufferTargetARB target, uint first, BufferHandle[] buffers)
+            public static unsafe void BindBuffersBase(BufferTargetARB target, uint first, int[] buffers)
             {
                 int count = (int)(buffers.Length);
-                fixed (BufferHandle* buffers_ptr = buffers)
+                fixed (int* buffers_ptr = buffers)
                 {
                     BindBuffersBase(target, first, count, buffers_ptr);
                 }
             }
             /// <inheritdoc cref="BindBuffersBase"/>
-            public static unsafe void BindBuffersBase(BufferTargetARB target, uint first, int count, in BufferHandle buffers)
+            public static unsafe void BindBuffersBase(BufferTargetARB target, uint first, int count, in int buffers)
             {
-                fixed (BufferHandle* buffers_ptr = &buffers)
+                fixed (int* buffers_ptr = &buffers)
                 {
                     BindBuffersBase(target, first, count, buffers_ptr);
                 }
             }
             /// <inheritdoc cref="BindBuffersRange"/>
-            public static unsafe void BindBuffersRange(BufferTargetARB target, uint first, int count, ReadOnlySpan<BufferHandle> buffers, ReadOnlySpan<IntPtr> offsets, ReadOnlySpan<nint> sizes)
+            public static unsafe void BindBuffersRange(BufferTargetARB target, uint first, int count, ReadOnlySpan<int> buffers, ReadOnlySpan<IntPtr> offsets, ReadOnlySpan<nint> sizes)
             {
-                fixed (BufferHandle* buffers_ptr = buffers)
+                fixed (int* buffers_ptr = buffers)
                 {
                     fixed (IntPtr* offsets_ptr = offsets)
                     {
@@ -15836,9 +15836,9 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="BindBuffersRange"/>
-            public static unsafe void BindBuffersRange(BufferTargetARB target, uint first, int count, BufferHandle[] buffers, IntPtr[] offsets, nint[] sizes)
+            public static unsafe void BindBuffersRange(BufferTargetARB target, uint first, int count, int[] buffers, IntPtr[] offsets, nint[] sizes)
             {
-                fixed (BufferHandle* buffers_ptr = buffers)
+                fixed (int* buffers_ptr = buffers)
                 {
                     fixed (IntPtr* offsets_ptr = offsets)
                     {
@@ -15850,9 +15850,9 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="BindBuffersRange"/>
-            public static unsafe void BindBuffersRange(BufferTargetARB target, uint first, int count, in BufferHandle buffers, in IntPtr offsets, in nint sizes)
+            public static unsafe void BindBuffersRange(BufferTargetARB target, uint first, int count, in int buffers, in IntPtr offsets, in nint sizes)
             {
-                fixed (BufferHandle* buffers_ptr = &buffers)
+                fixed (int* buffers_ptr = &buffers)
                 fixed (IntPtr* offsets_ptr = &offsets)
                 fixed (nint* sizes_ptr = &sizes)
                 {
@@ -15860,87 +15860,87 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="BindTextures"/>
-            public static unsafe void BindTextures(uint first, ReadOnlySpan<TextureHandle> textures)
+            public static unsafe void BindTextures(uint first, ReadOnlySpan<int> textures)
             {
                 int count = (int)(textures.Length);
-                fixed (TextureHandle* textures_ptr = textures)
+                fixed (int* textures_ptr = textures)
                 {
                     BindTextures(first, count, textures_ptr);
                 }
             }
             /// <inheritdoc cref="BindTextures"/>
-            public static unsafe void BindTextures(uint first, TextureHandle[] textures)
+            public static unsafe void BindTextures(uint first, int[] textures)
             {
                 int count = (int)(textures.Length);
-                fixed (TextureHandle* textures_ptr = textures)
+                fixed (int* textures_ptr = textures)
                 {
                     BindTextures(first, count, textures_ptr);
                 }
             }
             /// <inheritdoc cref="BindTextures"/>
-            public static unsafe void BindTextures(uint first, int count, in TextureHandle textures)
+            public static unsafe void BindTextures(uint first, int count, in int textures)
             {
-                fixed (TextureHandle* textures_ptr = &textures)
+                fixed (int* textures_ptr = &textures)
                 {
                     BindTextures(first, count, textures_ptr);
                 }
             }
             /// <inheritdoc cref="BindSamplers"/>
-            public static unsafe void BindSamplers(uint first, ReadOnlySpan<SamplerHandle> samplers)
+            public static unsafe void BindSamplers(uint first, ReadOnlySpan<int> samplers)
             {
                 int count = (int)(samplers.Length);
-                fixed (SamplerHandle* samplers_ptr = samplers)
+                fixed (int* samplers_ptr = samplers)
                 {
                     BindSamplers(first, count, samplers_ptr);
                 }
             }
             /// <inheritdoc cref="BindSamplers"/>
-            public static unsafe void BindSamplers(uint first, SamplerHandle[] samplers)
+            public static unsafe void BindSamplers(uint first, int[] samplers)
             {
                 int count = (int)(samplers.Length);
-                fixed (SamplerHandle* samplers_ptr = samplers)
+                fixed (int* samplers_ptr = samplers)
                 {
                     BindSamplers(first, count, samplers_ptr);
                 }
             }
             /// <inheritdoc cref="BindSamplers"/>
-            public static unsafe void BindSamplers(uint first, int count, in SamplerHandle samplers)
+            public static unsafe void BindSamplers(uint first, int count, in int samplers)
             {
-                fixed (SamplerHandle* samplers_ptr = &samplers)
+                fixed (int* samplers_ptr = &samplers)
                 {
                     BindSamplers(first, count, samplers_ptr);
                 }
             }
             /// <inheritdoc cref="BindImageTextures"/>
-            public static unsafe void BindImageTextures(uint first, ReadOnlySpan<TextureHandle> textures)
+            public static unsafe void BindImageTextures(uint first, ReadOnlySpan<int> textures)
             {
                 int count = (int)(textures.Length);
-                fixed (TextureHandle* textures_ptr = textures)
+                fixed (int* textures_ptr = textures)
                 {
                     BindImageTextures(first, count, textures_ptr);
                 }
             }
             /// <inheritdoc cref="BindImageTextures"/>
-            public static unsafe void BindImageTextures(uint first, TextureHandle[] textures)
+            public static unsafe void BindImageTextures(uint first, int[] textures)
             {
                 int count = (int)(textures.Length);
-                fixed (TextureHandle* textures_ptr = textures)
+                fixed (int* textures_ptr = textures)
                 {
                     BindImageTextures(first, count, textures_ptr);
                 }
             }
             /// <inheritdoc cref="BindImageTextures"/>
-            public static unsafe void BindImageTextures(uint first, int count, in TextureHandle textures)
+            public static unsafe void BindImageTextures(uint first, int count, in int textures)
             {
-                fixed (TextureHandle* textures_ptr = &textures)
+                fixed (int* textures_ptr = &textures)
                 {
                     BindImageTextures(first, count, textures_ptr);
                 }
             }
             /// <inheritdoc cref="BindVertexBuffers"/>
-            public static unsafe void BindVertexBuffers(uint first, int count, ReadOnlySpan<BufferHandle> buffers, ReadOnlySpan<IntPtr> offsets, ReadOnlySpan<int> strides)
+            public static unsafe void BindVertexBuffers(uint first, int count, ReadOnlySpan<int> buffers, ReadOnlySpan<IntPtr> offsets, ReadOnlySpan<int> strides)
             {
-                fixed (BufferHandle* buffers_ptr = buffers)
+                fixed (int* buffers_ptr = buffers)
                 {
                     fixed (IntPtr* offsets_ptr = offsets)
                     {
@@ -15952,9 +15952,9 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="BindVertexBuffers"/>
-            public static unsafe void BindVertexBuffers(uint first, int count, BufferHandle[] buffers, IntPtr[] offsets, int[] strides)
+            public static unsafe void BindVertexBuffers(uint first, int count, int[] buffers, IntPtr[] offsets, int[] strides)
             {
-                fixed (BufferHandle* buffers_ptr = buffers)
+                fixed (int* buffers_ptr = buffers)
                 {
                     fixed (IntPtr* offsets_ptr = offsets)
                     {
@@ -15966,9 +15966,9 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="BindVertexBuffers"/>
-            public static unsafe void BindVertexBuffers(uint first, int count, in BufferHandle buffers, in IntPtr offsets, in int strides)
+            public static unsafe void BindVertexBuffers(uint first, int count, in int buffers, in IntPtr offsets, in int strides)
             {
-                fixed (BufferHandle* buffers_ptr = &buffers)
+                fixed (int* buffers_ptr = &buffers)
                 fixed (IntPtr* offsets_ptr = &offsets)
                 fixed (int* strides_ptr = &strides)
                 {
@@ -16426,53 +16426,53 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GenQueriesARB"/>
-            public static unsafe void GenQueriesARB(Span<QueryHandle> ids)
+            public static unsafe void GenQueriesARB(Span<int> ids)
             {
                 int n = (int)(ids.Length);
-                fixed (QueryHandle* ids_ptr = ids)
+                fixed (int* ids_ptr = ids)
                 {
                     GenQueriesARB(n, ids_ptr);
                 }
             }
             /// <inheritdoc cref="GenQueriesARB"/>
-            public static unsafe void GenQueriesARB(QueryHandle[] ids)
+            public static unsafe void GenQueriesARB(int[] ids)
             {
                 int n = (int)(ids.Length);
-                fixed (QueryHandle* ids_ptr = ids)
+                fixed (int* ids_ptr = ids)
                 {
                     GenQueriesARB(n, ids_ptr);
                 }
             }
             /// <inheritdoc cref="GenQueriesARB"/>
-            public static unsafe void GenQueriesARB(int n, ref QueryHandle ids)
+            public static unsafe void GenQueriesARB(int n, ref int ids)
             {
-                fixed (QueryHandle* ids_ptr = &ids)
+                fixed (int* ids_ptr = &ids)
                 {
                     GenQueriesARB(n, ids_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteQueriesARB"/>
-            public static unsafe void DeleteQueriesARB(ReadOnlySpan<QueryHandle> ids)
+            public static unsafe void DeleteQueriesARB(ReadOnlySpan<int> ids)
             {
                 int n = (int)(ids.Length);
-                fixed (QueryHandle* ids_ptr = ids)
+                fixed (int* ids_ptr = ids)
                 {
                     DeleteQueriesARB(n, ids_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteQueriesARB"/>
-            public static unsafe void DeleteQueriesARB(QueryHandle[] ids)
+            public static unsafe void DeleteQueriesARB(int[] ids)
             {
                 int n = (int)(ids.Length);
-                fixed (QueryHandle* ids_ptr = ids)
+                fixed (int* ids_ptr = ids)
                 {
                     DeleteQueriesARB(n, ids_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteQueriesARB"/>
-            public static unsafe void DeleteQueriesARB(int n, in QueryHandle ids)
+            public static unsafe void DeleteQueriesARB(int n, in int ids)
             {
-                fixed (QueryHandle* ids_ptr = &ids)
+                fixed (int* ids_ptr = &ids)
                 {
                     DeleteQueriesARB(n, ids_ptr);
                 }
@@ -16502,7 +16502,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetQueryObjectivARB"/>
-            public static unsafe void GetQueryObjectivARB(QueryHandle id, QueryObjectParameterName pname, Span<int> parameters)
+            public static unsafe void GetQueryObjectivARB(int id, QueryObjectParameterName pname, Span<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -16510,7 +16510,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetQueryObjectivARB"/>
-            public static unsafe void GetQueryObjectivARB(QueryHandle id, QueryObjectParameterName pname, int[] parameters)
+            public static unsafe void GetQueryObjectivARB(int id, QueryObjectParameterName pname, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -16518,7 +16518,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetQueryObjectivARB"/>
-            public static unsafe void GetQueryObjectivARB(QueryHandle id, QueryObjectParameterName pname, ref int parameters)
+            public static unsafe void GetQueryObjectivARB(int id, QueryObjectParameterName pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -16526,7 +16526,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetQueryObjectuivARB"/>
-            public static unsafe void GetQueryObjectuivARB(QueryHandle id, QueryObjectParameterName pname, Span<uint> parameters)
+            public static unsafe void GetQueryObjectuivARB(int id, QueryObjectParameterName pname, Span<uint> parameters)
             {
                 fixed (uint* parameters_ptr = parameters)
                 {
@@ -16534,7 +16534,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetQueryObjectuivARB"/>
-            public static unsafe void GetQueryObjectuivARB(QueryHandle id, QueryObjectParameterName pname, uint[] parameters)
+            public static unsafe void GetQueryObjectuivARB(int id, QueryObjectParameterName pname, uint[] parameters)
             {
                 fixed (uint* parameters_ptr = parameters)
                 {
@@ -16542,7 +16542,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetQueryObjectuivARB"/>
-            public static unsafe void GetQueryObjectuivARB(QueryHandle id, QueryObjectParameterName pname, ref uint parameters)
+            public static unsafe void GetQueryObjectuivARB(int id, QueryObjectParameterName pname, ref uint parameters)
             {
                 fixed (uint* parameters_ptr = &parameters)
                 {
@@ -16574,7 +16574,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetProgramInterfaceiv"/>
-            public static unsafe void GetProgramInterfacei(ProgramHandle program, ProgramInterface programInterface, ProgramInterfacePName pname, Span<int> parameters)
+            public static unsafe void GetProgramInterfacei(int program, ProgramInterface programInterface, ProgramInterfacePName pname, Span<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -16582,7 +16582,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetProgramInterfaceiv"/>
-            public static unsafe void GetProgramInterfacei(ProgramHandle program, ProgramInterface programInterface, ProgramInterfacePName pname, int[] parameters)
+            public static unsafe void GetProgramInterfacei(int program, ProgramInterface programInterface, ProgramInterfacePName pname, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -16590,7 +16590,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetProgramInterfaceiv"/>
-            public static unsafe void GetProgramInterfacei(ProgramHandle program, ProgramInterface programInterface, ProgramInterfacePName pname, ref int parameters)
+            public static unsafe void GetProgramInterfacei(int program, ProgramInterface programInterface, ProgramInterfacePName pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -16598,7 +16598,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetProgramResourceIndex"/>
-            public static unsafe uint GetProgramResourceIndex(ProgramHandle program, ProgramInterface programInterface, string name)
+            public static unsafe uint GetProgramResourceIndex(int program, ProgramInterface programInterface, string name)
             {
                 uint returnValue;
                 byte* name_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(name);
@@ -16607,7 +16607,7 @@ namespace OpenTK.Graphics.OpenGL
                 return returnValue;
             }
             /// <inheritdoc cref="GetProgramResourceName"/>
-            public static unsafe string GetProgramResourceName(ProgramHandle program, ProgramInterface programInterface, uint index, int bufSize, Span<int> length)
+            public static unsafe string GetProgramResourceName(int program, ProgramInterface programInterface, uint index, int bufSize, Span<int> length)
             {
                 string name;
                 fixed (int* length_ptr = length)
@@ -16620,7 +16620,7 @@ namespace OpenTK.Graphics.OpenGL
                 return name;
             }
             /// <inheritdoc cref="GetProgramResourceName"/>
-            public static unsafe void GetProgramResourceName(ProgramHandle program, ProgramInterface programInterface, uint index, int bufSize, Span<int> length, out string name)
+            public static unsafe void GetProgramResourceName(int program, ProgramInterface programInterface, uint index, int bufSize, Span<int> length, out string name)
             {
                 fixed (int* length_ptr = length)
                 {
@@ -16631,7 +16631,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetProgramResourceName"/>
-            public static unsafe string GetProgramResourceName(ProgramHandle program, ProgramInterface programInterface, uint index, int bufSize, int[] length)
+            public static unsafe string GetProgramResourceName(int program, ProgramInterface programInterface, uint index, int bufSize, int[] length)
             {
                 string name;
                 fixed (int* length_ptr = length)
@@ -16644,7 +16644,7 @@ namespace OpenTK.Graphics.OpenGL
                 return name;
             }
             /// <inheritdoc cref="GetProgramResourceName"/>
-            public static unsafe void GetProgramResourceName(ProgramHandle program, ProgramInterface programInterface, uint index, int bufSize, int[] length, out string name)
+            public static unsafe void GetProgramResourceName(int program, ProgramInterface programInterface, uint index, int bufSize, int[] length, out string name)
             {
                 fixed (int* length_ptr = length)
                 {
@@ -16655,7 +16655,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetProgramResourceName"/>
-            public static unsafe string GetProgramResourceName(ProgramHandle program, ProgramInterface programInterface, uint index, int bufSize, ref int length)
+            public static unsafe string GetProgramResourceName(int program, ProgramInterface programInterface, uint index, int bufSize, ref int length)
             {
                 string name;
                 fixed (int* length_ptr = &length)
@@ -16668,7 +16668,7 @@ namespace OpenTK.Graphics.OpenGL
                 return name;
             }
             /// <inheritdoc cref="GetProgramResourceName"/>
-            public static unsafe void GetProgramResourceName(ProgramHandle program, ProgramInterface programInterface, uint index, int bufSize, ref int length, out string name)
+            public static unsafe void GetProgramResourceName(int program, ProgramInterface programInterface, uint index, int bufSize, ref int length, out string name)
             {
                 fixed (int* length_ptr = &length)
                 {
@@ -16679,7 +16679,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetProgramResourceiv"/>
-            public static unsafe void GetProgramResourcei(ProgramHandle program, ProgramInterface programInterface, uint index, ReadOnlySpan<ProgramResourceProperty> props, Span<int> length, Span<int> parameters)
+            public static unsafe void GetProgramResourcei(int program, ProgramInterface programInterface, uint index, ReadOnlySpan<ProgramResourceProperty> props, Span<int> length, Span<int> parameters)
             {
                 int propCount = (int)(props.Length);
                 fixed (ProgramResourceProperty* props_ptr = props)
@@ -16695,7 +16695,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetProgramResourceiv"/>
-            public static unsafe void GetProgramResourcei(ProgramHandle program, ProgramInterface programInterface, uint index, ProgramResourceProperty[] props, int[] length, int[] parameters)
+            public static unsafe void GetProgramResourcei(int program, ProgramInterface programInterface, uint index, ProgramResourceProperty[] props, int[] length, int[] parameters)
             {
                 int propCount = (int)(props.Length);
                 fixed (ProgramResourceProperty* props_ptr = props)
@@ -16711,7 +16711,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetProgramResourceiv"/>
-            public static unsafe void GetProgramResourcei(ProgramHandle program, ProgramInterface programInterface, uint index, int propCount, in ProgramResourceProperty props, int count, ref int length, ref int parameters)
+            public static unsafe void GetProgramResourcei(int program, ProgramInterface programInterface, uint index, int propCount, in ProgramResourceProperty props, int count, ref int length, ref int parameters)
             {
                 fixed (ProgramResourceProperty* props_ptr = &props)
                 fixed (int* length_ptr = &length)
@@ -16721,7 +16721,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetProgramResourceLocation"/>
-            public static unsafe int GetProgramResourceLocation(ProgramHandle program, ProgramInterface programInterface, string name)
+            public static unsafe int GetProgramResourceLocation(int program, ProgramInterface programInterface, string name)
             {
                 int returnValue;
                 byte* name_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(name);
@@ -16730,7 +16730,7 @@ namespace OpenTK.Graphics.OpenGL
                 return returnValue;
             }
             /// <inheritdoc cref="GetProgramResourceLocationIndex"/>
-            public static unsafe int GetProgramResourceLocationIndex(ProgramHandle program, ProgramInterface programInterface, string name)
+            public static unsafe int GetProgramResourceLocationIndex(int program, ProgramInterface programInterface, string name)
             {
                 int returnValue;
                 byte* name_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(name);
@@ -16844,7 +16844,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetnUniformfvARB"/>
-            public static unsafe void GetnUniformfvARB(ProgramHandle program, int location, Span<float> parameters)
+            public static unsafe void GetnUniformfvARB(int program, int location, Span<float> parameters)
             {
                 int bufSize = (int)(parameters.Length * 4);
                 fixed (float* parameters_ptr = parameters)
@@ -16853,7 +16853,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetnUniformfvARB"/>
-            public static unsafe void GetnUniformfvARB(ProgramHandle program, int location, float[] parameters)
+            public static unsafe void GetnUniformfvARB(int program, int location, float[] parameters)
             {
                 int bufSize = (int)(parameters.Length * 4);
                 fixed (float* parameters_ptr = parameters)
@@ -16862,7 +16862,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetnUniformfvARB"/>
-            public static unsafe void GetnUniformfvARB(ProgramHandle program, int location, int bufSize, ref float parameters)
+            public static unsafe void GetnUniformfvARB(int program, int location, int bufSize, ref float parameters)
             {
                 fixed (float* parameters_ptr = &parameters)
                 {
@@ -16870,7 +16870,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetnUniformivARB"/>
-            public static unsafe void GetnUniformivARB(ProgramHandle program, int location, Span<int> parameters)
+            public static unsafe void GetnUniformivARB(int program, int location, Span<int> parameters)
             {
                 int bufSize = (int)(parameters.Length * 4);
                 fixed (int* parameters_ptr = parameters)
@@ -16879,7 +16879,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetnUniformivARB"/>
-            public static unsafe void GetnUniformivARB(ProgramHandle program, int location, int[] parameters)
+            public static unsafe void GetnUniformivARB(int program, int location, int[] parameters)
             {
                 int bufSize = (int)(parameters.Length * 4);
                 fixed (int* parameters_ptr = parameters)
@@ -16888,7 +16888,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetnUniformivARB"/>
-            public static unsafe void GetnUniformivARB(ProgramHandle program, int location, int bufSize, ref int parameters)
+            public static unsafe void GetnUniformivARB(int program, int location, int bufSize, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -16896,7 +16896,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetnUniformuivARB"/>
-            public static unsafe void GetnUniformuivARB(ProgramHandle program, int location, Span<uint> parameters)
+            public static unsafe void GetnUniformuivARB(int program, int location, Span<uint> parameters)
             {
                 int bufSize = (int)(parameters.Length * 4);
                 fixed (uint* parameters_ptr = parameters)
@@ -16905,7 +16905,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetnUniformuivARB"/>
-            public static unsafe void GetnUniformuivARB(ProgramHandle program, int location, uint[] parameters)
+            public static unsafe void GetnUniformuivARB(int program, int location, uint[] parameters)
             {
                 int bufSize = (int)(parameters.Length * 4);
                 fixed (uint* parameters_ptr = parameters)
@@ -16914,7 +16914,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetnUniformuivARB"/>
-            public static unsafe void GetnUniformuivARB(ProgramHandle program, int location, int bufSize, ref uint parameters)
+            public static unsafe void GetnUniformuivARB(int program, int location, int bufSize, ref uint parameters)
             {
                 fixed (uint* parameters_ptr = &parameters)
                 {
@@ -16922,7 +16922,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetnUniformdvARB"/>
-            public static unsafe void GetnUniformdvARB(ProgramHandle program, int location, Span<double> parameters)
+            public static unsafe void GetnUniformdvARB(int program, int location, Span<double> parameters)
             {
                 int bufSize = (int)(parameters.Length * 8);
                 fixed (double* parameters_ptr = parameters)
@@ -16931,7 +16931,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetnUniformdvARB"/>
-            public static unsafe void GetnUniformdvARB(ProgramHandle program, int location, double[] parameters)
+            public static unsafe void GetnUniformdvARB(int program, int location, double[] parameters)
             {
                 int bufSize = (int)(parameters.Length * 8);
                 fixed (double* parameters_ptr = parameters)
@@ -16940,7 +16940,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetnUniformdvARB"/>
-            public static unsafe void GetnUniformdvARB(ProgramHandle program, int location, int bufSize, ref double parameters)
+            public static unsafe void GetnUniformdvARB(int program, int location, int bufSize, ref double parameters)
             {
                 fixed (double* parameters_ptr = &parameters)
                 {
@@ -16956,7 +16956,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="NamedFramebufferSampleLocationsfvARB"/>
-            public static unsafe void NamedFramebufferSampleLocationsfvARB(FramebufferHandle framebuffer, uint start, int count, in float v)
+            public static unsafe void NamedFramebufferSampleLocationsfvARB(int framebuffer, uint start, int count, in float v)
             {
                 fixed (float* v_ptr = &v)
                 {
@@ -16964,9 +16964,9 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GenSamplers"/>
-            public static unsafe SamplerHandle GenSampler()
+            public static unsafe int GenSampler()
             {
-                SamplerHandle sampler;
+                int sampler;
                 int count = 1;
                 Unsafe.SkipInit(out sampler);
                 // FIXME: This could be a problem for the overloads that take an out parameter
@@ -16977,12 +16977,12 @@ namespace OpenTK.Graphics.OpenGL
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                SamplerHandle* samplers_handle = (SamplerHandle*)Unsafe.AsPointer(ref sampler);
+                int* samplers_handle = (int*)Unsafe.AsPointer(ref sampler);
                 GenSamplers(count, samplers_handle);
                 return sampler;
             }
             /// <inheritdoc cref="GenSamplers"/>
-            public static unsafe void GenSampler(out SamplerHandle sampler)
+            public static unsafe void GenSampler(out int sampler)
             {
                 int count = 1;
                 Unsafe.SkipInit(out sampler);
@@ -16994,72 +16994,72 @@ namespace OpenTK.Graphics.OpenGL
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                SamplerHandle* samplers_handle = (SamplerHandle*)Unsafe.AsPointer(ref sampler);
+                int* samplers_handle = (int*)Unsafe.AsPointer(ref sampler);
                 GenSamplers(count, samplers_handle);
             }
             /// <inheritdoc cref="GenSamplers"/>
-            public static unsafe void GenSamplers(Span<SamplerHandle> samplers)
+            public static unsafe void GenSamplers(Span<int> samplers)
             {
                 int count = (int)(samplers.Length);
-                fixed (SamplerHandle* samplers_ptr = samplers)
+                fixed (int* samplers_ptr = samplers)
                 {
                     GenSamplers(count, samplers_ptr);
                 }
             }
             /// <inheritdoc cref="GenSamplers"/>
-            public static unsafe void GenSamplers(SamplerHandle[] samplers)
+            public static unsafe void GenSamplers(int[] samplers)
             {
                 int count = (int)(samplers.Length);
-                fixed (SamplerHandle* samplers_ptr = samplers)
+                fixed (int* samplers_ptr = samplers)
                 {
                     GenSamplers(count, samplers_ptr);
                 }
             }
             /// <inheritdoc cref="GenSamplers"/>
-            public static unsafe void GenSamplers(int count, ref SamplerHandle samplers)
+            public static unsafe void GenSamplers(int count, ref int samplers)
             {
-                fixed (SamplerHandle* samplers_ptr = &samplers)
+                fixed (int* samplers_ptr = &samplers)
                 {
                     GenSamplers(count, samplers_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteSamplers"/>
-            public static unsafe void DeleteSampler(in SamplerHandle sampler)
+            public static unsafe void DeleteSampler(in int sampler)
             {
                 int count = 1;
-                fixed(SamplerHandle* samplers_handle = &sampler)
+                fixed(int* samplers_handle = &sampler)
                 {
                     DeleteSamplers(count, samplers_handle);
                 }
             }
             /// <inheritdoc cref="DeleteSamplers"/>
-            public static unsafe void DeleteSamplers(ReadOnlySpan<SamplerHandle> samplers)
+            public static unsafe void DeleteSamplers(ReadOnlySpan<int> samplers)
             {
                 int count = (int)(samplers.Length);
-                fixed (SamplerHandle* samplers_ptr = samplers)
+                fixed (int* samplers_ptr = samplers)
                 {
                     DeleteSamplers(count, samplers_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteSamplers"/>
-            public static unsafe void DeleteSamplers(SamplerHandle[] samplers)
+            public static unsafe void DeleteSamplers(int[] samplers)
             {
                 int count = (int)(samplers.Length);
-                fixed (SamplerHandle* samplers_ptr = samplers)
+                fixed (int* samplers_ptr = samplers)
                 {
                     DeleteSamplers(count, samplers_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteSamplers"/>
-            public static unsafe void DeleteSamplers(int count, in SamplerHandle samplers)
+            public static unsafe void DeleteSamplers(int count, in int samplers)
             {
-                fixed (SamplerHandle* samplers_ptr = &samplers)
+                fixed (int* samplers_ptr = &samplers)
                 {
                     DeleteSamplers(count, samplers_ptr);
                 }
             }
             /// <inheritdoc cref="SamplerParameteriv"/>
-            public static unsafe void SamplerParameteri(SamplerHandle sampler, SamplerParameterI pname, ReadOnlySpan<int> param)
+            public static unsafe void SamplerParameteri(int sampler, SamplerParameterI pname, ReadOnlySpan<int> param)
             {
                 fixed (int* param_ptr = param)
                 {
@@ -17067,7 +17067,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="SamplerParameteriv"/>
-            public static unsafe void SamplerParameteri(SamplerHandle sampler, SamplerParameterI pname, int[] param)
+            public static unsafe void SamplerParameteri(int sampler, SamplerParameterI pname, int[] param)
             {
                 fixed (int* param_ptr = param)
                 {
@@ -17075,7 +17075,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="SamplerParameteriv"/>
-            public static unsafe void SamplerParameteri(SamplerHandle sampler, SamplerParameterI pname, in int param)
+            public static unsafe void SamplerParameteri(int sampler, SamplerParameterI pname, in int param)
             {
                 fixed (int* param_ptr = &param)
                 {
@@ -17083,7 +17083,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="SamplerParameterfv"/>
-            public static unsafe void SamplerParameterf(SamplerHandle sampler, SamplerParameterF pname, ReadOnlySpan<float> param)
+            public static unsafe void SamplerParameterf(int sampler, SamplerParameterF pname, ReadOnlySpan<float> param)
             {
                 fixed (float* param_ptr = param)
                 {
@@ -17091,7 +17091,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="SamplerParameterfv"/>
-            public static unsafe void SamplerParameterf(SamplerHandle sampler, SamplerParameterF pname, float[] param)
+            public static unsafe void SamplerParameterf(int sampler, SamplerParameterF pname, float[] param)
             {
                 fixed (float* param_ptr = param)
                 {
@@ -17099,7 +17099,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="SamplerParameterfv"/>
-            public static unsafe void SamplerParameterf(SamplerHandle sampler, SamplerParameterF pname, in float param)
+            public static unsafe void SamplerParameterf(int sampler, SamplerParameterF pname, in float param)
             {
                 fixed (float* param_ptr = &param)
                 {
@@ -17107,7 +17107,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="SamplerParameterIiv"/>
-            public static unsafe void SamplerParameterIi(SamplerHandle sampler, SamplerParameterI pname, ReadOnlySpan<int> param)
+            public static unsafe void SamplerParameterIi(int sampler, SamplerParameterI pname, ReadOnlySpan<int> param)
             {
                 fixed (int* param_ptr = param)
                 {
@@ -17115,7 +17115,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="SamplerParameterIiv"/>
-            public static unsafe void SamplerParameterIi(SamplerHandle sampler, SamplerParameterI pname, int[] param)
+            public static unsafe void SamplerParameterIi(int sampler, SamplerParameterI pname, int[] param)
             {
                 fixed (int* param_ptr = param)
                 {
@@ -17123,7 +17123,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="SamplerParameterIiv"/>
-            public static unsafe void SamplerParameterIi(SamplerHandle sampler, SamplerParameterI pname, in int param)
+            public static unsafe void SamplerParameterIi(int sampler, SamplerParameterI pname, in int param)
             {
                 fixed (int* param_ptr = &param)
                 {
@@ -17131,7 +17131,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="SamplerParameterIuiv"/>
-            public static unsafe void SamplerParameterIui(SamplerHandle sampler, SamplerParameterI pname, ReadOnlySpan<uint> param)
+            public static unsafe void SamplerParameterIui(int sampler, SamplerParameterI pname, ReadOnlySpan<uint> param)
             {
                 fixed (uint* param_ptr = param)
                 {
@@ -17139,7 +17139,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="SamplerParameterIuiv"/>
-            public static unsafe void SamplerParameterIui(SamplerHandle sampler, SamplerParameterI pname, uint[] param)
+            public static unsafe void SamplerParameterIui(int sampler, SamplerParameterI pname, uint[] param)
             {
                 fixed (uint* param_ptr = param)
                 {
@@ -17147,7 +17147,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="SamplerParameterIuiv"/>
-            public static unsafe void SamplerParameterIui(SamplerHandle sampler, SamplerParameterI pname, in uint param)
+            public static unsafe void SamplerParameterIui(int sampler, SamplerParameterI pname, in uint param)
             {
                 fixed (uint* param_ptr = &param)
                 {
@@ -17155,7 +17155,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetSamplerParameteriv"/>
-            public static unsafe void GetSamplerParameteri(SamplerHandle sampler, SamplerParameterI pname, Span<int> parameters)
+            public static unsafe void GetSamplerParameteri(int sampler, SamplerParameterI pname, Span<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -17163,7 +17163,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetSamplerParameteriv"/>
-            public static unsafe void GetSamplerParameteri(SamplerHandle sampler, SamplerParameterI pname, int[] parameters)
+            public static unsafe void GetSamplerParameteri(int sampler, SamplerParameterI pname, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -17171,7 +17171,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetSamplerParameteriv"/>
-            public static unsafe void GetSamplerParameteri(SamplerHandle sampler, SamplerParameterI pname, ref int parameters)
+            public static unsafe void GetSamplerParameteri(int sampler, SamplerParameterI pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -17179,7 +17179,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetSamplerParameterIiv"/>
-            public static unsafe void GetSamplerParameterIi(SamplerHandle sampler, SamplerParameterI pname, Span<int> parameters)
+            public static unsafe void GetSamplerParameterIi(int sampler, SamplerParameterI pname, Span<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -17187,7 +17187,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetSamplerParameterIiv"/>
-            public static unsafe void GetSamplerParameterIi(SamplerHandle sampler, SamplerParameterI pname, int[] parameters)
+            public static unsafe void GetSamplerParameterIi(int sampler, SamplerParameterI pname, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -17195,7 +17195,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetSamplerParameterIiv"/>
-            public static unsafe void GetSamplerParameterIi(SamplerHandle sampler, SamplerParameterI pname, ref int parameters)
+            public static unsafe void GetSamplerParameterIi(int sampler, SamplerParameterI pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -17203,7 +17203,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetSamplerParameterfv"/>
-            public static unsafe void GetSamplerParameterf(SamplerHandle sampler, SamplerParameterF pname, Span<float> parameters)
+            public static unsafe void GetSamplerParameterf(int sampler, SamplerParameterF pname, Span<float> parameters)
             {
                 fixed (float* parameters_ptr = parameters)
                 {
@@ -17211,7 +17211,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetSamplerParameterfv"/>
-            public static unsafe void GetSamplerParameterf(SamplerHandle sampler, SamplerParameterF pname, float[] parameters)
+            public static unsafe void GetSamplerParameterf(int sampler, SamplerParameterF pname, float[] parameters)
             {
                 fixed (float* parameters_ptr = parameters)
                 {
@@ -17219,7 +17219,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetSamplerParameterfv"/>
-            public static unsafe void GetSamplerParameterf(SamplerHandle sampler, SamplerParameterF pname, ref float parameters)
+            public static unsafe void GetSamplerParameterf(int sampler, SamplerParameterF pname, ref float parameters)
             {
                 fixed (float* parameters_ptr = &parameters)
                 {
@@ -17227,7 +17227,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetSamplerParameterIuiv"/>
-            public static unsafe void GetSamplerParameterIui(SamplerHandle sampler, SamplerParameterI pname, Span<uint> parameters)
+            public static unsafe void GetSamplerParameterIui(int sampler, SamplerParameterI pname, Span<uint> parameters)
             {
                 fixed (uint* parameters_ptr = parameters)
                 {
@@ -17235,7 +17235,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetSamplerParameterIuiv"/>
-            public static unsafe void GetSamplerParameterIui(SamplerHandle sampler, SamplerParameterI pname, uint[] parameters)
+            public static unsafe void GetSamplerParameterIui(int sampler, SamplerParameterI pname, uint[] parameters)
             {
                 fixed (uint* parameters_ptr = parameters)
                 {
@@ -17243,7 +17243,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetSamplerParameterIuiv"/>
-            public static unsafe void GetSamplerParameterIui(SamplerHandle sampler, SamplerParameterI pname, ref uint parameters)
+            public static unsafe void GetSamplerParameterIui(int sampler, SamplerParameterI pname, ref uint parameters)
             {
                 fixed (uint* parameters_ptr = &parameters)
                 {
@@ -17251,51 +17251,51 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="CreateShaderProgramv"/>
-            public static unsafe ProgramHandle CreateShaderProgram(ShaderType type, int count, byte** strings)
+            public static unsafe int CreateShaderProgram(ShaderType type, int count, byte** strings)
             {
-                ProgramHandle returnValue;
+                int returnValue;
                 returnValue = CreateShaderProgramv(type, count, strings);
                 return returnValue;
             }
             /// <inheritdoc cref="DeleteProgramPipelines"/>
-            public static unsafe void DeleteProgramPipeline(in ProgramPipelineHandle pipeline)
+            public static unsafe void DeleteProgramPipeline(in int pipeline)
             {
                 int n = 1;
-                fixed(ProgramPipelineHandle* pipelines_handle = &pipeline)
+                fixed(int* pipelines_handle = &pipeline)
                 {
                     DeleteProgramPipelines(n, pipelines_handle);
                 }
             }
             /// <inheritdoc cref="DeleteProgramPipelines"/>
-            public static unsafe void DeleteProgramPipelines(ReadOnlySpan<ProgramPipelineHandle> pipelines)
+            public static unsafe void DeleteProgramPipelines(ReadOnlySpan<int> pipelines)
             {
                 int n = (int)(pipelines.Length);
-                fixed (ProgramPipelineHandle* pipelines_ptr = pipelines)
+                fixed (int* pipelines_ptr = pipelines)
                 {
                     DeleteProgramPipelines(n, pipelines_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteProgramPipelines"/>
-            public static unsafe void DeleteProgramPipelines(ProgramPipelineHandle[] pipelines)
+            public static unsafe void DeleteProgramPipelines(int[] pipelines)
             {
                 int n = (int)(pipelines.Length);
-                fixed (ProgramPipelineHandle* pipelines_ptr = pipelines)
+                fixed (int* pipelines_ptr = pipelines)
                 {
                     DeleteProgramPipelines(n, pipelines_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteProgramPipelines"/>
-            public static unsafe void DeleteProgramPipelines(int n, in ProgramPipelineHandle pipelines)
+            public static unsafe void DeleteProgramPipelines(int n, in int pipelines)
             {
-                fixed (ProgramPipelineHandle* pipelines_ptr = &pipelines)
+                fixed (int* pipelines_ptr = &pipelines)
                 {
                     DeleteProgramPipelines(n, pipelines_ptr);
                 }
             }
             /// <inheritdoc cref="GenProgramPipelines"/>
-            public static unsafe ProgramPipelineHandle GenProgramPipeline()
+            public static unsafe int GenProgramPipeline()
             {
-                ProgramPipelineHandle pipeline;
+                int pipeline;
                 int n = 1;
                 Unsafe.SkipInit(out pipeline);
                 // FIXME: This could be a problem for the overloads that take an out parameter
@@ -17306,12 +17306,12 @@ namespace OpenTK.Graphics.OpenGL
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                ProgramPipelineHandle* pipelines_handle = (ProgramPipelineHandle*)Unsafe.AsPointer(ref pipeline);
+                int* pipelines_handle = (int*)Unsafe.AsPointer(ref pipeline);
                 GenProgramPipelines(n, pipelines_handle);
                 return pipeline;
             }
             /// <inheritdoc cref="GenProgramPipelines"/>
-            public static unsafe void GenProgramPipeline(out ProgramPipelineHandle pipeline)
+            public static unsafe void GenProgramPipeline(out int pipeline)
             {
                 int n = 1;
                 Unsafe.SkipInit(out pipeline);
@@ -17323,37 +17323,37 @@ namespace OpenTK.Graphics.OpenGL
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                ProgramPipelineHandle* pipelines_handle = (ProgramPipelineHandle*)Unsafe.AsPointer(ref pipeline);
+                int* pipelines_handle = (int*)Unsafe.AsPointer(ref pipeline);
                 GenProgramPipelines(n, pipelines_handle);
             }
             /// <inheritdoc cref="GenProgramPipelines"/>
-            public static unsafe void GenProgramPipelines(Span<ProgramPipelineHandle> pipelines)
+            public static unsafe void GenProgramPipelines(Span<int> pipelines)
             {
                 int n = (int)(pipelines.Length);
-                fixed (ProgramPipelineHandle* pipelines_ptr = pipelines)
+                fixed (int* pipelines_ptr = pipelines)
                 {
                     GenProgramPipelines(n, pipelines_ptr);
                 }
             }
             /// <inheritdoc cref="GenProgramPipelines"/>
-            public static unsafe void GenProgramPipelines(ProgramPipelineHandle[] pipelines)
+            public static unsafe void GenProgramPipelines(int[] pipelines)
             {
                 int n = (int)(pipelines.Length);
-                fixed (ProgramPipelineHandle* pipelines_ptr = pipelines)
+                fixed (int* pipelines_ptr = pipelines)
                 {
                     GenProgramPipelines(n, pipelines_ptr);
                 }
             }
             /// <inheritdoc cref="GenProgramPipelines"/>
-            public static unsafe void GenProgramPipelines(int n, ref ProgramPipelineHandle pipelines)
+            public static unsafe void GenProgramPipelines(int n, ref int pipelines)
             {
-                fixed (ProgramPipelineHandle* pipelines_ptr = &pipelines)
+                fixed (int* pipelines_ptr = &pipelines)
                 {
                     GenProgramPipelines(n, pipelines_ptr);
                 }
             }
             /// <inheritdoc cref="GetProgramPipelineiv"/>
-            public static unsafe void GetProgramPipelinei(ProgramPipelineHandle pipeline, PipelineParameterName pname, Span<int> parameters)
+            public static unsafe void GetProgramPipelinei(int pipeline, PipelineParameterName pname, Span<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -17361,7 +17361,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetProgramPipelineiv"/>
-            public static unsafe void GetProgramPipelinei(ProgramPipelineHandle pipeline, PipelineParameterName pname, int[] parameters)
+            public static unsafe void GetProgramPipelinei(int pipeline, PipelineParameterName pname, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -17369,7 +17369,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetProgramPipelineiv"/>
-            public static unsafe void GetProgramPipelinei(ProgramPipelineHandle pipeline, PipelineParameterName pname, ref int parameters)
+            public static unsafe void GetProgramPipelinei(int pipeline, PipelineParameterName pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -17377,7 +17377,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform1iv"/>
-            public static unsafe void ProgramUniform1iv(ProgramHandle program, int location, ReadOnlySpan<int> value)
+            public static unsafe void ProgramUniform1iv(int program, int location, ReadOnlySpan<int> value)
             {
                 int count = (int)(value.Length);
                 fixed (int* value_ptr = value)
@@ -17386,7 +17386,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform1iv"/>
-            public static unsafe void ProgramUniform1iv(ProgramHandle program, int location, int[] value)
+            public static unsafe void ProgramUniform1iv(int program, int location, int[] value)
             {
                 int count = (int)(value.Length);
                 fixed (int* value_ptr = value)
@@ -17395,7 +17395,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform1iv"/>
-            public static unsafe void ProgramUniform1iv(ProgramHandle program, int location, int count, in int value)
+            public static unsafe void ProgramUniform1iv(int program, int location, int count, in int value)
             {
                 fixed (int* value_ptr = &value)
                 {
@@ -17403,7 +17403,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform1fv"/>
-            public static unsafe void ProgramUniform1fv(ProgramHandle program, int location, ReadOnlySpan<float> value)
+            public static unsafe void ProgramUniform1fv(int program, int location, ReadOnlySpan<float> value)
             {
                 int count = (int)(value.Length);
                 fixed (float* value_ptr = value)
@@ -17412,7 +17412,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform1fv"/>
-            public static unsafe void ProgramUniform1fv(ProgramHandle program, int location, float[] value)
+            public static unsafe void ProgramUniform1fv(int program, int location, float[] value)
             {
                 int count = (int)(value.Length);
                 fixed (float* value_ptr = value)
@@ -17421,7 +17421,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform1fv"/>
-            public static unsafe void ProgramUniform1fv(ProgramHandle program, int location, int count, in float value)
+            public static unsafe void ProgramUniform1fv(int program, int location, int count, in float value)
             {
                 fixed (float* value_ptr = &value)
                 {
@@ -17429,7 +17429,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform1dv"/>
-            public static unsafe void ProgramUniform1dv(ProgramHandle program, int location, ReadOnlySpan<double> value)
+            public static unsafe void ProgramUniform1dv(int program, int location, ReadOnlySpan<double> value)
             {
                 int count = (int)(value.Length);
                 fixed (double* value_ptr = value)
@@ -17438,7 +17438,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform1dv"/>
-            public static unsafe void ProgramUniform1dv(ProgramHandle program, int location, double[] value)
+            public static unsafe void ProgramUniform1dv(int program, int location, double[] value)
             {
                 int count = (int)(value.Length);
                 fixed (double* value_ptr = value)
@@ -17447,7 +17447,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform1dv"/>
-            public static unsafe void ProgramUniform1dv(ProgramHandle program, int location, int count, in double value)
+            public static unsafe void ProgramUniform1dv(int program, int location, int count, in double value)
             {
                 fixed (double* value_ptr = &value)
                 {
@@ -17455,7 +17455,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform1uiv"/>
-            public static unsafe void ProgramUniform1ui(ProgramHandle program, int location, ReadOnlySpan<uint> value)
+            public static unsafe void ProgramUniform1ui(int program, int location, ReadOnlySpan<uint> value)
             {
                 int count = (int)(value.Length);
                 fixed (uint* value_ptr = value)
@@ -17464,7 +17464,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform1uiv"/>
-            public static unsafe void ProgramUniform1ui(ProgramHandle program, int location, uint[] value)
+            public static unsafe void ProgramUniform1ui(int program, int location, uint[] value)
             {
                 int count = (int)(value.Length);
                 fixed (uint* value_ptr = value)
@@ -17473,7 +17473,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform1uiv"/>
-            public static unsafe void ProgramUniform1ui(ProgramHandle program, int location, int count, in uint value)
+            public static unsafe void ProgramUniform1ui(int program, int location, int count, in uint value)
             {
                 fixed (uint* value_ptr = &value)
                 {
@@ -17481,7 +17481,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform2iv"/>
-            public static unsafe void ProgramUniform2i(ProgramHandle program, int location, int count, in Vector2i value)
+            public static unsafe void ProgramUniform2i(int program, int location, int count, in Vector2i value)
             {
                 fixed (Vector2i* tmp_vecPtr = &value)
                 {
@@ -17490,7 +17490,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform2iv"/>
-            public static unsafe void ProgramUniform2i(ProgramHandle program, int location, int count, ReadOnlySpan<Vector2i> value)
+            public static unsafe void ProgramUniform2i(int program, int location, int count, ReadOnlySpan<Vector2i> value)
             {
                 fixed (Vector2i* tmp_vecPtr = value)
                 {
@@ -17499,7 +17499,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform2iv"/>
-            public static unsafe void ProgramUniform2i(ProgramHandle program, int location, int count, Vector2i[] value)
+            public static unsafe void ProgramUniform2i(int program, int location, int count, Vector2i[] value)
             {
                 fixed (Vector2i* tmp_vecPtr = value)
                 {
@@ -17508,7 +17508,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform2fv"/>
-            public static unsafe void ProgramUniform2f(ProgramHandle program, int location, int count, in Vector2 value)
+            public static unsafe void ProgramUniform2f(int program, int location, int count, in Vector2 value)
             {
                 fixed (Vector2* tmp_vecPtr = &value)
                 {
@@ -17517,7 +17517,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform2fv"/>
-            public static unsafe void ProgramUniform2f(ProgramHandle program, int location, int count, ReadOnlySpan<Vector2> value)
+            public static unsafe void ProgramUniform2f(int program, int location, int count, ReadOnlySpan<Vector2> value)
             {
                 fixed (Vector2* tmp_vecPtr = value)
                 {
@@ -17526,7 +17526,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform2fv"/>
-            public static unsafe void ProgramUniform2f(ProgramHandle program, int location, int count, Vector2[] value)
+            public static unsafe void ProgramUniform2f(int program, int location, int count, Vector2[] value)
             {
                 fixed (Vector2* tmp_vecPtr = value)
                 {
@@ -17535,7 +17535,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform2fv"/>
-            public static unsafe void ProgramUniform2f(ProgramHandle program, int location, int count, in System.Numerics.Vector2 value)
+            public static unsafe void ProgramUniform2f(int program, int location, int count, in System.Numerics.Vector2 value)
             {
                 fixed (System.Numerics.Vector2* tmp_vecPtr = &value)
                 {
@@ -17544,7 +17544,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform2fv"/>
-            public static unsafe void ProgramUniform2f(ProgramHandle program, int location, int count, ReadOnlySpan<System.Numerics.Vector2> value)
+            public static unsafe void ProgramUniform2f(int program, int location, int count, ReadOnlySpan<System.Numerics.Vector2> value)
             {
                 fixed (System.Numerics.Vector2* tmp_vecPtr = value)
                 {
@@ -17553,7 +17553,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform2fv"/>
-            public static unsafe void ProgramUniform2f(ProgramHandle program, int location, int count, System.Numerics.Vector2[] value)
+            public static unsafe void ProgramUniform2f(int program, int location, int count, System.Numerics.Vector2[] value)
             {
                 fixed (System.Numerics.Vector2* tmp_vecPtr = value)
                 {
@@ -17562,7 +17562,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform2dv"/>
-            public static unsafe void ProgramUniform2d(ProgramHandle program, int location, int count, in Vector2d value)
+            public static unsafe void ProgramUniform2d(int program, int location, int count, in Vector2d value)
             {
                 fixed (Vector2d* tmp_vecPtr = &value)
                 {
@@ -17571,7 +17571,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform2dv"/>
-            public static unsafe void ProgramUniform2d(ProgramHandle program, int location, int count, ReadOnlySpan<Vector2d> value)
+            public static unsafe void ProgramUniform2d(int program, int location, int count, ReadOnlySpan<Vector2d> value)
             {
                 fixed (Vector2d* tmp_vecPtr = value)
                 {
@@ -17580,7 +17580,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform2dv"/>
-            public static unsafe void ProgramUniform2d(ProgramHandle program, int location, int count, Vector2d[] value)
+            public static unsafe void ProgramUniform2d(int program, int location, int count, Vector2d[] value)
             {
                 fixed (Vector2d* tmp_vecPtr = value)
                 {
@@ -17589,7 +17589,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform2uiv"/>
-            public static unsafe void ProgramUniform2ui(ProgramHandle program, int location, ReadOnlySpan<uint> value)
+            public static unsafe void ProgramUniform2ui(int program, int location, ReadOnlySpan<uint> value)
             {
                 int count = (int)(value.Length / 2);
                 fixed (uint* value_ptr = value)
@@ -17598,7 +17598,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform2uiv"/>
-            public static unsafe void ProgramUniform2ui(ProgramHandle program, int location, uint[] value)
+            public static unsafe void ProgramUniform2ui(int program, int location, uint[] value)
             {
                 int count = (int)(value.Length / 2);
                 fixed (uint* value_ptr = value)
@@ -17607,7 +17607,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform2uiv"/>
-            public static unsafe void ProgramUniform2ui(ProgramHandle program, int location, int count, in uint value)
+            public static unsafe void ProgramUniform2ui(int program, int location, int count, in uint value)
             {
                 fixed (uint* value_ptr = &value)
                 {
@@ -17615,7 +17615,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform3iv"/>
-            public static unsafe void ProgramUniform3i(ProgramHandle program, int location, int count, in Vector3i value)
+            public static unsafe void ProgramUniform3i(int program, int location, int count, in Vector3i value)
             {
                 fixed (Vector3i* tmp_vecPtr = &value)
                 {
@@ -17624,7 +17624,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform3iv"/>
-            public static unsafe void ProgramUniform3i(ProgramHandle program, int location, int count, ReadOnlySpan<Vector3i> value)
+            public static unsafe void ProgramUniform3i(int program, int location, int count, ReadOnlySpan<Vector3i> value)
             {
                 fixed (Vector3i* tmp_vecPtr = value)
                 {
@@ -17633,7 +17633,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform3iv"/>
-            public static unsafe void ProgramUniform3i(ProgramHandle program, int location, int count, Vector3i[] value)
+            public static unsafe void ProgramUniform3i(int program, int location, int count, Vector3i[] value)
             {
                 fixed (Vector3i* tmp_vecPtr = value)
                 {
@@ -17642,7 +17642,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform3fv"/>
-            public static unsafe void ProgramUniform3f(ProgramHandle program, int location, int count, in Vector3 value)
+            public static unsafe void ProgramUniform3f(int program, int location, int count, in Vector3 value)
             {
                 fixed (Vector3* tmp_vecPtr = &value)
                 {
@@ -17651,7 +17651,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform3fv"/>
-            public static unsafe void ProgramUniform3f(ProgramHandle program, int location, int count, ReadOnlySpan<Vector3> value)
+            public static unsafe void ProgramUniform3f(int program, int location, int count, ReadOnlySpan<Vector3> value)
             {
                 fixed (Vector3* tmp_vecPtr = value)
                 {
@@ -17660,7 +17660,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform3fv"/>
-            public static unsafe void ProgramUniform3f(ProgramHandle program, int location, int count, Vector3[] value)
+            public static unsafe void ProgramUniform3f(int program, int location, int count, Vector3[] value)
             {
                 fixed (Vector3* tmp_vecPtr = value)
                 {
@@ -17669,7 +17669,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform3fv"/>
-            public static unsafe void ProgramUniform3f(ProgramHandle program, int location, int count, in System.Numerics.Vector3 value)
+            public static unsafe void ProgramUniform3f(int program, int location, int count, in System.Numerics.Vector3 value)
             {
                 fixed (System.Numerics.Vector3* tmp_vecPtr = &value)
                 {
@@ -17678,7 +17678,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform3fv"/>
-            public static unsafe void ProgramUniform3f(ProgramHandle program, int location, int count, ReadOnlySpan<System.Numerics.Vector3> value)
+            public static unsafe void ProgramUniform3f(int program, int location, int count, ReadOnlySpan<System.Numerics.Vector3> value)
             {
                 fixed (System.Numerics.Vector3* tmp_vecPtr = value)
                 {
@@ -17687,7 +17687,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform3fv"/>
-            public static unsafe void ProgramUniform3f(ProgramHandle program, int location, int count, System.Numerics.Vector3[] value)
+            public static unsafe void ProgramUniform3f(int program, int location, int count, System.Numerics.Vector3[] value)
             {
                 fixed (System.Numerics.Vector3* tmp_vecPtr = value)
                 {
@@ -17696,7 +17696,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform3dv"/>
-            public static unsafe void ProgramUniform3d(ProgramHandle program, int location, int count, in Vector3d value)
+            public static unsafe void ProgramUniform3d(int program, int location, int count, in Vector3d value)
             {
                 fixed (Vector3d* tmp_vecPtr = &value)
                 {
@@ -17705,7 +17705,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform3dv"/>
-            public static unsafe void ProgramUniform3d(ProgramHandle program, int location, int count, ReadOnlySpan<Vector3d> value)
+            public static unsafe void ProgramUniform3d(int program, int location, int count, ReadOnlySpan<Vector3d> value)
             {
                 fixed (Vector3d* tmp_vecPtr = value)
                 {
@@ -17714,7 +17714,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform3dv"/>
-            public static unsafe void ProgramUniform3d(ProgramHandle program, int location, int count, Vector3d[] value)
+            public static unsafe void ProgramUniform3d(int program, int location, int count, Vector3d[] value)
             {
                 fixed (Vector3d* tmp_vecPtr = value)
                 {
@@ -17723,7 +17723,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform3uiv"/>
-            public static unsafe void ProgramUniform3ui(ProgramHandle program, int location, ReadOnlySpan<uint> value)
+            public static unsafe void ProgramUniform3ui(int program, int location, ReadOnlySpan<uint> value)
             {
                 int count = (int)(value.Length / 3);
                 fixed (uint* value_ptr = value)
@@ -17732,7 +17732,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform3uiv"/>
-            public static unsafe void ProgramUniform3ui(ProgramHandle program, int location, uint[] value)
+            public static unsafe void ProgramUniform3ui(int program, int location, uint[] value)
             {
                 int count = (int)(value.Length / 3);
                 fixed (uint* value_ptr = value)
@@ -17741,7 +17741,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform3uiv"/>
-            public static unsafe void ProgramUniform3ui(ProgramHandle program, int location, int count, in uint value)
+            public static unsafe void ProgramUniform3ui(int program, int location, int count, in uint value)
             {
                 fixed (uint* value_ptr = &value)
                 {
@@ -17749,7 +17749,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform4iv"/>
-            public static unsafe void ProgramUniform4i(ProgramHandle program, int location, int count, in Vector4i value)
+            public static unsafe void ProgramUniform4i(int program, int location, int count, in Vector4i value)
             {
                 fixed (Vector4i* tmp_vecPtr = &value)
                 {
@@ -17758,7 +17758,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform4iv"/>
-            public static unsafe void ProgramUniform4i(ProgramHandle program, int location, int count, ReadOnlySpan<Vector4i> value)
+            public static unsafe void ProgramUniform4i(int program, int location, int count, ReadOnlySpan<Vector4i> value)
             {
                 fixed (Vector4i* tmp_vecPtr = value)
                 {
@@ -17767,7 +17767,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform4iv"/>
-            public static unsafe void ProgramUniform4i(ProgramHandle program, int location, int count, Vector4i[] value)
+            public static unsafe void ProgramUniform4i(int program, int location, int count, Vector4i[] value)
             {
                 fixed (Vector4i* tmp_vecPtr = value)
                 {
@@ -17776,7 +17776,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform4fv"/>
-            public static unsafe void ProgramUniform4f(ProgramHandle program, int location, int count, in Vector4 value)
+            public static unsafe void ProgramUniform4f(int program, int location, int count, in Vector4 value)
             {
                 fixed (Vector4* tmp_vecPtr = &value)
                 {
@@ -17785,7 +17785,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform4fv"/>
-            public static unsafe void ProgramUniform4f(ProgramHandle program, int location, int count, ReadOnlySpan<Vector4> value)
+            public static unsafe void ProgramUniform4f(int program, int location, int count, ReadOnlySpan<Vector4> value)
             {
                 fixed (Vector4* tmp_vecPtr = value)
                 {
@@ -17794,7 +17794,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform4fv"/>
-            public static unsafe void ProgramUniform4f(ProgramHandle program, int location, int count, Vector4[] value)
+            public static unsafe void ProgramUniform4f(int program, int location, int count, Vector4[] value)
             {
                 fixed (Vector4* tmp_vecPtr = value)
                 {
@@ -17803,7 +17803,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform4fv"/>
-            public static unsafe void ProgramUniform4f(ProgramHandle program, int location, int count, in System.Numerics.Vector4 value)
+            public static unsafe void ProgramUniform4f(int program, int location, int count, in System.Numerics.Vector4 value)
             {
                 fixed (System.Numerics.Vector4* tmp_vecPtr = &value)
                 {
@@ -17812,7 +17812,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform4fv"/>
-            public static unsafe void ProgramUniform4f(ProgramHandle program, int location, int count, ReadOnlySpan<System.Numerics.Vector4> value)
+            public static unsafe void ProgramUniform4f(int program, int location, int count, ReadOnlySpan<System.Numerics.Vector4> value)
             {
                 fixed (System.Numerics.Vector4* tmp_vecPtr = value)
                 {
@@ -17821,7 +17821,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform4fv"/>
-            public static unsafe void ProgramUniform4f(ProgramHandle program, int location, int count, System.Numerics.Vector4[] value)
+            public static unsafe void ProgramUniform4f(int program, int location, int count, System.Numerics.Vector4[] value)
             {
                 fixed (System.Numerics.Vector4* tmp_vecPtr = value)
                 {
@@ -17830,7 +17830,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform4dv"/>
-            public static unsafe void ProgramUniform4d(ProgramHandle program, int location, int count, in Vector4d value)
+            public static unsafe void ProgramUniform4d(int program, int location, int count, in Vector4d value)
             {
                 fixed (Vector4d* tmp_vecPtr = &value)
                 {
@@ -17839,7 +17839,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform4dv"/>
-            public static unsafe void ProgramUniform4d(ProgramHandle program, int location, int count, ReadOnlySpan<Vector4d> value)
+            public static unsafe void ProgramUniform4d(int program, int location, int count, ReadOnlySpan<Vector4d> value)
             {
                 fixed (Vector4d* tmp_vecPtr = value)
                 {
@@ -17848,7 +17848,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform4dv"/>
-            public static unsafe void ProgramUniform4d(ProgramHandle program, int location, int count, Vector4d[] value)
+            public static unsafe void ProgramUniform4d(int program, int location, int count, Vector4d[] value)
             {
                 fixed (Vector4d* tmp_vecPtr = value)
                 {
@@ -17857,7 +17857,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform4uiv"/>
-            public static unsafe void ProgramUniform4ui(ProgramHandle program, int location, ReadOnlySpan<uint> value)
+            public static unsafe void ProgramUniform4ui(int program, int location, ReadOnlySpan<uint> value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (uint* value_ptr = value)
@@ -17866,7 +17866,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform4uiv"/>
-            public static unsafe void ProgramUniform4ui(ProgramHandle program, int location, uint[] value)
+            public static unsafe void ProgramUniform4ui(int program, int location, uint[] value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (uint* value_ptr = value)
@@ -17875,7 +17875,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform4uiv"/>
-            public static unsafe void ProgramUniform4ui(ProgramHandle program, int location, int count, in uint value)
+            public static unsafe void ProgramUniform4ui(int program, int location, int count, in uint value)
             {
                 fixed (uint* value_ptr = &value)
                 {
@@ -17883,7 +17883,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2fv"/>
-            public static unsafe void ProgramUniformMatrix2f(ProgramHandle program, int location, int count, bool transpose, in Matrix2 value)
+            public static unsafe void ProgramUniformMatrix2f(int program, int location, int count, bool transpose, in Matrix2 value)
             {
                 fixed (Matrix2* tmp_vecPtr = &value)
                 {
@@ -17892,7 +17892,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2fv"/>
-            public static unsafe void ProgramUniformMatrix2f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix2> value)
+            public static unsafe void ProgramUniformMatrix2f(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix2> value)
             {
                 fixed (Matrix2* tmp_vecPtr = value)
                 {
@@ -17901,7 +17901,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2fv"/>
-            public static unsafe void ProgramUniformMatrix2f(ProgramHandle program, int location, int count, bool transpose, Matrix2[] value)
+            public static unsafe void ProgramUniformMatrix2f(int program, int location, int count, bool transpose, Matrix2[] value)
             {
                 fixed (Matrix2* tmp_vecPtr = value)
                 {
@@ -17910,7 +17910,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3fv"/>
-            public static unsafe void ProgramUniformMatrix3f(ProgramHandle program, int location, int count, bool transpose, in Matrix3 value)
+            public static unsafe void ProgramUniformMatrix3f(int program, int location, int count, bool transpose, in Matrix3 value)
             {
                 fixed (Matrix3* tmp_vecPtr = &value)
                 {
@@ -17919,7 +17919,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3fv"/>
-            public static unsafe void ProgramUniformMatrix3f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix3> value)
+            public static unsafe void ProgramUniformMatrix3f(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix3> value)
             {
                 fixed (Matrix3* tmp_vecPtr = value)
                 {
@@ -17928,7 +17928,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3fv"/>
-            public static unsafe void ProgramUniformMatrix3f(ProgramHandle program, int location, int count, bool transpose, Matrix3[] value)
+            public static unsafe void ProgramUniformMatrix3f(int program, int location, int count, bool transpose, Matrix3[] value)
             {
                 fixed (Matrix3* tmp_vecPtr = value)
                 {
@@ -17937,7 +17937,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
-            public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, int count, bool transpose, in Matrix4 value)
+            public static unsafe void ProgramUniformMatrix4f(int program, int location, int count, bool transpose, in Matrix4 value)
             {
                 fixed (Matrix4* tmp_vecPtr = &value)
                 {
@@ -17946,7 +17946,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
-            public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix4> value)
+            public static unsafe void ProgramUniformMatrix4f(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix4> value)
             {
                 fixed (Matrix4* tmp_vecPtr = value)
                 {
@@ -17955,7 +17955,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
-            public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, int count, bool transpose, Matrix4[] value)
+            public static unsafe void ProgramUniformMatrix4f(int program, int location, int count, bool transpose, Matrix4[] value)
             {
                 fixed (Matrix4* tmp_vecPtr = value)
                 {
@@ -17964,7 +17964,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
-            public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, int count, bool transpose, in System.Numerics.Matrix4x4 value)
+            public static unsafe void ProgramUniformMatrix4f(int program, int location, int count, bool transpose, in System.Numerics.Matrix4x4 value)
             {
                 fixed (System.Numerics.Matrix4x4* tmp_vecPtr = &value)
                 {
@@ -17973,7 +17973,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
-            public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<System.Numerics.Matrix4x4> value)
+            public static unsafe void ProgramUniformMatrix4f(int program, int location, int count, bool transpose, ReadOnlySpan<System.Numerics.Matrix4x4> value)
             {
                 fixed (System.Numerics.Matrix4x4* tmp_vecPtr = value)
                 {
@@ -17982,7 +17982,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
-            public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, int count, bool transpose, System.Numerics.Matrix4x4[] value)
+            public static unsafe void ProgramUniformMatrix4f(int program, int location, int count, bool transpose, System.Numerics.Matrix4x4[] value)
             {
                 fixed (System.Numerics.Matrix4x4* tmp_vecPtr = value)
                 {
@@ -17991,7 +17991,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2dv"/>
-            public static unsafe void ProgramUniformMatrix2d(ProgramHandle program, int location, int count, bool transpose, in Matrix2d value)
+            public static unsafe void ProgramUniformMatrix2d(int program, int location, int count, bool transpose, in Matrix2d value)
             {
                 fixed (Matrix2d* tmp_vecPtr = &value)
                 {
@@ -18000,7 +18000,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2dv"/>
-            public static unsafe void ProgramUniformMatrix2d(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix2d> value)
+            public static unsafe void ProgramUniformMatrix2d(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix2d> value)
             {
                 fixed (Matrix2d* tmp_vecPtr = value)
                 {
@@ -18009,7 +18009,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2dv"/>
-            public static unsafe void ProgramUniformMatrix2d(ProgramHandle program, int location, int count, bool transpose, Matrix2d[] value)
+            public static unsafe void ProgramUniformMatrix2d(int program, int location, int count, bool transpose, Matrix2d[] value)
             {
                 fixed (Matrix2d* tmp_vecPtr = value)
                 {
@@ -18018,7 +18018,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3dv"/>
-            public static unsafe void ProgramUniformMatrix3d(ProgramHandle program, int location, int count, bool transpose, in Matrix3d value)
+            public static unsafe void ProgramUniformMatrix3d(int program, int location, int count, bool transpose, in Matrix3d value)
             {
                 fixed (Matrix3d* tmp_vecPtr = &value)
                 {
@@ -18027,7 +18027,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3dv"/>
-            public static unsafe void ProgramUniformMatrix3d(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix3d> value)
+            public static unsafe void ProgramUniformMatrix3d(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix3d> value)
             {
                 fixed (Matrix3d* tmp_vecPtr = value)
                 {
@@ -18036,7 +18036,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3dv"/>
-            public static unsafe void ProgramUniformMatrix3d(ProgramHandle program, int location, int count, bool transpose, Matrix3d[] value)
+            public static unsafe void ProgramUniformMatrix3d(int program, int location, int count, bool transpose, Matrix3d[] value)
             {
                 fixed (Matrix3d* tmp_vecPtr = value)
                 {
@@ -18045,7 +18045,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4dv"/>
-            public static unsafe void ProgramUniformMatrix4d(ProgramHandle program, int location, int count, bool transpose, in Matrix4d value)
+            public static unsafe void ProgramUniformMatrix4d(int program, int location, int count, bool transpose, in Matrix4d value)
             {
                 fixed (Matrix4d* tmp_vecPtr = &value)
                 {
@@ -18054,7 +18054,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4dv"/>
-            public static unsafe void ProgramUniformMatrix4d(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix4d> value)
+            public static unsafe void ProgramUniformMatrix4d(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix4d> value)
             {
                 fixed (Matrix4d* tmp_vecPtr = value)
                 {
@@ -18063,7 +18063,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4dv"/>
-            public static unsafe void ProgramUniformMatrix4d(ProgramHandle program, int location, int count, bool transpose, Matrix4d[] value)
+            public static unsafe void ProgramUniformMatrix4d(int program, int location, int count, bool transpose, Matrix4d[] value)
             {
                 fixed (Matrix4d* tmp_vecPtr = value)
                 {
@@ -18072,7 +18072,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x3fv"/>
-            public static unsafe void ProgramUniformMatrix2x3f(ProgramHandle program, int location, int count, bool transpose, in Matrix2x3 value)
+            public static unsafe void ProgramUniformMatrix2x3f(int program, int location, int count, bool transpose, in Matrix2x3 value)
             {
                 fixed (Matrix2x3* tmp_vecPtr = &value)
                 {
@@ -18081,7 +18081,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x3fv"/>
-            public static unsafe void ProgramUniformMatrix2x3f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix2x3> value)
+            public static unsafe void ProgramUniformMatrix2x3f(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix2x3> value)
             {
                 fixed (Matrix2x3* tmp_vecPtr = value)
                 {
@@ -18090,7 +18090,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x3fv"/>
-            public static unsafe void ProgramUniformMatrix2x3f(ProgramHandle program, int location, int count, bool transpose, Matrix2x3[] value)
+            public static unsafe void ProgramUniformMatrix2x3f(int program, int location, int count, bool transpose, Matrix2x3[] value)
             {
                 fixed (Matrix2x3* tmp_vecPtr = value)
                 {
@@ -18099,7 +18099,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
-            public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, int count, bool transpose, in Matrix3x2 value)
+            public static unsafe void ProgramUniformMatrix3x2f(int program, int location, int count, bool transpose, in Matrix3x2 value)
             {
                 fixed (Matrix3x2* tmp_vecPtr = &value)
                 {
@@ -18108,7 +18108,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
-            public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix3x2> value)
+            public static unsafe void ProgramUniformMatrix3x2f(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix3x2> value)
             {
                 fixed (Matrix3x2* tmp_vecPtr = value)
                 {
@@ -18117,7 +18117,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
-            public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, int count, bool transpose, Matrix3x2[] value)
+            public static unsafe void ProgramUniformMatrix3x2f(int program, int location, int count, bool transpose, Matrix3x2[] value)
             {
                 fixed (Matrix3x2* tmp_vecPtr = value)
                 {
@@ -18126,7 +18126,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
-            public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, int count, bool transpose, in System.Numerics.Matrix3x2 value)
+            public static unsafe void ProgramUniformMatrix3x2f(int program, int location, int count, bool transpose, in System.Numerics.Matrix3x2 value)
             {
                 fixed (System.Numerics.Matrix3x2* tmp_vecPtr = &value)
                 {
@@ -18135,7 +18135,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
-            public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<System.Numerics.Matrix3x2> value)
+            public static unsafe void ProgramUniformMatrix3x2f(int program, int location, int count, bool transpose, ReadOnlySpan<System.Numerics.Matrix3x2> value)
             {
                 fixed (System.Numerics.Matrix3x2* tmp_vecPtr = value)
                 {
@@ -18144,7 +18144,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
-            public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, int count, bool transpose, System.Numerics.Matrix3x2[] value)
+            public static unsafe void ProgramUniformMatrix3x2f(int program, int location, int count, bool transpose, System.Numerics.Matrix3x2[] value)
             {
                 fixed (System.Numerics.Matrix3x2* tmp_vecPtr = value)
                 {
@@ -18153,7 +18153,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x4fv"/>
-            public static unsafe void ProgramUniformMatrix2x4f(ProgramHandle program, int location, int count, bool transpose, in Matrix2x4 value)
+            public static unsafe void ProgramUniformMatrix2x4f(int program, int location, int count, bool transpose, in Matrix2x4 value)
             {
                 fixed (Matrix2x4* tmp_vecPtr = &value)
                 {
@@ -18162,7 +18162,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x4fv"/>
-            public static unsafe void ProgramUniformMatrix2x4f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix2x4> value)
+            public static unsafe void ProgramUniformMatrix2x4f(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix2x4> value)
             {
                 fixed (Matrix2x4* tmp_vecPtr = value)
                 {
@@ -18171,7 +18171,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x4fv"/>
-            public static unsafe void ProgramUniformMatrix2x4f(ProgramHandle program, int location, int count, bool transpose, Matrix2x4[] value)
+            public static unsafe void ProgramUniformMatrix2x4f(int program, int location, int count, bool transpose, Matrix2x4[] value)
             {
                 fixed (Matrix2x4* tmp_vecPtr = value)
                 {
@@ -18180,7 +18180,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x2fv"/>
-            public static unsafe void ProgramUniformMatrix4x2f(ProgramHandle program, int location, int count, bool transpose, in Matrix4x2 value)
+            public static unsafe void ProgramUniformMatrix4x2f(int program, int location, int count, bool transpose, in Matrix4x2 value)
             {
                 fixed (Matrix4x2* tmp_vecPtr = &value)
                 {
@@ -18189,7 +18189,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x2fv"/>
-            public static unsafe void ProgramUniformMatrix4x2f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix4x2> value)
+            public static unsafe void ProgramUniformMatrix4x2f(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix4x2> value)
             {
                 fixed (Matrix4x2* tmp_vecPtr = value)
                 {
@@ -18198,7 +18198,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x2fv"/>
-            public static unsafe void ProgramUniformMatrix4x2f(ProgramHandle program, int location, int count, bool transpose, Matrix4x2[] value)
+            public static unsafe void ProgramUniformMatrix4x2f(int program, int location, int count, bool transpose, Matrix4x2[] value)
             {
                 fixed (Matrix4x2* tmp_vecPtr = value)
                 {
@@ -18207,7 +18207,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x4fv"/>
-            public static unsafe void ProgramUniformMatrix3x4f(ProgramHandle program, int location, int count, bool transpose, in Matrix3x4 value)
+            public static unsafe void ProgramUniformMatrix3x4f(int program, int location, int count, bool transpose, in Matrix3x4 value)
             {
                 fixed (Matrix3x4* tmp_vecPtr = &value)
                 {
@@ -18216,7 +18216,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x4fv"/>
-            public static unsafe void ProgramUniformMatrix3x4f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix3x4> value)
+            public static unsafe void ProgramUniformMatrix3x4f(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix3x4> value)
             {
                 fixed (Matrix3x4* tmp_vecPtr = value)
                 {
@@ -18225,7 +18225,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x4fv"/>
-            public static unsafe void ProgramUniformMatrix3x4f(ProgramHandle program, int location, int count, bool transpose, Matrix3x4[] value)
+            public static unsafe void ProgramUniformMatrix3x4f(int program, int location, int count, bool transpose, Matrix3x4[] value)
             {
                 fixed (Matrix3x4* tmp_vecPtr = value)
                 {
@@ -18234,7 +18234,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x3fv"/>
-            public static unsafe void ProgramUniformMatrix4x3f(ProgramHandle program, int location, int count, bool transpose, in Matrix4x3 value)
+            public static unsafe void ProgramUniformMatrix4x3f(int program, int location, int count, bool transpose, in Matrix4x3 value)
             {
                 fixed (Matrix4x3* tmp_vecPtr = &value)
                 {
@@ -18243,7 +18243,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x3fv"/>
-            public static unsafe void ProgramUniformMatrix4x3f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix4x3> value)
+            public static unsafe void ProgramUniformMatrix4x3f(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix4x3> value)
             {
                 fixed (Matrix4x3* tmp_vecPtr = value)
                 {
@@ -18252,7 +18252,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x3fv"/>
-            public static unsafe void ProgramUniformMatrix4x3f(ProgramHandle program, int location, int count, bool transpose, Matrix4x3[] value)
+            public static unsafe void ProgramUniformMatrix4x3f(int program, int location, int count, bool transpose, Matrix4x3[] value)
             {
                 fixed (Matrix4x3* tmp_vecPtr = value)
                 {
@@ -18261,7 +18261,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x3dv"/>
-            public static unsafe void ProgramUniformMatrix2x3d(ProgramHandle program, int location, int count, bool transpose, in Matrix2x3d value)
+            public static unsafe void ProgramUniformMatrix2x3d(int program, int location, int count, bool transpose, in Matrix2x3d value)
             {
                 fixed (Matrix2x3d* tmp_vecPtr = &value)
                 {
@@ -18270,7 +18270,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x3dv"/>
-            public static unsafe void ProgramUniformMatrix2x3d(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix2x3d> value)
+            public static unsafe void ProgramUniformMatrix2x3d(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix2x3d> value)
             {
                 fixed (Matrix2x3d* tmp_vecPtr = value)
                 {
@@ -18279,7 +18279,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x3dv"/>
-            public static unsafe void ProgramUniformMatrix2x3d(ProgramHandle program, int location, int count, bool transpose, Matrix2x3d[] value)
+            public static unsafe void ProgramUniformMatrix2x3d(int program, int location, int count, bool transpose, Matrix2x3d[] value)
             {
                 fixed (Matrix2x3d* tmp_vecPtr = value)
                 {
@@ -18288,7 +18288,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2dv"/>
-            public static unsafe void ProgramUniformMatrix3x2d(ProgramHandle program, int location, int count, bool transpose, in Matrix3x2d value)
+            public static unsafe void ProgramUniformMatrix3x2d(int program, int location, int count, bool transpose, in Matrix3x2d value)
             {
                 fixed (Matrix3x2d* tmp_vecPtr = &value)
                 {
@@ -18297,7 +18297,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2dv"/>
-            public static unsafe void ProgramUniformMatrix3x2d(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix3x2d> value)
+            public static unsafe void ProgramUniformMatrix3x2d(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix3x2d> value)
             {
                 fixed (Matrix3x2d* tmp_vecPtr = value)
                 {
@@ -18306,7 +18306,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2dv"/>
-            public static unsafe void ProgramUniformMatrix3x2d(ProgramHandle program, int location, int count, bool transpose, Matrix3x2d[] value)
+            public static unsafe void ProgramUniformMatrix3x2d(int program, int location, int count, bool transpose, Matrix3x2d[] value)
             {
                 fixed (Matrix3x2d* tmp_vecPtr = value)
                 {
@@ -18315,7 +18315,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x4dv"/>
-            public static unsafe void ProgramUniformMatrix2x4d(ProgramHandle program, int location, int count, bool transpose, in Matrix2x4d value)
+            public static unsafe void ProgramUniformMatrix2x4d(int program, int location, int count, bool transpose, in Matrix2x4d value)
             {
                 fixed (Matrix2x4d* tmp_vecPtr = &value)
                 {
@@ -18324,7 +18324,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x4dv"/>
-            public static unsafe void ProgramUniformMatrix2x4d(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix2x4d> value)
+            public static unsafe void ProgramUniformMatrix2x4d(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix2x4d> value)
             {
                 fixed (Matrix2x4d* tmp_vecPtr = value)
                 {
@@ -18333,7 +18333,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x4dv"/>
-            public static unsafe void ProgramUniformMatrix2x4d(ProgramHandle program, int location, int count, bool transpose, Matrix2x4d[] value)
+            public static unsafe void ProgramUniformMatrix2x4d(int program, int location, int count, bool transpose, Matrix2x4d[] value)
             {
                 fixed (Matrix2x4d* tmp_vecPtr = value)
                 {
@@ -18342,7 +18342,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x2dv"/>
-            public static unsafe void ProgramUniformMatrix4x2d(ProgramHandle program, int location, int count, bool transpose, in Matrix4x2d value)
+            public static unsafe void ProgramUniformMatrix4x2d(int program, int location, int count, bool transpose, in Matrix4x2d value)
             {
                 fixed (Matrix4x2d* tmp_vecPtr = &value)
                 {
@@ -18351,7 +18351,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x2dv"/>
-            public static unsafe void ProgramUniformMatrix4x2d(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix4x2d> value)
+            public static unsafe void ProgramUniformMatrix4x2d(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix4x2d> value)
             {
                 fixed (Matrix4x2d* tmp_vecPtr = value)
                 {
@@ -18360,7 +18360,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x2dv"/>
-            public static unsafe void ProgramUniformMatrix4x2d(ProgramHandle program, int location, int count, bool transpose, Matrix4x2d[] value)
+            public static unsafe void ProgramUniformMatrix4x2d(int program, int location, int count, bool transpose, Matrix4x2d[] value)
             {
                 fixed (Matrix4x2d* tmp_vecPtr = value)
                 {
@@ -18369,7 +18369,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x4dv"/>
-            public static unsafe void ProgramUniformMatrix3x4d(ProgramHandle program, int location, int count, bool transpose, in Matrix3x4d value)
+            public static unsafe void ProgramUniformMatrix3x4d(int program, int location, int count, bool transpose, in Matrix3x4d value)
             {
                 fixed (Matrix3x4d* tmp_vecPtr = &value)
                 {
@@ -18378,7 +18378,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x4dv"/>
-            public static unsafe void ProgramUniformMatrix3x4d(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix3x4d> value)
+            public static unsafe void ProgramUniformMatrix3x4d(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix3x4d> value)
             {
                 fixed (Matrix3x4d* tmp_vecPtr = value)
                 {
@@ -18387,7 +18387,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x4dv"/>
-            public static unsafe void ProgramUniformMatrix3x4d(ProgramHandle program, int location, int count, bool transpose, Matrix3x4d[] value)
+            public static unsafe void ProgramUniformMatrix3x4d(int program, int location, int count, bool transpose, Matrix3x4d[] value)
             {
                 fixed (Matrix3x4d* tmp_vecPtr = value)
                 {
@@ -18396,7 +18396,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x3dv"/>
-            public static unsafe void ProgramUniformMatrix4x3d(ProgramHandle program, int location, int count, bool transpose, in Matrix4x3d value)
+            public static unsafe void ProgramUniformMatrix4x3d(int program, int location, int count, bool transpose, in Matrix4x3d value)
             {
                 fixed (Matrix4x3d* tmp_vecPtr = &value)
                 {
@@ -18405,7 +18405,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x3dv"/>
-            public static unsafe void ProgramUniformMatrix4x3d(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix4x3d> value)
+            public static unsafe void ProgramUniformMatrix4x3d(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix4x3d> value)
             {
                 fixed (Matrix4x3d* tmp_vecPtr = value)
                 {
@@ -18414,7 +18414,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x3dv"/>
-            public static unsafe void ProgramUniformMatrix4x3d(ProgramHandle program, int location, int count, bool transpose, Matrix4x3d[] value)
+            public static unsafe void ProgramUniformMatrix4x3d(int program, int location, int count, bool transpose, Matrix4x3d[] value)
             {
                 fixed (Matrix4x3d* tmp_vecPtr = value)
                 {
@@ -18423,7 +18423,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetProgramPipelineInfoLog"/>
-            public static unsafe string GetProgramPipelineInfoLog(ProgramPipelineHandle pipeline, int bufSize, Span<int> length)
+            public static unsafe string GetProgramPipelineInfoLog(int pipeline, int bufSize, Span<int> length)
             {
                 string infoLog;
                 fixed (int* length_ptr = length)
@@ -18436,7 +18436,7 @@ namespace OpenTK.Graphics.OpenGL
                 return infoLog;
             }
             /// <inheritdoc cref="GetProgramPipelineInfoLog"/>
-            public static unsafe void GetProgramPipelineInfoLog(ProgramPipelineHandle pipeline, int bufSize, Span<int> length, out string infoLog)
+            public static unsafe void GetProgramPipelineInfoLog(int pipeline, int bufSize, Span<int> length, out string infoLog)
             {
                 fixed (int* length_ptr = length)
                 {
@@ -18447,7 +18447,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetProgramPipelineInfoLog"/>
-            public static unsafe string GetProgramPipelineInfoLog(ProgramPipelineHandle pipeline, int bufSize, int[] length)
+            public static unsafe string GetProgramPipelineInfoLog(int pipeline, int bufSize, int[] length)
             {
                 string infoLog;
                 fixed (int* length_ptr = length)
@@ -18460,7 +18460,7 @@ namespace OpenTK.Graphics.OpenGL
                 return infoLog;
             }
             /// <inheritdoc cref="GetProgramPipelineInfoLog"/>
-            public static unsafe void GetProgramPipelineInfoLog(ProgramPipelineHandle pipeline, int bufSize, int[] length, out string infoLog)
+            public static unsafe void GetProgramPipelineInfoLog(int pipeline, int bufSize, int[] length, out string infoLog)
             {
                 fixed (int* length_ptr = length)
                 {
@@ -18471,7 +18471,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetProgramPipelineInfoLog"/>
-            public static unsafe string GetProgramPipelineInfoLog(ProgramPipelineHandle pipeline, int bufSize, ref int length)
+            public static unsafe string GetProgramPipelineInfoLog(int pipeline, int bufSize, ref int length)
             {
                 string infoLog;
                 fixed (int* length_ptr = &length)
@@ -18484,7 +18484,7 @@ namespace OpenTK.Graphics.OpenGL
                 return infoLog;
             }
             /// <inheritdoc cref="GetProgramPipelineInfoLog"/>
-            public static unsafe void GetProgramPipelineInfoLog(ProgramPipelineHandle pipeline, int bufSize, ref int length, out string infoLog)
+            public static unsafe void GetProgramPipelineInfoLog(int pipeline, int bufSize, ref int length, out string infoLog)
             {
                 fixed (int* length_ptr = &length)
                 {
@@ -18495,7 +18495,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetActiveAtomicCounterBufferiv"/>
-            public static unsafe void GetActiveAtomicCounterBufferi(ProgramHandle program, uint bufferIndex, AtomicCounterBufferPName pname, Span<int> parameters)
+            public static unsafe void GetActiveAtomicCounterBufferi(int program, uint bufferIndex, AtomicCounterBufferPName pname, Span<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -18503,7 +18503,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetActiveAtomicCounterBufferiv"/>
-            public static unsafe void GetActiveAtomicCounterBufferi(ProgramHandle program, uint bufferIndex, AtomicCounterBufferPName pname, int[] parameters)
+            public static unsafe void GetActiveAtomicCounterBufferi(int program, uint bufferIndex, AtomicCounterBufferPName pname, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -18511,7 +18511,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetActiveAtomicCounterBufferiv"/>
-            public static unsafe void GetActiveAtomicCounterBufferi(ProgramHandle program, uint bufferIndex, AtomicCounterBufferPName pname, ref int parameters)
+            public static unsafe void GetActiveAtomicCounterBufferi(int program, uint bufferIndex, AtomicCounterBufferPName pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -19211,7 +19211,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetSubroutineUniformLocation"/>
-            public static unsafe int GetSubroutineUniformLocation(ProgramHandle program, ShaderType shadertype, string name)
+            public static unsafe int GetSubroutineUniformLocation(int program, ShaderType shadertype, string name)
             {
                 int returnValue;
                 byte* name_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(name);
@@ -19220,7 +19220,7 @@ namespace OpenTK.Graphics.OpenGL
                 return returnValue;
             }
             /// <inheritdoc cref="GetSubroutineIndex"/>
-            public static unsafe uint GetSubroutineIndex(ProgramHandle program, ShaderType shadertype, string name)
+            public static unsafe uint GetSubroutineIndex(int program, ShaderType shadertype, string name)
             {
                 uint returnValue;
                 byte* name_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(name);
@@ -19229,7 +19229,7 @@ namespace OpenTK.Graphics.OpenGL
                 return returnValue;
             }
             /// <inheritdoc cref="GetActiveSubroutineUniformiv"/>
-            public static unsafe void GetActiveSubroutineUniformi(ProgramHandle program, ShaderType shadertype, uint index, SubroutineParameterName pname, Span<int> values)
+            public static unsafe void GetActiveSubroutineUniformi(int program, ShaderType shadertype, uint index, SubroutineParameterName pname, Span<int> values)
             {
                 fixed (int* values_ptr = values)
                 {
@@ -19237,7 +19237,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetActiveSubroutineUniformiv"/>
-            public static unsafe void GetActiveSubroutineUniformi(ProgramHandle program, ShaderType shadertype, uint index, SubroutineParameterName pname, int[] values)
+            public static unsafe void GetActiveSubroutineUniformi(int program, ShaderType shadertype, uint index, SubroutineParameterName pname, int[] values)
             {
                 fixed (int* values_ptr = values)
                 {
@@ -19245,7 +19245,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetActiveSubroutineUniformiv"/>
-            public static unsafe void GetActiveSubroutineUniformi(ProgramHandle program, ShaderType shadertype, uint index, SubroutineParameterName pname, ref int values)
+            public static unsafe void GetActiveSubroutineUniformi(int program, ShaderType shadertype, uint index, SubroutineParameterName pname, ref int values)
             {
                 fixed (int* values_ptr = &values)
                 {
@@ -19253,7 +19253,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetActiveSubroutineUniformName"/>
-            public static unsafe string GetActiveSubroutineUniformName(ProgramHandle program, ShaderType shadertype, uint index, int bufSize, Span<int> length)
+            public static unsafe string GetActiveSubroutineUniformName(int program, ShaderType shadertype, uint index, int bufSize, Span<int> length)
             {
                 string name;
                 fixed (int* length_ptr = length)
@@ -19266,7 +19266,7 @@ namespace OpenTK.Graphics.OpenGL
                 return name;
             }
             /// <inheritdoc cref="GetActiveSubroutineUniformName"/>
-            public static unsafe void GetActiveSubroutineUniformName(ProgramHandle program, ShaderType shadertype, uint index, int bufSize, Span<int> length, out string name)
+            public static unsafe void GetActiveSubroutineUniformName(int program, ShaderType shadertype, uint index, int bufSize, Span<int> length, out string name)
             {
                 fixed (int* length_ptr = length)
                 {
@@ -19277,7 +19277,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetActiveSubroutineUniformName"/>
-            public static unsafe string GetActiveSubroutineUniformName(ProgramHandle program, ShaderType shadertype, uint index, int bufSize, int[] length)
+            public static unsafe string GetActiveSubroutineUniformName(int program, ShaderType shadertype, uint index, int bufSize, int[] length)
             {
                 string name;
                 fixed (int* length_ptr = length)
@@ -19290,7 +19290,7 @@ namespace OpenTK.Graphics.OpenGL
                 return name;
             }
             /// <inheritdoc cref="GetActiveSubroutineUniformName"/>
-            public static unsafe void GetActiveSubroutineUniformName(ProgramHandle program, ShaderType shadertype, uint index, int bufSize, int[] length, out string name)
+            public static unsafe void GetActiveSubroutineUniformName(int program, ShaderType shadertype, uint index, int bufSize, int[] length, out string name)
             {
                 fixed (int* length_ptr = length)
                 {
@@ -19301,7 +19301,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetActiveSubroutineUniformName"/>
-            public static unsafe string GetActiveSubroutineUniformName(ProgramHandle program, ShaderType shadertype, uint index, int bufSize, ref int length)
+            public static unsafe string GetActiveSubroutineUniformName(int program, ShaderType shadertype, uint index, int bufSize, ref int length)
             {
                 string name;
                 fixed (int* length_ptr = &length)
@@ -19314,7 +19314,7 @@ namespace OpenTK.Graphics.OpenGL
                 return name;
             }
             /// <inheritdoc cref="GetActiveSubroutineUniformName"/>
-            public static unsafe void GetActiveSubroutineUniformName(ProgramHandle program, ShaderType shadertype, uint index, int bufSize, ref int length, out string name)
+            public static unsafe void GetActiveSubroutineUniformName(int program, ShaderType shadertype, uint index, int bufSize, ref int length, out string name)
             {
                 fixed (int* length_ptr = &length)
                 {
@@ -19325,7 +19325,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetActiveSubroutineName"/>
-            public static unsafe string GetActiveSubroutineName(ProgramHandle program, ShaderType shadertype, uint index, int bufSize, Span<int> length)
+            public static unsafe string GetActiveSubroutineName(int program, ShaderType shadertype, uint index, int bufSize, Span<int> length)
             {
                 string name;
                 fixed (int* length_ptr = length)
@@ -19338,7 +19338,7 @@ namespace OpenTK.Graphics.OpenGL
                 return name;
             }
             /// <inheritdoc cref="GetActiveSubroutineName"/>
-            public static unsafe void GetActiveSubroutineName(ProgramHandle program, ShaderType shadertype, uint index, int bufSize, Span<int> length, out string name)
+            public static unsafe void GetActiveSubroutineName(int program, ShaderType shadertype, uint index, int bufSize, Span<int> length, out string name)
             {
                 fixed (int* length_ptr = length)
                 {
@@ -19349,7 +19349,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetActiveSubroutineName"/>
-            public static unsafe string GetActiveSubroutineName(ProgramHandle program, ShaderType shadertype, uint index, int bufSize, int[] length)
+            public static unsafe string GetActiveSubroutineName(int program, ShaderType shadertype, uint index, int bufSize, int[] length)
             {
                 string name;
                 fixed (int* length_ptr = length)
@@ -19362,7 +19362,7 @@ namespace OpenTK.Graphics.OpenGL
                 return name;
             }
             /// <inheritdoc cref="GetActiveSubroutineName"/>
-            public static unsafe void GetActiveSubroutineName(ProgramHandle program, ShaderType shadertype, uint index, int bufSize, int[] length, out string name)
+            public static unsafe void GetActiveSubroutineName(int program, ShaderType shadertype, uint index, int bufSize, int[] length, out string name)
             {
                 fixed (int* length_ptr = length)
                 {
@@ -19373,7 +19373,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetActiveSubroutineName"/>
-            public static unsafe string GetActiveSubroutineName(ProgramHandle program, ShaderType shadertype, uint index, int bufSize, ref int length)
+            public static unsafe string GetActiveSubroutineName(int program, ShaderType shadertype, uint index, int bufSize, ref int length)
             {
                 string name;
                 fixed (int* length_ptr = &length)
@@ -19386,7 +19386,7 @@ namespace OpenTK.Graphics.OpenGL
                 return name;
             }
             /// <inheritdoc cref="GetActiveSubroutineName"/>
-            public static unsafe void GetActiveSubroutineName(ProgramHandle program, ShaderType shadertype, uint index, int bufSize, ref int length, out string name)
+            public static unsafe void GetActiveSubroutineName(int program, ShaderType shadertype, uint index, int bufSize, ref int length, out string name)
             {
                 fixed (int* length_ptr = &length)
                 {
@@ -19447,7 +19447,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetProgramStageiv"/>
-            public static unsafe void GetProgramStagei(ProgramHandle program, ShaderType shadertype, ProgramStagePName pname, Span<int> values)
+            public static unsafe void GetProgramStagei(int program, ShaderType shadertype, ProgramStagePName pname, Span<int> values)
             {
                 fixed (int* values_ptr = values)
                 {
@@ -19455,7 +19455,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetProgramStageiv"/>
-            public static unsafe void GetProgramStagei(ProgramHandle program, ShaderType shadertype, ProgramStagePName pname, int[] values)
+            public static unsafe void GetProgramStagei(int program, ShaderType shadertype, ProgramStagePName pname, int[] values)
             {
                 fixed (int* values_ptr = values)
                 {
@@ -19463,7 +19463,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetProgramStageiv"/>
-            public static unsafe void GetProgramStagei(ProgramHandle program, ShaderType shadertype, ProgramStagePName pname, ref int values)
+            public static unsafe void GetProgramStagei(int program, ShaderType shadertype, ProgramStagePName pname, ref int values)
             {
                 fixed (int* values_ptr = &values)
                 {
@@ -19487,7 +19487,7 @@ namespace OpenTK.Graphics.OpenGL
                 Marshal.FreeCoTaskMem((IntPtr)name_ptr);
             }
             /// <inheritdoc cref="CompileShaderIncludeARB"/>
-            public static unsafe void CompileShaderIncludeARB(ShaderHandle shader, int count, byte** path, ReadOnlySpan<int> length)
+            public static unsafe void CompileShaderIncludeARB(int shader, int count, byte** path, ReadOnlySpan<int> length)
             {
                 fixed (int* length_ptr = length)
                 {
@@ -19495,7 +19495,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="CompileShaderIncludeARB"/>
-            public static unsafe void CompileShaderIncludeARB(ShaderHandle shader, int count, byte** path, int[] length)
+            public static unsafe void CompileShaderIncludeARB(int shader, int count, byte** path, int[] length)
             {
                 fixed (int* length_ptr = length)
                 {
@@ -19503,7 +19503,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="CompileShaderIncludeARB"/>
-            public static unsafe void CompileShaderIncludeARB(ShaderHandle shader, int count, byte** path, in int length)
+            public static unsafe void CompileShaderIncludeARB(int shader, int count, byte** path, in int length)
             {
                 fixed (int* length_ptr = &length)
                 {
@@ -19982,7 +19982,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetQueryObjecti64v"/>
-            public static unsafe void GetQueryObjecti64(QueryHandle id, QueryObjectParameterName pname, Span<long> parameters)
+            public static unsafe void GetQueryObjecti64(int id, QueryObjectParameterName pname, Span<long> parameters)
             {
                 fixed (long* parameters_ptr = parameters)
                 {
@@ -19990,7 +19990,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetQueryObjecti64v"/>
-            public static unsafe void GetQueryObjecti64(QueryHandle id, QueryObjectParameterName pname, long[] parameters)
+            public static unsafe void GetQueryObjecti64(int id, QueryObjectParameterName pname, long[] parameters)
             {
                 fixed (long* parameters_ptr = parameters)
                 {
@@ -19998,7 +19998,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetQueryObjecti64v"/>
-            public static unsafe void GetQueryObjecti64(QueryHandle id, QueryObjectParameterName pname, ref long parameters)
+            public static unsafe void GetQueryObjecti64(int id, QueryObjectParameterName pname, ref long parameters)
             {
                 fixed (long* parameters_ptr = &parameters)
                 {
@@ -20006,7 +20006,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetQueryObjectui64v"/>
-            public static unsafe void GetQueryObjectui64(QueryHandle id, QueryObjectParameterName pname, Span<ulong> parameters)
+            public static unsafe void GetQueryObjectui64(int id, QueryObjectParameterName pname, Span<ulong> parameters)
             {
                 fixed (ulong* parameters_ptr = parameters)
                 {
@@ -20014,7 +20014,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetQueryObjectui64v"/>
-            public static unsafe void GetQueryObjectui64(QueryHandle id, QueryObjectParameterName pname, ulong[] parameters)
+            public static unsafe void GetQueryObjectui64(int id, QueryObjectParameterName pname, ulong[] parameters)
             {
                 fixed (ulong* parameters_ptr = parameters)
                 {
@@ -20022,7 +20022,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetQueryObjectui64v"/>
-            public static unsafe void GetQueryObjectui64(QueryHandle id, QueryObjectParameterName pname, ref ulong parameters)
+            public static unsafe void GetQueryObjectui64(int id, QueryObjectParameterName pname, ref ulong parameters)
             {
                 fixed (ulong* parameters_ptr = &parameters)
                 {
@@ -20030,44 +20030,44 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="DeleteTransformFeedbacks"/>
-            public static unsafe void DeleteTransformFeedback(in TransformFeedbackHandle id)
+            public static unsafe void DeleteTransformFeedback(in int id)
             {
                 int n = 1;
-                fixed(TransformFeedbackHandle* ids_handle = &id)
+                fixed(int* ids_handle = &id)
                 {
                     DeleteTransformFeedbacks(n, ids_handle);
                 }
             }
             /// <inheritdoc cref="DeleteTransformFeedbacks"/>
-            public static unsafe void DeleteTransformFeedbacks(ReadOnlySpan<TransformFeedbackHandle> ids)
+            public static unsafe void DeleteTransformFeedbacks(ReadOnlySpan<int> ids)
             {
                 int n = (int)(ids.Length);
-                fixed (TransformFeedbackHandle* ids_ptr = ids)
+                fixed (int* ids_ptr = ids)
                 {
                     DeleteTransformFeedbacks(n, ids_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteTransformFeedbacks"/>
-            public static unsafe void DeleteTransformFeedbacks(TransformFeedbackHandle[] ids)
+            public static unsafe void DeleteTransformFeedbacks(int[] ids)
             {
                 int n = (int)(ids.Length);
-                fixed (TransformFeedbackHandle* ids_ptr = ids)
+                fixed (int* ids_ptr = ids)
                 {
                     DeleteTransformFeedbacks(n, ids_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteTransformFeedbacks"/>
-            public static unsafe void DeleteTransformFeedbacks(int n, in TransformFeedbackHandle ids)
+            public static unsafe void DeleteTransformFeedbacks(int n, in int ids)
             {
-                fixed (TransformFeedbackHandle* ids_ptr = &ids)
+                fixed (int* ids_ptr = &ids)
                 {
                     DeleteTransformFeedbacks(n, ids_ptr);
                 }
             }
             /// <inheritdoc cref="GenTransformFeedbacks"/>
-            public static unsafe TransformFeedbackHandle GenTransformFeedback()
+            public static unsafe int GenTransformFeedback()
             {
-                TransformFeedbackHandle id;
+                int id;
                 int n = 1;
                 Unsafe.SkipInit(out id);
                 // FIXME: This could be a problem for the overloads that take an out parameter
@@ -20078,12 +20078,12 @@ namespace OpenTK.Graphics.OpenGL
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                TransformFeedbackHandle* ids_handle = (TransformFeedbackHandle*)Unsafe.AsPointer(ref id);
+                int* ids_handle = (int*)Unsafe.AsPointer(ref id);
                 GenTransformFeedbacks(n, ids_handle);
                 return id;
             }
             /// <inheritdoc cref="GenTransformFeedbacks"/>
-            public static unsafe void GenTransformFeedback(out TransformFeedbackHandle id)
+            public static unsafe void GenTransformFeedback(out int id)
             {
                 int n = 1;
                 Unsafe.SkipInit(out id);
@@ -20095,31 +20095,31 @@ namespace OpenTK.Graphics.OpenGL
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                TransformFeedbackHandle* ids_handle = (TransformFeedbackHandle*)Unsafe.AsPointer(ref id);
+                int* ids_handle = (int*)Unsafe.AsPointer(ref id);
                 GenTransformFeedbacks(n, ids_handle);
             }
             /// <inheritdoc cref="GenTransformFeedbacks"/>
-            public static unsafe void GenTransformFeedbacks(Span<TransformFeedbackHandle> ids)
+            public static unsafe void GenTransformFeedbacks(Span<int> ids)
             {
                 int n = (int)(ids.Length);
-                fixed (TransformFeedbackHandle* ids_ptr = ids)
+                fixed (int* ids_ptr = ids)
                 {
                     GenTransformFeedbacks(n, ids_ptr);
                 }
             }
             /// <inheritdoc cref="GenTransformFeedbacks"/>
-            public static unsafe void GenTransformFeedbacks(TransformFeedbackHandle[] ids)
+            public static unsafe void GenTransformFeedbacks(int[] ids)
             {
                 int n = (int)(ids.Length);
-                fixed (TransformFeedbackHandle* ids_ptr = ids)
+                fixed (int* ids_ptr = ids)
                 {
                     GenTransformFeedbacks(n, ids_ptr);
                 }
             }
             /// <inheritdoc cref="GenTransformFeedbacks"/>
-            public static unsafe void GenTransformFeedbacks(int n, ref TransformFeedbackHandle ids)
+            public static unsafe void GenTransformFeedbacks(int n, ref int ids)
             {
-                fixed (TransformFeedbackHandle* ids_ptr = &ids)
+                fixed (int* ids_ptr = &ids)
                 {
                     GenTransformFeedbacks(n, ids_ptr);
                 }
@@ -20245,7 +20245,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetUniformIndices"/>
-            public static unsafe void GetUniformIndices(ProgramHandle program, int uniformCount, byte** uniformNames, Span<uint> uniformIndices)
+            public static unsafe void GetUniformIndices(int program, int uniformCount, byte** uniformNames, Span<uint> uniformIndices)
             {
                 fixed (uint* uniformIndices_ptr = uniformIndices)
                 {
@@ -20253,7 +20253,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetUniformIndices"/>
-            public static unsafe void GetUniformIndices(ProgramHandle program, int uniformCount, byte** uniformNames, uint[] uniformIndices)
+            public static unsafe void GetUniformIndices(int program, int uniformCount, byte** uniformNames, uint[] uniformIndices)
             {
                 fixed (uint* uniformIndices_ptr = uniformIndices)
                 {
@@ -20261,7 +20261,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetUniformIndices"/>
-            public static unsafe void GetUniformIndices(ProgramHandle program, int uniformCount, byte** uniformNames, ref uint uniformIndices)
+            public static unsafe void GetUniformIndices(int program, int uniformCount, byte** uniformNames, ref uint uniformIndices)
             {
                 fixed (uint* uniformIndices_ptr = &uniformIndices)
                 {
@@ -20269,7 +20269,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetActiveUniformsiv"/>
-            public static unsafe void GetActiveUniformsi(ProgramHandle program, ReadOnlySpan<uint> uniformIndices, UniformPName pname, Span<int> parameters)
+            public static unsafe void GetActiveUniformsi(int program, ReadOnlySpan<uint> uniformIndices, UniformPName pname, Span<int> parameters)
             {
                 int uniformCount = (int)(uniformIndices.Length);
                 fixed (uint* uniformIndices_ptr = uniformIndices)
@@ -20281,7 +20281,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetActiveUniformsiv"/>
-            public static unsafe void GetActiveUniformsi(ProgramHandle program, uint[] uniformIndices, UniformPName pname, int[] parameters)
+            public static unsafe void GetActiveUniformsi(int program, uint[] uniformIndices, UniformPName pname, int[] parameters)
             {
                 int uniformCount = (int)(uniformIndices.Length);
                 fixed (uint* uniformIndices_ptr = uniformIndices)
@@ -20293,7 +20293,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetActiveUniformsiv"/>
-            public static unsafe void GetActiveUniformsi(ProgramHandle program, int uniformCount, in uint uniformIndices, UniformPName pname, ref int parameters)
+            public static unsafe void GetActiveUniformsi(int program, int uniformCount, in uint uniformIndices, UniformPName pname, ref int parameters)
             {
                 fixed (uint* uniformIndices_ptr = &uniformIndices)
                 fixed (int* parameters_ptr = &parameters)
@@ -20302,7 +20302,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetActiveUniformName"/>
-            public static unsafe string GetActiveUniformName(ProgramHandle program, uint uniformIndex, int bufSize, Span<int> length)
+            public static unsafe string GetActiveUniformName(int program, uint uniformIndex, int bufSize, Span<int> length)
             {
                 string uniformName;
                 fixed (int* length_ptr = length)
@@ -20315,7 +20315,7 @@ namespace OpenTK.Graphics.OpenGL
                 return uniformName;
             }
             /// <inheritdoc cref="GetActiveUniformName"/>
-            public static unsafe void GetActiveUniformName(ProgramHandle program, uint uniformIndex, int bufSize, Span<int> length, out string uniformName)
+            public static unsafe void GetActiveUniformName(int program, uint uniformIndex, int bufSize, Span<int> length, out string uniformName)
             {
                 fixed (int* length_ptr = length)
                 {
@@ -20326,7 +20326,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetActiveUniformName"/>
-            public static unsafe string GetActiveUniformName(ProgramHandle program, uint uniformIndex, int bufSize, int[] length)
+            public static unsafe string GetActiveUniformName(int program, uint uniformIndex, int bufSize, int[] length)
             {
                 string uniformName;
                 fixed (int* length_ptr = length)
@@ -20339,7 +20339,7 @@ namespace OpenTK.Graphics.OpenGL
                 return uniformName;
             }
             /// <inheritdoc cref="GetActiveUniformName"/>
-            public static unsafe void GetActiveUniformName(ProgramHandle program, uint uniformIndex, int bufSize, int[] length, out string uniformName)
+            public static unsafe void GetActiveUniformName(int program, uint uniformIndex, int bufSize, int[] length, out string uniformName)
             {
                 fixed (int* length_ptr = length)
                 {
@@ -20350,7 +20350,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetActiveUniformName"/>
-            public static unsafe string GetActiveUniformName(ProgramHandle program, uint uniformIndex, int bufSize, ref int length)
+            public static unsafe string GetActiveUniformName(int program, uint uniformIndex, int bufSize, ref int length)
             {
                 string uniformName;
                 fixed (int* length_ptr = &length)
@@ -20363,7 +20363,7 @@ namespace OpenTK.Graphics.OpenGL
                 return uniformName;
             }
             /// <inheritdoc cref="GetActiveUniformName"/>
-            public static unsafe void GetActiveUniformName(ProgramHandle program, uint uniformIndex, int bufSize, ref int length, out string uniformName)
+            public static unsafe void GetActiveUniformName(int program, uint uniformIndex, int bufSize, ref int length, out string uniformName)
             {
                 fixed (int* length_ptr = &length)
                 {
@@ -20374,7 +20374,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetUniformBlockIndex"/>
-            public static unsafe uint GetUniformBlockIndex(ProgramHandle program, string uniformBlockName)
+            public static unsafe uint GetUniformBlockIndex(int program, string uniformBlockName)
             {
                 uint returnValue;
                 byte* uniformBlockName_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(uniformBlockName);
@@ -20383,7 +20383,7 @@ namespace OpenTK.Graphics.OpenGL
                 return returnValue;
             }
             /// <inheritdoc cref="GetActiveUniformBlockiv"/>
-            public static unsafe void GetActiveUniformBlocki(ProgramHandle program, uint uniformBlockIndex, UniformBlockPName pname, Span<int> parameters)
+            public static unsafe void GetActiveUniformBlocki(int program, uint uniformBlockIndex, UniformBlockPName pname, Span<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -20391,7 +20391,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetActiveUniformBlockiv"/>
-            public static unsafe void GetActiveUniformBlocki(ProgramHandle program, uint uniformBlockIndex, UniformBlockPName pname, int[] parameters)
+            public static unsafe void GetActiveUniformBlocki(int program, uint uniformBlockIndex, UniformBlockPName pname, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -20399,7 +20399,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetActiveUniformBlockiv"/>
-            public static unsafe void GetActiveUniformBlocki(ProgramHandle program, uint uniformBlockIndex, UniformBlockPName pname, ref int parameters)
+            public static unsafe void GetActiveUniformBlocki(int program, uint uniformBlockIndex, UniformBlockPName pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -20407,7 +20407,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetActiveUniformBlockName"/>
-            public static unsafe string GetActiveUniformBlockName(ProgramHandle program, uint uniformBlockIndex, int bufSize, Span<int> length)
+            public static unsafe string GetActiveUniformBlockName(int program, uint uniformBlockIndex, int bufSize, Span<int> length)
             {
                 string uniformBlockName;
                 fixed (int* length_ptr = length)
@@ -20420,7 +20420,7 @@ namespace OpenTK.Graphics.OpenGL
                 return uniformBlockName;
             }
             /// <inheritdoc cref="GetActiveUniformBlockName"/>
-            public static unsafe void GetActiveUniformBlockName(ProgramHandle program, uint uniformBlockIndex, int bufSize, Span<int> length, out string uniformBlockName)
+            public static unsafe void GetActiveUniformBlockName(int program, uint uniformBlockIndex, int bufSize, Span<int> length, out string uniformBlockName)
             {
                 fixed (int* length_ptr = length)
                 {
@@ -20431,7 +20431,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetActiveUniformBlockName"/>
-            public static unsafe string GetActiveUniformBlockName(ProgramHandle program, uint uniformBlockIndex, int bufSize, int[] length)
+            public static unsafe string GetActiveUniformBlockName(int program, uint uniformBlockIndex, int bufSize, int[] length)
             {
                 string uniformBlockName;
                 fixed (int* length_ptr = length)
@@ -20444,7 +20444,7 @@ namespace OpenTK.Graphics.OpenGL
                 return uniformBlockName;
             }
             /// <inheritdoc cref="GetActiveUniformBlockName"/>
-            public static unsafe void GetActiveUniformBlockName(ProgramHandle program, uint uniformBlockIndex, int bufSize, int[] length, out string uniformBlockName)
+            public static unsafe void GetActiveUniformBlockName(int program, uint uniformBlockIndex, int bufSize, int[] length, out string uniformBlockName)
             {
                 fixed (int* length_ptr = length)
                 {
@@ -20455,7 +20455,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetActiveUniformBlockName"/>
-            public static unsafe string GetActiveUniformBlockName(ProgramHandle program, uint uniformBlockIndex, int bufSize, ref int length)
+            public static unsafe string GetActiveUniformBlockName(int program, uint uniformBlockIndex, int bufSize, ref int length)
             {
                 string uniformBlockName;
                 fixed (int* length_ptr = &length)
@@ -20468,7 +20468,7 @@ namespace OpenTK.Graphics.OpenGL
                 return uniformBlockName;
             }
             /// <inheritdoc cref="GetActiveUniformBlockName"/>
-            public static unsafe void GetActiveUniformBlockName(ProgramHandle program, uint uniformBlockIndex, int bufSize, ref int length, out string uniformBlockName)
+            public static unsafe void GetActiveUniformBlockName(int program, uint uniformBlockIndex, int bufSize, ref int length, out string uniformBlockName)
             {
                 fixed (int* length_ptr = &length)
                 {
@@ -20503,44 +20503,44 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="DeleteVertexArrays"/>
-            public static unsafe void DeleteVertexArray(in VertexArrayHandle array)
+            public static unsafe void DeleteVertexArray(in int array)
             {
                 int n = 1;
-                fixed(VertexArrayHandle* arrays_handle = &array)
+                fixed(int* arrays_handle = &array)
                 {
                     DeleteVertexArrays(n, arrays_handle);
                 }
             }
             /// <inheritdoc cref="DeleteVertexArrays"/>
-            public static unsafe void DeleteVertexArrays(ReadOnlySpan<VertexArrayHandle> arrays)
+            public static unsafe void DeleteVertexArrays(ReadOnlySpan<int> arrays)
             {
                 int n = (int)(arrays.Length);
-                fixed (VertexArrayHandle* arrays_ptr = arrays)
+                fixed (int* arrays_ptr = arrays)
                 {
                     DeleteVertexArrays(n, arrays_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteVertexArrays"/>
-            public static unsafe void DeleteVertexArrays(VertexArrayHandle[] arrays)
+            public static unsafe void DeleteVertexArrays(int[] arrays)
             {
                 int n = (int)(arrays.Length);
-                fixed (VertexArrayHandle* arrays_ptr = arrays)
+                fixed (int* arrays_ptr = arrays)
                 {
                     DeleteVertexArrays(n, arrays_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteVertexArrays"/>
-            public static unsafe void DeleteVertexArrays(int n, in VertexArrayHandle arrays)
+            public static unsafe void DeleteVertexArrays(int n, in int arrays)
             {
-                fixed (VertexArrayHandle* arrays_ptr = &arrays)
+                fixed (int* arrays_ptr = &arrays)
                 {
                     DeleteVertexArrays(n, arrays_ptr);
                 }
             }
             /// <inheritdoc cref="GenVertexArrays"/>
-            public static unsafe VertexArrayHandle GenVertexArray()
+            public static unsafe int GenVertexArray()
             {
-                VertexArrayHandle array;
+                int array;
                 int n = 1;
                 Unsafe.SkipInit(out array);
                 // FIXME: This could be a problem for the overloads that take an out parameter
@@ -20551,12 +20551,12 @@ namespace OpenTK.Graphics.OpenGL
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                VertexArrayHandle* arrays_handle = (VertexArrayHandle*)Unsafe.AsPointer(ref array);
+                int* arrays_handle = (int*)Unsafe.AsPointer(ref array);
                 GenVertexArrays(n, arrays_handle);
                 return array;
             }
             /// <inheritdoc cref="GenVertexArrays"/>
-            public static unsafe void GenVertexArray(out VertexArrayHandle array)
+            public static unsafe void GenVertexArray(out int array)
             {
                 int n = 1;
                 Unsafe.SkipInit(out array);
@@ -20568,31 +20568,31 @@ namespace OpenTK.Graphics.OpenGL
                 // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
                 // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
                 // - 2021-05-18
-                VertexArrayHandle* arrays_handle = (VertexArrayHandle*)Unsafe.AsPointer(ref array);
+                int* arrays_handle = (int*)Unsafe.AsPointer(ref array);
                 GenVertexArrays(n, arrays_handle);
             }
             /// <inheritdoc cref="GenVertexArrays"/>
-            public static unsafe void GenVertexArrays(Span<VertexArrayHandle> arrays)
+            public static unsafe void GenVertexArrays(Span<int> arrays)
             {
                 int n = (int)(arrays.Length);
-                fixed (VertexArrayHandle* arrays_ptr = arrays)
+                fixed (int* arrays_ptr = arrays)
                 {
                     GenVertexArrays(n, arrays_ptr);
                 }
             }
             /// <inheritdoc cref="GenVertexArrays"/>
-            public static unsafe void GenVertexArrays(VertexArrayHandle[] arrays)
+            public static unsafe void GenVertexArrays(int[] arrays)
             {
                 int n = (int)(arrays.Length);
-                fixed (VertexArrayHandle* arrays_ptr = arrays)
+                fixed (int* arrays_ptr = arrays)
                 {
                     GenVertexArrays(n, arrays_ptr);
                 }
             }
             /// <inheritdoc cref="GenVertexArrays"/>
-            public static unsafe void GenVertexArrays(int n, ref VertexArrayHandle arrays)
+            public static unsafe void GenVertexArrays(int n, ref int arrays)
             {
-                fixed (VertexArrayHandle* arrays_ptr = &arrays)
+                fixed (int* arrays_ptr = &arrays)
                 {
                     GenVertexArrays(n, arrays_ptr);
                 }
@@ -20905,53 +20905,53 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="DeleteBuffersARB"/>
-            public static unsafe void DeleteBuffersARB(ReadOnlySpan<BufferHandle> buffers)
+            public static unsafe void DeleteBuffersARB(ReadOnlySpan<int> buffers)
             {
                 int n = (int)(buffers.Length);
-                fixed (BufferHandle* buffers_ptr = buffers)
+                fixed (int* buffers_ptr = buffers)
                 {
                     DeleteBuffersARB(n, buffers_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteBuffersARB"/>
-            public static unsafe void DeleteBuffersARB(BufferHandle[] buffers)
+            public static unsafe void DeleteBuffersARB(int[] buffers)
             {
                 int n = (int)(buffers.Length);
-                fixed (BufferHandle* buffers_ptr = buffers)
+                fixed (int* buffers_ptr = buffers)
                 {
                     DeleteBuffersARB(n, buffers_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteBuffersARB"/>
-            public static unsafe void DeleteBuffersARB(int n, in BufferHandle buffers)
+            public static unsafe void DeleteBuffersARB(int n, in int buffers)
             {
-                fixed (BufferHandle* buffers_ptr = &buffers)
+                fixed (int* buffers_ptr = &buffers)
                 {
                     DeleteBuffersARB(n, buffers_ptr);
                 }
             }
             /// <inheritdoc cref="GenBuffersARB"/>
-            public static unsafe void GenBuffersARB(Span<BufferHandle> buffers)
+            public static unsafe void GenBuffersARB(Span<int> buffers)
             {
                 int n = (int)(buffers.Length);
-                fixed (BufferHandle* buffers_ptr = buffers)
+                fixed (int* buffers_ptr = buffers)
                 {
                     GenBuffersARB(n, buffers_ptr);
                 }
             }
             /// <inheritdoc cref="GenBuffersARB"/>
-            public static unsafe void GenBuffersARB(BufferHandle[] buffers)
+            public static unsafe void GenBuffersARB(int[] buffers)
             {
                 int n = (int)(buffers.Length);
-                fixed (BufferHandle* buffers_ptr = buffers)
+                fixed (int* buffers_ptr = buffers)
                 {
                     GenBuffersARB(n, buffers_ptr);
                 }
             }
             /// <inheritdoc cref="GenBuffersARB"/>
-            public static unsafe void GenBuffersARB(int n, ref BufferHandle buffers)
+            public static unsafe void GenBuffersARB(int n, ref int buffers)
             {
-                fixed (BufferHandle* buffers_ptr = &buffers)
+                fixed (int* buffers_ptr = &buffers)
                 {
                     GenBuffersARB(n, buffers_ptr);
                 }
@@ -22548,13 +22548,13 @@ namespace OpenTK.Graphics.OpenGL
                 return returnValue;
             }
             /// <inheritdoc cref="UpdateObjectBufferATI"/>
-            public static unsafe void UpdateObjectBufferATI(BufferHandle buffer, uint offset, int size, IntPtr pointer, PreserveModeATI preserve)
+            public static unsafe void UpdateObjectBufferATI(int buffer, uint offset, int size, IntPtr pointer, PreserveModeATI preserve)
             {
                 void* pointer_vptr = (void*)pointer;
                 UpdateObjectBufferATI(buffer, offset, size, pointer_vptr, preserve);
             }
             /// <inheritdoc cref="UpdateObjectBufferATI"/>
-            public static unsafe void UpdateObjectBufferATI<T1>(BufferHandle buffer, uint offset, ReadOnlySpan<T1> pointer, PreserveModeATI preserve)
+            public static unsafe void UpdateObjectBufferATI<T1>(int buffer, uint offset, ReadOnlySpan<T1> pointer, PreserveModeATI preserve)
                 where T1 : unmanaged
             {
                 int size = (int)(pointer.Length * sizeof(T1));
@@ -22564,7 +22564,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="UpdateObjectBufferATI"/>
-            public static unsafe void UpdateObjectBufferATI<T1>(BufferHandle buffer, uint offset, T1[] pointer, PreserveModeATI preserve)
+            public static unsafe void UpdateObjectBufferATI<T1>(int buffer, uint offset, T1[] pointer, PreserveModeATI preserve)
                 where T1 : unmanaged
             {
                 int size = (int)(pointer.Length * sizeof(T1));
@@ -22574,7 +22574,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="UpdateObjectBufferATI"/>
-            public static unsafe void UpdateObjectBufferATI<T1>(BufferHandle buffer, uint offset, int size, in T1 pointer, PreserveModeATI preserve)
+            public static unsafe void UpdateObjectBufferATI<T1>(int buffer, uint offset, int size, in T1 pointer, PreserveModeATI preserve)
                 where T1 : unmanaged
             {
                 fixed (void* pointer_ptr = &pointer)
@@ -22583,7 +22583,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetObjectBufferfvATI"/>
-            public static unsafe void GetObjectBufferfvATI(BufferHandle buffer, ArrayObjectPNameATI pname, Span<float> parameters)
+            public static unsafe void GetObjectBufferfvATI(int buffer, ArrayObjectPNameATI pname, Span<float> parameters)
             {
                 fixed (float* parameters_ptr = parameters)
                 {
@@ -22591,7 +22591,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetObjectBufferfvATI"/>
-            public static unsafe void GetObjectBufferfvATI(BufferHandle buffer, ArrayObjectPNameATI pname, float[] parameters)
+            public static unsafe void GetObjectBufferfvATI(int buffer, ArrayObjectPNameATI pname, float[] parameters)
             {
                 fixed (float* parameters_ptr = parameters)
                 {
@@ -22599,7 +22599,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetObjectBufferfvATI"/>
-            public static unsafe void GetObjectBufferfvATI(BufferHandle buffer, ArrayObjectPNameATI pname, ref float parameters)
+            public static unsafe void GetObjectBufferfvATI(int buffer, ArrayObjectPNameATI pname, ref float parameters)
             {
                 fixed (float* parameters_ptr = &parameters)
                 {
@@ -22607,7 +22607,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetObjectBufferivATI"/>
-            public static unsafe void GetObjectBufferivATI(BufferHandle buffer, ArrayObjectPNameATI pname, Span<int> parameters)
+            public static unsafe void GetObjectBufferivATI(int buffer, ArrayObjectPNameATI pname, Span<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -22615,7 +22615,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetObjectBufferivATI"/>
-            public static unsafe void GetObjectBufferivATI(BufferHandle buffer, ArrayObjectPNameATI pname, int[] parameters)
+            public static unsafe void GetObjectBufferivATI(int buffer, ArrayObjectPNameATI pname, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -22623,7 +22623,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetObjectBufferivATI"/>
-            public static unsafe void GetObjectBufferivATI(BufferHandle buffer, ArrayObjectPNameATI pname, ref int parameters)
+            public static unsafe void GetObjectBufferivATI(int buffer, ArrayObjectPNameATI pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -23301,7 +23301,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="EGLImageTargetTextureStorageEXT"/>
-            public static unsafe void EGLImageTargetTextureStorageEXT(TextureHandle texture, IntPtr image, in int attrib_list)
+            public static unsafe void EGLImageTargetTextureStorageEXT(int texture, IntPtr image, in int attrib_list)
             {
                 fixed (int* attrib_list_ptr = &attrib_list)
                 {
@@ -23310,7 +23310,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="EGLImageTargetTextureStorageEXT"/>
-            public static unsafe void EGLImageTargetTextureStorageEXT<T1>(TextureHandle texture, ref T1 image, in int attrib_list)
+            public static unsafe void EGLImageTargetTextureStorageEXT<T1>(int texture, ref T1 image, in int attrib_list)
                 where T1 : unmanaged
             {
                 fixed (void* image_ptr = &image)
@@ -24190,7 +24190,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="TextureParameterfvEXT"/>
-            public static unsafe void TextureParameterfvEXT(TextureHandle texture, TextureTarget target, TextureParameterName pname, ReadOnlySpan<float> parameters)
+            public static unsafe void TextureParameterfvEXT(int texture, TextureTarget target, TextureParameterName pname, ReadOnlySpan<float> parameters)
             {
                 fixed (float* parameters_ptr = parameters)
                 {
@@ -24198,7 +24198,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="TextureParameterfvEXT"/>
-            public static unsafe void TextureParameterfvEXT(TextureHandle texture, TextureTarget target, TextureParameterName pname, float[] parameters)
+            public static unsafe void TextureParameterfvEXT(int texture, TextureTarget target, TextureParameterName pname, float[] parameters)
             {
                 fixed (float* parameters_ptr = parameters)
                 {
@@ -24206,7 +24206,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="TextureParameterfvEXT"/>
-            public static unsafe void TextureParameterfvEXT(TextureHandle texture, TextureTarget target, TextureParameterName pname, in float parameters)
+            public static unsafe void TextureParameterfvEXT(int texture, TextureTarget target, TextureParameterName pname, in float parameters)
             {
                 fixed (float* parameters_ptr = &parameters)
                 {
@@ -24214,7 +24214,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="TextureParameterivEXT"/>
-            public static unsafe void TextureParameterivEXT(TextureHandle texture, TextureTarget target, TextureParameterName pname, ReadOnlySpan<int> parameters)
+            public static unsafe void TextureParameterivEXT(int texture, TextureTarget target, TextureParameterName pname, ReadOnlySpan<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -24222,7 +24222,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="TextureParameterivEXT"/>
-            public static unsafe void TextureParameterivEXT(TextureHandle texture, TextureTarget target, TextureParameterName pname, int[] parameters)
+            public static unsafe void TextureParameterivEXT(int texture, TextureTarget target, TextureParameterName pname, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -24230,7 +24230,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="TextureParameterivEXT"/>
-            public static unsafe void TextureParameterivEXT(TextureHandle texture, TextureTarget target, TextureParameterName pname, in int parameters)
+            public static unsafe void TextureParameterivEXT(int texture, TextureTarget target, TextureParameterName pname, in int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -24238,13 +24238,13 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="TextureImage1DEXT"/>
-            public static unsafe void TextureImage1DEXT(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int width, int border, PixelFormat format, PixelType type, IntPtr pixels)
+            public static unsafe void TextureImage1DEXT(int texture, TextureTarget target, int level, InternalFormat internalformat, int width, int border, PixelFormat format, PixelType type, IntPtr pixels)
             {
                 void* pixels_vptr = (void*)pixels;
                 TextureImage1DEXT(texture, target, level, internalformat, width, border, format, type, pixels_vptr);
             }
             /// <inheritdoc cref="TextureImage1DEXT"/>
-            public static unsafe void TextureImage1DEXT<T1>(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int width, int border, PixelFormat format, PixelType type, ReadOnlySpan<T1> pixels)
+            public static unsafe void TextureImage1DEXT<T1>(int texture, TextureTarget target, int level, InternalFormat internalformat, int width, int border, PixelFormat format, PixelType type, ReadOnlySpan<T1> pixels)
                 where T1 : unmanaged
             {
                 fixed (void* pixels_ptr = pixels)
@@ -24253,7 +24253,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="TextureImage1DEXT"/>
-            public static unsafe void TextureImage1DEXT<T1>(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int width, int border, PixelFormat format, PixelType type, T1[] pixels)
+            public static unsafe void TextureImage1DEXT<T1>(int texture, TextureTarget target, int level, InternalFormat internalformat, int width, int border, PixelFormat format, PixelType type, T1[] pixels)
                 where T1 : unmanaged
             {
                 fixed (void* pixels_ptr = pixels)
@@ -24262,7 +24262,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="TextureImage1DEXT"/>
-            public static unsafe void TextureImage1DEXT<T1>(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int width, int border, PixelFormat format, PixelType type, in T1 pixels)
+            public static unsafe void TextureImage1DEXT<T1>(int texture, TextureTarget target, int level, InternalFormat internalformat, int width, int border, PixelFormat format, PixelType type, in T1 pixels)
                 where T1 : unmanaged
             {
                 fixed (void* pixels_ptr = &pixels)
@@ -24271,13 +24271,13 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="TextureImage2DEXT"/>
-            public static unsafe void TextureImage2DEXT(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int border, PixelFormat format, PixelType type, IntPtr pixels)
+            public static unsafe void TextureImage2DEXT(int texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int border, PixelFormat format, PixelType type, IntPtr pixels)
             {
                 void* pixels_vptr = (void*)pixels;
                 TextureImage2DEXT(texture, target, level, internalformat, width, height, border, format, type, pixels_vptr);
             }
             /// <inheritdoc cref="TextureImage2DEXT"/>
-            public static unsafe void TextureImage2DEXT<T1>(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int border, PixelFormat format, PixelType type, ReadOnlySpan<T1> pixels)
+            public static unsafe void TextureImage2DEXT<T1>(int texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int border, PixelFormat format, PixelType type, ReadOnlySpan<T1> pixels)
                 where T1 : unmanaged
             {
                 fixed (void* pixels_ptr = pixels)
@@ -24286,7 +24286,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="TextureImage2DEXT"/>
-            public static unsafe void TextureImage2DEXT<T1>(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int border, PixelFormat format, PixelType type, T1[] pixels)
+            public static unsafe void TextureImage2DEXT<T1>(int texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int border, PixelFormat format, PixelType type, T1[] pixels)
                 where T1 : unmanaged
             {
                 fixed (void* pixels_ptr = pixels)
@@ -24295,7 +24295,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="TextureImage2DEXT"/>
-            public static unsafe void TextureImage2DEXT<T1>(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int border, PixelFormat format, PixelType type, in T1 pixels)
+            public static unsafe void TextureImage2DEXT<T1>(int texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int border, PixelFormat format, PixelType type, in T1 pixels)
                 where T1 : unmanaged
             {
                 fixed (void* pixels_ptr = &pixels)
@@ -24304,13 +24304,13 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="TextureSubImage1DEXT"/>
-            public static unsafe void TextureSubImage1DEXT(TextureHandle texture, TextureTarget target, int level, int xoffset, int width, PixelFormat format, PixelType type, IntPtr pixels)
+            public static unsafe void TextureSubImage1DEXT(int texture, TextureTarget target, int level, int xoffset, int width, PixelFormat format, PixelType type, IntPtr pixels)
             {
                 void* pixels_vptr = (void*)pixels;
                 TextureSubImage1DEXT(texture, target, level, xoffset, width, format, type, pixels_vptr);
             }
             /// <inheritdoc cref="TextureSubImage1DEXT"/>
-            public static unsafe void TextureSubImage1DEXT<T1>(TextureHandle texture, TextureTarget target, int level, int xoffset, int width, PixelFormat format, PixelType type, ReadOnlySpan<T1> pixels)
+            public static unsafe void TextureSubImage1DEXT<T1>(int texture, TextureTarget target, int level, int xoffset, int width, PixelFormat format, PixelType type, ReadOnlySpan<T1> pixels)
                 where T1 : unmanaged
             {
                 fixed (void* pixels_ptr = pixels)
@@ -24319,7 +24319,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="TextureSubImage1DEXT"/>
-            public static unsafe void TextureSubImage1DEXT<T1>(TextureHandle texture, TextureTarget target, int level, int xoffset, int width, PixelFormat format, PixelType type, T1[] pixels)
+            public static unsafe void TextureSubImage1DEXT<T1>(int texture, TextureTarget target, int level, int xoffset, int width, PixelFormat format, PixelType type, T1[] pixels)
                 where T1 : unmanaged
             {
                 fixed (void* pixels_ptr = pixels)
@@ -24328,7 +24328,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="TextureSubImage1DEXT"/>
-            public static unsafe void TextureSubImage1DEXT<T1>(TextureHandle texture, TextureTarget target, int level, int xoffset, int width, PixelFormat format, PixelType type, in T1 pixels)
+            public static unsafe void TextureSubImage1DEXT<T1>(int texture, TextureTarget target, int level, int xoffset, int width, PixelFormat format, PixelType type, in T1 pixels)
                 where T1 : unmanaged
             {
                 fixed (void* pixels_ptr = &pixels)
@@ -24337,13 +24337,13 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="TextureSubImage2DEXT"/>
-            public static unsafe void TextureSubImage2DEXT(TextureHandle texture, TextureTarget target, int level, int xoffset, int yoffset, int width, int height, PixelFormat format, PixelType type, IntPtr pixels)
+            public static unsafe void TextureSubImage2DEXT(int texture, TextureTarget target, int level, int xoffset, int yoffset, int width, int height, PixelFormat format, PixelType type, IntPtr pixels)
             {
                 void* pixels_vptr = (void*)pixels;
                 TextureSubImage2DEXT(texture, target, level, xoffset, yoffset, width, height, format, type, pixels_vptr);
             }
             /// <inheritdoc cref="TextureSubImage2DEXT"/>
-            public static unsafe void TextureSubImage2DEXT<T1>(TextureHandle texture, TextureTarget target, int level, int xoffset, int yoffset, int width, int height, PixelFormat format, PixelType type, ReadOnlySpan<T1> pixels)
+            public static unsafe void TextureSubImage2DEXT<T1>(int texture, TextureTarget target, int level, int xoffset, int yoffset, int width, int height, PixelFormat format, PixelType type, ReadOnlySpan<T1> pixels)
                 where T1 : unmanaged
             {
                 fixed (void* pixels_ptr = pixels)
@@ -24352,7 +24352,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="TextureSubImage2DEXT"/>
-            public static unsafe void TextureSubImage2DEXT<T1>(TextureHandle texture, TextureTarget target, int level, int xoffset, int yoffset, int width, int height, PixelFormat format, PixelType type, T1[] pixels)
+            public static unsafe void TextureSubImage2DEXT<T1>(int texture, TextureTarget target, int level, int xoffset, int yoffset, int width, int height, PixelFormat format, PixelType type, T1[] pixels)
                 where T1 : unmanaged
             {
                 fixed (void* pixels_ptr = pixels)
@@ -24361,7 +24361,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="TextureSubImage2DEXT"/>
-            public static unsafe void TextureSubImage2DEXT<T1>(TextureHandle texture, TextureTarget target, int level, int xoffset, int yoffset, int width, int height, PixelFormat format, PixelType type, in T1 pixels)
+            public static unsafe void TextureSubImage2DEXT<T1>(int texture, TextureTarget target, int level, int xoffset, int yoffset, int width, int height, PixelFormat format, PixelType type, in T1 pixels)
                 where T1 : unmanaged
             {
                 fixed (void* pixels_ptr = &pixels)
@@ -24370,13 +24370,13 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetTextureImageEXT"/>
-            public static unsafe void GetTextureImageEXT(TextureHandle texture, TextureTarget target, int level, PixelFormat format, PixelType type, IntPtr pixels)
+            public static unsafe void GetTextureImageEXT(int texture, TextureTarget target, int level, PixelFormat format, PixelType type, IntPtr pixels)
             {
                 void* pixels_vptr = (void*)pixels;
                 GetTextureImageEXT(texture, target, level, format, type, pixels_vptr);
             }
             /// <inheritdoc cref="GetTextureImageEXT"/>
-            public static unsafe void GetTextureImageEXT<T1>(TextureHandle texture, TextureTarget target, int level, PixelFormat format, PixelType type, Span<T1> pixels)
+            public static unsafe void GetTextureImageEXT<T1>(int texture, TextureTarget target, int level, PixelFormat format, PixelType type, Span<T1> pixels)
                 where T1 : unmanaged
             {
                 fixed (void* pixels_ptr = pixels)
@@ -24385,7 +24385,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetTextureImageEXT"/>
-            public static unsafe void GetTextureImageEXT<T1>(TextureHandle texture, TextureTarget target, int level, PixelFormat format, PixelType type, T1[] pixels)
+            public static unsafe void GetTextureImageEXT<T1>(int texture, TextureTarget target, int level, PixelFormat format, PixelType type, T1[] pixels)
                 where T1 : unmanaged
             {
                 fixed (void* pixels_ptr = pixels)
@@ -24394,7 +24394,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetTextureImageEXT"/>
-            public static unsafe void GetTextureImageEXT<T1>(TextureHandle texture, TextureTarget target, int level, PixelFormat format, PixelType type, ref T1 pixels)
+            public static unsafe void GetTextureImageEXT<T1>(int texture, TextureTarget target, int level, PixelFormat format, PixelType type, ref T1 pixels)
                 where T1 : unmanaged
             {
                 fixed (void* pixels_ptr = &pixels)
@@ -24403,7 +24403,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetTextureParameterfvEXT"/>
-            public static unsafe void GetTextureParameterfvEXT(TextureHandle texture, TextureTarget target, GetTextureParameter pname, Span<float> parameters)
+            public static unsafe void GetTextureParameterfvEXT(int texture, TextureTarget target, GetTextureParameter pname, Span<float> parameters)
             {
                 fixed (float* parameters_ptr = parameters)
                 {
@@ -24411,7 +24411,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetTextureParameterfvEXT"/>
-            public static unsafe void GetTextureParameterfvEXT(TextureHandle texture, TextureTarget target, GetTextureParameter pname, float[] parameters)
+            public static unsafe void GetTextureParameterfvEXT(int texture, TextureTarget target, GetTextureParameter pname, float[] parameters)
             {
                 fixed (float* parameters_ptr = parameters)
                 {
@@ -24419,7 +24419,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetTextureParameterfvEXT"/>
-            public static unsafe void GetTextureParameterfvEXT(TextureHandle texture, TextureTarget target, GetTextureParameter pname, ref float parameters)
+            public static unsafe void GetTextureParameterfvEXT(int texture, TextureTarget target, GetTextureParameter pname, ref float parameters)
             {
                 fixed (float* parameters_ptr = &parameters)
                 {
@@ -24427,7 +24427,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetTextureParameterivEXT"/>
-            public static unsafe void GetTextureParameterivEXT(TextureHandle texture, TextureTarget target, GetTextureParameter pname, Span<int> parameters)
+            public static unsafe void GetTextureParameterivEXT(int texture, TextureTarget target, GetTextureParameter pname, Span<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -24435,7 +24435,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetTextureParameterivEXT"/>
-            public static unsafe void GetTextureParameterivEXT(TextureHandle texture, TextureTarget target, GetTextureParameter pname, int[] parameters)
+            public static unsafe void GetTextureParameterivEXT(int texture, TextureTarget target, GetTextureParameter pname, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -24443,7 +24443,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetTextureParameterivEXT"/>
-            public static unsafe void GetTextureParameterivEXT(TextureHandle texture, TextureTarget target, GetTextureParameter pname, ref int parameters)
+            public static unsafe void GetTextureParameterivEXT(int texture, TextureTarget target, GetTextureParameter pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -24451,7 +24451,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetTextureLevelParameterfvEXT"/>
-            public static unsafe void GetTextureLevelParameterfvEXT(TextureHandle texture, TextureTarget target, int level, GetTextureParameter pname, Span<float> parameters)
+            public static unsafe void GetTextureLevelParameterfvEXT(int texture, TextureTarget target, int level, GetTextureParameter pname, Span<float> parameters)
             {
                 fixed (float* parameters_ptr = parameters)
                 {
@@ -24459,7 +24459,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetTextureLevelParameterfvEXT"/>
-            public static unsafe void GetTextureLevelParameterfvEXT(TextureHandle texture, TextureTarget target, int level, GetTextureParameter pname, float[] parameters)
+            public static unsafe void GetTextureLevelParameterfvEXT(int texture, TextureTarget target, int level, GetTextureParameter pname, float[] parameters)
             {
                 fixed (float* parameters_ptr = parameters)
                 {
@@ -24467,7 +24467,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetTextureLevelParameterfvEXT"/>
-            public static unsafe void GetTextureLevelParameterfvEXT(TextureHandle texture, TextureTarget target, int level, GetTextureParameter pname, ref float parameters)
+            public static unsafe void GetTextureLevelParameterfvEXT(int texture, TextureTarget target, int level, GetTextureParameter pname, ref float parameters)
             {
                 fixed (float* parameters_ptr = &parameters)
                 {
@@ -24475,7 +24475,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetTextureLevelParameterivEXT"/>
-            public static unsafe void GetTextureLevelParameterivEXT(TextureHandle texture, TextureTarget target, int level, GetTextureParameter pname, Span<int> parameters)
+            public static unsafe void GetTextureLevelParameterivEXT(int texture, TextureTarget target, int level, GetTextureParameter pname, Span<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -24483,7 +24483,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetTextureLevelParameterivEXT"/>
-            public static unsafe void GetTextureLevelParameterivEXT(TextureHandle texture, TextureTarget target, int level, GetTextureParameter pname, int[] parameters)
+            public static unsafe void GetTextureLevelParameterivEXT(int texture, TextureTarget target, int level, GetTextureParameter pname, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -24491,7 +24491,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetTextureLevelParameterivEXT"/>
-            public static unsafe void GetTextureLevelParameterivEXT(TextureHandle texture, TextureTarget target, int level, GetTextureParameter pname, ref int parameters)
+            public static unsafe void GetTextureLevelParameterivEXT(int texture, TextureTarget target, int level, GetTextureParameter pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -24499,13 +24499,13 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="TextureImage3DEXT"/>
-            public static unsafe void TextureImage3DEXT(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int depth, int border, PixelFormat format, PixelType type, IntPtr pixels)
+            public static unsafe void TextureImage3DEXT(int texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int depth, int border, PixelFormat format, PixelType type, IntPtr pixels)
             {
                 void* pixels_vptr = (void*)pixels;
                 TextureImage3DEXT(texture, target, level, internalformat, width, height, depth, border, format, type, pixels_vptr);
             }
             /// <inheritdoc cref="TextureImage3DEXT"/>
-            public static unsafe void TextureImage3DEXT<T1>(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int depth, int border, PixelFormat format, PixelType type, ReadOnlySpan<T1> pixels)
+            public static unsafe void TextureImage3DEXT<T1>(int texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int depth, int border, PixelFormat format, PixelType type, ReadOnlySpan<T1> pixels)
                 where T1 : unmanaged
             {
                 fixed (void* pixels_ptr = pixels)
@@ -24514,7 +24514,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="TextureImage3DEXT"/>
-            public static unsafe void TextureImage3DEXT<T1>(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int depth, int border, PixelFormat format, PixelType type, T1[] pixels)
+            public static unsafe void TextureImage3DEXT<T1>(int texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int depth, int border, PixelFormat format, PixelType type, T1[] pixels)
                 where T1 : unmanaged
             {
                 fixed (void* pixels_ptr = pixels)
@@ -24523,7 +24523,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="TextureImage3DEXT"/>
-            public static unsafe void TextureImage3DEXT<T1>(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int depth, int border, PixelFormat format, PixelType type, in T1 pixels)
+            public static unsafe void TextureImage3DEXT<T1>(int texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int depth, int border, PixelFormat format, PixelType type, in T1 pixels)
                 where T1 : unmanaged
             {
                 fixed (void* pixels_ptr = &pixels)
@@ -24532,13 +24532,13 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="TextureSubImage3DEXT"/>
-            public static unsafe void TextureSubImage3DEXT(TextureHandle texture, TextureTarget target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, IntPtr pixels)
+            public static unsafe void TextureSubImage3DEXT(int texture, TextureTarget target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, IntPtr pixels)
             {
                 void* pixels_vptr = (void*)pixels;
                 TextureSubImage3DEXT(texture, target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, pixels_vptr);
             }
             /// <inheritdoc cref="TextureSubImage3DEXT"/>
-            public static unsafe void TextureSubImage3DEXT<T1>(TextureHandle texture, TextureTarget target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, ReadOnlySpan<T1> pixels)
+            public static unsafe void TextureSubImage3DEXT<T1>(int texture, TextureTarget target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, ReadOnlySpan<T1> pixels)
                 where T1 : unmanaged
             {
                 fixed (void* pixels_ptr = pixels)
@@ -24547,7 +24547,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="TextureSubImage3DEXT"/>
-            public static unsafe void TextureSubImage3DEXT<T1>(TextureHandle texture, TextureTarget target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, T1[] pixels)
+            public static unsafe void TextureSubImage3DEXT<T1>(int texture, TextureTarget target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, T1[] pixels)
                 where T1 : unmanaged
             {
                 fixed (void* pixels_ptr = pixels)
@@ -24556,7 +24556,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="TextureSubImage3DEXT"/>
-            public static unsafe void TextureSubImage3DEXT<T1>(TextureHandle texture, TextureTarget target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, in T1 pixels)
+            public static unsafe void TextureSubImage3DEXT<T1>(int texture, TextureTarget target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, in T1 pixels)
                 where T1 : unmanaged
             {
                 fixed (void* pixels_ptr = &pixels)
@@ -25309,13 +25309,13 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="CompressedTextureImage3DEXT"/>
-            public static unsafe void CompressedTextureImage3DEXT(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int depth, int border, int imageSize, IntPtr bits)
+            public static unsafe void CompressedTextureImage3DEXT(int texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int depth, int border, int imageSize, IntPtr bits)
             {
                 void* bits_vptr = (void*)bits;
                 CompressedTextureImage3DEXT(texture, target, level, internalformat, width, height, depth, border, imageSize, bits_vptr);
             }
             /// <inheritdoc cref="CompressedTextureImage3DEXT"/>
-            public static unsafe void CompressedTextureImage3DEXT<T1>(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int depth, int border, ReadOnlySpan<T1> bits)
+            public static unsafe void CompressedTextureImage3DEXT<T1>(int texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int depth, int border, ReadOnlySpan<T1> bits)
                 where T1 : unmanaged
             {
                 int imageSize = (int)(bits.Length * sizeof(T1));
@@ -25325,7 +25325,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="CompressedTextureImage3DEXT"/>
-            public static unsafe void CompressedTextureImage3DEXT<T1>(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int depth, int border, T1[] bits)
+            public static unsafe void CompressedTextureImage3DEXT<T1>(int texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int depth, int border, T1[] bits)
                 where T1 : unmanaged
             {
                 int imageSize = (int)(bits.Length * sizeof(T1));
@@ -25335,7 +25335,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="CompressedTextureImage3DEXT"/>
-            public static unsafe void CompressedTextureImage3DEXT<T1>(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int depth, int border, int imageSize, in T1 bits)
+            public static unsafe void CompressedTextureImage3DEXT<T1>(int texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int depth, int border, int imageSize, in T1 bits)
                 where T1 : unmanaged
             {
                 fixed (void* bits_ptr = &bits)
@@ -25344,13 +25344,13 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="CompressedTextureImage2DEXT"/>
-            public static unsafe void CompressedTextureImage2DEXT(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int border, int imageSize, IntPtr bits)
+            public static unsafe void CompressedTextureImage2DEXT(int texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int border, int imageSize, IntPtr bits)
             {
                 void* bits_vptr = (void*)bits;
                 CompressedTextureImage2DEXT(texture, target, level, internalformat, width, height, border, imageSize, bits_vptr);
             }
             /// <inheritdoc cref="CompressedTextureImage2DEXT"/>
-            public static unsafe void CompressedTextureImage2DEXT<T1>(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int border, ReadOnlySpan<T1> bits)
+            public static unsafe void CompressedTextureImage2DEXT<T1>(int texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int border, ReadOnlySpan<T1> bits)
                 where T1 : unmanaged
             {
                 int imageSize = (int)(bits.Length * sizeof(T1));
@@ -25360,7 +25360,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="CompressedTextureImage2DEXT"/>
-            public static unsafe void CompressedTextureImage2DEXT<T1>(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int border, T1[] bits)
+            public static unsafe void CompressedTextureImage2DEXT<T1>(int texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int border, T1[] bits)
                 where T1 : unmanaged
             {
                 int imageSize = (int)(bits.Length * sizeof(T1));
@@ -25370,7 +25370,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="CompressedTextureImage2DEXT"/>
-            public static unsafe void CompressedTextureImage2DEXT<T1>(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int border, int imageSize, in T1 bits)
+            public static unsafe void CompressedTextureImage2DEXT<T1>(int texture, TextureTarget target, int level, InternalFormat internalformat, int width, int height, int border, int imageSize, in T1 bits)
                 where T1 : unmanaged
             {
                 fixed (void* bits_ptr = &bits)
@@ -25379,13 +25379,13 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="CompressedTextureImage1DEXT"/>
-            public static unsafe void CompressedTextureImage1DEXT(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int width, int border, int imageSize, IntPtr bits)
+            public static unsafe void CompressedTextureImage1DEXT(int texture, TextureTarget target, int level, InternalFormat internalformat, int width, int border, int imageSize, IntPtr bits)
             {
                 void* bits_vptr = (void*)bits;
                 CompressedTextureImage1DEXT(texture, target, level, internalformat, width, border, imageSize, bits_vptr);
             }
             /// <inheritdoc cref="CompressedTextureImage1DEXT"/>
-            public static unsafe void CompressedTextureImage1DEXT<T1>(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int width, int border, ReadOnlySpan<T1> bits)
+            public static unsafe void CompressedTextureImage1DEXT<T1>(int texture, TextureTarget target, int level, InternalFormat internalformat, int width, int border, ReadOnlySpan<T1> bits)
                 where T1 : unmanaged
             {
                 int imageSize = (int)(bits.Length * sizeof(T1));
@@ -25395,7 +25395,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="CompressedTextureImage1DEXT"/>
-            public static unsafe void CompressedTextureImage1DEXT<T1>(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int width, int border, T1[] bits)
+            public static unsafe void CompressedTextureImage1DEXT<T1>(int texture, TextureTarget target, int level, InternalFormat internalformat, int width, int border, T1[] bits)
                 where T1 : unmanaged
             {
                 int imageSize = (int)(bits.Length * sizeof(T1));
@@ -25405,7 +25405,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="CompressedTextureImage1DEXT"/>
-            public static unsafe void CompressedTextureImage1DEXT<T1>(TextureHandle texture, TextureTarget target, int level, InternalFormat internalformat, int width, int border, int imageSize, in T1 bits)
+            public static unsafe void CompressedTextureImage1DEXT<T1>(int texture, TextureTarget target, int level, InternalFormat internalformat, int width, int border, int imageSize, in T1 bits)
                 where T1 : unmanaged
             {
                 fixed (void* bits_ptr = &bits)
@@ -25414,13 +25414,13 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="CompressedTextureSubImage3DEXT"/>
-            public static unsafe void CompressedTextureSubImage3DEXT(TextureHandle texture, TextureTarget target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, InternalFormat format, int imageSize, IntPtr bits)
+            public static unsafe void CompressedTextureSubImage3DEXT(int texture, TextureTarget target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, InternalFormat format, int imageSize, IntPtr bits)
             {
                 void* bits_vptr = (void*)bits;
                 CompressedTextureSubImage3DEXT(texture, target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, bits_vptr);
             }
             /// <inheritdoc cref="CompressedTextureSubImage3DEXT"/>
-            public static unsafe void CompressedTextureSubImage3DEXT<T1>(TextureHandle texture, TextureTarget target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, InternalFormat format, ReadOnlySpan<T1> bits)
+            public static unsafe void CompressedTextureSubImage3DEXT<T1>(int texture, TextureTarget target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, InternalFormat format, ReadOnlySpan<T1> bits)
                 where T1 : unmanaged
             {
                 int imageSize = (int)(bits.Length * sizeof(T1));
@@ -25430,7 +25430,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="CompressedTextureSubImage3DEXT"/>
-            public static unsafe void CompressedTextureSubImage3DEXT<T1>(TextureHandle texture, TextureTarget target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, InternalFormat format, T1[] bits)
+            public static unsafe void CompressedTextureSubImage3DEXT<T1>(int texture, TextureTarget target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, InternalFormat format, T1[] bits)
                 where T1 : unmanaged
             {
                 int imageSize = (int)(bits.Length * sizeof(T1));
@@ -25440,7 +25440,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="CompressedTextureSubImage3DEXT"/>
-            public static unsafe void CompressedTextureSubImage3DEXT<T1>(TextureHandle texture, TextureTarget target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, InternalFormat format, int imageSize, in T1 bits)
+            public static unsafe void CompressedTextureSubImage3DEXT<T1>(int texture, TextureTarget target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, InternalFormat format, int imageSize, in T1 bits)
                 where T1 : unmanaged
             {
                 fixed (void* bits_ptr = &bits)
@@ -25449,13 +25449,13 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="CompressedTextureSubImage2DEXT"/>
-            public static unsafe void CompressedTextureSubImage2DEXT(TextureHandle texture, TextureTarget target, int level, int xoffset, int yoffset, int width, int height, InternalFormat format, int imageSize, IntPtr bits)
+            public static unsafe void CompressedTextureSubImage2DEXT(int texture, TextureTarget target, int level, int xoffset, int yoffset, int width, int height, InternalFormat format, int imageSize, IntPtr bits)
             {
                 void* bits_vptr = (void*)bits;
                 CompressedTextureSubImage2DEXT(texture, target, level, xoffset, yoffset, width, height, format, imageSize, bits_vptr);
             }
             /// <inheritdoc cref="CompressedTextureSubImage2DEXT"/>
-            public static unsafe void CompressedTextureSubImage2DEXT<T1>(TextureHandle texture, TextureTarget target, int level, int xoffset, int yoffset, int width, int height, InternalFormat format, ReadOnlySpan<T1> bits)
+            public static unsafe void CompressedTextureSubImage2DEXT<T1>(int texture, TextureTarget target, int level, int xoffset, int yoffset, int width, int height, InternalFormat format, ReadOnlySpan<T1> bits)
                 where T1 : unmanaged
             {
                 int imageSize = (int)(bits.Length * sizeof(T1));
@@ -25465,7 +25465,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="CompressedTextureSubImage2DEXT"/>
-            public static unsafe void CompressedTextureSubImage2DEXT<T1>(TextureHandle texture, TextureTarget target, int level, int xoffset, int yoffset, int width, int height, InternalFormat format, T1[] bits)
+            public static unsafe void CompressedTextureSubImage2DEXT<T1>(int texture, TextureTarget target, int level, int xoffset, int yoffset, int width, int height, InternalFormat format, T1[] bits)
                 where T1 : unmanaged
             {
                 int imageSize = (int)(bits.Length * sizeof(T1));
@@ -25475,7 +25475,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="CompressedTextureSubImage2DEXT"/>
-            public static unsafe void CompressedTextureSubImage2DEXT<T1>(TextureHandle texture, TextureTarget target, int level, int xoffset, int yoffset, int width, int height, InternalFormat format, int imageSize, in T1 bits)
+            public static unsafe void CompressedTextureSubImage2DEXT<T1>(int texture, TextureTarget target, int level, int xoffset, int yoffset, int width, int height, InternalFormat format, int imageSize, in T1 bits)
                 where T1 : unmanaged
             {
                 fixed (void* bits_ptr = &bits)
@@ -25484,13 +25484,13 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="CompressedTextureSubImage1DEXT"/>
-            public static unsafe void CompressedTextureSubImage1DEXT(TextureHandle texture, TextureTarget target, int level, int xoffset, int width, InternalFormat format, int imageSize, IntPtr bits)
+            public static unsafe void CompressedTextureSubImage1DEXT(int texture, TextureTarget target, int level, int xoffset, int width, InternalFormat format, int imageSize, IntPtr bits)
             {
                 void* bits_vptr = (void*)bits;
                 CompressedTextureSubImage1DEXT(texture, target, level, xoffset, width, format, imageSize, bits_vptr);
             }
             /// <inheritdoc cref="CompressedTextureSubImage1DEXT"/>
-            public static unsafe void CompressedTextureSubImage1DEXT<T1>(TextureHandle texture, TextureTarget target, int level, int xoffset, int width, InternalFormat format, ReadOnlySpan<T1> bits)
+            public static unsafe void CompressedTextureSubImage1DEXT<T1>(int texture, TextureTarget target, int level, int xoffset, int width, InternalFormat format, ReadOnlySpan<T1> bits)
                 where T1 : unmanaged
             {
                 int imageSize = (int)(bits.Length * sizeof(T1));
@@ -25500,7 +25500,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="CompressedTextureSubImage1DEXT"/>
-            public static unsafe void CompressedTextureSubImage1DEXT<T1>(TextureHandle texture, TextureTarget target, int level, int xoffset, int width, InternalFormat format, T1[] bits)
+            public static unsafe void CompressedTextureSubImage1DEXT<T1>(int texture, TextureTarget target, int level, int xoffset, int width, InternalFormat format, T1[] bits)
                 where T1 : unmanaged
             {
                 int imageSize = (int)(bits.Length * sizeof(T1));
@@ -25510,7 +25510,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="CompressedTextureSubImage1DEXT"/>
-            public static unsafe void CompressedTextureSubImage1DEXT<T1>(TextureHandle texture, TextureTarget target, int level, int xoffset, int width, InternalFormat format, int imageSize, in T1 bits)
+            public static unsafe void CompressedTextureSubImage1DEXT<T1>(int texture, TextureTarget target, int level, int xoffset, int width, InternalFormat format, int imageSize, in T1 bits)
                 where T1 : unmanaged
             {
                 fixed (void* bits_ptr = &bits)
@@ -25519,13 +25519,13 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetCompressedTextureImageEXT"/>
-            public static unsafe void GetCompressedTextureImageEXT(TextureHandle texture, TextureTarget target, int lod, IntPtr img)
+            public static unsafe void GetCompressedTextureImageEXT(int texture, TextureTarget target, int lod, IntPtr img)
             {
                 void* img_vptr = (void*)img;
                 GetCompressedTextureImageEXT(texture, target, lod, img_vptr);
             }
             /// <inheritdoc cref="GetCompressedTextureImageEXT"/>
-            public static unsafe void GetCompressedTextureImageEXT<T1>(TextureHandle texture, TextureTarget target, int lod, Span<T1> img)
+            public static unsafe void GetCompressedTextureImageEXT<T1>(int texture, TextureTarget target, int lod, Span<T1> img)
                 where T1 : unmanaged
             {
                 fixed (void* img_ptr = img)
@@ -25534,7 +25534,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetCompressedTextureImageEXT"/>
-            public static unsafe void GetCompressedTextureImageEXT<T1>(TextureHandle texture, TextureTarget target, int lod, T1[] img)
+            public static unsafe void GetCompressedTextureImageEXT<T1>(int texture, TextureTarget target, int lod, T1[] img)
                 where T1 : unmanaged
             {
                 fixed (void* img_ptr = img)
@@ -25543,7 +25543,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetCompressedTextureImageEXT"/>
-            public static unsafe void GetCompressedTextureImageEXT<T1>(TextureHandle texture, TextureTarget target, int lod, ref T1 img)
+            public static unsafe void GetCompressedTextureImageEXT<T1>(int texture, TextureTarget target, int lod, ref T1 img)
                 where T1 : unmanaged
             {
                 fixed (void* img_ptr = &img)
@@ -25891,13 +25891,13 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="NamedBufferDataEXT"/>
-            public static unsafe void NamedBufferDataEXT(BufferHandle buffer, nint size, IntPtr data, VertexBufferObjectUsage usage)
+            public static unsafe void NamedBufferDataEXT(int buffer, nint size, IntPtr data, VertexBufferObjectUsage usage)
             {
                 void* data_vptr = (void*)data;
                 NamedBufferDataEXT(buffer, size, data_vptr, usage);
             }
             /// <inheritdoc cref="NamedBufferDataEXT"/>
-            public static unsafe void NamedBufferDataEXT<T1>(BufferHandle buffer, nint size, ReadOnlySpan<T1> data, VertexBufferObjectUsage usage)
+            public static unsafe void NamedBufferDataEXT<T1>(int buffer, nint size, ReadOnlySpan<T1> data, VertexBufferObjectUsage usage)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = data)
@@ -25906,7 +25906,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="NamedBufferDataEXT"/>
-            public static unsafe void NamedBufferDataEXT<T1>(BufferHandle buffer, nint size, T1[] data, VertexBufferObjectUsage usage)
+            public static unsafe void NamedBufferDataEXT<T1>(int buffer, nint size, T1[] data, VertexBufferObjectUsage usage)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = data)
@@ -25915,7 +25915,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="NamedBufferDataEXT"/>
-            public static unsafe void NamedBufferDataEXT<T1>(BufferHandle buffer, nint size, in T1 data, VertexBufferObjectUsage usage)
+            public static unsafe void NamedBufferDataEXT<T1>(int buffer, nint size, in T1 data, VertexBufferObjectUsage usage)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = &data)
@@ -25924,13 +25924,13 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="NamedBufferSubDataEXT"/>
-            public static unsafe void NamedBufferSubDataEXT(BufferHandle buffer, IntPtr offset, nint size, IntPtr data)
+            public static unsafe void NamedBufferSubDataEXT(int buffer, IntPtr offset, nint size, IntPtr data)
             {
                 void* data_vptr = (void*)data;
                 NamedBufferSubDataEXT(buffer, offset, size, data_vptr);
             }
             /// <inheritdoc cref="NamedBufferSubDataEXT"/>
-            public static unsafe void NamedBufferSubDataEXT<T1>(BufferHandle buffer, IntPtr offset, nint size, ReadOnlySpan<T1> data)
+            public static unsafe void NamedBufferSubDataEXT<T1>(int buffer, IntPtr offset, nint size, ReadOnlySpan<T1> data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = data)
@@ -25939,7 +25939,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="NamedBufferSubDataEXT"/>
-            public static unsafe void NamedBufferSubDataEXT<T1>(BufferHandle buffer, IntPtr offset, nint size, T1[] data)
+            public static unsafe void NamedBufferSubDataEXT<T1>(int buffer, IntPtr offset, nint size, T1[] data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = data)
@@ -25948,7 +25948,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="NamedBufferSubDataEXT"/>
-            public static unsafe void NamedBufferSubDataEXT<T1>(BufferHandle buffer, IntPtr offset, nint size, in T1 data)
+            public static unsafe void NamedBufferSubDataEXT<T1>(int buffer, IntPtr offset, nint size, in T1 data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = &data)
@@ -25957,7 +25957,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetNamedBufferParameterivEXT"/>
-            public static unsafe void GetNamedBufferParameterivEXT(BufferHandle buffer, BufferPNameARB pname, Span<int> parameters)
+            public static unsafe void GetNamedBufferParameterivEXT(int buffer, BufferPNameARB pname, Span<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -25965,7 +25965,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetNamedBufferParameterivEXT"/>
-            public static unsafe void GetNamedBufferParameterivEXT(BufferHandle buffer, BufferPNameARB pname, int[] parameters)
+            public static unsafe void GetNamedBufferParameterivEXT(int buffer, BufferPNameARB pname, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -25973,7 +25973,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetNamedBufferParameterivEXT"/>
-            public static unsafe void GetNamedBufferParameterivEXT(BufferHandle buffer, BufferPNameARB pname, ref int parameters)
+            public static unsafe void GetNamedBufferParameterivEXT(int buffer, BufferPNameARB pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -25981,13 +25981,13 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetNamedBufferSubDataEXT"/>
-            public static unsafe void GetNamedBufferSubDataEXT(BufferHandle buffer, IntPtr offset, nint size, IntPtr data)
+            public static unsafe void GetNamedBufferSubDataEXT(int buffer, IntPtr offset, nint size, IntPtr data)
             {
                 void* data_vptr = (void*)data;
                 GetNamedBufferSubDataEXT(buffer, offset, size, data_vptr);
             }
             /// <inheritdoc cref="GetNamedBufferSubDataEXT"/>
-            public static unsafe void GetNamedBufferSubDataEXT<T1>(BufferHandle buffer, IntPtr offset, nint size, Span<T1> data)
+            public static unsafe void GetNamedBufferSubDataEXT<T1>(int buffer, IntPtr offset, nint size, Span<T1> data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = data)
@@ -25996,7 +25996,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetNamedBufferSubDataEXT"/>
-            public static unsafe void GetNamedBufferSubDataEXT<T1>(BufferHandle buffer, IntPtr offset, nint size, T1[] data)
+            public static unsafe void GetNamedBufferSubDataEXT<T1>(int buffer, IntPtr offset, nint size, T1[] data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = data)
@@ -26005,7 +26005,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetNamedBufferSubDataEXT"/>
-            public static unsafe void GetNamedBufferSubDataEXT<T1>(BufferHandle buffer, IntPtr offset, nint size, ref T1 data)
+            public static unsafe void GetNamedBufferSubDataEXT<T1>(int buffer, IntPtr offset, nint size, ref T1 data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = &data)
@@ -26014,7 +26014,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform1fvEXT"/>
-            public static unsafe void ProgramUniform1fvEXT(ProgramHandle program, int location, ReadOnlySpan<float> value)
+            public static unsafe void ProgramUniform1fvEXT(int program, int location, ReadOnlySpan<float> value)
             {
                 int count = (int)(value.Length);
                 fixed (float* value_ptr = value)
@@ -26023,7 +26023,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform1fvEXT"/>
-            public static unsafe void ProgramUniform1fvEXT(ProgramHandle program, int location, float[] value)
+            public static unsafe void ProgramUniform1fvEXT(int program, int location, float[] value)
             {
                 int count = (int)(value.Length);
                 fixed (float* value_ptr = value)
@@ -26032,7 +26032,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform1fvEXT"/>
-            public static unsafe void ProgramUniform1fvEXT(ProgramHandle program, int location, int count, in float value)
+            public static unsafe void ProgramUniform1fvEXT(int program, int location, int count, in float value)
             {
                 fixed (float* value_ptr = &value)
                 {
@@ -26040,7 +26040,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform2fvEXT"/>
-            public static unsafe void ProgramUniform2fvEXT(ProgramHandle program, int location, ReadOnlySpan<float> value)
+            public static unsafe void ProgramUniform2fvEXT(int program, int location, ReadOnlySpan<float> value)
             {
                 int count = (int)(value.Length / 2);
                 fixed (float* value_ptr = value)
@@ -26049,7 +26049,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform2fvEXT"/>
-            public static unsafe void ProgramUniform2fvEXT(ProgramHandle program, int location, float[] value)
+            public static unsafe void ProgramUniform2fvEXT(int program, int location, float[] value)
             {
                 int count = (int)(value.Length / 2);
                 fixed (float* value_ptr = value)
@@ -26058,7 +26058,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform2fvEXT"/>
-            public static unsafe void ProgramUniform2fvEXT(ProgramHandle program, int location, int count, in float value)
+            public static unsafe void ProgramUniform2fvEXT(int program, int location, int count, in float value)
             {
                 fixed (float* value_ptr = &value)
                 {
@@ -26066,7 +26066,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform3fvEXT"/>
-            public static unsafe void ProgramUniform3fvEXT(ProgramHandle program, int location, ReadOnlySpan<float> value)
+            public static unsafe void ProgramUniform3fvEXT(int program, int location, ReadOnlySpan<float> value)
             {
                 int count = (int)(value.Length / 3);
                 fixed (float* value_ptr = value)
@@ -26075,7 +26075,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform3fvEXT"/>
-            public static unsafe void ProgramUniform3fvEXT(ProgramHandle program, int location, float[] value)
+            public static unsafe void ProgramUniform3fvEXT(int program, int location, float[] value)
             {
                 int count = (int)(value.Length / 3);
                 fixed (float* value_ptr = value)
@@ -26084,7 +26084,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform3fvEXT"/>
-            public static unsafe void ProgramUniform3fvEXT(ProgramHandle program, int location, int count, in float value)
+            public static unsafe void ProgramUniform3fvEXT(int program, int location, int count, in float value)
             {
                 fixed (float* value_ptr = &value)
                 {
@@ -26092,7 +26092,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform4fvEXT"/>
-            public static unsafe void ProgramUniform4fvEXT(ProgramHandle program, int location, ReadOnlySpan<float> value)
+            public static unsafe void ProgramUniform4fvEXT(int program, int location, ReadOnlySpan<float> value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (float* value_ptr = value)
@@ -26101,7 +26101,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform4fvEXT"/>
-            public static unsafe void ProgramUniform4fvEXT(ProgramHandle program, int location, float[] value)
+            public static unsafe void ProgramUniform4fvEXT(int program, int location, float[] value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (float* value_ptr = value)
@@ -26110,7 +26110,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform4fvEXT"/>
-            public static unsafe void ProgramUniform4fvEXT(ProgramHandle program, int location, int count, in float value)
+            public static unsafe void ProgramUniform4fvEXT(int program, int location, int count, in float value)
             {
                 fixed (float* value_ptr = &value)
                 {
@@ -26118,7 +26118,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform1ivEXT"/>
-            public static unsafe void ProgramUniform1ivEXT(ProgramHandle program, int location, ReadOnlySpan<int> value)
+            public static unsafe void ProgramUniform1ivEXT(int program, int location, ReadOnlySpan<int> value)
             {
                 int count = (int)(value.Length);
                 fixed (int* value_ptr = value)
@@ -26127,7 +26127,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform1ivEXT"/>
-            public static unsafe void ProgramUniform1ivEXT(ProgramHandle program, int location, int[] value)
+            public static unsafe void ProgramUniform1ivEXT(int program, int location, int[] value)
             {
                 int count = (int)(value.Length);
                 fixed (int* value_ptr = value)
@@ -26136,7 +26136,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform1ivEXT"/>
-            public static unsafe void ProgramUniform1ivEXT(ProgramHandle program, int location, int count, in int value)
+            public static unsafe void ProgramUniform1ivEXT(int program, int location, int count, in int value)
             {
                 fixed (int* value_ptr = &value)
                 {
@@ -26144,7 +26144,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform2ivEXT"/>
-            public static unsafe void ProgramUniform2ivEXT(ProgramHandle program, int location, ReadOnlySpan<int> value)
+            public static unsafe void ProgramUniform2ivEXT(int program, int location, ReadOnlySpan<int> value)
             {
                 int count = (int)(value.Length / 2);
                 fixed (int* value_ptr = value)
@@ -26153,7 +26153,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform2ivEXT"/>
-            public static unsafe void ProgramUniform2ivEXT(ProgramHandle program, int location, int[] value)
+            public static unsafe void ProgramUniform2ivEXT(int program, int location, int[] value)
             {
                 int count = (int)(value.Length / 2);
                 fixed (int* value_ptr = value)
@@ -26162,7 +26162,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform2ivEXT"/>
-            public static unsafe void ProgramUniform2ivEXT(ProgramHandle program, int location, int count, in int value)
+            public static unsafe void ProgramUniform2ivEXT(int program, int location, int count, in int value)
             {
                 fixed (int* value_ptr = &value)
                 {
@@ -26170,7 +26170,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform3ivEXT"/>
-            public static unsafe void ProgramUniform3ivEXT(ProgramHandle program, int location, ReadOnlySpan<int> value)
+            public static unsafe void ProgramUniform3ivEXT(int program, int location, ReadOnlySpan<int> value)
             {
                 int count = (int)(value.Length / 3);
                 fixed (int* value_ptr = value)
@@ -26179,7 +26179,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform3ivEXT"/>
-            public static unsafe void ProgramUniform3ivEXT(ProgramHandle program, int location, int[] value)
+            public static unsafe void ProgramUniform3ivEXT(int program, int location, int[] value)
             {
                 int count = (int)(value.Length / 3);
                 fixed (int* value_ptr = value)
@@ -26188,7 +26188,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform3ivEXT"/>
-            public static unsafe void ProgramUniform3ivEXT(ProgramHandle program, int location, int count, in int value)
+            public static unsafe void ProgramUniform3ivEXT(int program, int location, int count, in int value)
             {
                 fixed (int* value_ptr = &value)
                 {
@@ -26196,7 +26196,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform4ivEXT"/>
-            public static unsafe void ProgramUniform4ivEXT(ProgramHandle program, int location, ReadOnlySpan<int> value)
+            public static unsafe void ProgramUniform4ivEXT(int program, int location, ReadOnlySpan<int> value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (int* value_ptr = value)
@@ -26205,7 +26205,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform4ivEXT"/>
-            public static unsafe void ProgramUniform4ivEXT(ProgramHandle program, int location, int[] value)
+            public static unsafe void ProgramUniform4ivEXT(int program, int location, int[] value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (int* value_ptr = value)
@@ -26214,7 +26214,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform4ivEXT"/>
-            public static unsafe void ProgramUniform4ivEXT(ProgramHandle program, int location, int count, in int value)
+            public static unsafe void ProgramUniform4ivEXT(int program, int location, int count, in int value)
             {
                 fixed (int* value_ptr = &value)
                 {
@@ -26222,7 +26222,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2fvEXT"/>
-            public static unsafe void ProgramUniformMatrix2fvEXT(ProgramHandle program, int location, bool transpose, ReadOnlySpan<float> value)
+            public static unsafe void ProgramUniformMatrix2fvEXT(int program, int location, bool transpose, ReadOnlySpan<float> value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (float* value_ptr = value)
@@ -26231,7 +26231,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2fvEXT"/>
-            public static unsafe void ProgramUniformMatrix2fvEXT(ProgramHandle program, int location, bool transpose, float[] value)
+            public static unsafe void ProgramUniformMatrix2fvEXT(int program, int location, bool transpose, float[] value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (float* value_ptr = value)
@@ -26240,7 +26240,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2fvEXT"/>
-            public static unsafe void ProgramUniformMatrix2fvEXT(ProgramHandle program, int location, int count, bool transpose, in float value)
+            public static unsafe void ProgramUniformMatrix2fvEXT(int program, int location, int count, bool transpose, in float value)
             {
                 fixed (float* value_ptr = &value)
                 {
@@ -26248,7 +26248,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3fvEXT"/>
-            public static unsafe void ProgramUniformMatrix3fvEXT(ProgramHandle program, int location, bool transpose, ReadOnlySpan<float> value)
+            public static unsafe void ProgramUniformMatrix3fvEXT(int program, int location, bool transpose, ReadOnlySpan<float> value)
             {
                 int count = (int)(value.Length / 9);
                 fixed (float* value_ptr = value)
@@ -26257,7 +26257,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3fvEXT"/>
-            public static unsafe void ProgramUniformMatrix3fvEXT(ProgramHandle program, int location, bool transpose, float[] value)
+            public static unsafe void ProgramUniformMatrix3fvEXT(int program, int location, bool transpose, float[] value)
             {
                 int count = (int)(value.Length / 9);
                 fixed (float* value_ptr = value)
@@ -26266,7 +26266,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3fvEXT"/>
-            public static unsafe void ProgramUniformMatrix3fvEXT(ProgramHandle program, int location, int count, bool transpose, in float value)
+            public static unsafe void ProgramUniformMatrix3fvEXT(int program, int location, int count, bool transpose, in float value)
             {
                 fixed (float* value_ptr = &value)
                 {
@@ -26274,7 +26274,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4fvEXT"/>
-            public static unsafe void ProgramUniformMatrix4fvEXT(ProgramHandle program, int location, bool transpose, ReadOnlySpan<float> value)
+            public static unsafe void ProgramUniformMatrix4fvEXT(int program, int location, bool transpose, ReadOnlySpan<float> value)
             {
                 int count = (int)(value.Length / 16);
                 fixed (float* value_ptr = value)
@@ -26283,7 +26283,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4fvEXT"/>
-            public static unsafe void ProgramUniformMatrix4fvEXT(ProgramHandle program, int location, bool transpose, float[] value)
+            public static unsafe void ProgramUniformMatrix4fvEXT(int program, int location, bool transpose, float[] value)
             {
                 int count = (int)(value.Length / 16);
                 fixed (float* value_ptr = value)
@@ -26292,7 +26292,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4fvEXT"/>
-            public static unsafe void ProgramUniformMatrix4fvEXT(ProgramHandle program, int location, int count, bool transpose, in float value)
+            public static unsafe void ProgramUniformMatrix4fvEXT(int program, int location, int count, bool transpose, in float value)
             {
                 fixed (float* value_ptr = &value)
                 {
@@ -26300,7 +26300,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x3fvEXT"/>
-            public static unsafe void ProgramUniformMatrix2x3fvEXT(ProgramHandle program, int location, bool transpose, ReadOnlySpan<float> value)
+            public static unsafe void ProgramUniformMatrix2x3fvEXT(int program, int location, bool transpose, ReadOnlySpan<float> value)
             {
                 int count = (int)(value.Length / 6);
                 fixed (float* value_ptr = value)
@@ -26309,7 +26309,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x3fvEXT"/>
-            public static unsafe void ProgramUniformMatrix2x3fvEXT(ProgramHandle program, int location, bool transpose, float[] value)
+            public static unsafe void ProgramUniformMatrix2x3fvEXT(int program, int location, bool transpose, float[] value)
             {
                 int count = (int)(value.Length / 6);
                 fixed (float* value_ptr = value)
@@ -26318,7 +26318,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x3fvEXT"/>
-            public static unsafe void ProgramUniformMatrix2x3fvEXT(ProgramHandle program, int location, int count, bool transpose, in float value)
+            public static unsafe void ProgramUniformMatrix2x3fvEXT(int program, int location, int count, bool transpose, in float value)
             {
                 fixed (float* value_ptr = &value)
                 {
@@ -26326,7 +26326,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2fvEXT"/>
-            public static unsafe void ProgramUniformMatrix3x2fvEXT(ProgramHandle program, int location, bool transpose, ReadOnlySpan<float> value)
+            public static unsafe void ProgramUniformMatrix3x2fvEXT(int program, int location, bool transpose, ReadOnlySpan<float> value)
             {
                 int count = (int)(value.Length / 6);
                 fixed (float* value_ptr = value)
@@ -26335,7 +26335,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2fvEXT"/>
-            public static unsafe void ProgramUniformMatrix3x2fvEXT(ProgramHandle program, int location, bool transpose, float[] value)
+            public static unsafe void ProgramUniformMatrix3x2fvEXT(int program, int location, bool transpose, float[] value)
             {
                 int count = (int)(value.Length / 6);
                 fixed (float* value_ptr = value)
@@ -26344,7 +26344,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2fvEXT"/>
-            public static unsafe void ProgramUniformMatrix3x2fvEXT(ProgramHandle program, int location, int count, bool transpose, in float value)
+            public static unsafe void ProgramUniformMatrix3x2fvEXT(int program, int location, int count, bool transpose, in float value)
             {
                 fixed (float* value_ptr = &value)
                 {
@@ -26352,7 +26352,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x4fvEXT"/>
-            public static unsafe void ProgramUniformMatrix2x4fvEXT(ProgramHandle program, int location, bool transpose, ReadOnlySpan<float> value)
+            public static unsafe void ProgramUniformMatrix2x4fvEXT(int program, int location, bool transpose, ReadOnlySpan<float> value)
             {
                 int count = (int)(value.Length / 8);
                 fixed (float* value_ptr = value)
@@ -26361,7 +26361,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x4fvEXT"/>
-            public static unsafe void ProgramUniformMatrix2x4fvEXT(ProgramHandle program, int location, bool transpose, float[] value)
+            public static unsafe void ProgramUniformMatrix2x4fvEXT(int program, int location, bool transpose, float[] value)
             {
                 int count = (int)(value.Length / 8);
                 fixed (float* value_ptr = value)
@@ -26370,7 +26370,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x4fvEXT"/>
-            public static unsafe void ProgramUniformMatrix2x4fvEXT(ProgramHandle program, int location, int count, bool transpose, in float value)
+            public static unsafe void ProgramUniformMatrix2x4fvEXT(int program, int location, int count, bool transpose, in float value)
             {
                 fixed (float* value_ptr = &value)
                 {
@@ -26378,7 +26378,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x2fvEXT"/>
-            public static unsafe void ProgramUniformMatrix4x2fvEXT(ProgramHandle program, int location, bool transpose, ReadOnlySpan<float> value)
+            public static unsafe void ProgramUniformMatrix4x2fvEXT(int program, int location, bool transpose, ReadOnlySpan<float> value)
             {
                 int count = (int)(value.Length / 8);
                 fixed (float* value_ptr = value)
@@ -26387,7 +26387,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x2fvEXT"/>
-            public static unsafe void ProgramUniformMatrix4x2fvEXT(ProgramHandle program, int location, bool transpose, float[] value)
+            public static unsafe void ProgramUniformMatrix4x2fvEXT(int program, int location, bool transpose, float[] value)
             {
                 int count = (int)(value.Length / 8);
                 fixed (float* value_ptr = value)
@@ -26396,7 +26396,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x2fvEXT"/>
-            public static unsafe void ProgramUniformMatrix4x2fvEXT(ProgramHandle program, int location, int count, bool transpose, in float value)
+            public static unsafe void ProgramUniformMatrix4x2fvEXT(int program, int location, int count, bool transpose, in float value)
             {
                 fixed (float* value_ptr = &value)
                 {
@@ -26404,7 +26404,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x4fvEXT"/>
-            public static unsafe void ProgramUniformMatrix3x4fvEXT(ProgramHandle program, int location, bool transpose, ReadOnlySpan<float> value)
+            public static unsafe void ProgramUniformMatrix3x4fvEXT(int program, int location, bool transpose, ReadOnlySpan<float> value)
             {
                 int count = (int)(value.Length / 12);
                 fixed (float* value_ptr = value)
@@ -26413,7 +26413,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x4fvEXT"/>
-            public static unsafe void ProgramUniformMatrix3x4fvEXT(ProgramHandle program, int location, bool transpose, float[] value)
+            public static unsafe void ProgramUniformMatrix3x4fvEXT(int program, int location, bool transpose, float[] value)
             {
                 int count = (int)(value.Length / 12);
                 fixed (float* value_ptr = value)
@@ -26422,7 +26422,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x4fvEXT"/>
-            public static unsafe void ProgramUniformMatrix3x4fvEXT(ProgramHandle program, int location, int count, bool transpose, in float value)
+            public static unsafe void ProgramUniformMatrix3x4fvEXT(int program, int location, int count, bool transpose, in float value)
             {
                 fixed (float* value_ptr = &value)
                 {
@@ -26430,7 +26430,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x3fvEXT"/>
-            public static unsafe void ProgramUniformMatrix4x3fvEXT(ProgramHandle program, int location, bool transpose, ReadOnlySpan<float> value)
+            public static unsafe void ProgramUniformMatrix4x3fvEXT(int program, int location, bool transpose, ReadOnlySpan<float> value)
             {
                 int count = (int)(value.Length / 12);
                 fixed (float* value_ptr = value)
@@ -26439,7 +26439,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x3fvEXT"/>
-            public static unsafe void ProgramUniformMatrix4x3fvEXT(ProgramHandle program, int location, bool transpose, float[] value)
+            public static unsafe void ProgramUniformMatrix4x3fvEXT(int program, int location, bool transpose, float[] value)
             {
                 int count = (int)(value.Length / 12);
                 fixed (float* value_ptr = value)
@@ -26448,7 +26448,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x3fvEXT"/>
-            public static unsafe void ProgramUniformMatrix4x3fvEXT(ProgramHandle program, int location, int count, bool transpose, in float value)
+            public static unsafe void ProgramUniformMatrix4x3fvEXT(int program, int location, int count, bool transpose, in float value)
             {
                 fixed (float* value_ptr = &value)
                 {
@@ -26456,7 +26456,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="TextureParameterIivEXT"/>
-            public static unsafe void TextureParameterIivEXT(TextureHandle texture, TextureTarget target, TextureParameterName pname, ReadOnlySpan<int> parameters)
+            public static unsafe void TextureParameterIivEXT(int texture, TextureTarget target, TextureParameterName pname, ReadOnlySpan<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -26464,7 +26464,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="TextureParameterIivEXT"/>
-            public static unsafe void TextureParameterIivEXT(TextureHandle texture, TextureTarget target, TextureParameterName pname, int[] parameters)
+            public static unsafe void TextureParameterIivEXT(int texture, TextureTarget target, TextureParameterName pname, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -26472,7 +26472,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="TextureParameterIivEXT"/>
-            public static unsafe void TextureParameterIivEXT(TextureHandle texture, TextureTarget target, TextureParameterName pname, in int parameters)
+            public static unsafe void TextureParameterIivEXT(int texture, TextureTarget target, TextureParameterName pname, in int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -26480,7 +26480,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="TextureParameterIuivEXT"/>
-            public static unsafe void TextureParameterIuivEXT(TextureHandle texture, TextureTarget target, TextureParameterName pname, ReadOnlySpan<uint> parameters)
+            public static unsafe void TextureParameterIuivEXT(int texture, TextureTarget target, TextureParameterName pname, ReadOnlySpan<uint> parameters)
             {
                 fixed (uint* parameters_ptr = parameters)
                 {
@@ -26488,7 +26488,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="TextureParameterIuivEXT"/>
-            public static unsafe void TextureParameterIuivEXT(TextureHandle texture, TextureTarget target, TextureParameterName pname, uint[] parameters)
+            public static unsafe void TextureParameterIuivEXT(int texture, TextureTarget target, TextureParameterName pname, uint[] parameters)
             {
                 fixed (uint* parameters_ptr = parameters)
                 {
@@ -26496,7 +26496,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="TextureParameterIuivEXT"/>
-            public static unsafe void TextureParameterIuivEXT(TextureHandle texture, TextureTarget target, TextureParameterName pname, in uint parameters)
+            public static unsafe void TextureParameterIuivEXT(int texture, TextureTarget target, TextureParameterName pname, in uint parameters)
             {
                 fixed (uint* parameters_ptr = &parameters)
                 {
@@ -26504,7 +26504,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetTextureParameterIivEXT"/>
-            public static unsafe void GetTextureParameterIivEXT(TextureHandle texture, TextureTarget target, GetTextureParameter pname, Span<int> parameters)
+            public static unsafe void GetTextureParameterIivEXT(int texture, TextureTarget target, GetTextureParameter pname, Span<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -26512,7 +26512,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetTextureParameterIivEXT"/>
-            public static unsafe void GetTextureParameterIivEXT(TextureHandle texture, TextureTarget target, GetTextureParameter pname, int[] parameters)
+            public static unsafe void GetTextureParameterIivEXT(int texture, TextureTarget target, GetTextureParameter pname, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -26520,7 +26520,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetTextureParameterIivEXT"/>
-            public static unsafe void GetTextureParameterIivEXT(TextureHandle texture, TextureTarget target, GetTextureParameter pname, ref int parameters)
+            public static unsafe void GetTextureParameterIivEXT(int texture, TextureTarget target, GetTextureParameter pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -26528,7 +26528,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetTextureParameterIuivEXT"/>
-            public static unsafe void GetTextureParameterIuivEXT(TextureHandle texture, TextureTarget target, GetTextureParameter pname, Span<uint> parameters)
+            public static unsafe void GetTextureParameterIuivEXT(int texture, TextureTarget target, GetTextureParameter pname, Span<uint> parameters)
             {
                 fixed (uint* parameters_ptr = parameters)
                 {
@@ -26536,7 +26536,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetTextureParameterIuivEXT"/>
-            public static unsafe void GetTextureParameterIuivEXT(TextureHandle texture, TextureTarget target, GetTextureParameter pname, uint[] parameters)
+            public static unsafe void GetTextureParameterIuivEXT(int texture, TextureTarget target, GetTextureParameter pname, uint[] parameters)
             {
                 fixed (uint* parameters_ptr = parameters)
                 {
@@ -26544,7 +26544,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetTextureParameterIuivEXT"/>
-            public static unsafe void GetTextureParameterIuivEXT(TextureHandle texture, TextureTarget target, GetTextureParameter pname, ref uint parameters)
+            public static unsafe void GetTextureParameterIuivEXT(int texture, TextureTarget target, GetTextureParameter pname, ref uint parameters)
             {
                 fixed (uint* parameters_ptr = &parameters)
                 {
@@ -26648,7 +26648,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform1uivEXT"/>
-            public static unsafe void ProgramUniform1uivEXT(ProgramHandle program, int location, ReadOnlySpan<uint> value)
+            public static unsafe void ProgramUniform1uivEXT(int program, int location, ReadOnlySpan<uint> value)
             {
                 int count = (int)(value.Length);
                 fixed (uint* value_ptr = value)
@@ -26657,7 +26657,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform1uivEXT"/>
-            public static unsafe void ProgramUniform1uivEXT(ProgramHandle program, int location, uint[] value)
+            public static unsafe void ProgramUniform1uivEXT(int program, int location, uint[] value)
             {
                 int count = (int)(value.Length);
                 fixed (uint* value_ptr = value)
@@ -26666,7 +26666,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform1uivEXT"/>
-            public static unsafe void ProgramUniform1uivEXT(ProgramHandle program, int location, int count, in uint value)
+            public static unsafe void ProgramUniform1uivEXT(int program, int location, int count, in uint value)
             {
                 fixed (uint* value_ptr = &value)
                 {
@@ -26674,7 +26674,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform2uivEXT"/>
-            public static unsafe void ProgramUniform2uivEXT(ProgramHandle program, int location, ReadOnlySpan<uint> value)
+            public static unsafe void ProgramUniform2uivEXT(int program, int location, ReadOnlySpan<uint> value)
             {
                 int count = (int)(value.Length / 2);
                 fixed (uint* value_ptr = value)
@@ -26683,7 +26683,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform2uivEXT"/>
-            public static unsafe void ProgramUniform2uivEXT(ProgramHandle program, int location, uint[] value)
+            public static unsafe void ProgramUniform2uivEXT(int program, int location, uint[] value)
             {
                 int count = (int)(value.Length / 2);
                 fixed (uint* value_ptr = value)
@@ -26692,7 +26692,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform2uivEXT"/>
-            public static unsafe void ProgramUniform2uivEXT(ProgramHandle program, int location, int count, in uint value)
+            public static unsafe void ProgramUniform2uivEXT(int program, int location, int count, in uint value)
             {
                 fixed (uint* value_ptr = &value)
                 {
@@ -26700,7 +26700,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform3uivEXT"/>
-            public static unsafe void ProgramUniform3uivEXT(ProgramHandle program, int location, ReadOnlySpan<uint> value)
+            public static unsafe void ProgramUniform3uivEXT(int program, int location, ReadOnlySpan<uint> value)
             {
                 int count = (int)(value.Length / 3);
                 fixed (uint* value_ptr = value)
@@ -26709,7 +26709,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform3uivEXT"/>
-            public static unsafe void ProgramUniform3uivEXT(ProgramHandle program, int location, uint[] value)
+            public static unsafe void ProgramUniform3uivEXT(int program, int location, uint[] value)
             {
                 int count = (int)(value.Length / 3);
                 fixed (uint* value_ptr = value)
@@ -26718,7 +26718,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform3uivEXT"/>
-            public static unsafe void ProgramUniform3uivEXT(ProgramHandle program, int location, int count, in uint value)
+            public static unsafe void ProgramUniform3uivEXT(int program, int location, int count, in uint value)
             {
                 fixed (uint* value_ptr = &value)
                 {
@@ -26726,7 +26726,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform4uivEXT"/>
-            public static unsafe void ProgramUniform4uivEXT(ProgramHandle program, int location, ReadOnlySpan<uint> value)
+            public static unsafe void ProgramUniform4uivEXT(int program, int location, ReadOnlySpan<uint> value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (uint* value_ptr = value)
@@ -26735,7 +26735,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform4uivEXT"/>
-            public static unsafe void ProgramUniform4uivEXT(ProgramHandle program, int location, uint[] value)
+            public static unsafe void ProgramUniform4uivEXT(int program, int location, uint[] value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (uint* value_ptr = value)
@@ -26744,7 +26744,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform4uivEXT"/>
-            public static unsafe void ProgramUniform4uivEXT(ProgramHandle program, int location, int count, in uint value)
+            public static unsafe void ProgramUniform4uivEXT(int program, int location, int count, in uint value)
             {
                 fixed (uint* value_ptr = &value)
                 {
@@ -26752,7 +26752,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="NamedProgramLocalParameters4fvEXT"/>
-            public static unsafe void NamedProgramLocalParameters4fvEXT(ProgramHandle program, ProgramTarget target, uint index, ReadOnlySpan<float> parameters)
+            public static unsafe void NamedProgramLocalParameters4fvEXT(int program, ProgramTarget target, uint index, ReadOnlySpan<float> parameters)
             {
                 int count = (int)(parameters.Length / 4);
                 fixed (float* parameters_ptr = parameters)
@@ -26761,7 +26761,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="NamedProgramLocalParameters4fvEXT"/>
-            public static unsafe void NamedProgramLocalParameters4fvEXT(ProgramHandle program, ProgramTarget target, uint index, float[] parameters)
+            public static unsafe void NamedProgramLocalParameters4fvEXT(int program, ProgramTarget target, uint index, float[] parameters)
             {
                 int count = (int)(parameters.Length / 4);
                 fixed (float* parameters_ptr = parameters)
@@ -26770,7 +26770,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="NamedProgramLocalParameters4fvEXT"/>
-            public static unsafe void NamedProgramLocalParameters4fvEXT(ProgramHandle program, ProgramTarget target, uint index, int count, in float parameters)
+            public static unsafe void NamedProgramLocalParameters4fvEXT(int program, ProgramTarget target, uint index, int count, in float parameters)
             {
                 fixed (float* parameters_ptr = &parameters)
                 {
@@ -26778,7 +26778,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="NamedProgramLocalParameterI4ivEXT"/>
-            public static unsafe void NamedProgramLocalParameterI4ivEXT(ProgramHandle program, ProgramTarget target, uint index, ReadOnlySpan<int> parameters)
+            public static unsafe void NamedProgramLocalParameterI4ivEXT(int program, ProgramTarget target, uint index, ReadOnlySpan<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -26786,7 +26786,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="NamedProgramLocalParameterI4ivEXT"/>
-            public static unsafe void NamedProgramLocalParameterI4ivEXT(ProgramHandle program, ProgramTarget target, uint index, int[] parameters)
+            public static unsafe void NamedProgramLocalParameterI4ivEXT(int program, ProgramTarget target, uint index, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -26794,7 +26794,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="NamedProgramLocalParameterI4ivEXT"/>
-            public static unsafe void NamedProgramLocalParameterI4ivEXT(ProgramHandle program, ProgramTarget target, uint index, in int parameters)
+            public static unsafe void NamedProgramLocalParameterI4ivEXT(int program, ProgramTarget target, uint index, in int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -26802,7 +26802,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="NamedProgramLocalParametersI4ivEXT"/>
-            public static unsafe void NamedProgramLocalParametersI4ivEXT(ProgramHandle program, ProgramTarget target, uint index, ReadOnlySpan<int> parameters)
+            public static unsafe void NamedProgramLocalParametersI4ivEXT(int program, ProgramTarget target, uint index, ReadOnlySpan<int> parameters)
             {
                 int count = (int)(parameters.Length / 4);
                 fixed (int* parameters_ptr = parameters)
@@ -26811,7 +26811,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="NamedProgramLocalParametersI4ivEXT"/>
-            public static unsafe void NamedProgramLocalParametersI4ivEXT(ProgramHandle program, ProgramTarget target, uint index, int[] parameters)
+            public static unsafe void NamedProgramLocalParametersI4ivEXT(int program, ProgramTarget target, uint index, int[] parameters)
             {
                 int count = (int)(parameters.Length / 4);
                 fixed (int* parameters_ptr = parameters)
@@ -26820,7 +26820,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="NamedProgramLocalParametersI4ivEXT"/>
-            public static unsafe void NamedProgramLocalParametersI4ivEXT(ProgramHandle program, ProgramTarget target, uint index, int count, in int parameters)
+            public static unsafe void NamedProgramLocalParametersI4ivEXT(int program, ProgramTarget target, uint index, int count, in int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -26828,7 +26828,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="NamedProgramLocalParameterI4uivEXT"/>
-            public static unsafe void NamedProgramLocalParameterI4uivEXT(ProgramHandle program, ProgramTarget target, uint index, ReadOnlySpan<uint> parameters)
+            public static unsafe void NamedProgramLocalParameterI4uivEXT(int program, ProgramTarget target, uint index, ReadOnlySpan<uint> parameters)
             {
                 fixed (uint* parameters_ptr = parameters)
                 {
@@ -26836,7 +26836,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="NamedProgramLocalParameterI4uivEXT"/>
-            public static unsafe void NamedProgramLocalParameterI4uivEXT(ProgramHandle program, ProgramTarget target, uint index, uint[] parameters)
+            public static unsafe void NamedProgramLocalParameterI4uivEXT(int program, ProgramTarget target, uint index, uint[] parameters)
             {
                 fixed (uint* parameters_ptr = parameters)
                 {
@@ -26844,7 +26844,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="NamedProgramLocalParameterI4uivEXT"/>
-            public static unsafe void NamedProgramLocalParameterI4uivEXT(ProgramHandle program, ProgramTarget target, uint index, in uint parameters)
+            public static unsafe void NamedProgramLocalParameterI4uivEXT(int program, ProgramTarget target, uint index, in uint parameters)
             {
                 fixed (uint* parameters_ptr = &parameters)
                 {
@@ -26852,7 +26852,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="NamedProgramLocalParametersI4uivEXT"/>
-            public static unsafe void NamedProgramLocalParametersI4uivEXT(ProgramHandle program, ProgramTarget target, uint index, ReadOnlySpan<uint> parameters)
+            public static unsafe void NamedProgramLocalParametersI4uivEXT(int program, ProgramTarget target, uint index, ReadOnlySpan<uint> parameters)
             {
                 int count = (int)(parameters.Length / 4);
                 fixed (uint* parameters_ptr = parameters)
@@ -26861,7 +26861,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="NamedProgramLocalParametersI4uivEXT"/>
-            public static unsafe void NamedProgramLocalParametersI4uivEXT(ProgramHandle program, ProgramTarget target, uint index, uint[] parameters)
+            public static unsafe void NamedProgramLocalParametersI4uivEXT(int program, ProgramTarget target, uint index, uint[] parameters)
             {
                 int count = (int)(parameters.Length / 4);
                 fixed (uint* parameters_ptr = parameters)
@@ -26870,7 +26870,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="NamedProgramLocalParametersI4uivEXT"/>
-            public static unsafe void NamedProgramLocalParametersI4uivEXT(ProgramHandle program, ProgramTarget target, uint index, int count, in uint parameters)
+            public static unsafe void NamedProgramLocalParametersI4uivEXT(int program, ProgramTarget target, uint index, int count, in uint parameters)
             {
                 fixed (uint* parameters_ptr = &parameters)
                 {
@@ -26878,7 +26878,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetNamedProgramLocalParameterIivEXT"/>
-            public static unsafe void GetNamedProgramLocalParameterIivEXT(ProgramHandle program, ProgramTarget target, uint index, Span<int> parameters)
+            public static unsafe void GetNamedProgramLocalParameterIivEXT(int program, ProgramTarget target, uint index, Span<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -26886,7 +26886,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetNamedProgramLocalParameterIivEXT"/>
-            public static unsafe void GetNamedProgramLocalParameterIivEXT(ProgramHandle program, ProgramTarget target, uint index, int[] parameters)
+            public static unsafe void GetNamedProgramLocalParameterIivEXT(int program, ProgramTarget target, uint index, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -26894,7 +26894,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetNamedProgramLocalParameterIivEXT"/>
-            public static unsafe void GetNamedProgramLocalParameterIivEXT(ProgramHandle program, ProgramTarget target, uint index, ref int parameters)
+            public static unsafe void GetNamedProgramLocalParameterIivEXT(int program, ProgramTarget target, uint index, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -26902,7 +26902,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetNamedProgramLocalParameterIuivEXT"/>
-            public static unsafe void GetNamedProgramLocalParameterIuivEXT(ProgramHandle program, ProgramTarget target, uint index, Span<uint> parameters)
+            public static unsafe void GetNamedProgramLocalParameterIuivEXT(int program, ProgramTarget target, uint index, Span<uint> parameters)
             {
                 fixed (uint* parameters_ptr = parameters)
                 {
@@ -26910,7 +26910,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetNamedProgramLocalParameterIuivEXT"/>
-            public static unsafe void GetNamedProgramLocalParameterIuivEXT(ProgramHandle program, ProgramTarget target, uint index, uint[] parameters)
+            public static unsafe void GetNamedProgramLocalParameterIuivEXT(int program, ProgramTarget target, uint index, uint[] parameters)
             {
                 fixed (uint* parameters_ptr = parameters)
                 {
@@ -26918,7 +26918,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetNamedProgramLocalParameterIuivEXT"/>
-            public static unsafe void GetNamedProgramLocalParameterIuivEXT(ProgramHandle program, ProgramTarget target, uint index, ref uint parameters)
+            public static unsafe void GetNamedProgramLocalParameterIuivEXT(int program, ProgramTarget target, uint index, ref uint parameters)
             {
                 fixed (uint* parameters_ptr = &parameters)
                 {
@@ -26974,13 +26974,13 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="NamedProgramStringEXT"/>
-            public static unsafe void NamedProgramStringEXT(ProgramHandle program, ProgramTarget target, ProgramFormat format, int len, IntPtr str)
+            public static unsafe void NamedProgramStringEXT(int program, ProgramTarget target, ProgramFormat format, int len, IntPtr str)
             {
                 void* str_vptr = (void*)str;
                 NamedProgramStringEXT(program, target, format, len, str_vptr);
             }
             /// <inheritdoc cref="NamedProgramStringEXT"/>
-            public static unsafe void NamedProgramStringEXT<T1>(ProgramHandle program, ProgramTarget target, ProgramFormat format, ReadOnlySpan<T1> str)
+            public static unsafe void NamedProgramStringEXT<T1>(int program, ProgramTarget target, ProgramFormat format, ReadOnlySpan<T1> str)
                 where T1 : unmanaged
             {
                 int len = (int)(str.Length * sizeof(T1));
@@ -26990,7 +26990,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="NamedProgramStringEXT"/>
-            public static unsafe void NamedProgramStringEXT<T1>(ProgramHandle program, ProgramTarget target, ProgramFormat format, T1[] str)
+            public static unsafe void NamedProgramStringEXT<T1>(int program, ProgramTarget target, ProgramFormat format, T1[] str)
                 where T1 : unmanaged
             {
                 int len = (int)(str.Length * sizeof(T1));
@@ -27000,7 +27000,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="NamedProgramStringEXT"/>
-            public static unsafe void NamedProgramStringEXT<T1>(ProgramHandle program, ProgramTarget target, ProgramFormat format, int len, in T1 str)
+            public static unsafe void NamedProgramStringEXT<T1>(int program, ProgramTarget target, ProgramFormat format, int len, in T1 str)
                 where T1 : unmanaged
             {
                 fixed (void* str_ptr = &str)
@@ -27009,7 +27009,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="NamedProgramLocalParameter4dvEXT"/>
-            public static unsafe void NamedProgramLocalParameter4dvEXT(ProgramHandle program, ProgramTarget target, uint index, ReadOnlySpan<double> parameters)
+            public static unsafe void NamedProgramLocalParameter4dvEXT(int program, ProgramTarget target, uint index, ReadOnlySpan<double> parameters)
             {
                 fixed (double* parameters_ptr = parameters)
                 {
@@ -27017,7 +27017,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="NamedProgramLocalParameter4dvEXT"/>
-            public static unsafe void NamedProgramLocalParameter4dvEXT(ProgramHandle program, ProgramTarget target, uint index, double[] parameters)
+            public static unsafe void NamedProgramLocalParameter4dvEXT(int program, ProgramTarget target, uint index, double[] parameters)
             {
                 fixed (double* parameters_ptr = parameters)
                 {
@@ -27025,7 +27025,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="NamedProgramLocalParameter4dvEXT"/>
-            public static unsafe void NamedProgramLocalParameter4dvEXT(ProgramHandle program, ProgramTarget target, uint index, in double parameters)
+            public static unsafe void NamedProgramLocalParameter4dvEXT(int program, ProgramTarget target, uint index, in double parameters)
             {
                 fixed (double* parameters_ptr = &parameters)
                 {
@@ -27033,7 +27033,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="NamedProgramLocalParameter4fvEXT"/>
-            public static unsafe void NamedProgramLocalParameter4fvEXT(ProgramHandle program, ProgramTarget target, uint index, ReadOnlySpan<float> parameters)
+            public static unsafe void NamedProgramLocalParameter4fvEXT(int program, ProgramTarget target, uint index, ReadOnlySpan<float> parameters)
             {
                 fixed (float* parameters_ptr = parameters)
                 {
@@ -27041,7 +27041,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="NamedProgramLocalParameter4fvEXT"/>
-            public static unsafe void NamedProgramLocalParameter4fvEXT(ProgramHandle program, ProgramTarget target, uint index, float[] parameters)
+            public static unsafe void NamedProgramLocalParameter4fvEXT(int program, ProgramTarget target, uint index, float[] parameters)
             {
                 fixed (float* parameters_ptr = parameters)
                 {
@@ -27049,7 +27049,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="NamedProgramLocalParameter4fvEXT"/>
-            public static unsafe void NamedProgramLocalParameter4fvEXT(ProgramHandle program, ProgramTarget target, uint index, in float parameters)
+            public static unsafe void NamedProgramLocalParameter4fvEXT(int program, ProgramTarget target, uint index, in float parameters)
             {
                 fixed (float* parameters_ptr = &parameters)
                 {
@@ -27057,7 +27057,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetNamedProgramLocalParameterdvEXT"/>
-            public static unsafe void GetNamedProgramLocalParameterdvEXT(ProgramHandle program, ProgramTarget target, uint index, Span<double> parameters)
+            public static unsafe void GetNamedProgramLocalParameterdvEXT(int program, ProgramTarget target, uint index, Span<double> parameters)
             {
                 fixed (double* parameters_ptr = parameters)
                 {
@@ -27065,7 +27065,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetNamedProgramLocalParameterdvEXT"/>
-            public static unsafe void GetNamedProgramLocalParameterdvEXT(ProgramHandle program, ProgramTarget target, uint index, double[] parameters)
+            public static unsafe void GetNamedProgramLocalParameterdvEXT(int program, ProgramTarget target, uint index, double[] parameters)
             {
                 fixed (double* parameters_ptr = parameters)
                 {
@@ -27073,7 +27073,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetNamedProgramLocalParameterdvEXT"/>
-            public static unsafe void GetNamedProgramLocalParameterdvEXT(ProgramHandle program, ProgramTarget target, uint index, ref double parameters)
+            public static unsafe void GetNamedProgramLocalParameterdvEXT(int program, ProgramTarget target, uint index, ref double parameters)
             {
                 fixed (double* parameters_ptr = &parameters)
                 {
@@ -27081,7 +27081,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetNamedProgramLocalParameterfvEXT"/>
-            public static unsafe void GetNamedProgramLocalParameterfvEXT(ProgramHandle program, ProgramTarget target, uint index, Span<float> parameters)
+            public static unsafe void GetNamedProgramLocalParameterfvEXT(int program, ProgramTarget target, uint index, Span<float> parameters)
             {
                 fixed (float* parameters_ptr = parameters)
                 {
@@ -27089,7 +27089,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetNamedProgramLocalParameterfvEXT"/>
-            public static unsafe void GetNamedProgramLocalParameterfvEXT(ProgramHandle program, ProgramTarget target, uint index, float[] parameters)
+            public static unsafe void GetNamedProgramLocalParameterfvEXT(int program, ProgramTarget target, uint index, float[] parameters)
             {
                 fixed (float* parameters_ptr = parameters)
                 {
@@ -27097,7 +27097,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetNamedProgramLocalParameterfvEXT"/>
-            public static unsafe void GetNamedProgramLocalParameterfvEXT(ProgramHandle program, ProgramTarget target, uint index, ref float parameters)
+            public static unsafe void GetNamedProgramLocalParameterfvEXT(int program, ProgramTarget target, uint index, ref float parameters)
             {
                 fixed (float* parameters_ptr = &parameters)
                 {
@@ -27105,7 +27105,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetNamedProgramivEXT"/>
-            public static unsafe void GetNamedProgramivEXT(ProgramHandle program, ProgramTarget target, ProgramPropertyARB pname, Span<int> parameters)
+            public static unsafe void GetNamedProgramivEXT(int program, ProgramTarget target, ProgramPropertyARB pname, Span<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -27113,7 +27113,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetNamedProgramivEXT"/>
-            public static unsafe void GetNamedProgramivEXT(ProgramHandle program, ProgramTarget target, ProgramPropertyARB pname, int[] parameters)
+            public static unsafe void GetNamedProgramivEXT(int program, ProgramTarget target, ProgramPropertyARB pname, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -27121,7 +27121,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetNamedProgramivEXT"/>
-            public static unsafe void GetNamedProgramivEXT(ProgramHandle program, ProgramTarget target, ProgramPropertyARB pname, ref int parameters)
+            public static unsafe void GetNamedProgramivEXT(int program, ProgramTarget target, ProgramPropertyARB pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -27129,13 +27129,13 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetNamedProgramStringEXT"/>
-            public static unsafe void GetNamedProgramStringEXT(ProgramHandle program, ProgramTarget target, ProgramStringProperty pname, IntPtr str)
+            public static unsafe void GetNamedProgramStringEXT(int program, ProgramTarget target, ProgramStringProperty pname, IntPtr str)
             {
                 void* str_vptr = (void*)str;
                 GetNamedProgramStringEXT(program, target, pname, str_vptr);
             }
             /// <inheritdoc cref="GetNamedProgramStringEXT"/>
-            public static unsafe void GetNamedProgramStringEXT<T1>(ProgramHandle program, ProgramTarget target, ProgramStringProperty pname, Span<T1> str)
+            public static unsafe void GetNamedProgramStringEXT<T1>(int program, ProgramTarget target, ProgramStringProperty pname, Span<T1> str)
                 where T1 : unmanaged
             {
                 fixed (void* str_ptr = str)
@@ -27144,7 +27144,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetNamedProgramStringEXT"/>
-            public static unsafe void GetNamedProgramStringEXT<T1>(ProgramHandle program, ProgramTarget target, ProgramStringProperty pname, T1[] str)
+            public static unsafe void GetNamedProgramStringEXT<T1>(int program, ProgramTarget target, ProgramStringProperty pname, T1[] str)
                 where T1 : unmanaged
             {
                 fixed (void* str_ptr = str)
@@ -27153,7 +27153,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetNamedProgramStringEXT"/>
-            public static unsafe void GetNamedProgramStringEXT<T1>(ProgramHandle program, ProgramTarget target, ProgramStringProperty pname, ref T1 str)
+            public static unsafe void GetNamedProgramStringEXT<T1>(int program, ProgramTarget target, ProgramStringProperty pname, ref T1 str)
                 where T1 : unmanaged
             {
                 fixed (void* str_ptr = &str)
@@ -27162,7 +27162,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetNamedRenderbufferParameterivEXT"/>
-            public static unsafe void GetNamedRenderbufferParameterivEXT(RenderbufferHandle renderbuffer, RenderbufferParameterName pname, Span<int> parameters)
+            public static unsafe void GetNamedRenderbufferParameterivEXT(int renderbuffer, RenderbufferParameterName pname, Span<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -27170,7 +27170,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetNamedRenderbufferParameterivEXT"/>
-            public static unsafe void GetNamedRenderbufferParameterivEXT(RenderbufferHandle renderbuffer, RenderbufferParameterName pname, int[] parameters)
+            public static unsafe void GetNamedRenderbufferParameterivEXT(int renderbuffer, RenderbufferParameterName pname, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -27178,7 +27178,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetNamedRenderbufferParameterivEXT"/>
-            public static unsafe void GetNamedRenderbufferParameterivEXT(RenderbufferHandle renderbuffer, RenderbufferParameterName pname, ref int parameters)
+            public static unsafe void GetNamedRenderbufferParameterivEXT(int renderbuffer, RenderbufferParameterName pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -27186,7 +27186,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetNamedFramebufferAttachmentParameterivEXT"/>
-            public static unsafe void GetNamedFramebufferAttachmentParameterivEXT(FramebufferHandle framebuffer, FramebufferAttachment attachment, FramebufferAttachmentParameterName pname, Span<int> parameters)
+            public static unsafe void GetNamedFramebufferAttachmentParameterivEXT(int framebuffer, FramebufferAttachment attachment, FramebufferAttachmentParameterName pname, Span<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -27194,7 +27194,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetNamedFramebufferAttachmentParameterivEXT"/>
-            public static unsafe void GetNamedFramebufferAttachmentParameterivEXT(FramebufferHandle framebuffer, FramebufferAttachment attachment, FramebufferAttachmentParameterName pname, int[] parameters)
+            public static unsafe void GetNamedFramebufferAttachmentParameterivEXT(int framebuffer, FramebufferAttachment attachment, FramebufferAttachmentParameterName pname, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -27202,7 +27202,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetNamedFramebufferAttachmentParameterivEXT"/>
-            public static unsafe void GetNamedFramebufferAttachmentParameterivEXT(FramebufferHandle framebuffer, FramebufferAttachment attachment, FramebufferAttachmentParameterName pname, ref int parameters)
+            public static unsafe void GetNamedFramebufferAttachmentParameterivEXT(int framebuffer, FramebufferAttachment attachment, FramebufferAttachmentParameterName pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -27210,7 +27210,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="FramebufferDrawBuffersEXT"/>
-            public static unsafe void FramebufferDrawBuffersEXT(FramebufferHandle framebuffer, ReadOnlySpan<DrawBufferMode> bufs)
+            public static unsafe void FramebufferDrawBuffersEXT(int framebuffer, ReadOnlySpan<DrawBufferMode> bufs)
             {
                 int n = (int)(bufs.Length);
                 fixed (DrawBufferMode* bufs_ptr = bufs)
@@ -27219,7 +27219,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="FramebufferDrawBuffersEXT"/>
-            public static unsafe void FramebufferDrawBuffersEXT(FramebufferHandle framebuffer, DrawBufferMode[] bufs)
+            public static unsafe void FramebufferDrawBuffersEXT(int framebuffer, DrawBufferMode[] bufs)
             {
                 int n = (int)(bufs.Length);
                 fixed (DrawBufferMode* bufs_ptr = bufs)
@@ -27228,7 +27228,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="FramebufferDrawBuffersEXT"/>
-            public static unsafe void FramebufferDrawBuffersEXT(FramebufferHandle framebuffer, int n, in DrawBufferMode bufs)
+            public static unsafe void FramebufferDrawBuffersEXT(int framebuffer, int n, in DrawBufferMode bufs)
             {
                 fixed (DrawBufferMode* bufs_ptr = &bufs)
                 {
@@ -27236,7 +27236,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetFramebufferParameterivEXT"/>
-            public static unsafe void GetFramebufferParameterivEXT(FramebufferHandle framebuffer, GetFramebufferParameter pname, Span<int> parameters)
+            public static unsafe void GetFramebufferParameterivEXT(int framebuffer, GetFramebufferParameter pname, Span<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -27244,7 +27244,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetFramebufferParameterivEXT"/>
-            public static unsafe void GetFramebufferParameterivEXT(FramebufferHandle framebuffer, GetFramebufferParameter pname, int[] parameters)
+            public static unsafe void GetFramebufferParameterivEXT(int framebuffer, GetFramebufferParameter pname, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -27252,7 +27252,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetFramebufferParameterivEXT"/>
-            public static unsafe void GetFramebufferParameterivEXT(FramebufferHandle framebuffer, GetFramebufferParameter pname, ref int parameters)
+            public static unsafe void GetFramebufferParameterivEXT(int framebuffer, GetFramebufferParameter pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -27260,7 +27260,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetVertexArrayIntegervEXT"/>
-            public static unsafe void GetVertexArrayIntegervEXT(VertexArrayHandle vaobj, VertexArrayPName pname, ref int param)
+            public static unsafe void GetVertexArrayIntegervEXT(int vaobj, VertexArrayPName pname, ref int param)
             {
                 fixed (int* param_ptr = &param)
                 {
@@ -27268,7 +27268,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetVertexArrayIntegeri_vEXT"/>
-            public static unsafe void GetVertexArrayIntegeri_vEXT(VertexArrayHandle vaobj, uint index, VertexArrayPName pname, ref int param)
+            public static unsafe void GetVertexArrayIntegeri_vEXT(int vaobj, uint index, VertexArrayPName pname, ref int param)
             {
                 fixed (int* param_ptr = &param)
                 {
@@ -27276,13 +27276,13 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="NamedBufferStorageEXT"/>
-            public static unsafe void NamedBufferStorageEXT(BufferHandle buffer, nint size, IntPtr data, BufferStorageMask flags)
+            public static unsafe void NamedBufferStorageEXT(int buffer, nint size, IntPtr data, BufferStorageMask flags)
             {
                 void* data_vptr = (void*)data;
                 NamedBufferStorageEXT(buffer, size, data_vptr, flags);
             }
             /// <inheritdoc cref="NamedBufferStorageEXT"/>
-            public static unsafe void NamedBufferStorageEXT<T1>(BufferHandle buffer, ReadOnlySpan<T1> data, BufferStorageMask flags)
+            public static unsafe void NamedBufferStorageEXT<T1>(int buffer, ReadOnlySpan<T1> data, BufferStorageMask flags)
                 where T1 : unmanaged
             {
                 nint size = (nint)(data.Length * sizeof(T1));
@@ -27292,7 +27292,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="NamedBufferStorageEXT"/>
-            public static unsafe void NamedBufferStorageEXT<T1>(BufferHandle buffer, T1[] data, BufferStorageMask flags)
+            public static unsafe void NamedBufferStorageEXT<T1>(int buffer, T1[] data, BufferStorageMask flags)
                 where T1 : unmanaged
             {
                 nint size = (nint)(data.Length * sizeof(T1));
@@ -27302,7 +27302,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="NamedBufferStorageEXT"/>
-            public static unsafe void NamedBufferStorageEXT<T1>(BufferHandle buffer, nint size, in T1 data, BufferStorageMask flags)
+            public static unsafe void NamedBufferStorageEXT<T1>(int buffer, nint size, in T1 data, BufferStorageMask flags)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = &data)
@@ -27311,13 +27311,13 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ClearNamedBufferDataEXT"/>
-            public static unsafe void ClearNamedBufferDataEXT(BufferHandle buffer, SizedInternalFormat internalformat, PixelFormat format, PixelType type, IntPtr data)
+            public static unsafe void ClearNamedBufferDataEXT(int buffer, SizedInternalFormat internalformat, PixelFormat format, PixelType type, IntPtr data)
             {
                 void* data_vptr = (void*)data;
                 ClearNamedBufferDataEXT(buffer, internalformat, format, type, data_vptr);
             }
             /// <inheritdoc cref="ClearNamedBufferDataEXT"/>
-            public static unsafe void ClearNamedBufferDataEXT<T1>(BufferHandle buffer, SizedInternalFormat internalformat, PixelFormat format, PixelType type, ReadOnlySpan<T1> data)
+            public static unsafe void ClearNamedBufferDataEXT<T1>(int buffer, SizedInternalFormat internalformat, PixelFormat format, PixelType type, ReadOnlySpan<T1> data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = data)
@@ -27326,7 +27326,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ClearNamedBufferDataEXT"/>
-            public static unsafe void ClearNamedBufferDataEXT<T1>(BufferHandle buffer, SizedInternalFormat internalformat, PixelFormat format, PixelType type, T1[] data)
+            public static unsafe void ClearNamedBufferDataEXT<T1>(int buffer, SizedInternalFormat internalformat, PixelFormat format, PixelType type, T1[] data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = data)
@@ -27335,7 +27335,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ClearNamedBufferDataEXT"/>
-            public static unsafe void ClearNamedBufferDataEXT<T1>(BufferHandle buffer, SizedInternalFormat internalformat, PixelFormat format, PixelType type, in T1 data)
+            public static unsafe void ClearNamedBufferDataEXT<T1>(int buffer, SizedInternalFormat internalformat, PixelFormat format, PixelType type, in T1 data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = &data)
@@ -27344,13 +27344,13 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ClearNamedBufferSubDataEXT"/>
-            public static unsafe void ClearNamedBufferSubDataEXT(BufferHandle buffer, SizedInternalFormat internalformat, nint offset, nint size, PixelFormat format, PixelType type, IntPtr data)
+            public static unsafe void ClearNamedBufferSubDataEXT(int buffer, SizedInternalFormat internalformat, nint offset, nint size, PixelFormat format, PixelType type, IntPtr data)
             {
                 void* data_vptr = (void*)data;
                 ClearNamedBufferSubDataEXT(buffer, internalformat, offset, size, format, type, data_vptr);
             }
             /// <inheritdoc cref="ClearNamedBufferSubDataEXT"/>
-            public static unsafe void ClearNamedBufferSubDataEXT<T1>(BufferHandle buffer, SizedInternalFormat internalformat, nint offset, nint size, PixelFormat format, PixelType type, ReadOnlySpan<T1> data)
+            public static unsafe void ClearNamedBufferSubDataEXT<T1>(int buffer, SizedInternalFormat internalformat, nint offset, nint size, PixelFormat format, PixelType type, ReadOnlySpan<T1> data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = data)
@@ -27359,7 +27359,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ClearNamedBufferSubDataEXT"/>
-            public static unsafe void ClearNamedBufferSubDataEXT<T1>(BufferHandle buffer, SizedInternalFormat internalformat, nint offset, nint size, PixelFormat format, PixelType type, T1[] data)
+            public static unsafe void ClearNamedBufferSubDataEXT<T1>(int buffer, SizedInternalFormat internalformat, nint offset, nint size, PixelFormat format, PixelType type, T1[] data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = data)
@@ -27368,7 +27368,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ClearNamedBufferSubDataEXT"/>
-            public static unsafe void ClearNamedBufferSubDataEXT<T1>(BufferHandle buffer, SizedInternalFormat internalformat, nint offset, nint size, PixelFormat format, PixelType type, in T1 data)
+            public static unsafe void ClearNamedBufferSubDataEXT<T1>(int buffer, SizedInternalFormat internalformat, nint offset, nint size, PixelFormat format, PixelType type, in T1 data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = &data)
@@ -27377,7 +27377,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetNamedFramebufferParameterivEXT"/>
-            public static unsafe void GetNamedFramebufferParameterivEXT(FramebufferHandle framebuffer, GetFramebufferParameter pname, Span<int> parameters)
+            public static unsafe void GetNamedFramebufferParameterivEXT(int framebuffer, GetFramebufferParameter pname, Span<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -27385,7 +27385,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetNamedFramebufferParameterivEXT"/>
-            public static unsafe void GetNamedFramebufferParameterivEXT(FramebufferHandle framebuffer, GetFramebufferParameter pname, int[] parameters)
+            public static unsafe void GetNamedFramebufferParameterivEXT(int framebuffer, GetFramebufferParameter pname, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -27393,7 +27393,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetNamedFramebufferParameterivEXT"/>
-            public static unsafe void GetNamedFramebufferParameterivEXT(FramebufferHandle framebuffer, GetFramebufferParameter pname, ref int parameters)
+            public static unsafe void GetNamedFramebufferParameterivEXT(int framebuffer, GetFramebufferParameter pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -27401,7 +27401,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform1dvEXT"/>
-            public static unsafe void ProgramUniform1dvEXT(ProgramHandle program, int location, ReadOnlySpan<double> value)
+            public static unsafe void ProgramUniform1dvEXT(int program, int location, ReadOnlySpan<double> value)
             {
                 int count = (int)(value.Length);
                 fixed (double* value_ptr = value)
@@ -27410,7 +27410,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform1dvEXT"/>
-            public static unsafe void ProgramUniform1dvEXT(ProgramHandle program, int location, double[] value)
+            public static unsafe void ProgramUniform1dvEXT(int program, int location, double[] value)
             {
                 int count = (int)(value.Length);
                 fixed (double* value_ptr = value)
@@ -27419,7 +27419,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform1dvEXT"/>
-            public static unsafe void ProgramUniform1dvEXT(ProgramHandle program, int location, int count, in double value)
+            public static unsafe void ProgramUniform1dvEXT(int program, int location, int count, in double value)
             {
                 fixed (double* value_ptr = &value)
                 {
@@ -27427,7 +27427,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform2dvEXT"/>
-            public static unsafe void ProgramUniform2dvEXT(ProgramHandle program, int location, ReadOnlySpan<double> value)
+            public static unsafe void ProgramUniform2dvEXT(int program, int location, ReadOnlySpan<double> value)
             {
                 int count = (int)(value.Length / 2);
                 fixed (double* value_ptr = value)
@@ -27436,7 +27436,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform2dvEXT"/>
-            public static unsafe void ProgramUniform2dvEXT(ProgramHandle program, int location, double[] value)
+            public static unsafe void ProgramUniform2dvEXT(int program, int location, double[] value)
             {
                 int count = (int)(value.Length / 2);
                 fixed (double* value_ptr = value)
@@ -27445,7 +27445,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform2dvEXT"/>
-            public static unsafe void ProgramUniform2dvEXT(ProgramHandle program, int location, int count, in double value)
+            public static unsafe void ProgramUniform2dvEXT(int program, int location, int count, in double value)
             {
                 fixed (double* value_ptr = &value)
                 {
@@ -27453,7 +27453,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform3dvEXT"/>
-            public static unsafe void ProgramUniform3dvEXT(ProgramHandle program, int location, ReadOnlySpan<double> value)
+            public static unsafe void ProgramUniform3dvEXT(int program, int location, ReadOnlySpan<double> value)
             {
                 int count = (int)(value.Length / 3);
                 fixed (double* value_ptr = value)
@@ -27462,7 +27462,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform3dvEXT"/>
-            public static unsafe void ProgramUniform3dvEXT(ProgramHandle program, int location, double[] value)
+            public static unsafe void ProgramUniform3dvEXT(int program, int location, double[] value)
             {
                 int count = (int)(value.Length / 3);
                 fixed (double* value_ptr = value)
@@ -27471,7 +27471,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform3dvEXT"/>
-            public static unsafe void ProgramUniform3dvEXT(ProgramHandle program, int location, int count, in double value)
+            public static unsafe void ProgramUniform3dvEXT(int program, int location, int count, in double value)
             {
                 fixed (double* value_ptr = &value)
                 {
@@ -27479,7 +27479,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform4dvEXT"/>
-            public static unsafe void ProgramUniform4dvEXT(ProgramHandle program, int location, ReadOnlySpan<double> value)
+            public static unsafe void ProgramUniform4dvEXT(int program, int location, ReadOnlySpan<double> value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (double* value_ptr = value)
@@ -27488,7 +27488,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform4dvEXT"/>
-            public static unsafe void ProgramUniform4dvEXT(ProgramHandle program, int location, double[] value)
+            public static unsafe void ProgramUniform4dvEXT(int program, int location, double[] value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (double* value_ptr = value)
@@ -27497,7 +27497,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform4dvEXT"/>
-            public static unsafe void ProgramUniform4dvEXT(ProgramHandle program, int location, int count, in double value)
+            public static unsafe void ProgramUniform4dvEXT(int program, int location, int count, in double value)
             {
                 fixed (double* value_ptr = &value)
                 {
@@ -27505,7 +27505,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2dvEXT"/>
-            public static unsafe void ProgramUniformMatrix2dvEXT(ProgramHandle program, int location, bool transpose, ReadOnlySpan<double> value)
+            public static unsafe void ProgramUniformMatrix2dvEXT(int program, int location, bool transpose, ReadOnlySpan<double> value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (double* value_ptr = value)
@@ -27514,7 +27514,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2dvEXT"/>
-            public static unsafe void ProgramUniformMatrix2dvEXT(ProgramHandle program, int location, bool transpose, double[] value)
+            public static unsafe void ProgramUniformMatrix2dvEXT(int program, int location, bool transpose, double[] value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (double* value_ptr = value)
@@ -27523,7 +27523,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2dvEXT"/>
-            public static unsafe void ProgramUniformMatrix2dvEXT(ProgramHandle program, int location, int count, bool transpose, in double value)
+            public static unsafe void ProgramUniformMatrix2dvEXT(int program, int location, int count, bool transpose, in double value)
             {
                 fixed (double* value_ptr = &value)
                 {
@@ -27531,7 +27531,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3dvEXT"/>
-            public static unsafe void ProgramUniformMatrix3dvEXT(ProgramHandle program, int location, bool transpose, ReadOnlySpan<double> value)
+            public static unsafe void ProgramUniformMatrix3dvEXT(int program, int location, bool transpose, ReadOnlySpan<double> value)
             {
                 int count = (int)(value.Length / 9);
                 fixed (double* value_ptr = value)
@@ -27540,7 +27540,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3dvEXT"/>
-            public static unsafe void ProgramUniformMatrix3dvEXT(ProgramHandle program, int location, bool transpose, double[] value)
+            public static unsafe void ProgramUniformMatrix3dvEXT(int program, int location, bool transpose, double[] value)
             {
                 int count = (int)(value.Length / 9);
                 fixed (double* value_ptr = value)
@@ -27549,7 +27549,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3dvEXT"/>
-            public static unsafe void ProgramUniformMatrix3dvEXT(ProgramHandle program, int location, int count, bool transpose, in double value)
+            public static unsafe void ProgramUniformMatrix3dvEXT(int program, int location, int count, bool transpose, in double value)
             {
                 fixed (double* value_ptr = &value)
                 {
@@ -27557,7 +27557,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4dvEXT"/>
-            public static unsafe void ProgramUniformMatrix4dvEXT(ProgramHandle program, int location, bool transpose, ReadOnlySpan<double> value)
+            public static unsafe void ProgramUniformMatrix4dvEXT(int program, int location, bool transpose, ReadOnlySpan<double> value)
             {
                 int count = (int)(value.Length / 16);
                 fixed (double* value_ptr = value)
@@ -27566,7 +27566,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4dvEXT"/>
-            public static unsafe void ProgramUniformMatrix4dvEXT(ProgramHandle program, int location, bool transpose, double[] value)
+            public static unsafe void ProgramUniformMatrix4dvEXT(int program, int location, bool transpose, double[] value)
             {
                 int count = (int)(value.Length / 16);
                 fixed (double* value_ptr = value)
@@ -27575,7 +27575,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4dvEXT"/>
-            public static unsafe void ProgramUniformMatrix4dvEXT(ProgramHandle program, int location, int count, bool transpose, in double value)
+            public static unsafe void ProgramUniformMatrix4dvEXT(int program, int location, int count, bool transpose, in double value)
             {
                 fixed (double* value_ptr = &value)
                 {
@@ -27583,7 +27583,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x3dvEXT"/>
-            public static unsafe void ProgramUniformMatrix2x3dvEXT(ProgramHandle program, int location, bool transpose, ReadOnlySpan<double> value)
+            public static unsafe void ProgramUniformMatrix2x3dvEXT(int program, int location, bool transpose, ReadOnlySpan<double> value)
             {
                 int count = (int)(value.Length / 6);
                 fixed (double* value_ptr = value)
@@ -27592,7 +27592,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x3dvEXT"/>
-            public static unsafe void ProgramUniformMatrix2x3dvEXT(ProgramHandle program, int location, bool transpose, double[] value)
+            public static unsafe void ProgramUniformMatrix2x3dvEXT(int program, int location, bool transpose, double[] value)
             {
                 int count = (int)(value.Length / 6);
                 fixed (double* value_ptr = value)
@@ -27601,7 +27601,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x3dvEXT"/>
-            public static unsafe void ProgramUniformMatrix2x3dvEXT(ProgramHandle program, int location, int count, bool transpose, in double value)
+            public static unsafe void ProgramUniformMatrix2x3dvEXT(int program, int location, int count, bool transpose, in double value)
             {
                 fixed (double* value_ptr = &value)
                 {
@@ -27609,7 +27609,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x4dvEXT"/>
-            public static unsafe void ProgramUniformMatrix2x4dvEXT(ProgramHandle program, int location, bool transpose, ReadOnlySpan<double> value)
+            public static unsafe void ProgramUniformMatrix2x4dvEXT(int program, int location, bool transpose, ReadOnlySpan<double> value)
             {
                 int count = (int)(value.Length / 8);
                 fixed (double* value_ptr = value)
@@ -27618,7 +27618,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x4dvEXT"/>
-            public static unsafe void ProgramUniformMatrix2x4dvEXT(ProgramHandle program, int location, bool transpose, double[] value)
+            public static unsafe void ProgramUniformMatrix2x4dvEXT(int program, int location, bool transpose, double[] value)
             {
                 int count = (int)(value.Length / 8);
                 fixed (double* value_ptr = value)
@@ -27627,7 +27627,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x4dvEXT"/>
-            public static unsafe void ProgramUniformMatrix2x4dvEXT(ProgramHandle program, int location, int count, bool transpose, in double value)
+            public static unsafe void ProgramUniformMatrix2x4dvEXT(int program, int location, int count, bool transpose, in double value)
             {
                 fixed (double* value_ptr = &value)
                 {
@@ -27635,7 +27635,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2dvEXT"/>
-            public static unsafe void ProgramUniformMatrix3x2dvEXT(ProgramHandle program, int location, bool transpose, ReadOnlySpan<double> value)
+            public static unsafe void ProgramUniformMatrix3x2dvEXT(int program, int location, bool transpose, ReadOnlySpan<double> value)
             {
                 int count = (int)(value.Length / 6);
                 fixed (double* value_ptr = value)
@@ -27644,7 +27644,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2dvEXT"/>
-            public static unsafe void ProgramUniformMatrix3x2dvEXT(ProgramHandle program, int location, bool transpose, double[] value)
+            public static unsafe void ProgramUniformMatrix3x2dvEXT(int program, int location, bool transpose, double[] value)
             {
                 int count = (int)(value.Length / 6);
                 fixed (double* value_ptr = value)
@@ -27653,7 +27653,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2dvEXT"/>
-            public static unsafe void ProgramUniformMatrix3x2dvEXT(ProgramHandle program, int location, int count, bool transpose, in double value)
+            public static unsafe void ProgramUniformMatrix3x2dvEXT(int program, int location, int count, bool transpose, in double value)
             {
                 fixed (double* value_ptr = &value)
                 {
@@ -27661,7 +27661,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x4dvEXT"/>
-            public static unsafe void ProgramUniformMatrix3x4dvEXT(ProgramHandle program, int location, bool transpose, ReadOnlySpan<double> value)
+            public static unsafe void ProgramUniformMatrix3x4dvEXT(int program, int location, bool transpose, ReadOnlySpan<double> value)
             {
                 int count = (int)(value.Length / 12);
                 fixed (double* value_ptr = value)
@@ -27670,7 +27670,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x4dvEXT"/>
-            public static unsafe void ProgramUniformMatrix3x4dvEXT(ProgramHandle program, int location, bool transpose, double[] value)
+            public static unsafe void ProgramUniformMatrix3x4dvEXT(int program, int location, bool transpose, double[] value)
             {
                 int count = (int)(value.Length / 12);
                 fixed (double* value_ptr = value)
@@ -27679,7 +27679,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x4dvEXT"/>
-            public static unsafe void ProgramUniformMatrix3x4dvEXT(ProgramHandle program, int location, int count, bool transpose, in double value)
+            public static unsafe void ProgramUniformMatrix3x4dvEXT(int program, int location, int count, bool transpose, in double value)
             {
                 fixed (double* value_ptr = &value)
                 {
@@ -27687,7 +27687,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x2dvEXT"/>
-            public static unsafe void ProgramUniformMatrix4x2dvEXT(ProgramHandle program, int location, bool transpose, ReadOnlySpan<double> value)
+            public static unsafe void ProgramUniformMatrix4x2dvEXT(int program, int location, bool transpose, ReadOnlySpan<double> value)
             {
                 int count = (int)(value.Length / 8);
                 fixed (double* value_ptr = value)
@@ -27696,7 +27696,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x2dvEXT"/>
-            public static unsafe void ProgramUniformMatrix4x2dvEXT(ProgramHandle program, int location, bool transpose, double[] value)
+            public static unsafe void ProgramUniformMatrix4x2dvEXT(int program, int location, bool transpose, double[] value)
             {
                 int count = (int)(value.Length / 8);
                 fixed (double* value_ptr = value)
@@ -27705,7 +27705,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x2dvEXT"/>
-            public static unsafe void ProgramUniformMatrix4x2dvEXT(ProgramHandle program, int location, int count, bool transpose, in double value)
+            public static unsafe void ProgramUniformMatrix4x2dvEXT(int program, int location, int count, bool transpose, in double value)
             {
                 fixed (double* value_ptr = &value)
                 {
@@ -27713,7 +27713,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x3dvEXT"/>
-            public static unsafe void ProgramUniformMatrix4x3dvEXT(ProgramHandle program, int location, bool transpose, ReadOnlySpan<double> value)
+            public static unsafe void ProgramUniformMatrix4x3dvEXT(int program, int location, bool transpose, ReadOnlySpan<double> value)
             {
                 int count = (int)(value.Length / 12);
                 fixed (double* value_ptr = value)
@@ -27722,7 +27722,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x3dvEXT"/>
-            public static unsafe void ProgramUniformMatrix4x3dvEXT(ProgramHandle program, int location, bool transpose, double[] value)
+            public static unsafe void ProgramUniformMatrix4x3dvEXT(int program, int location, bool transpose, double[] value)
             {
                 int count = (int)(value.Length / 12);
                 fixed (double* value_ptr = value)
@@ -27731,7 +27731,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x3dvEXT"/>
-            public static unsafe void ProgramUniformMatrix4x3dvEXT(ProgramHandle program, int location, int count, bool transpose, in double value)
+            public static unsafe void ProgramUniformMatrix4x3dvEXT(int program, int location, int count, bool transpose, in double value)
             {
                 fixed (double* value_ptr = &value)
                 {
@@ -27766,13 +27766,13 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="NamedBufferStorageExternalEXT"/>
-            public static unsafe void NamedBufferStorageExternalEXT(BufferHandle buffer, IntPtr offset, nint size, IntPtr clientBuffer, BufferStorageMask flags)
+            public static unsafe void NamedBufferStorageExternalEXT(int buffer, IntPtr offset, nint size, IntPtr clientBuffer, BufferStorageMask flags)
             {
                 void* clientBuffer_vptr = (void*)clientBuffer;
                 NamedBufferStorageExternalEXT(buffer, offset, size, clientBuffer_vptr, flags);
             }
             /// <inheritdoc cref="NamedBufferStorageExternalEXT"/>
-            public static unsafe void NamedBufferStorageExternalEXT<T1>(BufferHandle buffer, IntPtr offset, nint size, ref T1 clientBuffer, BufferStorageMask flags)
+            public static unsafe void NamedBufferStorageExternalEXT<T1>(int buffer, IntPtr offset, nint size, ref T1 clientBuffer, BufferStorageMask flags)
                 where T1 : unmanaged
             {
                 fixed (void* clientBuffer_ptr = &clientBuffer)
@@ -27862,53 +27862,53 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="DeleteRenderbuffersEXT"/>
-            public static unsafe void DeleteRenderbuffersEXT(ReadOnlySpan<RenderbufferHandle> renderbuffers)
+            public static unsafe void DeleteRenderbuffersEXT(ReadOnlySpan<int> renderbuffers)
             {
                 int n = (int)(renderbuffers.Length);
-                fixed (RenderbufferHandle* renderbuffers_ptr = renderbuffers)
+                fixed (int* renderbuffers_ptr = renderbuffers)
                 {
                     DeleteRenderbuffersEXT(n, renderbuffers_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteRenderbuffersEXT"/>
-            public static unsafe void DeleteRenderbuffersEXT(RenderbufferHandle[] renderbuffers)
+            public static unsafe void DeleteRenderbuffersEXT(int[] renderbuffers)
             {
                 int n = (int)(renderbuffers.Length);
-                fixed (RenderbufferHandle* renderbuffers_ptr = renderbuffers)
+                fixed (int* renderbuffers_ptr = renderbuffers)
                 {
                     DeleteRenderbuffersEXT(n, renderbuffers_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteRenderbuffersEXT"/>
-            public static unsafe void DeleteRenderbuffersEXT(int n, in RenderbufferHandle renderbuffers)
+            public static unsafe void DeleteRenderbuffersEXT(int n, in int renderbuffers)
             {
-                fixed (RenderbufferHandle* renderbuffers_ptr = &renderbuffers)
+                fixed (int* renderbuffers_ptr = &renderbuffers)
                 {
                     DeleteRenderbuffersEXT(n, renderbuffers_ptr);
                 }
             }
             /// <inheritdoc cref="GenRenderbuffersEXT"/>
-            public static unsafe void GenRenderbuffersEXT(Span<RenderbufferHandle> renderbuffers)
+            public static unsafe void GenRenderbuffersEXT(Span<int> renderbuffers)
             {
                 int n = (int)(renderbuffers.Length);
-                fixed (RenderbufferHandle* renderbuffers_ptr = renderbuffers)
+                fixed (int* renderbuffers_ptr = renderbuffers)
                 {
                     GenRenderbuffersEXT(n, renderbuffers_ptr);
                 }
             }
             /// <inheritdoc cref="GenRenderbuffersEXT"/>
-            public static unsafe void GenRenderbuffersEXT(RenderbufferHandle[] renderbuffers)
+            public static unsafe void GenRenderbuffersEXT(int[] renderbuffers)
             {
                 int n = (int)(renderbuffers.Length);
-                fixed (RenderbufferHandle* renderbuffers_ptr = renderbuffers)
+                fixed (int* renderbuffers_ptr = renderbuffers)
                 {
                     GenRenderbuffersEXT(n, renderbuffers_ptr);
                 }
             }
             /// <inheritdoc cref="GenRenderbuffersEXT"/>
-            public static unsafe void GenRenderbuffersEXT(int n, ref RenderbufferHandle renderbuffers)
+            public static unsafe void GenRenderbuffersEXT(int n, ref int renderbuffers)
             {
-                fixed (RenderbufferHandle* renderbuffers_ptr = &renderbuffers)
+                fixed (int* renderbuffers_ptr = &renderbuffers)
                 {
                     GenRenderbuffersEXT(n, renderbuffers_ptr);
                 }
@@ -27938,53 +27938,53 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="DeleteFramebuffersEXT"/>
-            public static unsafe void DeleteFramebuffersEXT(ReadOnlySpan<FramebufferHandle> framebuffers)
+            public static unsafe void DeleteFramebuffersEXT(ReadOnlySpan<int> framebuffers)
             {
                 int n = (int)(framebuffers.Length);
-                fixed (FramebufferHandle* framebuffers_ptr = framebuffers)
+                fixed (int* framebuffers_ptr = framebuffers)
                 {
                     DeleteFramebuffersEXT(n, framebuffers_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteFramebuffersEXT"/>
-            public static unsafe void DeleteFramebuffersEXT(FramebufferHandle[] framebuffers)
+            public static unsafe void DeleteFramebuffersEXT(int[] framebuffers)
             {
                 int n = (int)(framebuffers.Length);
-                fixed (FramebufferHandle* framebuffers_ptr = framebuffers)
+                fixed (int* framebuffers_ptr = framebuffers)
                 {
                     DeleteFramebuffersEXT(n, framebuffers_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteFramebuffersEXT"/>
-            public static unsafe void DeleteFramebuffersEXT(int n, in FramebufferHandle framebuffers)
+            public static unsafe void DeleteFramebuffersEXT(int n, in int framebuffers)
             {
-                fixed (FramebufferHandle* framebuffers_ptr = &framebuffers)
+                fixed (int* framebuffers_ptr = &framebuffers)
                 {
                     DeleteFramebuffersEXT(n, framebuffers_ptr);
                 }
             }
             /// <inheritdoc cref="GenFramebuffersEXT"/>
-            public static unsafe void GenFramebuffersEXT(Span<FramebufferHandle> framebuffers)
+            public static unsafe void GenFramebuffersEXT(Span<int> framebuffers)
             {
                 int n = (int)(framebuffers.Length);
-                fixed (FramebufferHandle* framebuffers_ptr = framebuffers)
+                fixed (int* framebuffers_ptr = framebuffers)
                 {
                     GenFramebuffersEXT(n, framebuffers_ptr);
                 }
             }
             /// <inheritdoc cref="GenFramebuffersEXT"/>
-            public static unsafe void GenFramebuffersEXT(FramebufferHandle[] framebuffers)
+            public static unsafe void GenFramebuffersEXT(int[] framebuffers)
             {
                 int n = (int)(framebuffers.Length);
-                fixed (FramebufferHandle* framebuffers_ptr = framebuffers)
+                fixed (int* framebuffers_ptr = framebuffers)
                 {
                     GenFramebuffersEXT(n, framebuffers_ptr);
                 }
             }
             /// <inheritdoc cref="GenFramebuffersEXT"/>
-            public static unsafe void GenFramebuffersEXT(int n, ref FramebufferHandle framebuffers)
+            public static unsafe void GenFramebuffersEXT(int n, ref int framebuffers)
             {
-                fixed (FramebufferHandle* framebuffers_ptr = &framebuffers)
+                fixed (int* framebuffers_ptr = &framebuffers)
                 {
                     GenFramebuffersEXT(n, framebuffers_ptr);
                 }
@@ -28066,7 +28066,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetUniformuivEXT"/>
-            public static unsafe void GetUniformuivEXT(ProgramHandle program, int location, Span<uint> parameters)
+            public static unsafe void GetUniformuivEXT(int program, int location, Span<uint> parameters)
             {
                 fixed (uint* parameters_ptr = parameters)
                 {
@@ -28074,7 +28074,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetUniformuivEXT"/>
-            public static unsafe void GetUniformuivEXT(ProgramHandle program, int location, uint[] parameters)
+            public static unsafe void GetUniformuivEXT(int program, int location, uint[] parameters)
             {
                 fixed (uint* parameters_ptr = parameters)
                 {
@@ -28082,7 +28082,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetUniformuivEXT"/>
-            public static unsafe void GetUniformuivEXT(ProgramHandle program, int location, ref uint parameters)
+            public static unsafe void GetUniformuivEXT(int program, int location, ref uint parameters)
             {
                 fixed (uint* parameters_ptr = &parameters)
                 {
@@ -28090,14 +28090,14 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="BindFragDataLocationEXT"/>
-            public static unsafe void BindFragDataLocationEXT(ProgramHandle program, uint color, string name)
+            public static unsafe void BindFragDataLocationEXT(int program, uint color, string name)
             {
                 byte* name_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(name);
                 BindFragDataLocationEXT(program, color, name_ptr);
                 Marshal.FreeCoTaskMem((IntPtr)name_ptr);
             }
             /// <inheritdoc cref="GetFragDataLocationEXT"/>
-            public static unsafe int GetFragDataLocationEXT(ProgramHandle program, string name)
+            public static unsafe int GetFragDataLocationEXT(int program, string name)
             {
                 int returnValue;
                 byte* name_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(name);
@@ -29226,11 +29226,11 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="WaitSemaphoreEXT"/>
-            public static unsafe void WaitSemaphoreEXT(uint semaphore, uint numBufferBarriers, ReadOnlySpan<BufferHandle> buffers, uint numTextureBarriers, ReadOnlySpan<TextureHandle> textures, ReadOnlySpan<TextureLayout> srcLayouts)
+            public static unsafe void WaitSemaphoreEXT(uint semaphore, uint numBufferBarriers, ReadOnlySpan<int> buffers, uint numTextureBarriers, ReadOnlySpan<int> textures, ReadOnlySpan<TextureLayout> srcLayouts)
             {
-                fixed (BufferHandle* buffers_ptr = buffers)
+                fixed (int* buffers_ptr = buffers)
                 {
-                    fixed (TextureHandle* textures_ptr = textures)
+                    fixed (int* textures_ptr = textures)
                     {
                         fixed (TextureLayout* srcLayouts_ptr = srcLayouts)
                         {
@@ -29240,11 +29240,11 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="WaitSemaphoreEXT"/>
-            public static unsafe void WaitSemaphoreEXT(uint semaphore, uint numBufferBarriers, BufferHandle[] buffers, uint numTextureBarriers, TextureHandle[] textures, TextureLayout[] srcLayouts)
+            public static unsafe void WaitSemaphoreEXT(uint semaphore, uint numBufferBarriers, int[] buffers, uint numTextureBarriers, int[] textures, TextureLayout[] srcLayouts)
             {
-                fixed (BufferHandle* buffers_ptr = buffers)
+                fixed (int* buffers_ptr = buffers)
                 {
-                    fixed (TextureHandle* textures_ptr = textures)
+                    fixed (int* textures_ptr = textures)
                     {
                         fixed (TextureLayout* srcLayouts_ptr = srcLayouts)
                         {
@@ -29254,21 +29254,21 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="WaitSemaphoreEXT"/>
-            public static unsafe void WaitSemaphoreEXT(uint semaphore, uint numBufferBarriers, in BufferHandle buffers, uint numTextureBarriers, in TextureHandle textures, in TextureLayout srcLayouts)
+            public static unsafe void WaitSemaphoreEXT(uint semaphore, uint numBufferBarriers, in int buffers, uint numTextureBarriers, in int textures, in TextureLayout srcLayouts)
             {
-                fixed (BufferHandle* buffers_ptr = &buffers)
-                fixed (TextureHandle* textures_ptr = &textures)
+                fixed (int* buffers_ptr = &buffers)
+                fixed (int* textures_ptr = &textures)
                 fixed (TextureLayout* srcLayouts_ptr = &srcLayouts)
                 {
                     WaitSemaphoreEXT(semaphore, numBufferBarriers, buffers_ptr, numTextureBarriers, textures_ptr, srcLayouts_ptr);
                 }
             }
             /// <inheritdoc cref="SignalSemaphoreEXT"/>
-            public static unsafe void SignalSemaphoreEXT(uint semaphore, uint numBufferBarriers, ReadOnlySpan<BufferHandle> buffers, uint numTextureBarriers, ReadOnlySpan<TextureHandle> textures, ReadOnlySpan<TextureLayout> dstLayouts)
+            public static unsafe void SignalSemaphoreEXT(uint semaphore, uint numBufferBarriers, ReadOnlySpan<int> buffers, uint numTextureBarriers, ReadOnlySpan<int> textures, ReadOnlySpan<TextureLayout> dstLayouts)
             {
-                fixed (BufferHandle* buffers_ptr = buffers)
+                fixed (int* buffers_ptr = buffers)
                 {
-                    fixed (TextureHandle* textures_ptr = textures)
+                    fixed (int* textures_ptr = textures)
                     {
                         fixed (TextureLayout* dstLayouts_ptr = dstLayouts)
                         {
@@ -29278,11 +29278,11 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="SignalSemaphoreEXT"/>
-            public static unsafe void SignalSemaphoreEXT(uint semaphore, uint numBufferBarriers, BufferHandle[] buffers, uint numTextureBarriers, TextureHandle[] textures, TextureLayout[] dstLayouts)
+            public static unsafe void SignalSemaphoreEXT(uint semaphore, uint numBufferBarriers, int[] buffers, uint numTextureBarriers, int[] textures, TextureLayout[] dstLayouts)
             {
-                fixed (BufferHandle* buffers_ptr = buffers)
+                fixed (int* buffers_ptr = buffers)
                 {
-                    fixed (TextureHandle* textures_ptr = textures)
+                    fixed (int* textures_ptr = textures)
                     {
                         fixed (TextureLayout* dstLayouts_ptr = dstLayouts)
                         {
@@ -29292,10 +29292,10 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="SignalSemaphoreEXT"/>
-            public static unsafe void SignalSemaphoreEXT(uint semaphore, uint numBufferBarriers, in BufferHandle buffers, uint numTextureBarriers, in TextureHandle textures, in TextureLayout dstLayouts)
+            public static unsafe void SignalSemaphoreEXT(uint semaphore, uint numBufferBarriers, in int buffers, uint numTextureBarriers, in int textures, in TextureLayout dstLayouts)
             {
-                fixed (BufferHandle* buffers_ptr = &buffers)
-                fixed (TextureHandle* textures_ptr = &textures)
+                fixed (int* buffers_ptr = &buffers)
+                fixed (int* textures_ptr = &textures)
                 fixed (TextureLayout* dstLayouts_ptr = &dstLayouts)
                 {
                     SignalSemaphoreEXT(semaphore, numBufferBarriers, buffers_ptr, numTextureBarriers, textures_ptr, dstLayouts_ptr);
@@ -29542,68 +29542,68 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="CreateShaderProgramEXT"/>
-            public static unsafe ProgramHandle CreateShaderProgramEXT(ShaderType type, string str)
+            public static unsafe int CreateShaderProgramEXT(ShaderType type, string str)
             {
-                ProgramHandle returnValue;
+                int returnValue;
                 byte* str_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(str);
                 returnValue = CreateShaderProgramEXT(type, str_ptr);
                 Marshal.FreeCoTaskMem((IntPtr)str_ptr);
                 return returnValue;
             }
             /// <inheritdoc cref="DeleteProgramPipelinesEXT"/>
-            public static unsafe void DeleteProgramPipelinesEXT(ReadOnlySpan<ProgramPipelineHandle> pipelines)
+            public static unsafe void DeleteProgramPipelinesEXT(ReadOnlySpan<int> pipelines)
             {
                 int n = (int)(pipelines.Length);
-                fixed (ProgramPipelineHandle* pipelines_ptr = pipelines)
+                fixed (int* pipelines_ptr = pipelines)
                 {
                     DeleteProgramPipelinesEXT(n, pipelines_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteProgramPipelinesEXT"/>
-            public static unsafe void DeleteProgramPipelinesEXT(ProgramPipelineHandle[] pipelines)
+            public static unsafe void DeleteProgramPipelinesEXT(int[] pipelines)
             {
                 int n = (int)(pipelines.Length);
-                fixed (ProgramPipelineHandle* pipelines_ptr = pipelines)
+                fixed (int* pipelines_ptr = pipelines)
                 {
                     DeleteProgramPipelinesEXT(n, pipelines_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteProgramPipelinesEXT"/>
-            public static unsafe void DeleteProgramPipelinesEXT(int n, in ProgramPipelineHandle pipelines)
+            public static unsafe void DeleteProgramPipelinesEXT(int n, in int pipelines)
             {
-                fixed (ProgramPipelineHandle* pipelines_ptr = &pipelines)
+                fixed (int* pipelines_ptr = &pipelines)
                 {
                     DeleteProgramPipelinesEXT(n, pipelines_ptr);
                 }
             }
             /// <inheritdoc cref="GenProgramPipelinesEXT"/>
-            public static unsafe void GenProgramPipelinesEXT(Span<ProgramPipelineHandle> pipelines)
+            public static unsafe void GenProgramPipelinesEXT(Span<int> pipelines)
             {
                 int n = (int)(pipelines.Length);
-                fixed (ProgramPipelineHandle* pipelines_ptr = pipelines)
+                fixed (int* pipelines_ptr = pipelines)
                 {
                     GenProgramPipelinesEXT(n, pipelines_ptr);
                 }
             }
             /// <inheritdoc cref="GenProgramPipelinesEXT"/>
-            public static unsafe void GenProgramPipelinesEXT(ProgramPipelineHandle[] pipelines)
+            public static unsafe void GenProgramPipelinesEXT(int[] pipelines)
             {
                 int n = (int)(pipelines.Length);
-                fixed (ProgramPipelineHandle* pipelines_ptr = pipelines)
+                fixed (int* pipelines_ptr = pipelines)
                 {
                     GenProgramPipelinesEXT(n, pipelines_ptr);
                 }
             }
             /// <inheritdoc cref="GenProgramPipelinesEXT"/>
-            public static unsafe void GenProgramPipelinesEXT(int n, ref ProgramPipelineHandle pipelines)
+            public static unsafe void GenProgramPipelinesEXT(int n, ref int pipelines)
             {
-                fixed (ProgramPipelineHandle* pipelines_ptr = &pipelines)
+                fixed (int* pipelines_ptr = &pipelines)
                 {
                     GenProgramPipelinesEXT(n, pipelines_ptr);
                 }
             }
             /// <inheritdoc cref="GetProgramPipelineInfoLogEXT"/>
-            public static unsafe string GetProgramPipelineInfoLogEXT(ProgramPipelineHandle pipeline, int bufSize, Span<int> length)
+            public static unsafe string GetProgramPipelineInfoLogEXT(int pipeline, int bufSize, Span<int> length)
             {
                 string infoLog;
                 fixed (int* length_ptr = length)
@@ -29616,7 +29616,7 @@ namespace OpenTK.Graphics.OpenGL
                 return infoLog;
             }
             /// <inheritdoc cref="GetProgramPipelineInfoLogEXT"/>
-            public static unsafe void GetProgramPipelineInfoLogEXT(ProgramPipelineHandle pipeline, int bufSize, Span<int> length, out string infoLog)
+            public static unsafe void GetProgramPipelineInfoLogEXT(int pipeline, int bufSize, Span<int> length, out string infoLog)
             {
                 fixed (int* length_ptr = length)
                 {
@@ -29627,7 +29627,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetProgramPipelineInfoLogEXT"/>
-            public static unsafe string GetProgramPipelineInfoLogEXT(ProgramPipelineHandle pipeline, int bufSize, int[] length)
+            public static unsafe string GetProgramPipelineInfoLogEXT(int pipeline, int bufSize, int[] length)
             {
                 string infoLog;
                 fixed (int* length_ptr = length)
@@ -29640,7 +29640,7 @@ namespace OpenTK.Graphics.OpenGL
                 return infoLog;
             }
             /// <inheritdoc cref="GetProgramPipelineInfoLogEXT"/>
-            public static unsafe void GetProgramPipelineInfoLogEXT(ProgramPipelineHandle pipeline, int bufSize, int[] length, out string infoLog)
+            public static unsafe void GetProgramPipelineInfoLogEXT(int pipeline, int bufSize, int[] length, out string infoLog)
             {
                 fixed (int* length_ptr = length)
                 {
@@ -29651,7 +29651,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetProgramPipelineInfoLogEXT"/>
-            public static unsafe string GetProgramPipelineInfoLogEXT(ProgramPipelineHandle pipeline, int bufSize, ref int length)
+            public static unsafe string GetProgramPipelineInfoLogEXT(int pipeline, int bufSize, ref int length)
             {
                 string infoLog;
                 fixed (int* length_ptr = &length)
@@ -29664,7 +29664,7 @@ namespace OpenTK.Graphics.OpenGL
                 return infoLog;
             }
             /// <inheritdoc cref="GetProgramPipelineInfoLogEXT"/>
-            public static unsafe void GetProgramPipelineInfoLogEXT(ProgramPipelineHandle pipeline, int bufSize, ref int length, out string infoLog)
+            public static unsafe void GetProgramPipelineInfoLogEXT(int pipeline, int bufSize, ref int length, out string infoLog)
             {
                 fixed (int* length_ptr = &length)
                 {
@@ -29675,7 +29675,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetProgramPipelineivEXT"/>
-            public static unsafe void GetProgramPipelineivEXT(ProgramPipelineHandle pipeline, PipelineParameterName pname, ref int parameters)
+            public static unsafe void GetProgramPipelineivEXT(int pipeline, PipelineParameterName pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -29911,10 +29911,10 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="AreTexturesResidentEXT"/>
-            public static unsafe bool AreTexturesResidentEXT(int n, ReadOnlySpan<TextureHandle> textures, Span<bool> residences)
+            public static unsafe bool AreTexturesResidentEXT(int n, ReadOnlySpan<int> textures, Span<bool> residences)
             {
                 bool returnValue;
-                fixed (TextureHandle* textures_ptr = textures)
+                fixed (int* textures_ptr = textures)
                 {
                     fixed (bool* residences_ptr = residences)
                     {
@@ -29924,10 +29924,10 @@ namespace OpenTK.Graphics.OpenGL
                 return returnValue;
             }
             /// <inheritdoc cref="AreTexturesResidentEXT"/>
-            public static unsafe bool AreTexturesResidentEXT(int n, TextureHandle[] textures, bool[] residences)
+            public static unsafe bool AreTexturesResidentEXT(int n, int[] textures, bool[] residences)
             {
                 bool returnValue;
-                fixed (TextureHandle* textures_ptr = textures)
+                fixed (int* textures_ptr = textures)
                 {
                     fixed (bool* residences_ptr = residences)
                     {
@@ -29937,10 +29937,10 @@ namespace OpenTK.Graphics.OpenGL
                 return returnValue;
             }
             /// <inheritdoc cref="AreTexturesResidentEXT"/>
-            public static unsafe bool AreTexturesResidentEXT(int n, in TextureHandle textures, ref bool residences)
+            public static unsafe bool AreTexturesResidentEXT(int n, in int textures, ref bool residences)
             {
                 bool returnValue;
-                fixed (TextureHandle* textures_ptr = &textures)
+                fixed (int* textures_ptr = &textures)
                 fixed (bool* residences_ptr = &residences)
                 {
                     returnValue = AreTexturesResidentEXT(n, textures_ptr, residences_ptr);
@@ -29948,61 +29948,61 @@ namespace OpenTK.Graphics.OpenGL
                 return returnValue;
             }
             /// <inheritdoc cref="DeleteTexturesEXT"/>
-            public static unsafe void DeleteTexturesEXT(ReadOnlySpan<TextureHandle> textures)
+            public static unsafe void DeleteTexturesEXT(ReadOnlySpan<int> textures)
             {
                 int n = (int)(textures.Length);
-                fixed (TextureHandle* textures_ptr = textures)
+                fixed (int* textures_ptr = textures)
                 {
                     DeleteTexturesEXT(n, textures_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteTexturesEXT"/>
-            public static unsafe void DeleteTexturesEXT(TextureHandle[] textures)
+            public static unsafe void DeleteTexturesEXT(int[] textures)
             {
                 int n = (int)(textures.Length);
-                fixed (TextureHandle* textures_ptr = textures)
+                fixed (int* textures_ptr = textures)
                 {
                     DeleteTexturesEXT(n, textures_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteTexturesEXT"/>
-            public static unsafe void DeleteTexturesEXT(int n, in TextureHandle textures)
+            public static unsafe void DeleteTexturesEXT(int n, in int textures)
             {
-                fixed (TextureHandle* textures_ptr = &textures)
+                fixed (int* textures_ptr = &textures)
                 {
                     DeleteTexturesEXT(n, textures_ptr);
                 }
             }
             /// <inheritdoc cref="GenTexturesEXT"/>
-            public static unsafe void GenTexturesEXT(Span<TextureHandle> textures)
+            public static unsafe void GenTexturesEXT(Span<int> textures)
             {
                 int n = (int)(textures.Length);
-                fixed (TextureHandle* textures_ptr = textures)
+                fixed (int* textures_ptr = textures)
                 {
                     GenTexturesEXT(n, textures_ptr);
                 }
             }
             /// <inheritdoc cref="GenTexturesEXT"/>
-            public static unsafe void GenTexturesEXT(TextureHandle[] textures)
+            public static unsafe void GenTexturesEXT(int[] textures)
             {
                 int n = (int)(textures.Length);
-                fixed (TextureHandle* textures_ptr = textures)
+                fixed (int* textures_ptr = textures)
                 {
                     GenTexturesEXT(n, textures_ptr);
                 }
             }
             /// <inheritdoc cref="GenTexturesEXT"/>
-            public static unsafe void GenTexturesEXT(int n, ref TextureHandle textures)
+            public static unsafe void GenTexturesEXT(int n, ref int textures)
             {
-                fixed (TextureHandle* textures_ptr = &textures)
+                fixed (int* textures_ptr = &textures)
                 {
                     GenTexturesEXT(n, textures_ptr);
                 }
             }
             /// <inheritdoc cref="PrioritizeTexturesEXT"/>
-            public static unsafe void PrioritizeTexturesEXT(int n, ReadOnlySpan<TextureHandle> textures, ReadOnlySpan<float> priorities)
+            public static unsafe void PrioritizeTexturesEXT(int n, ReadOnlySpan<int> textures, ReadOnlySpan<float> priorities)
             {
-                fixed (TextureHandle* textures_ptr = textures)
+                fixed (int* textures_ptr = textures)
                 {
                     fixed (float* priorities_ptr = priorities)
                     {
@@ -30011,9 +30011,9 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="PrioritizeTexturesEXT"/>
-            public static unsafe void PrioritizeTexturesEXT(int n, TextureHandle[] textures, float[] priorities)
+            public static unsafe void PrioritizeTexturesEXT(int n, int[] textures, float[] priorities)
             {
-                fixed (TextureHandle* textures_ptr = textures)
+                fixed (int* textures_ptr = textures)
                 {
                     fixed (float* priorities_ptr = priorities)
                     {
@@ -30022,16 +30022,16 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="PrioritizeTexturesEXT"/>
-            public static unsafe void PrioritizeTexturesEXT(int n, in TextureHandle textures, in float priorities)
+            public static unsafe void PrioritizeTexturesEXT(int n, in int textures, in float priorities)
             {
-                fixed (TextureHandle* textures_ptr = &textures)
+                fixed (int* textures_ptr = &textures)
                 fixed (float* priorities_ptr = &priorities)
                 {
                     PrioritizeTexturesEXT(n, textures_ptr, priorities_ptr);
                 }
             }
             /// <inheritdoc cref="GetQueryObjecti64vEXT"/>
-            public static unsafe void GetQueryObjecti64vEXT(QueryHandle id, QueryObjectParameterName pname, Span<long> parameters)
+            public static unsafe void GetQueryObjecti64vEXT(int id, QueryObjectParameterName pname, Span<long> parameters)
             {
                 fixed (long* parameters_ptr = parameters)
                 {
@@ -30039,7 +30039,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetQueryObjecti64vEXT"/>
-            public static unsafe void GetQueryObjecti64vEXT(QueryHandle id, QueryObjectParameterName pname, long[] parameters)
+            public static unsafe void GetQueryObjecti64vEXT(int id, QueryObjectParameterName pname, long[] parameters)
             {
                 fixed (long* parameters_ptr = parameters)
                 {
@@ -30047,7 +30047,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetQueryObjecti64vEXT"/>
-            public static unsafe void GetQueryObjecti64vEXT(QueryHandle id, QueryObjectParameterName pname, ref long parameters)
+            public static unsafe void GetQueryObjecti64vEXT(int id, QueryObjectParameterName pname, ref long parameters)
             {
                 fixed (long* parameters_ptr = &parameters)
                 {
@@ -30055,7 +30055,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetQueryObjectui64vEXT"/>
-            public static unsafe void GetQueryObjectui64vEXT(QueryHandle id, QueryObjectParameterName pname, Span<ulong> parameters)
+            public static unsafe void GetQueryObjectui64vEXT(int id, QueryObjectParameterName pname, Span<ulong> parameters)
             {
                 fixed (ulong* parameters_ptr = parameters)
                 {
@@ -30063,7 +30063,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetQueryObjectui64vEXT"/>
-            public static unsafe void GetQueryObjectui64vEXT(QueryHandle id, QueryObjectParameterName pname, ulong[] parameters)
+            public static unsafe void GetQueryObjectui64vEXT(int id, QueryObjectParameterName pname, ulong[] parameters)
             {
                 fixed (ulong* parameters_ptr = parameters)
                 {
@@ -30071,7 +30071,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetQueryObjectui64vEXT"/>
-            public static unsafe void GetQueryObjectui64vEXT(QueryHandle id, QueryObjectParameterName pname, ref ulong parameters)
+            public static unsafe void GetQueryObjectui64vEXT(int id, QueryObjectParameterName pname, ref ulong parameters)
             {
                 fixed (ulong* parameters_ptr = &parameters)
                 {
@@ -30079,7 +30079,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetTransformFeedbackVaryingEXT"/>
-            public static unsafe string GetTransformFeedbackVaryingEXT(ProgramHandle program, uint index, int bufSize, Span<int> length, Span<int> size, Span<AttributeType> type)
+            public static unsafe string GetTransformFeedbackVaryingEXT(int program, uint index, int bufSize, Span<int> length, Span<int> size, Span<AttributeType> type)
             {
                 string name;
                 fixed (int* length_ptr = length)
@@ -30098,7 +30098,7 @@ namespace OpenTK.Graphics.OpenGL
                 return name;
             }
             /// <inheritdoc cref="GetTransformFeedbackVaryingEXT"/>
-            public static unsafe void GetTransformFeedbackVaryingEXT(ProgramHandle program, uint index, int bufSize, Span<int> length, Span<int> size, Span<AttributeType> type, out string name)
+            public static unsafe void GetTransformFeedbackVaryingEXT(int program, uint index, int bufSize, Span<int> length, Span<int> size, Span<AttributeType> type, out string name)
             {
                 fixed (int* length_ptr = length)
                 {
@@ -30115,7 +30115,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetTransformFeedbackVaryingEXT"/>
-            public static unsafe string GetTransformFeedbackVaryingEXT(ProgramHandle program, uint index, int bufSize, int[] length, int[] size, AttributeType[] type)
+            public static unsafe string GetTransformFeedbackVaryingEXT(int program, uint index, int bufSize, int[] length, int[] size, AttributeType[] type)
             {
                 string name;
                 fixed (int* length_ptr = length)
@@ -30134,7 +30134,7 @@ namespace OpenTK.Graphics.OpenGL
                 return name;
             }
             /// <inheritdoc cref="GetTransformFeedbackVaryingEXT"/>
-            public static unsafe void GetTransformFeedbackVaryingEXT(ProgramHandle program, uint index, int bufSize, int[] length, int[] size, AttributeType[] type, out string name)
+            public static unsafe void GetTransformFeedbackVaryingEXT(int program, uint index, int bufSize, int[] length, int[] size, AttributeType[] type, out string name)
             {
                 fixed (int* length_ptr = length)
                 {
@@ -30151,7 +30151,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetTransformFeedbackVaryingEXT"/>
-            public static unsafe string GetTransformFeedbackVaryingEXT(ProgramHandle program, uint index, int bufSize, ref int length, ref int size, ref AttributeType type)
+            public static unsafe string GetTransformFeedbackVaryingEXT(int program, uint index, int bufSize, ref int length, ref int size, ref AttributeType type)
             {
                 string name;
                 fixed (int* length_ptr = &length)
@@ -30166,7 +30166,7 @@ namespace OpenTK.Graphics.OpenGL
                 return name;
             }
             /// <inheritdoc cref="GetTransformFeedbackVaryingEXT"/>
-            public static unsafe void GetTransformFeedbackVaryingEXT(ProgramHandle program, uint index, int bufSize, ref int length, ref int size, ref AttributeType type, out string name)
+            public static unsafe void GetTransformFeedbackVaryingEXT(int program, uint index, int bufSize, ref int length, ref int size, ref AttributeType type, out string name)
             {
                 fixed (int* length_ptr = &length)
                 fixed (int* size_ptr = &size)
@@ -31242,7 +31242,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformHandleui64vNV"/>
-            public static unsafe void ProgramUniformHandleui64vNV(ProgramHandle program, int location, ReadOnlySpan<ulong> values)
+            public static unsafe void ProgramUniformHandleui64vNV(int program, int location, ReadOnlySpan<ulong> values)
             {
                 int count = (int)(values.Length);
                 fixed (ulong* values_ptr = values)
@@ -31251,7 +31251,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformHandleui64vNV"/>
-            public static unsafe void ProgramUniformHandleui64vNV(ProgramHandle program, int location, ulong[] values)
+            public static unsafe void ProgramUniformHandleui64vNV(int program, int location, ulong[] values)
             {
                 int count = (int)(values.Length);
                 fixed (ulong* values_ptr = values)
@@ -31260,7 +31260,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformHandleui64vNV"/>
-            public static unsafe void ProgramUniformHandleui64vNV(ProgramHandle program, int location, int count, in ulong values)
+            public static unsafe void ProgramUniformHandleui64vNV(int program, int location, int count, in ulong values)
             {
                 fixed (ulong* values_ptr = &values)
                 {
@@ -31338,7 +31338,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="DrawCommandsStatesNV"/>
-            public static unsafe void DrawCommandsStatesNV(BufferHandle buffer, in IntPtr indirects, in int sizes, in uint states, in uint fbos, uint count)
+            public static unsafe void DrawCommandsStatesNV(int buffer, in IntPtr indirects, in int sizes, in uint states, in uint fbos, uint count)
             {
                 fixed (IntPtr* indirects_ptr = &indirects)
                 fixed (int* sizes_ptr = &sizes)
@@ -31769,7 +31769,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramNamedParameter4fNV"/>
-            public static unsafe void ProgramNamedParameter4fNV(ProgramHandle id, int len, ReadOnlySpan<byte> name, float x, float y, float z, float w)
+            public static unsafe void ProgramNamedParameter4fNV(int id, int len, ReadOnlySpan<byte> name, float x, float y, float z, float w)
             {
                 fixed (byte* name_ptr = name)
                 {
@@ -31777,7 +31777,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramNamedParameter4fNV"/>
-            public static unsafe void ProgramNamedParameter4fNV(ProgramHandle id, int len, byte[] name, float x, float y, float z, float w)
+            public static unsafe void ProgramNamedParameter4fNV(int id, int len, byte[] name, float x, float y, float z, float w)
             {
                 fixed (byte* name_ptr = name)
                 {
@@ -31785,7 +31785,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramNamedParameter4fNV"/>
-            public static unsafe void ProgramNamedParameter4fNV(ProgramHandle id, int len, in byte name, float x, float y, float z, float w)
+            public static unsafe void ProgramNamedParameter4fNV(int id, int len, in byte name, float x, float y, float z, float w)
             {
                 fixed (byte* name_ptr = &name)
                 {
@@ -31793,7 +31793,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramNamedParameter4fvNV"/>
-            public static unsafe void ProgramNamedParameter4fvNV(ProgramHandle id, int len, ReadOnlySpan<byte> name, ReadOnlySpan<float> v)
+            public static unsafe void ProgramNamedParameter4fvNV(int id, int len, ReadOnlySpan<byte> name, ReadOnlySpan<float> v)
             {
                 fixed (byte* name_ptr = name)
                 {
@@ -31804,7 +31804,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramNamedParameter4fvNV"/>
-            public static unsafe void ProgramNamedParameter4fvNV(ProgramHandle id, int len, byte[] name, float[] v)
+            public static unsafe void ProgramNamedParameter4fvNV(int id, int len, byte[] name, float[] v)
             {
                 fixed (byte* name_ptr = name)
                 {
@@ -31815,7 +31815,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramNamedParameter4fvNV"/>
-            public static unsafe void ProgramNamedParameter4fvNV(ProgramHandle id, int len, in byte name, in float v)
+            public static unsafe void ProgramNamedParameter4fvNV(int id, int len, in byte name, in float v)
             {
                 fixed (byte* name_ptr = &name)
                 fixed (float* v_ptr = &v)
@@ -31824,7 +31824,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramNamedParameter4dNV"/>
-            public static unsafe void ProgramNamedParameter4dNV(ProgramHandle id, int len, ReadOnlySpan<byte> name, double x, double y, double z, double w)
+            public static unsafe void ProgramNamedParameter4dNV(int id, int len, ReadOnlySpan<byte> name, double x, double y, double z, double w)
             {
                 fixed (byte* name_ptr = name)
                 {
@@ -31832,7 +31832,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramNamedParameter4dNV"/>
-            public static unsafe void ProgramNamedParameter4dNV(ProgramHandle id, int len, byte[] name, double x, double y, double z, double w)
+            public static unsafe void ProgramNamedParameter4dNV(int id, int len, byte[] name, double x, double y, double z, double w)
             {
                 fixed (byte* name_ptr = name)
                 {
@@ -31840,7 +31840,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramNamedParameter4dNV"/>
-            public static unsafe void ProgramNamedParameter4dNV(ProgramHandle id, int len, in byte name, double x, double y, double z, double w)
+            public static unsafe void ProgramNamedParameter4dNV(int id, int len, in byte name, double x, double y, double z, double w)
             {
                 fixed (byte* name_ptr = &name)
                 {
@@ -31848,7 +31848,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramNamedParameter4dvNV"/>
-            public static unsafe void ProgramNamedParameter4dvNV(ProgramHandle id, int len, ReadOnlySpan<byte> name, ReadOnlySpan<double> v)
+            public static unsafe void ProgramNamedParameter4dvNV(int id, int len, ReadOnlySpan<byte> name, ReadOnlySpan<double> v)
             {
                 fixed (byte* name_ptr = name)
                 {
@@ -31859,7 +31859,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramNamedParameter4dvNV"/>
-            public static unsafe void ProgramNamedParameter4dvNV(ProgramHandle id, int len, byte[] name, double[] v)
+            public static unsafe void ProgramNamedParameter4dvNV(int id, int len, byte[] name, double[] v)
             {
                 fixed (byte* name_ptr = name)
                 {
@@ -31870,7 +31870,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramNamedParameter4dvNV"/>
-            public static unsafe void ProgramNamedParameter4dvNV(ProgramHandle id, int len, in byte name, in double v)
+            public static unsafe void ProgramNamedParameter4dvNV(int id, int len, in byte name, in double v)
             {
                 fixed (byte* name_ptr = &name)
                 fixed (double* v_ptr = &v)
@@ -31879,7 +31879,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetProgramNamedParameterfvNV"/>
-            public static unsafe void GetProgramNamedParameterfvNV(ProgramHandle id, int len, ReadOnlySpan<byte> name, Span<float> parameters)
+            public static unsafe void GetProgramNamedParameterfvNV(int id, int len, ReadOnlySpan<byte> name, Span<float> parameters)
             {
                 fixed (byte* name_ptr = name)
                 {
@@ -31890,7 +31890,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetProgramNamedParameterfvNV"/>
-            public static unsafe void GetProgramNamedParameterfvNV(ProgramHandle id, int len, byte[] name, float[] parameters)
+            public static unsafe void GetProgramNamedParameterfvNV(int id, int len, byte[] name, float[] parameters)
             {
                 fixed (byte* name_ptr = name)
                 {
@@ -31901,7 +31901,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetProgramNamedParameterfvNV"/>
-            public static unsafe void GetProgramNamedParameterfvNV(ProgramHandle id, int len, in byte name, ref float parameters)
+            public static unsafe void GetProgramNamedParameterfvNV(int id, int len, in byte name, ref float parameters)
             {
                 fixed (byte* name_ptr = &name)
                 fixed (float* parameters_ptr = &parameters)
@@ -31910,7 +31910,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetProgramNamedParameterdvNV"/>
-            public static unsafe void GetProgramNamedParameterdvNV(ProgramHandle id, int len, ReadOnlySpan<byte> name, Span<double> parameters)
+            public static unsafe void GetProgramNamedParameterdvNV(int id, int len, ReadOnlySpan<byte> name, Span<double> parameters)
             {
                 fixed (byte* name_ptr = name)
                 {
@@ -31921,7 +31921,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetProgramNamedParameterdvNV"/>
-            public static unsafe void GetProgramNamedParameterdvNV(ProgramHandle id, int len, byte[] name, double[] parameters)
+            public static unsafe void GetProgramNamedParameterdvNV(int id, int len, byte[] name, double[] parameters)
             {
                 fixed (byte* name_ptr = name)
                 {
@@ -31932,7 +31932,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetProgramNamedParameterdvNV"/>
-            public static unsafe void GetProgramNamedParameterdvNV(ProgramHandle id, int len, in byte name, ref double parameters)
+            public static unsafe void GetProgramNamedParameterdvNV(int id, int len, in byte name, ref double parameters)
             {
                 fixed (byte* name_ptr = &name)
                 fixed (double* parameters_ptr = &parameters)
@@ -32529,7 +32529,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetUniformi64vNV"/>
-            public static unsafe void GetUniformi64vNV(ProgramHandle program, int location, Span<long> parameters)
+            public static unsafe void GetUniformi64vNV(int program, int location, Span<long> parameters)
             {
                 fixed (long* parameters_ptr = parameters)
                 {
@@ -32537,7 +32537,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetUniformi64vNV"/>
-            public static unsafe void GetUniformi64vNV(ProgramHandle program, int location, long[] parameters)
+            public static unsafe void GetUniformi64vNV(int program, int location, long[] parameters)
             {
                 fixed (long* parameters_ptr = parameters)
                 {
@@ -32545,7 +32545,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetUniformi64vNV"/>
-            public static unsafe void GetUniformi64vNV(ProgramHandle program, int location, ref long parameters)
+            public static unsafe void GetUniformi64vNV(int program, int location, ref long parameters)
             {
                 fixed (long* parameters_ptr = &parameters)
                 {
@@ -32553,7 +32553,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform1i64vNV"/>
-            public static unsafe void ProgramUniform1i64vNV(ProgramHandle program, int location, ReadOnlySpan<long> value)
+            public static unsafe void ProgramUniform1i64vNV(int program, int location, ReadOnlySpan<long> value)
             {
                 int count = (int)(value.Length);
                 fixed (long* value_ptr = value)
@@ -32562,7 +32562,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform1i64vNV"/>
-            public static unsafe void ProgramUniform1i64vNV(ProgramHandle program, int location, long[] value)
+            public static unsafe void ProgramUniform1i64vNV(int program, int location, long[] value)
             {
                 int count = (int)(value.Length);
                 fixed (long* value_ptr = value)
@@ -32571,7 +32571,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform1i64vNV"/>
-            public static unsafe void ProgramUniform1i64vNV(ProgramHandle program, int location, int count, in long value)
+            public static unsafe void ProgramUniform1i64vNV(int program, int location, int count, in long value)
             {
                 fixed (long* value_ptr = &value)
                 {
@@ -32579,7 +32579,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform2i64vNV"/>
-            public static unsafe void ProgramUniform2i64vNV(ProgramHandle program, int location, ReadOnlySpan<long> value)
+            public static unsafe void ProgramUniform2i64vNV(int program, int location, ReadOnlySpan<long> value)
             {
                 int count = (int)(value.Length / 2);
                 fixed (long* value_ptr = value)
@@ -32588,7 +32588,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform2i64vNV"/>
-            public static unsafe void ProgramUniform2i64vNV(ProgramHandle program, int location, long[] value)
+            public static unsafe void ProgramUniform2i64vNV(int program, int location, long[] value)
             {
                 int count = (int)(value.Length / 2);
                 fixed (long* value_ptr = value)
@@ -32597,7 +32597,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform2i64vNV"/>
-            public static unsafe void ProgramUniform2i64vNV(ProgramHandle program, int location, int count, in long value)
+            public static unsafe void ProgramUniform2i64vNV(int program, int location, int count, in long value)
             {
                 fixed (long* value_ptr = &value)
                 {
@@ -32605,7 +32605,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform3i64vNV"/>
-            public static unsafe void ProgramUniform3i64vNV(ProgramHandle program, int location, ReadOnlySpan<long> value)
+            public static unsafe void ProgramUniform3i64vNV(int program, int location, ReadOnlySpan<long> value)
             {
                 int count = (int)(value.Length / 3);
                 fixed (long* value_ptr = value)
@@ -32614,7 +32614,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform3i64vNV"/>
-            public static unsafe void ProgramUniform3i64vNV(ProgramHandle program, int location, long[] value)
+            public static unsafe void ProgramUniform3i64vNV(int program, int location, long[] value)
             {
                 int count = (int)(value.Length / 3);
                 fixed (long* value_ptr = value)
@@ -32623,7 +32623,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform3i64vNV"/>
-            public static unsafe void ProgramUniform3i64vNV(ProgramHandle program, int location, int count, in long value)
+            public static unsafe void ProgramUniform3i64vNV(int program, int location, int count, in long value)
             {
                 fixed (long* value_ptr = &value)
                 {
@@ -32631,7 +32631,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform4i64vNV"/>
-            public static unsafe void ProgramUniform4i64vNV(ProgramHandle program, int location, ReadOnlySpan<long> value)
+            public static unsafe void ProgramUniform4i64vNV(int program, int location, ReadOnlySpan<long> value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (long* value_ptr = value)
@@ -32640,7 +32640,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform4i64vNV"/>
-            public static unsafe void ProgramUniform4i64vNV(ProgramHandle program, int location, long[] value)
+            public static unsafe void ProgramUniform4i64vNV(int program, int location, long[] value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (long* value_ptr = value)
@@ -32649,7 +32649,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform4i64vNV"/>
-            public static unsafe void ProgramUniform4i64vNV(ProgramHandle program, int location, int count, in long value)
+            public static unsafe void ProgramUniform4i64vNV(int program, int location, int count, in long value)
             {
                 fixed (long* value_ptr = &value)
                 {
@@ -32657,7 +32657,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform1ui64vNV"/>
-            public static unsafe void ProgramUniform1ui64vNV(ProgramHandle program, int location, ReadOnlySpan<ulong> value)
+            public static unsafe void ProgramUniform1ui64vNV(int program, int location, ReadOnlySpan<ulong> value)
             {
                 int count = (int)(value.Length);
                 fixed (ulong* value_ptr = value)
@@ -32666,7 +32666,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform1ui64vNV"/>
-            public static unsafe void ProgramUniform1ui64vNV(ProgramHandle program, int location, ulong[] value)
+            public static unsafe void ProgramUniform1ui64vNV(int program, int location, ulong[] value)
             {
                 int count = (int)(value.Length);
                 fixed (ulong* value_ptr = value)
@@ -32675,7 +32675,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform1ui64vNV"/>
-            public static unsafe void ProgramUniform1ui64vNV(ProgramHandle program, int location, int count, in ulong value)
+            public static unsafe void ProgramUniform1ui64vNV(int program, int location, int count, in ulong value)
             {
                 fixed (ulong* value_ptr = &value)
                 {
@@ -32683,7 +32683,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform2ui64vNV"/>
-            public static unsafe void ProgramUniform2ui64vNV(ProgramHandle program, int location, ReadOnlySpan<ulong> value)
+            public static unsafe void ProgramUniform2ui64vNV(int program, int location, ReadOnlySpan<ulong> value)
             {
                 int count = (int)(value.Length / 2);
                 fixed (ulong* value_ptr = value)
@@ -32692,7 +32692,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform2ui64vNV"/>
-            public static unsafe void ProgramUniform2ui64vNV(ProgramHandle program, int location, ulong[] value)
+            public static unsafe void ProgramUniform2ui64vNV(int program, int location, ulong[] value)
             {
                 int count = (int)(value.Length / 2);
                 fixed (ulong* value_ptr = value)
@@ -32701,7 +32701,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform2ui64vNV"/>
-            public static unsafe void ProgramUniform2ui64vNV(ProgramHandle program, int location, int count, in ulong value)
+            public static unsafe void ProgramUniform2ui64vNV(int program, int location, int count, in ulong value)
             {
                 fixed (ulong* value_ptr = &value)
                 {
@@ -32709,7 +32709,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform3ui64vNV"/>
-            public static unsafe void ProgramUniform3ui64vNV(ProgramHandle program, int location, ReadOnlySpan<ulong> value)
+            public static unsafe void ProgramUniform3ui64vNV(int program, int location, ReadOnlySpan<ulong> value)
             {
                 int count = (int)(value.Length / 3);
                 fixed (ulong* value_ptr = value)
@@ -32718,7 +32718,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform3ui64vNV"/>
-            public static unsafe void ProgramUniform3ui64vNV(ProgramHandle program, int location, ulong[] value)
+            public static unsafe void ProgramUniform3ui64vNV(int program, int location, ulong[] value)
             {
                 int count = (int)(value.Length / 3);
                 fixed (ulong* value_ptr = value)
@@ -32727,7 +32727,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform3ui64vNV"/>
-            public static unsafe void ProgramUniform3ui64vNV(ProgramHandle program, int location, int count, in ulong value)
+            public static unsafe void ProgramUniform3ui64vNV(int program, int location, int count, in ulong value)
             {
                 fixed (ulong* value_ptr = &value)
                 {
@@ -32735,7 +32735,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform4ui64vNV"/>
-            public static unsafe void ProgramUniform4ui64vNV(ProgramHandle program, int location, ReadOnlySpan<ulong> value)
+            public static unsafe void ProgramUniform4ui64vNV(int program, int location, ReadOnlySpan<ulong> value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (ulong* value_ptr = value)
@@ -32744,7 +32744,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform4ui64vNV"/>
-            public static unsafe void ProgramUniform4ui64vNV(ProgramHandle program, int location, ulong[] value)
+            public static unsafe void ProgramUniform4ui64vNV(int program, int location, ulong[] value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (ulong* value_ptr = value)
@@ -32753,7 +32753,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniform4ui64vNV"/>
-            public static unsafe void ProgramUniform4ui64vNV(ProgramHandle program, int location, int count, in ulong value)
+            public static unsafe void ProgramUniform4ui64vNV(int program, int location, int count, in ulong value)
             {
                 fixed (ulong* value_ptr = &value)
                 {
@@ -33395,13 +33395,13 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="MulticastBufferSubDataNV"/>
-            public static unsafe void MulticastBufferSubDataNV(All gpuMask, BufferHandle buffer, IntPtr offset, nint size, IntPtr data)
+            public static unsafe void MulticastBufferSubDataNV(All gpuMask, int buffer, IntPtr offset, nint size, IntPtr data)
             {
                 void* data_vptr = (void*)data;
                 MulticastBufferSubDataNV(gpuMask, buffer, offset, size, data_vptr);
             }
             /// <inheritdoc cref="MulticastBufferSubDataNV"/>
-            public static unsafe void MulticastBufferSubDataNV<T1>(All gpuMask, BufferHandle buffer, IntPtr offset, nint size, in T1 data)
+            public static unsafe void MulticastBufferSubDataNV<T1>(All gpuMask, int buffer, IntPtr offset, nint size, in T1 data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = &data)
@@ -33410,7 +33410,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="MulticastFramebufferSampleLocationsfvNV"/>
-            public static unsafe void MulticastFramebufferSampleLocationsfvNV(uint gpu, FramebufferHandle framebuffer, uint start, int count, in float v)
+            public static unsafe void MulticastFramebufferSampleLocationsfvNV(uint gpu, int framebuffer, uint start, int count, in float v)
             {
                 fixed (float* v_ptr = &v)
                 {
@@ -34915,7 +34915,7 @@ namespace OpenTK.Graphics.OpenGL
                 return returnValue;
             }
             /// <inheritdoc cref="ProgramPathFragmentInputGenNV"/>
-            public static unsafe void ProgramPathFragmentInputGenNV(ProgramHandle program, int location, All genMode, int components, in float coeffs)
+            public static unsafe void ProgramPathFragmentInputGenNV(int program, int location, All genMode, int components, in float coeffs)
             {
                 fixed (float* coeffs_ptr = &coeffs)
                 {
@@ -34923,7 +34923,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetProgramResourcefvNV"/>
-            public static unsafe void GetProgramResourcefvNV(ProgramHandle program, ProgramInterface programInterface, uint index, int propCount, in All props, Span<int> length, Span<float> parameters)
+            public static unsafe void GetProgramResourcefvNV(int program, ProgramInterface programInterface, uint index, int propCount, in All props, Span<int> length, Span<float> parameters)
             {
                 fixed (All* props_ptr = &props)
                 {
@@ -34938,7 +34938,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetProgramResourcefvNV"/>
-            public static unsafe void GetProgramResourcefvNV(ProgramHandle program, ProgramInterface programInterface, uint index, int propCount, in All props, int[] length, float[] parameters)
+            public static unsafe void GetProgramResourcefvNV(int program, ProgramInterface programInterface, uint index, int propCount, in All props, int[] length, float[] parameters)
             {
                 fixed (All* props_ptr = &props)
                 {
@@ -34953,7 +34953,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetProgramResourcefvNV"/>
-            public static unsafe void GetProgramResourcefvNV(ProgramHandle program, ProgramInterface programInterface, uint index, int propCount, in All props, int count, ref int length, ref float parameters)
+            public static unsafe void GetProgramResourcefvNV(int program, ProgramInterface programInterface, uint index, int propCount, in All props, int count, ref int length, ref float parameters)
             {
                 fixed (All* props_ptr = &props)
                 fixed (int* length_ptr = &length)
@@ -35649,7 +35649,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="NamedFramebufferSampleLocationsfvNV"/>
-            public static unsafe void NamedFramebufferSampleLocationsfvNV(FramebufferHandle framebuffer, uint start, int count, in float v)
+            public static unsafe void NamedFramebufferSampleLocationsfvNV(int framebuffer, uint start, int count, in float v)
             {
                 fixed (float* v_ptr = &v)
                 {
@@ -35705,7 +35705,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetNamedBufferParameterui64vNV"/>
-            public static unsafe void GetNamedBufferParameterui64vNV(BufferHandle buffer, BufferPNameARB pname, Span<ulong> parameters)
+            public static unsafe void GetNamedBufferParameterui64vNV(int buffer, BufferPNameARB pname, Span<ulong> parameters)
             {
                 fixed (ulong* parameters_ptr = parameters)
                 {
@@ -35713,7 +35713,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetNamedBufferParameterui64vNV"/>
-            public static unsafe void GetNamedBufferParameterui64vNV(BufferHandle buffer, BufferPNameARB pname, ulong[] parameters)
+            public static unsafe void GetNamedBufferParameterui64vNV(int buffer, BufferPNameARB pname, ulong[] parameters)
             {
                 fixed (ulong* parameters_ptr = parameters)
                 {
@@ -35721,7 +35721,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetNamedBufferParameterui64vNV"/>
-            public static unsafe void GetNamedBufferParameterui64vNV(BufferHandle buffer, BufferPNameARB pname, ref ulong parameters)
+            public static unsafe void GetNamedBufferParameterui64vNV(int buffer, BufferPNameARB pname, ref ulong parameters)
             {
                 fixed (ulong* parameters_ptr = &parameters)
                 {
@@ -35779,7 +35779,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetUniformui64vNV"/>
-            public static unsafe void GetUniformui64vNV(ProgramHandle program, int location, Span<ulong> parameters)
+            public static unsafe void GetUniformui64vNV(int program, int location, Span<ulong> parameters)
             {
                 fixed (ulong* parameters_ptr = parameters)
                 {
@@ -35787,7 +35787,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetUniformui64vNV"/>
-            public static unsafe void GetUniformui64vNV(ProgramHandle program, int location, ulong[] parameters)
+            public static unsafe void GetUniformui64vNV(int program, int location, ulong[] parameters)
             {
                 fixed (ulong* parameters_ptr = parameters)
                 {
@@ -35795,7 +35795,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetUniformui64vNV"/>
-            public static unsafe void GetUniformui64vNV(ProgramHandle program, int location, ref ulong parameters)
+            public static unsafe void GetUniformui64vNV(int program, int location, ref ulong parameters)
             {
                 fixed (ulong* parameters_ptr = &parameters)
                 {
@@ -35803,7 +35803,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformui64vNV"/>
-            public static unsafe void ProgramUniformui64vNV(ProgramHandle program, int location, ReadOnlySpan<ulong> value)
+            public static unsafe void ProgramUniformui64vNV(int program, int location, ReadOnlySpan<ulong> value)
             {
                 int count = (int)(value.Length);
                 fixed (ulong* value_ptr = value)
@@ -35812,7 +35812,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformui64vNV"/>
-            public static unsafe void ProgramUniformui64vNV(ProgramHandle program, int location, ulong[] value)
+            public static unsafe void ProgramUniformui64vNV(int program, int location, ulong[] value)
             {
                 int count = (int)(value.Length);
                 fixed (ulong* value_ptr = value)
@@ -35821,7 +35821,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ProgramUniformui64vNV"/>
-            public static unsafe void ProgramUniformui64vNV(ProgramHandle program, int location, int count, in ulong value)
+            public static unsafe void ProgramUniformui64vNV(int program, int location, int count, in ulong value)
             {
                 fixed (ulong* value_ptr = &value)
                 {
@@ -35951,7 +35951,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="TransformFeedbackVaryingsNV"/>
-            public static unsafe void TransformFeedbackVaryingsNV(ProgramHandle program, ReadOnlySpan<TransformFeedbackTokenNV> locations, TransformFeedbackBufferMode bufferMode)
+            public static unsafe void TransformFeedbackVaryingsNV(int program, ReadOnlySpan<TransformFeedbackTokenNV> locations, TransformFeedbackBufferMode bufferMode)
             {
                 int count = (int)(locations.Length);
                 fixed (TransformFeedbackTokenNV* locations_ptr = locations)
@@ -35960,7 +35960,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="TransformFeedbackVaryingsNV"/>
-            public static unsafe void TransformFeedbackVaryingsNV(ProgramHandle program, TransformFeedbackTokenNV[] locations, TransformFeedbackBufferMode bufferMode)
+            public static unsafe void TransformFeedbackVaryingsNV(int program, TransformFeedbackTokenNV[] locations, TransformFeedbackBufferMode bufferMode)
             {
                 int count = (int)(locations.Length);
                 fixed (TransformFeedbackTokenNV* locations_ptr = locations)
@@ -35969,7 +35969,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="TransformFeedbackVaryingsNV"/>
-            public static unsafe void TransformFeedbackVaryingsNV(ProgramHandle program, int count, in TransformFeedbackTokenNV locations, TransformFeedbackBufferMode bufferMode)
+            public static unsafe void TransformFeedbackVaryingsNV(int program, int count, in TransformFeedbackTokenNV locations, TransformFeedbackBufferMode bufferMode)
             {
                 fixed (TransformFeedbackTokenNV* locations_ptr = &locations)
                 {
@@ -35977,14 +35977,14 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ActiveVaryingNV"/>
-            public static unsafe void ActiveVaryingNV(ProgramHandle program, string name)
+            public static unsafe void ActiveVaryingNV(int program, string name)
             {
                 byte* name_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(name);
                 ActiveVaryingNV(program, name_ptr);
                 Marshal.FreeCoTaskMem((IntPtr)name_ptr);
             }
             /// <inheritdoc cref="GetVaryingLocationNV"/>
-            public static unsafe int GetVaryingLocationNV(ProgramHandle program, string name)
+            public static unsafe int GetVaryingLocationNV(int program, string name)
             {
                 int returnValue;
                 byte* name_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(name);
@@ -35993,7 +35993,7 @@ namespace OpenTK.Graphics.OpenGL
                 return returnValue;
             }
             /// <inheritdoc cref="GetActiveVaryingNV"/>
-            public static unsafe string GetActiveVaryingNV(ProgramHandle program, uint index, int bufSize, Span<int> length, Span<int> size, Span<All> type)
+            public static unsafe string GetActiveVaryingNV(int program, uint index, int bufSize, Span<int> length, Span<int> size, Span<All> type)
             {
                 string name;
                 fixed (int* length_ptr = length)
@@ -36012,7 +36012,7 @@ namespace OpenTK.Graphics.OpenGL
                 return name;
             }
             /// <inheritdoc cref="GetActiveVaryingNV"/>
-            public static unsafe void GetActiveVaryingNV(ProgramHandle program, uint index, int bufSize, Span<int> length, Span<int> size, Span<All> type, out string name)
+            public static unsafe void GetActiveVaryingNV(int program, uint index, int bufSize, Span<int> length, Span<int> size, Span<All> type, out string name)
             {
                 fixed (int* length_ptr = length)
                 {
@@ -36029,7 +36029,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetActiveVaryingNV"/>
-            public static unsafe string GetActiveVaryingNV(ProgramHandle program, uint index, int bufSize, int[] length, int[] size, All[] type)
+            public static unsafe string GetActiveVaryingNV(int program, uint index, int bufSize, int[] length, int[] size, All[] type)
             {
                 string name;
                 fixed (int* length_ptr = length)
@@ -36048,7 +36048,7 @@ namespace OpenTK.Graphics.OpenGL
                 return name;
             }
             /// <inheritdoc cref="GetActiveVaryingNV"/>
-            public static unsafe void GetActiveVaryingNV(ProgramHandle program, uint index, int bufSize, int[] length, int[] size, All[] type, out string name)
+            public static unsafe void GetActiveVaryingNV(int program, uint index, int bufSize, int[] length, int[] size, All[] type, out string name)
             {
                 fixed (int* length_ptr = length)
                 {
@@ -36065,7 +36065,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetActiveVaryingNV"/>
-            public static unsafe string GetActiveVaryingNV(ProgramHandle program, uint index, int bufSize, ref int length, ref int size, ref All type)
+            public static unsafe string GetActiveVaryingNV(int program, uint index, int bufSize, ref int length, ref int size, ref All type)
             {
                 string name;
                 fixed (int* length_ptr = &length)
@@ -36080,7 +36080,7 @@ namespace OpenTK.Graphics.OpenGL
                 return name;
             }
             /// <inheritdoc cref="GetActiveVaryingNV"/>
-            public static unsafe void GetActiveVaryingNV(ProgramHandle program, uint index, int bufSize, ref int length, ref int size, ref All type, out string name)
+            public static unsafe void GetActiveVaryingNV(int program, uint index, int bufSize, ref int length, ref int size, ref All type, out string name)
             {
                 fixed (int* length_ptr = &length)
                 fixed (int* size_ptr = &size)
@@ -36093,7 +36093,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetTransformFeedbackVaryingNV"/>
-            public static unsafe void GetTransformFeedbackVaryingNV(ProgramHandle program, uint index, Span<int> location)
+            public static unsafe void GetTransformFeedbackVaryingNV(int program, uint index, Span<int> location)
             {
                 fixed (int* location_ptr = location)
                 {
@@ -36101,7 +36101,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetTransformFeedbackVaryingNV"/>
-            public static unsafe void GetTransformFeedbackVaryingNV(ProgramHandle program, uint index, int[] location)
+            public static unsafe void GetTransformFeedbackVaryingNV(int program, uint index, int[] location)
             {
                 fixed (int* location_ptr = location)
                 {
@@ -36109,7 +36109,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetTransformFeedbackVaryingNV"/>
-            public static unsafe void GetTransformFeedbackVaryingNV(ProgramHandle program, uint index, ref int location)
+            public static unsafe void GetTransformFeedbackVaryingNV(int program, uint index, ref int location)
             {
                 fixed (int* location_ptr = &location)
                 {
@@ -36152,53 +36152,53 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="DeleteTransformFeedbacksNV"/>
-            public static unsafe void DeleteTransformFeedbacksNV(ReadOnlySpan<TransformFeedbackHandle> ids)
+            public static unsafe void DeleteTransformFeedbacksNV(ReadOnlySpan<int> ids)
             {
                 int n = (int)(ids.Length);
-                fixed (TransformFeedbackHandle* ids_ptr = ids)
+                fixed (int* ids_ptr = ids)
                 {
                     DeleteTransformFeedbacksNV(n, ids_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteTransformFeedbacksNV"/>
-            public static unsafe void DeleteTransformFeedbacksNV(TransformFeedbackHandle[] ids)
+            public static unsafe void DeleteTransformFeedbacksNV(int[] ids)
             {
                 int n = (int)(ids.Length);
-                fixed (TransformFeedbackHandle* ids_ptr = ids)
+                fixed (int* ids_ptr = ids)
                 {
                     DeleteTransformFeedbacksNV(n, ids_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteTransformFeedbacksNV"/>
-            public static unsafe void DeleteTransformFeedbacksNV(int n, in TransformFeedbackHandle ids)
+            public static unsafe void DeleteTransformFeedbacksNV(int n, in int ids)
             {
-                fixed (TransformFeedbackHandle* ids_ptr = &ids)
+                fixed (int* ids_ptr = &ids)
                 {
                     DeleteTransformFeedbacksNV(n, ids_ptr);
                 }
             }
             /// <inheritdoc cref="GenTransformFeedbacksNV"/>
-            public static unsafe void GenTransformFeedbacksNV(Span<TransformFeedbackHandle> ids)
+            public static unsafe void GenTransformFeedbacksNV(Span<int> ids)
             {
                 int n = (int)(ids.Length);
-                fixed (TransformFeedbackHandle* ids_ptr = ids)
+                fixed (int* ids_ptr = ids)
                 {
                     GenTransformFeedbacksNV(n, ids_ptr);
                 }
             }
             /// <inheritdoc cref="GenTransformFeedbacksNV"/>
-            public static unsafe void GenTransformFeedbacksNV(TransformFeedbackHandle[] ids)
+            public static unsafe void GenTransformFeedbacksNV(int[] ids)
             {
                 int n = (int)(ids.Length);
-                fixed (TransformFeedbackHandle* ids_ptr = ids)
+                fixed (int* ids_ptr = ids)
                 {
                     GenTransformFeedbacksNV(n, ids_ptr);
                 }
             }
             /// <inheritdoc cref="GenTransformFeedbacksNV"/>
-            public static unsafe void GenTransformFeedbacksNV(int n, ref TransformFeedbackHandle ids)
+            public static unsafe void GenTransformFeedbacksNV(int n, ref int ids)
             {
-                fixed (TransformFeedbackHandle* ids_ptr = &ids)
+                fixed (int* ids_ptr = &ids)
                 {
                     GenTransformFeedbacksNV(n, ids_ptr);
                 }
@@ -36835,10 +36835,10 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="AreProgramsResidentNV"/>
-            public static unsafe bool AreProgramsResidentNV(int n, ReadOnlySpan<ProgramHandle> programs, Span<bool> residences)
+            public static unsafe bool AreProgramsResidentNV(int n, ReadOnlySpan<int> programs, Span<bool> residences)
             {
                 bool returnValue;
-                fixed (ProgramHandle* programs_ptr = programs)
+                fixed (int* programs_ptr = programs)
                 {
                     fixed (bool* residences_ptr = residences)
                     {
@@ -36848,10 +36848,10 @@ namespace OpenTK.Graphics.OpenGL
                 return returnValue;
             }
             /// <inheritdoc cref="AreProgramsResidentNV"/>
-            public static unsafe bool AreProgramsResidentNV(int n, ProgramHandle[] programs, bool[] residences)
+            public static unsafe bool AreProgramsResidentNV(int n, int[] programs, bool[] residences)
             {
                 bool returnValue;
-                fixed (ProgramHandle* programs_ptr = programs)
+                fixed (int* programs_ptr = programs)
                 {
                     fixed (bool* residences_ptr = residences)
                     {
@@ -36861,10 +36861,10 @@ namespace OpenTK.Graphics.OpenGL
                 return returnValue;
             }
             /// <inheritdoc cref="AreProgramsResidentNV"/>
-            public static unsafe bool AreProgramsResidentNV(int n, in ProgramHandle programs, ref bool residences)
+            public static unsafe bool AreProgramsResidentNV(int n, in int programs, ref bool residences)
             {
                 bool returnValue;
-                fixed (ProgramHandle* programs_ptr = &programs)
+                fixed (int* programs_ptr = &programs)
                 fixed (bool* residences_ptr = &residences)
                 {
                     returnValue = AreProgramsResidentNV(n, programs_ptr, residences_ptr);
@@ -36872,27 +36872,27 @@ namespace OpenTK.Graphics.OpenGL
                 return returnValue;
             }
             /// <inheritdoc cref="DeleteProgramsNV"/>
-            public static unsafe void DeleteProgramsNV(ReadOnlySpan<ProgramHandle> programs)
+            public static unsafe void DeleteProgramsNV(ReadOnlySpan<int> programs)
             {
                 int n = (int)(programs.Length);
-                fixed (ProgramHandle* programs_ptr = programs)
+                fixed (int* programs_ptr = programs)
                 {
                     DeleteProgramsNV(n, programs_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteProgramsNV"/>
-            public static unsafe void DeleteProgramsNV(ProgramHandle[] programs)
+            public static unsafe void DeleteProgramsNV(int[] programs)
             {
                 int n = (int)(programs.Length);
-                fixed (ProgramHandle* programs_ptr = programs)
+                fixed (int* programs_ptr = programs)
                 {
                     DeleteProgramsNV(n, programs_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteProgramsNV"/>
-            public static unsafe void DeleteProgramsNV(int n, in ProgramHandle programs)
+            public static unsafe void DeleteProgramsNV(int n, in int programs)
             {
-                fixed (ProgramHandle* programs_ptr = &programs)
+                fixed (int* programs_ptr = &programs)
                 {
                     DeleteProgramsNV(n, programs_ptr);
                 }
@@ -36922,27 +36922,27 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GenProgramsNV"/>
-            public static unsafe void GenProgramsNV(Span<ProgramHandle> programs)
+            public static unsafe void GenProgramsNV(Span<int> programs)
             {
                 int n = (int)(programs.Length);
-                fixed (ProgramHandle* programs_ptr = programs)
+                fixed (int* programs_ptr = programs)
                 {
                     GenProgramsNV(n, programs_ptr);
                 }
             }
             /// <inheritdoc cref="GenProgramsNV"/>
-            public static unsafe void GenProgramsNV(ProgramHandle[] programs)
+            public static unsafe void GenProgramsNV(int[] programs)
             {
                 int n = (int)(programs.Length);
-                fixed (ProgramHandle* programs_ptr = programs)
+                fixed (int* programs_ptr = programs)
                 {
                     GenProgramsNV(n, programs_ptr);
                 }
             }
             /// <inheritdoc cref="GenProgramsNV"/>
-            public static unsafe void GenProgramsNV(int n, ref ProgramHandle programs)
+            public static unsafe void GenProgramsNV(int n, ref int programs)
             {
-                fixed (ProgramHandle* programs_ptr = &programs)
+                fixed (int* programs_ptr = &programs)
                 {
                     GenProgramsNV(n, programs_ptr);
                 }
@@ -36996,7 +36996,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetProgramivNV"/>
-            public static unsafe void GetProgramivNV(ProgramHandle id, VertexAttribEnumNV pname, Span<int> parameters)
+            public static unsafe void GetProgramivNV(int id, VertexAttribEnumNV pname, Span<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -37004,7 +37004,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetProgramivNV"/>
-            public static unsafe void GetProgramivNV(ProgramHandle id, VertexAttribEnumNV pname, int[] parameters)
+            public static unsafe void GetProgramivNV(int id, VertexAttribEnumNV pname, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -37012,7 +37012,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetProgramivNV"/>
-            public static unsafe void GetProgramivNV(ProgramHandle id, VertexAttribEnumNV pname, ref int parameters)
+            public static unsafe void GetProgramivNV(int id, VertexAttribEnumNV pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -37020,7 +37020,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetProgramStringNV"/>
-            public static unsafe void GetProgramStringNV(ProgramHandle id, VertexAttribEnumNV pname, Span<byte> program)
+            public static unsafe void GetProgramStringNV(int id, VertexAttribEnumNV pname, Span<byte> program)
             {
                 fixed (byte* program_ptr = program)
                 {
@@ -37028,7 +37028,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetProgramStringNV"/>
-            public static unsafe void GetProgramStringNV(ProgramHandle id, VertexAttribEnumNV pname, byte[] program)
+            public static unsafe void GetProgramStringNV(int id, VertexAttribEnumNV pname, byte[] program)
             {
                 fixed (byte* program_ptr = program)
                 {
@@ -37036,7 +37036,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetProgramStringNV"/>
-            public static unsafe void GetProgramStringNV(ProgramHandle id, VertexAttribEnumNV pname, ref byte program)
+            public static unsafe void GetProgramStringNV(int id, VertexAttribEnumNV pname, ref byte program)
             {
                 fixed (byte* program_ptr = &program)
                 {
@@ -37266,27 +37266,27 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="RequestResidentProgramsNV"/>
-            public static unsafe void RequestResidentProgramsNV(ReadOnlySpan<ProgramHandle> programs)
+            public static unsafe void RequestResidentProgramsNV(ReadOnlySpan<int> programs)
             {
                 int n = (int)(programs.Length);
-                fixed (ProgramHandle* programs_ptr = programs)
+                fixed (int* programs_ptr = programs)
                 {
                     RequestResidentProgramsNV(n, programs_ptr);
                 }
             }
             /// <inheritdoc cref="RequestResidentProgramsNV"/>
-            public static unsafe void RequestResidentProgramsNV(ProgramHandle[] programs)
+            public static unsafe void RequestResidentProgramsNV(int[] programs)
             {
                 int n = (int)(programs.Length);
-                fixed (ProgramHandle* programs_ptr = programs)
+                fixed (int* programs_ptr = programs)
                 {
                     RequestResidentProgramsNV(n, programs_ptr);
                 }
             }
             /// <inheritdoc cref="RequestResidentProgramsNV"/>
-            public static unsafe void RequestResidentProgramsNV(int n, in ProgramHandle programs)
+            public static unsafe void RequestResidentProgramsNV(int n, in int programs)
             {
-                fixed (ProgramHandle* programs_ptr = &programs)
+                fixed (int* programs_ptr = &programs)
                 {
                     RequestResidentProgramsNV(n, programs_ptr);
                 }
@@ -38738,7 +38738,7 @@ namespace OpenTK.Graphics.OpenGL
         public static unsafe partial class INTEL
         {
             /// <inheritdoc cref="MapTexture2DINTEL"/>
-            public static unsafe void* MapTexture2DINTEL(TextureHandle texture, int level, All access, Span<int> stride, Span<All> layout)
+            public static unsafe void* MapTexture2DINTEL(int texture, int level, All access, Span<int> stride, Span<All> layout)
             {
                 void* returnValue;
                 fixed (int* stride_ptr = stride)
@@ -38751,7 +38751,7 @@ namespace OpenTK.Graphics.OpenGL
                 return returnValue;
             }
             /// <inheritdoc cref="MapTexture2DINTEL"/>
-            public static unsafe void* MapTexture2DINTEL(TextureHandle texture, int level, All access, int[] stride, All[] layout)
+            public static unsafe void* MapTexture2DINTEL(int texture, int level, All access, int[] stride, All[] layout)
             {
                 void* returnValue;
                 fixed (int* stride_ptr = stride)
@@ -38764,7 +38764,7 @@ namespace OpenTK.Graphics.OpenGL
                 return returnValue;
             }
             /// <inheritdoc cref="MapTexture2DINTEL"/>
-            public static unsafe void* MapTexture2DINTEL(TextureHandle texture, int level, All access, ref int stride, ref All layout)
+            public static unsafe void* MapTexture2DINTEL(int texture, int level, All access, ref int stride, ref All layout)
             {
                 void* returnValue;
                 fixed (int* stride_ptr = &stride)
@@ -39630,7 +39630,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetnUniformfv"/>
-            public static unsafe void GetnUniformf(ProgramHandle program, int location, Span<float> parameters)
+            public static unsafe void GetnUniformf(int program, int location, Span<float> parameters)
             {
                 int bufSize = (int)(parameters.Length * 4);
                 fixed (float* parameters_ptr = parameters)
@@ -39639,7 +39639,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetnUniformfv"/>
-            public static unsafe void GetnUniformf(ProgramHandle program, int location, float[] parameters)
+            public static unsafe void GetnUniformf(int program, int location, float[] parameters)
             {
                 int bufSize = (int)(parameters.Length * 4);
                 fixed (float* parameters_ptr = parameters)
@@ -39648,7 +39648,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetnUniformfv"/>
-            public static unsafe void GetnUniformf(ProgramHandle program, int location, int bufSize, ref float parameters)
+            public static unsafe void GetnUniformf(int program, int location, int bufSize, ref float parameters)
             {
                 fixed (float* parameters_ptr = &parameters)
                 {
@@ -39656,7 +39656,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetnUniformiv"/>
-            public static unsafe void GetnUniformi(ProgramHandle program, int location, Span<int> parameters)
+            public static unsafe void GetnUniformi(int program, int location, Span<int> parameters)
             {
                 int bufSize = (int)(parameters.Length * 4);
                 fixed (int* parameters_ptr = parameters)
@@ -39665,7 +39665,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetnUniformiv"/>
-            public static unsafe void GetnUniformi(ProgramHandle program, int location, int[] parameters)
+            public static unsafe void GetnUniformi(int program, int location, int[] parameters)
             {
                 int bufSize = (int)(parameters.Length * 4);
                 fixed (int* parameters_ptr = parameters)
@@ -39674,7 +39674,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetnUniformiv"/>
-            public static unsafe void GetnUniformi(ProgramHandle program, int location, int bufSize, ref int parameters)
+            public static unsafe void GetnUniformi(int program, int location, int bufSize, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -39682,7 +39682,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetnUniformuiv"/>
-            public static unsafe void GetnUniformui(ProgramHandle program, int location, Span<uint> parameters)
+            public static unsafe void GetnUniformui(int program, int location, Span<uint> parameters)
             {
                 int bufSize = (int)(parameters.Length * 4);
                 fixed (uint* parameters_ptr = parameters)
@@ -39691,7 +39691,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetnUniformuiv"/>
-            public static unsafe void GetnUniformui(ProgramHandle program, int location, uint[] parameters)
+            public static unsafe void GetnUniformui(int program, int location, uint[] parameters)
             {
                 int bufSize = (int)(parameters.Length * 4);
                 fixed (uint* parameters_ptr = parameters)
@@ -39700,7 +39700,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetnUniformuiv"/>
-            public static unsafe void GetnUniformui(ProgramHandle program, int location, int bufSize, ref uint parameters)
+            public static unsafe void GetnUniformui(int program, int location, int bufSize, ref uint parameters)
             {
                 fixed (uint* parameters_ptr = &parameters)
                 {
@@ -39743,7 +39743,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetnUniformfvKHR"/>
-            public static unsafe void GetnUniformfvKHR(ProgramHandle program, int location, Span<float> parameters)
+            public static unsafe void GetnUniformfvKHR(int program, int location, Span<float> parameters)
             {
                 int bufSize = (int)(parameters.Length * 4);
                 fixed (float* parameters_ptr = parameters)
@@ -39752,7 +39752,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetnUniformfvKHR"/>
-            public static unsafe void GetnUniformfvKHR(ProgramHandle program, int location, float[] parameters)
+            public static unsafe void GetnUniformfvKHR(int program, int location, float[] parameters)
             {
                 int bufSize = (int)(parameters.Length * 4);
                 fixed (float* parameters_ptr = parameters)
@@ -39761,7 +39761,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetnUniformfvKHR"/>
-            public static unsafe void GetnUniformfvKHR(ProgramHandle program, int location, int bufSize, ref float parameters)
+            public static unsafe void GetnUniformfvKHR(int program, int location, int bufSize, ref float parameters)
             {
                 fixed (float* parameters_ptr = &parameters)
                 {
@@ -39769,7 +39769,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetnUniformivKHR"/>
-            public static unsafe void GetnUniformivKHR(ProgramHandle program, int location, Span<int> parameters)
+            public static unsafe void GetnUniformivKHR(int program, int location, Span<int> parameters)
             {
                 int bufSize = (int)(parameters.Length * 4);
                 fixed (int* parameters_ptr = parameters)
@@ -39778,7 +39778,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetnUniformivKHR"/>
-            public static unsafe void GetnUniformivKHR(ProgramHandle program, int location, int[] parameters)
+            public static unsafe void GetnUniformivKHR(int program, int location, int[] parameters)
             {
                 int bufSize = (int)(parameters.Length * 4);
                 fixed (int* parameters_ptr = parameters)
@@ -39787,7 +39787,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetnUniformivKHR"/>
-            public static unsafe void GetnUniformivKHR(ProgramHandle program, int location, int bufSize, ref int parameters)
+            public static unsafe void GetnUniformivKHR(int program, int location, int bufSize, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -39795,7 +39795,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetnUniformuivKHR"/>
-            public static unsafe void GetnUniformuivKHR(ProgramHandle program, int location, Span<uint> parameters)
+            public static unsafe void GetnUniformuivKHR(int program, int location, Span<uint> parameters)
             {
                 int bufSize = (int)(parameters.Length * 4);
                 fixed (uint* parameters_ptr = parameters)
@@ -39804,7 +39804,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetnUniformuivKHR"/>
-            public static unsafe void GetnUniformuivKHR(ProgramHandle program, int location, uint[] parameters)
+            public static unsafe void GetnUniformuivKHR(int program, int location, uint[] parameters)
             {
                 int bufSize = (int)(parameters.Length * 4);
                 fixed (uint* parameters_ptr = parameters)
@@ -39813,7 +39813,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetnUniformuivKHR"/>
-            public static unsafe void GetnUniformuivKHR(ProgramHandle program, int location, int bufSize, ref uint parameters)
+            public static unsafe void GetnUniformuivKHR(int program, int location, int bufSize, ref uint parameters)
             {
                 fixed (uint* parameters_ptr = &parameters)
                 {
@@ -40139,13 +40139,13 @@ namespace OpenTK.Graphics.OpenGL
         public static unsafe partial class NVX
         {
             /// <inheritdoc cref="LGPUNamedBufferSubDataNVX"/>
-            public static unsafe void LGPUNamedBufferSubDataNVX(All gpuMask, BufferHandle buffer, IntPtr offset, nint size, IntPtr data)
+            public static unsafe void LGPUNamedBufferSubDataNVX(All gpuMask, int buffer, IntPtr offset, nint size, IntPtr data)
             {
                 void* data_vptr = (void*)data;
                 LGPUNamedBufferSubDataNVX(gpuMask, buffer, offset, size, data_vptr);
             }
             /// <inheritdoc cref="LGPUNamedBufferSubDataNVX"/>
-            public static unsafe void LGPUNamedBufferSubDataNVX<T1>(All gpuMask, BufferHandle buffer, IntPtr offset, nint size, in T1 data)
+            public static unsafe void LGPUNamedBufferSubDataNVX<T1>(All gpuMask, int buffer, IntPtr offset, nint size, in T1 data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = &data)
@@ -40202,7 +40202,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="AsyncCopyBufferSubDataNVX"/>
-            public static unsafe uint AsyncCopyBufferSubDataNVX(int waitSemaphoreCount, ReadOnlySpan<uint> waitSemaphoreArray, ReadOnlySpan<ulong> fenceValueArray, uint readGpu, All writeGpuMask, BufferHandle readBuffer, BufferHandle writeBuffer, IntPtr readOffset, IntPtr writeOffset, nint size, int signalSemaphoreCount, ReadOnlySpan<uint> signalSemaphoreArray, ReadOnlySpan<ulong> signalValueArray)
+            public static unsafe uint AsyncCopyBufferSubDataNVX(int waitSemaphoreCount, ReadOnlySpan<uint> waitSemaphoreArray, ReadOnlySpan<ulong> fenceValueArray, uint readGpu, All writeGpuMask, int readBuffer, int writeBuffer, IntPtr readOffset, IntPtr writeOffset, nint size, int signalSemaphoreCount, ReadOnlySpan<uint> signalSemaphoreArray, ReadOnlySpan<ulong> signalValueArray)
             {
                 uint returnValue;
                 fixed (uint* waitSemaphoreArray_ptr = waitSemaphoreArray)
@@ -40221,7 +40221,7 @@ namespace OpenTK.Graphics.OpenGL
                 return returnValue;
             }
             /// <inheritdoc cref="AsyncCopyBufferSubDataNVX"/>
-            public static unsafe uint AsyncCopyBufferSubDataNVX(int waitSemaphoreCount, uint[] waitSemaphoreArray, ulong[] fenceValueArray, uint readGpu, All writeGpuMask, BufferHandle readBuffer, BufferHandle writeBuffer, IntPtr readOffset, IntPtr writeOffset, nint size, int signalSemaphoreCount, uint[] signalSemaphoreArray, ulong[] signalValueArray)
+            public static unsafe uint AsyncCopyBufferSubDataNVX(int waitSemaphoreCount, uint[] waitSemaphoreArray, ulong[] fenceValueArray, uint readGpu, All writeGpuMask, int readBuffer, int writeBuffer, IntPtr readOffset, IntPtr writeOffset, nint size, int signalSemaphoreCount, uint[] signalSemaphoreArray, ulong[] signalValueArray)
             {
                 uint returnValue;
                 fixed (uint* waitSemaphoreArray_ptr = waitSemaphoreArray)
@@ -40240,7 +40240,7 @@ namespace OpenTK.Graphics.OpenGL
                 return returnValue;
             }
             /// <inheritdoc cref="AsyncCopyBufferSubDataNVX"/>
-            public static unsafe uint AsyncCopyBufferSubDataNVX(int waitSemaphoreCount, in uint waitSemaphoreArray, in ulong fenceValueArray, uint readGpu, All writeGpuMask, BufferHandle readBuffer, BufferHandle writeBuffer, IntPtr readOffset, IntPtr writeOffset, nint size, int signalSemaphoreCount, in uint signalSemaphoreArray, in ulong signalValueArray)
+            public static unsafe uint AsyncCopyBufferSubDataNVX(int waitSemaphoreCount, in uint waitSemaphoreArray, in ulong fenceValueArray, uint readGpu, All writeGpuMask, int readBuffer, int writeBuffer, IntPtr readOffset, IntPtr writeOffset, nint size, int signalSemaphoreCount, in uint signalSemaphoreArray, in ulong signalValueArray)
             {
                 uint returnValue;
                 fixed (uint* waitSemaphoreArray_ptr = &waitSemaphoreArray)
@@ -41606,9 +41606,9 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="PrioritizeTexturesxOES"/>
-            public static unsafe void PrioritizeTexturesxOES(int n, ReadOnlySpan<TextureHandle> textures, ReadOnlySpan<int> priorities)
+            public static unsafe void PrioritizeTexturesxOES(int n, ReadOnlySpan<int> textures, ReadOnlySpan<int> priorities)
             {
-                fixed (TextureHandle* textures_ptr = textures)
+                fixed (int* textures_ptr = textures)
                 {
                     fixed (int* priorities_ptr = priorities)
                     {
@@ -41617,9 +41617,9 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="PrioritizeTexturesxOES"/>
-            public static unsafe void PrioritizeTexturesxOES(int n, TextureHandle[] textures, int[] priorities)
+            public static unsafe void PrioritizeTexturesxOES(int n, int[] textures, int[] priorities)
             {
-                fixed (TextureHandle* textures_ptr = textures)
+                fixed (int* textures_ptr = textures)
                 {
                     fixed (int* priorities_ptr = priorities)
                     {
@@ -41628,9 +41628,9 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="PrioritizeTexturesxOES"/>
-            public static unsafe void PrioritizeTexturesxOES(int n, in TextureHandle textures, in int priorities)
+            public static unsafe void PrioritizeTexturesxOES(int n, in int textures, in int priorities)
             {
-                fixed (TextureHandle* textures_ptr = &textures)
+                fixed (int* textures_ptr = &textures)
                 fixed (int* priorities_ptr = &priorities)
                 {
                     PrioritizeTexturesxOES(n, textures_ptr, priorities_ptr);
@@ -42804,7 +42804,7 @@ namespace OpenTK.Graphics.OpenGL
                 return returnValue;
             }
             /// <inheritdoc cref="GetListParameterfvSGIX"/>
-            public static unsafe void GetListParameterfvSGIX(DisplayListHandle list, ListParameterName pname, Span<float> parameters)
+            public static unsafe void GetListParameterfvSGIX(int list, ListParameterName pname, Span<float> parameters)
             {
                 fixed (float* parameters_ptr = parameters)
                 {
@@ -42812,7 +42812,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetListParameterfvSGIX"/>
-            public static unsafe void GetListParameterfvSGIX(DisplayListHandle list, ListParameterName pname, float[] parameters)
+            public static unsafe void GetListParameterfvSGIX(int list, ListParameterName pname, float[] parameters)
             {
                 fixed (float* parameters_ptr = parameters)
                 {
@@ -42820,7 +42820,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetListParameterfvSGIX"/>
-            public static unsafe void GetListParameterfvSGIX(DisplayListHandle list, ListParameterName pname, ref float parameters)
+            public static unsafe void GetListParameterfvSGIX(int list, ListParameterName pname, ref float parameters)
             {
                 fixed (float* parameters_ptr = &parameters)
                 {
@@ -42828,7 +42828,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetListParameterivSGIX"/>
-            public static unsafe void GetListParameterivSGIX(DisplayListHandle list, ListParameterName pname, Span<int> parameters)
+            public static unsafe void GetListParameterivSGIX(int list, ListParameterName pname, Span<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -42836,7 +42836,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetListParameterivSGIX"/>
-            public static unsafe void GetListParameterivSGIX(DisplayListHandle list, ListParameterName pname, int[] parameters)
+            public static unsafe void GetListParameterivSGIX(int list, ListParameterName pname, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -42844,7 +42844,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="GetListParameterivSGIX"/>
-            public static unsafe void GetListParameterivSGIX(DisplayListHandle list, ListParameterName pname, ref int parameters)
+            public static unsafe void GetListParameterivSGIX(int list, ListParameterName pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -42852,7 +42852,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ListParameterfvSGIX"/>
-            public static unsafe void ListParameterfvSGIX(DisplayListHandle list, ListParameterName pname, ReadOnlySpan<float> parameters)
+            public static unsafe void ListParameterfvSGIX(int list, ListParameterName pname, ReadOnlySpan<float> parameters)
             {
                 fixed (float* parameters_ptr = parameters)
                 {
@@ -42860,7 +42860,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ListParameterfvSGIX"/>
-            public static unsafe void ListParameterfvSGIX(DisplayListHandle list, ListParameterName pname, float[] parameters)
+            public static unsafe void ListParameterfvSGIX(int list, ListParameterName pname, float[] parameters)
             {
                 fixed (float* parameters_ptr = parameters)
                 {
@@ -42868,7 +42868,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ListParameterfvSGIX"/>
-            public static unsafe void ListParameterfvSGIX(DisplayListHandle list, ListParameterName pname, in float parameters)
+            public static unsafe void ListParameterfvSGIX(int list, ListParameterName pname, in float parameters)
             {
                 fixed (float* parameters_ptr = &parameters)
                 {
@@ -42876,7 +42876,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ListParameterivSGIX"/>
-            public static unsafe void ListParameterivSGIX(DisplayListHandle list, ListParameterName pname, ReadOnlySpan<int> parameters)
+            public static unsafe void ListParameterivSGIX(int list, ListParameterName pname, ReadOnlySpan<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -42884,7 +42884,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ListParameterivSGIX"/>
-            public static unsafe void ListParameterivSGIX(DisplayListHandle list, ListParameterName pname, int[] parameters)
+            public static unsafe void ListParameterivSGIX(int list, ListParameterName pname, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -42892,7 +42892,7 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
             /// <inheritdoc cref="ListParameterivSGIX"/>
-            public static unsafe void ListParameterivSGIX(DisplayListHandle list, ListParameterName pname, in int parameters)
+            public static unsafe void ListParameterivSGIX(int list, ListParameterName pname, in int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {

--- a/src/OpenTK.Graphics/OpenGLES1/GL.Native.cs
+++ b/src/OpenTK.Graphics/OpenGLES1/GL.Native.cs
@@ -245,13 +245,13 @@ namespace OpenTK.Graphics.OpenGLES1
         /// <param name="target"> Specifies the target to which the buffer is bound. The symbolic constant must be GL_ARRAY_BUFFER or GL_ELEMENT_ARRAY_BUFFER. </param>
         /// <param name="buffer">Specifies the name of a buffer object.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es1.1/xhtml/glBindBuffer.xml" /></remarks>
-        public static void BindBuffer(BufferTargetARB target, BufferHandle buffer) => GLPointers._BindBuffer_fnptr((uint)target, (int)buffer);
+        public static void BindBuffer(BufferTargetARB target, int buffer) => GLPointers._BindBuffer_fnptr((uint)target, buffer);
         
         /// <summary> <b>[requires: v1.0]</b> Bind a named texture to a texturing target. </summary>
         /// <param name="target">Specifies the target to which the texture is bound. Must be GL_TEXTURE_2D.</param>
         /// <param name="texture">Specifies the name of a texture.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es1.1/xhtml/glBindTexture.xml" /></remarks>
-        public static void BindTexture(TextureTarget target, TextureHandle texture) => GLPointers._BindTexture_fnptr((uint)target, (int)texture);
+        public static void BindTexture(TextureTarget target, int texture) => GLPointers._BindTexture_fnptr((uint)target, texture);
         
         /// <summary> <b>[requires: v1.0]</b> Specify pixel arithmetic. </summary>
         /// <param name="sfactor"> Specifies how the red, green, blue, and alpha source blending factors are computed. The following symbolic constants are accepted: GL_ZERO, GL_ONE, GL_DST_COLOR, GL_ONE_MINUS_DST_COLOR, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_DST_ALPHA, GL_ONE_MINUS_DST_ALPHA, and GL_SRC_ALPHA_SATURATE. The initial value is GL_ONE. </param>
@@ -399,13 +399,13 @@ namespace OpenTK.Graphics.OpenGLES1
         /// <param name="n">Specifies the number of buffer objects to be deleted.</param>
         /// <param name="buffers">Specifies an array of buffer object names to be deleted.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es1.1/xhtml/glDeleteBuffers.xml" /></remarks>
-        public static void DeleteBuffers(int n, BufferHandle* buffers) => GLPointers._DeleteBuffers_fnptr(n, (int*)buffers);
+        public static void DeleteBuffers(int n, int* buffers) => GLPointers._DeleteBuffers_fnptr(n, buffers);
         
         /// <summary> <b>[requires: v1.0]</b> Delete named textures. </summary>
         /// <param name="n">Specifies the number of textures to be deleted.</param>
         /// <param name="textures">Specifies an array of textures to be deleted.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es1.1/xhtml/glDeleteTextures.xml" /></remarks>
-        public static void DeleteTextures(int n, TextureHandle* textures) => GLPointers._DeleteTextures_fnptr(n, (int*)textures);
+        public static void DeleteTextures(int n, int* textures) => GLPointers._DeleteTextures_fnptr(n, textures);
         
         /// <summary> <b>[requires: v1.0]</b> Specify the value used for depth buffer comparisons. </summary>
         /// <param name="func">Specifies the depth comparison function. Symbolic constants GL_NEVER, GL_LESS, GL_EQUAL, GL_LEQUAL, GL_GREATER, GL_NOTEQUAL, GL_GEQUAL, and GL_ALWAYS are accepted. The initial value is GL_LESS.</param>
@@ -512,13 +512,13 @@ namespace OpenTK.Graphics.OpenGLES1
         /// <param name="n">Specifies the number of buffer object names to be generated.</param>
         /// <param name="buffers">Specifies an array in which the generated buffer object names are stored.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es1.1/xhtml/glGenBuffers.xml" /></remarks>
-        public static void GenBuffers(int n, BufferHandle* buffers) => GLPointers._GenBuffers_fnptr(n, (int*)buffers);
+        public static void GenBuffers(int n, int* buffers) => GLPointers._GenBuffers_fnptr(n, buffers);
         
         /// <summary> <b>[requires: v1.0]</b> Generate texture names. </summary>
         /// <param name="n">Specifies the number of texture names to be generated.</param>
         /// <param name="textures">Specifies an array in which the generated texture names are stored.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es1.1/xhtml/glGenTextures.xml" /></remarks>
-        public static void GenTextures(int n, TextureHandle* textures) => GLPointers._GenTextures_fnptr(n, (int*)textures);
+        public static void GenTextures(int n, int* textures) => GLPointers._GenTextures_fnptr(n, textures);
         
         /// <summary> <b>[requires: v1.0]</b> Return error information. </summary>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es1.1/xhtml/glGetError.xml" /></remarks>
@@ -598,7 +598,7 @@ namespace OpenTK.Graphics.OpenGLES1
         /// <summary> <b>[requires: v1.0]</b> Determine if a name corresponds to a buffer object. </summary>
         /// <param name="buffer"> Specifies a value that may be the name of a buffer object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es1.1/xhtml/glIsBuffer.xml" /></remarks>
-        public static bool IsBuffer(BufferHandle buffer) => GLPointers._IsBuffer_fnptr((int)buffer) != 0;
+        public static bool IsBuffer(int buffer) => GLPointers._IsBuffer_fnptr(buffer) != 0;
         
         /// <summary> <b>[requires: v1.0]</b> Test whether a capability is enabled. </summary>
         /// <param name="cap"> Specifies a symbolic constant indicating a GL capability. </param>
@@ -608,7 +608,7 @@ namespace OpenTK.Graphics.OpenGLES1
         /// <summary> <b>[requires: v1.0]</b> Determine if a name corresponds to a texture. </summary>
         /// <param name="texture"> Specifies a value that may be the name of a texture. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es1.1/xhtml/glIsTexture.xml" /></remarks>
-        public static bool IsTexture(TextureHandle texture) => GLPointers._IsTexture_fnptr((int)texture) != 0;
+        public static bool IsTexture(int texture) => GLPointers._IsTexture_fnptr(texture) != 0;
         
         /// <summary> <b>[requires: v1.0]</b> Set the lighting model parameters. </summary>
         /// <param name="pname">Specifies a single-valued lighting model parameter. Must be GL_LIGHT_MODEL_TWO_SIDE.</param>
@@ -981,7 +981,7 @@ namespace OpenTK.Graphics.OpenGLES1
             
             /// <summary> <b>[requires: GL_EXT_multisampled_render_to_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void FramebufferTexture2DMultisampleEXT(FramebufferTarget target, FramebufferAttachment attachment, TextureTarget textarget, TextureHandle texture, int level, int samples) => GLPointers._FramebufferTexture2DMultisampleEXT_fnptr((uint)target, (uint)attachment, (uint)textarget, (int)texture, level, samples);
+            public static void FramebufferTexture2DMultisampleEXT(FramebufferTarget target, FramebufferAttachment attachment, TextureTarget textarget, int texture, int level, int samples) => GLPointers._FramebufferTexture2DMultisampleEXT_fnptr((uint)target, (uint)attachment, (uint)textarget, texture, level, samples);
             
             /// <summary> <b>[requires: GL_EXT_robustness]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -993,11 +993,11 @@ namespace OpenTK.Graphics.OpenGLES1
             
             /// <summary> <b>[requires: GL_EXT_robustness]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetnUniformfvEXT(ProgramHandle program, int location, int bufSize, float* parameters) => GLPointers._GetnUniformfvEXT_fnptr((int)program, location, bufSize, parameters);
+            public static void GetnUniformfvEXT(int program, int location, int bufSize, float* parameters) => GLPointers._GetnUniformfvEXT_fnptr(program, location, bufSize, parameters);
             
             /// <summary> <b>[requires: GL_EXT_robustness]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetnUniformivEXT(ProgramHandle program, int location, int bufSize, int* parameters) => GLPointers._GetnUniformivEXT_fnptr((int)program, location, bufSize, parameters);
+            public static void GetnUniformivEXT(int program, int location, int bufSize, int* parameters) => GLPointers._GetnUniformivEXT_fnptr(program, location, bufSize, parameters);
             
             /// <summary> <b>[requires: GL_EXT_texture_storage]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -1013,15 +1013,15 @@ namespace OpenTK.Graphics.OpenGLES1
             
             /// <summary> <b>[requires: GL_EXT_texture_storage]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureStorage1DEXT(TextureHandle texture, All target, int levels, SizedInternalFormat internalformat, int width) => GLPointers._TextureStorage1DEXT_fnptr((int)texture, (uint)target, levels, (uint)internalformat, width);
+            public static void TextureStorage1DEXT(int texture, All target, int levels, SizedInternalFormat internalformat, int width) => GLPointers._TextureStorage1DEXT_fnptr(texture, (uint)target, levels, (uint)internalformat, width);
             
             /// <summary> <b>[requires: GL_EXT_texture_storage]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureStorage2DEXT(TextureHandle texture, All target, int levels, SizedInternalFormat internalformat, int width, int height) => GLPointers._TextureStorage2DEXT_fnptr((int)texture, (uint)target, levels, (uint)internalformat, width, height);
+            public static void TextureStorage2DEXT(int texture, All target, int levels, SizedInternalFormat internalformat, int width, int height) => GLPointers._TextureStorage2DEXT_fnptr(texture, (uint)target, levels, (uint)internalformat, width, height);
             
             /// <summary> <b>[requires: GL_EXT_texture_storage]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureStorage3DEXT(TextureHandle texture, All target, int levels, SizedInternalFormat internalformat, int width, int height, int depth) => GLPointers._TextureStorage3DEXT_fnptr((int)texture, (uint)target, levels, (uint)internalformat, width, height, depth);
+            public static void TextureStorage3DEXT(int texture, All target, int levels, SizedInternalFormat internalformat, int width, int height, int depth) => GLPointers._TextureStorage3DEXT_fnptr(texture, (uint)target, levels, (uint)internalformat, width, height, depth);
             
         }
         public static unsafe partial class IMG
@@ -1032,7 +1032,7 @@ namespace OpenTK.Graphics.OpenGLES1
             
             /// <summary> <b>[requires: GL_IMG_multisampled_render_to_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void FramebufferTexture2DMultisampleIMG(FramebufferTarget target, FramebufferAttachment attachment, TextureTarget textarget, TextureHandle texture, int level, int samples) => GLPointers._FramebufferTexture2DMultisampleIMG_fnptr((uint)target, (uint)attachment, (uint)textarget, (int)texture, level, samples);
+            public static void FramebufferTexture2DMultisampleIMG(FramebufferTarget target, FramebufferAttachment attachment, TextureTarget textarget, int texture, int level, int samples) => GLPointers._FramebufferTexture2DMultisampleIMG_fnptr((uint)target, (uint)attachment, (uint)textarget, texture, level, samples);
             
             /// <summary> <b>[requires: GL_IMG_user_clip_plane]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -1659,7 +1659,7 @@ namespace OpenTK.Graphics.OpenGLES1
             
             /// <summary> <b>[requires: GL_OES_fixed_point]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void PrioritizeTexturesxOES(int n, TextureHandle* textures, int* priorities) => GLPointers._PrioritizeTexturesxOES_fnptr(n, (int*)textures, priorities);
+            public static void PrioritizeTexturesxOES(int n, int* textures, int* priorities) => GLPointers._PrioritizeTexturesxOES_fnptr(n, textures, priorities);
             
             /// <summary> <b>[requires: GL_OES_fixed_point]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -1759,19 +1759,19 @@ namespace OpenTK.Graphics.OpenGLES1
             
             /// <summary> <b>[requires: GL_OES_framebuffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static bool IsRenderbufferOES(RenderbufferHandle renderbuffer) => GLPointers._IsRenderbufferOES_fnptr((int)renderbuffer) != 0;
+            public static bool IsRenderbufferOES(int renderbuffer) => GLPointers._IsRenderbufferOES_fnptr(renderbuffer) != 0;
             
             /// <summary> <b>[requires: GL_OES_framebuffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void BindRenderbufferOES(RenderbufferTarget target, RenderbufferHandle renderbuffer) => GLPointers._BindRenderbufferOES_fnptr((uint)target, (int)renderbuffer);
+            public static void BindRenderbufferOES(RenderbufferTarget target, int renderbuffer) => GLPointers._BindRenderbufferOES_fnptr((uint)target, renderbuffer);
             
             /// <summary> <b>[requires: GL_OES_framebuffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void DeleteRenderbuffersOES(int n, RenderbufferHandle* renderbuffers) => GLPointers._DeleteRenderbuffersOES_fnptr(n, (int*)renderbuffers);
+            public static void DeleteRenderbuffersOES(int n, int* renderbuffers) => GLPointers._DeleteRenderbuffersOES_fnptr(n, renderbuffers);
             
             /// <summary> <b>[requires: GL_OES_framebuffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GenRenderbuffersOES(int n, RenderbufferHandle* renderbuffers) => GLPointers._GenRenderbuffersOES_fnptr(n, (int*)renderbuffers);
+            public static void GenRenderbuffersOES(int n, int* renderbuffers) => GLPointers._GenRenderbuffersOES_fnptr(n, renderbuffers);
             
             /// <summary> <b>[requires: GL_OES_framebuffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -1783,19 +1783,19 @@ namespace OpenTK.Graphics.OpenGLES1
             
             /// <summary> <b>[requires: GL_OES_framebuffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static bool IsFramebufferOES(FramebufferHandle framebuffer) => GLPointers._IsFramebufferOES_fnptr((int)framebuffer) != 0;
+            public static bool IsFramebufferOES(int framebuffer) => GLPointers._IsFramebufferOES_fnptr(framebuffer) != 0;
             
             /// <summary> <b>[requires: GL_OES_framebuffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void BindFramebufferOES(FramebufferTarget target, FramebufferHandle framebuffer) => GLPointers._BindFramebufferOES_fnptr((uint)target, (int)framebuffer);
+            public static void BindFramebufferOES(FramebufferTarget target, int framebuffer) => GLPointers._BindFramebufferOES_fnptr((uint)target, framebuffer);
             
             /// <summary> <b>[requires: GL_OES_framebuffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void DeleteFramebuffersOES(int n, FramebufferHandle* framebuffers) => GLPointers._DeleteFramebuffersOES_fnptr(n, (int*)framebuffers);
+            public static void DeleteFramebuffersOES(int n, int* framebuffers) => GLPointers._DeleteFramebuffersOES_fnptr(n, framebuffers);
             
             /// <summary> <b>[requires: GL_OES_framebuffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GenFramebuffersOES(int n, FramebufferHandle* framebuffers) => GLPointers._GenFramebuffersOES_fnptr(n, (int*)framebuffers);
+            public static void GenFramebuffersOES(int n, int* framebuffers) => GLPointers._GenFramebuffersOES_fnptr(n, framebuffers);
             
             /// <summary> <b>[requires: GL_OES_framebuffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -1803,11 +1803,11 @@ namespace OpenTK.Graphics.OpenGLES1
             
             /// <summary> <b>[requires: GL_OES_framebuffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void FramebufferRenderbufferOES(FramebufferTarget target, FramebufferAttachment attachment, RenderbufferTarget renderbuffertarget, RenderbufferHandle renderbuffer) => GLPointers._FramebufferRenderbufferOES_fnptr((uint)target, (uint)attachment, (uint)renderbuffertarget, (int)renderbuffer);
+            public static void FramebufferRenderbufferOES(FramebufferTarget target, FramebufferAttachment attachment, RenderbufferTarget renderbuffertarget, int renderbuffer) => GLPointers._FramebufferRenderbufferOES_fnptr((uint)target, (uint)attachment, (uint)renderbuffertarget, renderbuffer);
             
             /// <summary> <b>[requires: GL_OES_framebuffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void FramebufferTexture2DOES(FramebufferTarget target, FramebufferAttachment attachment, TextureTarget textarget, TextureHandle texture, int level) => GLPointers._FramebufferTexture2DOES_fnptr((uint)target, (uint)attachment, (uint)textarget, (int)texture, level);
+            public static void FramebufferTexture2DOES(FramebufferTarget target, FramebufferAttachment attachment, TextureTarget textarget, int texture, int level) => GLPointers._FramebufferTexture2DOES_fnptr((uint)target, (uint)attachment, (uint)textarget, texture, level);
             
             /// <summary> <b>[requires: GL_OES_framebuffer_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -1917,19 +1917,19 @@ namespace OpenTK.Graphics.OpenGLES1
             
             /// <summary> <b>[requires: GL_OES_vertex_array_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void BindVertexArrayOES(VertexArrayHandle array) => GLPointers._BindVertexArrayOES_fnptr((int)array);
+            public static void BindVertexArrayOES(int array) => GLPointers._BindVertexArrayOES_fnptr(array);
             
             /// <summary> <b>[requires: GL_OES_vertex_array_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void DeleteVertexArraysOES(int n, VertexArrayHandle* arrays) => GLPointers._DeleteVertexArraysOES_fnptr(n, (int*)arrays);
+            public static void DeleteVertexArraysOES(int n, int* arrays) => GLPointers._DeleteVertexArraysOES_fnptr(n, arrays);
             
             /// <summary> <b>[requires: GL_OES_vertex_array_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GenVertexArraysOES(int n, VertexArrayHandle* arrays) => GLPointers._GenVertexArraysOES_fnptr(n, (int*)arrays);
+            public static void GenVertexArraysOES(int n, int* arrays) => GLPointers._GenVertexArraysOES_fnptr(n, arrays);
             
             /// <summary> <b>[requires: GL_OES_vertex_array_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static bool IsVertexArrayOES(VertexArrayHandle array) => GLPointers._IsVertexArrayOES_fnptr((int)array) != 0;
+            public static bool IsVertexArrayOES(int array) => GLPointers._IsVertexArrayOES_fnptr(array) != 0;
             
         }
         public static unsafe partial class QCOM
@@ -1952,23 +1952,23 @@ namespace OpenTK.Graphics.OpenGLES1
             
             /// <summary> <b>[requires: GL_QCOM_extended_get]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ExtGetTexturesQCOM(TextureHandle* textures, int maxTextures, int* numTextures) => GLPointers._ExtGetTexturesQCOM_fnptr((int*)textures, maxTextures, numTextures);
+            public static void ExtGetTexturesQCOM(int* textures, int maxTextures, int* numTextures) => GLPointers._ExtGetTexturesQCOM_fnptr(textures, maxTextures, numTextures);
             
             /// <summary> <b>[requires: GL_QCOM_extended_get]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ExtGetBuffersQCOM(BufferHandle* buffers, int maxBuffers, int* numBuffers) => GLPointers._ExtGetBuffersQCOM_fnptr((int*)buffers, maxBuffers, numBuffers);
+            public static void ExtGetBuffersQCOM(int* buffers, int maxBuffers, int* numBuffers) => GLPointers._ExtGetBuffersQCOM_fnptr(buffers, maxBuffers, numBuffers);
             
             /// <summary> <b>[requires: GL_QCOM_extended_get]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ExtGetRenderbuffersQCOM(RenderbufferHandle* renderbuffers, int maxRenderbuffers, int* numRenderbuffers) => GLPointers._ExtGetRenderbuffersQCOM_fnptr((int*)renderbuffers, maxRenderbuffers, numRenderbuffers);
+            public static void ExtGetRenderbuffersQCOM(int* renderbuffers, int maxRenderbuffers, int* numRenderbuffers) => GLPointers._ExtGetRenderbuffersQCOM_fnptr(renderbuffers, maxRenderbuffers, numRenderbuffers);
             
             /// <summary> <b>[requires: GL_QCOM_extended_get]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ExtGetFramebuffersQCOM(FramebufferHandle* framebuffers, int maxFramebuffers, int* numFramebuffers) => GLPointers._ExtGetFramebuffersQCOM_fnptr((int*)framebuffers, maxFramebuffers, numFramebuffers);
+            public static void ExtGetFramebuffersQCOM(int* framebuffers, int maxFramebuffers, int* numFramebuffers) => GLPointers._ExtGetFramebuffersQCOM_fnptr(framebuffers, maxFramebuffers, numFramebuffers);
             
             /// <summary> <b>[requires: GL_QCOM_extended_get]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ExtGetTexLevelParameterivQCOM(TextureHandle texture, All face, int level, All pname, int* parameters) => GLPointers._ExtGetTexLevelParameterivQCOM_fnptr((int)texture, (uint)face, level, (uint)pname, parameters);
+            public static void ExtGetTexLevelParameterivQCOM(int texture, All face, int level, All pname, int* parameters) => GLPointers._ExtGetTexLevelParameterivQCOM_fnptr(texture, (uint)face, level, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_QCOM_extended_get]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -1984,19 +1984,19 @@ namespace OpenTK.Graphics.OpenGLES1
             
             /// <summary> <b>[requires: GL_QCOM_extended_get2]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ExtGetShadersQCOM(ShaderHandle* shaders, int maxShaders, int* numShaders) => GLPointers._ExtGetShadersQCOM_fnptr((int*)shaders, maxShaders, numShaders);
+            public static void ExtGetShadersQCOM(int* shaders, int maxShaders, int* numShaders) => GLPointers._ExtGetShadersQCOM_fnptr(shaders, maxShaders, numShaders);
             
             /// <summary> <b>[requires: GL_QCOM_extended_get2]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ExtGetProgramsQCOM(ProgramHandle* programs, int maxPrograms, int* numPrograms) => GLPointers._ExtGetProgramsQCOM_fnptr((int*)programs, maxPrograms, numPrograms);
+            public static void ExtGetProgramsQCOM(int* programs, int maxPrograms, int* numPrograms) => GLPointers._ExtGetProgramsQCOM_fnptr(programs, maxPrograms, numPrograms);
             
             /// <summary> <b>[requires: GL_QCOM_extended_get2]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static bool ExtIsProgramBinaryQCOM(ProgramHandle program) => GLPointers._ExtIsProgramBinaryQCOM_fnptr((int)program) != 0;
+            public static bool ExtIsProgramBinaryQCOM(int program) => GLPointers._ExtIsProgramBinaryQCOM_fnptr(program) != 0;
             
             /// <summary> <b>[requires: GL_QCOM_extended_get2]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ExtGetProgramBinarySourceQCOM(ProgramHandle program, ShaderType shadertype, byte* source, int* length) => GLPointers._ExtGetProgramBinarySourceQCOM_fnptr((int)program, (uint)shadertype, source, length);
+            public static void ExtGetProgramBinarySourceQCOM(int program, ShaderType shadertype, byte* source, int* length) => GLPointers._ExtGetProgramBinarySourceQCOM_fnptr(program, (uint)shadertype, source, length);
             
             /// <summary> <b>[requires: GL_QCOM_tiled_rendering]</b>  </summary>
             /// <remarks><see href="" /></remarks>

--- a/src/OpenTK.Graphics/OpenGLES1/GL.Overloads.cs
+++ b/src/OpenTK.Graphics/OpenGLES1/GL.Overloads.cs
@@ -597,71 +597,71 @@ namespace OpenTK.Graphics.OpenGLES1
             }
         }
         /// <inheritdoc cref="DeleteBuffers"/>
-        public static unsafe void DeleteBuffer(in BufferHandle buffer)
+        public static unsafe void DeleteBuffer(in int buffer)
         {
             int n = 1;
-            fixed(BufferHandle* buffers_handle = &buffer)
+            fixed(int* buffers_handle = &buffer)
             {
                 DeleteBuffers(n, buffers_handle);
             }
         }
         /// <inheritdoc cref="DeleteBuffers"/>
-        public static unsafe void DeleteBuffers(ReadOnlySpan<BufferHandle> buffers)
+        public static unsafe void DeleteBuffers(ReadOnlySpan<int> buffers)
         {
             int n = (int)(buffers.Length);
-            fixed (BufferHandle* buffers_ptr = buffers)
+            fixed (int* buffers_ptr = buffers)
             {
                 DeleteBuffers(n, buffers_ptr);
             }
         }
         /// <inheritdoc cref="DeleteBuffers"/>
-        public static unsafe void DeleteBuffers(BufferHandle[] buffers)
+        public static unsafe void DeleteBuffers(int[] buffers)
         {
             int n = (int)(buffers.Length);
-            fixed (BufferHandle* buffers_ptr = buffers)
+            fixed (int* buffers_ptr = buffers)
             {
                 DeleteBuffers(n, buffers_ptr);
             }
         }
         /// <inheritdoc cref="DeleteBuffers"/>
-        public static unsafe void DeleteBuffers(int n, in BufferHandle buffers)
+        public static unsafe void DeleteBuffers(int n, in int buffers)
         {
-            fixed (BufferHandle* buffers_ptr = &buffers)
+            fixed (int* buffers_ptr = &buffers)
             {
                 DeleteBuffers(n, buffers_ptr);
             }
         }
         /// <inheritdoc cref="DeleteTextures"/>
-        public static unsafe void DeleteTexture(in TextureHandle texture)
+        public static unsafe void DeleteTexture(in int texture)
         {
             int n = 1;
-            fixed(TextureHandle* textures_handle = &texture)
+            fixed(int* textures_handle = &texture)
             {
                 DeleteTextures(n, textures_handle);
             }
         }
         /// <inheritdoc cref="DeleteTextures"/>
-        public static unsafe void DeleteTextures(ReadOnlySpan<TextureHandle> textures)
+        public static unsafe void DeleteTextures(ReadOnlySpan<int> textures)
         {
             int n = (int)(textures.Length);
-            fixed (TextureHandle* textures_ptr = textures)
+            fixed (int* textures_ptr = textures)
             {
                 DeleteTextures(n, textures_ptr);
             }
         }
         /// <inheritdoc cref="DeleteTextures"/>
-        public static unsafe void DeleteTextures(TextureHandle[] textures)
+        public static unsafe void DeleteTextures(int[] textures)
         {
             int n = (int)(textures.Length);
-            fixed (TextureHandle* textures_ptr = textures)
+            fixed (int* textures_ptr = textures)
             {
                 DeleteTextures(n, textures_ptr);
             }
         }
         /// <inheritdoc cref="DeleteTextures"/>
-        public static unsafe void DeleteTextures(int n, in TextureHandle textures)
+        public static unsafe void DeleteTextures(int n, in int textures)
         {
-            fixed (TextureHandle* textures_ptr = &textures)
+            fixed (int* textures_ptr = &textures)
             {
                 DeleteTextures(n, textures_ptr);
             }
@@ -769,9 +769,9 @@ namespace OpenTK.Graphics.OpenGLES1
             }
         }
         /// <inheritdoc cref="GenBuffers"/>
-        public static unsafe BufferHandle GenBuffer()
+        public static unsafe int GenBuffer()
         {
-            BufferHandle buffer;
+            int buffer;
             int n = 1;
             Unsafe.SkipInit(out buffer);
             // FIXME: This could be a problem for the overloads that take an out parameter
@@ -782,12 +782,12 @@ namespace OpenTK.Graphics.OpenGLES1
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            BufferHandle* buffers_handle = (BufferHandle*)Unsafe.AsPointer(ref buffer);
+            int* buffers_handle = (int*)Unsafe.AsPointer(ref buffer);
             GenBuffers(n, buffers_handle);
             return buffer;
         }
         /// <inheritdoc cref="GenBuffers"/>
-        public static unsafe void GenBuffer(out BufferHandle buffer)
+        public static unsafe void GenBuffer(out int buffer)
         {
             int n = 1;
             Unsafe.SkipInit(out buffer);
@@ -799,39 +799,39 @@ namespace OpenTK.Graphics.OpenGLES1
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            BufferHandle* buffers_handle = (BufferHandle*)Unsafe.AsPointer(ref buffer);
+            int* buffers_handle = (int*)Unsafe.AsPointer(ref buffer);
             GenBuffers(n, buffers_handle);
         }
         /// <inheritdoc cref="GenBuffers"/>
-        public static unsafe void GenBuffers(Span<BufferHandle> buffers)
+        public static unsafe void GenBuffers(Span<int> buffers)
         {
             int n = (int)(buffers.Length);
-            fixed (BufferHandle* buffers_ptr = buffers)
+            fixed (int* buffers_ptr = buffers)
             {
                 GenBuffers(n, buffers_ptr);
             }
         }
         /// <inheritdoc cref="GenBuffers"/>
-        public static unsafe void GenBuffers(BufferHandle[] buffers)
+        public static unsafe void GenBuffers(int[] buffers)
         {
             int n = (int)(buffers.Length);
-            fixed (BufferHandle* buffers_ptr = buffers)
+            fixed (int* buffers_ptr = buffers)
             {
                 GenBuffers(n, buffers_ptr);
             }
         }
         /// <inheritdoc cref="GenBuffers"/>
-        public static unsafe void GenBuffers(int n, ref BufferHandle buffers)
+        public static unsafe void GenBuffers(int n, ref int buffers)
         {
-            fixed (BufferHandle* buffers_ptr = &buffers)
+            fixed (int* buffers_ptr = &buffers)
             {
                 GenBuffers(n, buffers_ptr);
             }
         }
         /// <inheritdoc cref="GenTextures"/>
-        public static unsafe TextureHandle GenTexture()
+        public static unsafe int GenTexture()
         {
-            TextureHandle texture;
+            int texture;
             int n = 1;
             Unsafe.SkipInit(out texture);
             // FIXME: This could be a problem for the overloads that take an out parameter
@@ -842,12 +842,12 @@ namespace OpenTK.Graphics.OpenGLES1
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            TextureHandle* textures_handle = (TextureHandle*)Unsafe.AsPointer(ref texture);
+            int* textures_handle = (int*)Unsafe.AsPointer(ref texture);
             GenTextures(n, textures_handle);
             return texture;
         }
         /// <inheritdoc cref="GenTextures"/>
-        public static unsafe void GenTexture(out TextureHandle texture)
+        public static unsafe void GenTexture(out int texture)
         {
             int n = 1;
             Unsafe.SkipInit(out texture);
@@ -859,31 +859,31 @@ namespace OpenTK.Graphics.OpenGLES1
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            TextureHandle* textures_handle = (TextureHandle*)Unsafe.AsPointer(ref texture);
+            int* textures_handle = (int*)Unsafe.AsPointer(ref texture);
             GenTextures(n, textures_handle);
         }
         /// <inheritdoc cref="GenTextures"/>
-        public static unsafe void GenTextures(Span<TextureHandle> textures)
+        public static unsafe void GenTextures(Span<int> textures)
         {
             int n = (int)(textures.Length);
-            fixed (TextureHandle* textures_ptr = textures)
+            fixed (int* textures_ptr = textures)
             {
                 GenTextures(n, textures_ptr);
             }
         }
         /// <inheritdoc cref="GenTextures"/>
-        public static unsafe void GenTextures(TextureHandle[] textures)
+        public static unsafe void GenTextures(int[] textures)
         {
             int n = (int)(textures.Length);
-            fixed (TextureHandle* textures_ptr = textures)
+            fixed (int* textures_ptr = textures)
             {
                 GenTextures(n, textures_ptr);
             }
         }
         /// <inheritdoc cref="GenTextures"/>
-        public static unsafe void GenTextures(int n, ref TextureHandle textures)
+        public static unsafe void GenTextures(int n, ref int textures)
         {
-            fixed (TextureHandle* textures_ptr = &textures)
+            fixed (int* textures_ptr = &textures)
             {
                 GenTextures(n, textures_ptr);
             }
@@ -1693,7 +1693,7 @@ namespace OpenTK.Graphics.OpenGLES1
                 }
             }
             /// <inheritdoc cref="GetnUniformfvEXT"/>
-            public static unsafe void GetnUniformfvEXT(ProgramHandle program, int location, Span<float> parameters)
+            public static unsafe void GetnUniformfvEXT(int program, int location, Span<float> parameters)
             {
                 int bufSize = (int)(parameters.Length * 4);
                 fixed (float* parameters_ptr = parameters)
@@ -1702,7 +1702,7 @@ namespace OpenTK.Graphics.OpenGLES1
                 }
             }
             /// <inheritdoc cref="GetnUniformfvEXT"/>
-            public static unsafe void GetnUniformfvEXT(ProgramHandle program, int location, float[] parameters)
+            public static unsafe void GetnUniformfvEXT(int program, int location, float[] parameters)
             {
                 int bufSize = (int)(parameters.Length * 4);
                 fixed (float* parameters_ptr = parameters)
@@ -1711,7 +1711,7 @@ namespace OpenTK.Graphics.OpenGLES1
                 }
             }
             /// <inheritdoc cref="GetnUniformfvEXT"/>
-            public static unsafe void GetnUniformfvEXT(ProgramHandle program, int location, int bufSize, ref float parameters)
+            public static unsafe void GetnUniformfvEXT(int program, int location, int bufSize, ref float parameters)
             {
                 fixed (float* parameters_ptr = &parameters)
                 {
@@ -1719,7 +1719,7 @@ namespace OpenTK.Graphics.OpenGLES1
                 }
             }
             /// <inheritdoc cref="GetnUniformivEXT"/>
-            public static unsafe void GetnUniformivEXT(ProgramHandle program, int location, Span<int> parameters)
+            public static unsafe void GetnUniformivEXT(int program, int location, Span<int> parameters)
             {
                 int bufSize = (int)(parameters.Length * 4);
                 fixed (int* parameters_ptr = parameters)
@@ -1728,7 +1728,7 @@ namespace OpenTK.Graphics.OpenGLES1
                 }
             }
             /// <inheritdoc cref="GetnUniformivEXT"/>
-            public static unsafe void GetnUniformivEXT(ProgramHandle program, int location, int[] parameters)
+            public static unsafe void GetnUniformivEXT(int program, int location, int[] parameters)
             {
                 int bufSize = (int)(parameters.Length * 4);
                 fixed (int* parameters_ptr = parameters)
@@ -1737,7 +1737,7 @@ namespace OpenTK.Graphics.OpenGLES1
                 }
             }
             /// <inheritdoc cref="GetnUniformivEXT"/>
-            public static unsafe void GetnUniformivEXT(ProgramHandle program, int location, int bufSize, ref int parameters)
+            public static unsafe void GetnUniformivEXT(int program, int location, int bufSize, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -3936,9 +3936,9 @@ namespace OpenTK.Graphics.OpenGLES1
                 }
             }
             /// <inheritdoc cref="PrioritizeTexturesxOES"/>
-            public static unsafe void PrioritizeTexturesxOES(int n, ReadOnlySpan<TextureHandle> textures, ReadOnlySpan<int> priorities)
+            public static unsafe void PrioritizeTexturesxOES(int n, ReadOnlySpan<int> textures, ReadOnlySpan<int> priorities)
             {
-                fixed (TextureHandle* textures_ptr = textures)
+                fixed (int* textures_ptr = textures)
                 {
                     fixed (int* priorities_ptr = priorities)
                     {
@@ -3947,9 +3947,9 @@ namespace OpenTK.Graphics.OpenGLES1
                 }
             }
             /// <inheritdoc cref="PrioritizeTexturesxOES"/>
-            public static unsafe void PrioritizeTexturesxOES(int n, TextureHandle[] textures, int[] priorities)
+            public static unsafe void PrioritizeTexturesxOES(int n, int[] textures, int[] priorities)
             {
-                fixed (TextureHandle* textures_ptr = textures)
+                fixed (int* textures_ptr = textures)
                 {
                     fixed (int* priorities_ptr = priorities)
                     {
@@ -3958,9 +3958,9 @@ namespace OpenTK.Graphics.OpenGLES1
                 }
             }
             /// <inheritdoc cref="PrioritizeTexturesxOES"/>
-            public static unsafe void PrioritizeTexturesxOES(int n, in TextureHandle textures, in int priorities)
+            public static unsafe void PrioritizeTexturesxOES(int n, in int textures, in int priorities)
             {
-                fixed (TextureHandle* textures_ptr = &textures)
+                fixed (int* textures_ptr = &textures)
                 fixed (int* priorities_ptr = &priorities)
                 {
                     PrioritizeTexturesxOES(n, textures_ptr, priorities_ptr);
@@ -4262,53 +4262,53 @@ namespace OpenTK.Graphics.OpenGLES1
                 }
             }
             /// <inheritdoc cref="DeleteRenderbuffersOES"/>
-            public static unsafe void DeleteRenderbuffersOES(ReadOnlySpan<RenderbufferHandle> renderbuffers)
+            public static unsafe void DeleteRenderbuffersOES(ReadOnlySpan<int> renderbuffers)
             {
                 int n = (int)(renderbuffers.Length);
-                fixed (RenderbufferHandle* renderbuffers_ptr = renderbuffers)
+                fixed (int* renderbuffers_ptr = renderbuffers)
                 {
                     DeleteRenderbuffersOES(n, renderbuffers_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteRenderbuffersOES"/>
-            public static unsafe void DeleteRenderbuffersOES(RenderbufferHandle[] renderbuffers)
+            public static unsafe void DeleteRenderbuffersOES(int[] renderbuffers)
             {
                 int n = (int)(renderbuffers.Length);
-                fixed (RenderbufferHandle* renderbuffers_ptr = renderbuffers)
+                fixed (int* renderbuffers_ptr = renderbuffers)
                 {
                     DeleteRenderbuffersOES(n, renderbuffers_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteRenderbuffersOES"/>
-            public static unsafe void DeleteRenderbuffersOES(int n, in RenderbufferHandle renderbuffers)
+            public static unsafe void DeleteRenderbuffersOES(int n, in int renderbuffers)
             {
-                fixed (RenderbufferHandle* renderbuffers_ptr = &renderbuffers)
+                fixed (int* renderbuffers_ptr = &renderbuffers)
                 {
                     DeleteRenderbuffersOES(n, renderbuffers_ptr);
                 }
             }
             /// <inheritdoc cref="GenRenderbuffersOES"/>
-            public static unsafe void GenRenderbuffersOES(Span<RenderbufferHandle> renderbuffers)
+            public static unsafe void GenRenderbuffersOES(Span<int> renderbuffers)
             {
                 int n = (int)(renderbuffers.Length);
-                fixed (RenderbufferHandle* renderbuffers_ptr = renderbuffers)
+                fixed (int* renderbuffers_ptr = renderbuffers)
                 {
                     GenRenderbuffersOES(n, renderbuffers_ptr);
                 }
             }
             /// <inheritdoc cref="GenRenderbuffersOES"/>
-            public static unsafe void GenRenderbuffersOES(RenderbufferHandle[] renderbuffers)
+            public static unsafe void GenRenderbuffersOES(int[] renderbuffers)
             {
                 int n = (int)(renderbuffers.Length);
-                fixed (RenderbufferHandle* renderbuffers_ptr = renderbuffers)
+                fixed (int* renderbuffers_ptr = renderbuffers)
                 {
                     GenRenderbuffersOES(n, renderbuffers_ptr);
                 }
             }
             /// <inheritdoc cref="GenRenderbuffersOES"/>
-            public static unsafe void GenRenderbuffersOES(int n, ref RenderbufferHandle renderbuffers)
+            public static unsafe void GenRenderbuffersOES(int n, ref int renderbuffers)
             {
-                fixed (RenderbufferHandle* renderbuffers_ptr = &renderbuffers)
+                fixed (int* renderbuffers_ptr = &renderbuffers)
                 {
                     GenRenderbuffersOES(n, renderbuffers_ptr);
                 }
@@ -4338,53 +4338,53 @@ namespace OpenTK.Graphics.OpenGLES1
                 }
             }
             /// <inheritdoc cref="DeleteFramebuffersOES"/>
-            public static unsafe void DeleteFramebuffersOES(ReadOnlySpan<FramebufferHandle> framebuffers)
+            public static unsafe void DeleteFramebuffersOES(ReadOnlySpan<int> framebuffers)
             {
                 int n = (int)(framebuffers.Length);
-                fixed (FramebufferHandle* framebuffers_ptr = framebuffers)
+                fixed (int* framebuffers_ptr = framebuffers)
                 {
                     DeleteFramebuffersOES(n, framebuffers_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteFramebuffersOES"/>
-            public static unsafe void DeleteFramebuffersOES(FramebufferHandle[] framebuffers)
+            public static unsafe void DeleteFramebuffersOES(int[] framebuffers)
             {
                 int n = (int)(framebuffers.Length);
-                fixed (FramebufferHandle* framebuffers_ptr = framebuffers)
+                fixed (int* framebuffers_ptr = framebuffers)
                 {
                     DeleteFramebuffersOES(n, framebuffers_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteFramebuffersOES"/>
-            public static unsafe void DeleteFramebuffersOES(int n, in FramebufferHandle framebuffers)
+            public static unsafe void DeleteFramebuffersOES(int n, in int framebuffers)
             {
-                fixed (FramebufferHandle* framebuffers_ptr = &framebuffers)
+                fixed (int* framebuffers_ptr = &framebuffers)
                 {
                     DeleteFramebuffersOES(n, framebuffers_ptr);
                 }
             }
             /// <inheritdoc cref="GenFramebuffersOES"/>
-            public static unsafe void GenFramebuffersOES(Span<FramebufferHandle> framebuffers)
+            public static unsafe void GenFramebuffersOES(Span<int> framebuffers)
             {
                 int n = (int)(framebuffers.Length);
-                fixed (FramebufferHandle* framebuffers_ptr = framebuffers)
+                fixed (int* framebuffers_ptr = framebuffers)
                 {
                     GenFramebuffersOES(n, framebuffers_ptr);
                 }
             }
             /// <inheritdoc cref="GenFramebuffersOES"/>
-            public static unsafe void GenFramebuffersOES(FramebufferHandle[] framebuffers)
+            public static unsafe void GenFramebuffersOES(int[] framebuffers)
             {
                 int n = (int)(framebuffers.Length);
-                fixed (FramebufferHandle* framebuffers_ptr = framebuffers)
+                fixed (int* framebuffers_ptr = framebuffers)
                 {
                     GenFramebuffersOES(n, framebuffers_ptr);
                 }
             }
             /// <inheritdoc cref="GenFramebuffersOES"/>
-            public static unsafe void GenFramebuffersOES(int n, ref FramebufferHandle framebuffers)
+            public static unsafe void GenFramebuffersOES(int n, ref int framebuffers)
             {
-                fixed (FramebufferHandle* framebuffers_ptr = &framebuffers)
+                fixed (int* framebuffers_ptr = &framebuffers)
                 {
                     GenFramebuffersOES(n, framebuffers_ptr);
                 }
@@ -4694,53 +4694,53 @@ namespace OpenTK.Graphics.OpenGLES1
                 }
             }
             /// <inheritdoc cref="DeleteVertexArraysOES"/>
-            public static unsafe void DeleteVertexArraysOES(ReadOnlySpan<VertexArrayHandle> arrays)
+            public static unsafe void DeleteVertexArraysOES(ReadOnlySpan<int> arrays)
             {
                 int n = (int)(arrays.Length);
-                fixed (VertexArrayHandle* arrays_ptr = arrays)
+                fixed (int* arrays_ptr = arrays)
                 {
                     DeleteVertexArraysOES(n, arrays_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteVertexArraysOES"/>
-            public static unsafe void DeleteVertexArraysOES(VertexArrayHandle[] arrays)
+            public static unsafe void DeleteVertexArraysOES(int[] arrays)
             {
                 int n = (int)(arrays.Length);
-                fixed (VertexArrayHandle* arrays_ptr = arrays)
+                fixed (int* arrays_ptr = arrays)
                 {
                     DeleteVertexArraysOES(n, arrays_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteVertexArraysOES"/>
-            public static unsafe void DeleteVertexArraysOES(int n, in VertexArrayHandle arrays)
+            public static unsafe void DeleteVertexArraysOES(int n, in int arrays)
             {
-                fixed (VertexArrayHandle* arrays_ptr = &arrays)
+                fixed (int* arrays_ptr = &arrays)
                 {
                     DeleteVertexArraysOES(n, arrays_ptr);
                 }
             }
             /// <inheritdoc cref="GenVertexArraysOES"/>
-            public static unsafe void GenVertexArraysOES(Span<VertexArrayHandle> arrays)
+            public static unsafe void GenVertexArraysOES(Span<int> arrays)
             {
                 int n = (int)(arrays.Length);
-                fixed (VertexArrayHandle* arrays_ptr = arrays)
+                fixed (int* arrays_ptr = arrays)
                 {
                     GenVertexArraysOES(n, arrays_ptr);
                 }
             }
             /// <inheritdoc cref="GenVertexArraysOES"/>
-            public static unsafe void GenVertexArraysOES(VertexArrayHandle[] arrays)
+            public static unsafe void GenVertexArraysOES(int[] arrays)
             {
                 int n = (int)(arrays.Length);
-                fixed (VertexArrayHandle* arrays_ptr = arrays)
+                fixed (int* arrays_ptr = arrays)
                 {
                     GenVertexArraysOES(n, arrays_ptr);
                 }
             }
             /// <inheritdoc cref="GenVertexArraysOES"/>
-            public static unsafe void GenVertexArraysOES(int n, ref VertexArrayHandle arrays)
+            public static unsafe void GenVertexArraysOES(int n, ref int arrays)
             {
-                fixed (VertexArrayHandle* arrays_ptr = &arrays)
+                fixed (int* arrays_ptr = &arrays)
                 {
                     GenVertexArraysOES(n, arrays_ptr);
                 }
@@ -4806,19 +4806,19 @@ namespace OpenTK.Graphics.OpenGLES1
                 }
             }
             /// <inheritdoc cref="ExtGetTexturesQCOM"/>
-            public static unsafe void ExtGetTexturesQCOM(ref TextureHandle textures, int maxTextures, ref int numTextures)
+            public static unsafe void ExtGetTexturesQCOM(ref int textures, int maxTextures, ref int numTextures)
             {
-                fixed (TextureHandle* textures_ptr = &textures)
+                fixed (int* textures_ptr = &textures)
                 fixed (int* numTextures_ptr = &numTextures)
                 {
                     ExtGetTexturesQCOM(textures_ptr, maxTextures, numTextures_ptr);
                 }
             }
             /// <inheritdoc cref="ExtGetBuffersQCOM"/>
-            public static unsafe void ExtGetBuffersQCOM(Span<BufferHandle> buffers, Span<int> numBuffers)
+            public static unsafe void ExtGetBuffersQCOM(Span<int> buffers, Span<int> numBuffers)
             {
                 int maxBuffers = (int)(buffers.Length);
-                fixed (BufferHandle* buffers_ptr = buffers)
+                fixed (int* buffers_ptr = buffers)
                 {
                     fixed (int* numBuffers_ptr = numBuffers)
                     {
@@ -4827,10 +4827,10 @@ namespace OpenTK.Graphics.OpenGLES1
                 }
             }
             /// <inheritdoc cref="ExtGetBuffersQCOM"/>
-            public static unsafe void ExtGetBuffersQCOM(BufferHandle[] buffers, int[] numBuffers)
+            public static unsafe void ExtGetBuffersQCOM(int[] buffers, int[] numBuffers)
             {
                 int maxBuffers = (int)(buffers.Length);
-                fixed (BufferHandle* buffers_ptr = buffers)
+                fixed (int* buffers_ptr = buffers)
                 {
                     fixed (int* numBuffers_ptr = numBuffers)
                     {
@@ -4839,19 +4839,19 @@ namespace OpenTK.Graphics.OpenGLES1
                 }
             }
             /// <inheritdoc cref="ExtGetBuffersQCOM"/>
-            public static unsafe void ExtGetBuffersQCOM(ref BufferHandle buffers, int maxBuffers, ref int numBuffers)
+            public static unsafe void ExtGetBuffersQCOM(ref int buffers, int maxBuffers, ref int numBuffers)
             {
-                fixed (BufferHandle* buffers_ptr = &buffers)
+                fixed (int* buffers_ptr = &buffers)
                 fixed (int* numBuffers_ptr = &numBuffers)
                 {
                     ExtGetBuffersQCOM(buffers_ptr, maxBuffers, numBuffers_ptr);
                 }
             }
             /// <inheritdoc cref="ExtGetRenderbuffersQCOM"/>
-            public static unsafe void ExtGetRenderbuffersQCOM(Span<RenderbufferHandle> renderbuffers, Span<int> numRenderbuffers)
+            public static unsafe void ExtGetRenderbuffersQCOM(Span<int> renderbuffers, Span<int> numRenderbuffers)
             {
                 int maxRenderbuffers = (int)(renderbuffers.Length);
-                fixed (RenderbufferHandle* renderbuffers_ptr = renderbuffers)
+                fixed (int* renderbuffers_ptr = renderbuffers)
                 {
                     fixed (int* numRenderbuffers_ptr = numRenderbuffers)
                     {
@@ -4860,10 +4860,10 @@ namespace OpenTK.Graphics.OpenGLES1
                 }
             }
             /// <inheritdoc cref="ExtGetRenderbuffersQCOM"/>
-            public static unsafe void ExtGetRenderbuffersQCOM(RenderbufferHandle[] renderbuffers, int[] numRenderbuffers)
+            public static unsafe void ExtGetRenderbuffersQCOM(int[] renderbuffers, int[] numRenderbuffers)
             {
                 int maxRenderbuffers = (int)(renderbuffers.Length);
-                fixed (RenderbufferHandle* renderbuffers_ptr = renderbuffers)
+                fixed (int* renderbuffers_ptr = renderbuffers)
                 {
                     fixed (int* numRenderbuffers_ptr = numRenderbuffers)
                     {
@@ -4872,19 +4872,19 @@ namespace OpenTK.Graphics.OpenGLES1
                 }
             }
             /// <inheritdoc cref="ExtGetRenderbuffersQCOM"/>
-            public static unsafe void ExtGetRenderbuffersQCOM(ref RenderbufferHandle renderbuffers, int maxRenderbuffers, ref int numRenderbuffers)
+            public static unsafe void ExtGetRenderbuffersQCOM(ref int renderbuffers, int maxRenderbuffers, ref int numRenderbuffers)
             {
-                fixed (RenderbufferHandle* renderbuffers_ptr = &renderbuffers)
+                fixed (int* renderbuffers_ptr = &renderbuffers)
                 fixed (int* numRenderbuffers_ptr = &numRenderbuffers)
                 {
                     ExtGetRenderbuffersQCOM(renderbuffers_ptr, maxRenderbuffers, numRenderbuffers_ptr);
                 }
             }
             /// <inheritdoc cref="ExtGetFramebuffersQCOM"/>
-            public static unsafe void ExtGetFramebuffersQCOM(Span<FramebufferHandle> framebuffers, Span<int> numFramebuffers)
+            public static unsafe void ExtGetFramebuffersQCOM(Span<int> framebuffers, Span<int> numFramebuffers)
             {
                 int maxFramebuffers = (int)(framebuffers.Length);
-                fixed (FramebufferHandle* framebuffers_ptr = framebuffers)
+                fixed (int* framebuffers_ptr = framebuffers)
                 {
                     fixed (int* numFramebuffers_ptr = numFramebuffers)
                     {
@@ -4893,10 +4893,10 @@ namespace OpenTK.Graphics.OpenGLES1
                 }
             }
             /// <inheritdoc cref="ExtGetFramebuffersQCOM"/>
-            public static unsafe void ExtGetFramebuffersQCOM(FramebufferHandle[] framebuffers, int[] numFramebuffers)
+            public static unsafe void ExtGetFramebuffersQCOM(int[] framebuffers, int[] numFramebuffers)
             {
                 int maxFramebuffers = (int)(framebuffers.Length);
-                fixed (FramebufferHandle* framebuffers_ptr = framebuffers)
+                fixed (int* framebuffers_ptr = framebuffers)
                 {
                     fixed (int* numFramebuffers_ptr = numFramebuffers)
                     {
@@ -4905,16 +4905,16 @@ namespace OpenTK.Graphics.OpenGLES1
                 }
             }
             /// <inheritdoc cref="ExtGetFramebuffersQCOM"/>
-            public static unsafe void ExtGetFramebuffersQCOM(ref FramebufferHandle framebuffers, int maxFramebuffers, ref int numFramebuffers)
+            public static unsafe void ExtGetFramebuffersQCOM(ref int framebuffers, int maxFramebuffers, ref int numFramebuffers)
             {
-                fixed (FramebufferHandle* framebuffers_ptr = &framebuffers)
+                fixed (int* framebuffers_ptr = &framebuffers)
                 fixed (int* numFramebuffers_ptr = &numFramebuffers)
                 {
                     ExtGetFramebuffersQCOM(framebuffers_ptr, maxFramebuffers, numFramebuffers_ptr);
                 }
             }
             /// <inheritdoc cref="ExtGetTexLevelParameterivQCOM"/>
-            public static unsafe void ExtGetTexLevelParameterivQCOM(TextureHandle texture, All face, int level, All pname, ref int parameters)
+            public static unsafe void ExtGetTexLevelParameterivQCOM(int texture, All face, int level, All pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -4937,10 +4937,10 @@ namespace OpenTK.Graphics.OpenGLES1
                 }
             }
             /// <inheritdoc cref="ExtGetShadersQCOM"/>
-            public static unsafe void ExtGetShadersQCOM(Span<ShaderHandle> shaders, Span<int> numShaders)
+            public static unsafe void ExtGetShadersQCOM(Span<int> shaders, Span<int> numShaders)
             {
                 int maxShaders = (int)(shaders.Length);
-                fixed (ShaderHandle* shaders_ptr = shaders)
+                fixed (int* shaders_ptr = shaders)
                 {
                     fixed (int* numShaders_ptr = numShaders)
                     {
@@ -4949,10 +4949,10 @@ namespace OpenTK.Graphics.OpenGLES1
                 }
             }
             /// <inheritdoc cref="ExtGetShadersQCOM"/>
-            public static unsafe void ExtGetShadersQCOM(ShaderHandle[] shaders, int[] numShaders)
+            public static unsafe void ExtGetShadersQCOM(int[] shaders, int[] numShaders)
             {
                 int maxShaders = (int)(shaders.Length);
-                fixed (ShaderHandle* shaders_ptr = shaders)
+                fixed (int* shaders_ptr = shaders)
                 {
                     fixed (int* numShaders_ptr = numShaders)
                     {
@@ -4961,19 +4961,19 @@ namespace OpenTK.Graphics.OpenGLES1
                 }
             }
             /// <inheritdoc cref="ExtGetShadersQCOM"/>
-            public static unsafe void ExtGetShadersQCOM(ref ShaderHandle shaders, int maxShaders, ref int numShaders)
+            public static unsafe void ExtGetShadersQCOM(ref int shaders, int maxShaders, ref int numShaders)
             {
-                fixed (ShaderHandle* shaders_ptr = &shaders)
+                fixed (int* shaders_ptr = &shaders)
                 fixed (int* numShaders_ptr = &numShaders)
                 {
                     ExtGetShadersQCOM(shaders_ptr, maxShaders, numShaders_ptr);
                 }
             }
             /// <inheritdoc cref="ExtGetProgramsQCOM"/>
-            public static unsafe void ExtGetProgramsQCOM(Span<ProgramHandle> programs, Span<int> numPrograms)
+            public static unsafe void ExtGetProgramsQCOM(Span<int> programs, Span<int> numPrograms)
             {
                 int maxPrograms = (int)(programs.Length);
-                fixed (ProgramHandle* programs_ptr = programs)
+                fixed (int* programs_ptr = programs)
                 {
                     fixed (int* numPrograms_ptr = numPrograms)
                     {
@@ -4982,10 +4982,10 @@ namespace OpenTK.Graphics.OpenGLES1
                 }
             }
             /// <inheritdoc cref="ExtGetProgramsQCOM"/>
-            public static unsafe void ExtGetProgramsQCOM(ProgramHandle[] programs, int[] numPrograms)
+            public static unsafe void ExtGetProgramsQCOM(int[] programs, int[] numPrograms)
             {
                 int maxPrograms = (int)(programs.Length);
-                fixed (ProgramHandle* programs_ptr = programs)
+                fixed (int* programs_ptr = programs)
                 {
                     fixed (int* numPrograms_ptr = numPrograms)
                     {
@@ -4994,16 +4994,16 @@ namespace OpenTK.Graphics.OpenGLES1
                 }
             }
             /// <inheritdoc cref="ExtGetProgramsQCOM"/>
-            public static unsafe void ExtGetProgramsQCOM(ref ProgramHandle programs, int maxPrograms, ref int numPrograms)
+            public static unsafe void ExtGetProgramsQCOM(ref int programs, int maxPrograms, ref int numPrograms)
             {
-                fixed (ProgramHandle* programs_ptr = &programs)
+                fixed (int* programs_ptr = &programs)
                 fixed (int* numPrograms_ptr = &numPrograms)
                 {
                     ExtGetProgramsQCOM(programs_ptr, maxPrograms, numPrograms_ptr);
                 }
             }
             /// <inheritdoc cref="ExtGetProgramBinarySourceQCOM"/>
-            public static unsafe string ExtGetProgramBinarySourceQCOM(ProgramHandle program, ShaderType shadertype, ref int length)
+            public static unsafe string ExtGetProgramBinarySourceQCOM(int program, ShaderType shadertype, ref int length)
             {
                 string source;
                 fixed (int* length_ptr = &length)
@@ -5016,7 +5016,7 @@ namespace OpenTK.Graphics.OpenGLES1
                 return source;
             }
             /// <inheritdoc cref="ExtGetProgramBinarySourceQCOM"/>
-            public static unsafe void ExtGetProgramBinarySourceQCOM(ProgramHandle program, ShaderType shadertype, out string source, ref int length)
+            public static unsafe void ExtGetProgramBinarySourceQCOM(int program, ShaderType shadertype, out string source, ref int length)
             {
                 fixed (int* length_ptr = &length)
                 {

--- a/src/OpenTK.Graphics/OpenGLES3/GL.Manual.cs
+++ b/src/OpenTK.Graphics/OpenGLES3/GL.Manual.cs
@@ -4,6 +4,11 @@ using OpenTK.Mathematics;
 
 namespace OpenTK.Graphics.OpenGLES3
 {
+#if !TYPESAFE_HANDLES
+    using ShaderHandle = System.Int32;
+    using ProgramHandle = System.Int32;
+#endif
+
     // FIXME: Remove this when it's fixed
     // This is here because there in the gl.xml
     // one of the parameters for "glSampleMaskIndexedNV"

--- a/src/OpenTK.Graphics/OpenGLES3/GL.Native.cs
+++ b/src/OpenTK.Graphics/OpenGLES3/GL.Native.cs
@@ -16,38 +16,38 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="program">Specifies the program object to which a shader object will be attached.</param>
         /// <param name="shader">Specifies the shader object that is to be attached.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglAttachShader.xhtml" /></remarks>
-        public static void AttachShader(ProgramHandle program, ShaderHandle shader) => GLPointers._AttachShader_fnptr((int)program, (int)shader);
+        public static void AttachShader(int program, int shader) => GLPointers._AttachShader_fnptr(program, shader);
         
         /// <summary> <b>[requires: v2.0]</b> Associates a generic vertex attribute index with a named attribute variable. </summary>
         /// <param name="program">Specifies the handle of the program object in which the association is to be made.</param>
         /// <param name="index">Specifies the index of the generic vertex attribute to be bound.</param>
         /// <param name="name">Specifies a null terminated string containing the name of the vertex shader attribute variable to which index is to be bound.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglBindAttribLocation.xhtml" /></remarks>
-        public static void BindAttribLocation(ProgramHandle program, uint index, byte* name) => GLPointers._BindAttribLocation_fnptr((int)program, index, name);
+        public static void BindAttribLocation(int program, uint index, byte* name) => GLPointers._BindAttribLocation_fnptr(program, index, name);
         
         /// <summary> <b>[requires: v2.0]</b> Bind a named buffer object. </summary>
         /// <param name="target"> Specifies the target to which the buffer object is bound, which must be one of the buffer binding targets in the following table: </param>
         /// <param name="buffer"> Specifies the name of a buffer object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglBindBuffer.xhtml" /></remarks>
-        public static void BindBuffer(BufferTargetARB target, BufferHandle buffer) => GLPointers._BindBuffer_fnptr((uint)target, (int)buffer);
+        public static void BindBuffer(BufferTargetARB target, int buffer) => GLPointers._BindBuffer_fnptr((uint)target, buffer);
         
         /// <summary> <b>[requires: v2.0]</b> Bind a framebuffer to a framebuffer target. </summary>
         /// <param name="target"> Specifies the framebuffer target of the binding operation. </param>
         /// <param name="framebuffer"> Specifies the name of the framebuffer object to bind. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglBindFramebuffer.xhtml" /></remarks>
-        public static void BindFramebuffer(FramebufferTarget target, FramebufferHandle framebuffer) => GLPointers._BindFramebuffer_fnptr((uint)target, (int)framebuffer);
+        public static void BindFramebuffer(FramebufferTarget target, int framebuffer) => GLPointers._BindFramebuffer_fnptr((uint)target, framebuffer);
         
         /// <summary> <b>[requires: v2.0]</b> Bind a renderbuffer to a renderbuffer target. </summary>
         /// <param name="target"> Specifies the renderbuffer target of the binding operation. target must be GL_RENDERBUFFER. </param>
         /// <param name="renderbuffer"> Specifies the name of the renderbuffer object to bind. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglBindRenderbuffer.xhtml" /></remarks>
-        public static void BindRenderbuffer(RenderbufferTarget target, RenderbufferHandle renderbuffer) => GLPointers._BindRenderbuffer_fnptr((uint)target, (int)renderbuffer);
+        public static void BindRenderbuffer(RenderbufferTarget target, int renderbuffer) => GLPointers._BindRenderbuffer_fnptr((uint)target, renderbuffer);
         
         /// <summary> <b>[requires: v2.0]</b> Bind a named texture to a texturing target. </summary>
         /// <param name="target"> Specifies the target to which the texture is bound. Must be either GL_TEXTURE_2D, GL_TEXTURE_2D_MULTISAMPLE, GL_TEXTURE_2D_MULTISAMPLE_ARRAY, GL_TEXTURE_3D, GL_TEXTURE_2D_ARRAY, GL_TEXTURE_CUBE_MAP, GL_TEXTURE_CUBE_MAP_ARRAY, or GL_TEXTURE_BUFFER. </param>
         /// <param name="texture"> Specifies the name of a texture. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglBindTexture.xhtml" /></remarks>
-        public static void BindTexture(TextureTarget target, TextureHandle texture) => GLPointers._BindTexture_fnptr((uint)target, (int)texture);
+        public static void BindTexture(TextureTarget target, int texture) => GLPointers._BindTexture_fnptr((uint)target, texture);
         
         /// <summary> <b>[requires: v2.0]</b> Set the blend color. </summary>
         /// <param name="red"> specify the components of GL_BLEND_COLOR </param>
@@ -137,7 +137,7 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <summary> <b>[requires: v2.0]</b> Compiles a shader object. </summary>
         /// <param name="shader">Specifies the shader object to be compiled.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglCompileShader.xhtml" /></remarks>
-        public static void CompileShader(ShaderHandle shader) => GLPointers._CompileShader_fnptr((int)shader);
+        public static void CompileShader(int shader) => GLPointers._CompileShader_fnptr(shader);
         
         /// <summary> <b>[requires: v2.0]</b> Specify a two-dimensional texture image in a compressed format. </summary>
         /// <param name="target"> Specifies the target texture. Must be GL_TEXTURE_2D, GL_TEXTURE_CUBE_MAP_POSITIVE_X, GL_TEXTURE_CUBE_MAP_NEGATIVE_X, GL_TEXTURE_CUBE_MAP_POSITIVE_Y, GL_TEXTURE_CUBE_MAP_NEGATIVE_Y, GL_TEXTURE_CUBE_MAP_POSITIVE_Z, or GL_TEXTURE_CUBE_MAP_NEGATIVE_Z. </param>
@@ -190,12 +190,12 @@ namespace OpenTK.Graphics.OpenGLES3
         
         /// <summary> <b>[requires: v2.0]</b> Creates a program object. </summary>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglCreateProgram.xhtml" /></remarks>
-        public static ProgramHandle CreateProgram() => (ProgramHandle) GLPointers._CreateProgram_fnptr();
+        public static int CreateProgram() => GLPointers._CreateProgram_fnptr();
         
         /// <summary> <b>[requires: v2.0]</b> Creates a shader object. </summary>
         /// <param name="shaderType"> Specifies the type of shader to be created. Must be one of GL_COMPUTE_SHADER, GL_VERTEX_SHADER, GL_TESS_CONTROL_SHADER, GL_TESS_EVALUATION_SHADER, GL_GEOMETRY_SHADER, or GL_FRAGMENT_SHADER. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglCreateShader.xhtml" /></remarks>
-        public static ShaderHandle CreateShader(ShaderType type) => (ShaderHandle) GLPointers._CreateShader_fnptr((uint)type);
+        public static int CreateShader(ShaderType type) => GLPointers._CreateShader_fnptr((uint)type);
         
         /// <summary> <b>[requires: v2.0]</b> Specify whether front- or back-facing polygons can be culled. </summary>
         /// <param name="mode"> Specifies whether front- or back-facing polygons are candidates for culling. Symbolic constants GL_FRONT, GL_BACK, and GL_FRONT_AND_BACK are accepted. The initial value is GL_BACK. </param>
@@ -206,35 +206,35 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="n"> Specifies the number of buffer objects to be deleted. </param>
         /// <param name="buffers"> Specifies an array of buffer objects to be deleted. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglDeleteBuffers.xhtml" /></remarks>
-        public static void DeleteBuffers(int n, BufferHandle* buffers) => GLPointers._DeleteBuffers_fnptr(n, (int*)buffers);
+        public static void DeleteBuffers(int n, int* buffers) => GLPointers._DeleteBuffers_fnptr(n, buffers);
         
         /// <summary> <b>[requires: v2.0]</b> Delete framebuffer objects. </summary>
         /// <param name="n"> Specifies the number of framebuffer objects to be deleted. </param>
         /// <param name="framebuffers"> A pointer to an array containing n framebuffer objects to be deleted. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglDeleteFramebuffers.xhtml" /></remarks>
-        public static void DeleteFramebuffers(int n, FramebufferHandle* framebuffers) => GLPointers._DeleteFramebuffers_fnptr(n, (int*)framebuffers);
+        public static void DeleteFramebuffers(int n, int* framebuffers) => GLPointers._DeleteFramebuffers_fnptr(n, framebuffers);
         
         /// <summary> <b>[requires: v2.0]</b> Deletes a program object. </summary>
         /// <param name="program">Specifies the program object to be deleted.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglDeleteProgram.xhtml" /></remarks>
-        public static void DeleteProgram(ProgramHandle program) => GLPointers._DeleteProgram_fnptr((int)program);
+        public static void DeleteProgram(int program) => GLPointers._DeleteProgram_fnptr(program);
         
         /// <summary> <b>[requires: v2.0]</b> Delete renderbuffer objects. </summary>
         /// <param name="n"> Specifies the number of renderbuffer objects to be deleted. </param>
         /// <param name="renderbuffers"> A pointer to an array containing n renderbuffer objects to be deleted. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglDeleteRenderbuffers.xhtml" /></remarks>
-        public static void DeleteRenderbuffers(int n, RenderbufferHandle* renderbuffers) => GLPointers._DeleteRenderbuffers_fnptr(n, (int*)renderbuffers);
+        public static void DeleteRenderbuffers(int n, int* renderbuffers) => GLPointers._DeleteRenderbuffers_fnptr(n, renderbuffers);
         
         /// <summary> <b>[requires: v2.0]</b> Deletes a shader object. </summary>
         /// <param name="shader">Specifies the shader object to be deleted.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglDeleteShader.xhtml" /></remarks>
-        public static void DeleteShader(ShaderHandle shader) => GLPointers._DeleteShader_fnptr((int)shader);
+        public static void DeleteShader(int shader) => GLPointers._DeleteShader_fnptr(shader);
         
         /// <summary> <b>[requires: v2.0]</b> Delete named textures. </summary>
         /// <param name="n"> Specifies the number of textures to be deleted. </param>
         /// <param name="textures"> Specifies an array of textures to be deleted. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglDeleteTextures.xhtml" /></remarks>
-        public static void DeleteTextures(int n, TextureHandle* textures) => GLPointers._DeleteTextures_fnptr(n, (int*)textures);
+        public static void DeleteTextures(int n, int* textures) => GLPointers._DeleteTextures_fnptr(n, textures);
         
         /// <summary> <b>[requires: v2.0]</b> Specify the value used for depth buffer comparisons. </summary>
         /// <param name="func"> Specifies the depth comparison function. Symbolic constants GL_NEVER, GL_LESS, GL_EQUAL, GL_LEQUAL, GL_GREATER, GL_NOTEQUAL, GL_GEQUAL, and GL_ALWAYS are accepted. The initial value is GL_LESS. </param>
@@ -256,7 +256,7 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="program">Specifies the program object from which to detach the shader object.</param>
         /// <param name="shader">Specifies the shader object to be detached.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglDetachShader.xhtml" /></remarks>
-        public static void DetachShader(ProgramHandle program, ShaderHandle shader) => GLPointers._DetachShader_fnptr((int)program, (int)shader);
+        public static void DetachShader(int program, int shader) => GLPointers._DetachShader_fnptr(program, shader);
         
         /// <summary> <b>[requires: v2.0]</b> Enable or disable server-side GL capabilities. </summary>
         /// <param name="cap"> Specifies a symbolic constant indicating a GL capability. </param>
@@ -307,7 +307,7 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="renderbuffertarget"> Specifies the renderbuffer target and must be GL_RENDERBUFFER. </param>
         /// <param name="renderbuffer"> Specifies the name of an existing renderbuffer object of type renderbuffertarget to attach. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglFramebufferRenderbuffer.xhtml" /></remarks>
-        public static void FramebufferRenderbuffer(FramebufferTarget target, FramebufferAttachment attachment, RenderbufferTarget renderbuffertarget, RenderbufferHandle renderbuffer) => GLPointers._FramebufferRenderbuffer_fnptr((uint)target, (uint)attachment, (uint)renderbuffertarget, (int)renderbuffer);
+        public static void FramebufferRenderbuffer(FramebufferTarget target, FramebufferAttachment attachment, RenderbufferTarget renderbuffertarget, int renderbuffer) => GLPointers._FramebufferRenderbuffer_fnptr((uint)target, (uint)attachment, (uint)renderbuffertarget, renderbuffer);
         
         /// <summary> <b>[requires: v2.0]</b> Attach a level of a texture object as a logical buffer to the currently bound framebuffer object. </summary>
         /// <param name="target"> Specifies the framebuffer target. target must be GL_DRAW_FRAMEBUFFER, GL_READ_FRAMEBUFFER, or GL_FRAMEBUFFER. GL_FRAMEBUFFER is equivalent to GL_DRAW_FRAMEBUFFER. </param>
@@ -316,7 +316,7 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="texture"> Specifies the texture object to attach to the framebuffer attachment point named by attachment. </param>
         /// <param name="level"> Specifies the mipmap level of texture to attach. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglFramebufferTexture2D.xhtml" /></remarks>
-        public static void FramebufferTexture2D(FramebufferTarget target, FramebufferAttachment attachment, TextureTarget textarget, TextureHandle texture, int level) => GLPointers._FramebufferTexture2D_fnptr((uint)target, (uint)attachment, (uint)textarget, (int)texture, level);
+        public static void FramebufferTexture2D(FramebufferTarget target, FramebufferAttachment attachment, TextureTarget textarget, int texture, int level) => GLPointers._FramebufferTexture2D_fnptr((uint)target, (uint)attachment, (uint)textarget, texture, level);
         
         /// <summary> <b>[requires: v2.0]</b> Define front- and back-facing polygons. </summary>
         /// <param name="mode"> Specifies the orientation of front-facing polygons. GL_CW and GL_CCW are accepted. The initial value is GL_CCW. </param>
@@ -327,7 +327,7 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="n"> Specifies the number of buffer object names to be generated. </param>
         /// <param name="buffers"> Specifies an array in which the generated buffer object names are stored. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglGenBuffers.xhtml" /></remarks>
-        public static void GenBuffers(int n, BufferHandle* buffers) => GLPointers._GenBuffers_fnptr(n, (int*)buffers);
+        public static void GenBuffers(int n, int* buffers) => GLPointers._GenBuffers_fnptr(n, buffers);
         
         /// <summary> <b>[requires: v2.0]</b> Generate mipmaps for a specified texture target. </summary>
         /// <param name="target"> Specifies the target to which the texture whose mimaps to generate is bound. target must be GL_TEXTURE_2D, GL_TEXTURE_3D, GL_TEXTURE_2D_ARRAY, GL_TEXTURE_CUBE_MAP or GL_TEXTURE_CUBE_MAP_ARRAY. </param>
@@ -338,19 +338,19 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="n"> Specifies the number of framebuffer object names to generate. </param>
         /// <param name="framebuffers"> Specifies an array in which the generated framebuffer object names are stored. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglGenFramebuffers.xhtml" /></remarks>
-        public static void GenFramebuffers(int n, FramebufferHandle* framebuffers) => GLPointers._GenFramebuffers_fnptr(n, (int*)framebuffers);
+        public static void GenFramebuffers(int n, int* framebuffers) => GLPointers._GenFramebuffers_fnptr(n, framebuffers);
         
         /// <summary> <b>[requires: v2.0]</b> Generate renderbuffer object names. </summary>
         /// <param name="n"> Specifies the number of renderbuffer object names to generate. </param>
         /// <param name="renderbuffers"> Specifies an array in which the generated renderbuffer object names are stored. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglGenRenderbuffers.xhtml" /></remarks>
-        public static void GenRenderbuffers(int n, RenderbufferHandle* renderbuffers) => GLPointers._GenRenderbuffers_fnptr(n, (int*)renderbuffers);
+        public static void GenRenderbuffers(int n, int* renderbuffers) => GLPointers._GenRenderbuffers_fnptr(n, renderbuffers);
         
         /// <summary> <b>[requires: v2.0]</b> Generate texture names. </summary>
         /// <param name="n"> Specifies the number of texture names to be generated. </param>
         /// <param name="textures"> Specifies an array in which the generated texture names are stored. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglGenTextures.xhtml" /></remarks>
-        public static void GenTextures(int n, TextureHandle* textures) => GLPointers._GenTextures_fnptr(n, (int*)textures);
+        public static void GenTextures(int n, int* textures) => GLPointers._GenTextures_fnptr(n, textures);
         
         /// <summary> <b>[requires: v2.0]</b> Returns information about an active attribute variable for the specified program object. </summary>
         /// <param name="program">Specifies the program object to be queried.</param>
@@ -361,7 +361,7 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="type">Returns the data type of the attribute variable.</param>
         /// <param name="name">Returns a null terminated string containing the name of the attribute variable.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglGetActiveAttrib.xhtml" /></remarks>
-        public static void GetActiveAttrib(ProgramHandle program, uint index, int bufSize, int* length, int* size, AttributeType* type, byte* name) => GLPointers._GetActiveAttrib_fnptr((int)program, index, bufSize, length, size, (uint*)type, name);
+        public static void GetActiveAttrib(int program, uint index, int bufSize, int* length, int* size, AttributeType* type, byte* name) => GLPointers._GetActiveAttrib_fnptr(program, index, bufSize, length, size, (uint*)type, name);
         
         /// <summary> <b>[requires: v2.0]</b> Returns information about an active uniform variable for the specified program object. </summary>
         /// <param name="program">Specifies the program object to be queried.</param>
@@ -372,7 +372,7 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="type">Returns the data type of the uniform variable.</param>
         /// <param name="name">Returns a null terminated string containing the name of the uniform variable.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglGetActiveUniform.xhtml" /></remarks>
-        public static void GetActiveUniform(ProgramHandle program, uint index, int bufSize, int* length, int* size, UniformType* type, byte* name) => GLPointers._GetActiveUniform_fnptr((int)program, index, bufSize, length, size, (uint*)type, name);
+        public static void GetActiveUniform(int program, uint index, int bufSize, int* length, int* size, UniformType* type, byte* name) => GLPointers._GetActiveUniform_fnptr(program, index, bufSize, length, size, (uint*)type, name);
         
         /// <summary> <b>[requires: v2.0]</b> Returns the handles of the shader objects attached to a program object. </summary>
         /// <param name="program">Specifies the program object to be queried.</param>
@@ -380,13 +380,13 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="count">Returns the number of names actually returned in shaders.</param>
         /// <param name="shaders">Specifies an array that is used to return the names of attached shader objects.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglGetAttachedShaders.xhtml" /></remarks>
-        public static void GetAttachedShaders(ProgramHandle program, int maxCount, int* count, ShaderHandle* shaders) => GLPointers._GetAttachedShaders_fnptr((int)program, maxCount, count, (int*)shaders);
+        public static void GetAttachedShaders(int program, int maxCount, int* count, int* shaders) => GLPointers._GetAttachedShaders_fnptr(program, maxCount, count, shaders);
         
         /// <summary> <b>[requires: v2.0]</b> Returns the location of an attribute variable. </summary>
         /// <param name="program">Specifies the program object to be queried.</param>
         /// <param name="name">Points to a null terminated string containing the name of the attribute variable whose location is to be queried.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglGetAttribLocation.xhtml" /></remarks>
-        public static int GetAttribLocation(ProgramHandle program, byte* name) => GLPointers._GetAttribLocation_fnptr((int)program, name);
+        public static int GetAttribLocation(int program, byte* name) => GLPointers._GetAttribLocation_fnptr(program, name);
         
         /// <summary> <b>[requires: v2.0]</b> Return the value or values of a selected parameter. </summary>
         /// <param name="pname"> Specifies the parameter value to be returned. The symbolic constants in the list below are accepted. </param>
@@ -430,7 +430,7 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="pname">Specifies the object parameter. Accepted symbolic names are GL_ACTIVE_ATOMIC_COUNTER_BUFFERS, GL_ACTIVE_ATTRIBUTES, GL_ACTIVE_ATTRIBUTE_MAX_LENGTH, GL_ACTIVE_UNIFORMS, GL_ACTIVE_UNIFORM_BLOCKS, GL_ACTIVE_UNIFORM_BLOCK_MAX_NAME_LENGTH, GL_ACTIVE_UNIFORM_MAX_LENGTH, GL_ATTACHED_SHADERS, GL_COMPUTE_WORK_GROUP_SIZE, GL_DELETE_STATUS, GL_GEOMETRY_LINKED_INPUT_TYPE, GL_GEOMETRY_LINKED_OUTPUT_TYPE, GL_GEOMETRY_LINKED_VERTICES_OUT, GL_GEOMETRY_SHADER_INVOCATIONS, GL_INFO_LOG_LENGTH, GL_LINK_STATUS, GL_PROGRAM_BINARY_RETRIEVABLE_HINT, GL_PROGRAM_SEPARABLE, GL_TESS_CONTROL_OUTPUT_VERTICES, GL_TESS_GEN_MODE, GL_TESS_GEN_POINT_MODE, GL_TESS_GEN_SPACING, GL_TESS_GEN_VERTEX_ORDER, GL_TRANSFORM_FEEDBACK_BUFFER_MODE, GL_TRANSFORM_FEEDBACK_VARYINGS, GL_TRANSFORM_FEEDBACK_VARYING_MAX_LENGTH and GL_VALIDATE_STATUS.</param>
         /// <param name="parameters">Returns the requested object parameter.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglGetProgramiv.xhtml" /></remarks>
-        public static void GetProgramiv(ProgramHandle program, ProgramPropertyARB pname, int* parameters) => GLPointers._GetProgramiv_fnptr((int)program, (uint)pname, parameters);
+        public static void GetProgramiv(int program, ProgramPropertyARB pname, int* parameters) => GLPointers._GetProgramiv_fnptr(program, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v2.0]</b> Returns the information log for a program object. </summary>
         /// <param name="program">Specifies the program object whose information log is to be queried.</param>
@@ -438,7 +438,7 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="length">Returns the length of the string returned in infoLog (excluding the null terminator).</param>
         /// <param name="infoLog">Specifies an array of characters that is used to return the information log.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglGetProgramInfoLog.xhtml" /></remarks>
-        public static void GetProgramInfoLog(ProgramHandle program, int bufSize, int* length, byte* infoLog) => GLPointers._GetProgramInfoLog_fnptr((int)program, bufSize, length, infoLog);
+        public static void GetProgramInfoLog(int program, int bufSize, int* length, byte* infoLog) => GLPointers._GetProgramInfoLog_fnptr(program, bufSize, length, infoLog);
         
         /// <summary> <b>[requires: v2.0]</b> Retrieve information about a bound renderbuffer object. </summary>
         /// <param name="target"> Specifies the target of the query operation. target must be GL_RENDERBUFFER. </param>
@@ -452,7 +452,7 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="pname">Specifies the object parameter. Accepted symbolic names are GL_SHADER_TYPE, GL_DELETE_STATUS, GL_COMPILE_STATUS, GL_INFO_LOG_LENGTH, GL_SHADER_SOURCE_LENGTH.</param>
         /// <param name="parameters">Returns the requested object parameter.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglGetShaderiv.xhtml" /></remarks>
-        public static void GetShaderiv(ShaderHandle shader, ShaderParameterName pname, int* parameters) => GLPointers._GetShaderiv_fnptr((int)shader, (uint)pname, parameters);
+        public static void GetShaderiv(int shader, ShaderParameterName pname, int* parameters) => GLPointers._GetShaderiv_fnptr(shader, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v2.0]</b> Returns the information log for a shader object. </summary>
         /// <param name="shader">Specifies the shader object whose information log is to be queried.</param>
@@ -460,7 +460,7 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="length">Returns the length of the string returned in infoLog (excluding the null terminator).</param>
         /// <param name="infoLog">Specifies an array of characters that is used to return the information log.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglGetShaderInfoLog.xhtml" /></remarks>
-        public static void GetShaderInfoLog(ShaderHandle shader, int bufSize, int* length, byte* infoLog) => GLPointers._GetShaderInfoLog_fnptr((int)shader, bufSize, length, infoLog);
+        public static void GetShaderInfoLog(int shader, int bufSize, int* length, byte* infoLog) => GLPointers._GetShaderInfoLog_fnptr(shader, bufSize, length, infoLog);
         
         /// <summary> <b>[requires: v2.0]</b> Retrieve the range and precision for numeric formats supported by the shader compiler. </summary>
         /// <param name="shaderType"> Specifies the type of shader whose precision to query. shaderType must be GL_VERTEX_SHADER or GL_FRAGMENT_SHADER. </param>
@@ -476,7 +476,7 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="length">Returns the length of the string returned in source (excluding the null terminator).</param>
         /// <param name="source">Specifies an array of characters that is used to return the source code string.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglGetShaderSource.xhtml" /></remarks>
-        public static void GetShaderSource(ShaderHandle shader, int bufSize, int* length, byte* source) => GLPointers._GetShaderSource_fnptr((int)shader, bufSize, length, source);
+        public static void GetShaderSource(int shader, int bufSize, int* length, byte* source) => GLPointers._GetShaderSource_fnptr(shader, bufSize, length, source);
         
         /// <summary> <b>[requires: v2.0]</b> Return a string describing the current GL connection. </summary>
         /// <param name="name"> Specifies a symbolic constant, one of GL_EXTENSIONS, GL_RENDERER, GL_SHADING_LANGUAGE_VERSION, GL_VENDOR, or GL_VERSION. glGetStringi accepts only the GL_EXTENSIONS token. </param>
@@ -502,20 +502,20 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="location">Specifies the location of the uniform variable to be queried.</param>
         /// <param name="parameters">Returns the value of the specified uniform variable.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglGetUniform.xhtml" /></remarks>
-        public static void GetUniformfv(ProgramHandle program, int location, float* parameters) => GLPointers._GetUniformfv_fnptr((int)program, location, parameters);
+        public static void GetUniformfv(int program, int location, float* parameters) => GLPointers._GetUniformfv_fnptr(program, location, parameters);
         
         /// <summary> <b>[requires: v2.0]</b> Returns the value of a uniform variable. </summary>
         /// <param name="program">Specifies the program object to be queried.</param>
         /// <param name="location">Specifies the location of the uniform variable to be queried.</param>
         /// <param name="parameters">Returns the value of the specified uniform variable.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglGetUniform.xhtml" /></remarks>
-        public static void GetUniformiv(ProgramHandle program, int location, int* parameters) => GLPointers._GetUniformiv_fnptr((int)program, location, parameters);
+        public static void GetUniformiv(int program, int location, int* parameters) => GLPointers._GetUniformiv_fnptr(program, location, parameters);
         
         /// <summary> <b>[requires: v2.0]</b> Returns the location of a uniform variable. </summary>
         /// <param name="program">Specifies the program object to be queried.</param>
         /// <param name="name">Points to a null terminated string containing the name of the uniform variable whose location is to be queried.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglGetUniformLocation.xhtml" /></remarks>
-        public static int GetUniformLocation(ProgramHandle program, byte* name) => GLPointers._GetUniformLocation_fnptr((int)program, name);
+        public static int GetUniformLocation(int program, byte* name) => GLPointers._GetUniformLocation_fnptr(program, name);
         
         /// <summary> <b>[requires: v2.0]</b> Return a generic vertex attribute parameter. </summary>
         /// <param name="index">Specifies the generic vertex attribute parameter to be queried.</param>
@@ -547,7 +547,7 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <summary> <b>[requires: v2.0]</b> Determine if a name corresponds to a buffer object. </summary>
         /// <param name="buffer"> Specifies a value that may be the name of a buffer object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglIsBuffer.xhtml" /></remarks>
-        public static bool IsBuffer(BufferHandle buffer) => GLPointers._IsBuffer_fnptr((int)buffer) != 0;
+        public static bool IsBuffer(int buffer) => GLPointers._IsBuffer_fnptr(buffer) != 0;
         
         /// <summary> <b>[requires: v2.0]</b> Test whether a capability is enabled. </summary>
         /// <param name="cap"> Specifies a symbolic constant indicating a GL capability. </param>
@@ -557,27 +557,27 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <summary> <b>[requires: v2.0]</b> Determine if a name corresponds to a framebuffer object. </summary>
         /// <param name="framebuffer"> Specifies a value that may be the name of a framebuffer object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglIsFramebuffer.xhtml" /></remarks>
-        public static bool IsFramebuffer(FramebufferHandle framebuffer) => GLPointers._IsFramebuffer_fnptr((int)framebuffer) != 0;
+        public static bool IsFramebuffer(int framebuffer) => GLPointers._IsFramebuffer_fnptr(framebuffer) != 0;
         
         /// <summary> <b>[requires: v2.0]</b> Determines if a name corresponds to a program object. </summary>
         /// <param name="program">Specifies a potential program object.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglIsProgram.xhtml" /></remarks>
-        public static bool IsProgram(ProgramHandle program) => GLPointers._IsProgram_fnptr((int)program) != 0;
+        public static bool IsProgram(int program) => GLPointers._IsProgram_fnptr(program) != 0;
         
         /// <summary> <b>[requires: v2.0]</b> Determine if a name corresponds to a renderbuffer object. </summary>
         /// <param name="renderbuffer"> Specifies a value that may be the name of a renderbuffer object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglIsRenderbuffer.xhtml" /></remarks>
-        public static bool IsRenderbuffer(RenderbufferHandle renderbuffer) => GLPointers._IsRenderbuffer_fnptr((int)renderbuffer) != 0;
+        public static bool IsRenderbuffer(int renderbuffer) => GLPointers._IsRenderbuffer_fnptr(renderbuffer) != 0;
         
         /// <summary> <b>[requires: v2.0]</b> Determines if a name corresponds to a shader object. </summary>
         /// <param name="shader">Specifies a potential shader object.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglIsShader.xhtml" /></remarks>
-        public static bool IsShader(ShaderHandle shader) => GLPointers._IsShader_fnptr((int)shader) != 0;
+        public static bool IsShader(int shader) => GLPointers._IsShader_fnptr(shader) != 0;
         
         /// <summary> <b>[requires: v2.0]</b> Determine if a name corresponds to a texture. </summary>
         /// <param name="texture"> Specifies a value that may be the name of a texture. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglIsTexture.xhtml" /></remarks>
-        public static bool IsTexture(TextureHandle texture) => GLPointers._IsTexture_fnptr((int)texture) != 0;
+        public static bool IsTexture(int texture) => GLPointers._IsTexture_fnptr(texture) != 0;
         
         /// <summary> <b>[requires: v2.0]</b> Specify the width of rasterized lines. </summary>
         /// <param name="width"> Specifies the width of rasterized lines. The initial value is 1. </param>
@@ -587,7 +587,7 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <summary> <b>[requires: v2.0]</b> Links a program object. </summary>
         /// <param name="program">Specifies the handle of the program object to be linked.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglLinkProgram.xhtml" /></remarks>
-        public static void LinkProgram(ProgramHandle program) => GLPointers._LinkProgram_fnptr((int)program);
+        public static void LinkProgram(int program) => GLPointers._LinkProgram_fnptr(program);
         
         /// <summary> <b>[requires: v2.0]</b> Set pixel storage modes. </summary>
         /// <param name="pname"> Specifies the symbolic name of the parameter to be set. Four values affect the packing of pixel data into memory: GL_PACK_ROW_LENGTH, GL_PACK_SKIP_PIXELS, GL_PACK_SKIP_ROWS, and GL_PACK_ALIGNMENT. Six more affect the unpacking of pixel data from memory: GL_UNPACK_ROW_LENGTH, GL_UNPACK_IMAGE_HEIGHT, GL_UNPACK_SKIP_PIXELS, GL_UNPACK_SKIP_ROWS, GL_UNPACK_SKIP_IMAGES, and GL_UNPACK_ALIGNMENT. </param>
@@ -645,7 +645,7 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="binary"> Specifies the address of an array of bytes containing pre-compiled binary shader code. </param>
         /// <param name="length"> Specifies the length of the array whose address is given in binary. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglShaderBinary.xhtml" /></remarks>
-        public static void ShaderBinary(int count, ShaderHandle* shaders, ShaderBinaryFormat binaryFormat, void* binary, int length) => GLPointers._ShaderBinary_fnptr(count, (int*)shaders, (uint)binaryFormat, binary, length);
+        public static void ShaderBinary(int count, int* shaders, ShaderBinaryFormat binaryFormat, void* binary, int length) => GLPointers._ShaderBinary_fnptr(count, shaders, (uint)binaryFormat, binary, length);
         
         /// <summary> <b>[requires: v2.0]</b> Replaces the source code in a shader object. </summary>
         /// <param name="shader">Specifies the handle of the shader object whose source code is to be replaced.</param>
@@ -653,7 +653,7 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="str">Specifies an array of pointers to strings containing the source code to be loaded into the shader.</param>
         /// <param name="length">Specifies an array of string lengths.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglShaderSource.xhtml" /></remarks>
-        public static void ShaderSource(ShaderHandle shader, int count, byte** str, int* length) => GLPointers._ShaderSource_fnptr((int)shader, count, str, length);
+        public static void ShaderSource(int shader, int count, byte** str, int* length) => GLPointers._ShaderSource_fnptr(shader, count, str, length);
         
         /// <summary> <b>[requires: v2.0]</b> Set front and back function and reference value for stencil testing. </summary>
         /// <param name="func"> Specifies the test function. Eight symbolic constants are valid: GL_NEVER, GL_LESS, GL_LEQUAL, GL_GREATER, GL_GEQUAL, GL_EQUAL, GL_NOTEQUAL, and GL_ALWAYS. The initial value is GL_ALWAYS. </param>
@@ -893,12 +893,12 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <summary> <b>[requires: v2.0]</b> Installs a program object as part of current rendering state. </summary>
         /// <param name="program">Specifies the handle of the program object whose executables are to be used as part of current rendering state.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglUseProgram.xhtml" /></remarks>
-        public static void UseProgram(ProgramHandle program) => GLPointers._UseProgram_fnptr((int)program);
+        public static void UseProgram(int program) => GLPointers._UseProgram_fnptr(program);
         
         /// <summary> <b>[requires: v2.0]</b> Validates a program object. </summary>
         /// <param name="program">Specifies the handle of the program object to be validated.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglValidateProgram.xhtml" /></remarks>
-        public static void ValidateProgram(ProgramHandle program) => GLPointers._ValidateProgram_fnptr((int)program);
+        public static void ValidateProgram(int program) => GLPointers._ValidateProgram_fnptr(program);
         
         /// <summary> <b>[requires: v2.0]</b> Specifies the value of a generic vertex attribute. </summary>
         /// <param name="index">Specifies the index of the generic vertex attribute to be modified.</param>
@@ -1061,24 +1061,24 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="n"> Specifies the number of query object names to be generated. </param>
         /// <param name="ids"> Specifies an array in which the generated query object names are stored. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglGenQueries.xhtml" /></remarks>
-        public static void GenQueries(int n, QueryHandle* ids) => GLPointers._GenQueries_fnptr(n, (int*)ids);
+        public static void GenQueries(int n, int* ids) => GLPointers._GenQueries_fnptr(n, ids);
         
         /// <summary> <b>[requires: v3.0]</b> Delete named query objects. </summary>
         /// <param name="n"> Specifies the number of query objects to be deleted. </param>
         /// <param name="ids"> Specifies an array of query objects to be deleted. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglDeleteQueries.xhtml" /></remarks>
-        public static void DeleteQueries(int n, QueryHandle* ids) => GLPointers._DeleteQueries_fnptr(n, (int*)ids);
+        public static void DeleteQueries(int n, int* ids) => GLPointers._DeleteQueries_fnptr(n, ids);
         
         /// <summary> <b>[requires: v3.0]</b> Determine if a name corresponds to a query object. </summary>
         /// <param name="id"> Specifies a value that may be the name of a query object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglIsQuery.xhtml" /></remarks>
-        public static bool IsQuery(QueryHandle id) => GLPointers._IsQuery_fnptr((int)id) != 0;
+        public static bool IsQuery(int id) => GLPointers._IsQuery_fnptr(id) != 0;
         
         /// <summary> <b>[requires: v3.0]</b> Delimit the boundaries of a query object. </summary>
         /// <param name="target"> Specifies the target type of query object established between glBeginQuery and the subsequent glEndQuery. The symbolic constant must be one of GL_ANY_SAMPLES_PASSED, GL_ANY_SAMPLES_PASSED_CONSERVATIVE, GL_PRIMITIVES_GENERATED, or GL_TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN. </param>
         /// <param name="id"> Specifies the name of a query object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglBeginQuery.xhtml" /></remarks>
-        public static void BeginQuery(QueryTarget target, QueryHandle id) => GLPointers._BeginQuery_fnptr((uint)target, (int)id);
+        public static void BeginQuery(QueryTarget target, int id) => GLPointers._BeginQuery_fnptr((uint)target, id);
         
         /// <summary> <b>[requires: v3.0]</b> Delimit the boundaries of a query object. </summary>
         /// <param name="target"> Specifies the target type of query object established between glBeginQuery and the subsequent glEndQuery. The symbolic constant must be one of GL_ANY_SAMPLES_PASSED, GL_ANY_SAMPLES_PASSED_CONSERVATIVE, GL_PRIMITIVES_GENERATED, or GL_TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN. </param>
@@ -1097,7 +1097,7 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="pname"> Specifies the symbolic name of a query object parameter. Accepted values are GL_QUERY_RESULT or GL_QUERY_RESULT_AVAILABLE. </param>
         /// <param name="parameters"> Returns the requested data. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglGetQueryObjectuiv.xhtml" /></remarks>
-        public static void GetQueryObjectuiv(QueryHandle id, QueryObjectParameterName pname, uint* parameters) => GLPointers._GetQueryObjectuiv_fnptr((int)id, (uint)pname, parameters);
+        public static void GetQueryObjectuiv(int id, QueryObjectParameterName pname, uint* parameters) => GLPointers._GetQueryObjectuiv_fnptr(id, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v3.0]</b> Map a section of a buffer object's data store. </summary>
         /// <param name="target"> Specifies the target to which the buffer object is bound for glMapBufferRange, which must be one of the buffer binding targets in the following table: </param>
@@ -1195,7 +1195,7 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="level"> Specifies the mipmap level of texture to attach. </param>
         /// <param name="layer"> Specifies the layer of texture to attach. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglFramebufferTextureLayer.xhtml" /></remarks>
-        public static void FramebufferTextureLayer(FramebufferTarget target, FramebufferAttachment attachment, TextureHandle texture, int level, int layer) => GLPointers._FramebufferTextureLayer_fnptr((uint)target, (uint)attachment, (int)texture, level, layer);
+        public static void FramebufferTextureLayer(FramebufferTarget target, FramebufferAttachment attachment, int texture, int level, int layer) => GLPointers._FramebufferTextureLayer_fnptr((uint)target, (uint)attachment, texture, level, layer);
         
         /// <summary> <b>[requires: v3.0]</b> Map a section of a buffer object's data store. </summary>
         /// <param name="target"> Specifies the target to which the buffer object is bound for glMapBufferRange, which must be one of the buffer binding targets in the following table: </param>
@@ -1215,24 +1215,24 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <summary> <b>[requires: v3.0]</b> Bind a vertex array object. </summary>
         /// <param name="array"> Specifies the name of the vertex array to bind. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglBindVertexArray.xhtml" /></remarks>
-        public static void BindVertexArray(VertexArrayHandle array) => GLPointers._BindVertexArray_fnptr((int)array);
+        public static void BindVertexArray(int array) => GLPointers._BindVertexArray_fnptr(array);
         
         /// <summary> <b>[requires: v3.0]</b> Delete vertex array objects. </summary>
         /// <param name="n"> Specifies the number of vertex array objects to be deleted. </param>
         /// <param name="arrays"> Specifies the address of an array containing the n names of the objects to be deleted. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglDeleteVertexArrays.xhtml" /></remarks>
-        public static void DeleteVertexArrays(int n, VertexArrayHandle* arrays) => GLPointers._DeleteVertexArrays_fnptr(n, (int*)arrays);
+        public static void DeleteVertexArrays(int n, int* arrays) => GLPointers._DeleteVertexArrays_fnptr(n, arrays);
         
         /// <summary> <b>[requires: v3.0]</b> Generate vertex array object names. </summary>
         /// <param name="n"> Specifies the number of vertex array object names to generate. </param>
         /// <param name="arrays"> Specifies an array in which the generated vertex array object names are stored. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglGenVertexArrays.xhtml" /></remarks>
-        public static void GenVertexArrays(int n, VertexArrayHandle* arrays) => GLPointers._GenVertexArrays_fnptr(n, (int*)arrays);
+        public static void GenVertexArrays(int n, int* arrays) => GLPointers._GenVertexArrays_fnptr(n, arrays);
         
         /// <summary> <b>[requires: v3.0]</b> Determine if a name corresponds to a vertex array object. </summary>
         /// <param name="array"> Specifies a value that may be the name of a vertex array object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglIsVertexArray.xhtml" /></remarks>
-        public static bool IsVertexArray(VertexArrayHandle array) => GLPointers._IsVertexArray_fnptr((int)array) != 0;
+        public static bool IsVertexArray(int array) => GLPointers._IsVertexArray_fnptr(array) != 0;
         
         /// <summary> <b>[requires: v3.0]</b> Return the value or values of a selected parameter. </summary>
         /// <param name="target"> Specifies the parameter value to be returned for indexed versions of glGet. The symbolic constants in the list below are accepted. </param>
@@ -1257,14 +1257,14 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="offset"> The starting offset in basic machine units into the buffer object buffer. </param>
         /// <param name="size"> The amount of data in machine units that can be read from the buffet object while used as an indexed target. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglBindBufferRange.xhtml" /></remarks>
-        public static void BindBufferRange(BufferTargetARB target, uint index, BufferHandle buffer, IntPtr offset, nint size) => GLPointers._BindBufferRange_fnptr((uint)target, index, (int)buffer, offset, size);
+        public static void BindBufferRange(BufferTargetARB target, uint index, int buffer, IntPtr offset, nint size) => GLPointers._BindBufferRange_fnptr((uint)target, index, buffer, offset, size);
         
         /// <summary> <b>[requires: v3.0]</b> Bind a buffer object to an indexed buffer target. </summary>
         /// <param name="target"> Specify the target of the bind operation. target must be one of GL_ATOMIC_COUNTER_BUFFER, GL_SHADER_STORAGE_BUFFER, GL_TRANSFORM_FEEDBACK_BUFFER or GL_UNIFORM_BUFFER. </param>
         /// <param name="index"> Specify the index of the binding point within the array specified by target. </param>
         /// <param name="buffer"> The name of a buffer object to bind to the specified binding point. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglBindBufferBase.xhtml" /></remarks>
-        public static void BindBufferBase(BufferTargetARB target, uint index, BufferHandle buffer) => GLPointers._BindBufferBase_fnptr((uint)target, index, (int)buffer);
+        public static void BindBufferBase(BufferTargetARB target, uint index, int buffer) => GLPointers._BindBufferBase_fnptr((uint)target, index, buffer);
         
         /// <summary> <b>[requires: v3.0]</b> Specify values to record in transform feedback buffers. </summary>
         /// <param name="program"> The name of the target program object. </param>
@@ -1272,7 +1272,7 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="varyings"> An array of count zero-terminated strings specifying the names of the varying variables to use for transform feedback. </param>
         /// <param name="bufferMode"> Identifies the mode used to capture the varying variables when transform feedback is active. bufferMode must be GL_INTERLEAVED_ATTRIBS or GL_SEPARATE_ATTRIBS. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglTransformFeedbackVaryings.xhtml" /></remarks>
-        public static void TransformFeedbackVaryings(ProgramHandle program, int count, byte** varyings, TransformFeedbackBufferMode bufferMode) => GLPointers._TransformFeedbackVaryings_fnptr((int)program, count, varyings, (uint)bufferMode);
+        public static void TransformFeedbackVaryings(int program, int count, byte** varyings, TransformFeedbackBufferMode bufferMode) => GLPointers._TransformFeedbackVaryings_fnptr(program, count, varyings, (uint)bufferMode);
         
         /// <summary> <b>[requires: v3.0]</b> Retrieve information about varying variables selected for transform feedback. </summary>
         /// <param name="program"> The name of the target program object. </param>
@@ -1283,7 +1283,7 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="type"> The address of a variable that will receive the type of the varying. </param>
         /// <param name="name"> The address of a buffer into which will be written the name of the varying. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglGetTransformFeedbackVarying.xhtml" /></remarks>
-        public static void GetTransformFeedbackVarying(ProgramHandle program, uint index, int bufSize, int* length, int* size, AttributeType* type, byte* name) => GLPointers._GetTransformFeedbackVarying_fnptr((int)program, index, bufSize, length, size, (uint*)type, name);
+        public static void GetTransformFeedbackVarying(int program, uint index, int bufSize, int* length, int* size, AttributeType* type, byte* name) => GLPointers._GetTransformFeedbackVarying_fnptr(program, index, bufSize, length, size, (uint*)type, name);
         
         /// <summary> <b>[requires: v3.0]</b> Define an array of generic vertex attribute data. </summary>
         /// <param name="index">Specifies the index of the generic vertex attribute to be modified.</param>
@@ -1343,13 +1343,13 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="location">Specifies the location of the uniform variable to be queried.</param>
         /// <param name="parameters">Returns the value of the specified uniform variable.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglGetUniform.xhtml" /></remarks>
-        public static void GetUniformuiv(ProgramHandle program, int location, uint* parameters) => GLPointers._GetUniformuiv_fnptr((int)program, location, parameters);
+        public static void GetUniformuiv(int program, int location, uint* parameters) => GLPointers._GetUniformuiv_fnptr(program, location, parameters);
         
         /// <summary> <b>[requires: v3.0]</b> Query the bindings of color numbers to user-defined varying out variables. </summary>
         /// <param name="program"> The name of the program containing varying out variable whose binding to query </param>
         /// <param name="name"> The name of the user-defined varying out variable whose binding to query </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglGetFragDataLocation.xhtml" /></remarks>
-        public static int GetFragDataLocation(ProgramHandle program, byte* name) => GLPointers._GetFragDataLocation_fnptr((int)program, name);
+        public static int GetFragDataLocation(int program, byte* name) => GLPointers._GetFragDataLocation_fnptr(program, name);
         
         /// <summary> <b>[requires: v3.0]</b> Specify the value of a uniform variable for the current program object. </summary>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
@@ -1459,7 +1459,7 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="uniformNames"> Specifies the address of an array of pointers to buffers containing the names of the queried uniforms. </param>
         /// <param name="uniformIndices"> Specifies the address of an array that will receive the indices of the uniforms. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglGetUniformIndices.xhtml" /></remarks>
-        public static void GetUniformIndices(ProgramHandle program, int uniformCount, byte** uniformNames, uint* uniformIndices) => GLPointers._GetUniformIndices_fnptr((int)program, uniformCount, uniformNames, uniformIndices);
+        public static void GetUniformIndices(int program, int uniformCount, byte** uniformNames, uint* uniformIndices) => GLPointers._GetUniformIndices_fnptr(program, uniformCount, uniformNames, uniformIndices);
         
         /// <summary> <b>[requires: v3.0]</b> Returns information about several active uniform variables for the specified program object. </summary>
         /// <param name="program">Specifies the program object to be queried.</param>
@@ -1468,13 +1468,13 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="pname">Specifies the property of each uniform in uniformIndices that should be written into the corresponding element of params.</param>
         /// <param name="parameters">Specifies the address of an array of uniformCount integers which are to receive the value of pname for each uniform in uniformIndices.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglGetActiveUniformsiv.xhtml" /></remarks>
-        public static void GetActiveUniformsiv(ProgramHandle program, int uniformCount, uint* uniformIndices, UniformPName pname, int* parameters) => GLPointers._GetActiveUniformsiv_fnptr((int)program, uniformCount, uniformIndices, (uint)pname, parameters);
+        public static void GetActiveUniformsiv(int program, int uniformCount, uint* uniformIndices, UniformPName pname, int* parameters) => GLPointers._GetActiveUniformsiv_fnptr(program, uniformCount, uniformIndices, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v3.0]</b> Retrieve the index of a named uniform block. </summary>
         /// <param name="program"> Specifies the name of a program containing the uniform block. </param>
         /// <param name="uniformBlockName"> Specifies the address an array of characters containing the name of the uniform block whose index to retrieve. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglGetUniformBlockIndex.xhtml" /></remarks>
-        public static uint GetUniformBlockIndex(ProgramHandle program, byte* uniformBlockName) => GLPointers._GetUniformBlockIndex_fnptr((int)program, uniformBlockName);
+        public static uint GetUniformBlockIndex(int program, byte* uniformBlockName) => GLPointers._GetUniformBlockIndex_fnptr(program, uniformBlockName);
         
         /// <summary> <b>[requires: v3.0]</b> Query information about an active uniform block. </summary>
         /// <param name="program"> Specifies the name of a program containing the uniform block. </param>
@@ -1482,7 +1482,7 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="pname"> Specifies the name of the parameter to query. </param>
         /// <param name="parameters"> Specifies the address of a variable to receive the result of the query. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglGetActiveUniformBlockiv.xhtml" /></remarks>
-        public static void GetActiveUniformBlockiv(ProgramHandle program, uint uniformBlockIndex, UniformBlockPName pname, int* parameters) => GLPointers._GetActiveUniformBlockiv_fnptr((int)program, uniformBlockIndex, (uint)pname, parameters);
+        public static void GetActiveUniformBlockiv(int program, uint uniformBlockIndex, UniformBlockPName pname, int* parameters) => GLPointers._GetActiveUniformBlockiv_fnptr(program, uniformBlockIndex, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v3.0]</b> Retrieve the name of an active uniform block. </summary>
         /// <param name="program"> Specifies the name of a program containing the uniform block. </param>
@@ -1491,14 +1491,14 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="length"> Specifies the address of a variable to receive the number of characters that were written to uniformBlockName. </param>
         /// <param name="uniformBlockName"> Specifies the address an array of characters to receive the name of the uniform block at uniformBlockIndex. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglGetActiveUniformBlockName.xhtml" /></remarks>
-        public static void GetActiveUniformBlockName(ProgramHandle program, uint uniformBlockIndex, int bufSize, int* length, byte* uniformBlockName) => GLPointers._GetActiveUniformBlockName_fnptr((int)program, uniformBlockIndex, bufSize, length, uniformBlockName);
+        public static void GetActiveUniformBlockName(int program, uint uniformBlockIndex, int bufSize, int* length, byte* uniformBlockName) => GLPointers._GetActiveUniformBlockName_fnptr(program, uniformBlockIndex, bufSize, length, uniformBlockName);
         
         /// <summary> <b>[requires: v3.0]</b> Assign a binding point to an active uniform block. </summary>
         /// <param name="program"> The name of a program object containing the active uniform block whose binding to assign. </param>
         /// <param name="uniformBlockIndex"> The index of the active uniform block within program whose binding to assign. </param>
         /// <param name="uniformBlockBinding"> Specifies the binding point to which to bind the uniform block with index uniformBlockIndex within program. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglUniformBlockBinding.xhtml" /></remarks>
-        public static void UniformBlockBinding(ProgramHandle program, uint uniformBlockIndex, uint uniformBlockBinding) => GLPointers._UniformBlockBinding_fnptr((int)program, uniformBlockIndex, uniformBlockBinding);
+        public static void UniformBlockBinding(int program, uint uniformBlockIndex, uint uniformBlockBinding) => GLPointers._UniformBlockBinding_fnptr(program, uniformBlockIndex, uniformBlockBinding);
         
         /// <summary> <b>[requires: v3.0]</b> Draw multiple instances of a range of elements. </summary>
         /// <param name="mode"> Specifies what kind of primitives to render. Symbolic constants GL_POINTS, GL_LINE_STRIP, GL_LINE_LOOP, GL_LINES, GL_LINE_STRIP_ADJACENCY, GL_LINES_ADJACENCY, GL_TRIANGLE_STRIP, GL_TRIANGLE_FAN, GL_TRIANGLES, GL_TRIANGLE_STRIP_ADJACENCY, GL_TRIANGLES_ADJACENCY and GL_PATCHES are accepted. </param>
@@ -1580,66 +1580,66 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="n"> Specifies the number of sampler object names to generate. </param>
         /// <param name="samplers"> Specifies an array in which the generated sampler object names are stored. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglGenSamplers.xhtml" /></remarks>
-        public static void GenSamplers(int count, SamplerHandle* samplers) => GLPointers._GenSamplers_fnptr(count, (int*)samplers);
+        public static void GenSamplers(int count, int* samplers) => GLPointers._GenSamplers_fnptr(count, samplers);
         
         /// <summary> <b>[requires: v3.0]</b> Delete named sampler objects. </summary>
         /// <param name="n"> Specifies the number of sampler objects to be deleted. </param>
         /// <param name="samplers"> Specifies an array of sampler objects to be deleted. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglDeleteSamplers.xhtml" /></remarks>
-        public static void DeleteSamplers(int count, SamplerHandle* samplers) => GLPointers._DeleteSamplers_fnptr(count, (int*)samplers);
+        public static void DeleteSamplers(int count, int* samplers) => GLPointers._DeleteSamplers_fnptr(count, samplers);
         
         /// <summary> <b>[requires: v3.0]</b> Determine if a name corresponds to a sampler object. </summary>
         /// <param name="id"> Specifies a value that may be the name of a sampler object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglIsSampler.xhtml" /></remarks>
-        public static bool IsSampler(SamplerHandle sampler) => GLPointers._IsSampler_fnptr((int)sampler) != 0;
+        public static bool IsSampler(int sampler) => GLPointers._IsSampler_fnptr(sampler) != 0;
         
         /// <summary> <b>[requires: v3.0]</b> Bind a named sampler to a texturing target. </summary>
         /// <param name="unit"> Specifies the index of the texture unit to which the sampler is bound. </param>
         /// <param name="sampler"> Specifies the name of a sampler. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglBindSampler.xhtml" /></remarks>
-        public static void BindSampler(uint unit, SamplerHandle sampler) => GLPointers._BindSampler_fnptr(unit, (int)sampler);
+        public static void BindSampler(uint unit, int sampler) => GLPointers._BindSampler_fnptr(unit, sampler);
         
         /// <summary> <b>[requires: v3.0]</b> Set sampler parameters. </summary>
         /// <param name="sampler"> Specifies the sampler object whose parameter to modify. </param>
         /// <param name="pname"> Specifies the symbolic name of a single-valued sampler parameter. pname can be one of the following: GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, GL_TEXTURE_WRAP_R, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_COMPARE_MODE, GL_TEXTURE_COMPARE_FUNC. </param>
         /// <param name="param"> For the scalar commands, specifies the value of pname. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglSamplerParameter.xhtml" /></remarks>
-        public static void SamplerParameteri(SamplerHandle sampler, SamplerParameterI pname, int param) => GLPointers._SamplerParameteri_fnptr((int)sampler, (uint)pname, param);
+        public static void SamplerParameteri(int sampler, SamplerParameterI pname, int param) => GLPointers._SamplerParameteri_fnptr(sampler, (uint)pname, param);
         
         /// <summary> <b>[requires: v3.0]</b> Set sampler parameters. </summary>
         /// <param name="sampler"> Specifies the sampler object whose parameter to modify. </param>
         /// <param name="pname"> Specifies the symbolic name of a single-valued sampler parameter. pname can be one of the following: GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, GL_TEXTURE_WRAP_R, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_COMPARE_MODE, GL_TEXTURE_COMPARE_FUNC. </param>
         /// <param name="parameters"> For the vector commands (glSamplerParameter*v), specifies a pointer to an array where the value or values of pname are stored. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglSamplerParameter.xhtml" /></remarks>
-        public static void SamplerParameteriv(SamplerHandle sampler, SamplerParameterI pname, int* param) => GLPointers._SamplerParameteriv_fnptr((int)sampler, (uint)pname, param);
+        public static void SamplerParameteriv(int sampler, SamplerParameterI pname, int* param) => GLPointers._SamplerParameteriv_fnptr(sampler, (uint)pname, param);
         
         /// <summary> <b>[requires: v3.0]</b> Set sampler parameters. </summary>
         /// <param name="sampler"> Specifies the sampler object whose parameter to modify. </param>
         /// <param name="pname"> Specifies the symbolic name of a single-valued sampler parameter. pname can be one of the following: GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, GL_TEXTURE_WRAP_R, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_COMPARE_MODE, GL_TEXTURE_COMPARE_FUNC. </param>
         /// <param name="param"> For the scalar commands, specifies the value of pname. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglSamplerParameter.xhtml" /></remarks>
-        public static void SamplerParameterf(SamplerHandle sampler, SamplerParameterF pname, float param) => GLPointers._SamplerParameterf_fnptr((int)sampler, (uint)pname, param);
+        public static void SamplerParameterf(int sampler, SamplerParameterF pname, float param) => GLPointers._SamplerParameterf_fnptr(sampler, (uint)pname, param);
         
         /// <summary> <b>[requires: v3.0]</b> Set sampler parameters. </summary>
         /// <param name="sampler"> Specifies the sampler object whose parameter to modify. </param>
         /// <param name="pname"> Specifies the symbolic name of a single-valued sampler parameter. pname can be one of the following: GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, GL_TEXTURE_WRAP_R, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_COMPARE_MODE, GL_TEXTURE_COMPARE_FUNC. </param>
         /// <param name="parameters"> For the vector commands (glSamplerParameter*v), specifies a pointer to an array where the value or values of pname are stored. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglSamplerParameter.xhtml" /></remarks>
-        public static void SamplerParameterfv(SamplerHandle sampler, SamplerParameterF pname, float* param) => GLPointers._SamplerParameterfv_fnptr((int)sampler, (uint)pname, param);
+        public static void SamplerParameterfv(int sampler, SamplerParameterF pname, float* param) => GLPointers._SamplerParameterfv_fnptr(sampler, (uint)pname, param);
         
         /// <summary> <b>[requires: v3.0]</b> Return sampler parameter values. </summary>
         /// <param name="sampler"> Specifies name of the sampler object from which to retrieve parameters. </param>
         /// <param name="pname"> Specifies the symbolic name of a sampler parameter. GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, GL_TEXTURE_WRAP_R, GL_TEXTURE_COMPARE_MODE, GL_TEXTURE_COMPARE_FUNC, and GL_TEXTURE_BORDER_COLOR are accepted. </param>
         /// <param name="parameters"> Returns the sampler parameters. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglGetSamplerParameter.xhtml" /></remarks>
-        public static void GetSamplerParameteriv(SamplerHandle sampler, SamplerParameterI pname, int* parameters) => GLPointers._GetSamplerParameteriv_fnptr((int)sampler, (uint)pname, parameters);
+        public static void GetSamplerParameteriv(int sampler, SamplerParameterI pname, int* parameters) => GLPointers._GetSamplerParameteriv_fnptr(sampler, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v3.0]</b> Return sampler parameter values. </summary>
         /// <param name="sampler"> Specifies name of the sampler object from which to retrieve parameters. </param>
         /// <param name="pname"> Specifies the symbolic name of a sampler parameter. GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, GL_TEXTURE_WRAP_R, GL_TEXTURE_COMPARE_MODE, GL_TEXTURE_COMPARE_FUNC, and GL_TEXTURE_BORDER_COLOR are accepted. </param>
         /// <param name="parameters"> Returns the sampler parameters. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglGetSamplerParameter.xhtml" /></remarks>
-        public static void GetSamplerParameterfv(SamplerHandle sampler, SamplerParameterF pname, float* parameters) => GLPointers._GetSamplerParameterfv_fnptr((int)sampler, (uint)pname, parameters);
+        public static void GetSamplerParameterfv(int sampler, SamplerParameterF pname, float* parameters) => GLPointers._GetSamplerParameterfv_fnptr(sampler, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v3.0]</b> Modify the rate at which generic vertex attributes advance during instanced rendering. </summary>
         /// <param name="index"> Specify the index of the generic vertex attribute. </param>
@@ -1651,24 +1651,24 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="target"> Specifies the target to which to bind the transform feedback object id. target must be GL_TRANSFORM_FEEDBACK. </param>
         /// <param name="id"> Specifies the name of a transform feedback object reserved by glGenTransformFeedbacks. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglBindTransformFeedback.xhtml" /></remarks>
-        public static void BindTransformFeedback(BindTransformFeedbackTarget target, TransformFeedbackHandle id) => GLPointers._BindTransformFeedback_fnptr((uint)target, (int)id);
+        public static void BindTransformFeedback(BindTransformFeedbackTarget target, int id) => GLPointers._BindTransformFeedback_fnptr((uint)target, id);
         
         /// <summary> <b>[requires: v3.0]</b> Delete transform feedback objects. </summary>
         /// <param name="n"> Specifies the number of transform feedback objects to delete. </param>
         /// <param name="ids"> Specifies an array of names of transform feedback objects to delete. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglDeleteTransformFeedbacks.xhtml" /></remarks>
-        public static void DeleteTransformFeedbacks(int n, TransformFeedbackHandle* ids) => GLPointers._DeleteTransformFeedbacks_fnptr(n, (int*)ids);
+        public static void DeleteTransformFeedbacks(int n, int* ids) => GLPointers._DeleteTransformFeedbacks_fnptr(n, ids);
         
         /// <summary> <b>[requires: v3.0]</b> Reserve transform feedback object names. </summary>
         /// <param name="n"> Specifies the number of transform feedback object names to reserve. </param>
         /// <param name="ids"> Specifies an array of into which the reserved names will be written. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglGenTransformFeedbacks.xhtml" /></remarks>
-        public static void GenTransformFeedbacks(int n, TransformFeedbackHandle* ids) => GLPointers._GenTransformFeedbacks_fnptr(n, (int*)ids);
+        public static void GenTransformFeedbacks(int n, int* ids) => GLPointers._GenTransformFeedbacks_fnptr(n, ids);
         
         /// <summary> <b>[requires: v3.0]</b> Determine if a name corresponds to a transform feedback object. </summary>
         /// <param name="id"> Specifies a value that may be the name of a transform feedback object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglIsTransformFeedback.xhtml" /></remarks>
-        public static bool IsTransformFeedback(TransformFeedbackHandle id) => GLPointers._IsTransformFeedback_fnptr((int)id) != 0;
+        public static bool IsTransformFeedback(int id) => GLPointers._IsTransformFeedback_fnptr(id) != 0;
         
         /// <summary> <b>[requires: v3.0]</b> Pause transform feedback operations. </summary>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglPauseTransformFeedback.xhtml" /></remarks>
@@ -1685,7 +1685,7 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="binaryFormat"> Specifies the address of a variable to receive a token indicating the format of the binary data returned by the GL. </param>
         /// <param name="binary"> Specifies the address an array into which the GL will return program's binary representation. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglGetProgramBinary.xhtml" /></remarks>
-        public static void GetProgramBinary(ProgramHandle program, int bufSize, int* length, All* binaryFormat, void* binary) => GLPointers._GetProgramBinary_fnptr((int)program, bufSize, length, (uint*)binaryFormat, binary);
+        public static void GetProgramBinary(int program, int bufSize, int* length, All* binaryFormat, void* binary) => GLPointers._GetProgramBinary_fnptr(program, bufSize, length, (uint*)binaryFormat, binary);
         
         /// <summary> <b>[requires: v3.0]</b> Load a program object with a program binary. </summary>
         /// <param name="program"> Specifies the name of a program object into which to load a program binary. </param>
@@ -1693,14 +1693,14 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="binary"> Specifies the address of an array containing the binary to be loaded into program. </param>
         /// <param name="length"> Specifies the number of bytes contained in binary. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglProgramBinary.xhtml" /></remarks>
-        public static void ProgramBinary(ProgramHandle program, All binaryFormat, void* binary, int length) => GLPointers._ProgramBinary_fnptr((int)program, (uint)binaryFormat, binary, length);
+        public static void ProgramBinary(int program, All binaryFormat, void* binary, int length) => GLPointers._ProgramBinary_fnptr(program, (uint)binaryFormat, binary, length);
         
         /// <summary> <b>[requires: v3.0]</b> Specify a parameter for a program object. </summary>
         /// <param name="program"> Specifies the name of a program object whose parameter to modify. </param>
         /// <param name="pname"> Specifies the name of the parameter to modify. </param>
         /// <param name="value"> Specifies the new value of the parameter specified by pname for program. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglProgramParameteri.xhtml" /></remarks>
-        public static void ProgramParameteri(ProgramHandle program, ProgramParameterPName pname, int value) => GLPointers._ProgramParameteri_fnptr((int)program, (uint)pname, value);
+        public static void ProgramParameteri(int program, ProgramParameterPName pname, int value) => GLPointers._ProgramParameteri_fnptr(program, (uint)pname, value);
         
         /// <summary> <b>[requires: v3.0]</b> Invalidate the contents of attachments within a framebuffer. </summary>
         /// <param name="target"> Specifies the target of the invalidate operation. </param>
@@ -1793,14 +1793,14 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="pname"> The name of the parameter within programInterface to query. </param>
         /// <param name="parameters"> The address of a variable to retrieve the value of pname for the program interface. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglGetProgramInterface.xhtml" /></remarks>
-        public static void GetProgramInterfaceiv(ProgramHandle program, ProgramInterface programInterface, ProgramInterfacePName pname, int* parameters) => GLPointers._GetProgramInterfaceiv_fnptr((int)program, (uint)programInterface, (uint)pname, parameters);
+        public static void GetProgramInterfaceiv(int program, ProgramInterface programInterface, ProgramInterfacePName pname, int* parameters) => GLPointers._GetProgramInterfaceiv_fnptr(program, (uint)programInterface, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v3.1]</b> Query the index of a named resource within a program. </summary>
         /// <param name="program"> The name of a program object whose resources to query. </param>
         /// <param name="programInterface"> A token identifying the interface within program containing the resource named name. </param>
         /// <param name="name"> The name of the resource to query the index of. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglGetProgramResourceIndex.xhtml" /></remarks>
-        public static uint GetProgramResourceIndex(ProgramHandle program, ProgramInterface programInterface, byte* name) => GLPointers._GetProgramResourceIndex_fnptr((int)program, (uint)programInterface, name);
+        public static uint GetProgramResourceIndex(int program, ProgramInterface programInterface, byte* name) => GLPointers._GetProgramResourceIndex_fnptr(program, (uint)programInterface, name);
         
         /// <summary> <b>[requires: v3.1]</b> Query the name of an indexed resource within a program. </summary>
         /// <param name="program"> The name of a program object whose resources to query. </param>
@@ -1810,7 +1810,7 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="length"> The address of a variable which will receive the length of the resource name. </param>
         /// <param name="name"> The address of a character array into which will be written the name of the resource. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglGetProgramResourceName.xhtml" /></remarks>
-        public static void GetProgramResourceName(ProgramHandle program, ProgramInterface programInterface, uint index, int bufSize, int* length, byte* name) => GLPointers._GetProgramResourceName_fnptr((int)program, (uint)programInterface, index, bufSize, length, name);
+        public static void GetProgramResourceName(int program, ProgramInterface programInterface, uint index, int bufSize, int* length, byte* name) => GLPointers._GetProgramResourceName_fnptr(program, (uint)programInterface, index, bufSize, length, name);
         
         /// <summary> <b>[requires: v3.1]</b> Retrieve values for multiple properties of a single active resource within a program object. </summary>
         /// <param name="program"> The name of a program object whose resources to query. </param>
@@ -1822,104 +1822,70 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="length">!!missing documentation!!</param>
         /// <param name="parameters">!!missing documentation!!</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglGetProgramResource.xhtml" /></remarks>
-        public static void GetProgramResourceiv(ProgramHandle program, ProgramInterface programInterface, uint index, int propCount, ProgramResourceProperty* props, int count, int* length, int* parameters) => GLPointers._GetProgramResourceiv_fnptr((int)program, (uint)programInterface, index, propCount, (uint*)props, count, length, parameters);
+        public static void GetProgramResourceiv(int program, ProgramInterface programInterface, uint index, int propCount, ProgramResourceProperty* props, int count, int* length, int* parameters) => GLPointers._GetProgramResourceiv_fnptr(program, (uint)programInterface, index, propCount, (uint*)props, count, length, parameters);
         
         /// <summary> <b>[requires: v3.1]</b> Query the location of a named resource within a program. </summary>
         /// <param name="program"> The name of a program object whose resources to query. </param>
         /// <param name="programInterface"> A token identifying the interface within program containing the resource named name. </param>
         /// <param name="name"> The name of the resource to query the location of. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglGetProgramResourceLocation.xhtml" /></remarks>
-        public static int GetProgramResourceLocation(ProgramHandle program, ProgramInterface programInterface, byte* name) => GLPointers._GetProgramResourceLocation_fnptr((int)program, (uint)programInterface, name);
+        public static int GetProgramResourceLocation(int program, ProgramInterface programInterface, byte* name) => GLPointers._GetProgramResourceLocation_fnptr(program, (uint)programInterface, name);
         
         /// <summary> <b>[requires: v3.1]</b> Bind stages of a program object to a program pipeline. </summary>
         /// <param name="pipeline"> Specifies the program pipeline object to which to bind stages from program. </param>
         /// <param name="stages"> Specifies a set of program stages to bind to the program pipeline object. </param>
         /// <param name="program"> Specifies the program object containing the shader executables to use in pipeline. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglUseProgramStages.xhtml" /></remarks>
-        public static void UseProgramStages(ProgramPipelineHandle pipeline, UseProgramStageMask stages, ProgramHandle program) => GLPointers._UseProgramStages_fnptr((int)pipeline, (uint)stages, (int)program);
+        public static void UseProgramStages(int pipeline, UseProgramStageMask stages, int program) => GLPointers._UseProgramStages_fnptr(pipeline, (uint)stages, program);
         
         /// <summary> <b>[requires: v3.1]</b> Set the active program object for a program pipeline object. </summary>
         /// <param name="pipeline"> Specifies the program pipeline object to set the active program object for. </param>
         /// <param name="program"> Specifies the program object to set as the active program pipeline object pipeline. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglActiveShaderProgram.xhtml" /></remarks>
-        public static void ActiveShaderProgram(ProgramPipelineHandle pipeline, ProgramHandle program) => GLPointers._ActiveShaderProgram_fnptr((int)pipeline, (int)program);
+        public static void ActiveShaderProgram(int pipeline, int program) => GLPointers._ActiveShaderProgram_fnptr(pipeline, program);
         
         /// <summary> <b>[requires: v3.1]</b> Create a stand-alone program from an array of null-terminated source code strings. </summary>
         /// <param name="type"> Specifies the type of shader to create. </param>
         /// <param name="count"> Specifies the number of source code strings in the array strings. </param>
         /// <param name="strings"> Specifies the address of an array of pointers to source code strings from which to create the program object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglCreateShaderProgram.xhtml" /></remarks>
-        public static ProgramHandle CreateShaderProgramv(ShaderType type, int count, byte** strings) => (ProgramHandle) GLPointers._CreateShaderProgramv_fnptr((uint)type, count, strings);
+        public static int CreateShaderProgramv(ShaderType type, int count, byte** strings) => GLPointers._CreateShaderProgramv_fnptr((uint)type, count, strings);
         
         /// <summary> <b>[requires: v3.1]</b> Bind a program pipeline to the current context. </summary>
         /// <param name="pipeline"> Specifies the name of the pipeline object to bind to the context. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglBindProgramPipeline.xhtml" /></remarks>
-        public static void BindProgramPipeline(ProgramPipelineHandle pipeline) => GLPointers._BindProgramPipeline_fnptr((int)pipeline);
+        public static void BindProgramPipeline(int pipeline) => GLPointers._BindProgramPipeline_fnptr(pipeline);
         
         /// <summary> <b>[requires: v3.1]</b> Delete program pipeline objects. </summary>
         /// <param name="n"> Specifies the number of program pipeline objects to delete. </param>
         /// <param name="pipelines"> Specifies an array of names of program pipeline objects to delete. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglDeleteProgramPipelines.xhtml" /></remarks>
-        public static void DeleteProgramPipelines(int n, ProgramPipelineHandle* pipelines) => GLPointers._DeleteProgramPipelines_fnptr(n, (int*)pipelines);
+        public static void DeleteProgramPipelines(int n, int* pipelines) => GLPointers._DeleteProgramPipelines_fnptr(n, pipelines);
         
         /// <summary> <b>[requires: v3.1]</b> Reserve program pipeline object names. </summary>
         /// <param name="n"> Specifies the number of program pipeline object names to reserve. </param>
         /// <param name="pipelines"> Specifies an array of into which the reserved names will be written. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglGenProgramPipelines.xhtml" /></remarks>
-        public static void GenProgramPipelines(int n, ProgramPipelineHandle* pipelines) => GLPointers._GenProgramPipelines_fnptr(n, (int*)pipelines);
+        public static void GenProgramPipelines(int n, int* pipelines) => GLPointers._GenProgramPipelines_fnptr(n, pipelines);
         
         /// <summary> <b>[requires: v3.1]</b> Determine if a name corresponds to a program pipeline object. </summary>
         /// <param name="pipeline"> Specifies a value that may be the name of a program pipeline object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglIsProgramPipeline.xhtml" /></remarks>
-        public static bool IsProgramPipeline(ProgramPipelineHandle pipeline) => GLPointers._IsProgramPipeline_fnptr((int)pipeline) != 0;
+        public static bool IsProgramPipeline(int pipeline) => GLPointers._IsProgramPipeline_fnptr(pipeline) != 0;
         
         /// <summary> <b>[requires: v3.1]</b> Retrieve properties of a program pipeline object. </summary>
         /// <param name="pipeline"> Specifies the name of a program pipeline object whose parameter retrieve. </param>
         /// <param name="pname"> Specifies the name of the parameter to retrieve. </param>
         /// <param name="parameters"> Specifies the address of a variable into which will be written the value or values of pname for pipeline. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglGetProgramPipeline.xhtml" /></remarks>
-        public static void GetProgramPipelineiv(ProgramPipelineHandle pipeline, PipelineParameterName pname, int* parameters) => GLPointers._GetProgramPipelineiv_fnptr((int)pipeline, (uint)pname, parameters);
+        public static void GetProgramPipelineiv(int pipeline, PipelineParameterName pname, int* parameters) => GLPointers._GetProgramPipelineiv_fnptr(pipeline, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v3.1]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
         /// <param name="v0"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform1i(ProgramHandle program, int location, int v0) => GLPointers._ProgramUniform1i_fnptr((int)program, location, v0);
-        
-        /// <summary> <b>[requires: v3.1]</b> Specify the value of a uniform variable for a specified program object. </summary>
-        /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
-        /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
-        /// <param name="v0"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
-        /// <param name="v1"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
-        /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform2i(ProgramHandle program, int location, int v0, int v1) => GLPointers._ProgramUniform2i_fnptr((int)program, location, v0, v1);
-        
-        /// <summary> <b>[requires: v3.1]</b> Specify the value of a uniform variable for a specified program object. </summary>
-        /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
-        /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
-        /// <param name="v0"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
-        /// <param name="v1"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
-        /// <param name="v2"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
-        /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform3i(ProgramHandle program, int location, int v0, int v1, int v2) => GLPointers._ProgramUniform3i_fnptr((int)program, location, v0, v1, v2);
-        
-        /// <summary> <b>[requires: v3.1]</b> Specify the value of a uniform variable for a specified program object. </summary>
-        /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
-        /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
-        /// <param name="v0"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
-        /// <param name="v1"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
-        /// <param name="v2"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
-        /// <param name="v3"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
-        /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform4i(ProgramHandle program, int location, int v0, int v1, int v2, int v3) => GLPointers._ProgramUniform4i_fnptr((int)program, location, v0, v1, v2, v3);
-        
-        /// <summary> <b>[requires: v3.1]</b> Specify the value of a uniform variable for a specified program object. </summary>
-        /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
-        /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
-        /// <param name="v0"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
-        /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform1ui(ProgramHandle program, int location, uint v0) => GLPointers._ProgramUniform1ui_fnptr((int)program, location, v0);
+        public static void ProgramUniform1i(int program, int location, int v0) => GLPointers._ProgramUniform1i_fnptr(program, location, v0);
         
         /// <summary> <b>[requires: v3.1]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -1927,7 +1893,7 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="v0"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
         /// <param name="v1"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform2ui(ProgramHandle program, int location, uint v0, uint v1) => GLPointers._ProgramUniform2ui_fnptr((int)program, location, v0, v1);
+        public static void ProgramUniform2i(int program, int location, int v0, int v1) => GLPointers._ProgramUniform2i_fnptr(program, location, v0, v1);
         
         /// <summary> <b>[requires: v3.1]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -1936,7 +1902,7 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="v1"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
         /// <param name="v2"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform3ui(ProgramHandle program, int location, uint v0, uint v1, uint v2) => GLPointers._ProgramUniform3ui_fnptr((int)program, location, v0, v1, v2);
+        public static void ProgramUniform3i(int program, int location, int v0, int v1, int v2) => GLPointers._ProgramUniform3i_fnptr(program, location, v0, v1, v2);
         
         /// <summary> <b>[requires: v3.1]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -1946,14 +1912,14 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="v2"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
         /// <param name="v3"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform4ui(ProgramHandle program, int location, uint v0, uint v1, uint v2, uint v3) => GLPointers._ProgramUniform4ui_fnptr((int)program, location, v0, v1, v2, v3);
+        public static void ProgramUniform4i(int program, int location, int v0, int v1, int v2, int v3) => GLPointers._ProgramUniform4i_fnptr(program, location, v0, v1, v2, v3);
         
         /// <summary> <b>[requires: v3.1]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
         /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
         /// <param name="v0"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform1f(ProgramHandle program, int location, float v0) => GLPointers._ProgramUniform1f_fnptr((int)program, location, v0);
+        public static void ProgramUniform1ui(int program, int location, uint v0) => GLPointers._ProgramUniform1ui_fnptr(program, location, v0);
         
         /// <summary> <b>[requires: v3.1]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -1961,7 +1927,7 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="v0"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
         /// <param name="v1"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform2f(ProgramHandle program, int location, float v0, float v1) => GLPointers._ProgramUniform2f_fnptr((int)program, location, v0, v1);
+        public static void ProgramUniform2ui(int program, int location, uint v0, uint v1) => GLPointers._ProgramUniform2ui_fnptr(program, location, v0, v1);
         
         /// <summary> <b>[requires: v3.1]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -1970,7 +1936,7 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="v1"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
         /// <param name="v2"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform3f(ProgramHandle program, int location, float v0, float v1, float v2) => GLPointers._ProgramUniform3f_fnptr((int)program, location, v0, v1, v2);
+        public static void ProgramUniform3ui(int program, int location, uint v0, uint v1, uint v2) => GLPointers._ProgramUniform3ui_fnptr(program, location, v0, v1, v2);
         
         /// <summary> <b>[requires: v3.1]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -1980,7 +1946,41 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="v2"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
         /// <param name="v3"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform4f(ProgramHandle program, int location, float v0, float v1, float v2, float v3) => GLPointers._ProgramUniform4f_fnptr((int)program, location, v0, v1, v2, v3);
+        public static void ProgramUniform4ui(int program, int location, uint v0, uint v1, uint v2, uint v3) => GLPointers._ProgramUniform4ui_fnptr(program, location, v0, v1, v2, v3);
+        
+        /// <summary> <b>[requires: v3.1]</b> Specify the value of a uniform variable for a specified program object. </summary>
+        /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
+        /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
+        /// <param name="v0"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
+        /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglProgramUniform.xhtml" /></remarks>
+        public static void ProgramUniform1f(int program, int location, float v0) => GLPointers._ProgramUniform1f_fnptr(program, location, v0);
+        
+        /// <summary> <b>[requires: v3.1]</b> Specify the value of a uniform variable for a specified program object. </summary>
+        /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
+        /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
+        /// <param name="v0"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
+        /// <param name="v1"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
+        /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglProgramUniform.xhtml" /></remarks>
+        public static void ProgramUniform2f(int program, int location, float v0, float v1) => GLPointers._ProgramUniform2f_fnptr(program, location, v0, v1);
+        
+        /// <summary> <b>[requires: v3.1]</b> Specify the value of a uniform variable for a specified program object. </summary>
+        /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
+        /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
+        /// <param name="v0"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
+        /// <param name="v1"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
+        /// <param name="v2"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
+        /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglProgramUniform.xhtml" /></remarks>
+        public static void ProgramUniform3f(int program, int location, float v0, float v1, float v2) => GLPointers._ProgramUniform3f_fnptr(program, location, v0, v1, v2);
+        
+        /// <summary> <b>[requires: v3.1]</b> Specify the value of a uniform variable for a specified program object. </summary>
+        /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
+        /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
+        /// <param name="v0"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
+        /// <param name="v1"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
+        /// <param name="v2"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
+        /// <param name="v3"> For the scalar commands, specifies the new values to be used for the specified uniform variable. </param>
+        /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglProgramUniform.xhtml" /></remarks>
+        public static void ProgramUniform4f(int program, int location, float v0, float v1, float v2, float v3) => GLPointers._ProgramUniform4f_fnptr(program, location, v0, v1, v2, v3);
         
         /// <summary> <b>[requires: v3.1]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -1988,7 +1988,7 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform1iv(ProgramHandle program, int location, int count, int* value) => GLPointers._ProgramUniform1iv_fnptr((int)program, location, count, value);
+        public static void ProgramUniform1iv(int program, int location, int count, int* value) => GLPointers._ProgramUniform1iv_fnptr(program, location, count, value);
         
         /// <summary> <b>[requires: v3.1]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -1996,7 +1996,7 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform2iv(ProgramHandle program, int location, int count, int* value) => GLPointers._ProgramUniform2iv_fnptr((int)program, location, count, value);
+        public static void ProgramUniform2iv(int program, int location, int count, int* value) => GLPointers._ProgramUniform2iv_fnptr(program, location, count, value);
         
         /// <summary> <b>[requires: v3.1]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -2004,7 +2004,7 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform3iv(ProgramHandle program, int location, int count, int* value) => GLPointers._ProgramUniform3iv_fnptr((int)program, location, count, value);
+        public static void ProgramUniform3iv(int program, int location, int count, int* value) => GLPointers._ProgramUniform3iv_fnptr(program, location, count, value);
         
         /// <summary> <b>[requires: v3.1]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -2012,7 +2012,7 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform4iv(ProgramHandle program, int location, int count, int* value) => GLPointers._ProgramUniform4iv_fnptr((int)program, location, count, value);
+        public static void ProgramUniform4iv(int program, int location, int count, int* value) => GLPointers._ProgramUniform4iv_fnptr(program, location, count, value);
         
         /// <summary> <b>[requires: v3.1]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -2020,7 +2020,7 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform1uiv(ProgramHandle program, int location, int count, uint* value) => GLPointers._ProgramUniform1uiv_fnptr((int)program, location, count, value);
+        public static void ProgramUniform1uiv(int program, int location, int count, uint* value) => GLPointers._ProgramUniform1uiv_fnptr(program, location, count, value);
         
         /// <summary> <b>[requires: v3.1]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -2028,7 +2028,7 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform2uiv(ProgramHandle program, int location, int count, uint* value) => GLPointers._ProgramUniform2uiv_fnptr((int)program, location, count, value);
+        public static void ProgramUniform2uiv(int program, int location, int count, uint* value) => GLPointers._ProgramUniform2uiv_fnptr(program, location, count, value);
         
         /// <summary> <b>[requires: v3.1]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -2036,7 +2036,7 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform3uiv(ProgramHandle program, int location, int count, uint* value) => GLPointers._ProgramUniform3uiv_fnptr((int)program, location, count, value);
+        public static void ProgramUniform3uiv(int program, int location, int count, uint* value) => GLPointers._ProgramUniform3uiv_fnptr(program, location, count, value);
         
         /// <summary> <b>[requires: v3.1]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -2044,7 +2044,7 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform4uiv(ProgramHandle program, int location, int count, uint* value) => GLPointers._ProgramUniform4uiv_fnptr((int)program, location, count, value);
+        public static void ProgramUniform4uiv(int program, int location, int count, uint* value) => GLPointers._ProgramUniform4uiv_fnptr(program, location, count, value);
         
         /// <summary> <b>[requires: v3.1]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -2052,7 +2052,7 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform1fv(ProgramHandle program, int location, int count, float* value) => GLPointers._ProgramUniform1fv_fnptr((int)program, location, count, value);
+        public static void ProgramUniform1fv(int program, int location, int count, float* value) => GLPointers._ProgramUniform1fv_fnptr(program, location, count, value);
         
         /// <summary> <b>[requires: v3.1]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -2060,7 +2060,7 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform2fv(ProgramHandle program, int location, int count, float* value) => GLPointers._ProgramUniform2fv_fnptr((int)program, location, count, value);
+        public static void ProgramUniform2fv(int program, int location, int count, float* value) => GLPointers._ProgramUniform2fv_fnptr(program, location, count, value);
         
         /// <summary> <b>[requires: v3.1]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -2068,7 +2068,7 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform3fv(ProgramHandle program, int location, int count, float* value) => GLPointers._ProgramUniform3fv_fnptr((int)program, location, count, value);
+        public static void ProgramUniform3fv(int program, int location, int count, float* value) => GLPointers._ProgramUniform3fv_fnptr(program, location, count, value);
         
         /// <summary> <b>[requires: v3.1]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -2076,52 +2076,7 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniform4fv(ProgramHandle program, int location, int count, float* value) => GLPointers._ProgramUniform4fv_fnptr((int)program, location, count, value);
-        
-        /// <summary> <b>[requires: v3.1]</b> Specify the value of a uniform variable for a specified program object. </summary>
-        /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
-        /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
-        /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
-        /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
-        /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
-        /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniformMatrix2fv(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix2fv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
-        
-        /// <summary> <b>[requires: v3.1]</b> Specify the value of a uniform variable for a specified program object. </summary>
-        /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
-        /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
-        /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
-        /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
-        /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
-        /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniformMatrix3fv(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix3fv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
-        
-        /// <summary> <b>[requires: v3.1]</b> Specify the value of a uniform variable for a specified program object. </summary>
-        /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
-        /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
-        /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
-        /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
-        /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
-        /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniformMatrix4fv(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix4fv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
-        
-        /// <summary> <b>[requires: v3.1]</b> Specify the value of a uniform variable for a specified program object. </summary>
-        /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
-        /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
-        /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
-        /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
-        /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
-        /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniformMatrix2x3fv(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix2x3fv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
-        
-        /// <summary> <b>[requires: v3.1]</b> Specify the value of a uniform variable for a specified program object. </summary>
-        /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
-        /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
-        /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
-        /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
-        /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
-        /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniformMatrix3x2fv(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix3x2fv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+        public static void ProgramUniform4fv(int program, int location, int count, float* value) => GLPointers._ProgramUniform4fv_fnptr(program, location, count, value);
         
         /// <summary> <b>[requires: v3.1]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -2130,7 +2085,7 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniformMatrix2x4fv(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix2x4fv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+        public static void ProgramUniformMatrix2fv(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix2fv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
         
         /// <summary> <b>[requires: v3.1]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -2139,7 +2094,7 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniformMatrix4x2fv(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix4x2fv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+        public static void ProgramUniformMatrix3fv(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix3fv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
         
         /// <summary> <b>[requires: v3.1]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -2148,7 +2103,7 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniformMatrix3x4fv(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix3x4fv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+        public static void ProgramUniformMatrix4fv(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix4fv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
         
         /// <summary> <b>[requires: v3.1]</b> Specify the value of a uniform variable for a specified program object. </summary>
         /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
@@ -2157,12 +2112,57 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
         /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglProgramUniform.xhtml" /></remarks>
-        public static void ProgramUniformMatrix4x3fv(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix4x3fv_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+        public static void ProgramUniformMatrix2x3fv(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix2x3fv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
+        
+        /// <summary> <b>[requires: v3.1]</b> Specify the value of a uniform variable for a specified program object. </summary>
+        /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
+        /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
+        /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
+        /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
+        /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
+        /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglProgramUniform.xhtml" /></remarks>
+        public static void ProgramUniformMatrix3x2fv(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix3x2fv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
+        
+        /// <summary> <b>[requires: v3.1]</b> Specify the value of a uniform variable for a specified program object. </summary>
+        /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
+        /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
+        /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
+        /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
+        /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
+        /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglProgramUniform.xhtml" /></remarks>
+        public static void ProgramUniformMatrix2x4fv(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix2x4fv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
+        
+        /// <summary> <b>[requires: v3.1]</b> Specify the value of a uniform variable for a specified program object. </summary>
+        /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
+        /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
+        /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
+        /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
+        /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
+        /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglProgramUniform.xhtml" /></remarks>
+        public static void ProgramUniformMatrix4x2fv(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix4x2fv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
+        
+        /// <summary> <b>[requires: v3.1]</b> Specify the value of a uniform variable for a specified program object. </summary>
+        /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
+        /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
+        /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
+        /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
+        /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
+        /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglProgramUniform.xhtml" /></remarks>
+        public static void ProgramUniformMatrix3x4fv(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix3x4fv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
+        
+        /// <summary> <b>[requires: v3.1]</b> Specify the value of a uniform variable for a specified program object. </summary>
+        /// <param name="program">Specifies the handle of the program containing the uniform variable to be modified.</param>
+        /// <param name="location">Specifies the location of the uniform variable to be modified.</param>
+        /// <param name="count"> For the vector commands (glProgramUniform*v), specifies the number of elements that are to be modified. This should be 1 if the targeted uniform variable is not an array, and 1 or more if it is an array. </param>
+        /// <param name="transpose"> For the matrix commands, specifies whether to transpose the matrix as the values are loaded into the uniform variable. </param>
+        /// <param name="value"> For the vector and matrix commands, specifies a pointer to an array of count values that will be used to update the specified uniform variable. </param>
+        /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglProgramUniform.xhtml" /></remarks>
+        public static void ProgramUniformMatrix4x3fv(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix4x3fv_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
         
         /// <summary> <b>[requires: v3.1]</b> Validate a program pipeline object against current GL state. </summary>
         /// <param name="pipeline"> Specifies the name of a program pipeline object to validate. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglValidateProgramPipeline.xhtml" /></remarks>
-        public static void ValidateProgramPipeline(ProgramPipelineHandle pipeline) => GLPointers._ValidateProgramPipeline_fnptr((int)pipeline);
+        public static void ValidateProgramPipeline(int pipeline) => GLPointers._ValidateProgramPipeline_fnptr(pipeline);
         
         /// <summary> <b>[requires: v3.1]</b> Retrieve the info log string from a program pipeline object. </summary>
         /// <param name="pipeline"> Specifies the name of a program pipeline object from which to retrieve the info log. </param>
@@ -2170,7 +2170,7 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="length"> Specifies the address of a variable into which will be written the number of characters written into infoLog. </param>
         /// <param name="infoLog"> Specifies the address of an array of characters into which will be written the info log for pipeline. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglGetProgramPipelineInfoLog.xhtml" /></remarks>
-        public static void GetProgramPipelineInfoLog(ProgramPipelineHandle pipeline, int bufSize, int* length, byte* infoLog) => GLPointers._GetProgramPipelineInfoLog_fnptr((int)pipeline, bufSize, length, infoLog);
+        public static void GetProgramPipelineInfoLog(int pipeline, int bufSize, int* length, byte* infoLog) => GLPointers._GetProgramPipelineInfoLog_fnptr(pipeline, bufSize, length, infoLog);
         
         /// <summary> <b>[requires: v3.1]</b> Bind a level of a texture to an image unit. </summary>
         /// <param name="unit"> Specifies the index of the image unit to which to bind the texture </param>
@@ -2181,7 +2181,7 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="access"> Specifies a token indicating the type of access that will be performed on the image. </param>
         /// <param name="format"> Specifies the format that the elements of the image will be treated as for the purposes of formatted loads and stores. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglBindImageTexture.xhtml" /></remarks>
-        public static void BindImageTexture(uint unit, TextureHandle texture, int level, bool layered, int layer, BufferAccessARB access, InternalFormat format) => GLPointers._BindImageTexture_fnptr(unit, (int)texture, level, (byte)(layered ? 1 : 0), layer, (uint)access, (uint)format);
+        public static void BindImageTexture(uint unit, int texture, int level, bool layered, int layer, BufferAccessARB access, InternalFormat format) => GLPointers._BindImageTexture_fnptr(unit, texture, level, (byte)(layered ? 1 : 0), layer, (uint)access, (uint)format);
         
         /// <summary> <b>[requires: v3.1]</b> Return the value or values of a selected parameter. </summary>
         /// <param name="target"> Specifies the parameter value to be returned for indexed versions of glGet. The symbolic constants in the list below are accepted. </param>
@@ -2245,7 +2245,7 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="offset"> The offset of the first element of the buffer. </param>
         /// <param name="stride"> The distance between elements within the buffer. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglBindVertexBuffer.xhtml" /></remarks>
-        public static void BindVertexBuffer(uint bindingindex, BufferHandle buffer, IntPtr offset, int stride) => GLPointers._BindVertexBuffer_fnptr(bindingindex, (int)buffer, offset, stride);
+        public static void BindVertexBuffer(uint bindingindex, int buffer, IntPtr offset, int stride) => GLPointers._BindVertexBuffer_fnptr(bindingindex, buffer, offset, stride);
         
         /// <summary> <b>[requires: v3.1]</b> Specify the organization of vertex arrays. </summary>
         /// <param name="attribindex"> The generic vertex attribute array being described. </param>
@@ -2479,7 +2479,7 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="texture"> Specifies the name of an existing texture object to attach. </param>
         /// <param name="level"> Specifies the mipmap level of the texture object to attach. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglFramebufferTexture.xhtml" /></remarks>
-        public static void FramebufferTexture(FramebufferTarget target, FramebufferAttachment attachment, TextureHandle texture, int level) => GLPointers._FramebufferTexture_fnptr((uint)target, (uint)attachment, (int)texture, level);
+        public static void FramebufferTexture(FramebufferTarget target, FramebufferAttachment attachment, int texture, int level) => GLPointers._FramebufferTexture_fnptr((uint)target, (uint)attachment, texture, level);
         
         /// <summary> <b>[requires: v3.2]</b> Set the bounding box for a primitive. </summary>
         /// <param name="minX"> Specify the minimum clip space cooridnate of the bounding box. The initial value is (-1, -1, -1, -1). </param>
@@ -2515,7 +2515,7 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="bufSize">Specifies the size of the buffer params. </param>
         /// <param name="parameters">Returns the value of the specified uniform variable.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglGetUniform.xhtml" /></remarks>
-        public static void GetnUniformfv(ProgramHandle program, int location, int bufSize, float* parameters) => GLPointers._GetnUniformfv_fnptr((int)program, location, bufSize, parameters);
+        public static void GetnUniformfv(int program, int location, int bufSize, float* parameters) => GLPointers._GetnUniformfv_fnptr(program, location, bufSize, parameters);
         
         /// <summary> <b>[requires: v3.2 | GL_KHR_robustness]</b> Returns the value of a uniform variable. </summary>
         /// <param name="program">Specifies the program object to be queried.</param>
@@ -2523,7 +2523,7 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="bufSize">Specifies the size of the buffer params. </param>
         /// <param name="parameters">Returns the value of the specified uniform variable.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglGetUniform.xhtml" /></remarks>
-        public static void GetnUniformiv(ProgramHandle program, int location, int bufSize, int* parameters) => GLPointers._GetnUniformiv_fnptr((int)program, location, bufSize, parameters);
+        public static void GetnUniformiv(int program, int location, int bufSize, int* parameters) => GLPointers._GetnUniformiv_fnptr(program, location, bufSize, parameters);
         
         /// <summary> <b>[requires: v3.2 | GL_KHR_robustness]</b> Returns the value of a uniform variable. </summary>
         /// <param name="program">Specifies the program object to be queried.</param>
@@ -2531,7 +2531,7 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="bufSize">Specifies the size of the buffer params. </param>
         /// <param name="parameters">Returns the value of the specified uniform variable.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglGetUniform.xhtml" /></remarks>
-        public static void GetnUniformuiv(ProgramHandle program, int location, int bufSize, uint* parameters) => GLPointers._GetnUniformuiv_fnptr((int)program, location, bufSize, parameters);
+        public static void GetnUniformuiv(int program, int location, int bufSize, uint* parameters) => GLPointers._GetnUniformuiv_fnptr(program, location, bufSize, parameters);
         
         /// <summary> <b>[requires: v3.2]</b> Specifies minimum rate at which sample shading takes place. </summary>
         /// <param name="value"> Specifies the rate at which samples are shaded within each covered pixel. </param>
@@ -2577,35 +2577,35 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="pname"> Specifies the symbolic name of a single-valued sampler parameter. pname can be one of the following: GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, GL_TEXTURE_WRAP_R, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_COMPARE_MODE, GL_TEXTURE_COMPARE_FUNC. </param>
         /// <param name="parameters"> For the vector commands (glSamplerParameter*v), specifies a pointer to an array where the value or values of pname are stored. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglSamplerParameter.xhtml" /></remarks>
-        public static void SamplerParameterIiv(SamplerHandle sampler, SamplerParameterI pname, int* param) => GLPointers._SamplerParameterIiv_fnptr((int)sampler, (uint)pname, param);
+        public static void SamplerParameterIiv(int sampler, SamplerParameterI pname, int* param) => GLPointers._SamplerParameterIiv_fnptr(sampler, (uint)pname, param);
         
         /// <summary> <b>[requires: v3.2]</b> Set sampler parameters. </summary>
         /// <param name="sampler"> Specifies the sampler object whose parameter to modify. </param>
         /// <param name="pname"> Specifies the symbolic name of a single-valued sampler parameter. pname can be one of the following: GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, GL_TEXTURE_WRAP_R, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_COMPARE_MODE, GL_TEXTURE_COMPARE_FUNC. </param>
         /// <param name="parameters"> For the vector commands (glSamplerParameter*v), specifies a pointer to an array where the value or values of pname are stored. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglSamplerParameter.xhtml" /></remarks>
-        public static void SamplerParameterIuiv(SamplerHandle sampler, SamplerParameterI pname, uint* param) => GLPointers._SamplerParameterIuiv_fnptr((int)sampler, (uint)pname, param);
+        public static void SamplerParameterIuiv(int sampler, SamplerParameterI pname, uint* param) => GLPointers._SamplerParameterIuiv_fnptr(sampler, (uint)pname, param);
         
         /// <summary> <b>[requires: v3.2]</b> Return sampler parameter values. </summary>
         /// <param name="sampler"> Specifies name of the sampler object from which to retrieve parameters. </param>
         /// <param name="pname"> Specifies the symbolic name of a sampler parameter. GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, GL_TEXTURE_WRAP_R, GL_TEXTURE_COMPARE_MODE, GL_TEXTURE_COMPARE_FUNC, and GL_TEXTURE_BORDER_COLOR are accepted. </param>
         /// <param name="parameters"> Returns the sampler parameters. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglGetSamplerParameter.xhtml" /></remarks>
-        public static void GetSamplerParameterIiv(SamplerHandle sampler, SamplerParameterI pname, int* parameters) => GLPointers._GetSamplerParameterIiv_fnptr((int)sampler, (uint)pname, parameters);
+        public static void GetSamplerParameterIiv(int sampler, SamplerParameterI pname, int* parameters) => GLPointers._GetSamplerParameterIiv_fnptr(sampler, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v3.2]</b> Return sampler parameter values. </summary>
         /// <param name="sampler"> Specifies name of the sampler object from which to retrieve parameters. </param>
         /// <param name="pname"> Specifies the symbolic name of a sampler parameter. GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MIN_FILTER, GL_TEXTURE_MIN_LOD, GL_TEXTURE_MAX_LOD, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, GL_TEXTURE_WRAP_R, GL_TEXTURE_COMPARE_MODE, GL_TEXTURE_COMPARE_FUNC, and GL_TEXTURE_BORDER_COLOR are accepted. </param>
         /// <param name="parameters"> Returns the sampler parameters. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglGetSamplerParameter.xhtml" /></remarks>
-        public static void GetSamplerParameterIuiv(SamplerHandle sampler, SamplerParameterI pname, uint* parameters) => GLPointers._GetSamplerParameterIuiv_fnptr((int)sampler, (uint)pname, parameters);
+        public static void GetSamplerParameterIuiv(int sampler, SamplerParameterI pname, uint* parameters) => GLPointers._GetSamplerParameterIuiv_fnptr(sampler, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v3.2]</b> Attach a buffer object's data store to a buffer texture object. </summary>
         /// <param name="target"> Specifies the target to which the texture is bound for glTexBuffer. Must be GL_TEXTURE_BUFFER. </param>
         /// <param name="internalFormat"> Specifies the internal format of the data in the store belonging to buffer. </param>
         /// <param name="buffer"> Specifies the name of the buffer object whose storage to attach to the active buffer texture. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglTexBuffer.xhtml" /></remarks>
-        public static void TexBuffer(TextureTarget target, SizedInternalFormat internalformat, BufferHandle buffer) => GLPointers._TexBuffer_fnptr((uint)target, (uint)internalformat, (int)buffer);
+        public static void TexBuffer(TextureTarget target, SizedInternalFormat internalformat, int buffer) => GLPointers._TexBuffer_fnptr((uint)target, (uint)internalformat, buffer);
         
         /// <summary> <b>[requires: v3.2]</b> Attach a range of a buffer object's data store to a buffer texture object. </summary>
         /// <param name="target"> Specifies the target to which the texture object is bound for glTexBufferRange. Must be GL_TEXTURE_BUFFER. </param>
@@ -2614,7 +2614,7 @@ namespace OpenTK.Graphics.OpenGLES3
         /// <param name="offset"> Specifies the offset of the start of the range of the buffer's data store to attach. </param>
         /// <param name="size"> Specifies the size of the range of the buffer's data store to attach. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglTexBufferRange.xhtml" /></remarks>
-        public static void TexBufferRange(TextureTarget target, SizedInternalFormat internalformat, BufferHandle buffer, IntPtr offset, nint size) => GLPointers._TexBufferRange_fnptr((uint)target, (uint)internalformat, (int)buffer, offset, size);
+        public static void TexBufferRange(TextureTarget target, SizedInternalFormat internalformat, int buffer, IntPtr offset, nint size) => GLPointers._TexBufferRange_fnptr((uint)target, (uint)internalformat, buffer, offset, size);
         
         /// <summary> <b>[requires: v3.2]</b> Specify storage for a two-dimensional multisample array texture. </summary>
         /// <param name="target"> Specifies the target to which the texture object is bound for glTexStorage3DMultisample. Must be GL_TEXTURE_2D_MULTISAMPLE_ARRAY. </param>
@@ -2635,7 +2635,7 @@ namespace OpenTK.Graphics.OpenGLES3
             
             /// <summary> <b>[requires: GL_AMD_framebuffer_multisample_advanced]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedRenderbufferStorageMultisampleAdvancedAMD(RenderbufferHandle renderbuffer, int samples, int storageSamples, InternalFormat internalformat, int width, int height) => GLPointers._NamedRenderbufferStorageMultisampleAdvancedAMD_fnptr((int)renderbuffer, samples, storageSamples, (uint)internalformat, width, height);
+            public static void NamedRenderbufferStorageMultisampleAdvancedAMD(int renderbuffer, int samples, int storageSamples, InternalFormat internalformat, int width, int height) => GLPointers._NamedRenderbufferStorageMultisampleAdvancedAMD_fnptr(renderbuffer, samples, storageSamples, (uint)internalformat, width, height);
             
             /// <summary> <b>[requires: GL_AMD_performance_monitor]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -2706,7 +2706,7 @@ namespace OpenTK.Graphics.OpenGLES3
             
             /// <summary> <b>[requires: GL_ANGLE_translated_shader_source]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetTranslatedShaderSourceANGLE(ShaderHandle shader, int bufSize, int* length, byte* source) => GLPointers._GetTranslatedShaderSourceANGLE_fnptr((int)shader, bufSize, length, source);
+            public static void GetTranslatedShaderSourceANGLE(int shader, int bufSize, int* length, byte* source) => GLPointers._GetTranslatedShaderSourceANGLE_fnptr(shader, bufSize, length, source);
             
         }
         public static unsafe partial class APPLE
@@ -2760,7 +2760,7 @@ namespace OpenTK.Graphics.OpenGLES3
             
             /// <summary> <b>[requires: GL_EXT_EGL_image_storage]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void EGLImageTargetTextureStorageEXT(TextureHandle texture, void* image, int* attrib_list) => GLPointers._EGLImageTargetTextureStorageEXT_fnptr((int)texture, image, attrib_list);
+            public static void EGLImageTargetTextureStorageEXT(int texture, void* image, int* attrib_list) => GLPointers._EGLImageTargetTextureStorageEXT_fnptr(texture, image, attrib_list);
             
             /// <summary> <b>[requires: GL_EXT_base_instance]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -2776,19 +2776,19 @@ namespace OpenTK.Graphics.OpenGLES3
             
             /// <summary> <b>[requires: GL_EXT_blend_func_extended]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void BindFragDataLocationIndexedEXT(ProgramHandle program, uint colorNumber, uint index, byte* name) => GLPointers._BindFragDataLocationIndexedEXT_fnptr((int)program, colorNumber, index, name);
+            public static void BindFragDataLocationIndexedEXT(int program, uint colorNumber, uint index, byte* name) => GLPointers._BindFragDataLocationIndexedEXT_fnptr(program, colorNumber, index, name);
             
             /// <summary> <b>[requires: GL_EXT_blend_func_extended]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void BindFragDataLocationEXT(ProgramHandle program, uint color, byte* name) => GLPointers._BindFragDataLocationEXT_fnptr((int)program, color, name);
+            public static void BindFragDataLocationEXT(int program, uint color, byte* name) => GLPointers._BindFragDataLocationEXT_fnptr(program, color, name);
             
             /// <summary> <b>[requires: GL_EXT_blend_func_extended]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static int GetProgramResourceLocationIndexEXT(ProgramHandle program, ProgramInterface programInterface, byte* name) => GLPointers._GetProgramResourceLocationIndexEXT_fnptr((int)program, (uint)programInterface, name);
+            public static int GetProgramResourceLocationIndexEXT(int program, ProgramInterface programInterface, byte* name) => GLPointers._GetProgramResourceLocationIndexEXT_fnptr(program, (uint)programInterface, name);
             
             /// <summary> <b>[requires: GL_EXT_blend_func_extended]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static int GetFragDataIndexEXT(ProgramHandle program, byte* name) => GLPointers._GetFragDataIndexEXT_fnptr((int)program, name);
+            public static int GetFragDataIndexEXT(int program, byte* name) => GLPointers._GetFragDataIndexEXT_fnptr(program, name);
             
             /// <summary> <b>[requires: GL_EXT_blend_minmax]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -2800,11 +2800,11 @@ namespace OpenTK.Graphics.OpenGLES3
             
             /// <summary> <b>[requires: GL_EXT_clear_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ClearTexImageEXT(TextureHandle texture, int level, PixelFormat format, PixelType type, void* data) => GLPointers._ClearTexImageEXT_fnptr((int)texture, level, (uint)format, (uint)type, data);
+            public static void ClearTexImageEXT(int texture, int level, PixelFormat format, PixelType type, void* data) => GLPointers._ClearTexImageEXT_fnptr(texture, level, (uint)format, (uint)type, data);
             
             /// <summary> <b>[requires: GL_EXT_clear_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ClearTexSubImageEXT(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, void* data) => GLPointers._ClearTexSubImageEXT_fnptr((int)texture, level, xoffset, yoffset, zoffset, width, height, depth, (uint)format, (uint)type, data);
+            public static void ClearTexSubImageEXT(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, void* data) => GLPointers._ClearTexSubImageEXT_fnptr(texture, level, xoffset, yoffset, zoffset, width, height, depth, (uint)format, (uint)type, data);
             
             /// <summary> <b>[requires: GL_EXT_clip_control]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -2840,19 +2840,19 @@ namespace OpenTK.Graphics.OpenGLES3
             
             /// <summary> <b>[requires: GL_EXT_disjoint_timer_query | GL_EXT_occlusion_query_boolean]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GenQueriesEXT(int n, QueryHandle* ids) => GLPointers._GenQueriesEXT_fnptr(n, (int*)ids);
+            public static void GenQueriesEXT(int n, int* ids) => GLPointers._GenQueriesEXT_fnptr(n, ids);
             
             /// <summary> <b>[requires: GL_EXT_disjoint_timer_query | GL_EXT_occlusion_query_boolean]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void DeleteQueriesEXT(int n, QueryHandle* ids) => GLPointers._DeleteQueriesEXT_fnptr(n, (int*)ids);
+            public static void DeleteQueriesEXT(int n, int* ids) => GLPointers._DeleteQueriesEXT_fnptr(n, ids);
             
             /// <summary> <b>[requires: GL_EXT_disjoint_timer_query | GL_EXT_occlusion_query_boolean]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static bool IsQueryEXT(QueryHandle id) => GLPointers._IsQueryEXT_fnptr((int)id) != 0;
+            public static bool IsQueryEXT(int id) => GLPointers._IsQueryEXT_fnptr(id) != 0;
             
             /// <summary> <b>[requires: GL_EXT_disjoint_timer_query | GL_EXT_occlusion_query_boolean]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void BeginQueryEXT(QueryTarget target, QueryHandle id) => GLPointers._BeginQueryEXT_fnptr((uint)target, (int)id);
+            public static void BeginQueryEXT(QueryTarget target, int id) => GLPointers._BeginQueryEXT_fnptr((uint)target, id);
             
             /// <summary> <b>[requires: GL_EXT_disjoint_timer_query | GL_EXT_occlusion_query_boolean]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -2860,7 +2860,7 @@ namespace OpenTK.Graphics.OpenGLES3
             
             /// <summary> <b>[requires: GL_EXT_disjoint_timer_query]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void QueryCounterEXT(QueryHandle id, QueryCounterTarget target) => GLPointers._QueryCounterEXT_fnptr((int)id, (uint)target);
+            public static void QueryCounterEXT(int id, QueryCounterTarget target) => GLPointers._QueryCounterEXT_fnptr(id, (uint)target);
             
             /// <summary> <b>[requires: GL_EXT_disjoint_timer_query | GL_EXT_occlusion_query_boolean]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -2868,19 +2868,19 @@ namespace OpenTK.Graphics.OpenGLES3
             
             /// <summary> <b>[requires: GL_EXT_disjoint_timer_query]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetQueryObjectivEXT(QueryHandle id, QueryObjectParameterName pname, int* parameters) => GLPointers._GetQueryObjectivEXT_fnptr((int)id, (uint)pname, parameters);
+            public static void GetQueryObjectivEXT(int id, QueryObjectParameterName pname, int* parameters) => GLPointers._GetQueryObjectivEXT_fnptr(id, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_EXT_disjoint_timer_query | GL_EXT_occlusion_query_boolean]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetQueryObjectuivEXT(QueryHandle id, QueryObjectParameterName pname, uint* parameters) => GLPointers._GetQueryObjectuivEXT_fnptr((int)id, (uint)pname, parameters);
+            public static void GetQueryObjectuivEXT(int id, QueryObjectParameterName pname, uint* parameters) => GLPointers._GetQueryObjectuivEXT_fnptr(id, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_EXT_disjoint_timer_query]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetQueryObjecti64vEXT(QueryHandle id, QueryObjectParameterName pname, long* parameters) => GLPointers._GetQueryObjecti64vEXT_fnptr((int)id, (uint)pname, parameters);
+            public static void GetQueryObjecti64vEXT(int id, QueryObjectParameterName pname, long* parameters) => GLPointers._GetQueryObjecti64vEXT_fnptr(id, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_EXT_disjoint_timer_query]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetQueryObjectui64vEXT(QueryHandle id, QueryObjectParameterName pname, ulong* parameters) => GLPointers._GetQueryObjectui64vEXT_fnptr((int)id, (uint)pname, parameters);
+            public static void GetQueryObjectui64vEXT(int id, QueryObjectParameterName pname, ulong* parameters) => GLPointers._GetQueryObjectui64vEXT_fnptr(id, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_EXT_disjoint_timer_query]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -2948,11 +2948,11 @@ namespace OpenTK.Graphics.OpenGLES3
             
             /// <summary> <b>[requires: GL_EXT_draw_transform_feedback]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void DrawTransformFeedbackEXT(PrimitiveType mode, TransformFeedbackHandle id) => GLPointers._DrawTransformFeedbackEXT_fnptr((uint)mode, (int)id);
+            public static void DrawTransformFeedbackEXT(PrimitiveType mode, int id) => GLPointers._DrawTransformFeedbackEXT_fnptr((uint)mode, id);
             
             /// <summary> <b>[requires: GL_EXT_draw_transform_feedback]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void DrawTransformFeedbackInstancedEXT(PrimitiveType mode, TransformFeedbackHandle id, int instancecount) => GLPointers._DrawTransformFeedbackInstancedEXT_fnptr((uint)mode, (int)id, instancecount);
+            public static void DrawTransformFeedbackInstancedEXT(PrimitiveType mode, int id, int instancecount) => GLPointers._DrawTransformFeedbackInstancedEXT_fnptr((uint)mode, id, instancecount);
             
             /// <summary> <b>[requires: GL_EXT_external_buffer]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -2960,7 +2960,7 @@ namespace OpenTK.Graphics.OpenGLES3
             
             /// <summary> <b>[requires: GL_EXT_external_buffer]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedBufferStorageExternalEXT(BufferHandle buffer, IntPtr offset, nint size, void* clientBuffer, BufferStorageMask flags) => GLPointers._NamedBufferStorageExternalEXT_fnptr((int)buffer, offset, size, clientBuffer, (uint)flags);
+            public static void NamedBufferStorageExternalEXT(int buffer, IntPtr offset, nint size, void* clientBuffer, BufferStorageMask flags) => GLPointers._NamedBufferStorageExternalEXT_fnptr(buffer, offset, size, clientBuffer, (uint)flags);
             
             /// <summary> <b>[requires: GL_EXT_fragment_shading_rate]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -2976,11 +2976,11 @@ namespace OpenTK.Graphics.OpenGLES3
             
             /// <summary> <b>[requires: GL_EXT_fragment_shading_rate]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void FramebufferShadingRateEXT(FramebufferTarget target, FramebufferAttachment attachment, TextureHandle texture, int baseLayer, int numLayers, int texelWidth, int texelHeight) => GLPointers._FramebufferShadingRateEXT_fnptr((uint)target, (uint)attachment, (int)texture, baseLayer, numLayers, texelWidth, texelHeight);
+            public static void FramebufferShadingRateEXT(FramebufferTarget target, FramebufferAttachment attachment, int texture, int baseLayer, int numLayers, int texelWidth, int texelHeight) => GLPointers._FramebufferShadingRateEXT_fnptr((uint)target, (uint)attachment, texture, baseLayer, numLayers, texelWidth, texelHeight);
             
             /// <summary> <b>[requires: GL_EXT_geometry_shader]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void FramebufferTextureEXT(FramebufferTarget target, FramebufferAttachment attachment, TextureHandle texture, int level) => GLPointers._FramebufferTextureEXT_fnptr((uint)target, (uint)attachment, (int)texture, level);
+            public static void FramebufferTextureEXT(FramebufferTarget target, FramebufferAttachment attachment, int texture, int level) => GLPointers._FramebufferTextureEXT_fnptr((uint)target, (uint)attachment, texture, level);
             
             /// <summary> <b>[requires: GL_EXT_instanced_arrays]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -3044,23 +3044,23 @@ namespace OpenTK.Graphics.OpenGLES3
             
             /// <summary> <b>[requires: GL_EXT_memory_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureStorageMem2DEXT(TextureHandle texture, int levels, SizedInternalFormat internalFormat, int width, int height, uint memory, ulong offset) => GLPointers._TextureStorageMem2DEXT_fnptr((int)texture, levels, (uint)internalFormat, width, height, memory, offset);
+            public static void TextureStorageMem2DEXT(int texture, int levels, SizedInternalFormat internalFormat, int width, int height, uint memory, ulong offset) => GLPointers._TextureStorageMem2DEXT_fnptr(texture, levels, (uint)internalFormat, width, height, memory, offset);
             
             /// <summary> <b>[requires: GL_EXT_memory_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureStorageMem2DMultisampleEXT(TextureHandle texture, int samples, SizedInternalFormat internalFormat, int width, int height, bool fixedSampleLocations, uint memory, ulong offset) => GLPointers._TextureStorageMem2DMultisampleEXT_fnptr((int)texture, samples, (uint)internalFormat, width, height, (byte)(fixedSampleLocations ? 1 : 0), memory, offset);
+            public static void TextureStorageMem2DMultisampleEXT(int texture, int samples, SizedInternalFormat internalFormat, int width, int height, bool fixedSampleLocations, uint memory, ulong offset) => GLPointers._TextureStorageMem2DMultisampleEXT_fnptr(texture, samples, (uint)internalFormat, width, height, (byte)(fixedSampleLocations ? 1 : 0), memory, offset);
             
             /// <summary> <b>[requires: GL_EXT_memory_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureStorageMem3DEXT(TextureHandle texture, int levels, SizedInternalFormat internalFormat, int width, int height, int depth, uint memory, ulong offset) => GLPointers._TextureStorageMem3DEXT_fnptr((int)texture, levels, (uint)internalFormat, width, height, depth, memory, offset);
+            public static void TextureStorageMem3DEXT(int texture, int levels, SizedInternalFormat internalFormat, int width, int height, int depth, uint memory, ulong offset) => GLPointers._TextureStorageMem3DEXT_fnptr(texture, levels, (uint)internalFormat, width, height, depth, memory, offset);
             
             /// <summary> <b>[requires: GL_EXT_memory_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureStorageMem3DMultisampleEXT(TextureHandle texture, int samples, SizedInternalFormat internalFormat, int width, int height, int depth, bool fixedSampleLocations, uint memory, ulong offset) => GLPointers._TextureStorageMem3DMultisampleEXT_fnptr((int)texture, samples, (uint)internalFormat, width, height, depth, (byte)(fixedSampleLocations ? 1 : 0), memory, offset);
+            public static void TextureStorageMem3DMultisampleEXT(int texture, int samples, SizedInternalFormat internalFormat, int width, int height, int depth, bool fixedSampleLocations, uint memory, ulong offset) => GLPointers._TextureStorageMem3DMultisampleEXT_fnptr(texture, samples, (uint)internalFormat, width, height, depth, (byte)(fixedSampleLocations ? 1 : 0), memory, offset);
             
             /// <summary> <b>[requires: GL_EXT_memory_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedBufferStorageMemEXT(BufferHandle buffer, nint size, uint memory, ulong offset) => GLPointers._NamedBufferStorageMemEXT_fnptr((int)buffer, size, memory, offset);
+            public static void NamedBufferStorageMemEXT(int buffer, nint size, uint memory, ulong offset) => GLPointers._NamedBufferStorageMemEXT_fnptr(buffer, size, memory, offset);
             
             /// <summary> <b>[requires: GL_EXT_memory_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -3068,7 +3068,7 @@ namespace OpenTK.Graphics.OpenGLES3
             
             /// <summary> <b>[requires: GL_EXT_memory_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureStorageMem1DEXT(TextureHandle texture, int levels, SizedInternalFormat internalFormat, int width, uint memory, ulong offset) => GLPointers._TextureStorageMem1DEXT_fnptr((int)texture, levels, (uint)internalFormat, width, memory, offset);
+            public static void TextureStorageMem1DEXT(int texture, int levels, SizedInternalFormat internalFormat, int width, uint memory, ulong offset) => GLPointers._TextureStorageMem1DEXT_fnptr(texture, levels, (uint)internalFormat, width, memory, offset);
             
             /// <summary> <b>[requires: GL_EXT_memory_object_fd]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -3104,7 +3104,7 @@ namespace OpenTK.Graphics.OpenGLES3
             
             /// <summary> <b>[requires: GL_EXT_multisampled_render_to_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void FramebufferTexture2DMultisampleEXT(FramebufferTarget target, FramebufferAttachment attachment, TextureTarget textarget, TextureHandle texture, int level, int samples) => GLPointers._FramebufferTexture2DMultisampleEXT_fnptr((uint)target, (uint)attachment, (uint)textarget, (int)texture, level, samples);
+            public static void FramebufferTexture2DMultisampleEXT(FramebufferTarget target, FramebufferAttachment attachment, TextureTarget textarget, int texture, int level, int samples) => GLPointers._FramebufferTexture2DMultisampleEXT_fnptr((uint)target, (uint)attachment, (uint)textarget, texture, level, samples);
             
             /// <summary> <b>[requires: GL_EXT_multiview_draw_buffers]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -3140,11 +3140,11 @@ namespace OpenTK.Graphics.OpenGLES3
             
             /// <summary> <b>[requires: GL_EXT_robustness]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetnUniformfvEXT(ProgramHandle program, int location, int bufSize, float* parameters) => GLPointers._GetnUniformfvEXT_fnptr((int)program, location, bufSize, parameters);
+            public static void GetnUniformfvEXT(int program, int location, int bufSize, float* parameters) => GLPointers._GetnUniformfvEXT_fnptr(program, location, bufSize, parameters);
             
             /// <summary> <b>[requires: GL_EXT_robustness]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetnUniformivEXT(ProgramHandle program, int location, int bufSize, int* parameters) => GLPointers._GetnUniformivEXT_fnptr((int)program, location, bufSize, parameters);
+            public static void GetnUniformivEXT(int program, int location, int bufSize, int* parameters) => GLPointers._GetnUniformivEXT_fnptr(program, location, bufSize, parameters);
             
             /// <summary> <b>[requires: GL_EXT_semaphore]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -3168,11 +3168,11 @@ namespace OpenTK.Graphics.OpenGLES3
             
             /// <summary> <b>[requires: GL_EXT_semaphore]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void WaitSemaphoreEXT(uint semaphore, uint numBufferBarriers, BufferHandle* buffers, uint numTextureBarriers, TextureHandle* textures, TextureLayout* srcLayouts) => GLPointers._WaitSemaphoreEXT_fnptr(semaphore, numBufferBarriers, (int*)buffers, numTextureBarriers, (int*)textures, (uint*)srcLayouts);
+            public static void WaitSemaphoreEXT(uint semaphore, uint numBufferBarriers, int* buffers, uint numTextureBarriers, int* textures, TextureLayout* srcLayouts) => GLPointers._WaitSemaphoreEXT_fnptr(semaphore, numBufferBarriers, buffers, numTextureBarriers, textures, (uint*)srcLayouts);
             
             /// <summary> <b>[requires: GL_EXT_semaphore]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void SignalSemaphoreEXT(uint semaphore, uint numBufferBarriers, BufferHandle* buffers, uint numTextureBarriers, TextureHandle* textures, TextureLayout* dstLayouts) => GLPointers._SignalSemaphoreEXT_fnptr(semaphore, numBufferBarriers, (int*)buffers, numTextureBarriers, (int*)textures, (uint*)dstLayouts);
+            public static void SignalSemaphoreEXT(uint semaphore, uint numBufferBarriers, int* buffers, uint numTextureBarriers, int* textures, TextureLayout* dstLayouts) => GLPointers._SignalSemaphoreEXT_fnptr(semaphore, numBufferBarriers, buffers, numTextureBarriers, textures, (uint*)dstLayouts);
             
             /// <summary> <b>[requires: GL_EXT_semaphore_fd]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -3188,191 +3188,191 @@ namespace OpenTK.Graphics.OpenGLES3
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void UseShaderProgramEXT(All type, ProgramHandle program) => GLPointers._UseShaderProgramEXT_fnptr((uint)type, (int)program);
+            public static void UseShaderProgramEXT(All type, int program) => GLPointers._UseShaderProgramEXT_fnptr((uint)type, program);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ActiveProgramEXT(ProgramHandle program) => GLPointers._ActiveProgramEXT_fnptr((int)program);
+            public static void ActiveProgramEXT(int program) => GLPointers._ActiveProgramEXT_fnptr(program);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static ProgramHandle CreateShaderProgramEXT(ShaderType type, byte* str) => (ProgramHandle) GLPointers._CreateShaderProgramEXT_fnptr((uint)type, str);
+            public static int CreateShaderProgramEXT(ShaderType type, byte* str) => GLPointers._CreateShaderProgramEXT_fnptr((uint)type, str);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ActiveShaderProgramEXT(ProgramPipelineHandle pipeline, ProgramHandle program) => GLPointers._ActiveShaderProgramEXT_fnptr((int)pipeline, (int)program);
+            public static void ActiveShaderProgramEXT(int pipeline, int program) => GLPointers._ActiveShaderProgramEXT_fnptr(pipeline, program);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void BindProgramPipelineEXT(ProgramPipelineHandle pipeline) => GLPointers._BindProgramPipelineEXT_fnptr((int)pipeline);
+            public static void BindProgramPipelineEXT(int pipeline) => GLPointers._BindProgramPipelineEXT_fnptr(pipeline);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static ProgramHandle CreateShaderProgramvEXT(ShaderType type, int count, byte** strings) => (ProgramHandle) GLPointers._CreateShaderProgramvEXT_fnptr((uint)type, count, strings);
+            public static int CreateShaderProgramvEXT(ShaderType type, int count, byte** strings) => GLPointers._CreateShaderProgramvEXT_fnptr((uint)type, count, strings);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void DeleteProgramPipelinesEXT(int n, ProgramPipelineHandle* pipelines) => GLPointers._DeleteProgramPipelinesEXT_fnptr(n, (int*)pipelines);
+            public static void DeleteProgramPipelinesEXT(int n, int* pipelines) => GLPointers._DeleteProgramPipelinesEXT_fnptr(n, pipelines);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GenProgramPipelinesEXT(int n, ProgramPipelineHandle* pipelines) => GLPointers._GenProgramPipelinesEXT_fnptr(n, (int*)pipelines);
+            public static void GenProgramPipelinesEXT(int n, int* pipelines) => GLPointers._GenProgramPipelinesEXT_fnptr(n, pipelines);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetProgramPipelineInfoLogEXT(ProgramPipelineHandle pipeline, int bufSize, int* length, byte* infoLog) => GLPointers._GetProgramPipelineInfoLogEXT_fnptr((int)pipeline, bufSize, length, infoLog);
+            public static void GetProgramPipelineInfoLogEXT(int pipeline, int bufSize, int* length, byte* infoLog) => GLPointers._GetProgramPipelineInfoLogEXT_fnptr(pipeline, bufSize, length, infoLog);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetProgramPipelineivEXT(ProgramPipelineHandle pipeline, PipelineParameterName pname, int* parameters) => GLPointers._GetProgramPipelineivEXT_fnptr((int)pipeline, (uint)pname, parameters);
+            public static void GetProgramPipelineivEXT(int pipeline, PipelineParameterName pname, int* parameters) => GLPointers._GetProgramPipelineivEXT_fnptr(pipeline, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static bool IsProgramPipelineEXT(ProgramPipelineHandle pipeline) => GLPointers._IsProgramPipelineEXT_fnptr((int)pipeline) != 0;
+            public static bool IsProgramPipelineEXT(int pipeline) => GLPointers._IsProgramPipelineEXT_fnptr(pipeline) != 0;
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramParameteriEXT(ProgramHandle program, ProgramParameterPName pname, int value) => GLPointers._ProgramParameteriEXT_fnptr((int)program, (uint)pname, value);
+            public static void ProgramParameteriEXT(int program, ProgramParameterPName pname, int value) => GLPointers._ProgramParameteriEXT_fnptr(program, (uint)pname, value);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform1fEXT(ProgramHandle program, int location, float v0) => GLPointers._ProgramUniform1fEXT_fnptr((int)program, location, v0);
+            public static void ProgramUniform1fEXT(int program, int location, float v0) => GLPointers._ProgramUniform1fEXT_fnptr(program, location, v0);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform1fvEXT(ProgramHandle program, int location, int count, float* value) => GLPointers._ProgramUniform1fvEXT_fnptr((int)program, location, count, value);
+            public static void ProgramUniform1fvEXT(int program, int location, int count, float* value) => GLPointers._ProgramUniform1fvEXT_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform1iEXT(ProgramHandle program, int location, int v0) => GLPointers._ProgramUniform1iEXT_fnptr((int)program, location, v0);
+            public static void ProgramUniform1iEXT(int program, int location, int v0) => GLPointers._ProgramUniform1iEXT_fnptr(program, location, v0);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform1ivEXT(ProgramHandle program, int location, int count, int* value) => GLPointers._ProgramUniform1ivEXT_fnptr((int)program, location, count, value);
+            public static void ProgramUniform1ivEXT(int program, int location, int count, int* value) => GLPointers._ProgramUniform1ivEXT_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform2fEXT(ProgramHandle program, int location, float v0, float v1) => GLPointers._ProgramUniform2fEXT_fnptr((int)program, location, v0, v1);
+            public static void ProgramUniform2fEXT(int program, int location, float v0, float v1) => GLPointers._ProgramUniform2fEXT_fnptr(program, location, v0, v1);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform2fvEXT(ProgramHandle program, int location, int count, float* value) => GLPointers._ProgramUniform2fvEXT_fnptr((int)program, location, count, value);
+            public static void ProgramUniform2fvEXT(int program, int location, int count, float* value) => GLPointers._ProgramUniform2fvEXT_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform2iEXT(ProgramHandle program, int location, int v0, int v1) => GLPointers._ProgramUniform2iEXT_fnptr((int)program, location, v0, v1);
+            public static void ProgramUniform2iEXT(int program, int location, int v0, int v1) => GLPointers._ProgramUniform2iEXT_fnptr(program, location, v0, v1);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform2ivEXT(ProgramHandle program, int location, int count, int* value) => GLPointers._ProgramUniform2ivEXT_fnptr((int)program, location, count, value);
+            public static void ProgramUniform2ivEXT(int program, int location, int count, int* value) => GLPointers._ProgramUniform2ivEXT_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform3fEXT(ProgramHandle program, int location, float v0, float v1, float v2) => GLPointers._ProgramUniform3fEXT_fnptr((int)program, location, v0, v1, v2);
+            public static void ProgramUniform3fEXT(int program, int location, float v0, float v1, float v2) => GLPointers._ProgramUniform3fEXT_fnptr(program, location, v0, v1, v2);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform3fvEXT(ProgramHandle program, int location, int count, float* value) => GLPointers._ProgramUniform3fvEXT_fnptr((int)program, location, count, value);
+            public static void ProgramUniform3fvEXT(int program, int location, int count, float* value) => GLPointers._ProgramUniform3fvEXT_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform3iEXT(ProgramHandle program, int location, int v0, int v1, int v2) => GLPointers._ProgramUniform3iEXT_fnptr((int)program, location, v0, v1, v2);
+            public static void ProgramUniform3iEXT(int program, int location, int v0, int v1, int v2) => GLPointers._ProgramUniform3iEXT_fnptr(program, location, v0, v1, v2);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform3ivEXT(ProgramHandle program, int location, int count, int* value) => GLPointers._ProgramUniform3ivEXT_fnptr((int)program, location, count, value);
+            public static void ProgramUniform3ivEXT(int program, int location, int count, int* value) => GLPointers._ProgramUniform3ivEXT_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform4fEXT(ProgramHandle program, int location, float v0, float v1, float v2, float v3) => GLPointers._ProgramUniform4fEXT_fnptr((int)program, location, v0, v1, v2, v3);
+            public static void ProgramUniform4fEXT(int program, int location, float v0, float v1, float v2, float v3) => GLPointers._ProgramUniform4fEXT_fnptr(program, location, v0, v1, v2, v3);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform4fvEXT(ProgramHandle program, int location, int count, float* value) => GLPointers._ProgramUniform4fvEXT_fnptr((int)program, location, count, value);
+            public static void ProgramUniform4fvEXT(int program, int location, int count, float* value) => GLPointers._ProgramUniform4fvEXT_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform4iEXT(ProgramHandle program, int location, int v0, int v1, int v2, int v3) => GLPointers._ProgramUniform4iEXT_fnptr((int)program, location, v0, v1, v2, v3);
+            public static void ProgramUniform4iEXT(int program, int location, int v0, int v1, int v2, int v3) => GLPointers._ProgramUniform4iEXT_fnptr(program, location, v0, v1, v2, v3);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform4ivEXT(ProgramHandle program, int location, int count, int* value) => GLPointers._ProgramUniform4ivEXT_fnptr((int)program, location, count, value);
+            public static void ProgramUniform4ivEXT(int program, int location, int count, int* value) => GLPointers._ProgramUniform4ivEXT_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix2fvEXT(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix2fvEXT_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix2fvEXT(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix2fvEXT_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix3fvEXT(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix3fvEXT_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix3fvEXT(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix3fvEXT_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix4fvEXT(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix4fvEXT_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix4fvEXT(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix4fvEXT_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void UseProgramStagesEXT(ProgramPipelineHandle pipeline, UseProgramStageMask stages, ProgramHandle program) => GLPointers._UseProgramStagesEXT_fnptr((int)pipeline, (uint)stages, (int)program);
+            public static void UseProgramStagesEXT(int pipeline, UseProgramStageMask stages, int program) => GLPointers._UseProgramStagesEXT_fnptr(pipeline, (uint)stages, program);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ValidateProgramPipelineEXT(ProgramPipelineHandle pipeline) => GLPointers._ValidateProgramPipelineEXT_fnptr((int)pipeline);
+            public static void ValidateProgramPipelineEXT(int pipeline) => GLPointers._ValidateProgramPipelineEXT_fnptr(pipeline);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform1uiEXT(ProgramHandle program, int location, uint v0) => GLPointers._ProgramUniform1uiEXT_fnptr((int)program, location, v0);
+            public static void ProgramUniform1uiEXT(int program, int location, uint v0) => GLPointers._ProgramUniform1uiEXT_fnptr(program, location, v0);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform2uiEXT(ProgramHandle program, int location, uint v0, uint v1) => GLPointers._ProgramUniform2uiEXT_fnptr((int)program, location, v0, v1);
+            public static void ProgramUniform2uiEXT(int program, int location, uint v0, uint v1) => GLPointers._ProgramUniform2uiEXT_fnptr(program, location, v0, v1);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform3uiEXT(ProgramHandle program, int location, uint v0, uint v1, uint v2) => GLPointers._ProgramUniform3uiEXT_fnptr((int)program, location, v0, v1, v2);
+            public static void ProgramUniform3uiEXT(int program, int location, uint v0, uint v1, uint v2) => GLPointers._ProgramUniform3uiEXT_fnptr(program, location, v0, v1, v2);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform4uiEXT(ProgramHandle program, int location, uint v0, uint v1, uint v2, uint v3) => GLPointers._ProgramUniform4uiEXT_fnptr((int)program, location, v0, v1, v2, v3);
+            public static void ProgramUniform4uiEXT(int program, int location, uint v0, uint v1, uint v2, uint v3) => GLPointers._ProgramUniform4uiEXT_fnptr(program, location, v0, v1, v2, v3);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform1uivEXT(ProgramHandle program, int location, int count, uint* value) => GLPointers._ProgramUniform1uivEXT_fnptr((int)program, location, count, value);
+            public static void ProgramUniform1uivEXT(int program, int location, int count, uint* value) => GLPointers._ProgramUniform1uivEXT_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform2uivEXT(ProgramHandle program, int location, int count, uint* value) => GLPointers._ProgramUniform2uivEXT_fnptr((int)program, location, count, value);
+            public static void ProgramUniform2uivEXT(int program, int location, int count, uint* value) => GLPointers._ProgramUniform2uivEXT_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform3uivEXT(ProgramHandle program, int location, int count, uint* value) => GLPointers._ProgramUniform3uivEXT_fnptr((int)program, location, count, value);
+            public static void ProgramUniform3uivEXT(int program, int location, int count, uint* value) => GLPointers._ProgramUniform3uivEXT_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform4uivEXT(ProgramHandle program, int location, int count, uint* value) => GLPointers._ProgramUniform4uivEXT_fnptr((int)program, location, count, value);
+            public static void ProgramUniform4uivEXT(int program, int location, int count, uint* value) => GLPointers._ProgramUniform4uivEXT_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix2x3fvEXT(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix2x3fvEXT_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix2x3fvEXT(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix2x3fvEXT_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix3x2fvEXT(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix3x2fvEXT_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix3x2fvEXT(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix3x2fvEXT_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix2x4fvEXT(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix2x4fvEXT_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix2x4fvEXT(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix2x4fvEXT_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix4x2fvEXT(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix4x2fvEXT_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix4x2fvEXT(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix4x2fvEXT_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix3x4fvEXT(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix3x4fvEXT_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix3x4fvEXT(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix3x4fvEXT_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: GL_EXT_separate_shader_objects]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformMatrix4x3fvEXT(ProgramHandle program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix4x3fvEXT_fnptr((int)program, location, count, (byte)(transpose ? 1 : 0), value);
+            public static void ProgramUniformMatrix4x3fvEXT(int program, int location, int count, bool transpose, float* value) => GLPointers._ProgramUniformMatrix4x3fvEXT_fnptr(program, location, count, (byte)(transpose ? 1 : 0), value);
             
             /// <summary> <b>[requires: GL_EXT_shader_framebuffer_fetch_non_coherent]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -3416,27 +3416,27 @@ namespace OpenTK.Graphics.OpenGLES3
             
             /// <summary> <b>[requires: GL_EXT_texture_border_clamp]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void SamplerParameterIivEXT(SamplerHandle sampler, SamplerParameterI pname, int* param) => GLPointers._SamplerParameterIivEXT_fnptr((int)sampler, (uint)pname, param);
+            public static void SamplerParameterIivEXT(int sampler, SamplerParameterI pname, int* param) => GLPointers._SamplerParameterIivEXT_fnptr(sampler, (uint)pname, param);
             
             /// <summary> <b>[requires: GL_EXT_texture_border_clamp]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void SamplerParameterIuivEXT(SamplerHandle sampler, SamplerParameterI pname, uint* param) => GLPointers._SamplerParameterIuivEXT_fnptr((int)sampler, (uint)pname, param);
+            public static void SamplerParameterIuivEXT(int sampler, SamplerParameterI pname, uint* param) => GLPointers._SamplerParameterIuivEXT_fnptr(sampler, (uint)pname, param);
             
             /// <summary> <b>[requires: GL_EXT_texture_border_clamp]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetSamplerParameterIivEXT(SamplerHandle sampler, SamplerParameterI pname, int* parameters) => GLPointers._GetSamplerParameterIivEXT_fnptr((int)sampler, (uint)pname, parameters);
+            public static void GetSamplerParameterIivEXT(int sampler, SamplerParameterI pname, int* parameters) => GLPointers._GetSamplerParameterIivEXT_fnptr(sampler, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_EXT_texture_border_clamp]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetSamplerParameterIuivEXT(SamplerHandle sampler, SamplerParameterI pname, uint* parameters) => GLPointers._GetSamplerParameterIuivEXT_fnptr((int)sampler, (uint)pname, parameters);
+            public static void GetSamplerParameterIuivEXT(int sampler, SamplerParameterI pname, uint* parameters) => GLPointers._GetSamplerParameterIuivEXT_fnptr(sampler, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_EXT_texture_buffer]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TexBufferEXT(TextureTarget target, SizedInternalFormat internalformat, BufferHandle buffer) => GLPointers._TexBufferEXT_fnptr((uint)target, (uint)internalformat, (int)buffer);
+            public static void TexBufferEXT(TextureTarget target, SizedInternalFormat internalformat, int buffer) => GLPointers._TexBufferEXT_fnptr((uint)target, (uint)internalformat, buffer);
             
             /// <summary> <b>[requires: GL_EXT_texture_buffer]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TexBufferRangeEXT(TextureTarget target, SizedInternalFormat internalformat, BufferHandle buffer, IntPtr offset, nint size) => GLPointers._TexBufferRangeEXT_fnptr((uint)target, (uint)internalformat, (int)buffer, offset, size);
+            public static void TexBufferRangeEXT(TextureTarget target, SizedInternalFormat internalformat, int buffer, IntPtr offset, nint size) => GLPointers._TexBufferRangeEXT_fnptr((uint)target, (uint)internalformat, buffer, offset, size);
             
             /// <summary> <b>[requires: GL_EXT_texture_storage]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -3452,15 +3452,15 @@ namespace OpenTK.Graphics.OpenGLES3
             
             /// <summary> <b>[requires: GL_EXT_texture_storage]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureStorage1DEXT(TextureHandle texture, All target, int levels, SizedInternalFormat internalformat, int width) => GLPointers._TextureStorage1DEXT_fnptr((int)texture, (uint)target, levels, (uint)internalformat, width);
+            public static void TextureStorage1DEXT(int texture, All target, int levels, SizedInternalFormat internalformat, int width) => GLPointers._TextureStorage1DEXT_fnptr(texture, (uint)target, levels, (uint)internalformat, width);
             
             /// <summary> <b>[requires: GL_EXT_texture_storage]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureStorage2DEXT(TextureHandle texture, All target, int levels, SizedInternalFormat internalformat, int width, int height) => GLPointers._TextureStorage2DEXT_fnptr((int)texture, (uint)target, levels, (uint)internalformat, width, height);
+            public static void TextureStorage2DEXT(int texture, All target, int levels, SizedInternalFormat internalformat, int width, int height) => GLPointers._TextureStorage2DEXT_fnptr(texture, (uint)target, levels, (uint)internalformat, width, height);
             
             /// <summary> <b>[requires: GL_EXT_texture_storage]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureStorage3DEXT(TextureHandle texture, All target, int levels, SizedInternalFormat internalformat, int width, int height, int depth) => GLPointers._TextureStorage3DEXT_fnptr((int)texture, (uint)target, levels, (uint)internalformat, width, height, depth);
+            public static void TextureStorage3DEXT(int texture, All target, int levels, SizedInternalFormat internalformat, int width, int height, int depth) => GLPointers._TextureStorage3DEXT_fnptr(texture, (uint)target, levels, (uint)internalformat, width, height, depth);
             
             /// <summary> <b>[requires: GL_EXT_texture_storage_compression]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -3472,7 +3472,7 @@ namespace OpenTK.Graphics.OpenGLES3
             
             /// <summary> <b>[requires: GL_EXT_texture_view]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureViewEXT(TextureHandle texture, TextureTarget target, TextureHandle origtexture, SizedInternalFormat internalformat, uint minlevel, uint numlevels, uint minlayer, uint numlayers) => GLPointers._TextureViewEXT_fnptr((int)texture, (uint)target, (int)origtexture, (uint)internalformat, minlevel, numlevels, minlayer, numlayers);
+            public static void TextureViewEXT(int texture, TextureTarget target, int origtexture, SizedInternalFormat internalformat, uint minlevel, uint numlevels, uint minlayer, uint numlayers) => GLPointers._TextureViewEXT_fnptr(texture, (uint)target, origtexture, (uint)internalformat, minlevel, numlevels, minlayer, numlayers);
             
             /// <summary> <b>[requires: GL_EXT_win32_keyed_mutex]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -3503,11 +3503,11 @@ namespace OpenTK.Graphics.OpenGLES3
             
             /// <summary> <b>[requires: GL_NV_bindless_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static ulong GetTextureHandleNV(TextureHandle texture) => GLPointers._GetTextureHandleNV_fnptr((int)texture);
+            public static ulong GetTextureHandleNV(int texture) => GLPointers._GetTextureHandleNV_fnptr(texture);
             
             /// <summary> <b>[requires: GL_NV_bindless_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static ulong GetTextureSamplerHandleNV(TextureHandle texture, SamplerHandle sampler) => GLPointers._GetTextureSamplerHandleNV_fnptr((int)texture, (int)sampler);
+            public static ulong GetTextureSamplerHandleNV(int texture, int sampler) => GLPointers._GetTextureSamplerHandleNV_fnptr(texture, sampler);
             
             /// <summary> <b>[requires: GL_NV_bindless_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -3519,7 +3519,7 @@ namespace OpenTK.Graphics.OpenGLES3
             
             /// <summary> <b>[requires: GL_NV_bindless_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static ulong GetImageHandleNV(TextureHandle texture, int level, bool layered, int layer, PixelFormat format) => GLPointers._GetImageHandleNV_fnptr((int)texture, level, (byte)(layered ? 1 : 0), layer, (uint)format);
+            public static ulong GetImageHandleNV(int texture, int level, bool layered, int layer, PixelFormat format) => GLPointers._GetImageHandleNV_fnptr(texture, level, (byte)(layered ? 1 : 0), layer, (uint)format);
             
             /// <summary> <b>[requires: GL_NV_bindless_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -3539,11 +3539,11 @@ namespace OpenTK.Graphics.OpenGLES3
             
             /// <summary> <b>[requires: GL_NV_bindless_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformHandleui64NV(ProgramHandle program, int location, ulong value) => GLPointers._ProgramUniformHandleui64NV_fnptr((int)program, location, value);
+            public static void ProgramUniformHandleui64NV(int program, int location, ulong value) => GLPointers._ProgramUniformHandleui64NV_fnptr(program, location, value);
             
             /// <summary> <b>[requires: GL_NV_bindless_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformHandleui64vNV(ProgramHandle program, int location, int count, ulong* values) => GLPointers._ProgramUniformHandleui64vNV_fnptr((int)program, location, count, values);
+            public static void ProgramUniformHandleui64vNV(int program, int location, int count, ulong* values) => GLPointers._ProgramUniformHandleui64vNV_fnptr(program, location, count, values);
             
             /// <summary> <b>[requires: GL_NV_bindless_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -3607,7 +3607,7 @@ namespace OpenTK.Graphics.OpenGLES3
             
             /// <summary> <b>[requires: GL_NV_draw_vulkan_image]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void DrawVkImageNV(ulong vkImage, SamplerHandle sampler, float x0, float y0, float x1, float y1, float z, float s0, float t0, float s1, float t1) => GLPointers._DrawVkImageNV_fnptr(vkImage, (int)sampler, x0, y0, x1, y1, z, s0, t0, s1, t1);
+            public static void DrawVkImageNV(ulong vkImage, int sampler, float x0, float y0, float x1, float y1, float z, float s0, float t0, float s1, float t1) => GLPointers._DrawVkImageNV_fnptr(vkImage, sampler, x0, y0, x1, y1, z, s0, t0, s1, t1);
             
             /// <summary> <b>[requires: GL_NV_draw_vulkan_image]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -3747,71 +3747,71 @@ namespace OpenTK.Graphics.OpenGLES3
             
             /// <summary> <b>[requires: GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetUniformi64vNV(ProgramHandle program, int location, long* parameters) => GLPointers._GetUniformi64vNV_fnptr((int)program, location, parameters);
+            public static void GetUniformi64vNV(int program, int location, long* parameters) => GLPointers._GetUniformi64vNV_fnptr(program, location, parameters);
             
             /// <summary> <b>[requires: GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform1i64NV(ProgramHandle program, int location, long x) => GLPointers._ProgramUniform1i64NV_fnptr((int)program, location, x);
+            public static void ProgramUniform1i64NV(int program, int location, long x) => GLPointers._ProgramUniform1i64NV_fnptr(program, location, x);
             
             /// <summary> <b>[requires: GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform2i64NV(ProgramHandle program, int location, long x, long y) => GLPointers._ProgramUniform2i64NV_fnptr((int)program, location, x, y);
+            public static void ProgramUniform2i64NV(int program, int location, long x, long y) => GLPointers._ProgramUniform2i64NV_fnptr(program, location, x, y);
             
             /// <summary> <b>[requires: GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform3i64NV(ProgramHandle program, int location, long x, long y, long z) => GLPointers._ProgramUniform3i64NV_fnptr((int)program, location, x, y, z);
+            public static void ProgramUniform3i64NV(int program, int location, long x, long y, long z) => GLPointers._ProgramUniform3i64NV_fnptr(program, location, x, y, z);
             
             /// <summary> <b>[requires: GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform4i64NV(ProgramHandle program, int location, long x, long y, long z, long w) => GLPointers._ProgramUniform4i64NV_fnptr((int)program, location, x, y, z, w);
+            public static void ProgramUniform4i64NV(int program, int location, long x, long y, long z, long w) => GLPointers._ProgramUniform4i64NV_fnptr(program, location, x, y, z, w);
             
             /// <summary> <b>[requires: GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform1i64vNV(ProgramHandle program, int location, int count, long* value) => GLPointers._ProgramUniform1i64vNV_fnptr((int)program, location, count, value);
+            public static void ProgramUniform1i64vNV(int program, int location, int count, long* value) => GLPointers._ProgramUniform1i64vNV_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform2i64vNV(ProgramHandle program, int location, int count, long* value) => GLPointers._ProgramUniform2i64vNV_fnptr((int)program, location, count, value);
+            public static void ProgramUniform2i64vNV(int program, int location, int count, long* value) => GLPointers._ProgramUniform2i64vNV_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform3i64vNV(ProgramHandle program, int location, int count, long* value) => GLPointers._ProgramUniform3i64vNV_fnptr((int)program, location, count, value);
+            public static void ProgramUniform3i64vNV(int program, int location, int count, long* value) => GLPointers._ProgramUniform3i64vNV_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform4i64vNV(ProgramHandle program, int location, int count, long* value) => GLPointers._ProgramUniform4i64vNV_fnptr((int)program, location, count, value);
+            public static void ProgramUniform4i64vNV(int program, int location, int count, long* value) => GLPointers._ProgramUniform4i64vNV_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform1ui64NV(ProgramHandle program, int location, ulong x) => GLPointers._ProgramUniform1ui64NV_fnptr((int)program, location, x);
+            public static void ProgramUniform1ui64NV(int program, int location, ulong x) => GLPointers._ProgramUniform1ui64NV_fnptr(program, location, x);
             
             /// <summary> <b>[requires: GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform2ui64NV(ProgramHandle program, int location, ulong x, ulong y) => GLPointers._ProgramUniform2ui64NV_fnptr((int)program, location, x, y);
+            public static void ProgramUniform2ui64NV(int program, int location, ulong x, ulong y) => GLPointers._ProgramUniform2ui64NV_fnptr(program, location, x, y);
             
             /// <summary> <b>[requires: GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform3ui64NV(ProgramHandle program, int location, ulong x, ulong y, ulong z) => GLPointers._ProgramUniform3ui64NV_fnptr((int)program, location, x, y, z);
+            public static void ProgramUniform3ui64NV(int program, int location, ulong x, ulong y, ulong z) => GLPointers._ProgramUniform3ui64NV_fnptr(program, location, x, y, z);
             
             /// <summary> <b>[requires: GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform4ui64NV(ProgramHandle program, int location, ulong x, ulong y, ulong z, ulong w) => GLPointers._ProgramUniform4ui64NV_fnptr((int)program, location, x, y, z, w);
+            public static void ProgramUniform4ui64NV(int program, int location, ulong x, ulong y, ulong z, ulong w) => GLPointers._ProgramUniform4ui64NV_fnptr(program, location, x, y, z, w);
             
             /// <summary> <b>[requires: GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform1ui64vNV(ProgramHandle program, int location, int count, ulong* value) => GLPointers._ProgramUniform1ui64vNV_fnptr((int)program, location, count, value);
+            public static void ProgramUniform1ui64vNV(int program, int location, int count, ulong* value) => GLPointers._ProgramUniform1ui64vNV_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform2ui64vNV(ProgramHandle program, int location, int count, ulong* value) => GLPointers._ProgramUniform2ui64vNV_fnptr((int)program, location, count, value);
+            public static void ProgramUniform2ui64vNV(int program, int location, int count, ulong* value) => GLPointers._ProgramUniform2ui64vNV_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform3ui64vNV(ProgramHandle program, int location, int count, ulong* value) => GLPointers._ProgramUniform3ui64vNV_fnptr((int)program, location, count, value);
+            public static void ProgramUniform3ui64vNV(int program, int location, int count, ulong* value) => GLPointers._ProgramUniform3ui64vNV_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_NV_gpu_shader5]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniform4ui64vNV(ProgramHandle program, int location, int count, ulong* value) => GLPointers._ProgramUniform4ui64vNV_fnptr((int)program, location, count, value);
+            public static void ProgramUniform4ui64vNV(int program, int location, int count, ulong* value) => GLPointers._ProgramUniform4ui64vNV_fnptr(program, location, count, value);
             
             /// <summary> <b>[requires: GL_NV_instanced_arrays]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -3839,11 +3839,11 @@ namespace OpenTK.Graphics.OpenGLES3
             
             /// <summary> <b>[requires: GL_NV_memory_attachment]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureAttachMemoryNV(TextureHandle texture, uint memory, ulong offset) => GLPointers._TextureAttachMemoryNV_fnptr((int)texture, memory, offset);
+            public static void TextureAttachMemoryNV(int texture, uint memory, ulong offset) => GLPointers._TextureAttachMemoryNV_fnptr(texture, memory, offset);
             
             /// <summary> <b>[requires: GL_NV_memory_attachment]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedBufferAttachMemoryNV(BufferHandle buffer, uint memory, ulong offset) => GLPointers._NamedBufferAttachMemoryNV_fnptr((int)buffer, memory, offset);
+            public static void NamedBufferAttachMemoryNV(int buffer, uint memory, ulong offset) => GLPointers._NamedBufferAttachMemoryNV_fnptr(buffer, memory, offset);
             
             /// <summary> <b>[requires: GL_NV_memory_object_sparse]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -3855,11 +3855,11 @@ namespace OpenTK.Graphics.OpenGLES3
             
             /// <summary> <b>[requires: GL_NV_memory_object_sparse]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedBufferPageCommitmentMemNV(BufferHandle buffer, IntPtr offset, nint size, uint memory, ulong memOffset, bool commit) => GLPointers._NamedBufferPageCommitmentMemNV_fnptr((int)buffer, offset, size, memory, memOffset, (byte)(commit ? 1 : 0));
+            public static void NamedBufferPageCommitmentMemNV(int buffer, IntPtr offset, nint size, uint memory, ulong memOffset, bool commit) => GLPointers._NamedBufferPageCommitmentMemNV_fnptr(buffer, offset, size, memory, memOffset, (byte)(commit ? 1 : 0));
             
             /// <summary> <b>[requires: GL_NV_memory_object_sparse]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TexturePageCommitmentMemNV(TextureHandle texture, int layer, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, uint memory, ulong offset, bool commit) => GLPointers._TexturePageCommitmentMemNV_fnptr((int)texture, layer, level, xoffset, yoffset, zoffset, width, height, depth, memory, offset, (byte)(commit ? 1 : 0));
+            public static void TexturePageCommitmentMemNV(int texture, int layer, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, uint memory, ulong offset, bool commit) => GLPointers._TexturePageCommitmentMemNV_fnptr(texture, layer, level, xoffset, yoffset, zoffset, width, height, depth, memory, offset, (byte)(commit ? 1 : 0));
             
             /// <summary> <b>[requires: GL_NV_mesh_shader]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -4123,11 +4123,11 @@ namespace OpenTK.Graphics.OpenGLES3
             
             /// <summary> <b>[requires: GL_NV_path_rendering]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramPathFragmentInputGenNV(ProgramHandle program, int location, All genMode, int components, float* coeffs) => GLPointers._ProgramPathFragmentInputGenNV_fnptr((int)program, location, (uint)genMode, components, coeffs);
+            public static void ProgramPathFragmentInputGenNV(int program, int location, All genMode, int components, float* coeffs) => GLPointers._ProgramPathFragmentInputGenNV_fnptr(program, location, (uint)genMode, components, coeffs);
             
             /// <summary> <b>[requires: GL_NV_path_rendering]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetProgramResourcefvNV(ProgramHandle program, ProgramInterface programInterface, uint index, int propCount, All* props, int count, int* length, float* parameters) => GLPointers._GetProgramResourcefvNV_fnptr((int)program, (uint)programInterface, index, propCount, (uint*)props, count, length, parameters);
+            public static void GetProgramResourcefvNV(int program, ProgramInterface programInterface, uint index, int propCount, All* props, int count, int* length, float* parameters) => GLPointers._GetProgramResourcefvNV_fnptr(program, (uint)programInterface, index, propCount, (uint*)props, count, length, parameters);
             
             /// <summary> <b>[requires: GL_NV_path_rendering]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -4219,7 +4219,7 @@ namespace OpenTK.Graphics.OpenGLES3
             
             /// <summary> <b>[requires: GL_NV_sample_locations]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void NamedFramebufferSampleLocationsfvNV(FramebufferHandle framebuffer, uint start, int count, float* v) => GLPointers._NamedFramebufferSampleLocationsfvNV_fnptr((int)framebuffer, start, count, v);
+            public static void NamedFramebufferSampleLocationsfvNV(int framebuffer, uint start, int count, float* v) => GLPointers._NamedFramebufferSampleLocationsfvNV_fnptr(framebuffer, start, count, v);
             
             /// <summary> <b>[requires: GL_NV_sample_locations]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -4235,7 +4235,7 @@ namespace OpenTK.Graphics.OpenGLES3
             
             /// <summary> <b>[requires: GL_NV_shading_rate_image]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void BindShadingRateImageNV(TextureHandle texture) => GLPointers._BindShadingRateImageNV_fnptr((int)texture);
+            public static void BindShadingRateImageNV(int texture) => GLPointers._BindShadingRateImageNV_fnptr(texture);
             
             /// <summary> <b>[requires: GL_NV_shading_rate_image]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -4318,11 +4318,11 @@ namespace OpenTK.Graphics.OpenGLES3
         {
             /// <summary> <b>[requires: GL_IMG_bindless_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static ulong GetTextureHandleIMG(TextureHandle texture) => GLPointers._GetTextureHandleIMG_fnptr((int)texture);
+            public static ulong GetTextureHandleIMG(int texture) => GLPointers._GetTextureHandleIMG_fnptr(texture);
             
             /// <summary> <b>[requires: GL_IMG_bindless_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static ulong GetTextureSamplerHandleIMG(TextureHandle texture, SamplerHandle sampler) => GLPointers._GetTextureSamplerHandleIMG_fnptr((int)texture, (int)sampler);
+            public static ulong GetTextureSamplerHandleIMG(int texture, int sampler) => GLPointers._GetTextureSamplerHandleIMG_fnptr(texture, sampler);
             
             /// <summary> <b>[requires: GL_IMG_bindless_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -4334,19 +4334,19 @@ namespace OpenTK.Graphics.OpenGLES3
             
             /// <summary> <b>[requires: GL_IMG_bindless_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformHandleui64IMG(ProgramHandle program, int location, ulong value) => GLPointers._ProgramUniformHandleui64IMG_fnptr((int)program, location, value);
+            public static void ProgramUniformHandleui64IMG(int program, int location, ulong value) => GLPointers._ProgramUniformHandleui64IMG_fnptr(program, location, value);
             
             /// <summary> <b>[requires: GL_IMG_bindless_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramUniformHandleui64vIMG(ProgramHandle program, int location, int count, ulong* values) => GLPointers._ProgramUniformHandleui64vIMG_fnptr((int)program, location, count, values);
+            public static void ProgramUniformHandleui64vIMG(int program, int location, int count, ulong* values) => GLPointers._ProgramUniformHandleui64vIMG_fnptr(program, location, count, values);
             
             /// <summary> <b>[requires: GL_IMG_framebuffer_downsample]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void FramebufferTexture2DDownsampleIMG(FramebufferTarget target, FramebufferAttachment attachment, TextureTarget textarget, TextureHandle texture, int level, int xscale, int yscale) => GLPointers._FramebufferTexture2DDownsampleIMG_fnptr((uint)target, (uint)attachment, (uint)textarget, (int)texture, level, xscale, yscale);
+            public static void FramebufferTexture2DDownsampleIMG(FramebufferTarget target, FramebufferAttachment attachment, TextureTarget textarget, int texture, int level, int xscale, int yscale) => GLPointers._FramebufferTexture2DDownsampleIMG_fnptr((uint)target, (uint)attachment, (uint)textarget, texture, level, xscale, yscale);
             
             /// <summary> <b>[requires: GL_IMG_framebuffer_downsample]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void FramebufferTextureLayerDownsampleIMG(FramebufferTarget target, FramebufferAttachment attachment, TextureHandle texture, int level, int layer, int xscale, int yscale) => GLPointers._FramebufferTextureLayerDownsampleIMG_fnptr((uint)target, (uint)attachment, (int)texture, level, layer, xscale, yscale);
+            public static void FramebufferTextureLayerDownsampleIMG(FramebufferTarget target, FramebufferAttachment attachment, int texture, int level, int layer, int xscale, int yscale) => GLPointers._FramebufferTextureLayerDownsampleIMG_fnptr((uint)target, (uint)attachment, texture, level, layer, xscale, yscale);
             
             /// <summary> <b>[requires: GL_IMG_multisampled_render_to_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -4354,7 +4354,7 @@ namespace OpenTK.Graphics.OpenGLES3
             
             /// <summary> <b>[requires: GL_IMG_multisampled_render_to_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void FramebufferTexture2DMultisampleIMG(FramebufferTarget target, FramebufferAttachment attachment, TextureTarget textarget, TextureHandle texture, int level, int samples) => GLPointers._FramebufferTexture2DMultisampleIMG_fnptr((uint)target, (uint)attachment, (uint)textarget, (int)texture, level, samples);
+            public static void FramebufferTexture2DMultisampleIMG(FramebufferTarget target, FramebufferAttachment attachment, TextureTarget textarget, int texture, int level, int samples) => GLPointers._FramebufferTexture2DMultisampleIMG_fnptr((uint)target, (uint)attachment, (uint)textarget, texture, level, samples);
             
         }
         public static unsafe partial class INTEL
@@ -4564,7 +4564,7 @@ namespace OpenTK.Graphics.OpenGLES3
             /// <param name="bufSize">Specifies the size of the buffer params. </param>
             /// <param name="parameters">Returns the value of the specified uniform variable.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglGetUniform.xhtml" /></remarks>
-            public static void GetnUniformfv(ProgramHandle program, int location, int bufSize, float* parameters) => GLPointers._GetnUniformfv_fnptr((int)program, location, bufSize, parameters);
+            public static void GetnUniformfv(int program, int location, int bufSize, float* parameters) => GLPointers._GetnUniformfv_fnptr(program, location, bufSize, parameters);
             
             /// <summary> <b>[requires: v3.2 | GL_KHR_robustness]</b> Returns the value of a uniform variable. </summary>
             /// <param name="program">Specifies the program object to be queried.</param>
@@ -4572,7 +4572,7 @@ namespace OpenTK.Graphics.OpenGLES3
             /// <param name="bufSize">Specifies the size of the buffer params. </param>
             /// <param name="parameters">Returns the value of the specified uniform variable.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglGetUniform.xhtml" /></remarks>
-            public static void GetnUniformiv(ProgramHandle program, int location, int bufSize, int* parameters) => GLPointers._GetnUniformiv_fnptr((int)program, location, bufSize, parameters);
+            public static void GetnUniformiv(int program, int location, int bufSize, int* parameters) => GLPointers._GetnUniformiv_fnptr(program, location, bufSize, parameters);
             
             /// <summary> <b>[requires: v3.2 | GL_KHR_robustness]</b> Returns the value of a uniform variable. </summary>
             /// <param name="program">Specifies the program object to be queried.</param>
@@ -4580,7 +4580,7 @@ namespace OpenTK.Graphics.OpenGLES3
             /// <param name="bufSize">Specifies the size of the buffer params. </param>
             /// <param name="parameters">Returns the value of the specified uniform variable.</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/htmlglGetUniform.xhtml" /></remarks>
-            public static void GetnUniformuiv(ProgramHandle program, int location, int bufSize, uint* parameters) => GLPointers._GetnUniformuiv_fnptr((int)program, location, bufSize, parameters);
+            public static void GetnUniformuiv(int program, int location, int bufSize, uint* parameters) => GLPointers._GetnUniformuiv_fnptr(program, location, bufSize, parameters);
             
             /// <summary> <b>[requires: GL_KHR_robustness]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -4592,15 +4592,15 @@ namespace OpenTK.Graphics.OpenGLES3
             
             /// <summary> <b>[requires: GL_KHR_robustness]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetnUniformfvKHR(ProgramHandle program, int location, int bufSize, float* parameters) => GLPointers._GetnUniformfvKHR_fnptr((int)program, location, bufSize, parameters);
+            public static void GetnUniformfvKHR(int program, int location, int bufSize, float* parameters) => GLPointers._GetnUniformfvKHR_fnptr(program, location, bufSize, parameters);
             
             /// <summary> <b>[requires: GL_KHR_robustness]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetnUniformivKHR(ProgramHandle program, int location, int bufSize, int* parameters) => GLPointers._GetnUniformivKHR_fnptr((int)program, location, bufSize, parameters);
+            public static void GetnUniformivKHR(int program, int location, int bufSize, int* parameters) => GLPointers._GetnUniformivKHR_fnptr(program, location, bufSize, parameters);
             
             /// <summary> <b>[requires: GL_KHR_robustness]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetnUniformuivKHR(ProgramHandle program, int location, int bufSize, uint* parameters) => GLPointers._GetnUniformuivKHR_fnptr((int)program, location, bufSize, parameters);
+            public static void GetnUniformuivKHR(int program, int location, int bufSize, uint* parameters) => GLPointers._GetnUniformuivKHR_fnptr(program, location, bufSize, parameters);
             
             /// <summary> <b>[requires: GL_KHR_parallel_shader_compile]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -4682,15 +4682,15 @@ namespace OpenTK.Graphics.OpenGLES3
             
             /// <summary> <b>[requires: GL_OES_geometry_shader]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void FramebufferTextureOES(FramebufferTarget target, FramebufferAttachment attachment, TextureHandle texture, int level) => GLPointers._FramebufferTextureOES_fnptr((uint)target, (uint)attachment, (int)texture, level);
+            public static void FramebufferTextureOES(FramebufferTarget target, FramebufferAttachment attachment, int texture, int level) => GLPointers._FramebufferTextureOES_fnptr((uint)target, (uint)attachment, texture, level);
             
             /// <summary> <b>[requires: GL_OES_get_program_binary]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetProgramBinaryOES(ProgramHandle program, int bufSize, int* length, All* binaryFormat, void* binary) => GLPointers._GetProgramBinaryOES_fnptr((int)program, bufSize, length, (uint*)binaryFormat, binary);
+            public static void GetProgramBinaryOES(int program, int bufSize, int* length, All* binaryFormat, void* binary) => GLPointers._GetProgramBinaryOES_fnptr(program, bufSize, length, (uint*)binaryFormat, binary);
             
             /// <summary> <b>[requires: GL_OES_get_program_binary]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ProgramBinaryOES(ProgramHandle program, All binaryFormat, void* binary, int length) => GLPointers._ProgramBinaryOES_fnptr((int)program, (uint)binaryFormat, binary, length);
+            public static void ProgramBinaryOES(int program, All binaryFormat, void* binary, int length) => GLPointers._ProgramBinaryOES_fnptr(program, (uint)binaryFormat, binary, length);
             
             /// <summary> <b>[requires: GL_OES_mapbuffer]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -4738,7 +4738,7 @@ namespace OpenTK.Graphics.OpenGLES3
             
             /// <summary> <b>[requires: GL_OES_texture_3D]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void FramebufferTexture3DOES(FramebufferTarget target, FramebufferAttachment attachment, TextureTarget textarget, TextureHandle texture, int level, int zoffset) => GLPointers._FramebufferTexture3DOES_fnptr((uint)target, (uint)attachment, (uint)textarget, (int)texture, level, zoffset);
+            public static void FramebufferTexture3DOES(FramebufferTarget target, FramebufferAttachment attachment, TextureTarget textarget, int texture, int level, int zoffset) => GLPointers._FramebufferTexture3DOES_fnptr((uint)target, (uint)attachment, (uint)textarget, texture, level, zoffset);
             
             /// <summary> <b>[requires: GL_OES_texture_border_clamp]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -4758,27 +4758,27 @@ namespace OpenTK.Graphics.OpenGLES3
             
             /// <summary> <b>[requires: GL_OES_texture_border_clamp]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void SamplerParameterIivOES(SamplerHandle sampler, SamplerParameterI pname, int* param) => GLPointers._SamplerParameterIivOES_fnptr((int)sampler, (uint)pname, param);
+            public static void SamplerParameterIivOES(int sampler, SamplerParameterI pname, int* param) => GLPointers._SamplerParameterIivOES_fnptr(sampler, (uint)pname, param);
             
             /// <summary> <b>[requires: GL_OES_texture_border_clamp]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void SamplerParameterIuivOES(SamplerHandle sampler, SamplerParameterI pname, uint* param) => GLPointers._SamplerParameterIuivOES_fnptr((int)sampler, (uint)pname, param);
+            public static void SamplerParameterIuivOES(int sampler, SamplerParameterI pname, uint* param) => GLPointers._SamplerParameterIuivOES_fnptr(sampler, (uint)pname, param);
             
             /// <summary> <b>[requires: GL_OES_texture_border_clamp]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetSamplerParameterIivOES(SamplerHandle sampler, SamplerParameterI pname, int* parameters) => GLPointers._GetSamplerParameterIivOES_fnptr((int)sampler, (uint)pname, parameters);
+            public static void GetSamplerParameterIivOES(int sampler, SamplerParameterI pname, int* parameters) => GLPointers._GetSamplerParameterIivOES_fnptr(sampler, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_OES_texture_border_clamp]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GetSamplerParameterIuivOES(SamplerHandle sampler, SamplerParameterI pname, uint* parameters) => GLPointers._GetSamplerParameterIuivOES_fnptr((int)sampler, (uint)pname, parameters);
+            public static void GetSamplerParameterIuivOES(int sampler, SamplerParameterI pname, uint* parameters) => GLPointers._GetSamplerParameterIuivOES_fnptr(sampler, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_OES_texture_buffer]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TexBufferOES(TextureTarget target, SizedInternalFormat internalformat, BufferHandle buffer) => GLPointers._TexBufferOES_fnptr((uint)target, (uint)internalformat, (int)buffer);
+            public static void TexBufferOES(TextureTarget target, SizedInternalFormat internalformat, int buffer) => GLPointers._TexBufferOES_fnptr((uint)target, (uint)internalformat, buffer);
             
             /// <summary> <b>[requires: GL_OES_texture_buffer]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TexBufferRangeOES(TextureTarget target, SizedInternalFormat internalformat, BufferHandle buffer, IntPtr offset, nint size) => GLPointers._TexBufferRangeOES_fnptr((uint)target, (uint)internalformat, (int)buffer, offset, size);
+            public static void TexBufferRangeOES(TextureTarget target, SizedInternalFormat internalformat, int buffer, IntPtr offset, nint size) => GLPointers._TexBufferRangeOES_fnptr((uint)target, (uint)internalformat, buffer, offset, size);
             
             /// <summary> <b>[requires: GL_OES_texture_storage_multisample_2d_array]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -4786,23 +4786,23 @@ namespace OpenTK.Graphics.OpenGLES3
             
             /// <summary> <b>[requires: GL_OES_texture_view]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureViewOES(TextureHandle texture, TextureTarget target, TextureHandle origtexture, SizedInternalFormat internalformat, uint minlevel, uint numlevels, uint minlayer, uint numlayers) => GLPointers._TextureViewOES_fnptr((int)texture, (uint)target, (int)origtexture, (uint)internalformat, minlevel, numlevels, minlayer, numlayers);
+            public static void TextureViewOES(int texture, TextureTarget target, int origtexture, SizedInternalFormat internalformat, uint minlevel, uint numlevels, uint minlayer, uint numlayers) => GLPointers._TextureViewOES_fnptr(texture, (uint)target, origtexture, (uint)internalformat, minlevel, numlevels, minlayer, numlayers);
             
             /// <summary> <b>[requires: GL_OES_vertex_array_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void BindVertexArrayOES(VertexArrayHandle array) => GLPointers._BindVertexArrayOES_fnptr((int)array);
+            public static void BindVertexArrayOES(int array) => GLPointers._BindVertexArrayOES_fnptr(array);
             
             /// <summary> <b>[requires: GL_OES_vertex_array_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void DeleteVertexArraysOES(int n, VertexArrayHandle* arrays) => GLPointers._DeleteVertexArraysOES_fnptr(n, (int*)arrays);
+            public static void DeleteVertexArraysOES(int n, int* arrays) => GLPointers._DeleteVertexArraysOES_fnptr(n, arrays);
             
             /// <summary> <b>[requires: GL_OES_vertex_array_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void GenVertexArraysOES(int n, VertexArrayHandle* arrays) => GLPointers._GenVertexArraysOES_fnptr(n, (int*)arrays);
+            public static void GenVertexArraysOES(int n, int* arrays) => GLPointers._GenVertexArraysOES_fnptr(n, arrays);
             
             /// <summary> <b>[requires: GL_OES_vertex_array_object]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static bool IsVertexArrayOES(VertexArrayHandle array) => GLPointers._IsVertexArrayOES_fnptr((int)array) != 0;
+            public static bool IsVertexArrayOES(int array) => GLPointers._IsVertexArrayOES_fnptr(array) != 0;
             
             /// <summary> <b>[requires: GL_OES_viewport_array]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -4845,11 +4845,11 @@ namespace OpenTK.Graphics.OpenGLES3
         {
             /// <summary> <b>[requires: GL_OVR_multiview]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void FramebufferTextureMultiviewOVR(FramebufferTarget target, FramebufferAttachment attachment, TextureHandle texture, int level, int baseViewIndex, int numViews) => GLPointers._FramebufferTextureMultiviewOVR_fnptr((uint)target, (uint)attachment, (int)texture, level, baseViewIndex, numViews);
+            public static void FramebufferTextureMultiviewOVR(FramebufferTarget target, FramebufferAttachment attachment, int texture, int level, int baseViewIndex, int numViews) => GLPointers._FramebufferTextureMultiviewOVR_fnptr((uint)target, (uint)attachment, texture, level, baseViewIndex, numViews);
             
             /// <summary> <b>[requires: GL_OVR_multiview_multisampled_render_to_texture]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void FramebufferTextureMultisampleMultiviewOVR(FramebufferTarget target, FramebufferAttachment attachment, TextureHandle texture, int level, int samples, int baseViewIndex, int numViews) => GLPointers._FramebufferTextureMultisampleMultiviewOVR_fnptr((uint)target, (uint)attachment, (int)texture, level, samples, baseViewIndex, numViews);
+            public static void FramebufferTextureMultisampleMultiviewOVR(FramebufferTarget target, FramebufferAttachment attachment, int texture, int level, int samples, int baseViewIndex, int numViews) => GLPointers._FramebufferTextureMultisampleMultiviewOVR_fnptr((uint)target, (uint)attachment, texture, level, samples, baseViewIndex, numViews);
             
         }
         public static unsafe partial class QCOM
@@ -4876,23 +4876,23 @@ namespace OpenTK.Graphics.OpenGLES3
             
             /// <summary> <b>[requires: GL_QCOM_extended_get]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ExtGetTexturesQCOM(TextureHandle* textures, int maxTextures, int* numTextures) => GLPointers._ExtGetTexturesQCOM_fnptr((int*)textures, maxTextures, numTextures);
+            public static void ExtGetTexturesQCOM(int* textures, int maxTextures, int* numTextures) => GLPointers._ExtGetTexturesQCOM_fnptr(textures, maxTextures, numTextures);
             
             /// <summary> <b>[requires: GL_QCOM_extended_get]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ExtGetBuffersQCOM(BufferHandle* buffers, int maxBuffers, int* numBuffers) => GLPointers._ExtGetBuffersQCOM_fnptr((int*)buffers, maxBuffers, numBuffers);
+            public static void ExtGetBuffersQCOM(int* buffers, int maxBuffers, int* numBuffers) => GLPointers._ExtGetBuffersQCOM_fnptr(buffers, maxBuffers, numBuffers);
             
             /// <summary> <b>[requires: GL_QCOM_extended_get]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ExtGetRenderbuffersQCOM(RenderbufferHandle* renderbuffers, int maxRenderbuffers, int* numRenderbuffers) => GLPointers._ExtGetRenderbuffersQCOM_fnptr((int*)renderbuffers, maxRenderbuffers, numRenderbuffers);
+            public static void ExtGetRenderbuffersQCOM(int* renderbuffers, int maxRenderbuffers, int* numRenderbuffers) => GLPointers._ExtGetRenderbuffersQCOM_fnptr(renderbuffers, maxRenderbuffers, numRenderbuffers);
             
             /// <summary> <b>[requires: GL_QCOM_extended_get]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ExtGetFramebuffersQCOM(FramebufferHandle* framebuffers, int maxFramebuffers, int* numFramebuffers) => GLPointers._ExtGetFramebuffersQCOM_fnptr((int*)framebuffers, maxFramebuffers, numFramebuffers);
+            public static void ExtGetFramebuffersQCOM(int* framebuffers, int maxFramebuffers, int* numFramebuffers) => GLPointers._ExtGetFramebuffersQCOM_fnptr(framebuffers, maxFramebuffers, numFramebuffers);
             
             /// <summary> <b>[requires: GL_QCOM_extended_get]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ExtGetTexLevelParameterivQCOM(TextureHandle texture, All face, int level, All pname, int* parameters) => GLPointers._ExtGetTexLevelParameterivQCOM_fnptr((int)texture, (uint)face, level, (uint)pname, parameters);
+            public static void ExtGetTexLevelParameterivQCOM(int texture, All face, int level, All pname, int* parameters) => GLPointers._ExtGetTexLevelParameterivQCOM_fnptr(texture, (uint)face, level, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_QCOM_extended_get]</b>  </summary>
             /// <remarks><see href="" /></remarks>
@@ -4908,43 +4908,43 @@ namespace OpenTK.Graphics.OpenGLES3
             
             /// <summary> <b>[requires: GL_QCOM_extended_get2]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ExtGetShadersQCOM(ShaderHandle* shaders, int maxShaders, int* numShaders) => GLPointers._ExtGetShadersQCOM_fnptr((int*)shaders, maxShaders, numShaders);
+            public static void ExtGetShadersQCOM(int* shaders, int maxShaders, int* numShaders) => GLPointers._ExtGetShadersQCOM_fnptr(shaders, maxShaders, numShaders);
             
             /// <summary> <b>[requires: GL_QCOM_extended_get2]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ExtGetProgramsQCOM(ProgramHandle* programs, int maxPrograms, int* numPrograms) => GLPointers._ExtGetProgramsQCOM_fnptr((int*)programs, maxPrograms, numPrograms);
+            public static void ExtGetProgramsQCOM(int* programs, int maxPrograms, int* numPrograms) => GLPointers._ExtGetProgramsQCOM_fnptr(programs, maxPrograms, numPrograms);
             
             /// <summary> <b>[requires: GL_QCOM_extended_get2]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static bool ExtIsProgramBinaryQCOM(ProgramHandle program) => GLPointers._ExtIsProgramBinaryQCOM_fnptr((int)program) != 0;
+            public static bool ExtIsProgramBinaryQCOM(int program) => GLPointers._ExtIsProgramBinaryQCOM_fnptr(program) != 0;
             
             /// <summary> <b>[requires: GL_QCOM_extended_get2]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ExtGetProgramBinarySourceQCOM(ProgramHandle program, ShaderType shadertype, byte* source, int* length) => GLPointers._ExtGetProgramBinarySourceQCOM_fnptr((int)program, (uint)shadertype, source, length);
+            public static void ExtGetProgramBinarySourceQCOM(int program, ShaderType shadertype, byte* source, int* length) => GLPointers._ExtGetProgramBinarySourceQCOM_fnptr(program, (uint)shadertype, source, length);
             
             /// <summary> <b>[requires: GL_QCOM_framebuffer_foveated]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void FramebufferFoveationConfigQCOM(FramebufferHandle framebuffer, uint numLayers, uint focalPointsPerLayer, uint requestedFeatures, uint* providedFeatures) => GLPointers._FramebufferFoveationConfigQCOM_fnptr((int)framebuffer, numLayers, focalPointsPerLayer, requestedFeatures, providedFeatures);
+            public static void FramebufferFoveationConfigQCOM(int framebuffer, uint numLayers, uint focalPointsPerLayer, uint requestedFeatures, uint* providedFeatures) => GLPointers._FramebufferFoveationConfigQCOM_fnptr(framebuffer, numLayers, focalPointsPerLayer, requestedFeatures, providedFeatures);
             
             /// <summary> <b>[requires: GL_QCOM_framebuffer_foveated]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void FramebufferFoveationParametersQCOM(FramebufferHandle framebuffer, uint layer, uint focalPoint, float focalX, float focalY, float gainX, float gainY, float foveaArea) => GLPointers._FramebufferFoveationParametersQCOM_fnptr((int)framebuffer, layer, focalPoint, focalX, focalY, gainX, gainY, foveaArea);
+            public static void FramebufferFoveationParametersQCOM(int framebuffer, uint layer, uint focalPoint, float focalX, float focalY, float gainX, float gainY, float foveaArea) => GLPointers._FramebufferFoveationParametersQCOM_fnptr(framebuffer, layer, focalPoint, focalX, focalY, gainX, gainY, foveaArea);
             
             /// <summary> <b>[requires: GL_QCOM_motion_estimation]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TexEstimateMotionQCOM(TextureHandle reference, TextureHandle target, TextureHandle output) => GLPointers._TexEstimateMotionQCOM_fnptr((int)reference, (int)target, (int)output);
+            public static void TexEstimateMotionQCOM(int reference, int target, int output) => GLPointers._TexEstimateMotionQCOM_fnptr(reference, target, output);
             
             /// <summary> <b>[requires: GL_QCOM_motion_estimation]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TexEstimateMotionRegionsQCOM(TextureHandle reference, TextureHandle target, TextureHandle output, TextureHandle mask) => GLPointers._TexEstimateMotionRegionsQCOM_fnptr((int)reference, (int)target, (int)output, (int)mask);
+            public static void TexEstimateMotionRegionsQCOM(int reference, int target, int output, int mask) => GLPointers._TexEstimateMotionRegionsQCOM_fnptr(reference, target, output, mask);
             
             /// <summary> <b>[requires: GL_QCOM_frame_extrapolation]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void ExtrapolateTex2DQCOM(TextureHandle src1, TextureHandle src2, TextureHandle output, float scaleFactor) => GLPointers._ExtrapolateTex2DQCOM_fnptr((int)src1, (int)src2, (int)output, scaleFactor);
+            public static void ExtrapolateTex2DQCOM(int src1, int src2, int output, float scaleFactor) => GLPointers._ExtrapolateTex2DQCOM_fnptr(src1, src2, output, scaleFactor);
             
             /// <summary> <b>[requires: GL_QCOM_texture_foveated]</b>  </summary>
             /// <remarks><see href="" /></remarks>
-            public static void TextureFoveationParametersQCOM(TextureHandle texture, uint layer, uint focalPoint, float focalX, float focalY, float gainX, float gainY, float foveaArea) => GLPointers._TextureFoveationParametersQCOM_fnptr((int)texture, layer, focalPoint, focalX, focalY, gainX, gainY, foveaArea);
+            public static void TextureFoveationParametersQCOM(int texture, uint layer, uint focalPoint, float focalX, float focalY, float gainX, float gainY, float foveaArea) => GLPointers._TextureFoveationParametersQCOM_fnptr(texture, layer, focalPoint, focalX, focalY, gainX, gainY, foveaArea);
             
             /// <summary> <b>[requires: GL_QCOM_shader_framebuffer_fetch_noncoherent]</b>  </summary>
             /// <remarks><see href="" /></remarks>

--- a/src/OpenTK.Graphics/OpenGLES3/GL.Overloads.cs
+++ b/src/OpenTK.Graphics/OpenGLES3/GL.Overloads.cs
@@ -11,7 +11,7 @@ namespace OpenTK.Graphics.OpenGLES3
     public static unsafe partial class GL
     {
         /// <inheritdoc cref="BindAttribLocation"/>
-        public static unsafe void BindAttribLocation(ProgramHandle program, uint index, string name)
+        public static unsafe void BindAttribLocation(int program, uint index, string name)
         {
             byte* name_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(name);
             BindAttribLocation(program, index, name_ptr);
@@ -158,141 +158,141 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="DeleteBuffers"/>
-        public static unsafe void DeleteBuffer(in BufferHandle buffer)
+        public static unsafe void DeleteBuffer(in int buffer)
         {
             int n = 1;
-            fixed(BufferHandle* buffers_handle = &buffer)
+            fixed(int* buffers_handle = &buffer)
             {
                 DeleteBuffers(n, buffers_handle);
             }
         }
         /// <inheritdoc cref="DeleteBuffers"/>
-        public static unsafe void DeleteBuffers(ReadOnlySpan<BufferHandle> buffers)
+        public static unsafe void DeleteBuffers(ReadOnlySpan<int> buffers)
         {
             int n = (int)(buffers.Length);
-            fixed (BufferHandle* buffers_ptr = buffers)
+            fixed (int* buffers_ptr = buffers)
             {
                 DeleteBuffers(n, buffers_ptr);
             }
         }
         /// <inheritdoc cref="DeleteBuffers"/>
-        public static unsafe void DeleteBuffers(BufferHandle[] buffers)
+        public static unsafe void DeleteBuffers(int[] buffers)
         {
             int n = (int)(buffers.Length);
-            fixed (BufferHandle* buffers_ptr = buffers)
+            fixed (int* buffers_ptr = buffers)
             {
                 DeleteBuffers(n, buffers_ptr);
             }
         }
         /// <inheritdoc cref="DeleteBuffers"/>
-        public static unsafe void DeleteBuffers(int n, in BufferHandle buffers)
+        public static unsafe void DeleteBuffers(int n, in int buffers)
         {
-            fixed (BufferHandle* buffers_ptr = &buffers)
+            fixed (int* buffers_ptr = &buffers)
             {
                 DeleteBuffers(n, buffers_ptr);
             }
         }
         /// <inheritdoc cref="DeleteFramebuffers"/>
-        public static unsafe void DeleteFramebuffer(in FramebufferHandle framebuffer)
+        public static unsafe void DeleteFramebuffer(in int framebuffer)
         {
             int n = 1;
-            fixed(FramebufferHandle* framebuffers_handle = &framebuffer)
+            fixed(int* framebuffers_handle = &framebuffer)
             {
                 DeleteFramebuffers(n, framebuffers_handle);
             }
         }
         /// <inheritdoc cref="DeleteFramebuffers"/>
-        public static unsafe void DeleteFramebuffers(ReadOnlySpan<FramebufferHandle> framebuffers)
+        public static unsafe void DeleteFramebuffers(ReadOnlySpan<int> framebuffers)
         {
             int n = (int)(framebuffers.Length);
-            fixed (FramebufferHandle* framebuffers_ptr = framebuffers)
+            fixed (int* framebuffers_ptr = framebuffers)
             {
                 DeleteFramebuffers(n, framebuffers_ptr);
             }
         }
         /// <inheritdoc cref="DeleteFramebuffers"/>
-        public static unsafe void DeleteFramebuffers(FramebufferHandle[] framebuffers)
+        public static unsafe void DeleteFramebuffers(int[] framebuffers)
         {
             int n = (int)(framebuffers.Length);
-            fixed (FramebufferHandle* framebuffers_ptr = framebuffers)
+            fixed (int* framebuffers_ptr = framebuffers)
             {
                 DeleteFramebuffers(n, framebuffers_ptr);
             }
         }
         /// <inheritdoc cref="DeleteFramebuffers"/>
-        public static unsafe void DeleteFramebuffers(int n, in FramebufferHandle framebuffers)
+        public static unsafe void DeleteFramebuffers(int n, in int framebuffers)
         {
-            fixed (FramebufferHandle* framebuffers_ptr = &framebuffers)
+            fixed (int* framebuffers_ptr = &framebuffers)
             {
                 DeleteFramebuffers(n, framebuffers_ptr);
             }
         }
         /// <inheritdoc cref="DeleteRenderbuffers"/>
-        public static unsafe void DeleteRenderbuffer(in RenderbufferHandle renderbuffer)
+        public static unsafe void DeleteRenderbuffer(in int renderbuffer)
         {
             int n = 1;
-            fixed(RenderbufferHandle* renderbuffers_handle = &renderbuffer)
+            fixed(int* renderbuffers_handle = &renderbuffer)
             {
                 DeleteRenderbuffers(n, renderbuffers_handle);
             }
         }
         /// <inheritdoc cref="DeleteRenderbuffers"/>
-        public static unsafe void DeleteRenderbuffers(ReadOnlySpan<RenderbufferHandle> renderbuffers)
+        public static unsafe void DeleteRenderbuffers(ReadOnlySpan<int> renderbuffers)
         {
             int n = (int)(renderbuffers.Length);
-            fixed (RenderbufferHandle* renderbuffers_ptr = renderbuffers)
+            fixed (int* renderbuffers_ptr = renderbuffers)
             {
                 DeleteRenderbuffers(n, renderbuffers_ptr);
             }
         }
         /// <inheritdoc cref="DeleteRenderbuffers"/>
-        public static unsafe void DeleteRenderbuffers(RenderbufferHandle[] renderbuffers)
+        public static unsafe void DeleteRenderbuffers(int[] renderbuffers)
         {
             int n = (int)(renderbuffers.Length);
-            fixed (RenderbufferHandle* renderbuffers_ptr = renderbuffers)
+            fixed (int* renderbuffers_ptr = renderbuffers)
             {
                 DeleteRenderbuffers(n, renderbuffers_ptr);
             }
         }
         /// <inheritdoc cref="DeleteRenderbuffers"/>
-        public static unsafe void DeleteRenderbuffers(int n, in RenderbufferHandle renderbuffers)
+        public static unsafe void DeleteRenderbuffers(int n, in int renderbuffers)
         {
-            fixed (RenderbufferHandle* renderbuffers_ptr = &renderbuffers)
+            fixed (int* renderbuffers_ptr = &renderbuffers)
             {
                 DeleteRenderbuffers(n, renderbuffers_ptr);
             }
         }
         /// <inheritdoc cref="DeleteTextures"/>
-        public static unsafe void DeleteTexture(in TextureHandle texture)
+        public static unsafe void DeleteTexture(in int texture)
         {
             int n = 1;
-            fixed(TextureHandle* textures_handle = &texture)
+            fixed(int* textures_handle = &texture)
             {
                 DeleteTextures(n, textures_handle);
             }
         }
         /// <inheritdoc cref="DeleteTextures"/>
-        public static unsafe void DeleteTextures(ReadOnlySpan<TextureHandle> textures)
+        public static unsafe void DeleteTextures(ReadOnlySpan<int> textures)
         {
             int n = (int)(textures.Length);
-            fixed (TextureHandle* textures_ptr = textures)
+            fixed (int* textures_ptr = textures)
             {
                 DeleteTextures(n, textures_ptr);
             }
         }
         /// <inheritdoc cref="DeleteTextures"/>
-        public static unsafe void DeleteTextures(TextureHandle[] textures)
+        public static unsafe void DeleteTextures(int[] textures)
         {
             int n = (int)(textures.Length);
-            fixed (TextureHandle* textures_ptr = textures)
+            fixed (int* textures_ptr = textures)
             {
                 DeleteTextures(n, textures_ptr);
             }
         }
         /// <inheritdoc cref="DeleteTextures"/>
-        public static unsafe void DeleteTextures(int n, in TextureHandle textures)
+        public static unsafe void DeleteTextures(int n, in int textures)
         {
-            fixed (TextureHandle* textures_ptr = &textures)
+            fixed (int* textures_ptr = &textures)
             {
                 DeleteTextures(n, textures_ptr);
             }
@@ -304,9 +304,9 @@ namespace OpenTK.Graphics.OpenGLES3
             DrawElements(mode, count, type, indices);
         }
         /// <inheritdoc cref="GenBuffers"/>
-        public static unsafe BufferHandle GenBuffer()
+        public static unsafe int GenBuffer()
         {
-            BufferHandle buffer;
+            int buffer;
             int n = 1;
             Unsafe.SkipInit(out buffer);
             // FIXME: This could be a problem for the overloads that take an out parameter
@@ -317,12 +317,12 @@ namespace OpenTK.Graphics.OpenGLES3
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            BufferHandle* buffers_handle = (BufferHandle*)Unsafe.AsPointer(ref buffer);
+            int* buffers_handle = (int*)Unsafe.AsPointer(ref buffer);
             GenBuffers(n, buffers_handle);
             return buffer;
         }
         /// <inheritdoc cref="GenBuffers"/>
-        public static unsafe void GenBuffer(out BufferHandle buffer)
+        public static unsafe void GenBuffer(out int buffer)
         {
             int n = 1;
             Unsafe.SkipInit(out buffer);
@@ -334,39 +334,39 @@ namespace OpenTK.Graphics.OpenGLES3
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            BufferHandle* buffers_handle = (BufferHandle*)Unsafe.AsPointer(ref buffer);
+            int* buffers_handle = (int*)Unsafe.AsPointer(ref buffer);
             GenBuffers(n, buffers_handle);
         }
         /// <inheritdoc cref="GenBuffers"/>
-        public static unsafe void GenBuffers(Span<BufferHandle> buffers)
+        public static unsafe void GenBuffers(Span<int> buffers)
         {
             int n = (int)(buffers.Length);
-            fixed (BufferHandle* buffers_ptr = buffers)
+            fixed (int* buffers_ptr = buffers)
             {
                 GenBuffers(n, buffers_ptr);
             }
         }
         /// <inheritdoc cref="GenBuffers"/>
-        public static unsafe void GenBuffers(BufferHandle[] buffers)
+        public static unsafe void GenBuffers(int[] buffers)
         {
             int n = (int)(buffers.Length);
-            fixed (BufferHandle* buffers_ptr = buffers)
+            fixed (int* buffers_ptr = buffers)
             {
                 GenBuffers(n, buffers_ptr);
             }
         }
         /// <inheritdoc cref="GenBuffers"/>
-        public static unsafe void GenBuffers(int n, ref BufferHandle buffers)
+        public static unsafe void GenBuffers(int n, ref int buffers)
         {
-            fixed (BufferHandle* buffers_ptr = &buffers)
+            fixed (int* buffers_ptr = &buffers)
             {
                 GenBuffers(n, buffers_ptr);
             }
         }
         /// <inheritdoc cref="GenFramebuffers"/>
-        public static unsafe FramebufferHandle GenFramebuffer()
+        public static unsafe int GenFramebuffer()
         {
-            FramebufferHandle framebuffer;
+            int framebuffer;
             int n = 1;
             Unsafe.SkipInit(out framebuffer);
             // FIXME: This could be a problem for the overloads that take an out parameter
@@ -377,12 +377,12 @@ namespace OpenTK.Graphics.OpenGLES3
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            FramebufferHandle* framebuffers_handle = (FramebufferHandle*)Unsafe.AsPointer(ref framebuffer);
+            int* framebuffers_handle = (int*)Unsafe.AsPointer(ref framebuffer);
             GenFramebuffers(n, framebuffers_handle);
             return framebuffer;
         }
         /// <inheritdoc cref="GenFramebuffers"/>
-        public static unsafe void GenFramebuffer(out FramebufferHandle framebuffer)
+        public static unsafe void GenFramebuffer(out int framebuffer)
         {
             int n = 1;
             Unsafe.SkipInit(out framebuffer);
@@ -394,39 +394,39 @@ namespace OpenTK.Graphics.OpenGLES3
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            FramebufferHandle* framebuffers_handle = (FramebufferHandle*)Unsafe.AsPointer(ref framebuffer);
+            int* framebuffers_handle = (int*)Unsafe.AsPointer(ref framebuffer);
             GenFramebuffers(n, framebuffers_handle);
         }
         /// <inheritdoc cref="GenFramebuffers"/>
-        public static unsafe void GenFramebuffers(Span<FramebufferHandle> framebuffers)
+        public static unsafe void GenFramebuffers(Span<int> framebuffers)
         {
             int n = (int)(framebuffers.Length);
-            fixed (FramebufferHandle* framebuffers_ptr = framebuffers)
+            fixed (int* framebuffers_ptr = framebuffers)
             {
                 GenFramebuffers(n, framebuffers_ptr);
             }
         }
         /// <inheritdoc cref="GenFramebuffers"/>
-        public static unsafe void GenFramebuffers(FramebufferHandle[] framebuffers)
+        public static unsafe void GenFramebuffers(int[] framebuffers)
         {
             int n = (int)(framebuffers.Length);
-            fixed (FramebufferHandle* framebuffers_ptr = framebuffers)
+            fixed (int* framebuffers_ptr = framebuffers)
             {
                 GenFramebuffers(n, framebuffers_ptr);
             }
         }
         /// <inheritdoc cref="GenFramebuffers"/>
-        public static unsafe void GenFramebuffers(int n, ref FramebufferHandle framebuffers)
+        public static unsafe void GenFramebuffers(int n, ref int framebuffers)
         {
-            fixed (FramebufferHandle* framebuffers_ptr = &framebuffers)
+            fixed (int* framebuffers_ptr = &framebuffers)
             {
                 GenFramebuffers(n, framebuffers_ptr);
             }
         }
         /// <inheritdoc cref="GenRenderbuffers"/>
-        public static unsafe RenderbufferHandle GenRenderbuffer()
+        public static unsafe int GenRenderbuffer()
         {
-            RenderbufferHandle renderbuffer;
+            int renderbuffer;
             int n = 1;
             Unsafe.SkipInit(out renderbuffer);
             // FIXME: This could be a problem for the overloads that take an out parameter
@@ -437,12 +437,12 @@ namespace OpenTK.Graphics.OpenGLES3
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            RenderbufferHandle* renderbuffers_handle = (RenderbufferHandle*)Unsafe.AsPointer(ref renderbuffer);
+            int* renderbuffers_handle = (int*)Unsafe.AsPointer(ref renderbuffer);
             GenRenderbuffers(n, renderbuffers_handle);
             return renderbuffer;
         }
         /// <inheritdoc cref="GenRenderbuffers"/>
-        public static unsafe void GenRenderbuffer(out RenderbufferHandle renderbuffer)
+        public static unsafe void GenRenderbuffer(out int renderbuffer)
         {
             int n = 1;
             Unsafe.SkipInit(out renderbuffer);
@@ -454,39 +454,39 @@ namespace OpenTK.Graphics.OpenGLES3
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            RenderbufferHandle* renderbuffers_handle = (RenderbufferHandle*)Unsafe.AsPointer(ref renderbuffer);
+            int* renderbuffers_handle = (int*)Unsafe.AsPointer(ref renderbuffer);
             GenRenderbuffers(n, renderbuffers_handle);
         }
         /// <inheritdoc cref="GenRenderbuffers"/>
-        public static unsafe void GenRenderbuffers(Span<RenderbufferHandle> renderbuffers)
+        public static unsafe void GenRenderbuffers(Span<int> renderbuffers)
         {
             int n = (int)(renderbuffers.Length);
-            fixed (RenderbufferHandle* renderbuffers_ptr = renderbuffers)
+            fixed (int* renderbuffers_ptr = renderbuffers)
             {
                 GenRenderbuffers(n, renderbuffers_ptr);
             }
         }
         /// <inheritdoc cref="GenRenderbuffers"/>
-        public static unsafe void GenRenderbuffers(RenderbufferHandle[] renderbuffers)
+        public static unsafe void GenRenderbuffers(int[] renderbuffers)
         {
             int n = (int)(renderbuffers.Length);
-            fixed (RenderbufferHandle* renderbuffers_ptr = renderbuffers)
+            fixed (int* renderbuffers_ptr = renderbuffers)
             {
                 GenRenderbuffers(n, renderbuffers_ptr);
             }
         }
         /// <inheritdoc cref="GenRenderbuffers"/>
-        public static unsafe void GenRenderbuffers(int n, ref RenderbufferHandle renderbuffers)
+        public static unsafe void GenRenderbuffers(int n, ref int renderbuffers)
         {
-            fixed (RenderbufferHandle* renderbuffers_ptr = &renderbuffers)
+            fixed (int* renderbuffers_ptr = &renderbuffers)
             {
                 GenRenderbuffers(n, renderbuffers_ptr);
             }
         }
         /// <inheritdoc cref="GenTextures"/>
-        public static unsafe TextureHandle GenTexture()
+        public static unsafe int GenTexture()
         {
-            TextureHandle texture;
+            int texture;
             int n = 1;
             Unsafe.SkipInit(out texture);
             // FIXME: This could be a problem for the overloads that take an out parameter
@@ -497,12 +497,12 @@ namespace OpenTK.Graphics.OpenGLES3
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            TextureHandle* textures_handle = (TextureHandle*)Unsafe.AsPointer(ref texture);
+            int* textures_handle = (int*)Unsafe.AsPointer(ref texture);
             GenTextures(n, textures_handle);
             return texture;
         }
         /// <inheritdoc cref="GenTextures"/>
-        public static unsafe void GenTexture(out TextureHandle texture)
+        public static unsafe void GenTexture(out int texture)
         {
             int n = 1;
             Unsafe.SkipInit(out texture);
@@ -514,37 +514,37 @@ namespace OpenTK.Graphics.OpenGLES3
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            TextureHandle* textures_handle = (TextureHandle*)Unsafe.AsPointer(ref texture);
+            int* textures_handle = (int*)Unsafe.AsPointer(ref texture);
             GenTextures(n, textures_handle);
         }
         /// <inheritdoc cref="GenTextures"/>
-        public static unsafe void GenTextures(Span<TextureHandle> textures)
+        public static unsafe void GenTextures(Span<int> textures)
         {
             int n = (int)(textures.Length);
-            fixed (TextureHandle* textures_ptr = textures)
+            fixed (int* textures_ptr = textures)
             {
                 GenTextures(n, textures_ptr);
             }
         }
         /// <inheritdoc cref="GenTextures"/>
-        public static unsafe void GenTextures(TextureHandle[] textures)
+        public static unsafe void GenTextures(int[] textures)
         {
             int n = (int)(textures.Length);
-            fixed (TextureHandle* textures_ptr = textures)
+            fixed (int* textures_ptr = textures)
             {
                 GenTextures(n, textures_ptr);
             }
         }
         /// <inheritdoc cref="GenTextures"/>
-        public static unsafe void GenTextures(int n, ref TextureHandle textures)
+        public static unsafe void GenTextures(int n, ref int textures)
         {
-            fixed (TextureHandle* textures_ptr = &textures)
+            fixed (int* textures_ptr = &textures)
             {
                 GenTextures(n, textures_ptr);
             }
         }
         /// <inheritdoc cref="GetActiveAttrib"/>
-        public static unsafe string GetActiveAttrib(ProgramHandle program, uint index, int bufSize, Span<int> length, Span<int> size, Span<AttributeType> type)
+        public static unsafe string GetActiveAttrib(int program, uint index, int bufSize, Span<int> length, Span<int> size, Span<AttributeType> type)
         {
             string name;
             fixed (int* length_ptr = length)
@@ -563,7 +563,7 @@ namespace OpenTK.Graphics.OpenGLES3
             return name;
         }
         /// <inheritdoc cref="GetActiveAttrib"/>
-        public static unsafe void GetActiveAttrib(ProgramHandle program, uint index, int bufSize, Span<int> length, Span<int> size, Span<AttributeType> type, out string name)
+        public static unsafe void GetActiveAttrib(int program, uint index, int bufSize, Span<int> length, Span<int> size, Span<AttributeType> type, out string name)
         {
             fixed (int* length_ptr = length)
             {
@@ -580,7 +580,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetActiveAttrib"/>
-        public static unsafe string GetActiveAttrib(ProgramHandle program, uint index, int bufSize, int[] length, int[] size, AttributeType[] type)
+        public static unsafe string GetActiveAttrib(int program, uint index, int bufSize, int[] length, int[] size, AttributeType[] type)
         {
             string name;
             fixed (int* length_ptr = length)
@@ -599,7 +599,7 @@ namespace OpenTK.Graphics.OpenGLES3
             return name;
         }
         /// <inheritdoc cref="GetActiveAttrib"/>
-        public static unsafe void GetActiveAttrib(ProgramHandle program, uint index, int bufSize, int[] length, int[] size, AttributeType[] type, out string name)
+        public static unsafe void GetActiveAttrib(int program, uint index, int bufSize, int[] length, int[] size, AttributeType[] type, out string name)
         {
             fixed (int* length_ptr = length)
             {
@@ -616,7 +616,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetActiveAttrib"/>
-        public static unsafe string GetActiveAttrib(ProgramHandle program, uint index, int bufSize, ref int length, ref int size, ref AttributeType type)
+        public static unsafe string GetActiveAttrib(int program, uint index, int bufSize, ref int length, ref int size, ref AttributeType type)
         {
             string name;
             fixed (int* length_ptr = &length)
@@ -631,7 +631,7 @@ namespace OpenTK.Graphics.OpenGLES3
             return name;
         }
         /// <inheritdoc cref="GetActiveAttrib"/>
-        public static unsafe void GetActiveAttrib(ProgramHandle program, uint index, int bufSize, ref int length, ref int size, ref AttributeType type, out string name)
+        public static unsafe void GetActiveAttrib(int program, uint index, int bufSize, ref int length, ref int size, ref AttributeType type, out string name)
         {
             fixed (int* length_ptr = &length)
             fixed (int* size_ptr = &size)
@@ -644,7 +644,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetActiveUniform"/>
-        public static unsafe string GetActiveUniform(ProgramHandle program, uint index, int bufSize, Span<int> length, Span<int> size, Span<UniformType> type)
+        public static unsafe string GetActiveUniform(int program, uint index, int bufSize, Span<int> length, Span<int> size, Span<UniformType> type)
         {
             string name;
             fixed (int* length_ptr = length)
@@ -663,7 +663,7 @@ namespace OpenTK.Graphics.OpenGLES3
             return name;
         }
         /// <inheritdoc cref="GetActiveUniform"/>
-        public static unsafe void GetActiveUniform(ProgramHandle program, uint index, int bufSize, Span<int> length, Span<int> size, Span<UniformType> type, out string name)
+        public static unsafe void GetActiveUniform(int program, uint index, int bufSize, Span<int> length, Span<int> size, Span<UniformType> type, out string name)
         {
             fixed (int* length_ptr = length)
             {
@@ -680,7 +680,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetActiveUniform"/>
-        public static unsafe string GetActiveUniform(ProgramHandle program, uint index, int bufSize, int[] length, int[] size, UniformType[] type)
+        public static unsafe string GetActiveUniform(int program, uint index, int bufSize, int[] length, int[] size, UniformType[] type)
         {
             string name;
             fixed (int* length_ptr = length)
@@ -699,7 +699,7 @@ namespace OpenTK.Graphics.OpenGLES3
             return name;
         }
         /// <inheritdoc cref="GetActiveUniform"/>
-        public static unsafe void GetActiveUniform(ProgramHandle program, uint index, int bufSize, int[] length, int[] size, UniformType[] type, out string name)
+        public static unsafe void GetActiveUniform(int program, uint index, int bufSize, int[] length, int[] size, UniformType[] type, out string name)
         {
             fixed (int* length_ptr = length)
             {
@@ -716,7 +716,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetActiveUniform"/>
-        public static unsafe string GetActiveUniform(ProgramHandle program, uint index, int bufSize, ref int length, ref int size, ref UniformType type)
+        public static unsafe string GetActiveUniform(int program, uint index, int bufSize, ref int length, ref int size, ref UniformType type)
         {
             string name;
             fixed (int* length_ptr = &length)
@@ -731,7 +731,7 @@ namespace OpenTK.Graphics.OpenGLES3
             return name;
         }
         /// <inheritdoc cref="GetActiveUniform"/>
-        public static unsafe void GetActiveUniform(ProgramHandle program, uint index, int bufSize, ref int length, ref int size, ref UniformType type, out string name)
+        public static unsafe void GetActiveUniform(int program, uint index, int bufSize, ref int length, ref int size, ref UniformType type, out string name)
         {
             fixed (int* length_ptr = &length)
             fixed (int* size_ptr = &size)
@@ -744,40 +744,40 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetAttachedShaders"/>
-        public static unsafe void GetAttachedShaders(ProgramHandle program, Span<int> count, Span<ShaderHandle> shaders)
+        public static unsafe void GetAttachedShaders(int program, Span<int> count, Span<int> shaders)
         {
             fixed (int* count_ptr = count)
             {
                 int maxCount = (int)(shaders.Length);
-                fixed (ShaderHandle* shaders_ptr = shaders)
+                fixed (int* shaders_ptr = shaders)
                 {
                     GetAttachedShaders(program, maxCount, count_ptr, shaders_ptr);
                 }
             }
         }
         /// <inheritdoc cref="GetAttachedShaders"/>
-        public static unsafe void GetAttachedShaders(ProgramHandle program, int[] count, ShaderHandle[] shaders)
+        public static unsafe void GetAttachedShaders(int program, int[] count, int[] shaders)
         {
             fixed (int* count_ptr = count)
             {
                 int maxCount = (int)(shaders.Length);
-                fixed (ShaderHandle* shaders_ptr = shaders)
+                fixed (int* shaders_ptr = shaders)
                 {
                     GetAttachedShaders(program, maxCount, count_ptr, shaders_ptr);
                 }
             }
         }
         /// <inheritdoc cref="GetAttachedShaders"/>
-        public static unsafe void GetAttachedShaders(ProgramHandle program, int maxCount, ref int count, ref ShaderHandle shaders)
+        public static unsafe void GetAttachedShaders(int program, int maxCount, ref int count, ref int shaders)
         {
             fixed (int* count_ptr = &count)
-            fixed (ShaderHandle* shaders_ptr = &shaders)
+            fixed (int* shaders_ptr = &shaders)
             {
                 GetAttachedShaders(program, maxCount, count_ptr, shaders_ptr);
             }
         }
         /// <inheritdoc cref="GetAttribLocation"/>
-        public static unsafe int GetAttribLocation(ProgramHandle program, string name)
+        public static unsafe int GetAttribLocation(int program, string name)
         {
             int returnValue;
             byte* name_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(name);
@@ -906,7 +906,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetProgramiv"/>
-        public static unsafe void GetProgrami(ProgramHandle program, ProgramPropertyARB pname, Span<int> parameters)
+        public static unsafe void GetProgrami(int program, ProgramPropertyARB pname, Span<int> parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
@@ -914,7 +914,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetProgramiv"/>
-        public static unsafe void GetProgrami(ProgramHandle program, ProgramPropertyARB pname, int[] parameters)
+        public static unsafe void GetProgrami(int program, ProgramPropertyARB pname, int[] parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
@@ -922,7 +922,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetProgramiv"/>
-        public static unsafe void GetProgrami(ProgramHandle program, ProgramPropertyARB pname, ref int parameters)
+        public static unsafe void GetProgrami(int program, ProgramPropertyARB pname, ref int parameters)
         {
             fixed (int* parameters_ptr = &parameters)
             {
@@ -930,7 +930,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetProgramInfoLog"/>
-        public static unsafe string GetProgramInfoLog(ProgramHandle program, int bufSize, Span<int> length)
+        public static unsafe string GetProgramInfoLog(int program, int bufSize, Span<int> length)
         {
             string infoLog;
             fixed (int* length_ptr = length)
@@ -943,7 +943,7 @@ namespace OpenTK.Graphics.OpenGLES3
             return infoLog;
         }
         /// <inheritdoc cref="GetProgramInfoLog"/>
-        public static unsafe void GetProgramInfoLog(ProgramHandle program, int bufSize, Span<int> length, out string infoLog)
+        public static unsafe void GetProgramInfoLog(int program, int bufSize, Span<int> length, out string infoLog)
         {
             fixed (int* length_ptr = length)
             {
@@ -954,7 +954,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetProgramInfoLog"/>
-        public static unsafe string GetProgramInfoLog(ProgramHandle program, int bufSize, int[] length)
+        public static unsafe string GetProgramInfoLog(int program, int bufSize, int[] length)
         {
             string infoLog;
             fixed (int* length_ptr = length)
@@ -967,7 +967,7 @@ namespace OpenTK.Graphics.OpenGLES3
             return infoLog;
         }
         /// <inheritdoc cref="GetProgramInfoLog"/>
-        public static unsafe void GetProgramInfoLog(ProgramHandle program, int bufSize, int[] length, out string infoLog)
+        public static unsafe void GetProgramInfoLog(int program, int bufSize, int[] length, out string infoLog)
         {
             fixed (int* length_ptr = length)
             {
@@ -978,7 +978,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetProgramInfoLog"/>
-        public static unsafe string GetProgramInfoLog(ProgramHandle program, int bufSize, ref int length)
+        public static unsafe string GetProgramInfoLog(int program, int bufSize, ref int length)
         {
             string infoLog;
             fixed (int* length_ptr = &length)
@@ -991,7 +991,7 @@ namespace OpenTK.Graphics.OpenGLES3
             return infoLog;
         }
         /// <inheritdoc cref="GetProgramInfoLog"/>
-        public static unsafe void GetProgramInfoLog(ProgramHandle program, int bufSize, ref int length, out string infoLog)
+        public static unsafe void GetProgramInfoLog(int program, int bufSize, ref int length, out string infoLog)
         {
             fixed (int* length_ptr = &length)
             {
@@ -1026,7 +1026,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetShaderiv"/>
-        public static unsafe void GetShaderi(ShaderHandle shader, ShaderParameterName pname, Span<int> parameters)
+        public static unsafe void GetShaderi(int shader, ShaderParameterName pname, Span<int> parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
@@ -1034,7 +1034,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetShaderiv"/>
-        public static unsafe void GetShaderi(ShaderHandle shader, ShaderParameterName pname, int[] parameters)
+        public static unsafe void GetShaderi(int shader, ShaderParameterName pname, int[] parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
@@ -1042,7 +1042,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetShaderiv"/>
-        public static unsafe void GetShaderi(ShaderHandle shader, ShaderParameterName pname, ref int parameters)
+        public static unsafe void GetShaderi(int shader, ShaderParameterName pname, ref int parameters)
         {
             fixed (int* parameters_ptr = &parameters)
             {
@@ -1050,7 +1050,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetShaderInfoLog"/>
-        public static unsafe string GetShaderInfoLog(ShaderHandle shader, int bufSize, Span<int> length)
+        public static unsafe string GetShaderInfoLog(int shader, int bufSize, Span<int> length)
         {
             string infoLog;
             fixed (int* length_ptr = length)
@@ -1063,7 +1063,7 @@ namespace OpenTK.Graphics.OpenGLES3
             return infoLog;
         }
         /// <inheritdoc cref="GetShaderInfoLog"/>
-        public static unsafe void GetShaderInfoLog(ShaderHandle shader, int bufSize, Span<int> length, out string infoLog)
+        public static unsafe void GetShaderInfoLog(int shader, int bufSize, Span<int> length, out string infoLog)
         {
             fixed (int* length_ptr = length)
             {
@@ -1074,7 +1074,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetShaderInfoLog"/>
-        public static unsafe string GetShaderInfoLog(ShaderHandle shader, int bufSize, int[] length)
+        public static unsafe string GetShaderInfoLog(int shader, int bufSize, int[] length)
         {
             string infoLog;
             fixed (int* length_ptr = length)
@@ -1087,7 +1087,7 @@ namespace OpenTK.Graphics.OpenGLES3
             return infoLog;
         }
         /// <inheritdoc cref="GetShaderInfoLog"/>
-        public static unsafe void GetShaderInfoLog(ShaderHandle shader, int bufSize, int[] length, out string infoLog)
+        public static unsafe void GetShaderInfoLog(int shader, int bufSize, int[] length, out string infoLog)
         {
             fixed (int* length_ptr = length)
             {
@@ -1098,7 +1098,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetShaderInfoLog"/>
-        public static unsafe string GetShaderInfoLog(ShaderHandle shader, int bufSize, ref int length)
+        public static unsafe string GetShaderInfoLog(int shader, int bufSize, ref int length)
         {
             string infoLog;
             fixed (int* length_ptr = &length)
@@ -1111,7 +1111,7 @@ namespace OpenTK.Graphics.OpenGLES3
             return infoLog;
         }
         /// <inheritdoc cref="GetShaderInfoLog"/>
-        public static unsafe void GetShaderInfoLog(ShaderHandle shader, int bufSize, ref int length, out string infoLog)
+        public static unsafe void GetShaderInfoLog(int shader, int bufSize, ref int length, out string infoLog)
         {
             fixed (int* length_ptr = &length)
             {
@@ -1153,7 +1153,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetShaderSource"/>
-        public static unsafe string GetShaderSource(ShaderHandle shader, int bufSize, Span<int> length)
+        public static unsafe string GetShaderSource(int shader, int bufSize, Span<int> length)
         {
             string source;
             fixed (int* length_ptr = length)
@@ -1166,7 +1166,7 @@ namespace OpenTK.Graphics.OpenGLES3
             return source;
         }
         /// <inheritdoc cref="GetShaderSource"/>
-        public static unsafe void GetShaderSource(ShaderHandle shader, int bufSize, Span<int> length, out string source)
+        public static unsafe void GetShaderSource(int shader, int bufSize, Span<int> length, out string source)
         {
             fixed (int* length_ptr = length)
             {
@@ -1177,7 +1177,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetShaderSource"/>
-        public static unsafe string GetShaderSource(ShaderHandle shader, int bufSize, int[] length)
+        public static unsafe string GetShaderSource(int shader, int bufSize, int[] length)
         {
             string source;
             fixed (int* length_ptr = length)
@@ -1190,7 +1190,7 @@ namespace OpenTK.Graphics.OpenGLES3
             return source;
         }
         /// <inheritdoc cref="GetShaderSource"/>
-        public static unsafe void GetShaderSource(ShaderHandle shader, int bufSize, int[] length, out string source)
+        public static unsafe void GetShaderSource(int shader, int bufSize, int[] length, out string source)
         {
             fixed (int* length_ptr = length)
             {
@@ -1201,7 +1201,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetShaderSource"/>
-        public static unsafe string GetShaderSource(ShaderHandle shader, int bufSize, ref int length)
+        public static unsafe string GetShaderSource(int shader, int bufSize, ref int length)
         {
             string source;
             fixed (int* length_ptr = &length)
@@ -1214,7 +1214,7 @@ namespace OpenTK.Graphics.OpenGLES3
             return source;
         }
         /// <inheritdoc cref="GetShaderSource"/>
-        public static unsafe void GetShaderSource(ShaderHandle shader, int bufSize, ref int length, out string source)
+        public static unsafe void GetShaderSource(int shader, int bufSize, ref int length, out string source)
         {
             fixed (int* length_ptr = &length)
             {
@@ -1282,7 +1282,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetUniformfv"/>
-        public static unsafe void GetUniformf(ProgramHandle program, int location, Span<float> parameters)
+        public static unsafe void GetUniformf(int program, int location, Span<float> parameters)
         {
             fixed (float* parameters_ptr = parameters)
             {
@@ -1290,7 +1290,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetUniformfv"/>
-        public static unsafe void GetUniformf(ProgramHandle program, int location, float[] parameters)
+        public static unsafe void GetUniformf(int program, int location, float[] parameters)
         {
             fixed (float* parameters_ptr = parameters)
             {
@@ -1298,7 +1298,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetUniformfv"/>
-        public static unsafe void GetUniformf(ProgramHandle program, int location, ref float parameters)
+        public static unsafe void GetUniformf(int program, int location, ref float parameters)
         {
             fixed (float* parameters_ptr = &parameters)
             {
@@ -1306,7 +1306,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetUniformiv"/>
-        public static unsafe void GetUniformi(ProgramHandle program, int location, Span<int> parameters)
+        public static unsafe void GetUniformi(int program, int location, Span<int> parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
@@ -1314,7 +1314,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetUniformiv"/>
-        public static unsafe void GetUniformi(ProgramHandle program, int location, int[] parameters)
+        public static unsafe void GetUniformi(int program, int location, int[] parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
@@ -1322,7 +1322,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetUniformiv"/>
-        public static unsafe void GetUniformi(ProgramHandle program, int location, ref int parameters)
+        public static unsafe void GetUniformi(int program, int location, ref int parameters)
         {
             fixed (int* parameters_ptr = &parameters)
             {
@@ -1330,7 +1330,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetUniformLocation"/>
-        public static unsafe int GetUniformLocation(ProgramHandle program, string name)
+        public static unsafe int GetUniformLocation(int program, string name)
         {
             int returnValue;
             byte* name_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(name);
@@ -1425,40 +1425,40 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ShaderBinary"/>
-        public static unsafe void ShaderBinary(ReadOnlySpan<ShaderHandle> shaders, ShaderBinaryFormat binaryFormat, IntPtr binary, int length)
+        public static unsafe void ShaderBinary(ReadOnlySpan<int> shaders, ShaderBinaryFormat binaryFormat, IntPtr binary, int length)
         {
             int count = (int)(shaders.Length);
-            fixed (ShaderHandle* shaders_ptr = shaders)
+            fixed (int* shaders_ptr = shaders)
             {
                 void* binary_vptr = (void*)binary;
                 ShaderBinary(count, shaders_ptr, binaryFormat, binary_vptr, length);
             }
         }
         /// <inheritdoc cref="ShaderBinary"/>
-        public static unsafe void ShaderBinary(ShaderHandle[] shaders, ShaderBinaryFormat binaryFormat, IntPtr binary, int length)
+        public static unsafe void ShaderBinary(int[] shaders, ShaderBinaryFormat binaryFormat, IntPtr binary, int length)
         {
             int count = (int)(shaders.Length);
-            fixed (ShaderHandle* shaders_ptr = shaders)
+            fixed (int* shaders_ptr = shaders)
             {
                 void* binary_vptr = (void*)binary;
                 ShaderBinary(count, shaders_ptr, binaryFormat, binary_vptr, length);
             }
         }
         /// <inheritdoc cref="ShaderBinary"/>
-        public static unsafe void ShaderBinary(int count, in ShaderHandle shaders, ShaderBinaryFormat binaryFormat, IntPtr binary, int length)
+        public static unsafe void ShaderBinary(int count, in int shaders, ShaderBinaryFormat binaryFormat, IntPtr binary, int length)
         {
-            fixed (ShaderHandle* shaders_ptr = &shaders)
+            fixed (int* shaders_ptr = &shaders)
             {
                 void* binary_vptr = (void*)binary;
                 ShaderBinary(count, shaders_ptr, binaryFormat, binary_vptr, length);
             }
         }
         /// <inheritdoc cref="ShaderBinary"/>
-        public static unsafe void ShaderBinary<T1>(ReadOnlySpan<ShaderHandle> shaders, ShaderBinaryFormat binaryFormat, ReadOnlySpan<T1> binary)
+        public static unsafe void ShaderBinary<T1>(ReadOnlySpan<int> shaders, ShaderBinaryFormat binaryFormat, ReadOnlySpan<T1> binary)
             where T1 : unmanaged
         {
             int count = (int)(shaders.Length);
-            fixed (ShaderHandle* shaders_ptr = shaders)
+            fixed (int* shaders_ptr = shaders)
             {
                 int length = (int)(binary.Length * sizeof(T1));
                 fixed (void* binary_ptr = binary)
@@ -1468,11 +1468,11 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ShaderBinary"/>
-        public static unsafe void ShaderBinary<T1>(ShaderHandle[] shaders, ShaderBinaryFormat binaryFormat, T1[] binary)
+        public static unsafe void ShaderBinary<T1>(int[] shaders, ShaderBinaryFormat binaryFormat, T1[] binary)
             where T1 : unmanaged
         {
             int count = (int)(shaders.Length);
-            fixed (ShaderHandle* shaders_ptr = shaders)
+            fixed (int* shaders_ptr = shaders)
             {
                 int length = (int)(binary.Length * sizeof(T1));
                 fixed (void* binary_ptr = binary)
@@ -1482,17 +1482,17 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ShaderBinary"/>
-        public static unsafe void ShaderBinary<T1>(int count, in ShaderHandle shaders, ShaderBinaryFormat binaryFormat, in T1 binary, int length)
+        public static unsafe void ShaderBinary<T1>(int count, in int shaders, ShaderBinaryFormat binaryFormat, in T1 binary, int length)
             where T1 : unmanaged
         {
-            fixed (ShaderHandle* shaders_ptr = &shaders)
+            fixed (int* shaders_ptr = &shaders)
             fixed (void* binary_ptr = &binary)
             {
                 ShaderBinary(count, shaders_ptr, binaryFormat, binary_ptr, length);
             }
         }
         /// <inheritdoc cref="ShaderSource"/>
-        public static unsafe void ShaderSource(ShaderHandle shader, int count, byte** str, ReadOnlySpan<int> length)
+        public static unsafe void ShaderSource(int shader, int count, byte** str, ReadOnlySpan<int> length)
         {
             fixed (int* length_ptr = length)
             {
@@ -1500,7 +1500,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ShaderSource"/>
-        public static unsafe void ShaderSource(ShaderHandle shader, int count, byte** str, int[] length)
+        public static unsafe void ShaderSource(int shader, int count, byte** str, int[] length)
         {
             fixed (int* length_ptr = length)
             {
@@ -1508,7 +1508,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ShaderSource"/>
-        public static unsafe void ShaderSource(ShaderHandle shader, int count, byte** str, in int length)
+        public static unsafe void ShaderSource(int shader, int count, byte** str, in int length)
         {
             fixed (int* length_ptr = &length)
             {
@@ -2246,9 +2246,9 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GenQueries"/>
-        public static unsafe QueryHandle GenQuery()
+        public static unsafe int GenQuery()
         {
-            QueryHandle id;
+            int id;
             int n = 1;
             Unsafe.SkipInit(out id);
             // FIXME: This could be a problem for the overloads that take an out parameter
@@ -2259,12 +2259,12 @@ namespace OpenTK.Graphics.OpenGLES3
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            QueryHandle* ids_handle = (QueryHandle*)Unsafe.AsPointer(ref id);
+            int* ids_handle = (int*)Unsafe.AsPointer(ref id);
             GenQueries(n, ids_handle);
             return id;
         }
         /// <inheritdoc cref="GenQueries"/>
-        public static unsafe void GenQuery(out QueryHandle id)
+        public static unsafe void GenQuery(out int id)
         {
             int n = 1;
             Unsafe.SkipInit(out id);
@@ -2276,66 +2276,66 @@ namespace OpenTK.Graphics.OpenGLES3
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            QueryHandle* ids_handle = (QueryHandle*)Unsafe.AsPointer(ref id);
+            int* ids_handle = (int*)Unsafe.AsPointer(ref id);
             GenQueries(n, ids_handle);
         }
         /// <inheritdoc cref="GenQueries"/>
-        public static unsafe void GenQueries(Span<QueryHandle> ids)
+        public static unsafe void GenQueries(Span<int> ids)
         {
             int n = (int)(ids.Length);
-            fixed (QueryHandle* ids_ptr = ids)
+            fixed (int* ids_ptr = ids)
             {
                 GenQueries(n, ids_ptr);
             }
         }
         /// <inheritdoc cref="GenQueries"/>
-        public static unsafe void GenQueries(QueryHandle[] ids)
+        public static unsafe void GenQueries(int[] ids)
         {
             int n = (int)(ids.Length);
-            fixed (QueryHandle* ids_ptr = ids)
+            fixed (int* ids_ptr = ids)
             {
                 GenQueries(n, ids_ptr);
             }
         }
         /// <inheritdoc cref="GenQueries"/>
-        public static unsafe void GenQueries(int n, ref QueryHandle ids)
+        public static unsafe void GenQueries(int n, ref int ids)
         {
-            fixed (QueryHandle* ids_ptr = &ids)
+            fixed (int* ids_ptr = &ids)
             {
                 GenQueries(n, ids_ptr);
             }
         }
         /// <inheritdoc cref="DeleteQueries"/>
-        public static unsafe void DeleteQuery(in QueryHandle id)
+        public static unsafe void DeleteQuery(in int id)
         {
             int n = 1;
-            fixed(QueryHandle* ids_handle = &id)
+            fixed(int* ids_handle = &id)
             {
                 DeleteQueries(n, ids_handle);
             }
         }
         /// <inheritdoc cref="DeleteQueries"/>
-        public static unsafe void DeleteQueries(ReadOnlySpan<QueryHandle> ids)
+        public static unsafe void DeleteQueries(ReadOnlySpan<int> ids)
         {
             int n = (int)(ids.Length);
-            fixed (QueryHandle* ids_ptr = ids)
+            fixed (int* ids_ptr = ids)
             {
                 DeleteQueries(n, ids_ptr);
             }
         }
         /// <inheritdoc cref="DeleteQueries"/>
-        public static unsafe void DeleteQueries(QueryHandle[] ids)
+        public static unsafe void DeleteQueries(int[] ids)
         {
             int n = (int)(ids.Length);
-            fixed (QueryHandle* ids_ptr = ids)
+            fixed (int* ids_ptr = ids)
             {
                 DeleteQueries(n, ids_ptr);
             }
         }
         /// <inheritdoc cref="DeleteQueries"/>
-        public static unsafe void DeleteQueries(int n, in QueryHandle ids)
+        public static unsafe void DeleteQueries(int n, in int ids)
         {
-            fixed (QueryHandle* ids_ptr = &ids)
+            fixed (int* ids_ptr = &ids)
             {
                 DeleteQueries(n, ids_ptr);
             }
@@ -2365,7 +2365,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetQueryObjectuiv"/>
-        public static unsafe void GetQueryObjectui(QueryHandle id, QueryObjectParameterName pname, Span<uint> parameters)
+        public static unsafe void GetQueryObjectui(int id, QueryObjectParameterName pname, Span<uint> parameters)
         {
             fixed (uint* parameters_ptr = parameters)
             {
@@ -2373,7 +2373,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetQueryObjectuiv"/>
-        public static unsafe void GetQueryObjectui(QueryHandle id, QueryObjectParameterName pname, uint[] parameters)
+        public static unsafe void GetQueryObjectui(int id, QueryObjectParameterName pname, uint[] parameters)
         {
             fixed (uint* parameters_ptr = parameters)
             {
@@ -2381,7 +2381,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetQueryObjectuiv"/>
-        public static unsafe void GetQueryObjectui(QueryHandle id, QueryObjectParameterName pname, ref uint parameters)
+        public static unsafe void GetQueryObjectui(int id, QueryObjectParameterName pname, ref uint parameters)
         {
             fixed (uint* parameters_ptr = &parameters)
             {
@@ -2609,44 +2609,44 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="DeleteVertexArrays"/>
-        public static unsafe void DeleteVertexArray(in VertexArrayHandle array)
+        public static unsafe void DeleteVertexArray(in int array)
         {
             int n = 1;
-            fixed(VertexArrayHandle* arrays_handle = &array)
+            fixed(int* arrays_handle = &array)
             {
                 DeleteVertexArrays(n, arrays_handle);
             }
         }
         /// <inheritdoc cref="DeleteVertexArrays"/>
-        public static unsafe void DeleteVertexArrays(ReadOnlySpan<VertexArrayHandle> arrays)
+        public static unsafe void DeleteVertexArrays(ReadOnlySpan<int> arrays)
         {
             int n = (int)(arrays.Length);
-            fixed (VertexArrayHandle* arrays_ptr = arrays)
+            fixed (int* arrays_ptr = arrays)
             {
                 DeleteVertexArrays(n, arrays_ptr);
             }
         }
         /// <inheritdoc cref="DeleteVertexArrays"/>
-        public static unsafe void DeleteVertexArrays(VertexArrayHandle[] arrays)
+        public static unsafe void DeleteVertexArrays(int[] arrays)
         {
             int n = (int)(arrays.Length);
-            fixed (VertexArrayHandle* arrays_ptr = arrays)
+            fixed (int* arrays_ptr = arrays)
             {
                 DeleteVertexArrays(n, arrays_ptr);
             }
         }
         /// <inheritdoc cref="DeleteVertexArrays"/>
-        public static unsafe void DeleteVertexArrays(int n, in VertexArrayHandle arrays)
+        public static unsafe void DeleteVertexArrays(int n, in int arrays)
         {
-            fixed (VertexArrayHandle* arrays_ptr = &arrays)
+            fixed (int* arrays_ptr = &arrays)
             {
                 DeleteVertexArrays(n, arrays_ptr);
             }
         }
         /// <inheritdoc cref="GenVertexArrays"/>
-        public static unsafe VertexArrayHandle GenVertexArray()
+        public static unsafe int GenVertexArray()
         {
-            VertexArrayHandle array;
+            int array;
             int n = 1;
             Unsafe.SkipInit(out array);
             // FIXME: This could be a problem for the overloads that take an out parameter
@@ -2657,12 +2657,12 @@ namespace OpenTK.Graphics.OpenGLES3
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            VertexArrayHandle* arrays_handle = (VertexArrayHandle*)Unsafe.AsPointer(ref array);
+            int* arrays_handle = (int*)Unsafe.AsPointer(ref array);
             GenVertexArrays(n, arrays_handle);
             return array;
         }
         /// <inheritdoc cref="GenVertexArrays"/>
-        public static unsafe void GenVertexArray(out VertexArrayHandle array)
+        public static unsafe void GenVertexArray(out int array)
         {
             int n = 1;
             Unsafe.SkipInit(out array);
@@ -2674,31 +2674,31 @@ namespace OpenTK.Graphics.OpenGLES3
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            VertexArrayHandle* arrays_handle = (VertexArrayHandle*)Unsafe.AsPointer(ref array);
+            int* arrays_handle = (int*)Unsafe.AsPointer(ref array);
             GenVertexArrays(n, arrays_handle);
         }
         /// <inheritdoc cref="GenVertexArrays"/>
-        public static unsafe void GenVertexArrays(Span<VertexArrayHandle> arrays)
+        public static unsafe void GenVertexArrays(Span<int> arrays)
         {
             int n = (int)(arrays.Length);
-            fixed (VertexArrayHandle* arrays_ptr = arrays)
+            fixed (int* arrays_ptr = arrays)
             {
                 GenVertexArrays(n, arrays_ptr);
             }
         }
         /// <inheritdoc cref="GenVertexArrays"/>
-        public static unsafe void GenVertexArrays(VertexArrayHandle[] arrays)
+        public static unsafe void GenVertexArrays(int[] arrays)
         {
             int n = (int)(arrays.Length);
-            fixed (VertexArrayHandle* arrays_ptr = arrays)
+            fixed (int* arrays_ptr = arrays)
             {
                 GenVertexArrays(n, arrays_ptr);
             }
         }
         /// <inheritdoc cref="GenVertexArrays"/>
-        public static unsafe void GenVertexArrays(int n, ref VertexArrayHandle arrays)
+        public static unsafe void GenVertexArrays(int n, ref int arrays)
         {
-            fixed (VertexArrayHandle* arrays_ptr = &arrays)
+            fixed (int* arrays_ptr = &arrays)
             {
                 GenVertexArrays(n, arrays_ptr);
             }
@@ -2728,7 +2728,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetTransformFeedbackVarying"/>
-        public static unsafe string GetTransformFeedbackVarying(ProgramHandle program, uint index, int bufSize, Span<int> length, Span<int> size, Span<AttributeType> type)
+        public static unsafe string GetTransformFeedbackVarying(int program, uint index, int bufSize, Span<int> length, Span<int> size, Span<AttributeType> type)
         {
             string name;
             fixed (int* length_ptr = length)
@@ -2747,7 +2747,7 @@ namespace OpenTK.Graphics.OpenGLES3
             return name;
         }
         /// <inheritdoc cref="GetTransformFeedbackVarying"/>
-        public static unsafe void GetTransformFeedbackVarying(ProgramHandle program, uint index, int bufSize, Span<int> length, Span<int> size, Span<AttributeType> type, out string name)
+        public static unsafe void GetTransformFeedbackVarying(int program, uint index, int bufSize, Span<int> length, Span<int> size, Span<AttributeType> type, out string name)
         {
             fixed (int* length_ptr = length)
             {
@@ -2764,7 +2764,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetTransformFeedbackVarying"/>
-        public static unsafe string GetTransformFeedbackVarying(ProgramHandle program, uint index, int bufSize, int[] length, int[] size, AttributeType[] type)
+        public static unsafe string GetTransformFeedbackVarying(int program, uint index, int bufSize, int[] length, int[] size, AttributeType[] type)
         {
             string name;
             fixed (int* length_ptr = length)
@@ -2783,7 +2783,7 @@ namespace OpenTK.Graphics.OpenGLES3
             return name;
         }
         /// <inheritdoc cref="GetTransformFeedbackVarying"/>
-        public static unsafe void GetTransformFeedbackVarying(ProgramHandle program, uint index, int bufSize, int[] length, int[] size, AttributeType[] type, out string name)
+        public static unsafe void GetTransformFeedbackVarying(int program, uint index, int bufSize, int[] length, int[] size, AttributeType[] type, out string name)
         {
             fixed (int* length_ptr = length)
             {
@@ -2800,7 +2800,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetTransformFeedbackVarying"/>
-        public static unsafe string GetTransformFeedbackVarying(ProgramHandle program, uint index, int bufSize, ref int length, ref int size, ref AttributeType type)
+        public static unsafe string GetTransformFeedbackVarying(int program, uint index, int bufSize, ref int length, ref int size, ref AttributeType type)
         {
             string name;
             fixed (int* length_ptr = &length)
@@ -2815,7 +2815,7 @@ namespace OpenTK.Graphics.OpenGLES3
             return name;
         }
         /// <inheritdoc cref="GetTransformFeedbackVarying"/>
-        public static unsafe void GetTransformFeedbackVarying(ProgramHandle program, uint index, int bufSize, ref int length, ref int size, ref AttributeType type, out string name)
+        public static unsafe void GetTransformFeedbackVarying(int program, uint index, int bufSize, ref int length, ref int size, ref AttributeType type, out string name)
         {
             fixed (int* length_ptr = &length)
             fixed (int* size_ptr = &size)
@@ -2915,7 +2915,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetUniformuiv"/>
-        public static unsafe void GetUniformui(ProgramHandle program, int location, Span<uint> parameters)
+        public static unsafe void GetUniformui(int program, int location, Span<uint> parameters)
         {
             fixed (uint* parameters_ptr = parameters)
             {
@@ -2923,7 +2923,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetUniformuiv"/>
-        public static unsafe void GetUniformui(ProgramHandle program, int location, uint[] parameters)
+        public static unsafe void GetUniformui(int program, int location, uint[] parameters)
         {
             fixed (uint* parameters_ptr = parameters)
             {
@@ -2931,7 +2931,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetUniformuiv"/>
-        public static unsafe void GetUniformui(ProgramHandle program, int location, ref uint parameters)
+        public static unsafe void GetUniformui(int program, int location, ref uint parameters)
         {
             fixed (uint* parameters_ptr = &parameters)
             {
@@ -2939,7 +2939,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetFragDataLocation"/>
-        public static unsafe int GetFragDataLocation(ProgramHandle program, string name)
+        public static unsafe int GetFragDataLocation(int program, string name)
         {
             int returnValue;
             byte* name_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(name);
@@ -3138,7 +3138,7 @@ namespace OpenTK.Graphics.OpenGLES3
             return returnValue_str;
         }
         /// <inheritdoc cref="GetUniformIndices"/>
-        public static unsafe void GetUniformIndices(ProgramHandle program, int uniformCount, byte** uniformNames, Span<uint> uniformIndices)
+        public static unsafe void GetUniformIndices(int program, int uniformCount, byte** uniformNames, Span<uint> uniformIndices)
         {
             fixed (uint* uniformIndices_ptr = uniformIndices)
             {
@@ -3146,7 +3146,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetUniformIndices"/>
-        public static unsafe void GetUniformIndices(ProgramHandle program, int uniformCount, byte** uniformNames, uint[] uniformIndices)
+        public static unsafe void GetUniformIndices(int program, int uniformCount, byte** uniformNames, uint[] uniformIndices)
         {
             fixed (uint* uniformIndices_ptr = uniformIndices)
             {
@@ -3154,7 +3154,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetUniformIndices"/>
-        public static unsafe void GetUniformIndices(ProgramHandle program, int uniformCount, byte** uniformNames, ref uint uniformIndices)
+        public static unsafe void GetUniformIndices(int program, int uniformCount, byte** uniformNames, ref uint uniformIndices)
         {
             fixed (uint* uniformIndices_ptr = &uniformIndices)
             {
@@ -3162,7 +3162,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetActiveUniformsiv"/>
-        public static unsafe void GetActiveUniformsi(ProgramHandle program, ReadOnlySpan<uint> uniformIndices, UniformPName pname, Span<int> parameters)
+        public static unsafe void GetActiveUniformsi(int program, ReadOnlySpan<uint> uniformIndices, UniformPName pname, Span<int> parameters)
         {
             int uniformCount = (int)(uniformIndices.Length);
             fixed (uint* uniformIndices_ptr = uniformIndices)
@@ -3174,7 +3174,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetActiveUniformsiv"/>
-        public static unsafe void GetActiveUniformsi(ProgramHandle program, uint[] uniformIndices, UniformPName pname, int[] parameters)
+        public static unsafe void GetActiveUniformsi(int program, uint[] uniformIndices, UniformPName pname, int[] parameters)
         {
             int uniformCount = (int)(uniformIndices.Length);
             fixed (uint* uniformIndices_ptr = uniformIndices)
@@ -3186,7 +3186,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetActiveUniformsiv"/>
-        public static unsafe void GetActiveUniformsi(ProgramHandle program, int uniformCount, in uint uniformIndices, UniformPName pname, ref int parameters)
+        public static unsafe void GetActiveUniformsi(int program, int uniformCount, in uint uniformIndices, UniformPName pname, ref int parameters)
         {
             fixed (uint* uniformIndices_ptr = &uniformIndices)
             fixed (int* parameters_ptr = &parameters)
@@ -3195,7 +3195,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetUniformBlockIndex"/>
-        public static unsafe uint GetUniformBlockIndex(ProgramHandle program, string uniformBlockName)
+        public static unsafe uint GetUniformBlockIndex(int program, string uniformBlockName)
         {
             uint returnValue;
             byte* uniformBlockName_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(uniformBlockName);
@@ -3204,7 +3204,7 @@ namespace OpenTK.Graphics.OpenGLES3
             return returnValue;
         }
         /// <inheritdoc cref="GetActiveUniformBlockiv"/>
-        public static unsafe void GetActiveUniformBlocki(ProgramHandle program, uint uniformBlockIndex, UniformBlockPName pname, Span<int> parameters)
+        public static unsafe void GetActiveUniformBlocki(int program, uint uniformBlockIndex, UniformBlockPName pname, Span<int> parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
@@ -3212,7 +3212,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetActiveUniformBlockiv"/>
-        public static unsafe void GetActiveUniformBlocki(ProgramHandle program, uint uniformBlockIndex, UniformBlockPName pname, int[] parameters)
+        public static unsafe void GetActiveUniformBlocki(int program, uint uniformBlockIndex, UniformBlockPName pname, int[] parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
@@ -3220,7 +3220,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetActiveUniformBlockiv"/>
-        public static unsafe void GetActiveUniformBlocki(ProgramHandle program, uint uniformBlockIndex, UniformBlockPName pname, ref int parameters)
+        public static unsafe void GetActiveUniformBlocki(int program, uint uniformBlockIndex, UniformBlockPName pname, ref int parameters)
         {
             fixed (int* parameters_ptr = &parameters)
             {
@@ -3228,7 +3228,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetActiveUniformBlockName"/>
-        public static unsafe string GetActiveUniformBlockName(ProgramHandle program, uint uniformBlockIndex, int bufSize, Span<int> length)
+        public static unsafe string GetActiveUniformBlockName(int program, uint uniformBlockIndex, int bufSize, Span<int> length)
         {
             string uniformBlockName;
             fixed (int* length_ptr = length)
@@ -3241,7 +3241,7 @@ namespace OpenTK.Graphics.OpenGLES3
             return uniformBlockName;
         }
         /// <inheritdoc cref="GetActiveUniformBlockName"/>
-        public static unsafe void GetActiveUniformBlockName(ProgramHandle program, uint uniformBlockIndex, int bufSize, Span<int> length, out string uniformBlockName)
+        public static unsafe void GetActiveUniformBlockName(int program, uint uniformBlockIndex, int bufSize, Span<int> length, out string uniformBlockName)
         {
             fixed (int* length_ptr = length)
             {
@@ -3252,7 +3252,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetActiveUniformBlockName"/>
-        public static unsafe string GetActiveUniformBlockName(ProgramHandle program, uint uniformBlockIndex, int bufSize, int[] length)
+        public static unsafe string GetActiveUniformBlockName(int program, uint uniformBlockIndex, int bufSize, int[] length)
         {
             string uniformBlockName;
             fixed (int* length_ptr = length)
@@ -3265,7 +3265,7 @@ namespace OpenTK.Graphics.OpenGLES3
             return uniformBlockName;
         }
         /// <inheritdoc cref="GetActiveUniformBlockName"/>
-        public static unsafe void GetActiveUniformBlockName(ProgramHandle program, uint uniformBlockIndex, int bufSize, int[] length, out string uniformBlockName)
+        public static unsafe void GetActiveUniformBlockName(int program, uint uniformBlockIndex, int bufSize, int[] length, out string uniformBlockName)
         {
             fixed (int* length_ptr = length)
             {
@@ -3276,7 +3276,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetActiveUniformBlockName"/>
-        public static unsafe string GetActiveUniformBlockName(ProgramHandle program, uint uniformBlockIndex, int bufSize, ref int length)
+        public static unsafe string GetActiveUniformBlockName(int program, uint uniformBlockIndex, int bufSize, ref int length)
         {
             string uniformBlockName;
             fixed (int* length_ptr = &length)
@@ -3289,7 +3289,7 @@ namespace OpenTK.Graphics.OpenGLES3
             return uniformBlockName;
         }
         /// <inheritdoc cref="GetActiveUniformBlockName"/>
-        public static unsafe void GetActiveUniformBlockName(ProgramHandle program, uint uniformBlockIndex, int bufSize, ref int length, out string uniformBlockName)
+        public static unsafe void GetActiveUniformBlockName(int program, uint uniformBlockIndex, int bufSize, ref int length, out string uniformBlockName)
         {
             fixed (int* length_ptr = &length)
             {
@@ -3411,9 +3411,9 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GenSamplers"/>
-        public static unsafe SamplerHandle GenSampler()
+        public static unsafe int GenSampler()
         {
-            SamplerHandle sampler;
+            int sampler;
             int count = 1;
             Unsafe.SkipInit(out sampler);
             // FIXME: This could be a problem for the overloads that take an out parameter
@@ -3424,12 +3424,12 @@ namespace OpenTK.Graphics.OpenGLES3
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            SamplerHandle* samplers_handle = (SamplerHandle*)Unsafe.AsPointer(ref sampler);
+            int* samplers_handle = (int*)Unsafe.AsPointer(ref sampler);
             GenSamplers(count, samplers_handle);
             return sampler;
         }
         /// <inheritdoc cref="GenSamplers"/>
-        public static unsafe void GenSampler(out SamplerHandle sampler)
+        public static unsafe void GenSampler(out int sampler)
         {
             int count = 1;
             Unsafe.SkipInit(out sampler);
@@ -3441,72 +3441,72 @@ namespace OpenTK.Graphics.OpenGLES3
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            SamplerHandle* samplers_handle = (SamplerHandle*)Unsafe.AsPointer(ref sampler);
+            int* samplers_handle = (int*)Unsafe.AsPointer(ref sampler);
             GenSamplers(count, samplers_handle);
         }
         /// <inheritdoc cref="GenSamplers"/>
-        public static unsafe void GenSamplers(Span<SamplerHandle> samplers)
+        public static unsafe void GenSamplers(Span<int> samplers)
         {
             int count = (int)(samplers.Length);
-            fixed (SamplerHandle* samplers_ptr = samplers)
+            fixed (int* samplers_ptr = samplers)
             {
                 GenSamplers(count, samplers_ptr);
             }
         }
         /// <inheritdoc cref="GenSamplers"/>
-        public static unsafe void GenSamplers(SamplerHandle[] samplers)
+        public static unsafe void GenSamplers(int[] samplers)
         {
             int count = (int)(samplers.Length);
-            fixed (SamplerHandle* samplers_ptr = samplers)
+            fixed (int* samplers_ptr = samplers)
             {
                 GenSamplers(count, samplers_ptr);
             }
         }
         /// <inheritdoc cref="GenSamplers"/>
-        public static unsafe void GenSamplers(int count, ref SamplerHandle samplers)
+        public static unsafe void GenSamplers(int count, ref int samplers)
         {
-            fixed (SamplerHandle* samplers_ptr = &samplers)
+            fixed (int* samplers_ptr = &samplers)
             {
                 GenSamplers(count, samplers_ptr);
             }
         }
         /// <inheritdoc cref="DeleteSamplers"/>
-        public static unsafe void DeleteSampler(in SamplerHandle sampler)
+        public static unsafe void DeleteSampler(in int sampler)
         {
             int count = 1;
-            fixed(SamplerHandle* samplers_handle = &sampler)
+            fixed(int* samplers_handle = &sampler)
             {
                 DeleteSamplers(count, samplers_handle);
             }
         }
         /// <inheritdoc cref="DeleteSamplers"/>
-        public static unsafe void DeleteSamplers(ReadOnlySpan<SamplerHandle> samplers)
+        public static unsafe void DeleteSamplers(ReadOnlySpan<int> samplers)
         {
             int count = (int)(samplers.Length);
-            fixed (SamplerHandle* samplers_ptr = samplers)
+            fixed (int* samplers_ptr = samplers)
             {
                 DeleteSamplers(count, samplers_ptr);
             }
         }
         /// <inheritdoc cref="DeleteSamplers"/>
-        public static unsafe void DeleteSamplers(SamplerHandle[] samplers)
+        public static unsafe void DeleteSamplers(int[] samplers)
         {
             int count = (int)(samplers.Length);
-            fixed (SamplerHandle* samplers_ptr = samplers)
+            fixed (int* samplers_ptr = samplers)
             {
                 DeleteSamplers(count, samplers_ptr);
             }
         }
         /// <inheritdoc cref="DeleteSamplers"/>
-        public static unsafe void DeleteSamplers(int count, in SamplerHandle samplers)
+        public static unsafe void DeleteSamplers(int count, in int samplers)
         {
-            fixed (SamplerHandle* samplers_ptr = &samplers)
+            fixed (int* samplers_ptr = &samplers)
             {
                 DeleteSamplers(count, samplers_ptr);
             }
         }
         /// <inheritdoc cref="SamplerParameteriv"/>
-        public static unsafe void SamplerParameteri(SamplerHandle sampler, SamplerParameterI pname, ReadOnlySpan<int> param)
+        public static unsafe void SamplerParameteri(int sampler, SamplerParameterI pname, ReadOnlySpan<int> param)
         {
             fixed (int* param_ptr = param)
             {
@@ -3514,7 +3514,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="SamplerParameteriv"/>
-        public static unsafe void SamplerParameteri(SamplerHandle sampler, SamplerParameterI pname, int[] param)
+        public static unsafe void SamplerParameteri(int sampler, SamplerParameterI pname, int[] param)
         {
             fixed (int* param_ptr = param)
             {
@@ -3522,7 +3522,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="SamplerParameteriv"/>
-        public static unsafe void SamplerParameteri(SamplerHandle sampler, SamplerParameterI pname, in int param)
+        public static unsafe void SamplerParameteri(int sampler, SamplerParameterI pname, in int param)
         {
             fixed (int* param_ptr = &param)
             {
@@ -3530,7 +3530,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="SamplerParameterfv"/>
-        public static unsafe void SamplerParameterf(SamplerHandle sampler, SamplerParameterF pname, ReadOnlySpan<float> param)
+        public static unsafe void SamplerParameterf(int sampler, SamplerParameterF pname, ReadOnlySpan<float> param)
         {
             fixed (float* param_ptr = param)
             {
@@ -3538,7 +3538,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="SamplerParameterfv"/>
-        public static unsafe void SamplerParameterf(SamplerHandle sampler, SamplerParameterF pname, float[] param)
+        public static unsafe void SamplerParameterf(int sampler, SamplerParameterF pname, float[] param)
         {
             fixed (float* param_ptr = param)
             {
@@ -3546,7 +3546,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="SamplerParameterfv"/>
-        public static unsafe void SamplerParameterf(SamplerHandle sampler, SamplerParameterF pname, in float param)
+        public static unsafe void SamplerParameterf(int sampler, SamplerParameterF pname, in float param)
         {
             fixed (float* param_ptr = &param)
             {
@@ -3554,7 +3554,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetSamplerParameteriv"/>
-        public static unsafe void GetSamplerParameteri(SamplerHandle sampler, SamplerParameterI pname, Span<int> parameters)
+        public static unsafe void GetSamplerParameteri(int sampler, SamplerParameterI pname, Span<int> parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
@@ -3562,7 +3562,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetSamplerParameteriv"/>
-        public static unsafe void GetSamplerParameteri(SamplerHandle sampler, SamplerParameterI pname, int[] parameters)
+        public static unsafe void GetSamplerParameteri(int sampler, SamplerParameterI pname, int[] parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
@@ -3570,7 +3570,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetSamplerParameteriv"/>
-        public static unsafe void GetSamplerParameteri(SamplerHandle sampler, SamplerParameterI pname, ref int parameters)
+        public static unsafe void GetSamplerParameteri(int sampler, SamplerParameterI pname, ref int parameters)
         {
             fixed (int* parameters_ptr = &parameters)
             {
@@ -3578,7 +3578,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetSamplerParameterfv"/>
-        public static unsafe void GetSamplerParameterf(SamplerHandle sampler, SamplerParameterF pname, Span<float> parameters)
+        public static unsafe void GetSamplerParameterf(int sampler, SamplerParameterF pname, Span<float> parameters)
         {
             fixed (float* parameters_ptr = parameters)
             {
@@ -3586,7 +3586,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetSamplerParameterfv"/>
-        public static unsafe void GetSamplerParameterf(SamplerHandle sampler, SamplerParameterF pname, float[] parameters)
+        public static unsafe void GetSamplerParameterf(int sampler, SamplerParameterF pname, float[] parameters)
         {
             fixed (float* parameters_ptr = parameters)
             {
@@ -3594,7 +3594,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetSamplerParameterfv"/>
-        public static unsafe void GetSamplerParameterf(SamplerHandle sampler, SamplerParameterF pname, ref float parameters)
+        public static unsafe void GetSamplerParameterf(int sampler, SamplerParameterF pname, ref float parameters)
         {
             fixed (float* parameters_ptr = &parameters)
             {
@@ -3602,44 +3602,44 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="DeleteTransformFeedbacks"/>
-        public static unsafe void DeleteTransformFeedback(in TransformFeedbackHandle id)
+        public static unsafe void DeleteTransformFeedback(in int id)
         {
             int n = 1;
-            fixed(TransformFeedbackHandle* ids_handle = &id)
+            fixed(int* ids_handle = &id)
             {
                 DeleteTransformFeedbacks(n, ids_handle);
             }
         }
         /// <inheritdoc cref="DeleteTransformFeedbacks"/>
-        public static unsafe void DeleteTransformFeedbacks(ReadOnlySpan<TransformFeedbackHandle> ids)
+        public static unsafe void DeleteTransformFeedbacks(ReadOnlySpan<int> ids)
         {
             int n = (int)(ids.Length);
-            fixed (TransformFeedbackHandle* ids_ptr = ids)
+            fixed (int* ids_ptr = ids)
             {
                 DeleteTransformFeedbacks(n, ids_ptr);
             }
         }
         /// <inheritdoc cref="DeleteTransformFeedbacks"/>
-        public static unsafe void DeleteTransformFeedbacks(TransformFeedbackHandle[] ids)
+        public static unsafe void DeleteTransformFeedbacks(int[] ids)
         {
             int n = (int)(ids.Length);
-            fixed (TransformFeedbackHandle* ids_ptr = ids)
+            fixed (int* ids_ptr = ids)
             {
                 DeleteTransformFeedbacks(n, ids_ptr);
             }
         }
         /// <inheritdoc cref="DeleteTransformFeedbacks"/>
-        public static unsafe void DeleteTransformFeedbacks(int n, in TransformFeedbackHandle ids)
+        public static unsafe void DeleteTransformFeedbacks(int n, in int ids)
         {
-            fixed (TransformFeedbackHandle* ids_ptr = &ids)
+            fixed (int* ids_ptr = &ids)
             {
                 DeleteTransformFeedbacks(n, ids_ptr);
             }
         }
         /// <inheritdoc cref="GenTransformFeedbacks"/>
-        public static unsafe TransformFeedbackHandle GenTransformFeedback()
+        public static unsafe int GenTransformFeedback()
         {
-            TransformFeedbackHandle id;
+            int id;
             int n = 1;
             Unsafe.SkipInit(out id);
             // FIXME: This could be a problem for the overloads that take an out parameter
@@ -3650,12 +3650,12 @@ namespace OpenTK.Graphics.OpenGLES3
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            TransformFeedbackHandle* ids_handle = (TransformFeedbackHandle*)Unsafe.AsPointer(ref id);
+            int* ids_handle = (int*)Unsafe.AsPointer(ref id);
             GenTransformFeedbacks(n, ids_handle);
             return id;
         }
         /// <inheritdoc cref="GenTransformFeedbacks"/>
-        public static unsafe void GenTransformFeedback(out TransformFeedbackHandle id)
+        public static unsafe void GenTransformFeedback(out int id)
         {
             int n = 1;
             Unsafe.SkipInit(out id);
@@ -3667,37 +3667,37 @@ namespace OpenTK.Graphics.OpenGLES3
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            TransformFeedbackHandle* ids_handle = (TransformFeedbackHandle*)Unsafe.AsPointer(ref id);
+            int* ids_handle = (int*)Unsafe.AsPointer(ref id);
             GenTransformFeedbacks(n, ids_handle);
         }
         /// <inheritdoc cref="GenTransformFeedbacks"/>
-        public static unsafe void GenTransformFeedbacks(Span<TransformFeedbackHandle> ids)
+        public static unsafe void GenTransformFeedbacks(Span<int> ids)
         {
             int n = (int)(ids.Length);
-            fixed (TransformFeedbackHandle* ids_ptr = ids)
+            fixed (int* ids_ptr = ids)
             {
                 GenTransformFeedbacks(n, ids_ptr);
             }
         }
         /// <inheritdoc cref="GenTransformFeedbacks"/>
-        public static unsafe void GenTransformFeedbacks(TransformFeedbackHandle[] ids)
+        public static unsafe void GenTransformFeedbacks(int[] ids)
         {
             int n = (int)(ids.Length);
-            fixed (TransformFeedbackHandle* ids_ptr = ids)
+            fixed (int* ids_ptr = ids)
             {
                 GenTransformFeedbacks(n, ids_ptr);
             }
         }
         /// <inheritdoc cref="GenTransformFeedbacks"/>
-        public static unsafe void GenTransformFeedbacks(int n, ref TransformFeedbackHandle ids)
+        public static unsafe void GenTransformFeedbacks(int n, ref int ids)
         {
-            fixed (TransformFeedbackHandle* ids_ptr = &ids)
+            fixed (int* ids_ptr = &ids)
             {
                 GenTransformFeedbacks(n, ids_ptr);
             }
         }
         /// <inheritdoc cref="GetProgramBinary"/>
-        public static unsafe void GetProgramBinary(ProgramHandle program, int bufSize, Span<int> length, Span<All> binaryFormat, IntPtr binary)
+        public static unsafe void GetProgramBinary(int program, int bufSize, Span<int> length, Span<All> binaryFormat, IntPtr binary)
         {
             fixed (int* length_ptr = length)
             {
@@ -3709,7 +3709,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetProgramBinary"/>
-        public static unsafe void GetProgramBinary(ProgramHandle program, int bufSize, int[] length, All[] binaryFormat, IntPtr binary)
+        public static unsafe void GetProgramBinary(int program, int bufSize, int[] length, All[] binaryFormat, IntPtr binary)
         {
             fixed (int* length_ptr = length)
             {
@@ -3721,7 +3721,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetProgramBinary"/>
-        public static unsafe void GetProgramBinary(ProgramHandle program, int bufSize, ref int length, ref All binaryFormat, IntPtr binary)
+        public static unsafe void GetProgramBinary(int program, int bufSize, ref int length, ref All binaryFormat, IntPtr binary)
         {
             fixed (int* length_ptr = &length)
             fixed (All* binaryFormat_ptr = &binaryFormat)
@@ -3731,7 +3731,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetProgramBinary"/>
-        public static unsafe void GetProgramBinary<T1>(ProgramHandle program, Span<int> length, Span<All> binaryFormat, Span<T1> binary)
+        public static unsafe void GetProgramBinary<T1>(int program, Span<int> length, Span<All> binaryFormat, Span<T1> binary)
             where T1 : unmanaged
         {
             fixed (int* length_ptr = length)
@@ -3747,7 +3747,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetProgramBinary"/>
-        public static unsafe void GetProgramBinary<T1>(ProgramHandle program, int[] length, All[] binaryFormat, T1[] binary)
+        public static unsafe void GetProgramBinary<T1>(int program, int[] length, All[] binaryFormat, T1[] binary)
             where T1 : unmanaged
         {
             fixed (int* length_ptr = length)
@@ -3763,7 +3763,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetProgramBinary"/>
-        public static unsafe void GetProgramBinary<T1>(ProgramHandle program, int bufSize, ref int length, ref All binaryFormat, ref T1 binary)
+        public static unsafe void GetProgramBinary<T1>(int program, int bufSize, ref int length, ref All binaryFormat, ref T1 binary)
             where T1 : unmanaged
         {
             fixed (int* length_ptr = &length)
@@ -3774,13 +3774,13 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramBinary"/>
-        public static unsafe void ProgramBinary(ProgramHandle program, All binaryFormat, IntPtr binary, int length)
+        public static unsafe void ProgramBinary(int program, All binaryFormat, IntPtr binary, int length)
         {
             void* binary_vptr = (void*)binary;
             ProgramBinary(program, binaryFormat, binary_vptr, length);
         }
         /// <inheritdoc cref="ProgramBinary"/>
-        public static unsafe void ProgramBinary<T1>(ProgramHandle program, All binaryFormat, ReadOnlySpan<T1> binary)
+        public static unsafe void ProgramBinary<T1>(int program, All binaryFormat, ReadOnlySpan<T1> binary)
             where T1 : unmanaged
         {
             int length = (int)(binary.Length * sizeof(T1));
@@ -3790,7 +3790,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramBinary"/>
-        public static unsafe void ProgramBinary<T1>(ProgramHandle program, All binaryFormat, T1[] binary)
+        public static unsafe void ProgramBinary<T1>(int program, All binaryFormat, T1[] binary)
             where T1 : unmanaged
         {
             int length = (int)(binary.Length * sizeof(T1));
@@ -3800,7 +3800,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramBinary"/>
-        public static unsafe void ProgramBinary<T1>(ProgramHandle program, All binaryFormat, in T1 binary, int length)
+        public static unsafe void ProgramBinary<T1>(int program, All binaryFormat, in T1 binary, int length)
             where T1 : unmanaged
         {
             fixed (void* binary_ptr = &binary)
@@ -3941,7 +3941,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetProgramInterfaceiv"/>
-        public static unsafe void GetProgramInterfacei(ProgramHandle program, ProgramInterface programInterface, ProgramInterfacePName pname, Span<int> parameters)
+        public static unsafe void GetProgramInterfacei(int program, ProgramInterface programInterface, ProgramInterfacePName pname, Span<int> parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
@@ -3949,7 +3949,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetProgramInterfaceiv"/>
-        public static unsafe void GetProgramInterfacei(ProgramHandle program, ProgramInterface programInterface, ProgramInterfacePName pname, int[] parameters)
+        public static unsafe void GetProgramInterfacei(int program, ProgramInterface programInterface, ProgramInterfacePName pname, int[] parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
@@ -3957,7 +3957,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetProgramInterfaceiv"/>
-        public static unsafe void GetProgramInterfacei(ProgramHandle program, ProgramInterface programInterface, ProgramInterfacePName pname, ref int parameters)
+        public static unsafe void GetProgramInterfacei(int program, ProgramInterface programInterface, ProgramInterfacePName pname, ref int parameters)
         {
             fixed (int* parameters_ptr = &parameters)
             {
@@ -3965,7 +3965,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetProgramResourceIndex"/>
-        public static unsafe uint GetProgramResourceIndex(ProgramHandle program, ProgramInterface programInterface, string name)
+        public static unsafe uint GetProgramResourceIndex(int program, ProgramInterface programInterface, string name)
         {
             uint returnValue;
             byte* name_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(name);
@@ -3974,7 +3974,7 @@ namespace OpenTK.Graphics.OpenGLES3
             return returnValue;
         }
         /// <inheritdoc cref="GetProgramResourceName"/>
-        public static unsafe string GetProgramResourceName(ProgramHandle program, ProgramInterface programInterface, uint index, int bufSize, Span<int> length)
+        public static unsafe string GetProgramResourceName(int program, ProgramInterface programInterface, uint index, int bufSize, Span<int> length)
         {
             string name;
             fixed (int* length_ptr = length)
@@ -3987,7 +3987,7 @@ namespace OpenTK.Graphics.OpenGLES3
             return name;
         }
         /// <inheritdoc cref="GetProgramResourceName"/>
-        public static unsafe void GetProgramResourceName(ProgramHandle program, ProgramInterface programInterface, uint index, int bufSize, Span<int> length, out string name)
+        public static unsafe void GetProgramResourceName(int program, ProgramInterface programInterface, uint index, int bufSize, Span<int> length, out string name)
         {
             fixed (int* length_ptr = length)
             {
@@ -3998,7 +3998,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetProgramResourceName"/>
-        public static unsafe string GetProgramResourceName(ProgramHandle program, ProgramInterface programInterface, uint index, int bufSize, int[] length)
+        public static unsafe string GetProgramResourceName(int program, ProgramInterface programInterface, uint index, int bufSize, int[] length)
         {
             string name;
             fixed (int* length_ptr = length)
@@ -4011,7 +4011,7 @@ namespace OpenTK.Graphics.OpenGLES3
             return name;
         }
         /// <inheritdoc cref="GetProgramResourceName"/>
-        public static unsafe void GetProgramResourceName(ProgramHandle program, ProgramInterface programInterface, uint index, int bufSize, int[] length, out string name)
+        public static unsafe void GetProgramResourceName(int program, ProgramInterface programInterface, uint index, int bufSize, int[] length, out string name)
         {
             fixed (int* length_ptr = length)
             {
@@ -4022,7 +4022,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetProgramResourceName"/>
-        public static unsafe string GetProgramResourceName(ProgramHandle program, ProgramInterface programInterface, uint index, int bufSize, ref int length)
+        public static unsafe string GetProgramResourceName(int program, ProgramInterface programInterface, uint index, int bufSize, ref int length)
         {
             string name;
             fixed (int* length_ptr = &length)
@@ -4035,7 +4035,7 @@ namespace OpenTK.Graphics.OpenGLES3
             return name;
         }
         /// <inheritdoc cref="GetProgramResourceName"/>
-        public static unsafe void GetProgramResourceName(ProgramHandle program, ProgramInterface programInterface, uint index, int bufSize, ref int length, out string name)
+        public static unsafe void GetProgramResourceName(int program, ProgramInterface programInterface, uint index, int bufSize, ref int length, out string name)
         {
             fixed (int* length_ptr = &length)
             {
@@ -4046,7 +4046,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetProgramResourceiv"/>
-        public static unsafe void GetProgramResourcei(ProgramHandle program, ProgramInterface programInterface, uint index, ReadOnlySpan<ProgramResourceProperty> props, Span<int> length, Span<int> parameters)
+        public static unsafe void GetProgramResourcei(int program, ProgramInterface programInterface, uint index, ReadOnlySpan<ProgramResourceProperty> props, Span<int> length, Span<int> parameters)
         {
             int propCount = (int)(props.Length);
             fixed (ProgramResourceProperty* props_ptr = props)
@@ -4062,7 +4062,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetProgramResourceiv"/>
-        public static unsafe void GetProgramResourcei(ProgramHandle program, ProgramInterface programInterface, uint index, ProgramResourceProperty[] props, int[] length, int[] parameters)
+        public static unsafe void GetProgramResourcei(int program, ProgramInterface programInterface, uint index, ProgramResourceProperty[] props, int[] length, int[] parameters)
         {
             int propCount = (int)(props.Length);
             fixed (ProgramResourceProperty* props_ptr = props)
@@ -4078,7 +4078,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetProgramResourceiv"/>
-        public static unsafe void GetProgramResourcei(ProgramHandle program, ProgramInterface programInterface, uint index, int propCount, in ProgramResourceProperty props, int count, ref int length, ref int parameters)
+        public static unsafe void GetProgramResourcei(int program, ProgramInterface programInterface, uint index, int propCount, in ProgramResourceProperty props, int count, ref int length, ref int parameters)
         {
             fixed (ProgramResourceProperty* props_ptr = &props)
             fixed (int* length_ptr = &length)
@@ -4088,7 +4088,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetProgramResourceLocation"/>
-        public static unsafe int GetProgramResourceLocation(ProgramHandle program, ProgramInterface programInterface, string name)
+        public static unsafe int GetProgramResourceLocation(int program, ProgramInterface programInterface, string name)
         {
             int returnValue;
             byte* name_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(name);
@@ -4097,51 +4097,51 @@ namespace OpenTK.Graphics.OpenGLES3
             return returnValue;
         }
         /// <inheritdoc cref="CreateShaderProgramv"/>
-        public static unsafe ProgramHandle CreateShaderProgram(ShaderType type, int count, byte** strings)
+        public static unsafe int CreateShaderProgram(ShaderType type, int count, byte** strings)
         {
-            ProgramHandle returnValue;
+            int returnValue;
             returnValue = CreateShaderProgramv(type, count, strings);
             return returnValue;
         }
         /// <inheritdoc cref="DeleteProgramPipelines"/>
-        public static unsafe void DeleteProgramPipeline(in ProgramPipelineHandle pipeline)
+        public static unsafe void DeleteProgramPipeline(in int pipeline)
         {
             int n = 1;
-            fixed(ProgramPipelineHandle* pipelines_handle = &pipeline)
+            fixed(int* pipelines_handle = &pipeline)
             {
                 DeleteProgramPipelines(n, pipelines_handle);
             }
         }
         /// <inheritdoc cref="DeleteProgramPipelines"/>
-        public static unsafe void DeleteProgramPipelines(ReadOnlySpan<ProgramPipelineHandle> pipelines)
+        public static unsafe void DeleteProgramPipelines(ReadOnlySpan<int> pipelines)
         {
             int n = (int)(pipelines.Length);
-            fixed (ProgramPipelineHandle* pipelines_ptr = pipelines)
+            fixed (int* pipelines_ptr = pipelines)
             {
                 DeleteProgramPipelines(n, pipelines_ptr);
             }
         }
         /// <inheritdoc cref="DeleteProgramPipelines"/>
-        public static unsafe void DeleteProgramPipelines(ProgramPipelineHandle[] pipelines)
+        public static unsafe void DeleteProgramPipelines(int[] pipelines)
         {
             int n = (int)(pipelines.Length);
-            fixed (ProgramPipelineHandle* pipelines_ptr = pipelines)
+            fixed (int* pipelines_ptr = pipelines)
             {
                 DeleteProgramPipelines(n, pipelines_ptr);
             }
         }
         /// <inheritdoc cref="DeleteProgramPipelines"/>
-        public static unsafe void DeleteProgramPipelines(int n, in ProgramPipelineHandle pipelines)
+        public static unsafe void DeleteProgramPipelines(int n, in int pipelines)
         {
-            fixed (ProgramPipelineHandle* pipelines_ptr = &pipelines)
+            fixed (int* pipelines_ptr = &pipelines)
             {
                 DeleteProgramPipelines(n, pipelines_ptr);
             }
         }
         /// <inheritdoc cref="GenProgramPipelines"/>
-        public static unsafe ProgramPipelineHandle GenProgramPipeline()
+        public static unsafe int GenProgramPipeline()
         {
-            ProgramPipelineHandle pipeline;
+            int pipeline;
             int n = 1;
             Unsafe.SkipInit(out pipeline);
             // FIXME: This could be a problem for the overloads that take an out parameter
@@ -4152,12 +4152,12 @@ namespace OpenTK.Graphics.OpenGLES3
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            ProgramPipelineHandle* pipelines_handle = (ProgramPipelineHandle*)Unsafe.AsPointer(ref pipeline);
+            int* pipelines_handle = (int*)Unsafe.AsPointer(ref pipeline);
             GenProgramPipelines(n, pipelines_handle);
             return pipeline;
         }
         /// <inheritdoc cref="GenProgramPipelines"/>
-        public static unsafe void GenProgramPipeline(out ProgramPipelineHandle pipeline)
+        public static unsafe void GenProgramPipeline(out int pipeline)
         {
             int n = 1;
             Unsafe.SkipInit(out pipeline);
@@ -4169,37 +4169,37 @@ namespace OpenTK.Graphics.OpenGLES3
             // that will make it so this tries to fix a local variable which is not allowed in C# for some reason.
             // If you have problems with this we would really appreciate you opening an issue at https://github.com/opentk/opentk
             // - 2021-05-18
-            ProgramPipelineHandle* pipelines_handle = (ProgramPipelineHandle*)Unsafe.AsPointer(ref pipeline);
+            int* pipelines_handle = (int*)Unsafe.AsPointer(ref pipeline);
             GenProgramPipelines(n, pipelines_handle);
         }
         /// <inheritdoc cref="GenProgramPipelines"/>
-        public static unsafe void GenProgramPipelines(Span<ProgramPipelineHandle> pipelines)
+        public static unsafe void GenProgramPipelines(Span<int> pipelines)
         {
             int n = (int)(pipelines.Length);
-            fixed (ProgramPipelineHandle* pipelines_ptr = pipelines)
+            fixed (int* pipelines_ptr = pipelines)
             {
                 GenProgramPipelines(n, pipelines_ptr);
             }
         }
         /// <inheritdoc cref="GenProgramPipelines"/>
-        public static unsafe void GenProgramPipelines(ProgramPipelineHandle[] pipelines)
+        public static unsafe void GenProgramPipelines(int[] pipelines)
         {
             int n = (int)(pipelines.Length);
-            fixed (ProgramPipelineHandle* pipelines_ptr = pipelines)
+            fixed (int* pipelines_ptr = pipelines)
             {
                 GenProgramPipelines(n, pipelines_ptr);
             }
         }
         /// <inheritdoc cref="GenProgramPipelines"/>
-        public static unsafe void GenProgramPipelines(int n, ref ProgramPipelineHandle pipelines)
+        public static unsafe void GenProgramPipelines(int n, ref int pipelines)
         {
-            fixed (ProgramPipelineHandle* pipelines_ptr = &pipelines)
+            fixed (int* pipelines_ptr = &pipelines)
             {
                 GenProgramPipelines(n, pipelines_ptr);
             }
         }
         /// <inheritdoc cref="GetProgramPipelineiv"/>
-        public static unsafe void GetProgramPipelinei(ProgramPipelineHandle pipeline, PipelineParameterName pname, Span<int> parameters)
+        public static unsafe void GetProgramPipelinei(int pipeline, PipelineParameterName pname, Span<int> parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
@@ -4207,7 +4207,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetProgramPipelineiv"/>
-        public static unsafe void GetProgramPipelinei(ProgramPipelineHandle pipeline, PipelineParameterName pname, int[] parameters)
+        public static unsafe void GetProgramPipelinei(int pipeline, PipelineParameterName pname, int[] parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
@@ -4215,7 +4215,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetProgramPipelineiv"/>
-        public static unsafe void GetProgramPipelinei(ProgramPipelineHandle pipeline, PipelineParameterName pname, ref int parameters)
+        public static unsafe void GetProgramPipelinei(int pipeline, PipelineParameterName pname, ref int parameters)
         {
             fixed (int* parameters_ptr = &parameters)
             {
@@ -4223,7 +4223,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniform1iv"/>
-        public static unsafe void ProgramUniform1iv(ProgramHandle program, int location, ReadOnlySpan<int> value)
+        public static unsafe void ProgramUniform1iv(int program, int location, ReadOnlySpan<int> value)
         {
             int count = (int)(value.Length);
             fixed (int* value_ptr = value)
@@ -4232,7 +4232,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniform1iv"/>
-        public static unsafe void ProgramUniform1iv(ProgramHandle program, int location, int[] value)
+        public static unsafe void ProgramUniform1iv(int program, int location, int[] value)
         {
             int count = (int)(value.Length);
             fixed (int* value_ptr = value)
@@ -4241,7 +4241,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniform1iv"/>
-        public static unsafe void ProgramUniform1iv(ProgramHandle program, int location, int count, in int value)
+        public static unsafe void ProgramUniform1iv(int program, int location, int count, in int value)
         {
             fixed (int* value_ptr = &value)
             {
@@ -4249,7 +4249,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniform2iv"/>
-        public static unsafe void ProgramUniform2i(ProgramHandle program, int location, int count, in Vector2i value)
+        public static unsafe void ProgramUniform2i(int program, int location, int count, in Vector2i value)
         {
             fixed (Vector2i* tmp_vecPtr = &value)
             {
@@ -4258,7 +4258,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniform2iv"/>
-        public static unsafe void ProgramUniform2i(ProgramHandle program, int location, int count, ReadOnlySpan<Vector2i> value)
+        public static unsafe void ProgramUniform2i(int program, int location, int count, ReadOnlySpan<Vector2i> value)
         {
             fixed (Vector2i* tmp_vecPtr = value)
             {
@@ -4267,7 +4267,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniform2iv"/>
-        public static unsafe void ProgramUniform2i(ProgramHandle program, int location, int count, Vector2i[] value)
+        public static unsafe void ProgramUniform2i(int program, int location, int count, Vector2i[] value)
         {
             fixed (Vector2i* tmp_vecPtr = value)
             {
@@ -4276,7 +4276,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniform3iv"/>
-        public static unsafe void ProgramUniform3i(ProgramHandle program, int location, int count, in Vector3i value)
+        public static unsafe void ProgramUniform3i(int program, int location, int count, in Vector3i value)
         {
             fixed (Vector3i* tmp_vecPtr = &value)
             {
@@ -4285,7 +4285,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniform3iv"/>
-        public static unsafe void ProgramUniform3i(ProgramHandle program, int location, int count, ReadOnlySpan<Vector3i> value)
+        public static unsafe void ProgramUniform3i(int program, int location, int count, ReadOnlySpan<Vector3i> value)
         {
             fixed (Vector3i* tmp_vecPtr = value)
             {
@@ -4294,7 +4294,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniform3iv"/>
-        public static unsafe void ProgramUniform3i(ProgramHandle program, int location, int count, Vector3i[] value)
+        public static unsafe void ProgramUniform3i(int program, int location, int count, Vector3i[] value)
         {
             fixed (Vector3i* tmp_vecPtr = value)
             {
@@ -4303,7 +4303,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniform4iv"/>
-        public static unsafe void ProgramUniform4i(ProgramHandle program, int location, int count, in Vector4i value)
+        public static unsafe void ProgramUniform4i(int program, int location, int count, in Vector4i value)
         {
             fixed (Vector4i* tmp_vecPtr = &value)
             {
@@ -4312,7 +4312,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniform4iv"/>
-        public static unsafe void ProgramUniform4i(ProgramHandle program, int location, int count, ReadOnlySpan<Vector4i> value)
+        public static unsafe void ProgramUniform4i(int program, int location, int count, ReadOnlySpan<Vector4i> value)
         {
             fixed (Vector4i* tmp_vecPtr = value)
             {
@@ -4321,7 +4321,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniform4iv"/>
-        public static unsafe void ProgramUniform4i(ProgramHandle program, int location, int count, Vector4i[] value)
+        public static unsafe void ProgramUniform4i(int program, int location, int count, Vector4i[] value)
         {
             fixed (Vector4i* tmp_vecPtr = value)
             {
@@ -4330,7 +4330,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniform1uiv"/>
-        public static unsafe void ProgramUniform1ui(ProgramHandle program, int location, ReadOnlySpan<uint> value)
+        public static unsafe void ProgramUniform1ui(int program, int location, ReadOnlySpan<uint> value)
         {
             int count = (int)(value.Length);
             fixed (uint* value_ptr = value)
@@ -4339,7 +4339,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniform1uiv"/>
-        public static unsafe void ProgramUniform1ui(ProgramHandle program, int location, uint[] value)
+        public static unsafe void ProgramUniform1ui(int program, int location, uint[] value)
         {
             int count = (int)(value.Length);
             fixed (uint* value_ptr = value)
@@ -4348,7 +4348,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniform1uiv"/>
-        public static unsafe void ProgramUniform1ui(ProgramHandle program, int location, int count, in uint value)
+        public static unsafe void ProgramUniform1ui(int program, int location, int count, in uint value)
         {
             fixed (uint* value_ptr = &value)
             {
@@ -4356,7 +4356,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniform2uiv"/>
-        public static unsafe void ProgramUniform2ui(ProgramHandle program, int location, ReadOnlySpan<uint> value)
+        public static unsafe void ProgramUniform2ui(int program, int location, ReadOnlySpan<uint> value)
         {
             int count = (int)(value.Length / 2);
             fixed (uint* value_ptr = value)
@@ -4365,7 +4365,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniform2uiv"/>
-        public static unsafe void ProgramUniform2ui(ProgramHandle program, int location, uint[] value)
+        public static unsafe void ProgramUniform2ui(int program, int location, uint[] value)
         {
             int count = (int)(value.Length / 2);
             fixed (uint* value_ptr = value)
@@ -4374,7 +4374,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniform2uiv"/>
-        public static unsafe void ProgramUniform2ui(ProgramHandle program, int location, int count, in uint value)
+        public static unsafe void ProgramUniform2ui(int program, int location, int count, in uint value)
         {
             fixed (uint* value_ptr = &value)
             {
@@ -4382,7 +4382,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniform3uiv"/>
-        public static unsafe void ProgramUniform3ui(ProgramHandle program, int location, ReadOnlySpan<uint> value)
+        public static unsafe void ProgramUniform3ui(int program, int location, ReadOnlySpan<uint> value)
         {
             int count = (int)(value.Length / 3);
             fixed (uint* value_ptr = value)
@@ -4391,7 +4391,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniform3uiv"/>
-        public static unsafe void ProgramUniform3ui(ProgramHandle program, int location, uint[] value)
+        public static unsafe void ProgramUniform3ui(int program, int location, uint[] value)
         {
             int count = (int)(value.Length / 3);
             fixed (uint* value_ptr = value)
@@ -4400,7 +4400,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniform3uiv"/>
-        public static unsafe void ProgramUniform3ui(ProgramHandle program, int location, int count, in uint value)
+        public static unsafe void ProgramUniform3ui(int program, int location, int count, in uint value)
         {
             fixed (uint* value_ptr = &value)
             {
@@ -4408,7 +4408,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniform4uiv"/>
-        public static unsafe void ProgramUniform4ui(ProgramHandle program, int location, ReadOnlySpan<uint> value)
+        public static unsafe void ProgramUniform4ui(int program, int location, ReadOnlySpan<uint> value)
         {
             int count = (int)(value.Length / 4);
             fixed (uint* value_ptr = value)
@@ -4417,7 +4417,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniform4uiv"/>
-        public static unsafe void ProgramUniform4ui(ProgramHandle program, int location, uint[] value)
+        public static unsafe void ProgramUniform4ui(int program, int location, uint[] value)
         {
             int count = (int)(value.Length / 4);
             fixed (uint* value_ptr = value)
@@ -4426,7 +4426,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniform4uiv"/>
-        public static unsafe void ProgramUniform4ui(ProgramHandle program, int location, int count, in uint value)
+        public static unsafe void ProgramUniform4ui(int program, int location, int count, in uint value)
         {
             fixed (uint* value_ptr = &value)
             {
@@ -4434,7 +4434,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniform1fv"/>
-        public static unsafe void ProgramUniform1fv(ProgramHandle program, int location, ReadOnlySpan<float> value)
+        public static unsafe void ProgramUniform1fv(int program, int location, ReadOnlySpan<float> value)
         {
             int count = (int)(value.Length);
             fixed (float* value_ptr = value)
@@ -4443,7 +4443,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniform1fv"/>
-        public static unsafe void ProgramUniform1fv(ProgramHandle program, int location, float[] value)
+        public static unsafe void ProgramUniform1fv(int program, int location, float[] value)
         {
             int count = (int)(value.Length);
             fixed (float* value_ptr = value)
@@ -4452,7 +4452,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniform1fv"/>
-        public static unsafe void ProgramUniform1fv(ProgramHandle program, int location, int count, in float value)
+        public static unsafe void ProgramUniform1fv(int program, int location, int count, in float value)
         {
             fixed (float* value_ptr = &value)
             {
@@ -4460,7 +4460,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniform2fv"/>
-        public static unsafe void ProgramUniform2f(ProgramHandle program, int location, int count, in Vector2 value)
+        public static unsafe void ProgramUniform2f(int program, int location, int count, in Vector2 value)
         {
             fixed (Vector2* tmp_vecPtr = &value)
             {
@@ -4469,7 +4469,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniform2fv"/>
-        public static unsafe void ProgramUniform2f(ProgramHandle program, int location, int count, ReadOnlySpan<Vector2> value)
+        public static unsafe void ProgramUniform2f(int program, int location, int count, ReadOnlySpan<Vector2> value)
         {
             fixed (Vector2* tmp_vecPtr = value)
             {
@@ -4478,7 +4478,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniform2fv"/>
-        public static unsafe void ProgramUniform2f(ProgramHandle program, int location, int count, Vector2[] value)
+        public static unsafe void ProgramUniform2f(int program, int location, int count, Vector2[] value)
         {
             fixed (Vector2* tmp_vecPtr = value)
             {
@@ -4487,7 +4487,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniform2fv"/>
-        public static unsafe void ProgramUniform2f(ProgramHandle program, int location, int count, in System.Numerics.Vector2 value)
+        public static unsafe void ProgramUniform2f(int program, int location, int count, in System.Numerics.Vector2 value)
         {
             fixed (System.Numerics.Vector2* tmp_vecPtr = &value)
             {
@@ -4496,7 +4496,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniform2fv"/>
-        public static unsafe void ProgramUniform2f(ProgramHandle program, int location, int count, ReadOnlySpan<System.Numerics.Vector2> value)
+        public static unsafe void ProgramUniform2f(int program, int location, int count, ReadOnlySpan<System.Numerics.Vector2> value)
         {
             fixed (System.Numerics.Vector2* tmp_vecPtr = value)
             {
@@ -4505,7 +4505,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniform2fv"/>
-        public static unsafe void ProgramUniform2f(ProgramHandle program, int location, int count, System.Numerics.Vector2[] value)
+        public static unsafe void ProgramUniform2f(int program, int location, int count, System.Numerics.Vector2[] value)
         {
             fixed (System.Numerics.Vector2* tmp_vecPtr = value)
             {
@@ -4514,7 +4514,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniform3fv"/>
-        public static unsafe void ProgramUniform3f(ProgramHandle program, int location, int count, in Vector3 value)
+        public static unsafe void ProgramUniform3f(int program, int location, int count, in Vector3 value)
         {
             fixed (Vector3* tmp_vecPtr = &value)
             {
@@ -4523,7 +4523,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniform3fv"/>
-        public static unsafe void ProgramUniform3f(ProgramHandle program, int location, int count, ReadOnlySpan<Vector3> value)
+        public static unsafe void ProgramUniform3f(int program, int location, int count, ReadOnlySpan<Vector3> value)
         {
             fixed (Vector3* tmp_vecPtr = value)
             {
@@ -4532,7 +4532,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniform3fv"/>
-        public static unsafe void ProgramUniform3f(ProgramHandle program, int location, int count, Vector3[] value)
+        public static unsafe void ProgramUniform3f(int program, int location, int count, Vector3[] value)
         {
             fixed (Vector3* tmp_vecPtr = value)
             {
@@ -4541,7 +4541,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniform3fv"/>
-        public static unsafe void ProgramUniform3f(ProgramHandle program, int location, int count, in System.Numerics.Vector3 value)
+        public static unsafe void ProgramUniform3f(int program, int location, int count, in System.Numerics.Vector3 value)
         {
             fixed (System.Numerics.Vector3* tmp_vecPtr = &value)
             {
@@ -4550,7 +4550,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniform3fv"/>
-        public static unsafe void ProgramUniform3f(ProgramHandle program, int location, int count, ReadOnlySpan<System.Numerics.Vector3> value)
+        public static unsafe void ProgramUniform3f(int program, int location, int count, ReadOnlySpan<System.Numerics.Vector3> value)
         {
             fixed (System.Numerics.Vector3* tmp_vecPtr = value)
             {
@@ -4559,7 +4559,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniform3fv"/>
-        public static unsafe void ProgramUniform3f(ProgramHandle program, int location, int count, System.Numerics.Vector3[] value)
+        public static unsafe void ProgramUniform3f(int program, int location, int count, System.Numerics.Vector3[] value)
         {
             fixed (System.Numerics.Vector3* tmp_vecPtr = value)
             {
@@ -4568,7 +4568,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniform4fv"/>
-        public static unsafe void ProgramUniform4f(ProgramHandle program, int location, int count, in Vector4 value)
+        public static unsafe void ProgramUniform4f(int program, int location, int count, in Vector4 value)
         {
             fixed (Vector4* tmp_vecPtr = &value)
             {
@@ -4577,7 +4577,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniform4fv"/>
-        public static unsafe void ProgramUniform4f(ProgramHandle program, int location, int count, ReadOnlySpan<Vector4> value)
+        public static unsafe void ProgramUniform4f(int program, int location, int count, ReadOnlySpan<Vector4> value)
         {
             fixed (Vector4* tmp_vecPtr = value)
             {
@@ -4586,7 +4586,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniform4fv"/>
-        public static unsafe void ProgramUniform4f(ProgramHandle program, int location, int count, Vector4[] value)
+        public static unsafe void ProgramUniform4f(int program, int location, int count, Vector4[] value)
         {
             fixed (Vector4* tmp_vecPtr = value)
             {
@@ -4595,7 +4595,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniform4fv"/>
-        public static unsafe void ProgramUniform4f(ProgramHandle program, int location, int count, in System.Numerics.Vector4 value)
+        public static unsafe void ProgramUniform4f(int program, int location, int count, in System.Numerics.Vector4 value)
         {
             fixed (System.Numerics.Vector4* tmp_vecPtr = &value)
             {
@@ -4604,7 +4604,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniform4fv"/>
-        public static unsafe void ProgramUniform4f(ProgramHandle program, int location, int count, ReadOnlySpan<System.Numerics.Vector4> value)
+        public static unsafe void ProgramUniform4f(int program, int location, int count, ReadOnlySpan<System.Numerics.Vector4> value)
         {
             fixed (System.Numerics.Vector4* tmp_vecPtr = value)
             {
@@ -4613,7 +4613,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniform4fv"/>
-        public static unsafe void ProgramUniform4f(ProgramHandle program, int location, int count, System.Numerics.Vector4[] value)
+        public static unsafe void ProgramUniform4f(int program, int location, int count, System.Numerics.Vector4[] value)
         {
             fixed (System.Numerics.Vector4* tmp_vecPtr = value)
             {
@@ -4622,7 +4622,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2fv"/>
-        public static unsafe void ProgramUniformMatrix2f(ProgramHandle program, int location, int count, bool transpose, in Matrix2 value)
+        public static unsafe void ProgramUniformMatrix2f(int program, int location, int count, bool transpose, in Matrix2 value)
         {
             fixed (Matrix2* tmp_vecPtr = &value)
             {
@@ -4631,7 +4631,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2fv"/>
-        public static unsafe void ProgramUniformMatrix2f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix2> value)
+        public static unsafe void ProgramUniformMatrix2f(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix2> value)
         {
             fixed (Matrix2* tmp_vecPtr = value)
             {
@@ -4640,7 +4640,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2fv"/>
-        public static unsafe void ProgramUniformMatrix2f(ProgramHandle program, int location, int count, bool transpose, Matrix2[] value)
+        public static unsafe void ProgramUniformMatrix2f(int program, int location, int count, bool transpose, Matrix2[] value)
         {
             fixed (Matrix2* tmp_vecPtr = value)
             {
@@ -4649,7 +4649,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3fv"/>
-        public static unsafe void ProgramUniformMatrix3f(ProgramHandle program, int location, int count, bool transpose, in Matrix3 value)
+        public static unsafe void ProgramUniformMatrix3f(int program, int location, int count, bool transpose, in Matrix3 value)
         {
             fixed (Matrix3* tmp_vecPtr = &value)
             {
@@ -4658,7 +4658,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3fv"/>
-        public static unsafe void ProgramUniformMatrix3f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix3> value)
+        public static unsafe void ProgramUniformMatrix3f(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix3> value)
         {
             fixed (Matrix3* tmp_vecPtr = value)
             {
@@ -4667,7 +4667,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3fv"/>
-        public static unsafe void ProgramUniformMatrix3f(ProgramHandle program, int location, int count, bool transpose, Matrix3[] value)
+        public static unsafe void ProgramUniformMatrix3f(int program, int location, int count, bool transpose, Matrix3[] value)
         {
             fixed (Matrix3* tmp_vecPtr = value)
             {
@@ -4676,7 +4676,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
-        public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, int count, bool transpose, in Matrix4 value)
+        public static unsafe void ProgramUniformMatrix4f(int program, int location, int count, bool transpose, in Matrix4 value)
         {
             fixed (Matrix4* tmp_vecPtr = &value)
             {
@@ -4685,7 +4685,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
-        public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix4> value)
+        public static unsafe void ProgramUniformMatrix4f(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix4> value)
         {
             fixed (Matrix4* tmp_vecPtr = value)
             {
@@ -4694,7 +4694,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
-        public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, int count, bool transpose, Matrix4[] value)
+        public static unsafe void ProgramUniformMatrix4f(int program, int location, int count, bool transpose, Matrix4[] value)
         {
             fixed (Matrix4* tmp_vecPtr = value)
             {
@@ -4703,7 +4703,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
-        public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, int count, bool transpose, in System.Numerics.Matrix4x4 value)
+        public static unsafe void ProgramUniformMatrix4f(int program, int location, int count, bool transpose, in System.Numerics.Matrix4x4 value)
         {
             fixed (System.Numerics.Matrix4x4* tmp_vecPtr = &value)
             {
@@ -4712,7 +4712,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
-        public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<System.Numerics.Matrix4x4> value)
+        public static unsafe void ProgramUniformMatrix4f(int program, int location, int count, bool transpose, ReadOnlySpan<System.Numerics.Matrix4x4> value)
         {
             fixed (System.Numerics.Matrix4x4* tmp_vecPtr = value)
             {
@@ -4721,7 +4721,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4fv"/>
-        public static unsafe void ProgramUniformMatrix4f(ProgramHandle program, int location, int count, bool transpose, System.Numerics.Matrix4x4[] value)
+        public static unsafe void ProgramUniformMatrix4f(int program, int location, int count, bool transpose, System.Numerics.Matrix4x4[] value)
         {
             fixed (System.Numerics.Matrix4x4* tmp_vecPtr = value)
             {
@@ -4730,7 +4730,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x3fv"/>
-        public static unsafe void ProgramUniformMatrix2x3f(ProgramHandle program, int location, int count, bool transpose, in Matrix2x3 value)
+        public static unsafe void ProgramUniformMatrix2x3f(int program, int location, int count, bool transpose, in Matrix2x3 value)
         {
             fixed (Matrix2x3* tmp_vecPtr = &value)
             {
@@ -4739,7 +4739,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x3fv"/>
-        public static unsafe void ProgramUniformMatrix2x3f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix2x3> value)
+        public static unsafe void ProgramUniformMatrix2x3f(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix2x3> value)
         {
             fixed (Matrix2x3* tmp_vecPtr = value)
             {
@@ -4748,7 +4748,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x3fv"/>
-        public static unsafe void ProgramUniformMatrix2x3f(ProgramHandle program, int location, int count, bool transpose, Matrix2x3[] value)
+        public static unsafe void ProgramUniformMatrix2x3f(int program, int location, int count, bool transpose, Matrix2x3[] value)
         {
             fixed (Matrix2x3* tmp_vecPtr = value)
             {
@@ -4757,7 +4757,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
-        public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, int count, bool transpose, in Matrix3x2 value)
+        public static unsafe void ProgramUniformMatrix3x2f(int program, int location, int count, bool transpose, in Matrix3x2 value)
         {
             fixed (Matrix3x2* tmp_vecPtr = &value)
             {
@@ -4766,7 +4766,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
-        public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix3x2> value)
+        public static unsafe void ProgramUniformMatrix3x2f(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix3x2> value)
         {
             fixed (Matrix3x2* tmp_vecPtr = value)
             {
@@ -4775,7 +4775,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
-        public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, int count, bool transpose, Matrix3x2[] value)
+        public static unsafe void ProgramUniformMatrix3x2f(int program, int location, int count, bool transpose, Matrix3x2[] value)
         {
             fixed (Matrix3x2* tmp_vecPtr = value)
             {
@@ -4784,7 +4784,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
-        public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, int count, bool transpose, in System.Numerics.Matrix3x2 value)
+        public static unsafe void ProgramUniformMatrix3x2f(int program, int location, int count, bool transpose, in System.Numerics.Matrix3x2 value)
         {
             fixed (System.Numerics.Matrix3x2* tmp_vecPtr = &value)
             {
@@ -4793,7 +4793,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
-        public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<System.Numerics.Matrix3x2> value)
+        public static unsafe void ProgramUniformMatrix3x2f(int program, int location, int count, bool transpose, ReadOnlySpan<System.Numerics.Matrix3x2> value)
         {
             fixed (System.Numerics.Matrix3x2* tmp_vecPtr = value)
             {
@@ -4802,7 +4802,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x2fv"/>
-        public static unsafe void ProgramUniformMatrix3x2f(ProgramHandle program, int location, int count, bool transpose, System.Numerics.Matrix3x2[] value)
+        public static unsafe void ProgramUniformMatrix3x2f(int program, int location, int count, bool transpose, System.Numerics.Matrix3x2[] value)
         {
             fixed (System.Numerics.Matrix3x2* tmp_vecPtr = value)
             {
@@ -4811,7 +4811,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x4fv"/>
-        public static unsafe void ProgramUniformMatrix2x4f(ProgramHandle program, int location, int count, bool transpose, in Matrix2x4 value)
+        public static unsafe void ProgramUniformMatrix2x4f(int program, int location, int count, bool transpose, in Matrix2x4 value)
         {
             fixed (Matrix2x4* tmp_vecPtr = &value)
             {
@@ -4820,7 +4820,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x4fv"/>
-        public static unsafe void ProgramUniformMatrix2x4f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix2x4> value)
+        public static unsafe void ProgramUniformMatrix2x4f(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix2x4> value)
         {
             fixed (Matrix2x4* tmp_vecPtr = value)
             {
@@ -4829,7 +4829,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix2x4fv"/>
-        public static unsafe void ProgramUniformMatrix2x4f(ProgramHandle program, int location, int count, bool transpose, Matrix2x4[] value)
+        public static unsafe void ProgramUniformMatrix2x4f(int program, int location, int count, bool transpose, Matrix2x4[] value)
         {
             fixed (Matrix2x4* tmp_vecPtr = value)
             {
@@ -4838,7 +4838,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x2fv"/>
-        public static unsafe void ProgramUniformMatrix4x2f(ProgramHandle program, int location, int count, bool transpose, in Matrix4x2 value)
+        public static unsafe void ProgramUniformMatrix4x2f(int program, int location, int count, bool transpose, in Matrix4x2 value)
         {
             fixed (Matrix4x2* tmp_vecPtr = &value)
             {
@@ -4847,7 +4847,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x2fv"/>
-        public static unsafe void ProgramUniformMatrix4x2f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix4x2> value)
+        public static unsafe void ProgramUniformMatrix4x2f(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix4x2> value)
         {
             fixed (Matrix4x2* tmp_vecPtr = value)
             {
@@ -4856,7 +4856,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x2fv"/>
-        public static unsafe void ProgramUniformMatrix4x2f(ProgramHandle program, int location, int count, bool transpose, Matrix4x2[] value)
+        public static unsafe void ProgramUniformMatrix4x2f(int program, int location, int count, bool transpose, Matrix4x2[] value)
         {
             fixed (Matrix4x2* tmp_vecPtr = value)
             {
@@ -4865,7 +4865,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x4fv"/>
-        public static unsafe void ProgramUniformMatrix3x4f(ProgramHandle program, int location, int count, bool transpose, in Matrix3x4 value)
+        public static unsafe void ProgramUniformMatrix3x4f(int program, int location, int count, bool transpose, in Matrix3x4 value)
         {
             fixed (Matrix3x4* tmp_vecPtr = &value)
             {
@@ -4874,7 +4874,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x4fv"/>
-        public static unsafe void ProgramUniformMatrix3x4f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix3x4> value)
+        public static unsafe void ProgramUniformMatrix3x4f(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix3x4> value)
         {
             fixed (Matrix3x4* tmp_vecPtr = value)
             {
@@ -4883,7 +4883,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix3x4fv"/>
-        public static unsafe void ProgramUniformMatrix3x4f(ProgramHandle program, int location, int count, bool transpose, Matrix3x4[] value)
+        public static unsafe void ProgramUniformMatrix3x4f(int program, int location, int count, bool transpose, Matrix3x4[] value)
         {
             fixed (Matrix3x4* tmp_vecPtr = value)
             {
@@ -4892,7 +4892,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x3fv"/>
-        public static unsafe void ProgramUniformMatrix4x3f(ProgramHandle program, int location, int count, bool transpose, in Matrix4x3 value)
+        public static unsafe void ProgramUniformMatrix4x3f(int program, int location, int count, bool transpose, in Matrix4x3 value)
         {
             fixed (Matrix4x3* tmp_vecPtr = &value)
             {
@@ -4901,7 +4901,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x3fv"/>
-        public static unsafe void ProgramUniformMatrix4x3f(ProgramHandle program, int location, int count, bool transpose, ReadOnlySpan<Matrix4x3> value)
+        public static unsafe void ProgramUniformMatrix4x3f(int program, int location, int count, bool transpose, ReadOnlySpan<Matrix4x3> value)
         {
             fixed (Matrix4x3* tmp_vecPtr = value)
             {
@@ -4910,7 +4910,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="ProgramUniformMatrix4x3fv"/>
-        public static unsafe void ProgramUniformMatrix4x3f(ProgramHandle program, int location, int count, bool transpose, Matrix4x3[] value)
+        public static unsafe void ProgramUniformMatrix4x3f(int program, int location, int count, bool transpose, Matrix4x3[] value)
         {
             fixed (Matrix4x3* tmp_vecPtr = value)
             {
@@ -4919,7 +4919,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetProgramPipelineInfoLog"/>
-        public static unsafe string GetProgramPipelineInfoLog(ProgramPipelineHandle pipeline, int bufSize, Span<int> length)
+        public static unsafe string GetProgramPipelineInfoLog(int pipeline, int bufSize, Span<int> length)
         {
             string infoLog;
             fixed (int* length_ptr = length)
@@ -4932,7 +4932,7 @@ namespace OpenTK.Graphics.OpenGLES3
             return infoLog;
         }
         /// <inheritdoc cref="GetProgramPipelineInfoLog"/>
-        public static unsafe void GetProgramPipelineInfoLog(ProgramPipelineHandle pipeline, int bufSize, Span<int> length, out string infoLog)
+        public static unsafe void GetProgramPipelineInfoLog(int pipeline, int bufSize, Span<int> length, out string infoLog)
         {
             fixed (int* length_ptr = length)
             {
@@ -4943,7 +4943,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetProgramPipelineInfoLog"/>
-        public static unsafe string GetProgramPipelineInfoLog(ProgramPipelineHandle pipeline, int bufSize, int[] length)
+        public static unsafe string GetProgramPipelineInfoLog(int pipeline, int bufSize, int[] length)
         {
             string infoLog;
             fixed (int* length_ptr = length)
@@ -4956,7 +4956,7 @@ namespace OpenTK.Graphics.OpenGLES3
             return infoLog;
         }
         /// <inheritdoc cref="GetProgramPipelineInfoLog"/>
-        public static unsafe void GetProgramPipelineInfoLog(ProgramPipelineHandle pipeline, int bufSize, int[] length, out string infoLog)
+        public static unsafe void GetProgramPipelineInfoLog(int pipeline, int bufSize, int[] length, out string infoLog)
         {
             fixed (int* length_ptr = length)
             {
@@ -4967,7 +4967,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetProgramPipelineInfoLog"/>
-        public static unsafe string GetProgramPipelineInfoLog(ProgramPipelineHandle pipeline, int bufSize, ref int length)
+        public static unsafe string GetProgramPipelineInfoLog(int pipeline, int bufSize, ref int length)
         {
             string infoLog;
             fixed (int* length_ptr = &length)
@@ -4980,7 +4980,7 @@ namespace OpenTK.Graphics.OpenGLES3
             return infoLog;
         }
         /// <inheritdoc cref="GetProgramPipelineInfoLog"/>
-        public static unsafe void GetProgramPipelineInfoLog(ProgramPipelineHandle pipeline, int bufSize, ref int length, out string infoLog)
+        public static unsafe void GetProgramPipelineInfoLog(int pipeline, int bufSize, ref int length, out string infoLog)
         {
             fixed (int* length_ptr = &length)
             {
@@ -5537,7 +5537,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetnUniformfv"/>
-        public static unsafe void GetnUniformf(ProgramHandle program, int location, Span<float> parameters)
+        public static unsafe void GetnUniformf(int program, int location, Span<float> parameters)
         {
             int bufSize = (int)(parameters.Length * 4);
             fixed (float* parameters_ptr = parameters)
@@ -5546,7 +5546,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetnUniformfv"/>
-        public static unsafe void GetnUniformf(ProgramHandle program, int location, float[] parameters)
+        public static unsafe void GetnUniformf(int program, int location, float[] parameters)
         {
             int bufSize = (int)(parameters.Length * 4);
             fixed (float* parameters_ptr = parameters)
@@ -5555,7 +5555,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetnUniformfv"/>
-        public static unsafe void GetnUniformf(ProgramHandle program, int location, int bufSize, ref float parameters)
+        public static unsafe void GetnUniformf(int program, int location, int bufSize, ref float parameters)
         {
             fixed (float* parameters_ptr = &parameters)
             {
@@ -5563,7 +5563,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetnUniformiv"/>
-        public static unsafe void GetnUniformi(ProgramHandle program, int location, Span<int> parameters)
+        public static unsafe void GetnUniformi(int program, int location, Span<int> parameters)
         {
             int bufSize = (int)(parameters.Length * 4);
             fixed (int* parameters_ptr = parameters)
@@ -5572,7 +5572,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetnUniformiv"/>
-        public static unsafe void GetnUniformi(ProgramHandle program, int location, int[] parameters)
+        public static unsafe void GetnUniformi(int program, int location, int[] parameters)
         {
             int bufSize = (int)(parameters.Length * 4);
             fixed (int* parameters_ptr = parameters)
@@ -5581,7 +5581,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetnUniformiv"/>
-        public static unsafe void GetnUniformi(ProgramHandle program, int location, int bufSize, ref int parameters)
+        public static unsafe void GetnUniformi(int program, int location, int bufSize, ref int parameters)
         {
             fixed (int* parameters_ptr = &parameters)
             {
@@ -5589,7 +5589,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetnUniformuiv"/>
-        public static unsafe void GetnUniformui(ProgramHandle program, int location, Span<uint> parameters)
+        public static unsafe void GetnUniformui(int program, int location, Span<uint> parameters)
         {
             int bufSize = (int)(parameters.Length * 4);
             fixed (uint* parameters_ptr = parameters)
@@ -5598,7 +5598,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetnUniformuiv"/>
-        public static unsafe void GetnUniformui(ProgramHandle program, int location, uint[] parameters)
+        public static unsafe void GetnUniformui(int program, int location, uint[] parameters)
         {
             int bufSize = (int)(parameters.Length * 4);
             fixed (uint* parameters_ptr = parameters)
@@ -5607,7 +5607,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetnUniformuiv"/>
-        public static unsafe void GetnUniformui(ProgramHandle program, int location, int bufSize, ref uint parameters)
+        public static unsafe void GetnUniformui(int program, int location, int bufSize, ref uint parameters)
         {
             fixed (uint* parameters_ptr = &parameters)
             {
@@ -5711,7 +5711,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="SamplerParameterIiv"/>
-        public static unsafe void SamplerParameterIi(SamplerHandle sampler, SamplerParameterI pname, ReadOnlySpan<int> param)
+        public static unsafe void SamplerParameterIi(int sampler, SamplerParameterI pname, ReadOnlySpan<int> param)
         {
             fixed (int* param_ptr = param)
             {
@@ -5719,7 +5719,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="SamplerParameterIiv"/>
-        public static unsafe void SamplerParameterIi(SamplerHandle sampler, SamplerParameterI pname, int[] param)
+        public static unsafe void SamplerParameterIi(int sampler, SamplerParameterI pname, int[] param)
         {
             fixed (int* param_ptr = param)
             {
@@ -5727,7 +5727,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="SamplerParameterIiv"/>
-        public static unsafe void SamplerParameterIi(SamplerHandle sampler, SamplerParameterI pname, in int param)
+        public static unsafe void SamplerParameterIi(int sampler, SamplerParameterI pname, in int param)
         {
             fixed (int* param_ptr = &param)
             {
@@ -5735,7 +5735,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="SamplerParameterIuiv"/>
-        public static unsafe void SamplerParameterIui(SamplerHandle sampler, SamplerParameterI pname, ReadOnlySpan<uint> param)
+        public static unsafe void SamplerParameterIui(int sampler, SamplerParameterI pname, ReadOnlySpan<uint> param)
         {
             fixed (uint* param_ptr = param)
             {
@@ -5743,7 +5743,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="SamplerParameterIuiv"/>
-        public static unsafe void SamplerParameterIui(SamplerHandle sampler, SamplerParameterI pname, uint[] param)
+        public static unsafe void SamplerParameterIui(int sampler, SamplerParameterI pname, uint[] param)
         {
             fixed (uint* param_ptr = param)
             {
@@ -5751,7 +5751,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="SamplerParameterIuiv"/>
-        public static unsafe void SamplerParameterIui(SamplerHandle sampler, SamplerParameterI pname, in uint param)
+        public static unsafe void SamplerParameterIui(int sampler, SamplerParameterI pname, in uint param)
         {
             fixed (uint* param_ptr = &param)
             {
@@ -5759,7 +5759,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetSamplerParameterIiv"/>
-        public static unsafe void GetSamplerParameterIi(SamplerHandle sampler, SamplerParameterI pname, Span<int> parameters)
+        public static unsafe void GetSamplerParameterIi(int sampler, SamplerParameterI pname, Span<int> parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
@@ -5767,7 +5767,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetSamplerParameterIiv"/>
-        public static unsafe void GetSamplerParameterIi(SamplerHandle sampler, SamplerParameterI pname, int[] parameters)
+        public static unsafe void GetSamplerParameterIi(int sampler, SamplerParameterI pname, int[] parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
@@ -5775,7 +5775,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetSamplerParameterIiv"/>
-        public static unsafe void GetSamplerParameterIi(SamplerHandle sampler, SamplerParameterI pname, ref int parameters)
+        public static unsafe void GetSamplerParameterIi(int sampler, SamplerParameterI pname, ref int parameters)
         {
             fixed (int* parameters_ptr = &parameters)
             {
@@ -5783,7 +5783,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetSamplerParameterIuiv"/>
-        public static unsafe void GetSamplerParameterIui(SamplerHandle sampler, SamplerParameterI pname, Span<uint> parameters)
+        public static unsafe void GetSamplerParameterIui(int sampler, SamplerParameterI pname, Span<uint> parameters)
         {
             fixed (uint* parameters_ptr = parameters)
             {
@@ -5791,7 +5791,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetSamplerParameterIuiv"/>
-        public static unsafe void GetSamplerParameterIui(SamplerHandle sampler, SamplerParameterI pname, uint[] parameters)
+        public static unsafe void GetSamplerParameterIui(int sampler, SamplerParameterI pname, uint[] parameters)
         {
             fixed (uint* parameters_ptr = parameters)
             {
@@ -5799,7 +5799,7 @@ namespace OpenTK.Graphics.OpenGLES3
             }
         }
         /// <inheritdoc cref="GetSamplerParameterIuiv"/>
-        public static unsafe void GetSamplerParameterIui(SamplerHandle sampler, SamplerParameterI pname, ref uint parameters)
+        public static unsafe void GetSamplerParameterIui(int sampler, SamplerParameterI pname, ref uint parameters)
         {
             fixed (uint* parameters_ptr = &parameters)
             {
@@ -6179,7 +6179,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 DrawElementsInstancedANGLE(mode, count, type, indices, primcount);
             }
             /// <inheritdoc cref="GetTranslatedShaderSourceANGLE"/>
-            public static unsafe string GetTranslatedShaderSourceANGLE(ShaderHandle shader, int bufSize, Span<int> length)
+            public static unsafe string GetTranslatedShaderSourceANGLE(int shader, int bufSize, Span<int> length)
             {
                 string source;
                 fixed (int* length_ptr = length)
@@ -6192,7 +6192,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 return source;
             }
             /// <inheritdoc cref="GetTranslatedShaderSourceANGLE"/>
-            public static unsafe void GetTranslatedShaderSourceANGLE(ShaderHandle shader, int bufSize, Span<int> length, out string source)
+            public static unsafe void GetTranslatedShaderSourceANGLE(int shader, int bufSize, Span<int> length, out string source)
             {
                 fixed (int* length_ptr = length)
                 {
@@ -6203,7 +6203,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetTranslatedShaderSourceANGLE"/>
-            public static unsafe string GetTranslatedShaderSourceANGLE(ShaderHandle shader, int bufSize, int[] length)
+            public static unsafe string GetTranslatedShaderSourceANGLE(int shader, int bufSize, int[] length)
             {
                 string source;
                 fixed (int* length_ptr = length)
@@ -6216,7 +6216,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 return source;
             }
             /// <inheritdoc cref="GetTranslatedShaderSourceANGLE"/>
-            public static unsafe void GetTranslatedShaderSourceANGLE(ShaderHandle shader, int bufSize, int[] length, out string source)
+            public static unsafe void GetTranslatedShaderSourceANGLE(int shader, int bufSize, int[] length, out string source)
             {
                 fixed (int* length_ptr = length)
                 {
@@ -6227,7 +6227,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetTranslatedShaderSourceANGLE"/>
-            public static unsafe string GetTranslatedShaderSourceANGLE(ShaderHandle shader, int bufSize, ref int length)
+            public static unsafe string GetTranslatedShaderSourceANGLE(int shader, int bufSize, ref int length)
             {
                 string source;
                 fixed (int* length_ptr = &length)
@@ -6240,7 +6240,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 return source;
             }
             /// <inheritdoc cref="GetTranslatedShaderSourceANGLE"/>
-            public static unsafe void GetTranslatedShaderSourceANGLE(ShaderHandle shader, int bufSize, ref int length, out string source)
+            public static unsafe void GetTranslatedShaderSourceANGLE(int shader, int bufSize, ref int length, out string source)
             {
                 fixed (int* length_ptr = &length)
                 {
@@ -6317,7 +6317,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="EGLImageTargetTextureStorageEXT"/>
-            public static unsafe void EGLImageTargetTextureStorageEXT(TextureHandle texture, IntPtr image, in int attrib_list)
+            public static unsafe void EGLImageTargetTextureStorageEXT(int texture, IntPtr image, in int attrib_list)
             {
                 fixed (int* attrib_list_ptr = &attrib_list)
                 {
@@ -6326,7 +6326,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="EGLImageTargetTextureStorageEXT"/>
-            public static unsafe void EGLImageTargetTextureStorageEXT<T1>(TextureHandle texture, ref T1 image, in int attrib_list)
+            public static unsafe void EGLImageTargetTextureStorageEXT<T1>(int texture, ref T1 image, in int attrib_list)
                 where T1 : unmanaged
             {
                 fixed (void* image_ptr = &image)
@@ -6348,21 +6348,21 @@ namespace OpenTK.Graphics.OpenGLES3
                 DrawElementsInstancedBaseVertexBaseInstanceEXT(mode, count, type, indices, instancecount, basevertex, baseinstance);
             }
             /// <inheritdoc cref="BindFragDataLocationIndexedEXT"/>
-            public static unsafe void BindFragDataLocationIndexedEXT(ProgramHandle program, uint colorNumber, uint index, string name)
+            public static unsafe void BindFragDataLocationIndexedEXT(int program, uint colorNumber, uint index, string name)
             {
                 byte* name_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(name);
                 BindFragDataLocationIndexedEXT(program, colorNumber, index, name_ptr);
                 Marshal.FreeCoTaskMem((IntPtr)name_ptr);
             }
             /// <inheritdoc cref="BindFragDataLocationEXT"/>
-            public static unsafe void BindFragDataLocationEXT(ProgramHandle program, uint color, string name)
+            public static unsafe void BindFragDataLocationEXT(int program, uint color, string name)
             {
                 byte* name_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(name);
                 BindFragDataLocationEXT(program, color, name_ptr);
                 Marshal.FreeCoTaskMem((IntPtr)name_ptr);
             }
             /// <inheritdoc cref="GetProgramResourceLocationIndexEXT"/>
-            public static unsafe int GetProgramResourceLocationIndexEXT(ProgramHandle program, ProgramInterface programInterface, string name)
+            public static unsafe int GetProgramResourceLocationIndexEXT(int program, ProgramInterface programInterface, string name)
             {
                 int returnValue;
                 byte* name_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(name);
@@ -6371,7 +6371,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 return returnValue;
             }
             /// <inheritdoc cref="GetFragDataIndexEXT"/>
-            public static unsafe int GetFragDataIndexEXT(ProgramHandle program, string name)
+            public static unsafe int GetFragDataIndexEXT(int program, string name)
             {
                 int returnValue;
                 byte* name_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(name);
@@ -6415,13 +6415,13 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ClearTexImageEXT"/>
-            public static unsafe void ClearTexImageEXT(TextureHandle texture, int level, PixelFormat format, PixelType type, IntPtr data)
+            public static unsafe void ClearTexImageEXT(int texture, int level, PixelFormat format, PixelType type, IntPtr data)
             {
                 void* data_vptr = (void*)data;
                 ClearTexImageEXT(texture, level, format, type, data_vptr);
             }
             /// <inheritdoc cref="ClearTexImageEXT"/>
-            public static unsafe void ClearTexImageEXT<T1>(TextureHandle texture, int level, PixelFormat format, PixelType type, ReadOnlySpan<T1> data)
+            public static unsafe void ClearTexImageEXT<T1>(int texture, int level, PixelFormat format, PixelType type, ReadOnlySpan<T1> data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = data)
@@ -6430,7 +6430,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ClearTexImageEXT"/>
-            public static unsafe void ClearTexImageEXT<T1>(TextureHandle texture, int level, PixelFormat format, PixelType type, T1[] data)
+            public static unsafe void ClearTexImageEXT<T1>(int texture, int level, PixelFormat format, PixelType type, T1[] data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = data)
@@ -6439,7 +6439,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ClearTexImageEXT"/>
-            public static unsafe void ClearTexImageEXT<T1>(TextureHandle texture, int level, PixelFormat format, PixelType type, in T1 data)
+            public static unsafe void ClearTexImageEXT<T1>(int texture, int level, PixelFormat format, PixelType type, in T1 data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = &data)
@@ -6448,13 +6448,13 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ClearTexSubImageEXT"/>
-            public static unsafe void ClearTexSubImageEXT(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, IntPtr data)
+            public static unsafe void ClearTexSubImageEXT(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, IntPtr data)
             {
                 void* data_vptr = (void*)data;
                 ClearTexSubImageEXT(texture, level, xoffset, yoffset, zoffset, width, height, depth, format, type, data_vptr);
             }
             /// <inheritdoc cref="ClearTexSubImageEXT"/>
-            public static unsafe void ClearTexSubImageEXT<T1>(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, ReadOnlySpan<T1> data)
+            public static unsafe void ClearTexSubImageEXT<T1>(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, ReadOnlySpan<T1> data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = data)
@@ -6463,7 +6463,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ClearTexSubImageEXT"/>
-            public static unsafe void ClearTexSubImageEXT<T1>(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, T1[] data)
+            public static unsafe void ClearTexSubImageEXT<T1>(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, T1[] data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = data)
@@ -6472,7 +6472,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ClearTexSubImageEXT"/>
-            public static unsafe void ClearTexSubImageEXT<T1>(TextureHandle texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, in T1 data)
+            public static unsafe void ClearTexSubImageEXT<T1>(int texture, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, PixelFormat format, PixelType type, in T1 data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = &data)
@@ -6600,53 +6600,53 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GenQueriesEXT"/>
-            public static unsafe void GenQueriesEXT(Span<QueryHandle> ids)
+            public static unsafe void GenQueriesEXT(Span<int> ids)
             {
                 int n = (int)(ids.Length);
-                fixed (QueryHandle* ids_ptr = ids)
+                fixed (int* ids_ptr = ids)
                 {
                     GenQueriesEXT(n, ids_ptr);
                 }
             }
             /// <inheritdoc cref="GenQueriesEXT"/>
-            public static unsafe void GenQueriesEXT(QueryHandle[] ids)
+            public static unsafe void GenQueriesEXT(int[] ids)
             {
                 int n = (int)(ids.Length);
-                fixed (QueryHandle* ids_ptr = ids)
+                fixed (int* ids_ptr = ids)
                 {
                     GenQueriesEXT(n, ids_ptr);
                 }
             }
             /// <inheritdoc cref="GenQueriesEXT"/>
-            public static unsafe void GenQueriesEXT(int n, ref QueryHandle ids)
+            public static unsafe void GenQueriesEXT(int n, ref int ids)
             {
-                fixed (QueryHandle* ids_ptr = &ids)
+                fixed (int* ids_ptr = &ids)
                 {
                     GenQueriesEXT(n, ids_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteQueriesEXT"/>
-            public static unsafe void DeleteQueriesEXT(ReadOnlySpan<QueryHandle> ids)
+            public static unsafe void DeleteQueriesEXT(ReadOnlySpan<int> ids)
             {
                 int n = (int)(ids.Length);
-                fixed (QueryHandle* ids_ptr = ids)
+                fixed (int* ids_ptr = ids)
                 {
                     DeleteQueriesEXT(n, ids_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteQueriesEXT"/>
-            public static unsafe void DeleteQueriesEXT(QueryHandle[] ids)
+            public static unsafe void DeleteQueriesEXT(int[] ids)
             {
                 int n = (int)(ids.Length);
-                fixed (QueryHandle* ids_ptr = ids)
+                fixed (int* ids_ptr = ids)
                 {
                     DeleteQueriesEXT(n, ids_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteQueriesEXT"/>
-            public static unsafe void DeleteQueriesEXT(int n, in QueryHandle ids)
+            public static unsafe void DeleteQueriesEXT(int n, in int ids)
             {
-                fixed (QueryHandle* ids_ptr = &ids)
+                fixed (int* ids_ptr = &ids)
                 {
                     DeleteQueriesEXT(n, ids_ptr);
                 }
@@ -6676,7 +6676,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetQueryObjectivEXT"/>
-            public static unsafe void GetQueryObjectivEXT(QueryHandle id, QueryObjectParameterName pname, Span<int> parameters)
+            public static unsafe void GetQueryObjectivEXT(int id, QueryObjectParameterName pname, Span<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -6684,7 +6684,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetQueryObjectivEXT"/>
-            public static unsafe void GetQueryObjectivEXT(QueryHandle id, QueryObjectParameterName pname, int[] parameters)
+            public static unsafe void GetQueryObjectivEXT(int id, QueryObjectParameterName pname, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -6692,7 +6692,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetQueryObjectivEXT"/>
-            public static unsafe void GetQueryObjectivEXT(QueryHandle id, QueryObjectParameterName pname, ref int parameters)
+            public static unsafe void GetQueryObjectivEXT(int id, QueryObjectParameterName pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -6700,7 +6700,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetQueryObjectuivEXT"/>
-            public static unsafe void GetQueryObjectuivEXT(QueryHandle id, QueryObjectParameterName pname, Span<uint> parameters)
+            public static unsafe void GetQueryObjectuivEXT(int id, QueryObjectParameterName pname, Span<uint> parameters)
             {
                 fixed (uint* parameters_ptr = parameters)
                 {
@@ -6708,7 +6708,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetQueryObjectuivEXT"/>
-            public static unsafe void GetQueryObjectuivEXT(QueryHandle id, QueryObjectParameterName pname, uint[] parameters)
+            public static unsafe void GetQueryObjectuivEXT(int id, QueryObjectParameterName pname, uint[] parameters)
             {
                 fixed (uint* parameters_ptr = parameters)
                 {
@@ -6716,7 +6716,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetQueryObjectuivEXT"/>
-            public static unsafe void GetQueryObjectuivEXT(QueryHandle id, QueryObjectParameterName pname, ref uint parameters)
+            public static unsafe void GetQueryObjectuivEXT(int id, QueryObjectParameterName pname, ref uint parameters)
             {
                 fixed (uint* parameters_ptr = &parameters)
                 {
@@ -6724,7 +6724,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetQueryObjecti64vEXT"/>
-            public static unsafe void GetQueryObjecti64vEXT(QueryHandle id, QueryObjectParameterName pname, Span<long> parameters)
+            public static unsafe void GetQueryObjecti64vEXT(int id, QueryObjectParameterName pname, Span<long> parameters)
             {
                 fixed (long* parameters_ptr = parameters)
                 {
@@ -6732,7 +6732,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetQueryObjecti64vEXT"/>
-            public static unsafe void GetQueryObjecti64vEXT(QueryHandle id, QueryObjectParameterName pname, long[] parameters)
+            public static unsafe void GetQueryObjecti64vEXT(int id, QueryObjectParameterName pname, long[] parameters)
             {
                 fixed (long* parameters_ptr = parameters)
                 {
@@ -6740,7 +6740,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetQueryObjecti64vEXT"/>
-            public static unsafe void GetQueryObjecti64vEXT(QueryHandle id, QueryObjectParameterName pname, ref long parameters)
+            public static unsafe void GetQueryObjecti64vEXT(int id, QueryObjectParameterName pname, ref long parameters)
             {
                 fixed (long* parameters_ptr = &parameters)
                 {
@@ -6748,7 +6748,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetQueryObjectui64vEXT"/>
-            public static unsafe void GetQueryObjectui64vEXT(QueryHandle id, QueryObjectParameterName pname, Span<ulong> parameters)
+            public static unsafe void GetQueryObjectui64vEXT(int id, QueryObjectParameterName pname, Span<ulong> parameters)
             {
                 fixed (ulong* parameters_ptr = parameters)
                 {
@@ -6756,7 +6756,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetQueryObjectui64vEXT"/>
-            public static unsafe void GetQueryObjectui64vEXT(QueryHandle id, QueryObjectParameterName pname, ulong[] parameters)
+            public static unsafe void GetQueryObjectui64vEXT(int id, QueryObjectParameterName pname, ulong[] parameters)
             {
                 fixed (ulong* parameters_ptr = parameters)
                 {
@@ -6764,7 +6764,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetQueryObjectui64vEXT"/>
-            public static unsafe void GetQueryObjectui64vEXT(QueryHandle id, QueryObjectParameterName pname, ref ulong parameters)
+            public static unsafe void GetQueryObjectui64vEXT(int id, QueryObjectParameterName pname, ref ulong parameters)
             {
                 fixed (ulong* parameters_ptr = &parameters)
                 {
@@ -6892,13 +6892,13 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="NamedBufferStorageExternalEXT"/>
-            public static unsafe void NamedBufferStorageExternalEXT(BufferHandle buffer, IntPtr offset, nint size, IntPtr clientBuffer, BufferStorageMask flags)
+            public static unsafe void NamedBufferStorageExternalEXT(int buffer, IntPtr offset, nint size, IntPtr clientBuffer, BufferStorageMask flags)
             {
                 void* clientBuffer_vptr = (void*)clientBuffer;
                 NamedBufferStorageExternalEXT(buffer, offset, size, clientBuffer_vptr, flags);
             }
             /// <inheritdoc cref="NamedBufferStorageExternalEXT"/>
-            public static unsafe void NamedBufferStorageExternalEXT<T1>(BufferHandle buffer, IntPtr offset, nint size, ref T1 clientBuffer, BufferStorageMask flags)
+            public static unsafe void NamedBufferStorageExternalEXT<T1>(int buffer, IntPtr offset, nint size, ref T1 clientBuffer, BufferStorageMask flags)
                 where T1 : unmanaged
             {
                 fixed (void* clientBuffer_ptr = &clientBuffer)
@@ -7263,7 +7263,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetnUniformfvEXT"/>
-            public static unsafe void GetnUniformfvEXT(ProgramHandle program, int location, Span<float> parameters)
+            public static unsafe void GetnUniformfvEXT(int program, int location, Span<float> parameters)
             {
                 int bufSize = (int)(parameters.Length * 4);
                 fixed (float* parameters_ptr = parameters)
@@ -7272,7 +7272,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetnUniformfvEXT"/>
-            public static unsafe void GetnUniformfvEXT(ProgramHandle program, int location, float[] parameters)
+            public static unsafe void GetnUniformfvEXT(int program, int location, float[] parameters)
             {
                 int bufSize = (int)(parameters.Length * 4);
                 fixed (float* parameters_ptr = parameters)
@@ -7281,7 +7281,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetnUniformfvEXT"/>
-            public static unsafe void GetnUniformfvEXT(ProgramHandle program, int location, int bufSize, ref float parameters)
+            public static unsafe void GetnUniformfvEXT(int program, int location, int bufSize, ref float parameters)
             {
                 fixed (float* parameters_ptr = &parameters)
                 {
@@ -7289,7 +7289,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetnUniformivEXT"/>
-            public static unsafe void GetnUniformivEXT(ProgramHandle program, int location, Span<int> parameters)
+            public static unsafe void GetnUniformivEXT(int program, int location, Span<int> parameters)
             {
                 int bufSize = (int)(parameters.Length * 4);
                 fixed (int* parameters_ptr = parameters)
@@ -7298,7 +7298,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetnUniformivEXT"/>
-            public static unsafe void GetnUniformivEXT(ProgramHandle program, int location, int[] parameters)
+            public static unsafe void GetnUniformivEXT(int program, int location, int[] parameters)
             {
                 int bufSize = (int)(parameters.Length * 4);
                 fixed (int* parameters_ptr = parameters)
@@ -7307,7 +7307,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetnUniformivEXT"/>
-            public static unsafe void GetnUniformivEXT(ProgramHandle program, int location, int bufSize, ref int parameters)
+            public static unsafe void GetnUniformivEXT(int program, int location, int bufSize, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -7383,11 +7383,11 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="WaitSemaphoreEXT"/>
-            public static unsafe void WaitSemaphoreEXT(uint semaphore, uint numBufferBarriers, ReadOnlySpan<BufferHandle> buffers, uint numTextureBarriers, ReadOnlySpan<TextureHandle> textures, ReadOnlySpan<TextureLayout> srcLayouts)
+            public static unsafe void WaitSemaphoreEXT(uint semaphore, uint numBufferBarriers, ReadOnlySpan<int> buffers, uint numTextureBarriers, ReadOnlySpan<int> textures, ReadOnlySpan<TextureLayout> srcLayouts)
             {
-                fixed (BufferHandle* buffers_ptr = buffers)
+                fixed (int* buffers_ptr = buffers)
                 {
-                    fixed (TextureHandle* textures_ptr = textures)
+                    fixed (int* textures_ptr = textures)
                     {
                         fixed (TextureLayout* srcLayouts_ptr = srcLayouts)
                         {
@@ -7397,11 +7397,11 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="WaitSemaphoreEXT"/>
-            public static unsafe void WaitSemaphoreEXT(uint semaphore, uint numBufferBarriers, BufferHandle[] buffers, uint numTextureBarriers, TextureHandle[] textures, TextureLayout[] srcLayouts)
+            public static unsafe void WaitSemaphoreEXT(uint semaphore, uint numBufferBarriers, int[] buffers, uint numTextureBarriers, int[] textures, TextureLayout[] srcLayouts)
             {
-                fixed (BufferHandle* buffers_ptr = buffers)
+                fixed (int* buffers_ptr = buffers)
                 {
-                    fixed (TextureHandle* textures_ptr = textures)
+                    fixed (int* textures_ptr = textures)
                     {
                         fixed (TextureLayout* srcLayouts_ptr = srcLayouts)
                         {
@@ -7411,21 +7411,21 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="WaitSemaphoreEXT"/>
-            public static unsafe void WaitSemaphoreEXT(uint semaphore, uint numBufferBarriers, in BufferHandle buffers, uint numTextureBarriers, in TextureHandle textures, in TextureLayout srcLayouts)
+            public static unsafe void WaitSemaphoreEXT(uint semaphore, uint numBufferBarriers, in int buffers, uint numTextureBarriers, in int textures, in TextureLayout srcLayouts)
             {
-                fixed (BufferHandle* buffers_ptr = &buffers)
-                fixed (TextureHandle* textures_ptr = &textures)
+                fixed (int* buffers_ptr = &buffers)
+                fixed (int* textures_ptr = &textures)
                 fixed (TextureLayout* srcLayouts_ptr = &srcLayouts)
                 {
                     WaitSemaphoreEXT(semaphore, numBufferBarriers, buffers_ptr, numTextureBarriers, textures_ptr, srcLayouts_ptr);
                 }
             }
             /// <inheritdoc cref="SignalSemaphoreEXT"/>
-            public static unsafe void SignalSemaphoreEXT(uint semaphore, uint numBufferBarriers, ReadOnlySpan<BufferHandle> buffers, uint numTextureBarriers, ReadOnlySpan<TextureHandle> textures, ReadOnlySpan<TextureLayout> dstLayouts)
+            public static unsafe void SignalSemaphoreEXT(uint semaphore, uint numBufferBarriers, ReadOnlySpan<int> buffers, uint numTextureBarriers, ReadOnlySpan<int> textures, ReadOnlySpan<TextureLayout> dstLayouts)
             {
-                fixed (BufferHandle* buffers_ptr = buffers)
+                fixed (int* buffers_ptr = buffers)
                 {
-                    fixed (TextureHandle* textures_ptr = textures)
+                    fixed (int* textures_ptr = textures)
                     {
                         fixed (TextureLayout* dstLayouts_ptr = dstLayouts)
                         {
@@ -7435,11 +7435,11 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="SignalSemaphoreEXT"/>
-            public static unsafe void SignalSemaphoreEXT(uint semaphore, uint numBufferBarriers, BufferHandle[] buffers, uint numTextureBarriers, TextureHandle[] textures, TextureLayout[] dstLayouts)
+            public static unsafe void SignalSemaphoreEXT(uint semaphore, uint numBufferBarriers, int[] buffers, uint numTextureBarriers, int[] textures, TextureLayout[] dstLayouts)
             {
-                fixed (BufferHandle* buffers_ptr = buffers)
+                fixed (int* buffers_ptr = buffers)
                 {
-                    fixed (TextureHandle* textures_ptr = textures)
+                    fixed (int* textures_ptr = textures)
                     {
                         fixed (TextureLayout* dstLayouts_ptr = dstLayouts)
                         {
@@ -7449,10 +7449,10 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="SignalSemaphoreEXT"/>
-            public static unsafe void SignalSemaphoreEXT(uint semaphore, uint numBufferBarriers, in BufferHandle buffers, uint numTextureBarriers, in TextureHandle textures, in TextureLayout dstLayouts)
+            public static unsafe void SignalSemaphoreEXT(uint semaphore, uint numBufferBarriers, in int buffers, uint numTextureBarriers, in int textures, in TextureLayout dstLayouts)
             {
-                fixed (BufferHandle* buffers_ptr = &buffers)
-                fixed (TextureHandle* textures_ptr = &textures)
+                fixed (int* buffers_ptr = &buffers)
+                fixed (int* textures_ptr = &textures)
                 fixed (TextureLayout* dstLayouts_ptr = &dstLayouts)
                 {
                     SignalSemaphoreEXT(semaphore, numBufferBarriers, buffers_ptr, numTextureBarriers, textures_ptr, dstLayouts_ptr);
@@ -7489,68 +7489,68 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="CreateShaderProgramEXT"/>
-            public static unsafe ProgramHandle CreateShaderProgramEXT(ShaderType type, string str)
+            public static unsafe int CreateShaderProgramEXT(ShaderType type, string str)
             {
-                ProgramHandle returnValue;
+                int returnValue;
                 byte* str_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(str);
                 returnValue = CreateShaderProgramEXT(type, str_ptr);
                 Marshal.FreeCoTaskMem((IntPtr)str_ptr);
                 return returnValue;
             }
             /// <inheritdoc cref="DeleteProgramPipelinesEXT"/>
-            public static unsafe void DeleteProgramPipelinesEXT(ReadOnlySpan<ProgramPipelineHandle> pipelines)
+            public static unsafe void DeleteProgramPipelinesEXT(ReadOnlySpan<int> pipelines)
             {
                 int n = (int)(pipelines.Length);
-                fixed (ProgramPipelineHandle* pipelines_ptr = pipelines)
+                fixed (int* pipelines_ptr = pipelines)
                 {
                     DeleteProgramPipelinesEXT(n, pipelines_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteProgramPipelinesEXT"/>
-            public static unsafe void DeleteProgramPipelinesEXT(ProgramPipelineHandle[] pipelines)
+            public static unsafe void DeleteProgramPipelinesEXT(int[] pipelines)
             {
                 int n = (int)(pipelines.Length);
-                fixed (ProgramPipelineHandle* pipelines_ptr = pipelines)
+                fixed (int* pipelines_ptr = pipelines)
                 {
                     DeleteProgramPipelinesEXT(n, pipelines_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteProgramPipelinesEXT"/>
-            public static unsafe void DeleteProgramPipelinesEXT(int n, in ProgramPipelineHandle pipelines)
+            public static unsafe void DeleteProgramPipelinesEXT(int n, in int pipelines)
             {
-                fixed (ProgramPipelineHandle* pipelines_ptr = &pipelines)
+                fixed (int* pipelines_ptr = &pipelines)
                 {
                     DeleteProgramPipelinesEXT(n, pipelines_ptr);
                 }
             }
             /// <inheritdoc cref="GenProgramPipelinesEXT"/>
-            public static unsafe void GenProgramPipelinesEXT(Span<ProgramPipelineHandle> pipelines)
+            public static unsafe void GenProgramPipelinesEXT(Span<int> pipelines)
             {
                 int n = (int)(pipelines.Length);
-                fixed (ProgramPipelineHandle* pipelines_ptr = pipelines)
+                fixed (int* pipelines_ptr = pipelines)
                 {
                     GenProgramPipelinesEXT(n, pipelines_ptr);
                 }
             }
             /// <inheritdoc cref="GenProgramPipelinesEXT"/>
-            public static unsafe void GenProgramPipelinesEXT(ProgramPipelineHandle[] pipelines)
+            public static unsafe void GenProgramPipelinesEXT(int[] pipelines)
             {
                 int n = (int)(pipelines.Length);
-                fixed (ProgramPipelineHandle* pipelines_ptr = pipelines)
+                fixed (int* pipelines_ptr = pipelines)
                 {
                     GenProgramPipelinesEXT(n, pipelines_ptr);
                 }
             }
             /// <inheritdoc cref="GenProgramPipelinesEXT"/>
-            public static unsafe void GenProgramPipelinesEXT(int n, ref ProgramPipelineHandle pipelines)
+            public static unsafe void GenProgramPipelinesEXT(int n, ref int pipelines)
             {
-                fixed (ProgramPipelineHandle* pipelines_ptr = &pipelines)
+                fixed (int* pipelines_ptr = &pipelines)
                 {
                     GenProgramPipelinesEXT(n, pipelines_ptr);
                 }
             }
             /// <inheritdoc cref="GetProgramPipelineInfoLogEXT"/>
-            public static unsafe string GetProgramPipelineInfoLogEXT(ProgramPipelineHandle pipeline, int bufSize, Span<int> length)
+            public static unsafe string GetProgramPipelineInfoLogEXT(int pipeline, int bufSize, Span<int> length)
             {
                 string infoLog;
                 fixed (int* length_ptr = length)
@@ -7563,7 +7563,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 return infoLog;
             }
             /// <inheritdoc cref="GetProgramPipelineInfoLogEXT"/>
-            public static unsafe void GetProgramPipelineInfoLogEXT(ProgramPipelineHandle pipeline, int bufSize, Span<int> length, out string infoLog)
+            public static unsafe void GetProgramPipelineInfoLogEXT(int pipeline, int bufSize, Span<int> length, out string infoLog)
             {
                 fixed (int* length_ptr = length)
                 {
@@ -7574,7 +7574,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetProgramPipelineInfoLogEXT"/>
-            public static unsafe string GetProgramPipelineInfoLogEXT(ProgramPipelineHandle pipeline, int bufSize, int[] length)
+            public static unsafe string GetProgramPipelineInfoLogEXT(int pipeline, int bufSize, int[] length)
             {
                 string infoLog;
                 fixed (int* length_ptr = length)
@@ -7587,7 +7587,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 return infoLog;
             }
             /// <inheritdoc cref="GetProgramPipelineInfoLogEXT"/>
-            public static unsafe void GetProgramPipelineInfoLogEXT(ProgramPipelineHandle pipeline, int bufSize, int[] length, out string infoLog)
+            public static unsafe void GetProgramPipelineInfoLogEXT(int pipeline, int bufSize, int[] length, out string infoLog)
             {
                 fixed (int* length_ptr = length)
                 {
@@ -7598,7 +7598,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetProgramPipelineInfoLogEXT"/>
-            public static unsafe string GetProgramPipelineInfoLogEXT(ProgramPipelineHandle pipeline, int bufSize, ref int length)
+            public static unsafe string GetProgramPipelineInfoLogEXT(int pipeline, int bufSize, ref int length)
             {
                 string infoLog;
                 fixed (int* length_ptr = &length)
@@ -7611,7 +7611,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 return infoLog;
             }
             /// <inheritdoc cref="GetProgramPipelineInfoLogEXT"/>
-            public static unsafe void GetProgramPipelineInfoLogEXT(ProgramPipelineHandle pipeline, int bufSize, ref int length, out string infoLog)
+            public static unsafe void GetProgramPipelineInfoLogEXT(int pipeline, int bufSize, ref int length, out string infoLog)
             {
                 fixed (int* length_ptr = &length)
                 {
@@ -7622,7 +7622,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetProgramPipelineivEXT"/>
-            public static unsafe void GetProgramPipelineivEXT(ProgramPipelineHandle pipeline, PipelineParameterName pname, ref int parameters)
+            public static unsafe void GetProgramPipelineivEXT(int pipeline, PipelineParameterName pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -7630,7 +7630,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniform1fvEXT"/>
-            public static unsafe void ProgramUniform1fvEXT(ProgramHandle program, int location, ReadOnlySpan<float> value)
+            public static unsafe void ProgramUniform1fvEXT(int program, int location, ReadOnlySpan<float> value)
             {
                 int count = (int)(value.Length);
                 fixed (float* value_ptr = value)
@@ -7639,7 +7639,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniform1fvEXT"/>
-            public static unsafe void ProgramUniform1fvEXT(ProgramHandle program, int location, float[] value)
+            public static unsafe void ProgramUniform1fvEXT(int program, int location, float[] value)
             {
                 int count = (int)(value.Length);
                 fixed (float* value_ptr = value)
@@ -7648,7 +7648,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniform1fvEXT"/>
-            public static unsafe void ProgramUniform1fvEXT(ProgramHandle program, int location, int count, in float value)
+            public static unsafe void ProgramUniform1fvEXT(int program, int location, int count, in float value)
             {
                 fixed (float* value_ptr = &value)
                 {
@@ -7656,7 +7656,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniform1ivEXT"/>
-            public static unsafe void ProgramUniform1ivEXT(ProgramHandle program, int location, ReadOnlySpan<int> value)
+            public static unsafe void ProgramUniform1ivEXT(int program, int location, ReadOnlySpan<int> value)
             {
                 int count = (int)(value.Length);
                 fixed (int* value_ptr = value)
@@ -7665,7 +7665,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniform1ivEXT"/>
-            public static unsafe void ProgramUniform1ivEXT(ProgramHandle program, int location, int[] value)
+            public static unsafe void ProgramUniform1ivEXT(int program, int location, int[] value)
             {
                 int count = (int)(value.Length);
                 fixed (int* value_ptr = value)
@@ -7674,7 +7674,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniform1ivEXT"/>
-            public static unsafe void ProgramUniform1ivEXT(ProgramHandle program, int location, int count, in int value)
+            public static unsafe void ProgramUniform1ivEXT(int program, int location, int count, in int value)
             {
                 fixed (int* value_ptr = &value)
                 {
@@ -7682,7 +7682,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniform2fvEXT"/>
-            public static unsafe void ProgramUniform2fvEXT(ProgramHandle program, int location, ReadOnlySpan<float> value)
+            public static unsafe void ProgramUniform2fvEXT(int program, int location, ReadOnlySpan<float> value)
             {
                 int count = (int)(value.Length / 2);
                 fixed (float* value_ptr = value)
@@ -7691,7 +7691,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniform2fvEXT"/>
-            public static unsafe void ProgramUniform2fvEXT(ProgramHandle program, int location, float[] value)
+            public static unsafe void ProgramUniform2fvEXT(int program, int location, float[] value)
             {
                 int count = (int)(value.Length / 2);
                 fixed (float* value_ptr = value)
@@ -7700,7 +7700,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniform2fvEXT"/>
-            public static unsafe void ProgramUniform2fvEXT(ProgramHandle program, int location, int count, in float value)
+            public static unsafe void ProgramUniform2fvEXT(int program, int location, int count, in float value)
             {
                 fixed (float* value_ptr = &value)
                 {
@@ -7708,7 +7708,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniform2ivEXT"/>
-            public static unsafe void ProgramUniform2ivEXT(ProgramHandle program, int location, ReadOnlySpan<int> value)
+            public static unsafe void ProgramUniform2ivEXT(int program, int location, ReadOnlySpan<int> value)
             {
                 int count = (int)(value.Length / 2);
                 fixed (int* value_ptr = value)
@@ -7717,7 +7717,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniform2ivEXT"/>
-            public static unsafe void ProgramUniform2ivEXT(ProgramHandle program, int location, int[] value)
+            public static unsafe void ProgramUniform2ivEXT(int program, int location, int[] value)
             {
                 int count = (int)(value.Length / 2);
                 fixed (int* value_ptr = value)
@@ -7726,7 +7726,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniform2ivEXT"/>
-            public static unsafe void ProgramUniform2ivEXT(ProgramHandle program, int location, int count, in int value)
+            public static unsafe void ProgramUniform2ivEXT(int program, int location, int count, in int value)
             {
                 fixed (int* value_ptr = &value)
                 {
@@ -7734,7 +7734,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniform3fvEXT"/>
-            public static unsafe void ProgramUniform3fvEXT(ProgramHandle program, int location, ReadOnlySpan<float> value)
+            public static unsafe void ProgramUniform3fvEXT(int program, int location, ReadOnlySpan<float> value)
             {
                 int count = (int)(value.Length / 3);
                 fixed (float* value_ptr = value)
@@ -7743,7 +7743,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniform3fvEXT"/>
-            public static unsafe void ProgramUniform3fvEXT(ProgramHandle program, int location, float[] value)
+            public static unsafe void ProgramUniform3fvEXT(int program, int location, float[] value)
             {
                 int count = (int)(value.Length / 3);
                 fixed (float* value_ptr = value)
@@ -7752,7 +7752,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniform3fvEXT"/>
-            public static unsafe void ProgramUniform3fvEXT(ProgramHandle program, int location, int count, in float value)
+            public static unsafe void ProgramUniform3fvEXT(int program, int location, int count, in float value)
             {
                 fixed (float* value_ptr = &value)
                 {
@@ -7760,7 +7760,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniform3ivEXT"/>
-            public static unsafe void ProgramUniform3ivEXT(ProgramHandle program, int location, ReadOnlySpan<int> value)
+            public static unsafe void ProgramUniform3ivEXT(int program, int location, ReadOnlySpan<int> value)
             {
                 int count = (int)(value.Length / 3);
                 fixed (int* value_ptr = value)
@@ -7769,7 +7769,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniform3ivEXT"/>
-            public static unsafe void ProgramUniform3ivEXT(ProgramHandle program, int location, int[] value)
+            public static unsafe void ProgramUniform3ivEXT(int program, int location, int[] value)
             {
                 int count = (int)(value.Length / 3);
                 fixed (int* value_ptr = value)
@@ -7778,7 +7778,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniform3ivEXT"/>
-            public static unsafe void ProgramUniform3ivEXT(ProgramHandle program, int location, int count, in int value)
+            public static unsafe void ProgramUniform3ivEXT(int program, int location, int count, in int value)
             {
                 fixed (int* value_ptr = &value)
                 {
@@ -7786,7 +7786,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniform4fvEXT"/>
-            public static unsafe void ProgramUniform4fvEXT(ProgramHandle program, int location, ReadOnlySpan<float> value)
+            public static unsafe void ProgramUniform4fvEXT(int program, int location, ReadOnlySpan<float> value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (float* value_ptr = value)
@@ -7795,7 +7795,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniform4fvEXT"/>
-            public static unsafe void ProgramUniform4fvEXT(ProgramHandle program, int location, float[] value)
+            public static unsafe void ProgramUniform4fvEXT(int program, int location, float[] value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (float* value_ptr = value)
@@ -7804,7 +7804,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniform4fvEXT"/>
-            public static unsafe void ProgramUniform4fvEXT(ProgramHandle program, int location, int count, in float value)
+            public static unsafe void ProgramUniform4fvEXT(int program, int location, int count, in float value)
             {
                 fixed (float* value_ptr = &value)
                 {
@@ -7812,7 +7812,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniform4ivEXT"/>
-            public static unsafe void ProgramUniform4ivEXT(ProgramHandle program, int location, ReadOnlySpan<int> value)
+            public static unsafe void ProgramUniform4ivEXT(int program, int location, ReadOnlySpan<int> value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (int* value_ptr = value)
@@ -7821,7 +7821,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniform4ivEXT"/>
-            public static unsafe void ProgramUniform4ivEXT(ProgramHandle program, int location, int[] value)
+            public static unsafe void ProgramUniform4ivEXT(int program, int location, int[] value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (int* value_ptr = value)
@@ -7830,7 +7830,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniform4ivEXT"/>
-            public static unsafe void ProgramUniform4ivEXT(ProgramHandle program, int location, int count, in int value)
+            public static unsafe void ProgramUniform4ivEXT(int program, int location, int count, in int value)
             {
                 fixed (int* value_ptr = &value)
                 {
@@ -7838,7 +7838,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2fvEXT"/>
-            public static unsafe void ProgramUniformMatrix2fvEXT(ProgramHandle program, int location, bool transpose, ReadOnlySpan<float> value)
+            public static unsafe void ProgramUniformMatrix2fvEXT(int program, int location, bool transpose, ReadOnlySpan<float> value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (float* value_ptr = value)
@@ -7847,7 +7847,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2fvEXT"/>
-            public static unsafe void ProgramUniformMatrix2fvEXT(ProgramHandle program, int location, bool transpose, float[] value)
+            public static unsafe void ProgramUniformMatrix2fvEXT(int program, int location, bool transpose, float[] value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (float* value_ptr = value)
@@ -7856,7 +7856,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2fvEXT"/>
-            public static unsafe void ProgramUniformMatrix2fvEXT(ProgramHandle program, int location, int count, bool transpose, in float value)
+            public static unsafe void ProgramUniformMatrix2fvEXT(int program, int location, int count, bool transpose, in float value)
             {
                 fixed (float* value_ptr = &value)
                 {
@@ -7864,7 +7864,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3fvEXT"/>
-            public static unsafe void ProgramUniformMatrix3fvEXT(ProgramHandle program, int location, bool transpose, ReadOnlySpan<float> value)
+            public static unsafe void ProgramUniformMatrix3fvEXT(int program, int location, bool transpose, ReadOnlySpan<float> value)
             {
                 int count = (int)(value.Length / 9);
                 fixed (float* value_ptr = value)
@@ -7873,7 +7873,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3fvEXT"/>
-            public static unsafe void ProgramUniformMatrix3fvEXT(ProgramHandle program, int location, bool transpose, float[] value)
+            public static unsafe void ProgramUniformMatrix3fvEXT(int program, int location, bool transpose, float[] value)
             {
                 int count = (int)(value.Length / 9);
                 fixed (float* value_ptr = value)
@@ -7882,7 +7882,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3fvEXT"/>
-            public static unsafe void ProgramUniformMatrix3fvEXT(ProgramHandle program, int location, int count, bool transpose, in float value)
+            public static unsafe void ProgramUniformMatrix3fvEXT(int program, int location, int count, bool transpose, in float value)
             {
                 fixed (float* value_ptr = &value)
                 {
@@ -7890,7 +7890,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4fvEXT"/>
-            public static unsafe void ProgramUniformMatrix4fvEXT(ProgramHandle program, int location, bool transpose, ReadOnlySpan<float> value)
+            public static unsafe void ProgramUniformMatrix4fvEXT(int program, int location, bool transpose, ReadOnlySpan<float> value)
             {
                 int count = (int)(value.Length / 16);
                 fixed (float* value_ptr = value)
@@ -7899,7 +7899,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4fvEXT"/>
-            public static unsafe void ProgramUniformMatrix4fvEXT(ProgramHandle program, int location, bool transpose, float[] value)
+            public static unsafe void ProgramUniformMatrix4fvEXT(int program, int location, bool transpose, float[] value)
             {
                 int count = (int)(value.Length / 16);
                 fixed (float* value_ptr = value)
@@ -7908,7 +7908,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4fvEXT"/>
-            public static unsafe void ProgramUniformMatrix4fvEXT(ProgramHandle program, int location, int count, bool transpose, in float value)
+            public static unsafe void ProgramUniformMatrix4fvEXT(int program, int location, int count, bool transpose, in float value)
             {
                 fixed (float* value_ptr = &value)
                 {
@@ -7916,7 +7916,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniform1uivEXT"/>
-            public static unsafe void ProgramUniform1uivEXT(ProgramHandle program, int location, ReadOnlySpan<uint> value)
+            public static unsafe void ProgramUniform1uivEXT(int program, int location, ReadOnlySpan<uint> value)
             {
                 int count = (int)(value.Length);
                 fixed (uint* value_ptr = value)
@@ -7925,7 +7925,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniform1uivEXT"/>
-            public static unsafe void ProgramUniform1uivEXT(ProgramHandle program, int location, uint[] value)
+            public static unsafe void ProgramUniform1uivEXT(int program, int location, uint[] value)
             {
                 int count = (int)(value.Length);
                 fixed (uint* value_ptr = value)
@@ -7934,7 +7934,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniform1uivEXT"/>
-            public static unsafe void ProgramUniform1uivEXT(ProgramHandle program, int location, int count, in uint value)
+            public static unsafe void ProgramUniform1uivEXT(int program, int location, int count, in uint value)
             {
                 fixed (uint* value_ptr = &value)
                 {
@@ -7942,7 +7942,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniform2uivEXT"/>
-            public static unsafe void ProgramUniform2uivEXT(ProgramHandle program, int location, ReadOnlySpan<uint> value)
+            public static unsafe void ProgramUniform2uivEXT(int program, int location, ReadOnlySpan<uint> value)
             {
                 int count = (int)(value.Length / 2);
                 fixed (uint* value_ptr = value)
@@ -7951,7 +7951,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniform2uivEXT"/>
-            public static unsafe void ProgramUniform2uivEXT(ProgramHandle program, int location, uint[] value)
+            public static unsafe void ProgramUniform2uivEXT(int program, int location, uint[] value)
             {
                 int count = (int)(value.Length / 2);
                 fixed (uint* value_ptr = value)
@@ -7960,7 +7960,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniform2uivEXT"/>
-            public static unsafe void ProgramUniform2uivEXT(ProgramHandle program, int location, int count, in uint value)
+            public static unsafe void ProgramUniform2uivEXT(int program, int location, int count, in uint value)
             {
                 fixed (uint* value_ptr = &value)
                 {
@@ -7968,7 +7968,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniform3uivEXT"/>
-            public static unsafe void ProgramUniform3uivEXT(ProgramHandle program, int location, ReadOnlySpan<uint> value)
+            public static unsafe void ProgramUniform3uivEXT(int program, int location, ReadOnlySpan<uint> value)
             {
                 int count = (int)(value.Length / 3);
                 fixed (uint* value_ptr = value)
@@ -7977,7 +7977,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniform3uivEXT"/>
-            public static unsafe void ProgramUniform3uivEXT(ProgramHandle program, int location, uint[] value)
+            public static unsafe void ProgramUniform3uivEXT(int program, int location, uint[] value)
             {
                 int count = (int)(value.Length / 3);
                 fixed (uint* value_ptr = value)
@@ -7986,7 +7986,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniform3uivEXT"/>
-            public static unsafe void ProgramUniform3uivEXT(ProgramHandle program, int location, int count, in uint value)
+            public static unsafe void ProgramUniform3uivEXT(int program, int location, int count, in uint value)
             {
                 fixed (uint* value_ptr = &value)
                 {
@@ -7994,7 +7994,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniform4uivEXT"/>
-            public static unsafe void ProgramUniform4uivEXT(ProgramHandle program, int location, ReadOnlySpan<uint> value)
+            public static unsafe void ProgramUniform4uivEXT(int program, int location, ReadOnlySpan<uint> value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (uint* value_ptr = value)
@@ -8003,7 +8003,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniform4uivEXT"/>
-            public static unsafe void ProgramUniform4uivEXT(ProgramHandle program, int location, uint[] value)
+            public static unsafe void ProgramUniform4uivEXT(int program, int location, uint[] value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (uint* value_ptr = value)
@@ -8012,7 +8012,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniform4uivEXT"/>
-            public static unsafe void ProgramUniform4uivEXT(ProgramHandle program, int location, int count, in uint value)
+            public static unsafe void ProgramUniform4uivEXT(int program, int location, int count, in uint value)
             {
                 fixed (uint* value_ptr = &value)
                 {
@@ -8020,7 +8020,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x3fvEXT"/>
-            public static unsafe void ProgramUniformMatrix2x3fvEXT(ProgramHandle program, int location, bool transpose, ReadOnlySpan<float> value)
+            public static unsafe void ProgramUniformMatrix2x3fvEXT(int program, int location, bool transpose, ReadOnlySpan<float> value)
             {
                 int count = (int)(value.Length / 6);
                 fixed (float* value_ptr = value)
@@ -8029,7 +8029,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x3fvEXT"/>
-            public static unsafe void ProgramUniformMatrix2x3fvEXT(ProgramHandle program, int location, bool transpose, float[] value)
+            public static unsafe void ProgramUniformMatrix2x3fvEXT(int program, int location, bool transpose, float[] value)
             {
                 int count = (int)(value.Length / 6);
                 fixed (float* value_ptr = value)
@@ -8038,7 +8038,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x3fvEXT"/>
-            public static unsafe void ProgramUniformMatrix2x3fvEXT(ProgramHandle program, int location, int count, bool transpose, in float value)
+            public static unsafe void ProgramUniformMatrix2x3fvEXT(int program, int location, int count, bool transpose, in float value)
             {
                 fixed (float* value_ptr = &value)
                 {
@@ -8046,7 +8046,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2fvEXT"/>
-            public static unsafe void ProgramUniformMatrix3x2fvEXT(ProgramHandle program, int location, bool transpose, ReadOnlySpan<float> value)
+            public static unsafe void ProgramUniformMatrix3x2fvEXT(int program, int location, bool transpose, ReadOnlySpan<float> value)
             {
                 int count = (int)(value.Length / 6);
                 fixed (float* value_ptr = value)
@@ -8055,7 +8055,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2fvEXT"/>
-            public static unsafe void ProgramUniformMatrix3x2fvEXT(ProgramHandle program, int location, bool transpose, float[] value)
+            public static unsafe void ProgramUniformMatrix3x2fvEXT(int program, int location, bool transpose, float[] value)
             {
                 int count = (int)(value.Length / 6);
                 fixed (float* value_ptr = value)
@@ -8064,7 +8064,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x2fvEXT"/>
-            public static unsafe void ProgramUniformMatrix3x2fvEXT(ProgramHandle program, int location, int count, bool transpose, in float value)
+            public static unsafe void ProgramUniformMatrix3x2fvEXT(int program, int location, int count, bool transpose, in float value)
             {
                 fixed (float* value_ptr = &value)
                 {
@@ -8072,7 +8072,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x4fvEXT"/>
-            public static unsafe void ProgramUniformMatrix2x4fvEXT(ProgramHandle program, int location, bool transpose, ReadOnlySpan<float> value)
+            public static unsafe void ProgramUniformMatrix2x4fvEXT(int program, int location, bool transpose, ReadOnlySpan<float> value)
             {
                 int count = (int)(value.Length / 8);
                 fixed (float* value_ptr = value)
@@ -8081,7 +8081,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x4fvEXT"/>
-            public static unsafe void ProgramUniformMatrix2x4fvEXT(ProgramHandle program, int location, bool transpose, float[] value)
+            public static unsafe void ProgramUniformMatrix2x4fvEXT(int program, int location, bool transpose, float[] value)
             {
                 int count = (int)(value.Length / 8);
                 fixed (float* value_ptr = value)
@@ -8090,7 +8090,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix2x4fvEXT"/>
-            public static unsafe void ProgramUniformMatrix2x4fvEXT(ProgramHandle program, int location, int count, bool transpose, in float value)
+            public static unsafe void ProgramUniformMatrix2x4fvEXT(int program, int location, int count, bool transpose, in float value)
             {
                 fixed (float* value_ptr = &value)
                 {
@@ -8098,7 +8098,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x2fvEXT"/>
-            public static unsafe void ProgramUniformMatrix4x2fvEXT(ProgramHandle program, int location, bool transpose, ReadOnlySpan<float> value)
+            public static unsafe void ProgramUniformMatrix4x2fvEXT(int program, int location, bool transpose, ReadOnlySpan<float> value)
             {
                 int count = (int)(value.Length / 8);
                 fixed (float* value_ptr = value)
@@ -8107,7 +8107,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x2fvEXT"/>
-            public static unsafe void ProgramUniformMatrix4x2fvEXT(ProgramHandle program, int location, bool transpose, float[] value)
+            public static unsafe void ProgramUniformMatrix4x2fvEXT(int program, int location, bool transpose, float[] value)
             {
                 int count = (int)(value.Length / 8);
                 fixed (float* value_ptr = value)
@@ -8116,7 +8116,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x2fvEXT"/>
-            public static unsafe void ProgramUniformMatrix4x2fvEXT(ProgramHandle program, int location, int count, bool transpose, in float value)
+            public static unsafe void ProgramUniformMatrix4x2fvEXT(int program, int location, int count, bool transpose, in float value)
             {
                 fixed (float* value_ptr = &value)
                 {
@@ -8124,7 +8124,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x4fvEXT"/>
-            public static unsafe void ProgramUniformMatrix3x4fvEXT(ProgramHandle program, int location, bool transpose, ReadOnlySpan<float> value)
+            public static unsafe void ProgramUniformMatrix3x4fvEXT(int program, int location, bool transpose, ReadOnlySpan<float> value)
             {
                 int count = (int)(value.Length / 12);
                 fixed (float* value_ptr = value)
@@ -8133,7 +8133,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x4fvEXT"/>
-            public static unsafe void ProgramUniformMatrix3x4fvEXT(ProgramHandle program, int location, bool transpose, float[] value)
+            public static unsafe void ProgramUniformMatrix3x4fvEXT(int program, int location, bool transpose, float[] value)
             {
                 int count = (int)(value.Length / 12);
                 fixed (float* value_ptr = value)
@@ -8142,7 +8142,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix3x4fvEXT"/>
-            public static unsafe void ProgramUniformMatrix3x4fvEXT(ProgramHandle program, int location, int count, bool transpose, in float value)
+            public static unsafe void ProgramUniformMatrix3x4fvEXT(int program, int location, int count, bool transpose, in float value)
             {
                 fixed (float* value_ptr = &value)
                 {
@@ -8150,7 +8150,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x3fvEXT"/>
-            public static unsafe void ProgramUniformMatrix4x3fvEXT(ProgramHandle program, int location, bool transpose, ReadOnlySpan<float> value)
+            public static unsafe void ProgramUniformMatrix4x3fvEXT(int program, int location, bool transpose, ReadOnlySpan<float> value)
             {
                 int count = (int)(value.Length / 12);
                 fixed (float* value_ptr = value)
@@ -8159,7 +8159,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x3fvEXT"/>
-            public static unsafe void ProgramUniformMatrix4x3fvEXT(ProgramHandle program, int location, bool transpose, float[] value)
+            public static unsafe void ProgramUniformMatrix4x3fvEXT(int program, int location, bool transpose, float[] value)
             {
                 int count = (int)(value.Length / 12);
                 fixed (float* value_ptr = value)
@@ -8168,7 +8168,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniformMatrix4x3fvEXT"/>
-            public static unsafe void ProgramUniformMatrix4x3fvEXT(ProgramHandle program, int location, int count, bool transpose, in float value)
+            public static unsafe void ProgramUniformMatrix4x3fvEXT(int program, int location, int count, bool transpose, in float value)
             {
                 fixed (float* value_ptr = &value)
                 {
@@ -8298,7 +8298,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="SamplerParameterIivEXT"/>
-            public static unsafe void SamplerParameterIivEXT(SamplerHandle sampler, SamplerParameterI pname, ReadOnlySpan<int> param)
+            public static unsafe void SamplerParameterIivEXT(int sampler, SamplerParameterI pname, ReadOnlySpan<int> param)
             {
                 fixed (int* param_ptr = param)
                 {
@@ -8306,7 +8306,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="SamplerParameterIivEXT"/>
-            public static unsafe void SamplerParameterIivEXT(SamplerHandle sampler, SamplerParameterI pname, int[] param)
+            public static unsafe void SamplerParameterIivEXT(int sampler, SamplerParameterI pname, int[] param)
             {
                 fixed (int* param_ptr = param)
                 {
@@ -8314,7 +8314,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="SamplerParameterIivEXT"/>
-            public static unsafe void SamplerParameterIivEXT(SamplerHandle sampler, SamplerParameterI pname, in int param)
+            public static unsafe void SamplerParameterIivEXT(int sampler, SamplerParameterI pname, in int param)
             {
                 fixed (int* param_ptr = &param)
                 {
@@ -8322,7 +8322,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="SamplerParameterIuivEXT"/>
-            public static unsafe void SamplerParameterIuivEXT(SamplerHandle sampler, SamplerParameterI pname, ReadOnlySpan<uint> param)
+            public static unsafe void SamplerParameterIuivEXT(int sampler, SamplerParameterI pname, ReadOnlySpan<uint> param)
             {
                 fixed (uint* param_ptr = param)
                 {
@@ -8330,7 +8330,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="SamplerParameterIuivEXT"/>
-            public static unsafe void SamplerParameterIuivEXT(SamplerHandle sampler, SamplerParameterI pname, uint[] param)
+            public static unsafe void SamplerParameterIuivEXT(int sampler, SamplerParameterI pname, uint[] param)
             {
                 fixed (uint* param_ptr = param)
                 {
@@ -8338,7 +8338,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="SamplerParameterIuivEXT"/>
-            public static unsafe void SamplerParameterIuivEXT(SamplerHandle sampler, SamplerParameterI pname, in uint param)
+            public static unsafe void SamplerParameterIuivEXT(int sampler, SamplerParameterI pname, in uint param)
             {
                 fixed (uint* param_ptr = &param)
                 {
@@ -8346,7 +8346,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetSamplerParameterIivEXT"/>
-            public static unsafe void GetSamplerParameterIivEXT(SamplerHandle sampler, SamplerParameterI pname, Span<int> parameters)
+            public static unsafe void GetSamplerParameterIivEXT(int sampler, SamplerParameterI pname, Span<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -8354,7 +8354,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetSamplerParameterIivEXT"/>
-            public static unsafe void GetSamplerParameterIivEXT(SamplerHandle sampler, SamplerParameterI pname, int[] parameters)
+            public static unsafe void GetSamplerParameterIivEXT(int sampler, SamplerParameterI pname, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -8362,7 +8362,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetSamplerParameterIivEXT"/>
-            public static unsafe void GetSamplerParameterIivEXT(SamplerHandle sampler, SamplerParameterI pname, ref int parameters)
+            public static unsafe void GetSamplerParameterIivEXT(int sampler, SamplerParameterI pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -8370,7 +8370,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetSamplerParameterIuivEXT"/>
-            public static unsafe void GetSamplerParameterIuivEXT(SamplerHandle sampler, SamplerParameterI pname, Span<uint> parameters)
+            public static unsafe void GetSamplerParameterIuivEXT(int sampler, SamplerParameterI pname, Span<uint> parameters)
             {
                 fixed (uint* parameters_ptr = parameters)
                 {
@@ -8378,7 +8378,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetSamplerParameterIuivEXT"/>
-            public static unsafe void GetSamplerParameterIuivEXT(SamplerHandle sampler, SamplerParameterI pname, uint[] parameters)
+            public static unsafe void GetSamplerParameterIuivEXT(int sampler, SamplerParameterI pname, uint[] parameters)
             {
                 fixed (uint* parameters_ptr = parameters)
                 {
@@ -8386,7 +8386,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetSamplerParameterIuivEXT"/>
-            public static unsafe void GetSamplerParameterIuivEXT(SamplerHandle sampler, SamplerParameterI pname, ref uint parameters)
+            public static unsafe void GetSamplerParameterIuivEXT(int sampler, SamplerParameterI pname, ref uint parameters)
             {
                 fixed (uint* parameters_ptr = &parameters)
                 {
@@ -8505,7 +8505,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniformHandleui64vNV"/>
-            public static unsafe void ProgramUniformHandleui64vNV(ProgramHandle program, int location, ReadOnlySpan<ulong> values)
+            public static unsafe void ProgramUniformHandleui64vNV(int program, int location, ReadOnlySpan<ulong> values)
             {
                 int count = (int)(values.Length);
                 fixed (ulong* values_ptr = values)
@@ -8514,7 +8514,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniformHandleui64vNV"/>
-            public static unsafe void ProgramUniformHandleui64vNV(ProgramHandle program, int location, ulong[] values)
+            public static unsafe void ProgramUniformHandleui64vNV(int program, int location, ulong[] values)
             {
                 int count = (int)(values.Length);
                 fixed (ulong* values_ptr = values)
@@ -8523,7 +8523,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniformHandleui64vNV"/>
-            public static unsafe void ProgramUniformHandleui64vNV(ProgramHandle program, int location, int count, in ulong values)
+            public static unsafe void ProgramUniformHandleui64vNV(int program, int location, int count, in ulong values)
             {
                 fixed (ulong* values_ptr = &values)
                 {
@@ -8890,7 +8890,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetUniformi64vNV"/>
-            public static unsafe void GetUniformi64vNV(ProgramHandle program, int location, Span<long> parameters)
+            public static unsafe void GetUniformi64vNV(int program, int location, Span<long> parameters)
             {
                 fixed (long* parameters_ptr = parameters)
                 {
@@ -8898,7 +8898,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetUniformi64vNV"/>
-            public static unsafe void GetUniformi64vNV(ProgramHandle program, int location, long[] parameters)
+            public static unsafe void GetUniformi64vNV(int program, int location, long[] parameters)
             {
                 fixed (long* parameters_ptr = parameters)
                 {
@@ -8906,7 +8906,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetUniformi64vNV"/>
-            public static unsafe void GetUniformi64vNV(ProgramHandle program, int location, ref long parameters)
+            public static unsafe void GetUniformi64vNV(int program, int location, ref long parameters)
             {
                 fixed (long* parameters_ptr = &parameters)
                 {
@@ -8914,7 +8914,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniform1i64vNV"/>
-            public static unsafe void ProgramUniform1i64vNV(ProgramHandle program, int location, ReadOnlySpan<long> value)
+            public static unsafe void ProgramUniform1i64vNV(int program, int location, ReadOnlySpan<long> value)
             {
                 int count = (int)(value.Length);
                 fixed (long* value_ptr = value)
@@ -8923,7 +8923,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniform1i64vNV"/>
-            public static unsafe void ProgramUniform1i64vNV(ProgramHandle program, int location, long[] value)
+            public static unsafe void ProgramUniform1i64vNV(int program, int location, long[] value)
             {
                 int count = (int)(value.Length);
                 fixed (long* value_ptr = value)
@@ -8932,7 +8932,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniform1i64vNV"/>
-            public static unsafe void ProgramUniform1i64vNV(ProgramHandle program, int location, int count, in long value)
+            public static unsafe void ProgramUniform1i64vNV(int program, int location, int count, in long value)
             {
                 fixed (long* value_ptr = &value)
                 {
@@ -8940,7 +8940,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniform2i64vNV"/>
-            public static unsafe void ProgramUniform2i64vNV(ProgramHandle program, int location, ReadOnlySpan<long> value)
+            public static unsafe void ProgramUniform2i64vNV(int program, int location, ReadOnlySpan<long> value)
             {
                 int count = (int)(value.Length / 2);
                 fixed (long* value_ptr = value)
@@ -8949,7 +8949,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniform2i64vNV"/>
-            public static unsafe void ProgramUniform2i64vNV(ProgramHandle program, int location, long[] value)
+            public static unsafe void ProgramUniform2i64vNV(int program, int location, long[] value)
             {
                 int count = (int)(value.Length / 2);
                 fixed (long* value_ptr = value)
@@ -8958,7 +8958,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniform2i64vNV"/>
-            public static unsafe void ProgramUniform2i64vNV(ProgramHandle program, int location, int count, in long value)
+            public static unsafe void ProgramUniform2i64vNV(int program, int location, int count, in long value)
             {
                 fixed (long* value_ptr = &value)
                 {
@@ -8966,7 +8966,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniform3i64vNV"/>
-            public static unsafe void ProgramUniform3i64vNV(ProgramHandle program, int location, ReadOnlySpan<long> value)
+            public static unsafe void ProgramUniform3i64vNV(int program, int location, ReadOnlySpan<long> value)
             {
                 int count = (int)(value.Length / 3);
                 fixed (long* value_ptr = value)
@@ -8975,7 +8975,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniform3i64vNV"/>
-            public static unsafe void ProgramUniform3i64vNV(ProgramHandle program, int location, long[] value)
+            public static unsafe void ProgramUniform3i64vNV(int program, int location, long[] value)
             {
                 int count = (int)(value.Length / 3);
                 fixed (long* value_ptr = value)
@@ -8984,7 +8984,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniform3i64vNV"/>
-            public static unsafe void ProgramUniform3i64vNV(ProgramHandle program, int location, int count, in long value)
+            public static unsafe void ProgramUniform3i64vNV(int program, int location, int count, in long value)
             {
                 fixed (long* value_ptr = &value)
                 {
@@ -8992,7 +8992,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniform4i64vNV"/>
-            public static unsafe void ProgramUniform4i64vNV(ProgramHandle program, int location, ReadOnlySpan<long> value)
+            public static unsafe void ProgramUniform4i64vNV(int program, int location, ReadOnlySpan<long> value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (long* value_ptr = value)
@@ -9001,7 +9001,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniform4i64vNV"/>
-            public static unsafe void ProgramUniform4i64vNV(ProgramHandle program, int location, long[] value)
+            public static unsafe void ProgramUniform4i64vNV(int program, int location, long[] value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (long* value_ptr = value)
@@ -9010,7 +9010,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniform4i64vNV"/>
-            public static unsafe void ProgramUniform4i64vNV(ProgramHandle program, int location, int count, in long value)
+            public static unsafe void ProgramUniform4i64vNV(int program, int location, int count, in long value)
             {
                 fixed (long* value_ptr = &value)
                 {
@@ -9018,7 +9018,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniform1ui64vNV"/>
-            public static unsafe void ProgramUniform1ui64vNV(ProgramHandle program, int location, ReadOnlySpan<ulong> value)
+            public static unsafe void ProgramUniform1ui64vNV(int program, int location, ReadOnlySpan<ulong> value)
             {
                 int count = (int)(value.Length);
                 fixed (ulong* value_ptr = value)
@@ -9027,7 +9027,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniform1ui64vNV"/>
-            public static unsafe void ProgramUniform1ui64vNV(ProgramHandle program, int location, ulong[] value)
+            public static unsafe void ProgramUniform1ui64vNV(int program, int location, ulong[] value)
             {
                 int count = (int)(value.Length);
                 fixed (ulong* value_ptr = value)
@@ -9036,7 +9036,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniform1ui64vNV"/>
-            public static unsafe void ProgramUniform1ui64vNV(ProgramHandle program, int location, int count, in ulong value)
+            public static unsafe void ProgramUniform1ui64vNV(int program, int location, int count, in ulong value)
             {
                 fixed (ulong* value_ptr = &value)
                 {
@@ -9044,7 +9044,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniform2ui64vNV"/>
-            public static unsafe void ProgramUniform2ui64vNV(ProgramHandle program, int location, ReadOnlySpan<ulong> value)
+            public static unsafe void ProgramUniform2ui64vNV(int program, int location, ReadOnlySpan<ulong> value)
             {
                 int count = (int)(value.Length / 2);
                 fixed (ulong* value_ptr = value)
@@ -9053,7 +9053,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniform2ui64vNV"/>
-            public static unsafe void ProgramUniform2ui64vNV(ProgramHandle program, int location, ulong[] value)
+            public static unsafe void ProgramUniform2ui64vNV(int program, int location, ulong[] value)
             {
                 int count = (int)(value.Length / 2);
                 fixed (ulong* value_ptr = value)
@@ -9062,7 +9062,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniform2ui64vNV"/>
-            public static unsafe void ProgramUniform2ui64vNV(ProgramHandle program, int location, int count, in ulong value)
+            public static unsafe void ProgramUniform2ui64vNV(int program, int location, int count, in ulong value)
             {
                 fixed (ulong* value_ptr = &value)
                 {
@@ -9070,7 +9070,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniform3ui64vNV"/>
-            public static unsafe void ProgramUniform3ui64vNV(ProgramHandle program, int location, ReadOnlySpan<ulong> value)
+            public static unsafe void ProgramUniform3ui64vNV(int program, int location, ReadOnlySpan<ulong> value)
             {
                 int count = (int)(value.Length / 3);
                 fixed (ulong* value_ptr = value)
@@ -9079,7 +9079,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniform3ui64vNV"/>
-            public static unsafe void ProgramUniform3ui64vNV(ProgramHandle program, int location, ulong[] value)
+            public static unsafe void ProgramUniform3ui64vNV(int program, int location, ulong[] value)
             {
                 int count = (int)(value.Length / 3);
                 fixed (ulong* value_ptr = value)
@@ -9088,7 +9088,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniform3ui64vNV"/>
-            public static unsafe void ProgramUniform3ui64vNV(ProgramHandle program, int location, int count, in ulong value)
+            public static unsafe void ProgramUniform3ui64vNV(int program, int location, int count, in ulong value)
             {
                 fixed (ulong* value_ptr = &value)
                 {
@@ -9096,7 +9096,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniform4ui64vNV"/>
-            public static unsafe void ProgramUniform4ui64vNV(ProgramHandle program, int location, ReadOnlySpan<ulong> value)
+            public static unsafe void ProgramUniform4ui64vNV(int program, int location, ReadOnlySpan<ulong> value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (ulong* value_ptr = value)
@@ -9105,7 +9105,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniform4ui64vNV"/>
-            public static unsafe void ProgramUniform4ui64vNV(ProgramHandle program, int location, ulong[] value)
+            public static unsafe void ProgramUniform4ui64vNV(int program, int location, ulong[] value)
             {
                 int count = (int)(value.Length / 4);
                 fixed (ulong* value_ptr = value)
@@ -9114,7 +9114,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniform4ui64vNV"/>
-            public static unsafe void ProgramUniform4ui64vNV(ProgramHandle program, int location, int count, in ulong value)
+            public static unsafe void ProgramUniform4ui64vNV(int program, int location, int count, in ulong value)
             {
                 fixed (ulong* value_ptr = &value)
                 {
@@ -10591,7 +10591,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 return returnValue;
             }
             /// <inheritdoc cref="ProgramPathFragmentInputGenNV"/>
-            public static unsafe void ProgramPathFragmentInputGenNV(ProgramHandle program, int location, All genMode, int components, in float coeffs)
+            public static unsafe void ProgramPathFragmentInputGenNV(int program, int location, All genMode, int components, in float coeffs)
             {
                 fixed (float* coeffs_ptr = &coeffs)
                 {
@@ -10599,7 +10599,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetProgramResourcefvNV"/>
-            public static unsafe void GetProgramResourcefvNV(ProgramHandle program, ProgramInterface programInterface, uint index, int propCount, in All props, Span<int> length, Span<float> parameters)
+            public static unsafe void GetProgramResourcefvNV(int program, ProgramInterface programInterface, uint index, int propCount, in All props, Span<int> length, Span<float> parameters)
             {
                 fixed (All* props_ptr = &props)
                 {
@@ -10614,7 +10614,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetProgramResourcefvNV"/>
-            public static unsafe void GetProgramResourcefvNV(ProgramHandle program, ProgramInterface programInterface, uint index, int propCount, in All props, int[] length, float[] parameters)
+            public static unsafe void GetProgramResourcefvNV(int program, ProgramInterface programInterface, uint index, int propCount, in All props, int[] length, float[] parameters)
             {
                 fixed (All* props_ptr = &props)
                 {
@@ -10629,7 +10629,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetProgramResourcefvNV"/>
-            public static unsafe void GetProgramResourcefvNV(ProgramHandle program, ProgramInterface programInterface, uint index, int propCount, in All props, int count, ref int length, ref float parameters)
+            public static unsafe void GetProgramResourcefvNV(int program, ProgramInterface programInterface, uint index, int propCount, in All props, int count, ref int length, ref float parameters)
             {
                 fixed (All* props_ptr = &props)
                 fixed (int* length_ptr = &length)
@@ -10839,7 +10839,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="NamedFramebufferSampleLocationsfvNV"/>
-            public static unsafe void NamedFramebufferSampleLocationsfvNV(FramebufferHandle framebuffer, uint start, int count, in float v)
+            public static unsafe void NamedFramebufferSampleLocationsfvNV(int framebuffer, uint start, int count, in float v)
             {
                 fixed (float* v_ptr = &v)
                 {
@@ -11126,7 +11126,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniformHandleui64vIMG"/>
-            public static unsafe void ProgramUniformHandleui64vIMG(ProgramHandle program, int location, ReadOnlySpan<ulong> values)
+            public static unsafe void ProgramUniformHandleui64vIMG(int program, int location, ReadOnlySpan<ulong> values)
             {
                 int count = (int)(values.Length);
                 fixed (ulong* values_ptr = values)
@@ -11135,7 +11135,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniformHandleui64vIMG"/>
-            public static unsafe void ProgramUniformHandleui64vIMG(ProgramHandle program, int location, ulong[] values)
+            public static unsafe void ProgramUniformHandleui64vIMG(int program, int location, ulong[] values)
             {
                 int count = (int)(values.Length);
                 fixed (ulong* values_ptr = values)
@@ -11144,7 +11144,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramUniformHandleui64vIMG"/>
-            public static unsafe void ProgramUniformHandleui64vIMG(ProgramHandle program, int location, int count, in ulong values)
+            public static unsafe void ProgramUniformHandleui64vIMG(int program, int location, int count, in ulong values)
             {
                 fixed (ulong* values_ptr = &values)
                 {
@@ -12015,7 +12015,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetnUniformfv"/>
-            public static unsafe void GetnUniformf(ProgramHandle program, int location, Span<float> parameters)
+            public static unsafe void GetnUniformf(int program, int location, Span<float> parameters)
             {
                 int bufSize = (int)(parameters.Length * 4);
                 fixed (float* parameters_ptr = parameters)
@@ -12024,7 +12024,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetnUniformfv"/>
-            public static unsafe void GetnUniformf(ProgramHandle program, int location, float[] parameters)
+            public static unsafe void GetnUniformf(int program, int location, float[] parameters)
             {
                 int bufSize = (int)(parameters.Length * 4);
                 fixed (float* parameters_ptr = parameters)
@@ -12033,7 +12033,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetnUniformfv"/>
-            public static unsafe void GetnUniformf(ProgramHandle program, int location, int bufSize, ref float parameters)
+            public static unsafe void GetnUniformf(int program, int location, int bufSize, ref float parameters)
             {
                 fixed (float* parameters_ptr = &parameters)
                 {
@@ -12041,7 +12041,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetnUniformiv"/>
-            public static unsafe void GetnUniformi(ProgramHandle program, int location, Span<int> parameters)
+            public static unsafe void GetnUniformi(int program, int location, Span<int> parameters)
             {
                 int bufSize = (int)(parameters.Length * 4);
                 fixed (int* parameters_ptr = parameters)
@@ -12050,7 +12050,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetnUniformiv"/>
-            public static unsafe void GetnUniformi(ProgramHandle program, int location, int[] parameters)
+            public static unsafe void GetnUniformi(int program, int location, int[] parameters)
             {
                 int bufSize = (int)(parameters.Length * 4);
                 fixed (int* parameters_ptr = parameters)
@@ -12059,7 +12059,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetnUniformiv"/>
-            public static unsafe void GetnUniformi(ProgramHandle program, int location, int bufSize, ref int parameters)
+            public static unsafe void GetnUniformi(int program, int location, int bufSize, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -12067,7 +12067,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetnUniformuiv"/>
-            public static unsafe void GetnUniformui(ProgramHandle program, int location, Span<uint> parameters)
+            public static unsafe void GetnUniformui(int program, int location, Span<uint> parameters)
             {
                 int bufSize = (int)(parameters.Length * 4);
                 fixed (uint* parameters_ptr = parameters)
@@ -12076,7 +12076,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetnUniformuiv"/>
-            public static unsafe void GetnUniformui(ProgramHandle program, int location, uint[] parameters)
+            public static unsafe void GetnUniformui(int program, int location, uint[] parameters)
             {
                 int bufSize = (int)(parameters.Length * 4);
                 fixed (uint* parameters_ptr = parameters)
@@ -12085,7 +12085,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetnUniformuiv"/>
-            public static unsafe void GetnUniformui(ProgramHandle program, int location, int bufSize, ref uint parameters)
+            public static unsafe void GetnUniformui(int program, int location, int bufSize, ref uint parameters)
             {
                 fixed (uint* parameters_ptr = &parameters)
                 {
@@ -12128,7 +12128,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetnUniformfvKHR"/>
-            public static unsafe void GetnUniformfvKHR(ProgramHandle program, int location, Span<float> parameters)
+            public static unsafe void GetnUniformfvKHR(int program, int location, Span<float> parameters)
             {
                 int bufSize = (int)(parameters.Length * 4);
                 fixed (float* parameters_ptr = parameters)
@@ -12137,7 +12137,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetnUniformfvKHR"/>
-            public static unsafe void GetnUniformfvKHR(ProgramHandle program, int location, float[] parameters)
+            public static unsafe void GetnUniformfvKHR(int program, int location, float[] parameters)
             {
                 int bufSize = (int)(parameters.Length * 4);
                 fixed (float* parameters_ptr = parameters)
@@ -12146,7 +12146,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetnUniformfvKHR"/>
-            public static unsafe void GetnUniformfvKHR(ProgramHandle program, int location, int bufSize, ref float parameters)
+            public static unsafe void GetnUniformfvKHR(int program, int location, int bufSize, ref float parameters)
             {
                 fixed (float* parameters_ptr = &parameters)
                 {
@@ -12154,7 +12154,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetnUniformivKHR"/>
-            public static unsafe void GetnUniformivKHR(ProgramHandle program, int location, Span<int> parameters)
+            public static unsafe void GetnUniformivKHR(int program, int location, Span<int> parameters)
             {
                 int bufSize = (int)(parameters.Length * 4);
                 fixed (int* parameters_ptr = parameters)
@@ -12163,7 +12163,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetnUniformivKHR"/>
-            public static unsafe void GetnUniformivKHR(ProgramHandle program, int location, int[] parameters)
+            public static unsafe void GetnUniformivKHR(int program, int location, int[] parameters)
             {
                 int bufSize = (int)(parameters.Length * 4);
                 fixed (int* parameters_ptr = parameters)
@@ -12172,7 +12172,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetnUniformivKHR"/>
-            public static unsafe void GetnUniformivKHR(ProgramHandle program, int location, int bufSize, ref int parameters)
+            public static unsafe void GetnUniformivKHR(int program, int location, int bufSize, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -12180,7 +12180,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetnUniformuivKHR"/>
-            public static unsafe void GetnUniformuivKHR(ProgramHandle program, int location, Span<uint> parameters)
+            public static unsafe void GetnUniformuivKHR(int program, int location, Span<uint> parameters)
             {
                 int bufSize = (int)(parameters.Length * 4);
                 fixed (uint* parameters_ptr = parameters)
@@ -12189,7 +12189,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetnUniformuivKHR"/>
-            public static unsafe void GetnUniformuivKHR(ProgramHandle program, int location, uint[] parameters)
+            public static unsafe void GetnUniformuivKHR(int program, int location, uint[] parameters)
             {
                 int bufSize = (int)(parameters.Length * 4);
                 fixed (uint* parameters_ptr = parameters)
@@ -12198,7 +12198,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetnUniformuivKHR"/>
-            public static unsafe void GetnUniformuivKHR(ProgramHandle program, int location, int bufSize, ref uint parameters)
+            public static unsafe void GetnUniformuivKHR(int program, int location, int bufSize, ref uint parameters)
             {
                 fixed (uint* parameters_ptr = &parameters)
                 {
@@ -12315,7 +12315,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetProgramBinaryOES"/>
-            public static unsafe void GetProgramBinaryOES(ProgramHandle program, int bufSize, Span<int> length, Span<All> binaryFormat, IntPtr binary)
+            public static unsafe void GetProgramBinaryOES(int program, int bufSize, Span<int> length, Span<All> binaryFormat, IntPtr binary)
             {
                 fixed (int* length_ptr = length)
                 {
@@ -12327,7 +12327,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetProgramBinaryOES"/>
-            public static unsafe void GetProgramBinaryOES(ProgramHandle program, int bufSize, int[] length, All[] binaryFormat, IntPtr binary)
+            public static unsafe void GetProgramBinaryOES(int program, int bufSize, int[] length, All[] binaryFormat, IntPtr binary)
             {
                 fixed (int* length_ptr = length)
                 {
@@ -12339,7 +12339,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetProgramBinaryOES"/>
-            public static unsafe void GetProgramBinaryOES(ProgramHandle program, int bufSize, ref int length, ref All binaryFormat, IntPtr binary)
+            public static unsafe void GetProgramBinaryOES(int program, int bufSize, ref int length, ref All binaryFormat, IntPtr binary)
             {
                 fixed (int* length_ptr = &length)
                 fixed (All* binaryFormat_ptr = &binaryFormat)
@@ -12349,7 +12349,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetProgramBinaryOES"/>
-            public static unsafe void GetProgramBinaryOES<T1>(ProgramHandle program, Span<int> length, Span<All> binaryFormat, Span<T1> binary)
+            public static unsafe void GetProgramBinaryOES<T1>(int program, Span<int> length, Span<All> binaryFormat, Span<T1> binary)
                 where T1 : unmanaged
             {
                 fixed (int* length_ptr = length)
@@ -12365,7 +12365,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetProgramBinaryOES"/>
-            public static unsafe void GetProgramBinaryOES<T1>(ProgramHandle program, int[] length, All[] binaryFormat, T1[] binary)
+            public static unsafe void GetProgramBinaryOES<T1>(int program, int[] length, All[] binaryFormat, T1[] binary)
                 where T1 : unmanaged
             {
                 fixed (int* length_ptr = length)
@@ -12381,7 +12381,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetProgramBinaryOES"/>
-            public static unsafe void GetProgramBinaryOES<T1>(ProgramHandle program, int bufSize, ref int length, ref All binaryFormat, ref T1 binary)
+            public static unsafe void GetProgramBinaryOES<T1>(int program, int bufSize, ref int length, ref All binaryFormat, ref T1 binary)
                 where T1 : unmanaged
             {
                 fixed (int* length_ptr = &length)
@@ -12392,13 +12392,13 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramBinaryOES"/>
-            public static unsafe void ProgramBinaryOES(ProgramHandle program, All binaryFormat, IntPtr binary, int length)
+            public static unsafe void ProgramBinaryOES(int program, All binaryFormat, IntPtr binary, int length)
             {
                 void* binary_vptr = (void*)binary;
                 ProgramBinaryOES(program, binaryFormat, binary_vptr, length);
             }
             /// <inheritdoc cref="ProgramBinaryOES"/>
-            public static unsafe void ProgramBinaryOES<T1>(ProgramHandle program, All binaryFormat, ReadOnlySpan<T1> binary)
+            public static unsafe void ProgramBinaryOES<T1>(int program, All binaryFormat, ReadOnlySpan<T1> binary)
                 where T1 : unmanaged
             {
                 int length = (int)(binary.Length * sizeof(T1));
@@ -12408,7 +12408,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramBinaryOES"/>
-            public static unsafe void ProgramBinaryOES<T1>(ProgramHandle program, All binaryFormat, T1[] binary)
+            public static unsafe void ProgramBinaryOES<T1>(int program, All binaryFormat, T1[] binary)
                 where T1 : unmanaged
             {
                 int length = (int)(binary.Length * sizeof(T1));
@@ -12418,7 +12418,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ProgramBinaryOES"/>
-            public static unsafe void ProgramBinaryOES<T1>(ProgramHandle program, All binaryFormat, in T1 binary, int length)
+            public static unsafe void ProgramBinaryOES<T1>(int program, All binaryFormat, in T1 binary, int length)
                 where T1 : unmanaged
             {
                 fixed (void* binary_ptr = &binary)
@@ -12659,7 +12659,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="SamplerParameterIivOES"/>
-            public static unsafe void SamplerParameterIivOES(SamplerHandle sampler, SamplerParameterI pname, ReadOnlySpan<int> param)
+            public static unsafe void SamplerParameterIivOES(int sampler, SamplerParameterI pname, ReadOnlySpan<int> param)
             {
                 fixed (int* param_ptr = param)
                 {
@@ -12667,7 +12667,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="SamplerParameterIivOES"/>
-            public static unsafe void SamplerParameterIivOES(SamplerHandle sampler, SamplerParameterI pname, int[] param)
+            public static unsafe void SamplerParameterIivOES(int sampler, SamplerParameterI pname, int[] param)
             {
                 fixed (int* param_ptr = param)
                 {
@@ -12675,7 +12675,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="SamplerParameterIivOES"/>
-            public static unsafe void SamplerParameterIivOES(SamplerHandle sampler, SamplerParameterI pname, in int param)
+            public static unsafe void SamplerParameterIivOES(int sampler, SamplerParameterI pname, in int param)
             {
                 fixed (int* param_ptr = &param)
                 {
@@ -12683,7 +12683,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="SamplerParameterIuivOES"/>
-            public static unsafe void SamplerParameterIuivOES(SamplerHandle sampler, SamplerParameterI pname, ReadOnlySpan<uint> param)
+            public static unsafe void SamplerParameterIuivOES(int sampler, SamplerParameterI pname, ReadOnlySpan<uint> param)
             {
                 fixed (uint* param_ptr = param)
                 {
@@ -12691,7 +12691,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="SamplerParameterIuivOES"/>
-            public static unsafe void SamplerParameterIuivOES(SamplerHandle sampler, SamplerParameterI pname, uint[] param)
+            public static unsafe void SamplerParameterIuivOES(int sampler, SamplerParameterI pname, uint[] param)
             {
                 fixed (uint* param_ptr = param)
                 {
@@ -12699,7 +12699,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="SamplerParameterIuivOES"/>
-            public static unsafe void SamplerParameterIuivOES(SamplerHandle sampler, SamplerParameterI pname, in uint param)
+            public static unsafe void SamplerParameterIuivOES(int sampler, SamplerParameterI pname, in uint param)
             {
                 fixed (uint* param_ptr = &param)
                 {
@@ -12707,7 +12707,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetSamplerParameterIivOES"/>
-            public static unsafe void GetSamplerParameterIivOES(SamplerHandle sampler, SamplerParameterI pname, Span<int> parameters)
+            public static unsafe void GetSamplerParameterIivOES(int sampler, SamplerParameterI pname, Span<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -12715,7 +12715,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetSamplerParameterIivOES"/>
-            public static unsafe void GetSamplerParameterIivOES(SamplerHandle sampler, SamplerParameterI pname, int[] parameters)
+            public static unsafe void GetSamplerParameterIivOES(int sampler, SamplerParameterI pname, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
@@ -12723,7 +12723,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetSamplerParameterIivOES"/>
-            public static unsafe void GetSamplerParameterIivOES(SamplerHandle sampler, SamplerParameterI pname, ref int parameters)
+            public static unsafe void GetSamplerParameterIivOES(int sampler, SamplerParameterI pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -12731,7 +12731,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetSamplerParameterIuivOES"/>
-            public static unsafe void GetSamplerParameterIuivOES(SamplerHandle sampler, SamplerParameterI pname, Span<uint> parameters)
+            public static unsafe void GetSamplerParameterIuivOES(int sampler, SamplerParameterI pname, Span<uint> parameters)
             {
                 fixed (uint* parameters_ptr = parameters)
                 {
@@ -12739,7 +12739,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetSamplerParameterIuivOES"/>
-            public static unsafe void GetSamplerParameterIuivOES(SamplerHandle sampler, SamplerParameterI pname, uint[] parameters)
+            public static unsafe void GetSamplerParameterIuivOES(int sampler, SamplerParameterI pname, uint[] parameters)
             {
                 fixed (uint* parameters_ptr = parameters)
                 {
@@ -12747,7 +12747,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="GetSamplerParameterIuivOES"/>
-            public static unsafe void GetSamplerParameterIuivOES(SamplerHandle sampler, SamplerParameterI pname, ref uint parameters)
+            public static unsafe void GetSamplerParameterIuivOES(int sampler, SamplerParameterI pname, ref uint parameters)
             {
                 fixed (uint* parameters_ptr = &parameters)
                 {
@@ -12755,53 +12755,53 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="DeleteVertexArraysOES"/>
-            public static unsafe void DeleteVertexArraysOES(ReadOnlySpan<VertexArrayHandle> arrays)
+            public static unsafe void DeleteVertexArraysOES(ReadOnlySpan<int> arrays)
             {
                 int n = (int)(arrays.Length);
-                fixed (VertexArrayHandle* arrays_ptr = arrays)
+                fixed (int* arrays_ptr = arrays)
                 {
                     DeleteVertexArraysOES(n, arrays_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteVertexArraysOES"/>
-            public static unsafe void DeleteVertexArraysOES(VertexArrayHandle[] arrays)
+            public static unsafe void DeleteVertexArraysOES(int[] arrays)
             {
                 int n = (int)(arrays.Length);
-                fixed (VertexArrayHandle* arrays_ptr = arrays)
+                fixed (int* arrays_ptr = arrays)
                 {
                     DeleteVertexArraysOES(n, arrays_ptr);
                 }
             }
             /// <inheritdoc cref="DeleteVertexArraysOES"/>
-            public static unsafe void DeleteVertexArraysOES(int n, in VertexArrayHandle arrays)
+            public static unsafe void DeleteVertexArraysOES(int n, in int arrays)
             {
-                fixed (VertexArrayHandle* arrays_ptr = &arrays)
+                fixed (int* arrays_ptr = &arrays)
                 {
                     DeleteVertexArraysOES(n, arrays_ptr);
                 }
             }
             /// <inheritdoc cref="GenVertexArraysOES"/>
-            public static unsafe void GenVertexArraysOES(Span<VertexArrayHandle> arrays)
+            public static unsafe void GenVertexArraysOES(Span<int> arrays)
             {
                 int n = (int)(arrays.Length);
-                fixed (VertexArrayHandle* arrays_ptr = arrays)
+                fixed (int* arrays_ptr = arrays)
                 {
                     GenVertexArraysOES(n, arrays_ptr);
                 }
             }
             /// <inheritdoc cref="GenVertexArraysOES"/>
-            public static unsafe void GenVertexArraysOES(VertexArrayHandle[] arrays)
+            public static unsafe void GenVertexArraysOES(int[] arrays)
             {
                 int n = (int)(arrays.Length);
-                fixed (VertexArrayHandle* arrays_ptr = arrays)
+                fixed (int* arrays_ptr = arrays)
                 {
                     GenVertexArraysOES(n, arrays_ptr);
                 }
             }
             /// <inheritdoc cref="GenVertexArraysOES"/>
-            public static unsafe void GenVertexArraysOES(int n, ref VertexArrayHandle arrays)
+            public static unsafe void GenVertexArraysOES(int n, ref int arrays)
             {
-                fixed (VertexArrayHandle* arrays_ptr = &arrays)
+                fixed (int* arrays_ptr = &arrays)
                 {
                     GenVertexArraysOES(n, arrays_ptr);
                 }
@@ -12998,19 +12998,19 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ExtGetTexturesQCOM"/>
-            public static unsafe void ExtGetTexturesQCOM(ref TextureHandle textures, int maxTextures, ref int numTextures)
+            public static unsafe void ExtGetTexturesQCOM(ref int textures, int maxTextures, ref int numTextures)
             {
-                fixed (TextureHandle* textures_ptr = &textures)
+                fixed (int* textures_ptr = &textures)
                 fixed (int* numTextures_ptr = &numTextures)
                 {
                     ExtGetTexturesQCOM(textures_ptr, maxTextures, numTextures_ptr);
                 }
             }
             /// <inheritdoc cref="ExtGetBuffersQCOM"/>
-            public static unsafe void ExtGetBuffersQCOM(Span<BufferHandle> buffers, Span<int> numBuffers)
+            public static unsafe void ExtGetBuffersQCOM(Span<int> buffers, Span<int> numBuffers)
             {
                 int maxBuffers = (int)(buffers.Length);
-                fixed (BufferHandle* buffers_ptr = buffers)
+                fixed (int* buffers_ptr = buffers)
                 {
                     fixed (int* numBuffers_ptr = numBuffers)
                     {
@@ -13019,10 +13019,10 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ExtGetBuffersQCOM"/>
-            public static unsafe void ExtGetBuffersQCOM(BufferHandle[] buffers, int[] numBuffers)
+            public static unsafe void ExtGetBuffersQCOM(int[] buffers, int[] numBuffers)
             {
                 int maxBuffers = (int)(buffers.Length);
-                fixed (BufferHandle* buffers_ptr = buffers)
+                fixed (int* buffers_ptr = buffers)
                 {
                     fixed (int* numBuffers_ptr = numBuffers)
                     {
@@ -13031,19 +13031,19 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ExtGetBuffersQCOM"/>
-            public static unsafe void ExtGetBuffersQCOM(ref BufferHandle buffers, int maxBuffers, ref int numBuffers)
+            public static unsafe void ExtGetBuffersQCOM(ref int buffers, int maxBuffers, ref int numBuffers)
             {
-                fixed (BufferHandle* buffers_ptr = &buffers)
+                fixed (int* buffers_ptr = &buffers)
                 fixed (int* numBuffers_ptr = &numBuffers)
                 {
                     ExtGetBuffersQCOM(buffers_ptr, maxBuffers, numBuffers_ptr);
                 }
             }
             /// <inheritdoc cref="ExtGetRenderbuffersQCOM"/>
-            public static unsafe void ExtGetRenderbuffersQCOM(Span<RenderbufferHandle> renderbuffers, Span<int> numRenderbuffers)
+            public static unsafe void ExtGetRenderbuffersQCOM(Span<int> renderbuffers, Span<int> numRenderbuffers)
             {
                 int maxRenderbuffers = (int)(renderbuffers.Length);
-                fixed (RenderbufferHandle* renderbuffers_ptr = renderbuffers)
+                fixed (int* renderbuffers_ptr = renderbuffers)
                 {
                     fixed (int* numRenderbuffers_ptr = numRenderbuffers)
                     {
@@ -13052,10 +13052,10 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ExtGetRenderbuffersQCOM"/>
-            public static unsafe void ExtGetRenderbuffersQCOM(RenderbufferHandle[] renderbuffers, int[] numRenderbuffers)
+            public static unsafe void ExtGetRenderbuffersQCOM(int[] renderbuffers, int[] numRenderbuffers)
             {
                 int maxRenderbuffers = (int)(renderbuffers.Length);
-                fixed (RenderbufferHandle* renderbuffers_ptr = renderbuffers)
+                fixed (int* renderbuffers_ptr = renderbuffers)
                 {
                     fixed (int* numRenderbuffers_ptr = numRenderbuffers)
                     {
@@ -13064,19 +13064,19 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ExtGetRenderbuffersQCOM"/>
-            public static unsafe void ExtGetRenderbuffersQCOM(ref RenderbufferHandle renderbuffers, int maxRenderbuffers, ref int numRenderbuffers)
+            public static unsafe void ExtGetRenderbuffersQCOM(ref int renderbuffers, int maxRenderbuffers, ref int numRenderbuffers)
             {
-                fixed (RenderbufferHandle* renderbuffers_ptr = &renderbuffers)
+                fixed (int* renderbuffers_ptr = &renderbuffers)
                 fixed (int* numRenderbuffers_ptr = &numRenderbuffers)
                 {
                     ExtGetRenderbuffersQCOM(renderbuffers_ptr, maxRenderbuffers, numRenderbuffers_ptr);
                 }
             }
             /// <inheritdoc cref="ExtGetFramebuffersQCOM"/>
-            public static unsafe void ExtGetFramebuffersQCOM(Span<FramebufferHandle> framebuffers, Span<int> numFramebuffers)
+            public static unsafe void ExtGetFramebuffersQCOM(Span<int> framebuffers, Span<int> numFramebuffers)
             {
                 int maxFramebuffers = (int)(framebuffers.Length);
-                fixed (FramebufferHandle* framebuffers_ptr = framebuffers)
+                fixed (int* framebuffers_ptr = framebuffers)
                 {
                     fixed (int* numFramebuffers_ptr = numFramebuffers)
                     {
@@ -13085,10 +13085,10 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ExtGetFramebuffersQCOM"/>
-            public static unsafe void ExtGetFramebuffersQCOM(FramebufferHandle[] framebuffers, int[] numFramebuffers)
+            public static unsafe void ExtGetFramebuffersQCOM(int[] framebuffers, int[] numFramebuffers)
             {
                 int maxFramebuffers = (int)(framebuffers.Length);
-                fixed (FramebufferHandle* framebuffers_ptr = framebuffers)
+                fixed (int* framebuffers_ptr = framebuffers)
                 {
                     fixed (int* numFramebuffers_ptr = numFramebuffers)
                     {
@@ -13097,16 +13097,16 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ExtGetFramebuffersQCOM"/>
-            public static unsafe void ExtGetFramebuffersQCOM(ref FramebufferHandle framebuffers, int maxFramebuffers, ref int numFramebuffers)
+            public static unsafe void ExtGetFramebuffersQCOM(ref int framebuffers, int maxFramebuffers, ref int numFramebuffers)
             {
-                fixed (FramebufferHandle* framebuffers_ptr = &framebuffers)
+                fixed (int* framebuffers_ptr = &framebuffers)
                 fixed (int* numFramebuffers_ptr = &numFramebuffers)
                 {
                     ExtGetFramebuffersQCOM(framebuffers_ptr, maxFramebuffers, numFramebuffers_ptr);
                 }
             }
             /// <inheritdoc cref="ExtGetTexLevelParameterivQCOM"/>
-            public static unsafe void ExtGetTexLevelParameterivQCOM(TextureHandle texture, All face, int level, All pname, ref int parameters)
+            public static unsafe void ExtGetTexLevelParameterivQCOM(int texture, All face, int level, All pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
@@ -13129,10 +13129,10 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ExtGetShadersQCOM"/>
-            public static unsafe void ExtGetShadersQCOM(Span<ShaderHandle> shaders, Span<int> numShaders)
+            public static unsafe void ExtGetShadersQCOM(Span<int> shaders, Span<int> numShaders)
             {
                 int maxShaders = (int)(shaders.Length);
-                fixed (ShaderHandle* shaders_ptr = shaders)
+                fixed (int* shaders_ptr = shaders)
                 {
                     fixed (int* numShaders_ptr = numShaders)
                     {
@@ -13141,10 +13141,10 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ExtGetShadersQCOM"/>
-            public static unsafe void ExtGetShadersQCOM(ShaderHandle[] shaders, int[] numShaders)
+            public static unsafe void ExtGetShadersQCOM(int[] shaders, int[] numShaders)
             {
                 int maxShaders = (int)(shaders.Length);
-                fixed (ShaderHandle* shaders_ptr = shaders)
+                fixed (int* shaders_ptr = shaders)
                 {
                     fixed (int* numShaders_ptr = numShaders)
                     {
@@ -13153,19 +13153,19 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ExtGetShadersQCOM"/>
-            public static unsafe void ExtGetShadersQCOM(ref ShaderHandle shaders, int maxShaders, ref int numShaders)
+            public static unsafe void ExtGetShadersQCOM(ref int shaders, int maxShaders, ref int numShaders)
             {
-                fixed (ShaderHandle* shaders_ptr = &shaders)
+                fixed (int* shaders_ptr = &shaders)
                 fixed (int* numShaders_ptr = &numShaders)
                 {
                     ExtGetShadersQCOM(shaders_ptr, maxShaders, numShaders_ptr);
                 }
             }
             /// <inheritdoc cref="ExtGetProgramsQCOM"/>
-            public static unsafe void ExtGetProgramsQCOM(Span<ProgramHandle> programs, Span<int> numPrograms)
+            public static unsafe void ExtGetProgramsQCOM(Span<int> programs, Span<int> numPrograms)
             {
                 int maxPrograms = (int)(programs.Length);
-                fixed (ProgramHandle* programs_ptr = programs)
+                fixed (int* programs_ptr = programs)
                 {
                     fixed (int* numPrograms_ptr = numPrograms)
                     {
@@ -13174,10 +13174,10 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ExtGetProgramsQCOM"/>
-            public static unsafe void ExtGetProgramsQCOM(ProgramHandle[] programs, int[] numPrograms)
+            public static unsafe void ExtGetProgramsQCOM(int[] programs, int[] numPrograms)
             {
                 int maxPrograms = (int)(programs.Length);
-                fixed (ProgramHandle* programs_ptr = programs)
+                fixed (int* programs_ptr = programs)
                 {
                     fixed (int* numPrograms_ptr = numPrograms)
                     {
@@ -13186,16 +13186,16 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="ExtGetProgramsQCOM"/>
-            public static unsafe void ExtGetProgramsQCOM(ref ProgramHandle programs, int maxPrograms, ref int numPrograms)
+            public static unsafe void ExtGetProgramsQCOM(ref int programs, int maxPrograms, ref int numPrograms)
             {
-                fixed (ProgramHandle* programs_ptr = &programs)
+                fixed (int* programs_ptr = &programs)
                 fixed (int* numPrograms_ptr = &numPrograms)
                 {
                     ExtGetProgramsQCOM(programs_ptr, maxPrograms, numPrograms_ptr);
                 }
             }
             /// <inheritdoc cref="ExtGetProgramBinarySourceQCOM"/>
-            public static unsafe string ExtGetProgramBinarySourceQCOM(ProgramHandle program, ShaderType shadertype, ref int length)
+            public static unsafe string ExtGetProgramBinarySourceQCOM(int program, ShaderType shadertype, ref int length)
             {
                 string source;
                 fixed (int* length_ptr = &length)
@@ -13208,7 +13208,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 return source;
             }
             /// <inheritdoc cref="ExtGetProgramBinarySourceQCOM"/>
-            public static unsafe void ExtGetProgramBinarySourceQCOM(ProgramHandle program, ShaderType shadertype, out string source, ref int length)
+            public static unsafe void ExtGetProgramBinarySourceQCOM(int program, ShaderType shadertype, out string source, ref int length)
             {
                 fixed (int* length_ptr = &length)
                 {
@@ -13219,7 +13219,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="FramebufferFoveationConfigQCOM"/>
-            public static unsafe void FramebufferFoveationConfigQCOM(FramebufferHandle framebuffer, uint numLayers, uint focalPointsPerLayer, uint requestedFeatures, Span<uint> providedFeatures)
+            public static unsafe void FramebufferFoveationConfigQCOM(int framebuffer, uint numLayers, uint focalPointsPerLayer, uint requestedFeatures, Span<uint> providedFeatures)
             {
                 fixed (uint* providedFeatures_ptr = providedFeatures)
                 {
@@ -13227,7 +13227,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="FramebufferFoveationConfigQCOM"/>
-            public static unsafe void FramebufferFoveationConfigQCOM(FramebufferHandle framebuffer, uint numLayers, uint focalPointsPerLayer, uint requestedFeatures, uint[] providedFeatures)
+            public static unsafe void FramebufferFoveationConfigQCOM(int framebuffer, uint numLayers, uint focalPointsPerLayer, uint requestedFeatures, uint[] providedFeatures)
             {
                 fixed (uint* providedFeatures_ptr = providedFeatures)
                 {
@@ -13235,7 +13235,7 @@ namespace OpenTK.Graphics.OpenGLES3
                 }
             }
             /// <inheritdoc cref="FramebufferFoveationConfigQCOM"/>
-            public static unsafe void FramebufferFoveationConfigQCOM(FramebufferHandle framebuffer, uint numLayers, uint focalPointsPerLayer, uint requestedFeatures, ref uint providedFeatures)
+            public static unsafe void FramebufferFoveationConfigQCOM(int framebuffer, uint numLayers, uint focalPointsPerLayer, uint requestedFeatures, ref uint providedFeatures)
             {
                 fixed (uint* providedFeatures_ptr = &providedFeatures)
                 {

--- a/src/OpenTK.Graphics/OpenTK.Graphics.csproj
+++ b/src/OpenTK.Graphics/OpenTK.Graphics.csproj
@@ -15,4 +15,5 @@
 
   <Import Project="..\..\props\common.props" />
   <Import Project="..\..\props\nuget-common.props" />
+  <Import Project="..\..\props\generator-options.props" />
 </Project>


### PR DESCRIPTION
### Purpose of this PR

This PR adds options to the generator as well as disabling "typesafe" handles by default. The option to enable them is still available, but will not be the code that is shipped on nuget.

### Testing status

The generator is run and the generated code looks good.