### PR TITLE
Fix GLFWNative.LoadLibrary for Linux(X11, Wayland) with dotnet pusblish

### DIFF
--- a/src/OpenTK.Windowing.GraphicsLibraryFramework/GLFWNative.cs
+++ b/src/OpenTK.Windowing.GraphicsLibraryFramework/GLFWNative.cs
@@ -45,10 +45,8 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
                 string useWayland = Environment.GetEnvironmentVariable("OPENTK_4_USE_WAYLAND");
                 if (sessionType == "wayland" && useWayland == "1")
                 {
-                    // As we have a delimiter in the name the runtime will not prepend or append
-                    // stuff like `lib` and stuff.
                     libNameFormatter = (libName, ver) =>
-                        "/wayland/lib" + libName + ".so" + (string.IsNullOrEmpty(ver) ? string.Empty : "." + ver);
+                        libName + "-wayland.so" + (string.IsNullOrEmpty(ver) ? string.Empty : "." + ver);
                 }
                 else
                 {

--- a/src/OpenTK.Windowing.GraphicsLibraryFramework/OpenTK.Windowing.GraphicsLibraryFramework.csproj
+++ b/src/OpenTK.Windowing.GraphicsLibraryFramework/OpenTK.Windowing.GraphicsLibraryFramework.csproj
@@ -10,7 +10,7 @@
     <ItemGroup>
       <ProjectReference Include="..\OpenTK.Core\OpenTK.Core.csproj" />
       <ProjectReference Include="..\OpenTK.Windowing.Common\OpenTK.Windowing.Common.csproj" />
-      <PackageReference Include="OpenTK.redist.glfw" Version="3.3.8.38" />
+      <PackageReference Include="OpenTK.redist.glfw" Version="3.3.8.39" />
     </ItemGroup>
 
     <Import Project="..\..\props\common.props" />

--- a/src/OpenTK.Windowing.GraphicsLibraryFramework/paket
+++ b/src/OpenTK.Windowing.GraphicsLibraryFramework/paket
@@ -5,7 +5,7 @@ description
 dependencies
     framework: netcoreapp3.1
         OpenTK.Core ~> #VERSION#
-        OpenTK.redist.glfw >= 3.3.8.38
+        OpenTK.redist.glfw >= 3.3.8.39
 files
     bin\Release\netcoreapp3.1\OpenTK.Windowing.GraphicsLibraryFramework.dll ==> lib\netcoreapp3.1
     bin\Release\netcoreapp3.1\OpenTK.Windowing.GraphicsLibraryFramework.xml ==> lib\netcoreapp3.1


### PR DESCRIPTION
### Purpose of this PR

This PR fixes an issue when an OpenTK app is published using `dotnet publish  --self-contained -r linux-x64 -f net6.0`  where both libraries (glwf x11 and wayland) would end up in the same output directory causing an error.

This PR fixes #1622

### Testing status

I did test it locally running on Ubuntu 23.04 with the `XDG_SESSION_TYPE=wayland` and `OPENTK_4_USE_WAYLAND=1`
and it successfully loads the wayland libraries in Debug mode and also the X11 one if those environment variables are not set.
Further, I tested the LocalTest project and I could successfully publish it using `dotnet publish  --self-contained -r linux-x64 -f net6.0` with a newly build `OpenTK.redist.glfw` package.
See https://github.com/opentk/glfw-redist/pull/12

### Comments
I could not successfully run the walyand version of LocalTest on a gnome wayland session but that should be another issue that was also stated in the change log that it is not working yet on wayland using `GameWindow` which the LocaTest project does.

I get the following output on the terminal 
```
libEGL warning: egl: failed to create dri2 screen
```
and an invisible window.



In an X11 session the X11 version worked fine. Launching the LocalTest project and displaying a Window cycling through all colors.


