### PR TITLE
Renamed BoxX.Inflate with BoxX.Extend and marked Inflate as obsolete.

### DIFF
--- a/src/OpenTK.Mathematics/Geometry/Box2.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box2.cs
@@ -263,7 +263,8 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Inflate this Box2 to encapsulate a given point.
         /// </summary>
-        /// <param name="point">The point to query.</param>
+        /// <param name="point">The point to inflate to.</param>
+        [Obsolete("Use " + nameof(Extend) + " instead. This function will have it's implementation changed in the future.")]
         public void Inflate(Vector2 point)
         {
             _min = Vector2.ComponentMin(_min, point);
@@ -273,14 +274,39 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Inflate this Box2 to encapsulate a given point.
         /// </summary>
-        /// <param name="point">The point to query.</param>
+        /// <param name="point">The point to inflate to.</param>
         /// <returns>The inflated box.</returns>
         [Pure]
+        [Obsolete("Use " + nameof(Extended) + " instead. This function will have it's implementation changed in the future.")]
         public Box2 Inflated(Vector2 point)
         {
             // create a local copy of this box
             Box2 box = this;
             box.Inflate(point);
+            return box;
+        }
+
+        /// <summary>
+        /// Extend this Box2 to encapsulate a given point.
+        /// </summary>
+        /// <param name="point">The point to contain.</param>
+        public void Extend(Vector2 point)
+        {
+            _min = Vector2.ComponentMin(_min, point);
+            _max = Vector2.ComponentMax(_max, point);
+        }
+
+        /// <summary>
+        /// Extend this Box2 to encapsulate a given point.
+        /// </summary>
+        /// <param name="point">The point to contain.</param>
+        /// <returns>The inflated box.</returns>
+        [Pure]
+        public Box2 Extended(Vector2 point)
+        {
+            // create a local copy of this box
+            Box2 box = this;
+            box.Extend(point);
             return box;
         }
 

--- a/src/OpenTK.Mathematics/Geometry/Box2d.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box2d.cs
@@ -264,6 +264,7 @@ namespace OpenTK.Mathematics
         /// Inflate this Box2d to encapsulate a given point.
         /// </summary>
         /// <param name="point">The point to query.</param>
+        [Obsolete("Use " + nameof(Extend) + " instead. This function will have it's implementation changed in the future.")]
         public void Inflate(Vector2d point)
         {
             _min = Vector2d.ComponentMin(_min, point);
@@ -276,11 +277,36 @@ namespace OpenTK.Mathematics
         /// <param name="point">The point to query.</param>
         /// <returns>The inflated box.</returns>
         [Pure]
+        [Obsolete("Use " + nameof(Extended) + " instead. This function will have it's implementation changed in the future.")]
         public Box2d Inflated(Vector2d point)
         {
             // create a local copy of this box
             Box2d box = this;
             box.Inflate(point);
+            return box;
+        }
+
+        /// <summary>
+        /// Extend this Box2d to encapsulate a given point.
+        /// </summary>
+        /// <param name="point">The point to contain.</param>
+        public void Extend(Vector2d point)
+        {
+            _min = Vector2d.ComponentMin(_min, point);
+            _max = Vector2d.ComponentMax(_max, point);
+        }
+
+        /// <summary>
+        /// Extend this Box2d to encapsulate a given point.
+        /// </summary>
+        /// <param name="point">The point to contain.</param>
+        /// <returns>The inflated box.</returns>
+        [Pure]
+        public Box2d Extended(Vector2d point)
+        {
+            // create a local copy of this box
+            Box2d box = this;
+            box.Extend(point);
             return box;
         }
 

--- a/src/OpenTK.Mathematics/Geometry/Box2i.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box2i.cs
@@ -274,6 +274,7 @@ namespace OpenTK.Mathematics
         /// Inflate this Box2i to encapsulate a given point.
         /// </summary>
         /// <param name="point">The point to query.</param>
+        [Obsolete("Use " + nameof(Extend) + " instead. This function will have it's implementation changed in the future.")]
         public void Inflate(Vector2i point)
         {
             _min = Vector2i.ComponentMin(_min, point);
@@ -286,11 +287,36 @@ namespace OpenTK.Mathematics
         /// <param name="point">The point to query.</param>
         /// <returns>The inflated box.</returns>
         [Pure]
+        [Obsolete("Use " + nameof(Extended) + " instead. This function will have it's implementation changed in the future.")]
         public Box2i Inflated(Vector2i point)
         {
             // create a local copy of this box
             Box2i box = this;
             box.Inflate(point);
+            return box;
+        }
+
+        /// <summary>
+        /// Extend this Box2i to encapsulate a given point.
+        /// </summary>
+        /// <param name="point">The point to contain.</param>
+        public void Extend(Vector2i point)
+        {
+            _min = Vector2i.ComponentMin(_min, point);
+            _max = Vector2i.ComponentMax(_max, point);
+        }
+
+        /// <summary>
+        /// Extend this Box2i to encapsulate a given point.
+        /// </summary>
+        /// <param name="point">The point to contain.</param>
+        /// <returns>The inflated box.</returns>
+        [Pure]
+        public Box2i Extended(Vector2i point)
+        {
+            // create a local copy of this box
+            Box2i box = this;
+            box.Extend(point);
             return box;
         }
 

--- a/src/OpenTK.Mathematics/Geometry/Box3.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box3.cs
@@ -279,6 +279,7 @@ namespace OpenTK.Mathematics
         /// Inflate this Box3 to encapsulate a given point.
         /// </summary>
         /// <param name="point">The point to query.</param>
+        [Obsolete("Use " + nameof(Extend) + " instead. This function will have it's implementation changed in the future.")]
         public void Inflate(Vector3 point)
         {
             _min = Vector3.ComponentMin(_min, point);
@@ -291,11 +292,36 @@ namespace OpenTK.Mathematics
         /// <param name="point">The point to query.</param>
         /// <returns>The inflated box.</returns>
         [Pure]
+        [Obsolete("Use " + nameof(Extended) + " instead. This function will have it's implementation changed in the future.")]
         public Box3 Inflated(Vector3 point)
         {
             // create a local copy of this box
             Box3 box = this;
             box.Inflate(point);
+            return box;
+        }
+
+        /// <summary>
+        /// Extend this Box3 to encapsulate a given point.
+        /// </summary>
+        /// <param name="point">The point to contain.</param>
+        public void Extend(Vector3 point)
+        {
+            _min = Vector3.ComponentMin(_min, point);
+            _max = Vector3.ComponentMax(_max, point);
+        }
+
+        /// <summary>
+        /// Extend this Box3 to encapsulate a given point.
+        /// </summary>
+        /// <param name="point">The point to contain.</param>
+        /// <returns>The inflated box.</returns>
+        [Pure]
+        public Box3 Extended(Vector3 point)
+        {
+            // create a local copy of this box
+            Box3 box = this;
+            box.Extend(point);
             return box;
         }
 

--- a/src/OpenTK.Mathematics/Geometry/Box3d.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box3d.cs
@@ -279,6 +279,7 @@ namespace OpenTK.Mathematics
         /// Inflate this Box3d to encapsulate a given point.
         /// </summary>
         /// <param name="point">The point to query.</param>
+        [Obsolete("Use " + nameof(Extend) + " instead. This function will have it's implementation changed in the future.")]
         public void Inflate(Vector3d point)
         {
             _min = Vector3d.ComponentMin(_min, point);
@@ -291,11 +292,36 @@ namespace OpenTK.Mathematics
         /// <param name="point">The point to query.</param>
         /// <returns>The inflated box.</returns>
         [Pure]
+        [Obsolete("Use " + nameof(Extended) + " instead. This function will have it's implementation changed in the future.")]
         public Box3d Inflated(Vector3d point)
         {
             // create a local copy of this box
             Box3d box = this;
             box.Inflate(point);
+            return box;
+        }
+
+        /// <summary>
+        /// Extend this Box3d to encapsulate a given point.
+        /// </summary>
+        /// <param name="point">The point to contain.</param>
+        public void Extend(Vector3d point)
+        {
+            _min = Vector3d.ComponentMin(_min, point);
+            _max = Vector3d.ComponentMax(_max, point);
+        }
+
+        /// <summary>
+        /// Extend this Box3d to encapsulate a given point.
+        /// </summary>
+        /// <param name="point">The point to contain.</param>
+        /// <returns>The inflated box.</returns>
+        [Pure]
+        public Box3d Extended(Vector3d point)
+        {
+            // create a local copy of this box
+            Box3d box = this;
+            box.Extend(point);
             return box;
         }
 

--- a/src/OpenTK.Mathematics/Geometry/Box3i.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box3i.cs
@@ -259,6 +259,7 @@ namespace OpenTK.Mathematics
         /// Inflate this Box3i to encapsulate a given point.
         /// </summary>
         /// <param name="point">The point to query.</param>
+        [Obsolete("Use " + nameof(Extend) + " instead. This function will have it's implementation changed in the future.")]
         public void Inflate(Vector3i point)
         {
             _min = Vector3i.ComponentMin(_min, point);
@@ -271,11 +272,36 @@ namespace OpenTK.Mathematics
         /// <param name="point">The point to query.</param>
         /// <returns>The inflated box.</returns>
         [Pure]
+        [Obsolete("Use " + nameof(Extended) + " instead. This function will have it's implementation changed in the future.")]
         public Box3i Inflated(Vector3i point)
         {
             // create a local copy of this box
             Box3i box = this;
             box.Inflate(point);
+            return box;
+        }
+
+        /// <summary>
+        /// Extend this Box3i to encapsulate a given point.
+        /// </summary>
+        /// <param name="point">The point to contain.</param>
+        public void Extend(Vector3i point)
+        {
+            _min = Vector3i.ComponentMin(_min, point);
+            _max = Vector3i.ComponentMax(_max, point);
+        }
+
+        /// <summary>
+        /// Extend this Box3i to encapsulate a given point.
+        /// </summary>
+        /// <param name="point">The point to contain.</param>
+        /// <returns>The inflated box.</returns>
+        [Pure]
+        public Box3i Extended(Vector3i point)
+        {
+            // create a local copy of this box
+            Box3i box = this;
+            box.Extend(point);
             return box;
         }
 


### PR DESCRIPTION
### Purpose of this PR

Partially fixes #1511 by renaming `Inflate` to `Extend` and marking `Inflate` as deprecated.
So that we can re-introduce `Inflate` with new behavior in `4.8.1` or later.

### Testing status

The new functions have the exact same implementation as the previous `Inflate`.