### PR TITLE
Add Wayland detection and env switch OPENTK_4_USE_WAYLAND

### DIFF
--- a/src/OpenTK.Graphics/OpenTK.Graphics.csproj
+++ b/src/OpenTK.Graphics/OpenTK.Graphics.csproj
@@ -35,7 +35,8 @@
     <GLSpec Include="..\gl.xml" />
     <GeneratedFiles Include="ES11/ES11.cs;ES11/ES11Enums.cs;ES20/ES20.cs;ES20/ES20Enums.cs;ES30/ES30.cs;ES30/ES30Enums.cs;OpenGL2/GL.cs;OpenGL2/GLEnums.cs;OpenGL4/GL4.cs;OpenGL4/GL4Enums.cs" Exclude="**/Helper.cs" />
     <!-- We use this to use as an input for the Generate bindings step, this means that if the we (msbuild) rebuilds the Generator.Bind we will rerun the generator -->
-    <GeneratorExe Include="..\Generator.Bind\bin\$(Configuration)\netcoreapp3.1\Bind.exe" />
+    <GeneratorExe Include="..\Generator.Bind\bin\$(Configuration)\netcoreapp3.1\Bind.exe" Condition="'$(OS)' == 'Windows_NT'" />
+    <GeneratorExe Include="..\Generator.Bind\bin\$(Configuration)\netcoreapp3.1\Bind" Condition="'$(OS)' != 'Windows_NT'" />
   </ItemGroup>
 
   <!--  'DispatchToInnerBuilds' is so that this target is only run once in contrast to task that run after 'PreBuildEvent' which get run multiple times for each target framework  -->
@@ -63,7 +64,8 @@
     <Message Text="Generating bindings..." Importance="high" />
 
     <!-- Run the exe directly to avoid dotnet rebuilding anything. -->
-    <Exec Command=".\src\Generator.Bind\bin\$(Configuration)\netcoreapp3.1\Bind.exe" WorkingDirectory="../../" />
+    <Exec Command=".\src\Generator.Bind\bin\$(Configuration)\netcoreapp3.1\Bind.exe" WorkingDirectory="../../" Condition="'$(OS)' == 'Windows_NT'" />
+    <Exec Command=".\src\Generator.Bind\bin\$(Configuration)\netcoreapp3.1\Bind" WorkingDirectory="../../" Condition="'$(OS)' != 'Windows_NT'" />
 
     <Message Text="Generated bindings!" Importance="high" />
 
@@ -78,7 +80,8 @@
   <!-- After we have compiled the dll we run the rewriter -->
   <Target Name="Rewrite" BeforeTargets="PostBuildEvent">
     <Message Text="Rewriting src/OpenTK.Graphics/bin/$(Configuration)/$(TargetFramework)" Importance="high" />
-    <Exec Command=".\src\Generator.Rewrite\bin\$(Configuration)\netcoreapp3.1\Rewrite.exe -a ./src/OpenTK.Graphics/bin/$(Configuration)/$(TargetFramework)/OpenTK.Graphics.dll" WorkingDirectory="../../" StandardOutputImportance="high" StandardErrorImportance="high" />
+    <Exec Command=".\src\Generator.Rewrite\bin\$(Configuration)\netcoreapp3.1\Rewrite.exe -a ./src/OpenTK.Graphics/bin/$(Configuration)/$(TargetFramework)/OpenTK.Graphics.dll" WorkingDirectory="../../" StandardOutputImportance="high" StandardErrorImportance="high" Condition="'$(OS)' == 'Windows_NT'" />
+    <Exec Command=".\src\Generator.Rewrite\bin\$(Configuration)\netcoreapp3.1\Rewrite -a ./src/OpenTK.Graphics/bin/$(Configuration)/$(TargetFramework)/OpenTK.Graphics.dll" WorkingDirectory="../../" StandardOutputImportance="high" StandardErrorImportance="high" Condition="'$(OS)' != 'Windows_NT'" />
     <Message Text="Rewrote src/OpenTK.Graphics/bin/$(Configuration)/$(TargetFramework)" Importance="high" />
   </Target>
 

