### PR TITLE
Get rid of using RuntimeInformation.IsOSPlatform()

### DIFF
--- a/src/OpenAL/OpenTK.OpenAL/OpenALLibraryNameContainer.cs
+++ b/src/OpenAL/OpenTK.OpenAL/OpenALLibraryNameContainer.cs
@@ -42,37 +42,32 @@ namespace OpenTK.Audio.OpenAL
         /// </summary>
         public string IOS => MacOS;
 
+        /// <summary>
+        /// Gets the library name for the target platform.
+        /// </summary>
+        /// <returns>Library name.</returns>
         public string GetLibraryName()
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            {
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Create("ANDROID")))
-                {
-                    return Android;
-                }
-                else
-                {
-                    return Linux;
-                }
-            }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.FreeBSD))
+            if (OperatingSystem.IsLinux() ||
+                OperatingSystem.IsFreeBSD())
             {
                 return Linux;
             }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            else if (OperatingSystem.IsWindows())
             {
                 return Windows;
             }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            else if (OperatingSystem.IsMacOS())
             {
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Create("IOS")))
-                {
-                    return IOS;
-                }
-                else
-                {
-                    return MacOS;
-                }
+                return MacOS;
+            }
+            else if (OperatingSystem.IsAndroid())
+            {
+                return Android;
+            }
+            else if (OperatingSystem.IsIOS())
+            {
+                return IOS;
             }
             else
             {

--- a/src/OpenTK.Compute/OpenCL/OpenCLLibraryNameContainer.cs
+++ b/src/OpenTK.Compute/OpenCL/OpenCLLibraryNameContainer.cs
@@ -3,46 +3,62 @@ using System.Runtime.InteropServices;
 
 namespace OpenTK.Compute.OpenCL
 {
+    /// <summary>
+    /// Contains the library name of OpenCL.
+    /// </summary>
     public class OpenCLLibraryNameContainer
     {
+        /// <summary>
+        /// Gets the library name to use on Linux.
+        /// </summary>
         public string Linux => "libOpenCL.so.1";
 
+        /// <summary>
+        /// Gets the library name to use on MacOS.
+        /// </summary>
         public string MacOS => "/System/Library/Frameworks/OpenCL.framework/OpenCL";
 
+        /// <summary>
+        /// Gets the library name to use on Android.
+        /// </summary>
         public string Android => Linux;
 
+        /// <summary>
+        /// Gets the library name to use on iOS.
+        /// </summary>
         public string IOS => MacOS;
 
+        /// <summary>
+        /// Gets the library name to use on Windows.
+        /// </summary>
         public string Windows => "OpenCL.dll";
 
+        /// <summary>
+        /// Gets the library name for the target platform.
+        /// </summary>
+        /// <returns>Library name.</returns>
         public string GetLibraryName()
         {
-	        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-	        {
-		        if (RuntimeInformation.IsOSPlatform(OSPlatform.Create("ANDROID")))
-		        {
-			        return Android;
-		        }
-		        else
-		        {
-			        return Linux;
-		        }
-	        }
-	        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-	        {
-		        return Windows;
-	        }
-	        else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-	        {
-		        if (RuntimeInformation.IsOSPlatform(OSPlatform.Create("IOS")))
-		        {
-			        return IOS;
-		        }
-		        else
-		        {
-			        return MacOS;
-		        }
-	        }
+            if (OperatingSystem.IsLinux() || OperatingSystem.IsFreeBSD())
+            {
+                return Linux;
+            }
+            else if (OperatingSystem.IsWindows())
+            {
+                return Windows;
+            }
+            else if (OperatingSystem.IsMacOS())
+            {
+                return MacOS;
+            }
+            else if (OperatingSystem.IsAndroid())
+            {
+                return Android;
+            }
+            else if (OperatingSystem.IsIOS())
+            {
+                return IOS;
+            }
 	        else
 	        {
 		        throw new NotSupportedException($"The library name couldn't be resolved for the given platform ('{RuntimeInformation.OSDescription}').");

--- a/src/OpenTK.Windowing.Desktop/Monitors.cs
+++ b/src/OpenTK.Windowing.Desktop/Monitors.cs
@@ -53,7 +53,7 @@ namespace OpenTK.Windowing.Desktop
         /// </remarks>
         public static float GetPlatformDefaultDpi()
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            if (OperatingSystem.IsMacOS())
             {
                 return 72f;
             }

--- a/src/OpenTK.Windowing.GraphicsLibraryFramework/GLFWNative.cs
+++ b/src/OpenTK.Windowing.GraphicsLibraryFramework/GLFWNative.cs
@@ -39,17 +39,17 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
             }
 
             Func<string, string, string> libNameFormatter;
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            if (OperatingSystem.IsLinux() || OperatingSystem.IsFreeBSD())
             {
                 libNameFormatter = (libName, ver) =>
                     libName + ".so" + (string.IsNullOrEmpty(ver) ? string.Empty : "." + ver);
             }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            else if (OperatingSystem.IsMacOS())
             {
                 libNameFormatter = (libName, ver) =>
                     libName + (string.IsNullOrEmpty(ver) ? string.Empty : "." + ver) + ".dylib";
             }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            else if (OperatingSystem.IsWindows())
             {
                 libNameFormatter = (libName, ver) =>
                     libName + (string.IsNullOrEmpty(ver) ? string.Empty : ver) + ".dll";

--- a/tests/OpenTK.Tests.Integration/GameWindowTests.fs
+++ b/tests/OpenTK.Tests.Integration/GameWindowTests.fs
@@ -173,7 +173,7 @@ module GameWindow =
             () |> ignore
 
         let defaultDpi () =
-            if RuntimeInformation.IsOSPlatform(OSPlatform.OSX) then
+            if OperatingSystem.IsMacOS() then
                 72.0f
             else
                 96.0f


### PR DESCRIPTION
### Description
RuntimeInformation.IsOSPlatform() method has issues on NET 5+ (please, see https://github.com/dotnet/runtime/issues/51052) and doesn't work with Android as expected.

NET 5+ has much simpler APIs to determine the target platform: [OperatingSystem.Is...](https://learn.microsoft.com/en-us/dotnet/api/system.operatingsystem?view=net-7.0#methods)

- [x] Fixed in OpenAL
- [x] Fixed in OpenCL
- [x] Fixed in GLFWNative
- [x] Fixed in Windowing.Desktop
- [x] Fixed in tests

### Related information
Effects OpenTK 5.x