### PR TITLE
Suspend timer during window drag via Win32 message hooks

### DIFF
--- a/src/OpenTK.Windowing.Desktop/GameWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/GameWindow.cs
@@ -264,8 +264,8 @@ namespace OpenTK.Windowing.Desktop
             // Make sure that the gl contexts is current for OnLoad and the initial OnResize
             Context?.MakeCurrent();
 
-            // Hook the Win32 window message handler and (TODO) wire up related events
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            // Hook the Win32 window message handler and wire up related events
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && _win32SuspendTimerOnDrag)
             {
                 _win32WndProc = new Win32WindowProc(WindowPtr);
                 _win32WndProc.OnModalSizeMoveBegin += Win32_OnModalSizeMoveBegin;
@@ -433,20 +433,16 @@ namespace OpenTK.Windowing.Desktop
             _watchUpdate.Restart();
         }
 
+        // Only fired when GameWindowSettings.Win32SuspendTimerOnDrag is enabled
         private void Win32_OnModalSizeMoveBegin()
         {
-            if (_win32SuspendTimerOnDrag)
-            {
-                _watchUpdate.Stop();
-            }
+            _watchUpdate.Stop();
         }
 
+        // Only fired when GameWindowSettings.Win32SuspendTimerOnDrag is enabled
         private void Win32_OnModalSizeMoveEnd()
         {
-            if (_win32SuspendTimerOnDrag)
-            {
-                _watchUpdate.Restart();
-            }
+            _watchUpdate.Restart();
         }
 
         /// <inheritdoc />
@@ -454,7 +450,7 @@ namespace OpenTK.Windowing.Desktop
         {
             base.Dispose();
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !(_win32WndProc is null))
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && _win32WndProc != null)
             {
                 _win32WndProc.OnModalSizeMoveBegin -= Win32_OnModalSizeMoveBegin;
                 _win32WndProc.OnModalSizeMoveEnd -= Win32_OnModalSizeMoveEnd;

--- a/src/OpenTK.Windowing.Desktop/GameWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/GameWindow.cs
@@ -178,9 +178,9 @@ namespace OpenTK.Windowing.Desktop
         /// </summary>
         public int ExpectedSchedulerPeriod { get; set; } = 16;
 
-        private Win32WindowProc _win32WndProc = null;
+        private readonly bool _win32SuspendTimerOnDrag;
 
-        private bool _win32SuspendTimerOnDrag;
+        private Win32WindowProc _win32WndProc = null;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="GameWindow"/> class with sensible default attributes.
@@ -445,10 +445,17 @@ namespace OpenTK.Windowing.Desktop
             _watchUpdate.Restart();
         }
 
+        private bool _isDisposed = false;
+
         /// <inheritdoc />
         public override void Dispose()
         {
             base.Dispose();
+
+            if (_isDisposed)
+            {
+                return;
+            }
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && _win32WndProc != null)
             {
@@ -457,6 +464,9 @@ namespace OpenTK.Windowing.Desktop
                 _win32WndProc.Dispose();
                 _win32WndProc = null;
             }
+
+            GC.SuppressFinalize(this);
+            _isDisposed = true;
         }
     }
 }

--- a/src/OpenTK.Windowing.Desktop/GameWindowSettings.cs
+++ b/src/OpenTK.Windowing.Desktop/GameWindowSettings.cs
@@ -52,5 +52,11 @@ namespace OpenTK.Windowing.Desktop
         ///  <para>Values lower than 1.0Hz are clamped to 0.0. Values higher than 500.0Hz are clamped to 500.0Hz.</para>
         /// </remarks>
         public double UpdateFrequency { get; set; } = 0.0;
+
+        /// <summary>
+        /// Gets or sets a value which controls whether the timer which drives <see cref="FrameEventArgs"/> is
+        /// suspended when the user begins dragging the window or window frame. Only applies to Windows applications.
+        /// </summary>
+        public bool Win32SuspendTimerOnDrag { get; set; } = false;
     }
 }

--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -1907,7 +1907,7 @@ namespace OpenTK.Windowing.Desktop
         }
 
         /// <inheritdoc />