--- a/src/OpenTK.Windowing.Desktop/GLFWProvider.cs
+++ b/src/OpenTK.Windowing.Desktop/GLFWProvider.cs
@@ -20,6 +20,7 @@ namespace OpenTK.Windowing.Desktop
     /// </summary>
     public static class GLFWProvider
     {
+        // FIXME: This will throw "through" native frames, which doesn't work anywhere other than windows.
         private static readonly GLFWCallbacks.ErrorCallback ErrorCallback =
             (errorCode, description) => throw new GLFWException(description, errorCode);
 

--- a/src/OpenTK.Windowing.GraphicsLibraryFramework/GLFW.cs
+++ b/src/OpenTK.Windowing.GraphicsLibraryFramework/GLFW.cs
@@ -15,6 +15,7 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
 {
     /// <summary>
     /// Provides access to the GLFW API.
+    /// On Linux to use GLFW compiled for Wayland set the environment variable <c>OPENTK_4_USE_WAYLAND=1</c>.
     /// </summary>
     public static class GLFW
     {

--- a/src/OpenTK.Windowing.GraphicsLibraryFramework/GLFWNative.cs
+++ b/src/OpenTK.Windowing.GraphicsLibraryFramework/GLFWNative.cs
@@ -41,8 +41,20 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
             Func<string, string, string> libNameFormatter;
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                libNameFormatter = (libName, ver) =>
-                    libName + ".so" + (string.IsNullOrEmpty(ver) ? string.Empty : "." + ver);
+                string sessionType = Environment.GetEnvironmentVariable("XDG_SESSION_TYPE");
+                string useWayland = Environment.GetEnvironmentVariable("OPENTK_4_USE_WAYLAND");
+                if (sessionType == "wayland" && useWayland == "1")
+                {
+                    // As we have a delimiter in the name the runtime will not prepend or append
+                    // stuff like `lib` and stuff.
+                    libNameFormatter = (libName, ver) =>
+                        "/wayland/lib" + libName + ".so" + (string.IsNullOrEmpty(ver) ? string.Empty : "." + ver);
+                }
+                else
+                {
+                    libNameFormatter = (libName, ver) =>
+                        libName + ".so" + (string.IsNullOrEmpty(ver) ? string.Empty : "." + ver);
+                }
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {

--- a/src/OpenTK.Windowing.GraphicsLibraryFramework/OpenTK.Windowing.GraphicsLibraryFramework.csproj
+++ b/src/OpenTK.Windowing.GraphicsLibraryFramework/OpenTK.Windowing.GraphicsLibraryFramework.csproj
@@ -10,7 +10,7 @@
     <ItemGroup>
       <ProjectReference Include="..\OpenTK.Core\OpenTK.Core.csproj" />
       <ProjectReference Include="..\OpenTK.Windowing.Common\OpenTK.Windowing.Common.csproj" />
-      <PackageReference Include="OpenTK.redist.glfw" Version="3.3.8.35" />
+      <PackageReference Include="OpenTK.redist.glfw" Version="3.3.8.38" />
     </ItemGroup>
 
     <Import Project="..\..\props\common.props" />

--- a/src/OpenTK.Windowing.GraphicsLibraryFramework/paket
+++ b/src/OpenTK.Windowing.GraphicsLibraryFramework/paket
@@ -5,7 +5,7 @@ description
 dependencies
     framework: netcoreapp3.1
         OpenTK.Core ~> #VERSION#
-        OpenTK.redist.glfw >= 3.3.8.35
+        OpenTK.redist.glfw >= 3.3.8.38
 files
     bin\Release\netcoreapp3.1\OpenTK.Windowing.GraphicsLibraryFramework.dll ==> lib\netcoreapp3.1
     bin\Release\netcoreapp3.1\OpenTK.Windowing.GraphicsLibraryFramework.xml ==> lib\netcoreapp3.1


### PR DESCRIPTION
### Purpose of this PR

Adds code for detecting Wayland and loading Wayland GLFW libraries (see https://github.com/opentk/glfw-redist/pull/11).
Which version (X11 or Wayland) controlled using an environment variable `OPENTK_4_USE_WAYLAND`.
To use Wayland set it to `OPENTK_4_USE_WAYLAND=1`, this is disabled by default though as the current implementation of `GaneWindow` and `NativeWindow` do not work well with Wayland (wayland is very restricted in what operations it allows).

Partially fixes #1452

### Testing status

This is tested on Ubuntu 20.04 on both X11 and Wayland.
