### PR TITLE
Add framebuffer size callbacks and NativeWindow.FramebufferSize

### DIFF
--- a/src/OpenTK.Windowing.Common/Events/FramebufferResizeEventArgs.cs
+++ b/src/OpenTK.Windowing.Common/Events/FramebufferResizeEventArgs.cs
@@ -1,0 +1,52 @@
+﻿//
+// FramebufferResizeEventArgs.cs
+//
+// Copyright (C) 2023 OpenTK
+//
+// This software may be modified and distributed under the terms
+// of the MIT license. See the LICENSE file for details.
+//
+using OpenTK.Mathematics;
+
+namespace OpenTK.Windowing.Common
+{
+    /// <summary>
+    /// Defines the event data for the framebuffer resize event.
+    /// </summary>
+    public readonly struct FramebufferResizeEventArgs
+    {
+        /// <summary>
+        /// Gets the new framebuffer size.
+        /// </summary>
+        public Vector2i Size { get; }
+
+        /// <summary>
+        /// Gets the new framebuffer width.
+        /// </summary>
+        public int Width => Size.X;
+
+        /// <summary>
+        /// Gets the new framebuffer height.
+        /// </summary>
+        public int Height => Size.Y;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FramebufferResizeEventArgs"/> struct.
+        /// </summary>
+        /// <param name="size">the new framebuffer size.</param>
+        public FramebufferResizeEventArgs(Vector2i size)
+        {
+            Size = size;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FramebufferResizeEventArgs"/> struct.
+        /// </summary>
+        /// <param name="width">The new framebuffer width.</param>
+        /// <param name="height">The new framebuffer height.</param>
+        public FramebufferResizeEventArgs(int width, int height)
+            : this(new Vector2i(width, height))
+        {
+        }
+    }
+}

--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -488,7 +488,7 @@ namespace OpenTK.Windowing.Desktop
         private Vector2i? _maximumSize;
 
         /// <summary>
-        /// Gets or sets a <see cref="OpenTK.Mathematics.Vector2i" /> structure that contains the external size of this window.
+        /// Gets or sets a <see cref="Vector2i" /> structure that contains the external size of this window.
         /// </summary>
         public unsafe Vector2i Size
         {
@@ -513,7 +513,7 @@ namespace OpenTK.Windowing.Desktop
         }
 
         /// <summary>
-        /// Gets or sets a <see cref="OpenTK.Mathematics.Vector2i" /> structure that contains the client size of this window.
+        /// Gets or sets a <see cref="Vector2i" /> structure that contains the client size of this window.
         /// </summary>
         public unsafe Vector2i ClientSize
         {
@@ -526,6 +526,18 @@ namespace OpenTK.Windowing.Desktop
             set
             {
                 GLFW.SetWindowSize(WindowPtr, value.X, value.Y);
+            }
+        }
+
+        /// <summary>
+        /// Gets a <see cref="Vector2i" /> structure that contains the framebuffer size of this window.
+        /// </summary>
+        public unsafe Vector2i FramebufferSize
+        {
+            get
+            {
+                GLFW.GetFramebufferSize(WindowPtr, out int width, out int height);
+                return (width, height);
             }
         }
 
@@ -1012,6 +1024,7 @@ namespace OpenTK.Windowing.Desktop
 
         private GLFWCallbacks.WindowPosCallback _windowPosCallback;
         private GLFWCallbacks.WindowSizeCallback _windowSizeCallback;
+        private GLFWCallbacks.FramebufferSizeCallback _framebufferSizeCallback;
         private GLFWCallbacks.WindowIconifyCallback _windowIconifyCallback;
         private GLFWCallbacks.WindowMaximizeCallback _windowMaximizeCallback;
         private GLFWCallbacks.WindowFocusCallback _windowFocusCallback;
@@ -1032,6 +1045,7 @@ namespace OpenTK.Windowing.Desktop
 
             _windowPosCallback = WindowPosCallback;
             _windowSizeCallback = WindowSizeCallback;
+            _framebufferSizeCallback = FramebufferSizeCallback;
             _windowCloseCallback = WindowCloseCallback;
             _windowRefreshCallback = WindowRefreshCallback;
             _windowFocusCallback = WindowFocusCallback;
@@ -1054,6 +1068,7 @@ namespace OpenTK.Windowing.Desktop
 
             GLFW.SetWindowPosCallback(WindowPtr, _windowPosCallback);
             GLFW.SetWindowSizeCallback(WindowPtr, _windowSizeCallback);
+            GLFW.SetFramebufferSizeCallback(WindowPtr, _framebufferSizeCallback);
             GLFW.SetWindowCloseCallback(WindowPtr, _windowCloseCallback);
             GLFW.SetWindowRefreshCallback(WindowPtr, _windowRefreshCallback);
             GLFW.SetWindowFocusCallback(WindowPtr, _windowFocusCallback);
@@ -1112,6 +1127,18 @@ namespace OpenTK.Windowing.Desktop
             try
             {
                 OnResize(new ResizeEventArgs(width, height));
+            }
+            catch (Exception e)
+            {
+                _callbackExceptions.Enqueue(ExceptionDispatchInfo.Capture(e));
+            }
+        }
+
+        private unsafe void FramebufferSizeCallback(Window* window, int width, int height)
+        {
+            try
+            {
+                OnFramebufferResize(new FramebufferResizeEventArgs(width, height));
             }
             catch (Exception e)
             {
@@ -1501,6 +1528,11 @@ namespace OpenTK.Windowing.Desktop
         public event Action<ResizeEventArgs> Resize;
 
         /// <summary>
+        /// Occurs whenever the framebuffer is resized.
+        /// </summary>
+        public event Action<FramebufferResizeEventArgs> FramebufferResize;
+
+        /// <summary>
         /// Occurs whenever the window is refreshed.
         /// </summary>
         public event Action Refresh;
@@ -1722,6 +1754,15 @@ namespace OpenTK.Windowing.Desktop
         protected virtual void OnResize(ResizeEventArgs e)
         {
             Resize?.Invoke(e);
+        }
+
+        /// <summary>
+        /// Raises the FramebufferResize event.
+        /// </summary>
+        /// <param name="e">A <see cref="FramebufferResizeEventArgs"/> that contains the event data.</param>
+        protected virtual void OnFramebufferResize(FramebufferResizeEventArgs e)
+        {
+            FramebufferResize?.Invoke(e);
         }
 
         /// <summary>

--- a/tests/LocalTest/Program.cs
+++ b/tests/LocalTest/Program.cs
@@ -56,6 +56,11 @@ namespace LocalTest
             base.OnUnload();
         }
 
+        protected override void OnUpdateFrame(FrameEventArgs args)
+        {
+            base.OnUpdateFrame(args);
+        }
+
         float time = 0;
 
         protected override void OnRenderFrame(FrameEventArgs args)
@@ -75,21 +80,16 @@ namespace LocalTest
             SwapBuffers();
         }
 
