### PR TITLE
[5.0] Fix so NativeWindow properly loads the OpenGL bindings

### DIFF
--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -958,28 +958,18 @@ namespace OpenTK.Windowing.Desktop
 
             var provider = new GLFWBindingsContext();
 
-            void LoadBindings(string typeNamespace)
+            Type type = assembly.GetType($"OpenTK.Graphics.GLLoader");
+            if (type != null)
             {
-                Type type = assembly.GetType($"OpenTK.Graphics.{typeNamespace}.GL");
-                if (type == null)
-                {
-                    return;
-                }
-
                 MethodInfo load = type.GetMethod("LoadBindings");
+                load.Invoke(null, new object[] { provider });
                 if (load == null)
                 {
-                    throw new MissingMethodException($"OpenTK tried to auto-load the OpenGL bindings. We found the {$"OpenTK.Graphics.{typeNamespace}.GL"} class, but we could not find the 'LoadBindings' method. " +
+                    throw new MissingMethodException($"OpenTK tried to auto-load the OpenGL bindings. We found the {$"OpenTK.Graphics.GLLoader"} class, but we could not find the 'LoadBindings' method. " +
                         $"If you are trying to run a trimmed assembly please add a [DynamicDependency()] attribute to your program, or set NativeWindowSettings.AutoLoadBindings = false and load the OpenGL bindings manually.");
                 }
                 load?.Invoke(null, new object[] { provider });
             }
-
-            LoadBindings("ES11");
-            LoadBindings("ES20");
-            LoadBindings("ES30");
-            LoadBindings("OpenGL");
-            LoadBindings("OpenGL4");
         }
 
         /// <summary>

--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -958,18 +958,18 @@ namespace OpenTK.Windowing.Desktop
 
             var provider = new GLFWBindingsContext();
 
-            Type type = assembly.GetType($"OpenTK.Graphics.GLLoader");
-            if (type != null)
+            var type = assembly.GetType($"OpenTK.Graphics.GLLoader");
+            if (type == null)
             {
-                MethodInfo load = type.GetMethod("LoadBindings");
-                load.Invoke(null, new object[] { provider });
-                if (load == null)
-                {
-                    throw new MissingMethodException($"OpenTK tried to auto-load the OpenGL bindings. We found the {$"OpenTK.Graphics.GLLoader"} class, but we could not find the 'LoadBindings' method. " +
-                        $"If you are trying to run a trimmed assembly please add a [DynamicDependency()] attribute to your program, or set NativeWindowSettings.AutoLoadBindings = false and load the OpenGL bindings manually.");
-                }
-                load?.Invoke(null, new object[] { provider });
+                return;
             }
+            var load = type.GetMethod("LoadBindings");
+            if (load == null)
+            {
+                throw new MissingMethodException($"OpenTK tried to auto-load the OpenGL bindings. We found the {$"OpenTK.Graphics.GLLoader"} class, but we could not find the 'LoadBindings' method. " +
+                        $"If you are trying to run a trimmed assembly please add a [DynamicDependency()] attribute to your program, or set NativeWindowSettings.AutoLoadBindings = false and load the OpenGL bindings manually.");
+            }
+            load.Invoke(null, new object[] { provider });
         }
 
         /// <summary>

--- a/tests/LocalTest/Program.cs
+++ b/tests/LocalTest/Program.cs
@@ -67,7 +67,7 @@ namespace LocalTest
             time += (float)args.Time;
             if (time > CycleTime) time = 0;
 
-            Color4 color = Color4.FromHsv(new Vector4(time / CycleTime, 1, 1, 1));
+            Color4<Rgba> color = new Color4<Hsva>(time / CycleTime, 1, 1, 1).ToRgba();
 
             GL.ClearColor(color);
             GL.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit);


### PR DESCRIPTION
### Purpose of this PR

This PR fixes the OpenGL autoloading for `NativeWindow` so that it uses the new way to load bindings.
This broke in `5.0-pre.9` with #1659.

### Testing status

Tested using the local test project.