### PR TITLE
Set cached window size to the windowsize instead of clientsize

### DIFF
--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -353,10 +353,10 @@ namespace OpenTK.Windowing.Desktop
                 // Set the new window state before any potential callback is called,
                 // so that the new state is available in for example OnResize.
                 // - Noggin_bops 2023-09-25
-                var switchFromFullscreen = _windowState == WindowState.Fullscreen && value != WindowState.Fullscreen;
+                var previousWindowState = _windowState;
                 _windowState = value;
 
-                if (switchFromFullscreen)
+                if (previousWindowState == WindowState.Fullscreen && value != WindowState.Fullscreen)
                 {
                     // We are going from fullscreen to something else.
                     GLFW.SetWindowMonitor(WindowPtr, null, _cachedWindowLocation.X, _cachedWindowLocation.Y, _cachedWindowClientSize.X, _cachedWindowClientSize.Y, 0);

--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -30,7 +30,7 @@ namespace OpenTK.Windowing.Desktop
 
         // Both of these are used to cache the size and location of the window before going into full screen mode.
         // When getting out of full screen mode, the location and size will be set to these value in all states other then minimized.
-        private Vector2i _cachedWindowClientSize;
+        private Vector2i _cachedWindowSize;
         private Vector2i _cachedWindowLocation;
 
         // Used for delta calculation in the mouse position changed event.
@@ -359,7 +359,7 @@ namespace OpenTK.Windowing.Desktop
                 if (previousWindowState == WindowState.Fullscreen && value != WindowState.Fullscreen)
                 {
                     // We are going from fullscreen to something else.
-                    GLFW.SetWindowMonitor(WindowPtr, null, _cachedWindowLocation.X, _cachedWindowLocation.Y, _cachedWindowClientSize.X, _cachedWindowClientSize.Y, 0);
+                    GLFW.SetWindowMonitor(WindowPtr, null, _cachedWindowLocation.X, _cachedWindowLocation.Y, _cachedWindowSize.X, _cachedWindowSize.Y, 0);
                 }
 
                 switch (value)
@@ -377,8 +377,8 @@ namespace OpenTK.Windowing.Desktop
                         break;
 
                     case WindowState.Fullscreen:
-                        _cachedWindowClientSize = ClientSize;
-                        _cachedWindowLocation = ClientLocation;
+                        _cachedWindowSize = Size;
+                        _cachedWindowLocation = Location;
                         var monitor = CurrentMonitor.ToUnsafePtr<GraphicsLibraryFramework.Monitor>();
                         var modePtr = GLFW.GetVideoMode(monitor);
                         GLFW.SetWindowMonitor(WindowPtr, monitor, 0, 0, modePtr->Width, modePtr->Height, modePtr->RefreshRate);
@@ -847,7 +847,7 @@ namespace OpenTK.Windowing.Desktop
             GLFW.WindowHint(WindowHintInt.RefreshRate, modePtr->RefreshRate);
 
             _cachedWindowLocation = settings.Location ?? new Vector2i(32, 32);  // Better than nothing.
-            _cachedWindowClientSize = settings.Size;
+            _cachedWindowSize = settings.Size;
 
             if (settings.WindowState == WindowState.Fullscreen && _isVisible)
             {

--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -353,9 +353,10 @@ namespace OpenTK.Windowing.Desktop
                 // Set the new window state before any potential callback is called,
                 // so that the new state is available in for example OnResize.
                 // - Noggin_bops 2023-09-25
+                var switchFromFullscreen = _windowState == WindowState.Fullscreen && value != WindowState.Fullscreen;
                 _windowState = value;
 
-                if (_windowState == WindowState.Fullscreen && value != WindowState.Fullscreen)
+                if (switchFromFullscreen)
                 {
                     // We are going from fullscreen to something else.
                     GLFW.SetWindowMonitor(WindowPtr, null, _cachedWindowLocation.X, _cachedWindowLocation.Y, _cachedWindowClientSize.X, _cachedWindowClientSize.Y, 0);

--- a/tests/LocalTest/Program.cs
+++ b/tests/LocalTest/Program.cs
@@ -89,5 +89,28 @@ namespace LocalTest
         {
             base.OnMove(e);
         }
+
+        protected override void OnKeyUp(KeyboardKeyEventArgs e)
+        {
+            if (e.Key == Keys.Escape)
+            {
+                Close();
+            }
+
+            if (e.Key == Keys.F && WindowState != WindowState.Fullscreen)
+            {
+                WindowState = WindowState.Fullscreen;
+            }
+
+            if (e.Key == Keys.N && WindowState != WindowState.Normal)
+            {
+                WindowState = WindowState.Normal;
+            }
+
+            if (e.Key == Keys.M && WindowState != WindowState.Maximized)
+            {
+                WindowState = WindowState.Maximized;
+            }
+        }
     }
 }


### PR DESCRIPTION
### Purpose of this PR

Fixes when a window is restored to Normal WindowState from Fullscreen it would shrink downwards by the window border amount.
Depends/Includes on #1650 only for the new testing of changing the WindowState

### Testing status

Manually by using the newly added keys in the LocalTest project to change the WindowState.

### Comment
Since the cached size is used with GLFW.SetWindowMonitor which expects a window size and not a client size.
