### PR TITLE
Removed BindBufferToSource to AL-ify the OpenAL bindings

### DIFF
--- a/src/OpenAL/OpenTK.OpenAL/AL/AL.cs
+++ b/src/OpenAL/OpenTK.OpenAL/AL/AL.cs
@@ -1086,23 +1086,5 @@ namespace OpenTK.Audio.OpenAL
         {
             return (ALDistanceModel)Get(ALGetInteger.DistanceModel);
         }
-
-        /// <summary>(Helper) Returns Source state information.</summary>
-        /// <param name="sid">The source to be queried.</param>
-        /// <returns>state information from OpenAL.</returns>
-        public static ALSourceState GetSourceState(int sid)
-        {
-            GetSource(sid, ALGetSourcei.SourceState, out int state);
-            return (ALSourceState)state;
-        }
-
-        /// <summary>(Helper) Returns Source type information.</summary>
-        /// <param name="sid">The source to be queried.</param>
-        /// <returns>type information from OpenAL.</returns>
-        public static ALSourceType GetSourceType(int sid)
-        {
-            GetSource(sid, ALGetSourcei.SourceType, out int temp);
-            return (ALSourceType)temp;
-        }
     }
 }

--- a/src/OpenAL/OpenTK.OpenAL/AL/AL.cs
+++ b/src/OpenAL/OpenTK.OpenAL/AL/AL.cs
@@ -474,14 +474,6 @@ namespace OpenTK.Audio.OpenAL
         public static extern void Source(int sid, ALSourceb param, bool value);
         // FIXME: Double check that the mashaling here works!!
 
-        /// <summary>(Helper) Binds a Buffer to a Source handle.</summary>
-        /// <param name="source">Source name to attach the Buffer to.</param>
-        /// <param name="buffer">Buffer name which is attached to the Source.</param>
-        public static void BindBufferToSource(int source, int buffer)
-        {
-            Source(source, ALSourcei.Buffer, buffer);
-        }
-
         /// <summary>This function sets 3 integer properties of a source.</summary>
         /// <param name="sid">Source name whose attribute is being set.</param>
         /// <param name="param">The name of the attribute to set: EfxAuxiliarySendFilter..</param>


### PR DESCRIPTION
I believe this function doesn't fit in the semi low-level nature of OpenTK, just basing it on what I read in some other PR, and it just wraps a single function call.

Whilst it doesn't slow the program down by most likely any amount, it is still not something in OpenAL

### Purpose of this PR

* Simply removed AL.BindBufferToSource

### Testing status

* Shouldn't make a difference at all

### Comments

This is just a proposal, feel free to reject it if you wish to so.
I understand it might be a breaking change, but it doesn't feel like it should be existent in the first place, and hence would have to be removed with the release of OpenTK 5.0

Please let me know if something is unclear, and I'll try to explain further
