### PR TITLE
Add missing enums from KHR_Debug to GetPName

### DIFF
--- a/src/Generator.Bind/Specifications/GL2/overrides.xml
+++ b/src/Generator.Bind/Specifications/GL2/overrides.xml
@@ -3645,6 +3645,13 @@
       <use enum="VERSION_4_5" token="RESET_NOTIFICATION_STRATEGY" />
       <use enum="VERSION_4_6" token="PARAMETER_BUFFER_BINDING" />
       <use enum="VERSION_4_6" token="MAX_TEXTURE_MAX_ANISOTROPY" />
+      <use token="MAX_DEBUG_MESSAGE_LENGTH" />
+      <use token="MAX_DEBUG_LOGGED_MESSAGES" />
+      <use token="DEBUG_LOGGED_MESSAGES" />
+      <use token="DEBUG_NEXT_LOGGED_MESSAGE_LENGTH" />
+      <use token="MAX_DEBUG_GROUP_STACK_DEPTH" />
+      <use token="DEBUG_GROUP_STACK_DEPTH" />
+      <use token="MAX_LABEL_LENGTH" />
     </enum>
     <enum name="GetPointervPName">
       <token name="FOG_COORD_ARRAY_POINTER" value="0x8456" />
@@ -6558,6 +6565,13 @@
       <token name="PolygonOffsetFill" value="0X8037" />
       <token name="SampleAlphaToCoverage" value="0X809e" />
       <token name="SampleCoverage" value="0X80a0" />
+      <use token="MAX_DEBUG_MESSAGE_LENGTH" />
+      <use token="MAX_DEBUG_LOGGED_MESSAGES" />
+      <use token="DEBUG_LOGGED_MESSAGES" />
+      <use token="DEBUG_NEXT_LOGGED_MESSAGE_LENGTH" />
+      <use token="MAX_DEBUG_GROUP_STACK_DEPTH" />
+      <use token="DEBUG_GROUP_STACK_DEPTH" />
+      <use token="MAX_LABEL_LENGTH" />
       <use enum="KHR_context_flush_control" token="CONTEXT_RELEASE_BEHAVIOR_KHR" />
     </enum>
 
@@ -7089,6 +7103,13 @@
       <use token="IMPLEMENTATION_COLOR_READ_FORMAT" />
       <use token="COPY_READ_BUFFER_BINDING" />
       <use token="COPY_WRITE_BUFFER_BINDING" />
+      <use token="MAX_DEBUG_MESSAGE_LENGTH" />
+      <use token="MAX_DEBUG_LOGGED_MESSAGES" />
+      <use token="DEBUG_LOGGED_MESSAGES" />
+      <use token="DEBUG_NEXT_LOGGED_MESSAGE_LENGTH" />
+      <use token="MAX_DEBUG_GROUP_STACK_DEPTH" />
+      <use token="DEBUG_GROUP_STACK_DEPTH" />
+      <use token="MAX_LABEL_LENGTH" />
       <use enum="KHR_context_flush_control" token="CONTEXT_RELEASE_BEHAVIOR_KHR" />
     </enum>
     <enum name="GetProgramParameterName">


### PR DESCRIPTION
### Purpose of this PR

Add missing enums in `GetPName` to the `OpenGL4`, `OpenGL`, `ES30` and `ES20`  namespaces.

Fixed #1611.