-        public void Dispose()
+        public virtual void Dispose()
         {
             Dispose(true);
             GC.SuppressFinalize(this);

--- a/src/OpenTK.Windowing.Desktop/Win32WindowProc.cs
+++ b/src/OpenTK.Windowing.Desktop/Win32WindowProc.cs
@@ -1,0 +1,162 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using OpenTK.Windowing.GraphicsLibraryFramework;
+
+namespace OpenTK.Windowing.Desktop
+{
+    /// <summary>
+    /// Windows-specific Win32 message-handling.
+    /// </summary>
+    internal unsafe class Win32WindowProc : IDisposable
+    {
+        [DllImport("user32.dll", EntryPoint = "SetWindowLong")]
+        private static extern int SetWindowLong32(IntPtr hWnd, int nIndex, int dwNewLong);
+
+        [DllImport("user32.dll", EntryPoint = "SetWindowLongPtr")]
+        private static extern IntPtr SetWindowLongPtr64(IntPtr hWnd, int nIndex, IntPtr dwNewLong);
+
+        // Invokes the 32- or 64-bit version depending on pointer size.
+        public static IntPtr SetWindowLongPtr(IntPtr hWnd, int nIndex, IntPtr dwNewLong)
+        {
+            if (IntPtr.Size == 8)
+            {
+                return SetWindowLongPtr64(hWnd, nIndex, dwNewLong);
+            }
+
+            return new IntPtr(SetWindowLong32(hWnd, nIndex, dwNewLong.ToInt32()));
+        }
+
+        /*
+        Included for completeness. Currently these are unnecessary since SetWindowLongPtr
+        will return the current value, and we aren't currently getting any value that
+        isn't being replaced (specifically the WndProc).
+
+        [DllImport("user32.dll", EntryPoint = "GetWindowLong")]
+        private static extern IntPtr GetWindowLongPtr32(IntPtr hWnd, int nIndex);
+
+        [DllImport("user32.dll", EntryPoint = "GetWindowLongPtr")]
+        private static extern IntPtr GetWindowLongPtr64(IntPtr hWnd, int nIndex);
+
+        // Invokes the 32- or 64-bit version depending on pointer size.
+        private static IntPtr GetWindowLongPtr(IntPtr hWnd, int nIndex)
+        {
+            if (IntPtr.Size == 8)
+            {
+                return GetWindowLongPtr64(hWnd, nIndex);
+            }
+
+            return GetWindowLongPtr32(hWnd, nIndex);
+        }
+        */
+
+        private enum WindowLongFlags : int
+        {
+            GWL_EXSTYLE = -20,
+            GWLP_HINSTANCE = -6,
+            GWLP_HWNDPARENT = -8,
+            GWL_ID = -12,
+            GWL_STYLE = -16,
+            GWL_USERDATA = -21,
+            GWL_WNDPROC = -4,
+            DWLP_USER = 0x8,
+            DWLP_MSGRESULT = 0x0,
+            DWLP_DLGPROC = 0x4,
+        }
+
+        [DllImport("user32.dll", CharSet = CharSet.Auto)]
+        private static extern IntPtr CallWindowProc(IntPtr wndProc, IntPtr hWnd, int msg, IntPtr wParam, IntPtr lParam);
+
+        private delegate IntPtr WndProcPointer(IntPtr hwnd, int msg, IntPtr wparam, IntPtr lparam);
+
+        // Indicates the beginning of modal size/move activity.
+        private const int WM_ENTERSIZEMOVE = 0x0231;
+
+        // Indicates the completion of modal size/move activity.
+        private const int WM_EXITSIZEMOVE = 0x0232;
+
+        // On older versions of Windows, this is sent when a user initiates
+        // sizing but then does not actually resize the window. In that case,
+        // WM_EXITSIZEMOVE is not sent. This can be sent in other scenarios
+        // so it is also necessary to track whether WM_ENTERSIZEMOVE has been
+        // received, in order to use this as a proxy for WM_EXITSIZEMOVE.
+        private const int WM_CAPTURECHANGED = 0x0215;
+
+        // Native win32 window handle
+        private IntPtr _hWnd = IntPtr.Zero;
+
+        // Original message-handler
+        private IntPtr _DefaultWndProc = IntPtr.Zero;
+
+        // When true, WM_ENTERSIZEMOVE has been received, and this will reset
+        // to false when WM_ENTERSIZEMOVE or WM_CAPTURECHANGED is received.
+        private bool _isModalSizeMoveState = false;
+
+        /// <summary>
+        /// Indicates the window is in a modal size/move state and update events
+        /// are temporarily suspended.
+        /// </summary>
+        public bool IsModalSizeMoveState { get => _isModalSizeMoveState; }
+
+        /// <summary>
+        /// Invoked when Windows indicates modal move/size activity has started (the user
+        /// is dragging or resizing the window).
+        /// </summary>
+        public event Action OnModalSizeMoveBegin;
+
+        /// <summary>
+        /// Invoked when Windows indicates modal move/size activity has ended.
+        /// </summary>
+        public event Action OnModalSizeMoveEnd;
+
+        public Win32WindowProc(Window* window)
+        {
+            _hWnd = GLFW.GetWin32Window(window);
+            var openTKWndProc = Marshal.GetFunctionPointerForDelegate((WndProcPointer)WndProc);
+            _DefaultWndProc = SetWindowLongPtr(_hWnd, (int)WindowLongFlags.GWL_WNDPROC, openTKWndProc);
+        }
+
+        private IntPtr WndProc(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam)
+        {
+            switch (msg)
+            {
+                case WM_ENTERSIZEMOVE:
+                    _isModalSizeMoveState = true;
+                    OnModalSizeMoveBegin?.Invoke();
+                    break;
+
+                case WM_EXITSIZEMOVE:
+                case WM_CAPTURECHANGED:
+                    if (_isModalSizeMoveState)
+                    {
+                        _isModalSizeMoveState = false;
+                        OnModalSizeMoveEnd?.Invoke();
+                    }
+                    break;
+
+                default:
+                    break;
+            }
+
+            return CallWindowProc(_DefaultWndProc, _hWnd, msg, wParam, lParam);
+        }
+
+        private bool _isDisposed = false;
+
+        public void Dispose()
+        {
+            if (_isDisposed)
+            {
+                return;
+            }
+
+            if (!_DefaultWndProc.Equals(IntPtr.Zero))
+            {
+                SetWindowLongPtr(_hWnd, (int)WindowLongFlags.GWL_WNDPROC, _DefaultWndProc);
+                _DefaultWndProc = IntPtr.Zero;
+            }
+
+            GC.SuppressFinalize(this);
+            _isDisposed = true;
+        }
+    }
+}

--- a/src/OpenTK.Windowing.Desktop/Win32WindowProc.cs
+++ b/src/OpenTK.Windowing.Desktop/Win32WindowProc.cs
@@ -59,13 +59,13 @@ namespace OpenTK.Windowing.Desktop
         private const int WM_CAPTURECHANGED = 0x0215;
 
         // Native win32 window handle
-        private IntPtr _hWnd;
+        private readonly IntPtr _hWnd;
 
         // Original message-handler
-        private IntPtr _defaultWndProc;
+        private readonly IntPtr _defaultWndProc;
 
         // Local message-handler
-        private WndProcPointer _openTKWndProcDelegate;
+        private readonly WndProcPointer _openTKWndProcDelegate;
 
         // When true, WM_ENTERSIZEMOVE has been received, and this will reset
         // to false when WM_ENTERSIZEMOVE or WM_CAPTURECHANGED is received.
@@ -127,7 +127,6 @@ namespace OpenTK.Windowing.Desktop
             if (_defaultWndProc != IntPtr.Zero)
             {
                 SetWindowPointer(_hWnd, (int)WindowLongFlags.GWL_WNDPROC, _defaultWndProc);
-                _defaultWndProc = IntPtr.Zero;
             }
 
             GC.SuppressFinalize(this);

--- a/src/OpenTK.Windowing.Desktop/Win32WindowProc.cs
+++ b/src/OpenTK.Windowing.Desktop/Win32WindowProc.cs
@@ -22,8 +22,10 @@ namespace OpenTK.Windowing.Desktop
             {
                 return SetWindowLongPtr(hWnd, nIndex, dwNewLong);
             }
-
-            return new IntPtr(SetWindowLong(hWnd, nIndex, dwNewLong.ToInt32()));
+            else
+            {
+                return new IntPtr(SetWindowLong(hWnd, nIndex, dwNewLong.ToInt32()));
+            }
         }
 
         private enum WindowLongFlags : int

