### PR TITLE
[NV_shading_rate_image] Move signatures.xml modifications to overrides.xml

### DIFF
--- a/src/Generator.Bind/Specifications/GL2/overrides.xml
+++ b/src/Generator.Bind/Specifications/GL2/overrides.xml
@@ -1598,6 +1598,18 @@
       </param>
     </function>
 
+    <function name="GetShadingRateImagePalette" extension="NV">
+      <param name="rate">
+        <type>NvShadingRateImage</type>
+      </param>
+    </function>
+
+    <function name="GetShadingRateSampleLocation" extension="NV">
+      <param name="rate">
+        <type>NvShadingRateImage</type>
+      </param>
+    </function>
+
     <function name="GetTrackMatrix" extension="NV">
       <param name="target">
         <type>AssemblyProgramTargetArb</type>
@@ -1634,6 +1646,24 @@
     <function name="ProgramParameters4" extension="NV">
       <param name="target">
         <type>AssemblyProgramTargetArb</type>
+      </param>
+    </function>
+
+    <function name="ShadingRateImagePalette" extension="NV">
+      <param name="rates">
+        <type>NvShadingRateImage</type>
+      </param>
+    </function>
+
+    <function name="ShadingRateSampleOrder" extension="NV">
+      <param name="order">
+        <type>NvShadingRateImage</type>
+      </param>
+    </function>
+
+    <function name="ShadingRateSampleOrderCustom" extension="NV">
+      <param name="rate">
+        <type>NvShadingRateImage</type>
       </param>
     </function>
 

--- a/src/Generator.Bind/Specifications/GL2/signatures.xml
+++ b/src/Generator.Bind/Specifications/GL2/signatures.xml
@@ -13770,11 +13770,11 @@
     <function name="GetShadingRateImagePaletteNV" category="NV_shading_rate_image" extension="NV">
       <param name="viewport" type="GLuint" flow="in" />
       <param name="entry" type="GLuint" flow="in" />
-      <param name="rate" type="NvShadingRateImage *" flow="out" count="1" />
+      <param name="rate" type="GLenum *" flow="out" count="1" />
       <returns type="void" />
     </function>
     <function name="GetShadingRateSampleLocationivNV" category="NV_shading_rate_image" extension="NV">
-      <param name="rate" type="NvShadingRateImage" flow="in" />
+      <param name="rate" type="GLenum" flow="in" />
       <param name="samples" type="GLuint" flow="in" />
       <param name="index" type="GLuint" flow="in" />
       <param name="location" type="GLint *" flow="out" count="3" />
@@ -19292,17 +19292,17 @@
       <param name="viewport" type="GLuint" flow="in" />
       <param name="first" type="GLuint" flow="in" />
       <param name="count" type="GLsizei" flow="in" />
-      <param name="rates" type="NvShadingRateImage *" flow="in" count="count" />
+      <param name="rates" type="GLenum *" flow="in" count="count" />
       <returns type="void" />
     </function>
     <function name="ShadingRateSampleOrderCustomNV" category="NV_shading_rate_image" extension="NV">
-      <param name="rate" type="NvShadingRateImage" flow="in" />
+      <param name="rate" type="GLenum" flow="in" />
       <param name="samples" type="GLuint" flow="in" />
       <param name="locations" type="GLint *" flow="in" count="COMPSIZE(rate,samples)" />
       <returns type="void" />
     </function>
     <function name="ShadingRateSampleOrderNV" category="NV_shading_rate_image" extension="NV">
-      <param name="order" type="NvShadingRateImage" flow="in" />
+      <param name="order" type="GLenum" flow="in" />
       <returns type="void" />
     </function>
     <function name="SharpenTexFuncSGIS" category="SGIS_sharpen_texture" extension="SGIS">
@@ -39331,11 +39331,11 @@
     <function name="GetShadingRateImagePaletteNV" category="NV_shading_rate_image" extension="NV">
       <param name="viewport" type="GLuint" flow="in" />
       <param name="entry" type="GLuint" flow="in" />
