### PR TITLE
Wayland freeze on setting the WindowState before Context.MakeCurrent()

### DIFF
--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -857,12 +857,6 @@ namespace OpenTK.Windowing.Desktop
             else
             {
                 WindowPtr = GLFW.CreateWindow(settings.Size.X, settings.Size.Y, _title, null, (Window*)(settings.SharedContext?.WindowPtr ?? IntPtr.Zero));
-
-                if (settings.StartVisible)
-                {
-                    // If we are starting the window maximized or minimized we need to set that here.
-                    WindowState = settings.WindowState;
-                }
             }
 
             // For Vulkan, we need to pass ContextAPI.NoAPI, otherwise we will get an exception.
@@ -886,6 +880,13 @@ namespace OpenTK.Windowing.Desktop
                 {
                     InitializeGlBindings();
                 }
+            }
+
+            // When WindowState is Normal on Wayland it freezes on calling GLFW.RestoreWindow(WindowPtr) before Context?.MakeCurrent()
+            if (settings.WindowState != WindowState.Fullscreen && _isVisible)
+            {
+                // If we are starting the window maximized or minimized we need to set that here.
+                WindowState = settings.WindowState;
             }
 
             // Enables the caps lock modifier to be detected and updated

--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -883,6 +883,7 @@ namespace OpenTK.Windowing.Desktop
             }
 
             // When WindowState is Normal on Wayland it freezes on calling GLFW.RestoreWindow(WindowPtr) before Context?.MakeCurrent()
+            // See https://github.com/opentk/opentk/pull/1656 and https://github.com/glfw/glfw/issues/2395
             if (settings.WindowState != WindowState.Fullscreen && _isVisible)
             {
                 // If we are starting the window maximized or minimized we need to set that here.


### PR DESCRIPTION
### Purpose of this PR

Fixes an issue introduced with https://github.com/opentk/opentk/commit/0c6d579e24d1deaa9d709196f97310d65327ae5a
The issue is on Wayland when using xwayland the window freezes after creation.
When setting the WindowState  before calling 
`Context?.MakeCurrent();`
there it just freezes when on `GLFW.RestoreWindow(WindowPtr);` inside the WindowState setter.

This seems to be an [issue](https://github.com/glfw/glfw/issues/2395) with GLFW but I did not look into GLFW itself yet and would suggest this "workaround" for now that restores the same behavior as in OpenTK 4.7.7

### Testing status

Manually tested using the LocalTest Project 
Tested on:
- Ubuntu 23.04 Wayland
- Ubuntu 23.04 X11
- Windows 10
So far that seems to work fine as it did before this change in 4.7.7

### Comments

I noticed that starting a window Minimized does not work on Linux (X11/Wayland) but works fine on Windows but that seems unrelated to this change.