--- a/src/OpenTK.Windowing.Desktop/Win32WindowProc.cs
+++ b/src/OpenTK.Windowing.Desktop/Win32WindowProc.cs
@@ -9,21 +9,21 @@ namespace OpenTK.Windowing.Desktop
     /// </summary>
     internal unsafe class Win32WindowProc : IDisposable
     {
-        [DllImport("user32.dll", EntryPoint = "SetWindowLong")]
-        private static extern int SetWindowLong32(IntPtr hWnd, int nIndex, int dwNewLong);
+        [DllImport("user32.dll")]
+        private static extern int SetWindowLong(IntPtr hWnd, int nIndex, int dwNewLong);
 
-        [DllImport("user32.dll", EntryPoint = "SetWindowLongPtr")]
-        private static extern IntPtr SetWindowLongPtr64(IntPtr hWnd, int nIndex, IntPtr dwNewLong);
+        [DllImport("user32.dll")]
+        private static extern IntPtr SetWindowLongPtr(IntPtr hWnd, int nIndex, IntPtr dwNewLong);
 
         // Invokes the 32- or 64-bit version depending on pointer size.
-        public static IntPtr SetWindowLongPtr(IntPtr hWnd, int nIndex, IntPtr dwNewLong)
+        public static IntPtr SetWindowPointer(IntPtr hWnd, int nIndex, IntPtr dwNewLong)
         {
-            if (IntPtr.Size == 8)
+            if (Environment.Is64BitProcess)
             {
-                return SetWindowLongPtr64(hWnd, nIndex, dwNewLong);
+                return SetWindowLongPtr(hWnd, nIndex, dwNewLong);
             }
 
-            return new IntPtr(SetWindowLong32(hWnd, nIndex, dwNewLong.ToInt32()));
+            return new IntPtr(SetWindowLong(hWnd, nIndex, dwNewLong.ToInt32()));
         }
 
         private enum WindowLongFlags : int
@@ -87,7 +87,7 @@ namespace OpenTK.Windowing.Desktop
             _hWnd = GLFW.GetWin32Window(window);
             _openTKWndProcDelegate = WndProc;
             var openTKWndProc = Marshal.GetFunctionPointerForDelegate(_openTKWndProcDelegate);
-            _defaultWndProc = SetWindowLongPtr(_hWnd, (int)WindowLongFlags.GWL_WNDPROC, openTKWndProc);
+            _defaultWndProc = SetWindowPointer(_hWnd, (int)WindowLongFlags.GWL_WNDPROC, openTKWndProc);
         }
 
         private IntPtr WndProc(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam)