-      <param name="rate" type="NvShadingRateImage *" flow="out" count="1" />
+      <param name="rate" type="GLenum *" flow="out" count="1" />
       <returns type="void" />
     </function>
     <function name="GetShadingRateSampleLocationivNV" category="NV_shading_rate_image" extension="NV">
-      <param name="rate" type="NvShadingRateImage" flow="in" />
+      <param name="rate" type="GLenum" flow="in" />
       <param name="samples" type="GLuint" flow="in" />
       <param name="index" type="GLuint" flow="in" />
       <param name="location" type="GLint *" flow="out" count="3" />
@@ -42320,17 +42320,17 @@
       <param name="viewport" type="GLuint" flow="in" />
       <param name="first" type="GLuint" flow="in" />
       <param name="count" type="GLsizei" flow="in" />
-      <param name="rates" type="NvShadingRateImage *" flow="in" count="count" />
+      <param name="rates" type="GLenum *" flow="in" count="count" />
       <returns type="void" />
     </function>
     <function name="ShadingRateSampleOrderCustomNV" category="NV_shading_rate_image" extension="NV">
-      <param name="rate" type="NvShadingRateImage" flow="in" />
+      <param name="rate" type="GLenum" flow="in" />
       <param name="samples" type="GLuint" flow="in" />
       <param name="locations" type="GLint *" flow="in" count="COMPSIZE(rate,samples)" />
       <returns type="void" />
     </function>
     <function name="ShadingRateSampleOrderNV" category="NV_shading_rate_image" extension="NV">
-      <param name="order" type="NvShadingRateImage" flow="in" />
+      <param name="order" type="GLenum" flow="in" />
       <returns type="void" />
     </function>
     <function name="SignalVkFenceNV" category="NV_draw_vulkan_image" extension="NV">
@@ -62922,11 +62922,11 @@
     <function name="GetShadingRateImagePaletteNV" category="NV_shading_rate_image" extension="NV">
       <param name="viewport" type="GLuint" flow="in" />
       <param name="entry" type="GLuint" flow="in" />
-      <param name="rate" type="NvShadingRateImage *" flow="out" count="1" />
+      <param name="rate" type="GLenum *" flow="out" count="1" />
       <returns type="void" />
     </function>
     <function name="GetShadingRateSampleLocationivNV" category="NV_shading_rate_image" extension="NV">
-      <param name="rate" type="NvShadingRateImage" flow="in" />
+      <param name="rate" type="GLenum" flow="in" />
       <param name="samples" type="GLuint" flow="in" />
       <param name="index" type="GLuint" flow="in" />
       <param name="location" type="GLint *" flow="out" count="3" />
@@ -64292,17 +64292,17 @@
       <param name="viewport" type="GLuint" flow="in" />
       <param name="first" type="GLuint" flow="in" />
       <param name="count" type="GLsizei" flow="in" />
-      <param name="rates" type="NvShadingRateImage *" flow="in" count="count" />
+      <param name="rates" type="GLenum *" flow="in" count="count" />
       <returns type="void" />
     </function>
     <function name="ShadingRateSampleOrderCustomNV" category="NV_shading_rate_image" extension="NV">
-      <param name="rate" type="NvShadingRateImage" flow="in" />
+      <param name="rate" type="GLenum" flow="in" />
       <param name="samples" type="GLuint" flow="in" />
       <param name="locations" type="GLint *" flow="in" count="COMPSIZE(rate,samples)" />
       <returns type="void" />
     </function>
     <function name="ShadingRateSampleOrderNV" category="NV_shading_rate_image" extension="NV">
-      <param name="order" type="NvShadingRateImage" flow="in" />
+      <param name="order" type="GLenum" flow="in" />
       <returns type="void" />
     </function>
     <function name="SignalSemaphoreEXT" category="EXT_semaphore" extension="EXT">


### PR DESCRIPTION
### Purpose of this PR

Back in this commit 839cb16d7f6657fe35e0b25a8dd961cdae8c8e53 I adjusted functions from the `NV_shading_rate_image` extension to accept `NvShadingRateImage` instead of `All`, however I made the changes in the wrong file.

In this PR the changes are ported over to `overrides.xml`. The API surface stays the same. No difference to the end user.
