### PR TITLE
Use MathF methods instead of Math (float vs double)

### DIFF
--- a/src/OpenTK.Mathematics/Geometry/BezierCurve.cs
+++ b/src/OpenTK.Mathematics/Geometry/BezierCurve.cs
@@ -204,7 +204,7 @@ namespace OpenTK.Mathematics
         public static Vector2 CalculatePoint(IList<Vector2> points, float t, float parallel)
         {
             var r = default(Vector2);
-            var c = 1.0d - t;
+            var c = 1 - t;
             float temp;
             var i = 0;
 
@@ -212,7 +212,7 @@ namespace OpenTK.Mathematics
             {
                 temp = MathHelper.BinomialCoefficient
                 (
-                    points.Count - 1, i) * (float)(Math.Pow(t, i) * Math.Pow(c, points.Count - 1 - i)
+                    points.Count - 1, i) * (MathF.Pow(t, i) * MathF.Pow(c, points.Count - 1 - i)
                 );
 
                 r.X += temp * pt.X;
@@ -249,7 +249,7 @@ namespace OpenTK.Mathematics
         private static Vector2 CalculatePointOfDerivative(IList<Vector2> points, float t)
         {
             var r = default(Vector2);
-            var c = 1.0d - t;
+            var c = 1 - t;
             float temp;
             var i = 0;
 
@@ -257,7 +257,7 @@ namespace OpenTK.Mathematics
             {
                 temp = MathHelper.BinomialCoefficient
                 (
-                    points.Count - 2, i) * (float)(Math.Pow(t, i) * Math.Pow(c, points.Count - 2 - i)
+                    points.Count - 2, i) * (MathF.Pow(t, i) * MathF.Pow(c, points.Count - 2 - i)
                 );
 
                 r.X += temp * pt.X;

--- a/src/OpenTK.Mathematics/Geometry/BezierCurve.cs
+++ b/src/OpenTK.Mathematics/Geometry/BezierCurve.cs
@@ -203,10 +203,10 @@ namespace OpenTK.Mathematics
         [Pure]
         public static Vector2 CalculatePoint(IList<Vector2> points, float t, float parallel)
         {
-            var r = default(Vector2);
-            var c = 1 - t;
+            Vector2 r = default(Vector2);
+            float c = 1 - t;
             float temp;
-            var i = 0;
+            int i = 0;
 
             foreach (var pt in points)
             {
@@ -248,10 +248,10 @@ namespace OpenTK.Mathematics
         [Pure]
         private static Vector2 CalculatePointOfDerivative(IList<Vector2> points, float t)
         {
-            var r = default(Vector2);
-            var c = 1 - t;
+            Vector2 r = default(Vector2);
+            float c = 1 - t;
             float temp;
-            var i = 0;
+            int i = 0;
 
             foreach (var pt in points)
             {

--- a/src/OpenTK.Mathematics/Matrix/Matrix4.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix4.cs
@@ -1117,7 +1117,7 @@ namespace OpenTK.Mathematics
             out Matrix4 result
         )
         {
-            if (fovy <= 0 || fovy > Math.PI)
+            if (fovy <= 0 || fovy > MathF.PI)
             {
                 throw new ArgumentOutOfRangeException(nameof(fovy));
             }

--- a/src/OpenTK.Mathematics/Matrix/Matrix4.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix4.cs
@@ -1137,10 +1137,10 @@ namespace OpenTK.Mathematics
                 throw new ArgumentOutOfRangeException(nameof(depthFar));
             }
 
-            var maxY = depthNear * MathF.Tan(0.5f * fovy);
-            var minY = -maxY;
-            var minX = minY * aspect;
-            var maxX = maxY * aspect;
+            float maxY = depthNear * MathF.Tan(0.5f * fovy);
+            float minY = -maxY;
+            float minX = minY * aspect;
+            float maxX = maxY * aspect;
 
             CreatePerspectiveOffCenter(minX, maxX, minY, maxY, depthNear, depthFar, out result);
         }


### PR DESCRIPTION
Changed `double`-based `Math.PI` and `Math.Pow` usage to the `MathF` equivalents. Changed a related variable from `double` to `float`. I checked the rest of the solution and didn't find similar candidates elsewhere.

Fixes #1673 

* PI changed in `Matrix4.CreatePerspectiveFieldOfView`
* Pow changed in `Vector2.CalcualtePoint` and `CalculatePointOfDerivative`

Did three simple before/after tests and verified the results are identical.

Gimme dat 4.8.2! 😁 