@@ -126,7 +126,7 @@ namespace OpenTK.Windowing.Desktop
 
             if (_defaultWndProc != IntPtr.Zero)
             {
-                SetWindowLongPtr(_hWnd, (int)WindowLongFlags.GWL_WNDPROC, _defaultWndProc);
+                SetWindowPointer(_hWnd, (int)WindowLongFlags.GWL_WNDPROC, _defaultWndProc);
                 _defaultWndProc = IntPtr.Zero;
             }
 


### PR DESCRIPTION
On Windows, suspends and resets the `Stopwatch` for `FrameEventArgs` timings when modal size/move activity begins.

Fixes #1195 

It should be entirely transparent to library consumers who don't want this behavior. It adds a `Win32SuspendTimerOnDrag` switch to `GameWindowSettings` which defaults to `false`. (Should this be named "Windows" instead of "Win32"?)

Since hooking the Windows message pump might be useful in the future, I implemented this in an extensible way with a new `Win32WindowProc` class. This is created in `GameWindow.Run` and the intercepted `WM` messages are used to fire events. Pretty simple stuff.

It was necessary to implement `Dispose` in the `GameWindow` class, so I altered the native dispose to be virtual.

I don't expose the events to the library consumer, but I suppose that would be an option.

I tested it, of course. Since all it does is stop then reset the timer, testing was trivial. I don't use this timing in my own code, so if a more sophisticated handling of the timing calcs is required, I'm open to suggestions.

Edit: I originally planned to wire the message handler from the native window class, but since the fix only applies to the game window, I put it there. It should be relatively simple to move it, if someone feels the win32 hooks might be more broadly useful at some future point.
