### PR TITLE
Fix monitor work area being reported incorrectly.

### DIFF
--- a/src/OpenTK.Windowing.Desktop/MonitorInfo.cs
+++ b/src/OpenTK.Windowing.Desktop/MonitorInfo.cs
@@ -147,7 +147,7 @@ namespace OpenTK.Windowing.Desktop
             ClientArea = new Box2i(x, y, x + videoMode->Width, y + videoMode->Height);
 
             GLFW.GetMonitorWorkarea(HandleAsPtr, out int workAreaX, out int workAreaY, out int workAreaWidth, out int workAreaHeight);
-            WorkArea = new Box2i(workAreaX, workAreaY, workAreaWidth, workAreaHeight);
+            WorkArea = new Box2i(workAreaX, workAreaY, workAreaX + workAreaWidth, workAreaY + workAreaHeight);
 
             GLFW.GetMonitorPhysicalSize(HandleAsPtr, out int width, out int height);
             PhysicalWidth = width;


### PR DESCRIPTION
The issue is that the constructor for Box2i is in min,max coordinates and not origin,size coordinates. Adding the origin to the size fixes the issue.

### Testing status
* It compiles.

### Comments
* I don't think anything could go wrong with this PR.