-        protected override void OnUpdateFrame(FrameEventArgs args)
-        {
-            base.OnUpdateFrame(args);
-        }
-
-        protected override void OnResize(ResizeEventArgs e)
-        {
-            base.OnResize(e);
-        }
-
         protected override void OnFramebufferResize(FramebufferResizeEventArgs e)
         {
             base.OnFramebufferResize(e);
 
             GL.Viewport(0, 0, e.Width, e.Height);
+        }
+
+        protected override void OnResize(ResizeEventArgs e)
+        {
+            base.OnResize(e);
         }
 
         protected override void OnMove(WindowPositionEventArgs e)

--- a/tests/LocalTest/Program.cs
+++ b/tests/LocalTest/Program.cs
@@ -85,6 +85,13 @@ namespace LocalTest
             base.OnResize(e);
         }
 
+        protected override void OnFramebufferResize(FramebufferResizeEventArgs e)
+        {
+            base.OnFramebufferResize(e);
+
+            GL.Viewport(0, 0, e.Width, e.Height);
+        }
+
         protected override void OnMove(WindowPositionEventArgs e)
         {
             base.OnMove(e);


### PR DESCRIPTION
### Purpose of this PR

Exposes framebuffer size and framebuffer size callbacks from GLFW through `NativeWindow`.

Fixes #1649

### Testing status

Tested using the local test project on Windows 10.