### PR TITLE
Fix locale bug involving group names. (#1668)

### DIFF
--- a/src/Generator/Utility/NameMangler.cs
+++ b/src/Generator/Utility/NameMangler.cs
@@ -205,7 +205,7 @@ namespace Generator.Utility
                 }
                 else
                 {
-                    stringBuilder.Append(nextUpper ? char.ToUpper(c) : char.ToLower(c));
+                    stringBuilder.Append(nextUpper ? char.ToUpperInvariant(c) : char.ToLowerInvariant(c));
                     nextUpper = false;
                 }
             }


### PR DESCRIPTION
### Purpose of this PR
Fix #1668

### Testing status
* Tested to ensure the generated bindings are correctly capitalized in locales that redefine capitalization rules.
